### PR TITLE
#254 job tree

### DIFF
--- a/docs/en/07-administration/07-chapter1.md
+++ b/docs/en/07-administration/07-chapter1.md
@@ -958,3 +958,8 @@ these properties in the [rundeck-config.properties](#rundeck-config.properties) 
 |`rundeck.gui.titleLink`  |URL for the link used by the app     |http://rundeck.org  |
 |                         |header icon.                         |                    |
 +-------------------------+-------------------------------------+--------------------+
+|`rundeck.gui.realJobTree`|Displaying a real tree in the Jobs   |true                |
+|                         |overview instead of collapsing       |                    |
+|                         |empty groups. **Default: false**     |                    |
++-------------------------+-------------------------------------+--------------------+
+

--- a/rundeckapp/grails-app/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/MenuController.groovy
@@ -283,6 +283,23 @@ class MenuController {
             }
 
         }
+
+        if(org.codehaus.groovy.grails.commons.ConfigurationHolder.config.rundeck?.gui?.realJobTree) {
+            //Adding group entries for empty hierachies to have a "real" tree 
+            def missinggroups = [:]
+            jobgroups.each { k, v ->
+                def splittedgroups = k.split('/')
+                splittedgroups.eachWithIndex { item, idx ->
+                    def thepath = splittedgroups[0..idx].join('/')
+                    if(!jobgroups.containsKey(thepath)) {
+                        missinggroups[thepath]=[]
+                    }
+                }
+            }
+            //sorting is done in the view
+            jobgroups.putAll(missinggroups)
+        }
+
         schedlist=newschedlist
         log.debug("listWorkflows(viewable): "+(System.currentTimeMillis()-viewable));
         long last=System.currentTimeMillis()

--- a/rundeckapp/grails-app/views/menu/_groupTree.gsp
+++ b/rundeckapp/grails-app/views/menu/_groupTree.gsp
@@ -37,7 +37,12 @@
 <g:each in="${gkeys}" var="group">
     <g:timerStart key="_groupTree2.gsp-loop"/>
     <g:timerStart key="prepare"/>
-    <g:set var="displaygroup" value="${group.key}"/>
+    <g:if test="${org.codehaus.groovy.grails.commons.ConfigurationHolder.config.rundeck?.gui?.realJobTree}">
+        <g:set var="displaygroup" value="${group.key.split('/')[-1]}"/>
+    </g:if>
+    <g:else>
+        <g:set var="displaygroup" value="${group.key}"/>
+    </g:else>
     <g:set var="currkey" value="${g.rkey()}"/>
     <g:if test="${prevkey && group.key.startsWith(prevkey+'/')}">
         %{
@@ -46,9 +51,27 @@
         <g:set var="displaygroup" value="${group.key.substring(prevkey.length()+1)}"/>
     </g:if>
     <g:else>
-        ${divcount.join('<!--rend-->')}
-        <g:set var="indent" value="${0}"/>
-        <g:set var="divcount" value="${[]}"/>
+        <g:if test="${org.codehaus.groovy.grails.commons.ConfigurationHolder.config.rundeck?.gui?.realJobTree}">
+        <%
+            if(prevkey) {
+                List prevKeyLst = prevkey.split('/')
+                List currKeyLst = group.key.split('/')
+                //define all different elements compared to the last key
+                def deltaGroups = prevKeyLst - currKeyLst
+                //We write 2 divs per iteration
+                def closeDivCount = deltaGroups.size() * 2
+                for(i in 1..closeDivCount) {
+                    out << divcount.pop() + '<!--rend-->' 
+                }
+                indent = indent - closeDivCount
+            }
+        %>
+        </g:if>
+        <g:else>
+            ${divcount.join('<!--rend-->')}
+            <g:set var="indent" value="${0}"/>
+            <g:set var="divcount" value="${[]}"/>
+        </g:else>
     </g:else>
     <g:set var="prevkey" value="${group.key}"/>
     <g:set var="groupopen" value="${(wasfiltered || jscallback)}"/>


### PR DESCRIPTION
This adresses lighhouseapp #254 and creates a new configuration option in order to display the Jobs as a real tree (making also empty elements of grouping-pathes expandable).
This feature is disabled by default. 
Added documentation to the GUI customization section about how to enable it.

Before: http://oi51.tinypic.com/2ueodw1.jpg
After: http://i51.tinypic.com/2ueodw1.png
