### PR TITLE
Issue68 nomarkdown

### DIFF
--- a/rundeckapp/grails-app/conf/BootStrap.groovy
+++ b/rundeckapp/grails-app/conf/BootStrap.groovy
@@ -126,10 +126,7 @@ class BootStrap {
          if(grailsApplication.config.output.markdown.enabled){
              servletContext.setAttribute("output.markdown.enabled",grailsApplication.config.output.markdown.enabled=="true"?"true":"false")
          }else{
-             servletContext.setAttribute("output.markdown.enabled","true")
-         }
-         if("true" != servletContext.getAttribute("output.markdown.enabled")){
-             log.info("Execution Output Markdown is disabled.")
+             servletContext.setAttribute("output.markdown.enabled","false")
          }
          if(grailsApplication.config.nowrunning.interval){
              servletContext.setAttribute("nowrunning.interval",grailsApplication.config.nowrunning.interval)


### PR DESCRIPTION
simply disables use of markdown formatting in execution output view by default

verify: execute a job like "echo _test_"  verify output is literal "_test_" and not html italics.

modify your rundeck-config.properties, and add output.markdown.enabled=true

restart rundeck, view same job output, and see that output is processed with markdown
