### PR TITLE
Fix ldap prefix handling

### DIFF
--- a/rundeckapp/src/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
@@ -244,17 +244,6 @@ public class JettyCachingLdapLoginModule extends AbstractLoginModule {
         Credential credential = Credential.getCredential(pwdCredential);
         List roles = getUserRoles(_rootContext, username);
 
-        if (_rolePrefix != null && !"".equalsIgnoreCase(_rolePrefix)) {
-            List<String> newRoles = new ArrayList<String>();
-
-            for (Object roleObj : roles) {
-                String role = (String) roleObj;
-                newRoles.add(role.replace(_rolePrefix, ""));
-            }
-
-            roles.addAll(newRoles);
-        }
-
         return new UserInfo(username, credential, roles);
     }
 
@@ -397,7 +386,13 @@ public class JettyCachingLdapLoginModule extends AbstractLoginModule {
 
             NamingEnumeration roles = roleAttribute.getAll();
             while (roles.hasMore()) {
-                roleList.add(roles.next());
+                if (_rolePrefix != null && !"".equalsIgnoreCase(_rolePrefix)) {
+                    String role = (String) roles.next();
+                    // Log.info("Role for user " + userDn + ": " + role); 
+                    roleList.add(role.replace(_rolePrefix, ""));
+                } else {
+                    roleList.add(roles.next());
+                }
             }
         }
 


### PR DESCRIPTION
The role prefix wasn't working when using a binding login. Move the code that handles role prefixing to make it work. This was discussed on the Control Tier mailing list: http://groups.google.com/group/controltier/browse_thread/thread/79a2e79387e2eabc?fwc=2
