### PR TITLE
Unprivileged users can access execution api actions

### DIFF
--- a/rundeckapp/grails-app/conf/rundeck/filters/ApiRequestFilters.groovy
+++ b/rundeckapp/grails-app/conf/rundeck/filters/ApiRequestFilters.groovy
@@ -1,4 +1,5 @@
 package rundeck.filters
+
 /*
  * Copyright 2011 DTO Labs, Inc. (http://dtolabs.com)
  * 
@@ -47,6 +48,7 @@ public class ApiRequestFilters {
             apiVersion(uri:'/api/**') {
                 before = {
                     if(controllerName=='api' && allowed_actions.contains(actionName) || request.api_version){
+                        request.is_allowed_api_request = true
                         return true
                     }
 

--- a/rundeckapp/grails-app/conf/rundeck/filters/AuthorizationFilters.groovy
+++ b/rundeckapp/grails-app/conf/rundeck/filters/AuthorizationFilters.groovy
@@ -9,7 +9,6 @@ import rundeck.User
 import rundeck.AuthToken
 
 import rundeck.services.FrameworkService
-import rundeck.filters.ApiRequestFilters
 
 /*
  * Copyright 2010 DTO Labs, Inc. (http://dtolabs.com)
@@ -38,6 +37,8 @@ import rundeck.filters.ApiRequestFilters
 public class AuthorizationFilters {
     def userService
     def FrameworkService frameworkService
+    
+    def dependsOn = [ApiRequestFilters]
 
     def filters = {
         /**
@@ -124,8 +125,7 @@ public class AuthorizationFilters {
          */
         postLoginAuthorizationCheck(controller: '*', action: '*') {
             before = {
-               
-                if (request.invalidApiAuthentication ) {
+                if (request.invalidApiAuthentication) {
                     response.setStatus(403)
                     def authid = session.user ?: "(${request.invalidAuthToken ?: 'unauthenticated'})"
                     log.error("${authid} UNAUTHORIZED for ${controllerName}/${actionName}");

--- a/rundeckapp/grails-app/conf/rundeck/filters/ProjectSelectFilters.groovy
+++ b/rundeckapp/grails-app/conf/rundeck/filters/ProjectSelectFilters.groovy
@@ -46,23 +46,17 @@ import com.dtolabs.rundeck.core.common.Framework
 public class ProjectSelectFilters {
     def userService
     def frameworkService
+    
+    def dependsOn = [ApiRequestFilters]
+    
     def filters = {
-        /**
-         * check api request and bypass the project defaulting/selection if so.  Filters are not applied in
-         * determinate order, so ApiRequestFilters might not have been called yet.
-         */
-        testApi(uri: '/api/**') {
-            before={
-                request.is_api_req=true
-            }
-        }
         /**
          * on first user login, set the session.project if it is not set, to the last user project selected, or
          * to the first project in the available list 
          */
         projectSelection(controller: 'framework', action: '(createProject|selectProject|projectSelect|noProjectAccess|(create|save|check|edit|view)ResourceModelConfig)',invert:true) {
             before = {
-                if (request.api_version || request.is_api_req) {
+                if (request.is_allowed_api_request || request.api_version || request.is_api_req) {
                     //only default the project if not an api request
                     return
                 }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -19,6 +19,9 @@ class ApiController {
         return error()
     }
     def renderError={
+        if (flash.responseCode) {
+            response.setStatus(flash.responseCode)
+        }
         if(flash.errorCode||request.errorCode){
             request.error=g.message(code:flash.errorCode?:request.errorCode,args:flash.errorArgs?:request.errorArgs)
         }else{


### PR DESCRIPTION
We have a deployment user with aclpolicy:

```
description: API Application level access control
context:
  application: 'rundeck'
for:
  resource:
    - equals:
        kind: system
      allow: [read] # allow read of system info
by:
  group: deploy_user
```

When we login to the rundeck UI with this user, we immediately are hit with this message:

```
No authorized access to projects. Contact your administrator. (User roles: deploy_user, user)
```

But when I try `http://localhost:4440/api/1/execution/32`, I can see the execution output.

After change:

```
HTTP/1.1 403 Forbidden
<result error='true' apiversion='8'><error><message>Not authorized for action "read" for Execution 32</message></error></result>
```
