### PR TITLE
Add support for textarea rendering option for String property type

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/PluginAdapterUtility.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/PluginAdapterUtility.java
@@ -24,19 +24,24 @@
 */
 package com.dtolabs.rundeck.core.execution.workflow.steps;
 
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.dtolabs.rundeck.core.common.PropertyRetriever;
 import com.dtolabs.rundeck.core.plugins.Plugin;
 import com.dtolabs.rundeck.core.plugins.configuration.Description;
 import com.dtolabs.rundeck.core.plugins.configuration.Property;
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope;
+import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants;
 import com.dtolabs.rundeck.plugins.descriptions.PluginDescription;
 import com.dtolabs.rundeck.plugins.descriptions.PluginProperty;
 import com.dtolabs.rundeck.plugins.descriptions.SelectValues;
+import com.dtolabs.rundeck.plugins.descriptions.TextArea;
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder;
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder;
-
-import java.lang.reflect.Field;
-import java.util.*;
 
 
 /**
@@ -150,12 +155,18 @@ public class PluginAdapterUtility {
         }
         pbuild.type(type);
         if (type == Property.Type.String) {
+            StringRenderingConstants.DisplayType renderBehaviour = StringRenderingConstants.DisplayType.SINGLE_LINE;
             //set select/freeselect
             final SelectValues selectAnnotation = field.getAnnotation(SelectValues.class);
             if (null != selectAnnotation) {
                 pbuild.type(selectAnnotation.freeSelect() ? Property.Type.FreeSelect : Property.Type.Select);
                 pbuild.values(selectAnnotation.values());
             }
+            
+            if (field.getAnnotation(TextArea.class) != null) {
+                renderBehaviour = StringRenderingConstants.DisplayType.MULTI_LINE;
+            }
+            pbuild.renderingOption(StringRenderingConstants.DISPLAY_TYPE_KEY, renderBehaviour);
         }
 
         String name = annotation.name();
@@ -264,7 +275,6 @@ public class PluginAdapterUtility {
     private static boolean setValueForProperty(final Property property, final Object value, final Object object) {
         final Field field = fieldForPropertyName(property.getName(), object);
         if (null == field) {
-
             return false;
         }
         final Property.Type type = property.getType();

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/Property.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/Property.java
@@ -24,6 +24,7 @@
 package com.dtolabs.rundeck.core.plugins.configuration;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Property describes a configuration property of a provider
@@ -58,9 +59,7 @@ public interface Property {
         /**
          * A string input property with a select
          */
-        FreeSelect,
-//        MultiSelect,
-//        MultiFreeSelect
+        FreeSelect
     }
 
     /**
@@ -108,4 +107,9 @@ public interface Property {
      * the default scope.
      */
     public PropertyScope getScope();
+    
+    /**
+     * Returns a map of optional rendering options for the UI
+     */
+    public Map<String, Object> getRenderingOptions();
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PropertyBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PropertyBase.java
@@ -23,7 +23,9 @@
 */
 package com.dtolabs.rundeck.core.plugins.configuration;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -39,6 +41,7 @@ abstract class PropertyBase implements Property {
     private final String defaultValue;
     private final PropertyValidator validator;
     private final PropertyScope scope;
+    private final Map<String, Object> renderingOptions;
 
     public PropertyBase(final String name, final String title, final String description, final boolean required,
                         final String defaultValue, final PropertyValidator validator) {
@@ -48,7 +51,12 @@ abstract class PropertyBase implements Property {
 
     public PropertyBase(final String name, final String title, final String description, final boolean required,
                         final String defaultValue, final PropertyValidator validator, final PropertyScope scope) {
+        this(name, title, description, required, defaultValue, validator, scope, null);
+    }
 
+    public PropertyBase(final String name, final String title, final String description, final boolean required,
+                        final String defaultValue, final PropertyValidator validator, final PropertyScope scope,
+                        final Map<String, Object> renderingOptions) {
         this.title = title;
         this.name = name;
         this.description = description;
@@ -56,6 +64,8 @@ abstract class PropertyBase implements Property {
         this.defaultValue = defaultValue;
         this.validator = validator;
         this.scope = scope;
+        this.renderingOptions = renderingOptions == null ? Collections.<String, Object> emptyMap() : Collections
+                .unmodifiableMap(renderingOptions);
     }
 
     public String getTitle() {
@@ -89,5 +99,10 @@ abstract class PropertyBase implements Property {
     @Override
     public PropertyScope getScope() {
         return scope;
+    }
+    
+    @Override
+    public Map<String, Object> getRenderingOptions() {
+        return renderingOptions;
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PropertyUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PropertyUtil.java
@@ -23,9 +23,15 @@
 */
 package com.dtolabs.rundeck.core.plugins.configuration;
 
-import java.util.List;
+import static com.dtolabs.rundeck.core.plugins.configuration.Property.Type.Boolean;
+import static com.dtolabs.rundeck.core.plugins.configuration.Property.Type.FreeSelect;
+import static com.dtolabs.rundeck.core.plugins.configuration.Property.Type.Integer;
+import static com.dtolabs.rundeck.core.plugins.configuration.Property.Type.Long;
+import static com.dtolabs.rundeck.core.plugins.configuration.Property.Type.Select;
+import static com.dtolabs.rundeck.core.plugins.configuration.Property.Type.String;
 
-import static com.dtolabs.rundeck.core.plugins.configuration.Property.Type.*;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -68,22 +74,38 @@ public class PropertyUtil {
                                    final String defaultValue,
                                    final List<String> values,
                                    final PropertyValidator validator,
-                                   final PropertyScope scope
+                                   final PropertyScope scope) {
+        return forType(type, name, title, description, required, defaultValue, values, validator, scope, null);
+    }
+    
+    /**
+     * Return a property instance for a particular simple type
+     */
+    public static Property forType(final Property.Type type,
+                                   final String name,
+                                   final String title,
+                                   final String description,
+                                   final boolean required,
+                                   final String defaultValue,
+                                   final List<String> values,
+                                   final PropertyValidator validator,
+                                   final PropertyScope scope,
+                                   final Map<String, Object> renderingOptions
     ) {
         switch (type) {
             case Integer:
-                return integer(name, title, description, required, defaultValue, validator, scope);
+                return integer(name, title, description, required, defaultValue, validator, scope, renderingOptions);
             case Boolean:
-                return bool(name, title, description, required, defaultValue, scope);
+                return bool(name, title, description, required, defaultValue, scope, renderingOptions);
             case Long:
-                return longProp(name, title, description, required, defaultValue, validator, scope);
+                return longProp(name, title, description, required, defaultValue, validator, scope, renderingOptions);
             case Select:
-                return PropertyUtil.select(name, title, description, required, defaultValue, values, scope);
+                return PropertyUtil.select(name, title, description, required, defaultValue, values, scope, renderingOptions);
             case FreeSelect:
                 return PropertyUtil.freeSelect(name, title, description, required, defaultValue, values, validator,
-                                               scope);
+                                               scope, renderingOptions);
             default:
-                return string(name, title, description, required, defaultValue, validator, scope);
+                return string(name, title, description, required, defaultValue, validator, scope, renderingOptions);
         }
     }
 
@@ -105,7 +127,7 @@ public class PropertyUtil {
                                   final String defaultValue, final PropertyValidator validator) {
         return string(name, title, description, required, defaultValue, validator, null);
     }
-
+    
     /**
      * Return a string property
      */
@@ -113,7 +135,17 @@ public class PropertyUtil {
                                   final boolean required,
                                   final String defaultValue, final PropertyValidator validator,
                                   final PropertyScope scope) {
-        return new StringProperty(name, title, description, required, defaultValue, validator, scope);
+        return string(name, title, description, required, defaultValue, validator, scope, null);
+    }
+
+    /**
+     * Return a string property
+     */
+    public static Property string(final String name, final String title, final String description,
+                                  final boolean required,
+                                  final String defaultValue, final PropertyValidator validator,
+                                  final PropertyScope scope, final Map<String, Object> renderingOptions) {
+        return new StringProperty(name, title, description, required, defaultValue, validator, scope, renderingOptions);
     }
 
     /**
@@ -123,7 +155,7 @@ public class PropertyUtil {
                                 final String defaultValue) {
         return bool(name, title, description, required, defaultValue, null);
     }
-
+    
     /**
      * Return a boolean property
      */
@@ -132,7 +164,19 @@ public class PropertyUtil {
                                        String description,
                                        boolean required,
                                        String defaultValue, final PropertyScope scope) {
-        return new BooleanProperty(name, title, description, required, defaultValue, scope);
+        return bool(name, title, description, required, defaultValue, scope, null);
+    }
+
+    /**
+     * Return a boolean property
+     */
+    public static BooleanProperty bool(String name,
+                                       String title,
+                                       String description,
+                                       boolean required,
+                                       String defaultValue, final PropertyScope scope, 
+                                       final Map<String, Object> renderingOptions) {
+        return new BooleanProperty(name, title, description, required, defaultValue, scope, renderingOptions);
     }
 
     /**
@@ -154,7 +198,7 @@ public class PropertyUtil {
 
         return integer(name, title, description, required, defaultValue, validator, null);
     }
-
+    
     /**
      * Return an integer property with additional validator
      */
@@ -165,8 +209,22 @@ public class PropertyUtil {
                                    final String defaultValue,
                                    final PropertyValidator validator,
                                    final PropertyScope scope) {
+        return integer(name, title, description, required, defaultValue, validator, scope, null);
+    }
 
-        return new IntegerProperty(name, title, description, required, defaultValue, validator, scope);
+    /**
+     * Return an integer property with additional validator
+     */
+    public static Property integer(final String name,
+                                   final String title,
+                                   final String description,
+                                   final boolean required,
+                                   final String defaultValue,
+                                   final PropertyValidator validator,
+                                   final PropertyScope scope,
+                                   final Map<String, Object> renderingOptions) {
+
+        return new IntegerProperty(name, title, description, required, defaultValue, validator, scope, renderingOptions);
     }
 
     /**
@@ -188,7 +246,7 @@ public class PropertyUtil {
                                     final PropertyValidator validator) {
         return longProp(name, title, description, required, defaultValue, validator, null);
     }
-
+    
     /**
      * Return a long property
      */
@@ -199,8 +257,21 @@ public class PropertyUtil {
                                     final String defaultValue,
                                     final PropertyValidator validator,
                                     final PropertyScope scope) {
+        return longProp(name, title, description, required, defaultValue, validator, scope, null);
+    }
 
-        return new LongProperty(name, title, description, required, defaultValue, validator, scope);
+    /**
+     * Return a long property
+     */
+    public static Property longProp(final String name,
+                                    final String title,
+                                    final String description,
+                                    final boolean required,
+                                    final String defaultValue,
+                                    final PropertyValidator validator,
+                                    final PropertyScope scope,
+                                    final Map<String, Object> renderingOptions) {
+        return new LongProperty(name, title, description, required, defaultValue, validator, scope, renderingOptions);
     }
 
 
@@ -219,7 +290,17 @@ public class PropertyUtil {
                                   final boolean required, final String defaultValue, final List<String> selectValues,
                                   final PropertyScope scope) {
 
-        return new SelectProperty(name, title, description, required, defaultValue, selectValues, scope);
+        return select(name, title, description, required, defaultValue, selectValues, scope, null);
+    }
+    
+    /**
+     * Create a Select property with a list of values
+     */
+    public static Property select(final String name, final String title, final String description,
+                                  final boolean required, final String defaultValue, final List<String> selectValues,
+                                  final PropertyScope scope, final Map<String, Object> renderingOptions) {
+
+        return new SelectProperty(name, title, description, required, defaultValue, selectValues, scope, renderingOptions);
     }
 
     /**
@@ -240,7 +321,7 @@ public class PropertyUtil {
 
         return freeSelect(name, title, description, required, defaultValue, selectValues, validator, null);
     }
-
+    
     /**
      * Create a Free Select property with a list of values
      */
@@ -249,7 +330,18 @@ public class PropertyUtil {
                                       final List<String> selectValues, final PropertyValidator validator,
                                       final PropertyScope scope) {
 
-        return new FreeSelectProperty(name, title, description, required, defaultValue, selectValues, validator, scope);
+        return freeSelect(name, title, description, required, defaultValue, selectValues, validator, scope, null);
+    }
+
+    /**
+     * Create a Free Select property with a list of values
+     */
+    public static Property freeSelect(final String name, final String title, final String description,
+                                      final boolean required, final String defaultValue,
+                                      final List<String> selectValues, final PropertyValidator validator,
+                                      final PropertyScope scope, final Map<String, Object> renderingOptions) {
+
+        return new FreeSelectProperty(name, title, description, required, defaultValue, selectValues, validator, scope, renderingOptions);
     }
 
     static final class StringProperty extends PropertyBase {
@@ -260,8 +352,9 @@ public class PropertyUtil {
                               final boolean required,
                               final String defaultValue,
                               final PropertyValidator validator,
-                              final PropertyScope scope) {
-            super(name, title, description, required, defaultValue, validator, scope);
+                              final PropertyScope scope,
+                              final Map<String, Object> renderingOptions) {
+            super(name, title, description, required, defaultValue, validator, scope, renderingOptions);
         }
 
         public Type getType() {
@@ -292,8 +385,8 @@ public class PropertyUtil {
                                   final boolean required,
                                   final String defaultValue,
                                   final List<String> selectValues, final PropertyValidator validator,
-                                  final PropertyScope scope) {
-            super(name, title, description, required, defaultValue, validator, scope);
+                                  final PropertyScope scope, final Map<String, Object> renderingOptions) {
+            super(name, title, description, required, defaultValue, validator, scope, renderingOptions);
             this.selectValues = selectValues;
         }
 
@@ -311,8 +404,9 @@ public class PropertyUtil {
         final List<String> selectValues;
 
         public SelectProperty(final String name, final String title, final String description, final boolean required,
-                              final String defaultValue, final List<String> selectValues, final PropertyScope scope) {
-            super(name, title, description, required, defaultValue, new SelectValidator(selectValues), scope);
+                              final String defaultValue, final List<String> selectValues, final PropertyScope scope, 
+                              final Map<String, Object> renderingOptions) {
+            super(name, title, description, required, defaultValue, new SelectValidator(selectValues), scope, renderingOptions);
             this.selectValues = selectValues;
         }
 
@@ -341,8 +435,8 @@ public class PropertyUtil {
 
     static final class BooleanProperty extends PropertyBase {
         public BooleanProperty(final String name, final String title, final String description, final boolean required,
-                               final String defaultValue, final PropertyScope scope) {
-            super(name, title, description, required, defaultValue, booleanValidator, scope);
+                               final String defaultValue, final PropertyScope scope, Map<String, Object> renderingOptions) {
+            super(name, title, description, required, defaultValue, booleanValidator, scope, renderingOptions);
         }
 
         public Type getType() {
@@ -358,8 +452,9 @@ public class PropertyUtil {
 
     static final class IntegerProperty extends PropertyBase {
         public IntegerProperty(final String name, final String title, final String description, final boolean required,
-                               final String defaultValue, final PropertyValidator validator, final PropertyScope scope) {
-            super(name, title, description, required, defaultValue, andValidator(integerValidator, validator), scope);
+                               final String defaultValue, final PropertyValidator validator, final PropertyScope scope, 
+                               final Map<String, Object> renderingOptions) {
+            super(name, title, description, required, defaultValue, andValidator(integerValidator, validator), scope, renderingOptions);
         }
 
         public Type getType() {
@@ -381,8 +476,9 @@ public class PropertyUtil {
 
     static final class LongProperty extends PropertyBase {
         public LongProperty(final String name, final String title, final String description, final boolean required,
-                            final String defaultValue, final PropertyValidator validator, final PropertyScope scope) {
-            super(name, title, description, required, defaultValue, andValidator(longValidator, validator), scope);
+                            final String defaultValue, final PropertyValidator validator, final PropertyScope scope,
+                            final Map<String, Object> renderingOptions) {
+            super(name, title, description, required, defaultValue, andValidator(longValidator, validator), scope, renderingOptions);
         }
 
         public Type getType() {

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/StringRenderingConstants.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/StringRenderingConstants.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2011 DTO Solutions, Inc. (http://dtosolutions.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.dtolabs.rundeck.core.plugins.configuration;
+
+/**
+ * Constants that govern the different ways a {@link Property.Type.String} can be rendered.
+ * 
+ * User: Kim Ho <a href="mailto:kim.ho@salesforce.com">kim.ho@salesforce.com</a>
+ */
+public class StringRenderingConstants {
+    
+    public static final String DISPLAY_TYPE_KEY = "displayType";
+    
+    public enum DisplayType {
+        SINGLE_LINE,
+        MULTI_LINE
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/descriptions/TextArea.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/descriptions/TextArea.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012 DTO Labs, Inc. (http://dtolabs.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.dtolabs.rundeck.plugins.descriptions;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+/*
+ * Designates the given String field with a MULTI_LINE displayType rendering option.
+ *
+ * User: Kim Ho <a href="mailto:kim.ho@salesforce.com">kim.ho@salesforce.com</a>
+ */
+public @interface TextArea {
+}
+

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/util/PropertyBuilder.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/util/PropertyBuilder.java
@@ -1,12 +1,14 @@
 package com.dtolabs.rundeck.plugins.util;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.dtolabs.rundeck.core.plugins.configuration.Property;
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope;
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyUtil;
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyValidator;
-
-import java.util.Arrays;
-import java.util.List;
 
 
 /**
@@ -22,6 +24,7 @@ public class PropertyBuilder {
     private List<String> values;
     private PropertyValidator validator;
     private PropertyScope scope;
+    private Map<String, Object> renderingOptions = new HashMap<String, Object>();
 
     private PropertyBuilder() {
 
@@ -45,6 +48,7 @@ public class PropertyBuilder {
             .values(orig.getSelectValues())
             .validator(orig.getValidator())
             .scope(orig.getScope())
+            .renderingOptions(orig.getRenderingOptions())
             ;
     }
 
@@ -181,6 +185,22 @@ public class PropertyBuilder {
         this.scope = scope;
         return this;
     }
+    
+    /**
+     * Adds all rendering options from the given renderingOptions
+     */
+    public PropertyBuilder renderingOptions(final Map<String, Object> renderingOptions) {
+        this.renderingOptions.putAll(renderingOptions);
+        return this;
+    }
+    
+    /**
+     * Adds the given renderingOption
+     */
+    public PropertyBuilder renderingOption(final String optionKey, final Object optionValue) {
+        this.renderingOptions.put(optionKey, optionValue);
+        return this;
+    }
 
     /**
      * Build the Property object
@@ -193,7 +213,7 @@ public class PropertyBuilder {
         if (null == name) {
             throw new IllegalStateException("name is required");
         }
-        return PropertyUtil.forType(type, name, title, description, required, value, values, validator, scope);
+        return PropertyUtil.forType(type, name, title, description, required, value, values, validator, scope, renderingOptions);
     }
 
     /**

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/PluginAdapterUtilityTest.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/PluginAdapterUtilityTest.java
@@ -24,17 +24,24 @@
 */
 package com.dtolabs.rundeck.core.execution.workflow.steps;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import junit.framework.TestCase;
+
 import com.dtolabs.rundeck.core.plugins.Plugin;
 import com.dtolabs.rundeck.core.plugins.configuration.Description;
 import com.dtolabs.rundeck.core.plugins.configuration.Property;
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope;
+import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants;
+import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants.DisplayType;
 import com.dtolabs.rundeck.plugins.descriptions.PluginDescription;
 import com.dtolabs.rundeck.plugins.descriptions.PluginProperty;
 import com.dtolabs.rundeck.plugins.descriptions.SelectValues;
+import com.dtolabs.rundeck.plugins.descriptions.TextArea;
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder;
-import junit.framework.TestCase;
-
-import java.util.*;
 
 
 /**
@@ -159,6 +166,7 @@ public class PluginAdapterUtilityTest extends TestCase {
         assertEquals(null, p1.getSelectValues());
         assertEquals(null, p1.getValidator());
         assertEquals(false, p1.isRequired());
+        assertEquals(DisplayType.SINGLE_LINE, p1.getRenderingOptions().get(StringRenderingConstants.DISPLAY_TYPE_KEY));
     }
 
     /**
@@ -251,6 +259,9 @@ public class PluginAdapterUtilityTest extends TestCase {
         private long testlong1;
         @PluginProperty
         private Long testlong2;
+        @TextArea
+        @PluginProperty(name = "textArea", title = "textAreaTitle", description = "textAreaDescription")
+        private String textArea;
     }
 
     public void testFieldTypesString() throws Exception {
@@ -273,6 +284,29 @@ public class PluginAdapterUtilityTest extends TestCase {
         assertEquals(fieldType, prop1.getType());
     }
 
+    public void testTextArea() {
+        typeTest1 test = new typeTest1();
+        Description desc = PluginAdapterUtility.buildDescription(test, DescriptionBuilder.builder());
+        assertNotNull(desc);
+        HashMap<String, Property> map = mapOfProperties(desc);
+
+        Property p1 = map.get("textArea");
+        assertEquals(Property.Type.String, p1.getType());
+        assertEquals(null, p1.getDefaultValue());
+        assertEquals("textAreaDescription", p1.getDescription());
+        assertEquals("textAreaTitle", p1.getTitle());
+        assertEquals(DisplayType.MULTI_LINE, p1.getRenderingOptions().get(StringRenderingConstants.DISPLAY_TYPE_KEY));
+    }
+
+    public void testSetTextArea() {
+        typeTest1 test = new typeTest1();
+        String value = "some value";
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("textArea", value);
+        PropertyResolver resolver = new mapResolver(values);
+        PluginAdapterUtility.configureProperties(resolver, test);
+        assertEquals(value, test.textArea);
+    }
 
     /**
      * test property types
@@ -447,6 +481,7 @@ public class PluginAdapterUtilityTest extends TestCase {
         assertFalse(test.testbool1);
         assertFalse(test.testbool2);
     }
+    
     public void testConfigurePropertiesInt() throws Exception {
         configuretest1 test = new configuretest1();
         HashMap<String, Object> configuration = new HashMap<String, Object>();
@@ -469,6 +504,7 @@ public class PluginAdapterUtilityTest extends TestCase {
         assertEquals(1, test.testint1);
         assertEquals(2, (int) test.testint2);
     }
+    
     public void testConfigurePropertiesLong() throws Exception {
         configuretest1 test = new configuretest1();
         HashMap<String, Object> configuration = new HashMap<String, Object>();

--- a/rundeckapp/grails-app/views/framework/_pluginConfigPropertyField.gsp
+++ b/rundeckapp/grails-app/views/framework/_pluginConfigPropertyField.gsp
@@ -67,8 +67,14 @@
     </td>
     <td>
     <g:hiddenField name="${origfieldname}" value="${values&&values[prop.name]?values[prop.name]:''}"/>
-    <g:textField name="${fieldname}" value="${values&&null!=values[prop.name]?values[prop.name]:prop.defaultValue}"
+    <g:if test="${prop.renderingOptions?.('displayType')?.name() == 'MULTI_LINE'}">
+        <g:textArea name="${fieldname}" value="${values&&null!=values[prop.name]?values[prop.name]:prop.defaultValue}"
+                 id="${fieldid}" rows="10" cols="80"/>
+    </g:if>
+    <g:else>
+        <g:textField name="${fieldname}" value="${values&&null!=values[prop.name]?values[prop.name]:prop.defaultValue}"
                  id="${fieldid}" size="80"/>
+    </g:else>
 </g:else>
     <div class="info note">${prop.description?.encodeAsHTML()}</div>
     <g:if test="${error}">


### PR DESCRIPTION
Plugins should be able to tell the UI how to render a given property. This should be done by exposing rendering options on properties and allowing them to be controlled via annotations.

Example:

```
@TextArea
@PluginProperty(name="foo")
protected String fooProperty;
```

Would end up being rendered as a text area. This concept can be expanded in the future to allow plugins finer control over exactly how they present input controls to the user.
