### PR TITLE
Fix too-long value for api token roles #327

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -184,8 +184,7 @@ class UserController {
                 while(AuthToken.findByToken(newtoken) != null){
                     newtoken = genRandomString()
                 }
-                final userroles = request.subject?.getPrincipals(com.dtolabs.rundeck.core.authentication.Group.class).collect { it.name }
-                AuthToken token = new AuthToken(token:newtoken,authRoles: userroles.join(","),user:u)
+                AuthToken token = new AuthToken(token:newtoken, authRoles: 'api_token_group',user:u)
 
                 if(token.save()){
                     log.debug("GENERATE TOKEN ${newtoken} for User ${login} with roles: ${token.authRoles}")

--- a/rundeckapp/grails-app/domain/rundeck/AuthToken.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/AuthToken.groovy
@@ -25,4 +25,7 @@ class AuthToken {
         authRoles(nullable:false)
         user(nullable:false)
     }
+    static mapping = {
+        authRoles type: 'text'
+    }
 }


### PR DESCRIPTION
don't store unused auth roles in token
change auth roles to text column for future use
