### PR TITLE
Issue59 fixterse

### DIFF
--- a/core/src/java/com/dtolabs/rundeck/core/cli/CLIExecutionListener.java
+++ b/core/src/java/com/dtolabs/rundeck/core/cli/CLIExecutionListener.java
@@ -40,6 +40,7 @@ public class CLIExecutionListener implements ExecutionListener {
     private FailedNodesListener failedNodesListener;
     private CLIToolLogger logger;
     private CLILoggerParams loggerParams;
+    private boolean terse;
 
     /**
      * Create the CLIExecutionListener
@@ -66,6 +67,16 @@ public class CLIExecutionListener implements ExecutionListener {
         this.failedNodesListener = failedNodesListener;
         this.logger = logger;
         this.loggerParams = loggerParams;
+    }
+
+    public CLIExecutionListener(final BuildListener buildListener, final FailedNodesListener failedNodesListener,
+                                final CLIToolLogger logger,
+                                final CLILoggerParams loggerParams, final boolean terse) {
+        this.buildListener = buildListener;
+        this.failedNodesListener = failedNodesListener;
+        this.logger = logger;
+        this.loggerParams = loggerParams;
+        this.terse = terse;
     }
 
     /**
@@ -111,4 +122,11 @@ public class CLIExecutionListener implements ExecutionListener {
         return buildListener;
     }
 
+    public boolean isTerse() {
+        return terse;
+    }
+
+    public void setTerse(final boolean terse) {
+        this.terse = terse;
+    }
 }

--- a/core/src/java/com/dtolabs/rundeck/core/cli/ExecTool.java
+++ b/core/src/java/com/dtolabs/rundeck/core/cli/ExecTool.java
@@ -493,18 +493,6 @@ public class ExecTool implements CLITool,IDispatchedScript,CLILoggerParams {
                 //STDOUT so they are captured later in the stream.
                 map.put(Project.MSG_INFO, Project.MSG_WARN);
                 blistener=new LogLevelConvertBuildListener(listener, map);
-            }else if(!argTerse) {
-                String logformat = DEFAULT_LOG_FORMAT;
-                if (getFramework().existsProperty(FRAMEWORK_LOG_RUNDECK_EXEC_CONSOLE_FORMAT)) {
-                    logformat = getFramework().getProperty(FRAMEWORK_LOG_RUNDECK_EXEC_CONSOLE_FORMAT);
-                }
-                final String nodeName = getFramework().getFrameworkNodeName();
-                final HashMap<String, String> contextData = new HashMap<String, String>();
-                contextData.put("node", nodeName);
-                contextData.put("user", user);
-                contextData.put("command", "run-exec");
-                final LogReformatter gen = new LogReformatter(logformat, contextData);
-                blistener = createExecToolCommandLogger(getAntLoglevel(), gen);
             }else {
                 blistener = createExecToolCommandLogger(getAntLoglevel(), null);
             }
@@ -524,7 +512,7 @@ public class ExecTool implements CLITool,IDispatchedScript,CLILoggerParams {
 
             //configure execution listener
             final ExecutionListener executionListener = new CLIExecutionListener(blistener,
-                FailedNodesFilestore.createListener(getFailedNodes()), this, this);
+                FailedNodesFilestore.createListener(getFailedNodes()), this, this, argTerse);
 
             //acquire ExecutionService object
             final ExecutionService service = ExecutionServiceFactory.instance().createExecutionService(framework,

--- a/core/src/java/com/dtolabs/rundeck/core/execution/ExecutionListener.java
+++ b/core/src/java/com/dtolabs/rundeck/core/execution/ExecutionListener.java
@@ -33,6 +33,11 @@ import org.apache.tools.ant.BuildListener;
  */
 public interface ExecutionListener {
     /**
+     * Return true if output should be terse and not prefixed
+     * @return
+     */
+    public boolean isTerse();
+    /**
      * Log a message
      *
      * @param level   the log level

--- a/core/src/java/com/dtolabs/rundeck/core/execution/script/CommandAction.java
+++ b/core/src/java/com/dtolabs/rundeck/core/execution/script/CommandAction.java
@@ -124,35 +124,39 @@ class CommandAction extends AbstractAction {
                                                       .getUsername();
 
         DefaultNodeDispatcher.configureNodeContextThreadLocalsForProject(project);
-
-        String logformat = ExecTool.DEFAULT_LOG_FORMAT;
-        if (getFramework().existsProperty(ExecTool.FRAMEWORK_LOG_RUNDECK_EXEC_CONSOLE_FORMAT)) {
-            logformat = getFramework().getProperty(ExecTool.FRAMEWORK_LOG_RUNDECK_EXEC_CONSOLE_FORMAT);
-        }
-        final LogReformatter gen = new LogReformatter(logformat, new MapGenerator<String, String>() {
-            public Map<String, String> getMap() {
-                final HashMap<String, String> contextData = new HashMap<String, String>();
-                //discover node name and username
-                final String thrNode = DefaultNodeDispatcher.getThreadLocalForProject(
-                    DefaultNodeDispatcher.NODE_NAME_LOCAL_REF_ID,
-                    CommandAction.this.project);
-                if(null!=thrNode){
-                    contextData.put("node", thrNode );
-                } else {
-                    contextData.put("node",  fwkNodeName );
-                }
-                final String thrUser = DefaultNodeDispatcher.getThreadLocalForProject(
-                    DefaultNodeDispatcher.NODE_USER_LOCAL_REF_ID,
-                    CommandAction.this.project);
-                if(null!=thrUser){
-                    contextData.put("user",  thrUser);
-                } else {
-                    contextData.put("user", fwkUser);
-                }
-                contextData.put("command", "run-exec");
-                return contextData;
+        final LogReformatter gen ;
+        if (null!=listener && listener.isTerse()) {
+            gen=null;
+        }else{
+            String logformat = ExecTool.DEFAULT_LOG_FORMAT;
+            if (getFramework().existsProperty(ExecTool.FRAMEWORK_LOG_RUNDECK_EXEC_CONSOLE_FORMAT)) {
+                logformat = getFramework().getProperty(ExecTool.FRAMEWORK_LOG_RUNDECK_EXEC_CONSOLE_FORMAT);
             }
-        });
+            gen= new LogReformatter(logformat, new MapGenerator<String, String>() {
+                public Map<String, String> getMap() {
+                    final HashMap<String, String> contextData = new HashMap<String, String>();
+                    //discover node name and username
+                    final String thrNode = DefaultNodeDispatcher.getThreadLocalForProject(
+                        DefaultNodeDispatcher.NODE_NAME_LOCAL_REF_ID,
+                        CommandAction.this.project);
+                    if(null!=thrNode){
+                        contextData.put("node", thrNode );
+                    } else {
+                        contextData.put("node",  fwkNodeName );
+                    }
+                    final String thrUser = DefaultNodeDispatcher.getThreadLocalForProject(
+                        DefaultNodeDispatcher.NODE_USER_LOCAL_REF_ID,
+                        CommandAction.this.project);
+                    if(null!=thrUser){
+                        contextData.put("user",  thrUser);
+                    } else {
+                        contextData.put("user", fwkUser);
+                    }
+                    contextData.put("command", "run-exec");
+                    return contextData;
+                }
+            });
+        }
 
         //bind System printstreams to the thread
         final ThreadBoundOutputStream threadBoundSysOut = ThreadBoundOutputStream.bindSystemOut();

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/execution/WorkflowActionTests.java
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/execution/WorkflowActionTests.java
@@ -983,6 +983,10 @@ public class WorkflowActionTests extends TestCase {
     }
 
     static class testListener implements ExecutionListener {
+        public boolean isTerse() {
+            return false;
+        }
+
         public void log(int i, String s) {
             System.err.println(i + ": " + s);
         }


### PR DESCRIPTION
corrects the terse commandline behavior.  previously it was working but there was 2 layers of formatted output, causing it to appear to not work.  i have changed the CLI tool to remove the extra formatting.  

by default, --terse is _enabled_ when you run the CLI tool.  this means that no extra formatting shows up (even for remote dispatches).  this is the way the file `profile` configures env var RUNDECK_CLI_TERSE if you are using bash.

to verify;  run tools/bin/run command to execute some command, there should be no formatting.  again with remote dispatch should have no extra prefixed output.

export RUNDECK_CLI_TERSE=false

run another command and you should see the prefixed output.   use the -z/--terse flag and the prefix should be removed again.
