### PR TITLE
Extract rundeck-jetty-server jaas dependency as separate installed maven dependency

### DIFF
--- a/rundeck-launcher/rundeck-jetty-server/build.gradle
+++ b/rundeck-launcher/rundeck-jetty-server/build.gradle
@@ -28,6 +28,7 @@ jar {
     }
 }
 
+install.dependsOn build 
 
 apply plugin: 'maven'
 task createPom << {

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -116,7 +116,7 @@ task extractGrails(dependsOn: downloadGrails) {
  * "core" needs to be built and installed into the local ~/.m2 repo before 
  * we attempt to do anything further with Grails. 
  */
-task installDependencies(dependsOn: [project(":core").install]) << {
+task installDependencies(dependsOn: [project(":core").install, project(":rundeck-launcher:rundeck-jetty-server").install]) << {
 	description = "Builds and installs dependencies on other subprojects"
 }
 

--- a/rundeckapp/grails-app/conf/BuildConfig.groovy
+++ b/rundeckapp/grails-app/conf/BuildConfig.groovy
@@ -48,6 +48,9 @@ grails.project.dependency.resolution = {
         runtime("org.rundeck:rundeck-core:${appVersion}") {
             changing = true
         }
+        runtime("org.rundeck:rundeck-jetty-server:${appVersion}") {
+            changing = true
+        }
     }
     
     grails.plugin.location.'webrealms' = "webrealms"

--- a/rundeckapp/pom.xml
+++ b/rundeckapp/pom.xml
@@ -255,6 +255,12 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.rundeck</groupId>
+      <artifactId>rundeck-jetty-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <!-- quartz dependency -->
     <dependency>
       <groupId>org.quartz-scheduler</groupId>

--- a/testbuild.groovy
+++ b/testbuild.groovy
@@ -49,6 +49,7 @@ def manifest=[
         "com/dtolabs/rundeck/#+",// require 1+ files in dir
         "pkgs/webapp/WEB-INF/classes/#+",
         "pkgs/webapp/WEB-INF/lib/rundeck-core-${version}.jar",
+        "pkgs/webapp/WEB-INF/lib/rundeck-jetty-server-${version}.jar",
         // ##file : require checksum verify to top level
         "pkgs/webapp/WEB-INF/lib/rundeck-core-${version}.jar##core/${target}/rundeck-core-${version}.jar",
         "libext/rundeck-script-plugin-${version}.jar",


### PR DESCRIPTION
Copied from: https://groups.google.com/forum/#!searchin/rundeck-discuss/burbridge/rundeck-discuss/VHszTzdqJ8I/3HZBGYtVZUoJ

According to the wiki the following is needed to get an instance of Rundeck running from the rundeckapp folder:

```
After a build, copy the file rundeck-launcher/rundeck-jetty-server/build/libs/rundeck-jetty-server-1.4.4-dev.jar into therundeckapp/lib directory.
```

If this step is skipped then we run into the dreaded "unable to find LoginModule class: com.dtolabs.rundeck.jetty.jaas.PropertyFileLoginModule" error when trying to login.

Is there any good reason why the package com.dtolabs.rundeck.jetty.jaas shouldn't be a stand-alone artifact? That would allow us to declare it as a runtime dependency in BuildConfig.groovy and get rid of the manual step by installing the dependencies into the ~/.m2 repo. 

Please assign to me if accepted.
