### PR TITLE
Issue55

### DIFF
--- a/rundeckapp/grails-app/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/FrameworkController.groovy
@@ -260,6 +260,12 @@ class FrameworkController  {
         def NodeFilter filter
         def boolean saveuser=false
         if(params.newFilterName && !params.existsFilterName){
+            def ofilter = NodeFilter.findByNameAndUser(params.newFilterName,u)
+            if(ofilter){
+                flash.error="Filter named ${params.newFilterName} already exists."
+                params.saveFilter=true
+                return chain(controller:'framework',action:'nodes',params:params)
+            }
             filter= new NodeFilter(query.properties)
             filter.name=params.newFilterName
             u.addToNodefilters(filter)
@@ -272,12 +278,12 @@ class FrameworkController  {
         }else if(!params.newFilterName && !params.existsFilterName){
             flash.error="Filter name not specified"
             params.saveFilter=true
-            chain(controller:'reports',action:'index',params:params)
+            return chain(controller:'framework',action:'nodes',params:params)
         }
         if(!filter.save(flush:true)){
             flash.error=filter.errors.allErrors.collect { g.message(error:it) }.join("\n")
             params.saveFilter=true
-            chain(controller:'reports',action:'index',params:params)
+            return chain(controller:'framework',action:'nodes',params:params)
         }
         if(saveuser){
             if(!u.save(flush:true)){

--- a/rundeckapp/grails-app/domain/NodeFilter.groovy
+++ b/rundeckapp/grails-app/domain/NodeFilter.groovy
@@ -45,7 +45,7 @@ public class NodeFilter {
 
     static belongsTo = [user:User]
     static constraints={
-        name(blank:false,unique:true)
+        name(blank:false)
         nodeInclude(nullable: true)
         nodeExclude(nullable: true)
         nodeIncludeName(nullable: true)


### PR DESCRIPTION
fix issue55:  two users should be able to create a nodefilter with the same name.  One user should not be able to overwrite their own nodefilter by creating a new one with the same name, but should be able to save over an existing one if selected in the dropdown menu.  Any errors shown when saving a filter (e.g. save a filter with empty name) should result in returning to the Nodes page with same filters in place and show the error message.
