### PR TITLE
Fixes for debian packaging

### DIFF
--- a/packaging/debroot/DEBIAN/control
+++ b/packaging/debroot/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.3
 Section: utils
 Priority: optional
 Architecture: all
-Depends: openssh-client, openjdk-6-jdk
+Depends: openssh-client, openjdk-6-jdk, adduser (>= 3.11)
 Maintainer: Noah Campbell <noahcampbell@gmail.com>
 Description: No ordinary wooden deck. You can build a bon fire on this deck.
  Rundeck provides a single console for dispatching commands across many 

--- a/packaging/debroot/DEBIAN/postinst
+++ b/packaging/debroot/DEBIAN/postinst
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+set -e
+
+setperm() {
+  local user="$1"
+  local group="$2"
+  local mode="$3"
+  local file="$4"
+  shift 4
+
+  # Only do something when no setting exists - if it was set, then it's already
+  # been unpacked using the appropriate ownership and permissions.
+  if ! dpkg-statoverride --list "$file" >/dev/null 2>&1; then
+    chown "$user":"$group" "$file"
+    chmod "$mode" "$file"
+  fi
+}
+
+case "$1" in
+  configure)
+    # If the package has default file it could be sourced, so that
+    # the local admin can overwrite the defaults
+
+    [ -f "/etc/default/rundeck" ] && . /etc/default/rundeck
+   
+    # Sane defaults:
+   
+    [ -z "$SERVER_HOME" ] && SERVER_HOME=/var/lib/rundeck
+    [ -z "$SERVER_USER" ] && SERVER_USER=rundeck
+    [ -z "$SERVER_NAME" ] && SERVER_NAME="Rundeck user account"
+    [ -z "$SERVER_GROUP" ] && SERVER_GROUP=rundeck
+
+    # create user to avoid running server as root
+    # 1. create group if not existing
+    if ! getent group | grep -q "^$SERVER_GROUP:" ; then
+       echo -n "Adding group $SERVER_GROUP.."
+       addgroup --quiet --system $SERVER_GROUP 2>/dev/null ||true
+       echo "..done"
+    fi
+    # 2. create homedir if not existing
+    test -d $SERVER_HOME || mkdir $SERVER_HOME
+    # 3. create user if not existing
+    if ! getent passwd | grep -q "^$SERVER_USER:"; then
+      echo -n "Adding system user $SERVER_USER.."
+      adduser --quiet \
+              --system \
+              --ingroup $SERVER_GROUP \
+              --no-create-home \
+              --disabled-password \
+              $SERVER_USER 2>/dev/null || true
+      echo "..done"
+    fi
+
+    # 4. adjust passwd entry
+    usermod -c "$SERVER_NAME" \
+            -d $SERVER_HOME   \
+            -g $SERVER_GROUP  \
+               $SERVER_USER
+
+    # 5. adjust file and directory permissions
+    setperm rundeck rundeck 0750 /var/lib/rundeck/work
+    setperm rundeck rundeck 0750 /var/lib/rundeck/data
+    setperm rundeck adm 2751 /var/lib/rundeck/logs
+    setperm rundeck rundeck 0750 /var/lib/rundeck/var/tmp
+    setperm rundeck rundeck 0750 /var/rundeck
+    setperm rundeck rundeck 0750 /var/rundeck/projects
+    setperm rundeck adm 2751 /var/log/rundeck
+    for file in `find /etc/rundeck -type f`; do
+      setperm rundeck rundeck 0640 $file
+    done
+    ;;
+
+  abort-upgrade|abort-remove|abort-deconfigure)
+    :
+    ;;
+
+  *)
+    echo "postinst called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac
+
+exit 0
+

--- a/packaging/debroot/DEBIAN/postrm
+++ b/packaging/debroot/DEBIAN/postrm
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  remove)
+    :
+    ;;
+
+  purge)
+    # find first and last SYSTEM_UID numbers
+    for LINE in `grep SYSTEM_UID /etc/adduser.conf | grep -v "^#"`; do
+       case $LINE in
+          FIRST_SYSTEM_UID*)
+            FIST_SYSTEM_UID=`echo $LINE | cut -f2 -d '='`
+            ;;
+          LAST_SYSTEM_UID*)
+            LAST_SYSTEM_UID=`echo $LINE | cut -f2 -d '='`
+            ;;
+          *)
+            ;;
+          esac
+    done
+    # Remove system account if necessary
+    CREATEDUSER="server_user"
+    if [ -n "$FIST_SYSTEM_UID" ] && [ -n "$LAST_SYSTEM_UID" ]; then
+      if USERID=`getent passwd $CREATEDUSER | cut -f 3 -d ':'`; then
+        if [ -n "$USERID" ]; then
+          if [ "$FIST_SYSTEM_UID" -le "$USERID" ] && \
+            [ "$USERID" -le "$LAST_SYSTEM_UID" ]; then
+               echo -n "Removing $CREATEDUSER system user.."
+               deluser --quiet $CREATEDUSER || true
+               echo "..done"
+          fi
+        fi
+      fi
+    fi
+    # Remove system group if necessary
+    CREATEDGROUP=server_group
+    FIRST_USER_GID=`grep ^USERS_GID /etc/adduser.conf | cut -f2 -d '='`
+    if [ -n "$FIST_USER_GID" ]; then
+      if GROUPGID=`getent group $CREATEDGROUP | cut -f 3 -d ':'`; then
+        if [ -n "$GROUPGID" ]; then
+          if [ "$FIST_USER_GID" -gt "$GROUPGID" ]; then
+            echo -n "Removing $CREATEDGROUP group.."
+            delgroup --only-if-empty $CREATEDGROUP || true
+            echo "..done"
+          fi
+        fi
+      fi
+    fi
+    ;;
+
+  upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+    ;;
+
+  *)
+    echo "postrm called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/packaging/debroot/etc/init/rundeckd.conf
+++ b/packaging/debroot/etc/init/rundeckd.conf
@@ -14,5 +14,5 @@ respawn limit 10 30
 
 script
 	. /etc/rundeck/profile
-	exec su -c rundeck ${JAVA_HOME:-/usr}/bin/java ${RDECK_JVM} -cp ${BOOTSTRAP_CP}:/etc/rundeck com.dtolabs.rundeck.RunServer /etc/rundeck 4440
-end-script
+	exec start-stop-daemon --start --make-pidfile --pidfile /var/run/rundeckd.pid --chuid rundeck --exec "${JAVA_HOME:-/usr}/bin/java" -- ${RDECK_JVM} -cp ${BOOTSTRAP_CP}:/etc/rundeck com.dtolabs.rundeck.RunServer /etc/rundeck 4440
+end script


### PR DESCRIPTION
- Fix upstart init script to not have syntax error
- Add rundeck user at package installation time.
- Fix startup script to properly change to rundeck user
- Set permissions dynamically at package installation to use rundeck user
- Use pidfile so we can run more than one java process through start-stop-daemon

(This pull request is for the development branch. It's untested because I'm still running 1.3.0, but it doesn't look like anyone else touched the debian packaging in the meantime.)
