### PR TITLE
Use not-so-commons-ssl to do hostname/certificate verification.

### DIFF
--- a/rundeck-launcher/rundeck-jetty-server/build.gradle
+++ b/rundeck-launcher/rundeck-jetty-server/build.gradle
@@ -16,6 +16,8 @@ dependencies {
         [group: 'org.mortbay.jetty', name: 'jetty', version: jettyVersion,ext:'jar'],
         [group: 'org.mortbay.jetty', name: 'jetty-util', version: jettyVersion,ext:'jar'],
         [group: 'org.mortbay.jetty', name: 'jetty-plus', version: jettyVersion,ext:'jar'],
+        // This is in httpcomponents 4+ but stuck on 3.x for now.
+        [group: 'ca.juliusdavies', name: 'not-yet-commons-ssl', version: '0.3.11', ext: 'jar'],
     )
     runtime(
         [group: 'org.mortbay.jetty', name: 'servlet-api', version: '2.5-20081211',ext:'jar'],

--- a/rundeck-launcher/rundeck-jetty-server/pom.xml
+++ b/rundeck-launcher/rundeck-jetty-server/pom.xml
@@ -47,6 +47,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>ca.juliusdavies</groupId>
+      <artifactId>not-yet-commons-ssl</artifactId>
+      <version>0.3.11</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.8.1</version>

--- a/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/jetty/jaas/HostnameVerifyingTrustManager.java
+++ b/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/jetty/jaas/HostnameVerifyingTrustManager.java
@@ -19,11 +19,11 @@ package com.dtolabs.rundeck.jetty.jaas;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
-import javax.naming.InvalidNameException;
-import javax.naming.ldap.LdapName;
-import javax.naming.ldap.Rdn;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+
+import org.apache.commons.ssl.HostnameVerifier;
 
 /**
  * A wrapper around an existing X509TrustManager that verifies the server
@@ -34,6 +34,7 @@ import javax.net.ssl.X509TrustManager;
 public class HostnameVerifyingTrustManager implements X509TrustManager {
 
     protected X509TrustManager realTrustManager;
+    protected HostnameVerifier verifier; 
 
     public HostnameVerifyingTrustManager(TrustManager trustManager) {
         if (!(trustManager instanceof X509TrustManager)) {
@@ -41,6 +42,7 @@ public class HostnameVerifyingTrustManager implements X509TrustManager {
                                                String.format("Expected trustManager to be of type X509TrustManager but was [%s]",
                                                              trustManager.getClass()));
         }
+        this.verifier = HostnameVerifier.STRICT;
         this.realTrustManager = (X509TrustManager) trustManager;
     }
 
@@ -53,30 +55,15 @@ public class HostnameVerifyingTrustManager implements X509TrustManager {
     public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
         if (chain.length > 0) {
             X509Certificate serverCert = chain[0];
+            String host = HostnameVerifyingSSLSocketFactory.getTargetHost();
             try {
-                String host = HostnameVerifyingSSLSocketFactory.getTargetHost();
-                String dn = serverCert.getSubjectDN().getName();
-                String cn = extractCnFromDn(dn);
-                if (!cn.equalsIgnoreCase(host)) {
-                    throw new CertificateException(String.format("[%s] does not match certificate subject [%s]", host,
-                                                                 cn));
-                }
+                verifier.check(host, serverCert);
             }
-            catch (InvalidNameException e) {
-                throw new CertificateException("Error processing certificate for subject.", e);
+            catch (SSLException e) {
+                throw new CertificateException(e);
             }
         }
         realTrustManager.checkServerTrusted(chain, authType);
-    }
-
-    protected String extractCnFromDn(String dn) throws InvalidNameException {
-        LdapName name = new LdapName(dn);
-        for (Rdn rdn : name.getRdns()) {
-            if (rdn.getType().equalsIgnoreCase("CN")) {
-                return (String) rdn.getValue();
-            }
-        }
-        throw new InvalidNameException("Could not find CN");
     }
 
     @Override


### PR DESCRIPTION
This verifies the host name against the x509v3 alternative names as noted by the comment by njanrepo.

https://github.com/forcedotcom/rundeck/commit/f709ce7629b76588e514845ff63f5a8d63452b1e#commitcomment-3787957
