### PR TITLE
Feature: support for ${option.xyz} syntax in dispatched nodes.

### DIFF
--- a/rundeckapp/src/java/com/dtolabs/rundeck/execution/WorkflowExecutionItemImpl.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/execution/WorkflowExecutionItemImpl.java
@@ -67,26 +67,34 @@ public class WorkflowExecutionItemImpl implements WorkflowExecutionItem {
 									// to avoid overwriting during first
 									// execution
 
-		Include includes = result.getInclude(); // TODO: find a generic way of
-												// replacing everything in
-												// includes and excludes
-		if (includes.getName() != null) {
-			includes.setName(DataContextUtils.replaceDataReferences(
-					includes.getName(), getDataContext()));
-		}
-		if (includes.getTags() != null) {
-			includes.setTags(DataContextUtils.replaceDataReferences(
-					includes.getTags(), getDataContext()));
-		}
+		if (result != null) {
+			Include includes = result.getInclude(); // TODO: find a generic way
+													// of
+													// replacing everything in
+													// includes and excludes
 
-		Exclude excludes = result.getExclude();
-		if (excludes.getName() != null) {
-			excludes.setName(DataContextUtils.replaceDataReferences(
-					excludes.getName(), getDataContext()));
-		}
-		if (excludes.getTags() != null) {
-			excludes.setTags(DataContextUtils.replaceDataReferences(
-					excludes.getTags(), getDataContext()));
+			if (includes != null) {
+				if (includes.getName() != null) {
+					includes.setName(DataContextUtils.replaceDataReferences(
+							includes.getName(), getDataContext()));
+				}
+				if (includes.getTags() != null) {
+					includes.setTags(DataContextUtils.replaceDataReferences(
+							includes.getTags(), getDataContext()));
+				}
+			}
+
+			Exclude excludes = result.getExclude();
+			if (excludes != null) {
+				if (excludes.getName() != null) {
+					excludes.setName(DataContextUtils.replaceDataReferences(
+							excludes.getName(), getDataContext()));
+				}
+				if (excludes.getTags() != null) {
+					excludes.setTags(DataContextUtils.replaceDataReferences(
+							excludes.getTags(), getDataContext()));
+				}
+			}
 		}
 
 		return result;


### PR DESCRIPTION
This fix shall allow using notation ${option.xyz} for specifying nodes the workflow must be dispatched to. This fix may be of great use for setups where lots of jobs and workflows are created for each dispatched node subset, thus giving the possibility to avoid copy/paste jobs and workflows.
