### PR TITLE
optionally allow using a local grails plugin repo

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -34,6 +34,7 @@ def boolean grailsZipFileBasePathOverriden = hasProperty("grailsZipFileBasePath"
 def grailsZipFileBasePath = grailsZipFileBasePathOverriden ? grailsZipFileBasePath : grailsZipFileDefaultBasePath
 def grailsZipFileLocation = "${grailsZipFileBasePath}/${grailsZipFile}"
 def grailsInstallLocation = "${rootProject.buildDir}/local"
+def grailsLocalRepo = hasProperty("grailsLocalRepo") ? grailsLocalRepo : "grails-app/plugins"
 def grailsDownloadUrl = "http://dist.springframework.org.s3.amazonaws.com/release/GRAILS/grails-${grailsVersion}.zip"
 def grailsHome = "${grailsInstallLocation}/${grailsBaseName}"
 def grailsCommandLine = "${grailsHome}/bin/grails"
@@ -111,10 +112,11 @@ task installJettyPlugin(type: Exec, dependsOn: [extractGrails]) {
 	environment 'GRAILS_HOME', grailsHome
 	commandLine grailsCommandLine
 	args "-Dmaven.central.url=${mavenCentralUrl}",
-        "-DRUNDECK_VERSION=${version}",
-		'install-plugin', 
-		'jetty', 
-		jettyPluginVersion
+            "-Dgrails.local.repo=${grailsLocalRepo}",
+            "-DRUNDECK_VERSION=${version}",
+            'install-plugin', 
+            'jetty', 
+            jettyPluginVersion
 }
 
 task cleanWar(type: Delete) {
@@ -141,10 +143,11 @@ task testGrails(type: Exec, overwrite: true, dependsOn: [installJettyPlugin, ins
 	environment 'GRAILS_HOME', grailsHome
 	commandLine grailsCommandLine
 	args "-Dmaven.central.url=${mavenCentralUrl}",
-        "-DRUNDECK_VERSION=${version}",
-		'test-app',
-		'-coverage',
-		'-xml'
+            "-Dgrails.local.repo=${grailsLocalRepo}",
+            "-DRUNDECK_VERSION=${version}",
+            'test-app',
+            '-coverage',
+            '-xml'
 }
 test.dependsOn testGrails
 
@@ -157,7 +160,12 @@ task grailsWar(type: Exec, overwrite:true, dependsOn: [installJettyPlugin, insta
 	workingDir project.projectDir
 	environment 'GRAILS_HOME', grailsHome
 	commandLine grailsCommandLine
-	args "-Dmaven.central.url=${mavenCentralUrl}", "-DRUNDECK_VERSION=${version}", 'prod','war', warFileLocation
+	args "-Dmaven.central.url=${mavenCentralUrl}",
+            "-Dgrails.local.repo=${grailsLocalRepo}",
+            "-DRUNDECK_VERSION=${version}",
+            'prod',
+            'war',
+            warFileLocation
 }
 
 // add the war to default configuration for this project
@@ -181,7 +189,9 @@ task install(type: Exec, overwrite: true, dependsOn: grailsWar) {
 	inputs.file file(warFileLocation)
 	workingDir project.projectDir
 	commandLine grailsCommandLine
-	args "-Dmaven.central.url=${mavenCentralUrl}", 'maven-install'
+	args "-Dmaven.central.url=${mavenCentralUrl}",
+            "-Dgrails.local.repo=${grailsLocalRepo}",
+            'maven-install'
 }
 
 //********* artifact signing *********

--- a/rundeckapp/grails-app/conf/BuildConfig.groovy
+++ b/rundeckapp/grails-app/conf/BuildConfig.groovy
@@ -8,12 +8,19 @@ if (System.properties["maven.central.url"]) {
 }
 println "Maven Central: ${mavenCentralUrl}"
 
+def grailsLocalRepo = "grails-app/plugins"
+if (System.properties["grails.local.repo"]) {
+        grailsLocalRepo = System.properties["grails.local.repo"]
+}
+println "Grails Local Repo: ${grailsLocalRepo}"
+
 grails.project.dependency.resolution = {
     inherits "global" // inherit Grails' default dependencies
     log "warn" // log level of Ivy resolver, either 'error', 'warn', 'info', 'debug' or 'verbose'
     repositories {
         useOrigin true
         mavenLocal()
+        flatDir name:'grailsLocalRepo', dirs:"${grailsLocalRepo}"
         grailsHome()
         grailsPlugins()
         grailsCentral()


### PR DESCRIPTION
Maven central and grails+gradle binaries can be sourced "locally".

Unfortunately, grails is still calling out to svn:

```
Downloading: http://svn.codehaus.org/grails-plugins/grails-mail/tags/RELEASE_0_9/grails-mail-0.9.zip ...
Download complete.
Downloading: http://svn.codehaus.org/grails-plugins/grails-codenarc/tags/RELEASE_0_16_1/grails-codenarc-0.16.1.zip ...
Download complete.
Downloading: http://svn.codehaus.org/grails-plugins/grails-codenarc/tags/RELEASE_0_16_1/grails-codenarc-0.16.1.zip.sha1 ...
Download complete.
Downloading: http://svn.codehaus.org/grails-plugins/grails-code-coverage/tags/RELEASE_1_2_5/grails-code-coverage-1.2.5.zip ...
Download complete.
Downloading: http://svn.codehaus.org/grails-plugins/grails-maven-publisher/tags/RELEASE_0_8_1/grails-maven-publisher-0.8.1.zip ...
Download complete.
Downloading: http://svn.codehaus.org/grails-plugins/grails-maven-publisher/tags/RELEASE_0_8_1/grails-maven-publisher-0.8.1.zip.sha1 ...
Download complete.
Downloading: http://svn.codehaus.org/grails-plugins/grails-quartz/tags/RELEASE_0_4_2/grails-quartz-0.4.2.zip ...
Download complete.
Downloading: http://svn.codehaus.org/grails-plugins/grails-h2/tags/RELEASE_0_2_6/grails-h2-0.2.6.zip ...
Download complete.
```

The build should optionally accept a parameter that defines a local grails plugin repo.

This comes into play when attempting to build rundeck in isolated/secure environments without access to the internet.

NOTE: Due to a pull request snafu on my part, this issue is the continuation of https://github.com/dtolabs/rundeck/pull/332
