### PR TITLE
Update sample scripts in plugin docs for best practices conformance

### DIFF
--- a/docs/en/manual/08-plugins.md
+++ b/docs/en/manual/08-plugins.md
@@ -1169,15 +1169,13 @@ Contents of `/tmp/myexec.sh`:
 
     # args are [hostname] [username] -- [command to exec...]
 
-    host=$1
-    shift
-    user=$1
-    shift
-    command="$*"
+    host=$1; shift
+    user=$1; shift
+    printf -v commands '%q ' "$@"
 
     REMOTECMD=ssh
 
-    exec $REMOTECMD $user@$host $command
+    exec "$REMOTECMD" "$user@$host" "$command"
 
 **Example script-copy**:
 
@@ -1197,20 +1195,17 @@ Contents of `/tmp/mycopy.sh`:
 
     # args are [hostname] [username] [destdir] [filepath]
 
-    host=$1
-    shift
-    user=$1
-    shift
-    dir=$1
-    shift
+    host=$1; shift
+    user=$1; shift
+    dir=$1; shift
     file=$1
 
-    name=`basename $file`
+    name=${file##*/}
 
     # copy to node
     CPCMD=scp
 
-    exec $CPCMD $file $user@$host:$dir/$name > /dev/null || exit $?
+    "$CPCMD" "$file" "$user@$host:$dir/$name" >/dev/null || exit
 
     echo "$dir/$name"
 


### PR DESCRIPTION
- Use `printf %q` to quote arguments to survive expansion by the remote
  shell (started by ssh) unharmed.
- Quote all local parameter expansions to prevent contents from being
  word-split and glob-expanded.
- Replace use of external tool `basename` with a parameter expansion
  (shell builtin; no fork/wait overhead)
- Do not use `exec` on a command for which additional commands are
  expected to be run in the same shell. (`exec` replaces the current
  process, and does not return).
- Move assignments from `$1` and `shift`s onto the same line for easier
  reading.
- `exit $?` is redundant; the default behavior of `exit` is to honor
  `$?`.
