### PR TITLE
Issue38

### DIFF
--- a/rundeckapp/grails-app/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/UserController.groovy
@@ -4,6 +4,7 @@ import javax.servlet.http.HttpSession
 class UserController {
     UserService userService
     RoleService roleService
+    def grailsApplication
 
     def index = {
         redirect(action:"login")
@@ -15,7 +16,11 @@ class UserController {
     }
     def logout = {
         session.invalidate()
-        redirect(controller:'menu', action:'index')
+        if(params.refLink && grailsApplication.config.grails.serverURL && params.refLink.startsWith(grailsApplication.config.grails.serverURL)){
+            return redirect(url:params.refLink)
+        }else{
+            return redirect(controller:'menu', action:'index')
+        }
     }
     
     def login = {

--- a/rundeckapp/grails-app/views/common/_topbar.gsp
+++ b/rundeckapp/grails-app/views/common/_topbar.gsp
@@ -82,7 +82,7 @@ function createProject(value){
                 <span class="userName" title="User ${session.user} is currently logged in.">
                     <g:link controller="user" action="profile">${session.user}</g:link>
                 </span> &raquo;
-                <g:link action="logout" controller="user" title="Logout user: ${session.user}">logout</g:link>
+                <g:link action="logout" controller="user" title="Logout user: ${session.user}" params="${[refLink:controllerName&&actionName?createLink(controller:controllerName,action:actionName,params:params,absolute:true):'']}">logout</g:link>
             </span>
             <a href="${g.message(code:'app.wiki.help')}" class="help">
                 help


### PR DESCRIPTION
change to let "logout" button use last logged-in page as destination after logging back in.  to test: log in and go to another page (not the jobs list).  click "logout".  enter login details, you should go back to page you were on before logout.  Note: session state is not preserved (selected project especially)
