### PR TITLE
Rundeck prints secure option data in DEBUG into execution logs

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -38,7 +38,8 @@ dependencies {
     compile ('commons-httpclient:commons-httpclient:3.0.1') {
         exclude group:'junit', module: 'junit'
     }
-    testCompile 'junit:junit:4.8.1'
+    testCompile 'junit:junit:4.8.1',
+        'org.mockito:mockito-all:1.8.5'
 }
 
 def rundeckToolsDependencies = configurations.runtime.files.collect { "$it.name" }.join(" ")

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -241,6 +241,12 @@
       <version>1.9</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.8.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <properties>
     <version_ident>1.6.2-SNAPSHOT-0</version_ident>

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/StepFirstWorkflowStrategy.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/StepFirstWorkflowStrategy.java
@@ -23,16 +23,18 @@
 */
 package com.dtolabs.rundeck.core.execution.workflow;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import com.dtolabs.rundeck.core.Constants;
 import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.execution.StepExecutionItem;
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutionResult;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * StepFirstWorkflowStrategy iterates over the workflow steps and dispatches each one to all nodes matching the filter.
@@ -46,6 +48,11 @@ import java.util.Map;
  */
 public class StepFirstWorkflowStrategy extends BaseWorkflowStrategy {
 
+    protected static final String DATA_CONTEXT_PREFIX = "data context: ";
+    protected static final String OPTION_KEY = "option";
+    protected static final String SECURE_OPTION_KEY = "secureOption";
+    protected static final String SECURE_OPTION_VALUE = "****";
+    
     public StepFirstWorkflowStrategy(final Framework framework) {
         super(framework);
     }
@@ -61,8 +68,9 @@ public class StepFirstWorkflowStrategy extends BaseWorkflowStrategy {
             executionContext.getExecutionListener().log(Constants.DEBUG_LEVEL,
                                                         "NodeSet: " + executionContext.getNodeSelector());
             executionContext.getExecutionListener().log(Constants.DEBUG_LEVEL, "Workflow: " + workflow);
-            executionContext.getExecutionListener().log(Constants.DEBUG_LEVEL, "data context: " + executionContext
-                .getDataContext());
+            
+            Map<String, Map<String, String>> printableContext = createPrintableDataContext(executionContext.getDataContext());
+            executionContext.getExecutionListener().log(Constants.DEBUG_LEVEL, String.format("%s %s", DATA_CONTEXT_PREFIX, printableContext));
 
             final List<StepExecutionItem> iWorkflowCmdItems = workflow.getCommands();
             if (iWorkflowCmdItems.size() < 1) {
@@ -78,6 +86,43 @@ public class StepFirstWorkflowStrategy extends BaseWorkflowStrategy {
         final Map<String, Collection<StepExecutionResult>> nodeFailures = convertFailures(stepFailures);
         return new BaseWorkflowExecutionResult(stepResults, nodeFailures, stepFailures, success, orig);
 
+    }
+    
+    /**
+     * Creates a copy of the given data context with the secure option values obfuscated.
+     * This does not modify the original data context.
+     * 
+     * "secureOption" map values will always be obfuscated. "option" entries that are also in "secureOption"
+     * will have their values obfuscated. All other maps within the data context will be added
+     * directly to the copy.
+     */
+    protected Map<String, Map<String, String>> createPrintableDataContext(Map<String, Map<String, String>> dataContext) {
+        Map<String, Map<String, String>> printableContext = new HashMap<String, Map<String, String>>();
+        if (dataContext != null) {
+            printableContext.putAll(dataContext);
+            Set<String> secureValues = new HashSet<String>();
+            if (dataContext.containsKey(SECURE_OPTION_KEY)) {
+                Map<String, String> secureOptions = new HashMap<String, String>();
+                secureOptions.putAll(dataContext.get(SECURE_OPTION_KEY));
+                secureValues.addAll(secureOptions.values());
+                for (Map.Entry<String, String> entry : secureOptions.entrySet()) {
+                    entry.setValue(SECURE_OPTION_VALUE);
+                }
+                printableContext.put(SECURE_OPTION_KEY, secureOptions);
+            }
+
+            if (dataContext.containsKey(OPTION_KEY)) {
+                Map<String, String> options = new HashMap<String, String>();
+                options.putAll(dataContext.get(OPTION_KEY));
+                for (Map.Entry<String, String> entry : options.entrySet()) {
+                    if (secureValues.contains(entry.getValue())) {
+                        entry.setValue(SECURE_OPTION_VALUE);
+                    }
+                }
+                printableContext.put(OPTION_KEY, options);
+            }
+        }
+        return printableContext;
     }
 
     static boolean isInnerLoop(final WorkflowExecutionItem item) {


### PR DESCRIPTION
Before:

```
data context: {..., secureOption={secureopt=secure}, option={plainopt=plain, secureopt=secure}}
```

After:

```
data context:  {..., secureOption={secureopt=****}, option={plainopt=plain, secureopt=****}}
```
