### PR TITLE
Depending on a specific java implementation in Debian is not good.

### DIFF
--- a/packaging/debroot/DEBIAN/control
+++ b/packaging/debroot/DEBIAN/control
@@ -3,7 +3,7 @@ Version: %VERSION%
 Section: utils
 Priority: optional
 Architecture: all
-Depends: openssh-client, openjdk-6-jdk, adduser (>= 3.11)
+Depends: openssh-client, java6-runtime, adduser (>= 3.11)
 Maintainer: Noah Campbell <noahcampbell@gmail.com>
 Description: No ordinary wooden deck. You can build a bon fire on this deck.
  Rundeck provides a single console for dispatching commands across many 


### PR DESCRIPTION
Depending on a specific java implementation in Debian is not good. For instance I am using sun-java6-jre which is also providing the virtual package java6-runtime. I hope this helps. 
Kind regards Hannes
