### PR TITLE
Remove un-overridable port configuration

### DIFF
--- a/packaging/debroot/etc/init.d/rundeckd
+++ b/packaging/debroot/etc/init.d/rundeckd
@@ -24,7 +24,7 @@ prog="rundeckd"
 RETVAL=0
 PIDFILE=/var/run/$prog.pid
 DAEMON="${JAVA_HOME:-/usr}/bin/java"
-DAEMON_ARGS="${RDECK_JVM} -cp ${BOOTSTRAP_CP}:/etc/rundeck com.dtolabs.rundeck.RunServer /etc/rundeck 4440"
+DAEMON_ARGS="${RDECK_JVM} -cp ${BOOTSTRAP_CP}:/etc/rundeck com.dtolabs.rundeck.RunServer /etc/rundeck"
 rundeckd="$DAEMON $DAEMON_ARGS"
 
 start() {


### PR DESCRIPTION
Port :4440 is defaulted-to at rundeck/RunServer.java:35. Having it hard-coded in the initscript renders any conffile setting of server.http.port moot. I believe.
