### PR TITLE
Issue60

### DIFF
--- a/core/src/java/com/dtolabs/rundeck/core/cli/CLIExecutionListener.java
+++ b/core/src/java/com/dtolabs/rundeck/core/cli/CLIExecutionListener.java
@@ -41,6 +41,7 @@ public class CLIExecutionListener implements ExecutionListener {
     private CLIToolLogger logger;
     private CLILoggerParams loggerParams;
     private boolean terse;
+    private String logFormat;
 
     /**
      * Create the CLIExecutionListener
@@ -77,6 +78,17 @@ public class CLIExecutionListener implements ExecutionListener {
         this.logger = logger;
         this.loggerParams = loggerParams;
         this.terse = terse;
+    }
+
+    public CLIExecutionListener(final BuildListener buildListener, final FailedNodesListener failedNodesListener,
+                                final CLIToolLogger logger,
+                                final CLILoggerParams loggerParams, final boolean terse, final String logFormat) {
+        this.buildListener = buildListener;
+        this.failedNodesListener = failedNodesListener;
+        this.logger = logger;
+        this.loggerParams = loggerParams;
+        this.terse = terse;
+        this.logFormat = logFormat;
     }
 
     /**
@@ -128,5 +140,13 @@ public class CLIExecutionListener implements ExecutionListener {
 
     public void setTerse(final boolean terse) {
         this.terse = terse;
+    }
+
+    public String getLogFormat() {
+        return logFormat;
+    }
+
+    public void setLogFormat(String logFormat) {
+        this.logFormat = logFormat;
     }
 }

--- a/core/src/java/com/dtolabs/rundeck/core/cli/ExecTool.java
+++ b/core/src/java/com/dtolabs/rundeck/core/cli/ExecTool.java
@@ -509,10 +509,15 @@ public class ExecTool implements CLITool,IDispatchedScript,CLILoggerParams {
             }else if(null!=scriptpath){
                 setScriptAsStream(new FileInputStream(getScriptpath()));
             }
-
+            final String logformat;
+            if (getFramework().existsProperty(ExecTool.FRAMEWORK_LOG_RUNDECK_EXEC_CONSOLE_FORMAT)) {
+                logformat = getFramework().getProperty(ExecTool.FRAMEWORK_LOG_RUNDECK_EXEC_CONSOLE_FORMAT);
+            }else{
+                logformat=null;
+            }
             //configure execution listener
             final ExecutionListener executionListener = new CLIExecutionListener(blistener,
-                FailedNodesFilestore.createListener(getFailedNodes()), this, this, argTerse);
+                FailedNodesFilestore.createListener(getFailedNodes()), this, this, argTerse, logformat);
 
             //acquire ExecutionService object
             final ExecutionService service = ExecutionServiceFactory.instance().createExecutionService(framework,

--- a/core/src/java/com/dtolabs/rundeck/core/execution/ExecutionListener.java
+++ b/core/src/java/com/dtolabs/rundeck/core/execution/ExecutionListener.java
@@ -37,6 +37,13 @@ public interface ExecutionListener {
      * @return
      */
     public boolean isTerse();
+
+    /**
+     * Return log message format 
+     * @return
+     */
+    public String getLogFormat();
+
     /**
      * Log a message
      *

--- a/core/src/java/com/dtolabs/rundeck/core/execution/script/CommandAction.java
+++ b/core/src/java/com/dtolabs/rundeck/core/execution/script/CommandAction.java
@@ -129,8 +129,8 @@ class CommandAction extends AbstractAction {
             gen=null;
         }else{
             String logformat = ExecTool.DEFAULT_LOG_FORMAT;
-            if (getFramework().existsProperty(ExecTool.FRAMEWORK_LOG_RUNDECK_EXEC_CONSOLE_FORMAT)) {
-                logformat = getFramework().getProperty(ExecTool.FRAMEWORK_LOG_RUNDECK_EXEC_CONSOLE_FORMAT);
+            if (null!=listener && null!=listener.getLogFormat()) {
+                logformat = listener.getLogFormat();
             }
             gen= new LogReformatter(logformat, new MapGenerator<String, String>() {
                 public Map<String, String> getMap() {

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/execution/WorkflowActionTests.java
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/execution/WorkflowActionTests.java
@@ -987,6 +987,10 @@ public class WorkflowActionTests extends TestCase {
             return false;
         }
 
+        public String getLogFormat() {
+            return null;
+        }
+
         public void log(int i, String s) {
             System.err.println(i + ": " + s);
         }


### PR DESCRIPTION
makes console log format in framework.properties used only for CLI execution, and not affect Rundeckapp dispatch

verify: modify framework.log.run-exec.console.format and verify that it changes the console log format. e.g. remove %node to remove node name.  You will have to set RUNDECK_CLI_TERSE=false to see the console log format.  Verify that running any dispatch job in Rundeck app _does_ correctly see node information, despite change to log format.
