### PR TITLE
Fix for Issue #544 - can't auth with ldap unless anonymous search is allowed

### DIFF
--- a/docs/en/administration/09-authentication.md
+++ b/docs/en/administration/09-authentication.md
@@ -186,7 +186,7 @@ userBaseDn
 :    base DN to search for users, example: "ou=People,dc=test1,dc=example,dc=com"
 
 userRdnAttribute
-:    Attribute name for username, used when searching for user role membership by DN, default "uid".
+:    Attribute name for username, used when searching for user role membership by DN, default "uid". **Note**: This is the unique identifier part of the DN. For example, if the DN is `uid=userName,ou=People,dc=test1,dc=example,dc=com` then "uid" would be the RDN attribute name.
 
 userIdAttribute
 :    Attribute name to identify user by username, default "cn".


### PR DESCRIPTION
- Replaced findUser with string formatted userDn
- Adding unit test for bindingLogin in ldap module
- Making a note of RDN in the ldap module docs
