### PR TITLE
Dependency management: mavenCentral should always be before grailsCentral

### DIFF
--- a/rundeckapp/grails-app/conf/BuildConfig.groovy
+++ b/rundeckapp/grails-app/conf/BuildConfig.groovy
@@ -23,8 +23,8 @@ grails.project.dependency.resolution = {
         flatDir name:'grailsLocalRepo', dirs:"${grailsLocalRepo}"
         grailsHome()
         grailsPlugins()
-        grailsCentral()
         mavenRepo mavenCentralUrl
+        grailsCentral()
     }
 
     grails.war.resources = {def stagingDir ->


### PR DESCRIPTION
Currently, mavenCentral (either default or user specified) is lower on the dependency repository list than grailsCentral. This causes issues for build machines that have a user specified mavenCentral since they will still try to access grailsCentral first.
