### PR TITLE
LDAP login module does not perform CN validation on certificate when ldaps is specified

### DIFF
--- a/rundeck-launcher/rundeck-jetty-server/build.gradle
+++ b/rundeck-launcher/rundeck-jetty-server/build.gradle
@@ -20,6 +20,10 @@ dependencies {
     runtime(
         [group: 'org.mortbay.jetty', name: 'servlet-api', version: '2.5-20081211',ext:'jar'],
     )
+    testCompile (
+        [group: 'junit', name: 'junit', version: '4.8.1',ext:'jar'],
+        [group: 'org.mockito', name: 'mockito-all', version: '1.8.5',ext:'jar'],
+    )
 }
 
 jar {

--- a/rundeck-launcher/rundeck-jetty-server/pom.xml
+++ b/rundeck-launcher/rundeck-jetty-server/pom.xml
@@ -47,6 +47,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.8.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mortbay.jetty</groupId>
       <artifactId>jetty-util</artifactId>
       <version>6.1.21</version>
@@ -69,6 +75,12 @@
       <artifactId>servlet-api</artifactId>
       <version>2.5-20081211</version>
       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.8.5</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/jetty/jaas/HostnameVerifyingSSLSocketFactory.java
+++ b/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/jetty/jaas/HostnameVerifyingSSLSocketFactory.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2013 DTO Labs, Inc. (http://dtolabs.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.jetty.jaas;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.KeyStore;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * Socket factory that generates wrapped X509TrustManagers that perform hostname cn verification.
+ * 
+ * @author Kim Ho <kim.ho@salesforce.com>
+ */ 
+public class HostnameVerifyingSSLSocketFactory extends SSLSocketFactory {
+
+	public static final String SSL_ALGORITHM = "TLS";
+	
+	protected static String host;
+	
+	protected SSLSocketFactory realSocketFactory;
+
+	public HostnameVerifyingSSLSocketFactory() {
+		try {
+			TrustManagerFactory factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+			factory.init((KeyStore) null);
+
+			TrustManager[] trustManagers = (TrustManager[]) factory.getTrustManagers();
+			for (int i = 0; i < trustManagers.length; i++) {
+				trustManagers[i] = wrapTrustManager(trustManagers[i]);
+			}
+
+			SSLContext sc = SSLContext.getInstance(SSL_ALGORITHM);
+			sc.init(null, trustManagers, null);
+			realSocketFactory = sc.getSocketFactory();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
+	protected TrustManager wrapTrustManager(TrustManager trustManager) {
+		return new HostnameVerifyingTrustManager(trustManager);
+	}
+
+	public static SocketFactory getDefault() {
+		return new HostnameVerifyingSSLSocketFactory();
+	}
+
+	@Override
+	public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+		return realSocketFactory.createSocket(host, port);
+	}
+
+	@Override
+	public Socket createSocket(InetAddress host, int port) throws IOException {
+		return realSocketFactory.createSocket(host, port);
+	}
+
+	@Override
+	public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException,
+			UnknownHostException {
+		return realSocketFactory.createSocket(host, port, localHost, localPort);
+	}
+
+	@Override
+	public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
+			throws IOException {
+		return realSocketFactory.createSocket(address, port, localAddress, localPort);
+	}
+
+	@Override
+	public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+		return realSocketFactory.createSocket(s, host, port, autoClose);
+	}
+
+	@Override
+	public String[] getDefaultCipherSuites() {
+		return realSocketFactory.getDefaultCipherSuites();
+	}
+
+	@Override
+	public String[] getSupportedCipherSuites() {
+		return realSocketFactory.getSupportedCipherSuites();
+	}
+
+	public static String getTargetHost() {
+		return host;
+	}
+
+    public static void setTargetHost(String host) {
+        HostnameVerifyingSSLSocketFactory.host = host;
+    }
+}

--- a/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/jetty/jaas/HostnameVerifyingTrustManager.java
+++ b/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/jetty/jaas/HostnameVerifyingTrustManager.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013 DTO Labs, Inc. (http://dtolabs.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.jetty.jaas;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * A wrapper around an existing X509TrustManager that verifies the server
+ * certificate against the remote host.
+ * 
+ * @author Kim Ho <kim.ho@salesforce.com>
+ */
+public class HostnameVerifyingTrustManager implements X509TrustManager {
+
+    protected X509TrustManager realTrustManager;
+
+    public HostnameVerifyingTrustManager(TrustManager trustManager) {
+        if (!(trustManager instanceof X509TrustManager)) {
+            throw new IllegalArgumentException(
+                                               String.format("Expected trustManager to be of type X509TrustManager but was [%s]",
+                                                             trustManager.getClass()));
+        }
+        this.realTrustManager = (X509TrustManager) trustManager;
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        realTrustManager.checkClientTrusted(chain, authType);
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        if (chain.length > 0) {
+            X509Certificate serverCert = chain[0];
+            try {
+                String host = HostnameVerifyingSSLSocketFactory.getTargetHost();
+                String dn = serverCert.getSubjectDN().getName();
+                String cn = extractCnFromDn(dn);
+                if (!cn.equalsIgnoreCase(host)) {
+                    throw new CertificateException(String.format("[%s] does not match certificate subject [%s]", host,
+                                                                 cn));
+                }
+            }
+            catch (InvalidNameException e) {
+                throw new CertificateException("Error processing certificate for subject.", e);
+            }
+        }
+        realTrustManager.checkServerTrusted(chain, authType);
+    }
+
+    protected String extractCnFromDn(String dn) throws InvalidNameException {
+        LdapName name = new LdapName(dn);
+        for (Rdn rdn : name.getRdns()) {
+            if (rdn.getType().equalsIgnoreCase("CN")) {
+                return (String) rdn.getValue();
+            }
+        }
+        throw new InvalidNameException("Could not find CN");
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        return realTrustManager.getAcceptedIssuers();
+    }
+}

--- a/rundeck-launcher/rundeck-jetty-server/src/test/java/com/dtolabs/rundeck/jetty/jaas/HostnameVerifyingSSLSocketFactoryTest.java
+++ b/rundeck-launcher/rundeck-jetty-server/src/test/java/com/dtolabs/rundeck/jetty/jaas/HostnameVerifyingSSLSocketFactoryTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2013 DTO Labs, Inc. (http://dtolabs.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.jetty.jaas;
+
+import java.net.InetAddress;
+import java.net.Socket;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class HostnameVerifyingSSLSocketFactoryTest {
+
+	protected HostnameVerifyingSSLSocketFactory factory;
+	protected SSLSocketFactory realSocketFactory;
+
+	@Before
+	public void setup() {
+		factory = new HostnameVerifyingSSLSocketFactory();
+		realSocketFactory = Mockito.mock(SSLSocketFactory.class);
+		factory.realSocketFactory = realSocketFactory;
+	}
+
+	@Test
+	public void testWrapTrustManager() {
+		TrustManager trustManager = Mockito.mock(X509TrustManager.class);
+		HostnameVerifyingTrustManager result = (HostnameVerifyingTrustManager) factory.wrapTrustManager(trustManager);
+		Assert.assertEquals("Expected real trust manager on returned trust manager to be the mock", trustManager,
+				result.realTrustManager);
+	}
+
+	@Test
+	public void testGetDefaultReturnsInstanceOfHostnameVerifyingSSLSocketFactory() {
+		SocketFactory factory = HostnameVerifyingSSLSocketFactory.getDefault();
+		Assert.assertTrue("Expected getDefault() to return an instance of HostnameVerifyingSSLSocketFactory",
+				factory instanceof HostnameVerifyingSSLSocketFactory);
+	}
+
+	@Test
+	public void testCreateSocket_String_int() throws Exception {
+		Socket socket = Mockito.mock(Socket.class);
+		String host = "host";
+		int port = 123;
+
+		Mockito.when(realSocketFactory.createSocket(Mockito.anyString(), Mockito.anyInt())).thenReturn(socket);
+		Socket result = factory.createSocket(host, port);
+
+		Assert.assertSame("Expected realSocketFactory to generate socket", socket, result);
+		Mockito.verify(realSocketFactory, Mockito.times(1)).createSocket(Mockito.eq(host), Mockito.eq(port));
+	}
+
+	@Test
+	public void testCreateSocket_InetAddress_int() throws Exception {
+		Socket socket = Mockito.mock(Socket.class);
+		int port = 123;
+		InetAddress address = Mockito.mock(InetAddress.class);
+
+		Mockito.when(realSocketFactory.createSocket(Mockito.any(InetAddress.class), Mockito.anyInt())).thenReturn(
+				socket);
+		Socket result = factory.createSocket(address, port);
+
+		Assert.assertSame("Expected realSocketFactory to generate socket", socket, result);
+		Mockito.verify(realSocketFactory, Mockito.times(1)).createSocket(Mockito.eq(address), Mockito.eq(port));
+	}
+
+	@Test
+	public void testCreateSocket_String_int_InetAddress_int() throws Exception {
+		Socket socket = Mockito.mock(Socket.class);
+		String host = "host";
+		int port = 123;
+		InetAddress address = Mockito.mock(InetAddress.class);
+
+		Mockito.when(
+				realSocketFactory.createSocket(Mockito.anyString(), Mockito.anyInt(), Mockito.any(InetAddress.class),
+						Mockito.anyInt())).thenReturn(socket);
+		Socket result = factory.createSocket(host, port, address, port);
+
+		Assert.assertSame("Expected realSocketFactory to generate socket", socket, result);
+		Mockito.verify(realSocketFactory, Mockito.times(1)).createSocket(Mockito.eq(host), Mockito.eq(port),
+				Mockito.eq(address), Mockito.eq(port));
+	}
+
+	@Test
+	public void testCreateSocket_InetAddress_int_InetAddress_int() throws Exception {
+		Socket socket = Mockito.mock(Socket.class);
+		int port = 123;
+		InetAddress host1 = Mockito.mock(InetAddress.class);
+		InetAddress host2 = Mockito.mock(InetAddress.class);
+
+		Mockito.when(
+				realSocketFactory.createSocket(Mockito.any(InetAddress.class), Mockito.anyInt(),
+						Mockito.any(InetAddress.class), Mockito.anyInt())).thenReturn(socket);
+		Socket result = factory.createSocket(host1, port, host2, port);
+
+		Assert.assertSame("Expected realSocketFactory to generate socket", socket, result);
+		Mockito.verify(realSocketFactory, Mockito.times(1)).createSocket(Mockito.eq(host1), Mockito.eq(port),
+				Mockito.eq(host2), Mockito.eq(port));
+	}
+
+	@Test
+	public void testCreateSocket_Socket_String_int_bool() throws Exception {
+		Socket socket = Mockito.mock(Socket.class);
+		Socket originalSocket = Mockito.mock(Socket.class);
+		String host = "host";
+		int port = 123;
+		boolean autoClose = true;
+
+		Mockito.when(
+				realSocketFactory.createSocket(Mockito.any(Socket.class), Mockito.anyString(), Mockito.anyInt(),
+						Mockito.anyBoolean())).thenReturn(socket);
+		Socket result = factory.createSocket(originalSocket, host, port, autoClose);
+
+		Assert.assertSame("Expected realSocketFactory to generate socket", socket, result);
+		Mockito.verify(realSocketFactory, Mockito.times(1)).createSocket(Mockito.eq(originalSocket), Mockito.eq(host),
+				Mockito.eq(port), Mockito.eq(autoClose));
+	}
+
+	@Test
+	public void testGetDefaultCipherSuites() {
+		String[] ciphers = { "cipher1", "cipher2" };
+		Mockito.when(realSocketFactory.getDefaultCipherSuites()).thenReturn(ciphers);
+
+		Assert.assertSame("Expected default ciphers to be returned from realSocketFactory", ciphers,
+				factory.getDefaultCipherSuites());
+	}
+
+	@Test
+	public void testGetSupportedCipherSuites() {
+		String[] ciphers = { "cipher1", "cipher2" };
+		Mockito.when(realSocketFactory.getSupportedCipherSuites()).thenReturn(ciphers);
+
+		Assert.assertSame("Expected supported ciphers to be returned from realSocketFactory", ciphers,
+				factory.getSupportedCipherSuites());
+	}
+
+	@Test
+	public void testTargetHost() {
+		String host = "host";
+		HostnameVerifyingSSLSocketFactory.setTargetHost(host);
+		Assert.assertEquals("Expected same host value to be returned", host, HostnameVerifyingSSLSocketFactory.getTargetHost());
+	}
+}

--- a/rundeck-launcher/rundeck-jetty-server/src/test/java/com/dtolabs/rundeck/jetty/jaas/HostnameVerifyingTrustManagerTest.java
+++ b/rundeck-launcher/rundeck-jetty-server/src/test/java/com/dtolabs/rundeck/jetty/jaas/HostnameVerifyingTrustManagerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2013 DTO Labs, Inc. (http://dtolabs.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.jetty.jaas;
+
+import java.security.Principal;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.naming.InvalidNameException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class HostnameVerifyingTrustManagerTest {
+
+    protected HostnameVerifyingTrustManager trustManager;
+    protected X509TrustManager realTrustManager;
+
+    @Before
+    public void setup() {
+        realTrustManager = Mockito.mock(X509TrustManager.class);
+        trustManager = new HostnameVerifyingTrustManager(realTrustManager);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInitializeWithNonX509TrustManager() {
+        trustManager = new HostnameVerifyingTrustManager(Mockito.mock(TrustManager.class));
+    }
+
+    @Test
+    public void testCheckClientTrusted() throws Exception {
+        X509Certificate[] chain = { null };
+        String authType = "type";
+        trustManager.checkClientTrusted(chain, authType);
+
+        Mockito.verify(realTrustManager, Mockito.times(1)).checkClientTrusted(Mockito.same(chain),
+                                                                              Mockito.same(authType));
+    }
+
+    @Test
+    public void testCheckServerTrusted() throws Exception {
+        X509Certificate certificate = Mockito.mock(X509Certificate.class);
+        Principal principal = Mockito.mock(Principal.class);
+        Mockito.when(certificate.getSubjectDN()).thenReturn(principal);
+        X509Certificate[] chain = { certificate };
+        String authType = "type";
+        String host = "host";
+        Mockito.when(principal.getName()).thenReturn(String.format("CN=%s", host));
+
+        HostnameVerifyingSSLSocketFactory.setTargetHost(host);
+
+        trustManager.checkServerTrusted(chain, authType);
+
+        Mockito.verify(realTrustManager, Mockito.times(1)).checkServerTrusted(Mockito.same(chain),
+                                                                              Mockito.same(authType));
+    }
+
+    @Test
+    public void testCheckServerTrustedEmptyChain() throws Exception {
+        X509Certificate[] chain = {};
+        String authType = "type";
+
+        trustManager.checkServerTrusted(chain, authType);
+
+        Mockito.verify(realTrustManager, Mockito.times(1)).checkServerTrusted(Mockito.same(chain),
+                                                                              Mockito.same(authType));
+    }
+
+    @Test
+    public void testCheckServerTrustedFailsCNExtraction() throws Exception {
+        X509Certificate certificate = Mockito.mock(X509Certificate.class);
+        Principal principal = Mockito.mock(Principal.class);
+        Mockito.when(certificate.getSubjectDN()).thenReturn(principal);
+        X509Certificate[] chain = { certificate };
+        String authType = "type";
+        String host = "host";
+        Mockito.when(principal.getName()).thenReturn("invalid");
+
+        HostnameVerifyingSSLSocketFactory.setTargetHost(host);
+
+        try {
+            trustManager.checkServerTrusted(chain, authType);
+            Assert.fail("Expected hostname verification to fail.");
+        }
+        catch (CertificateException e) {
+            Assert.assertTrue("Expected cause to be instanceof InvalidNameException", e.getCause() instanceof InvalidNameException);
+        }
+
+        Mockito.verifyZeroInteractions(realTrustManager);
+    }
+    
+    @Test
+    public void testCheckServerTrustedFailsCNVerification() throws Exception {
+        X509Certificate certificate = Mockito.mock(X509Certificate.class);
+        Principal principal = Mockito.mock(Principal.class);
+        Mockito.when(certificate.getSubjectDN()).thenReturn(principal);
+        X509Certificate[] chain = { certificate };
+        String authType = "type";
+        String host = "host";
+        Mockito.when(principal.getName()).thenReturn("CN=otherhost");
+
+        HostnameVerifyingSSLSocketFactory.setTargetHost(host);
+
+        try {
+            trustManager.checkServerTrusted(chain, authType);
+            Assert.fail("Expected hostname verification to fail.");
+        }
+        catch (CertificateException e) {
+            Assert.assertNull("Expected no underlying cause", e.getCause());
+        }
+
+        Mockito.verifyZeroInteractions(realTrustManager);
+    }
+
+    @Test
+    public void testGetAcceptedIssuers() {
+        X509Certificate certificate = Mockito.mock(X509Certificate.class);
+        X509Certificate[] chain = { certificate };
+        Mockito.when(realTrustManager.getAcceptedIssuers()).thenReturn(chain);
+
+        Assert.assertSame("Expected accepted issuers call to be delegated to actual trust manager", chain,
+                          trustManager.getAcceptedIssuers());
+    }
+}

--- a/rundeck-launcher/rundeck-jetty-server/src/test/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModuleTest.java
+++ b/rundeck-launcher/rundeck-jetty-server/src/test/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModuleTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013 DTO Labs, Inc. (http://dtolabs.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.jetty.jaas;
+
+import java.util.Hashtable;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+@SuppressWarnings("rawtypes")
+public class JettyCachingLdapLoginModuleTest {
+
+    @Test
+    public void testGetEnvironmentNoSSL() {
+        JettyCachingLdapLoginModule module = new JettyCachingLdapLoginModule();
+        module._contextFactory = "foo";
+        module._providerUrl = "ldap://localhost";
+
+        Hashtable env = module.getEnvironment();
+        Assert.assertFalse("Expected ldap socket factory to be unset",
+                           env.containsKey("java.naming.ldap.factory.socket"));
+    }
+
+    @Test
+    public void testGetEnvironmentSSLProviderUrl() {
+        JettyCachingLdapLoginModule module = new JettyCachingLdapLoginModule();
+        module._contextFactory = "foo";
+        String host = "somehost";
+        module._providerUrl = String.format("ldaps://%s", host);
+
+        Hashtable env = module.getEnvironment();
+        Assert.assertEquals("Expected ldap socket factory to be unset",
+                            "com.dtolabs.rundeck.jetty.jaas.HostnameVerifyingSSLSocketFactory",
+                            env.get("java.naming.ldap.factory.socket"));
+        Assert.assertEquals("Expected target host to be localhost", host, HostnameVerifyingSSLSocketFactory.getTargetHost());
+    }
+}


### PR DESCRIPTION
When configuring rundeck with ldaps as per these instructions[1], the CN of the cert is not verified - only that the cert is trusted. 

[1] http://rundeck.org/docs/administration/authentication.html#ldap
