### PR TITLE
Rundeck cannot parse log lines that start with a new line

### DIFF
--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/logging/RundeckLogFormat.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/logging/RundeckLogFormat.groovy
@@ -159,7 +159,6 @@ class RundeckLogFormat implements OutputLogFormat, LineLogFormat {
             def meta = [:]
             if (rest.startsWith('{')) {
                 //parse meta
-
                 rest = rest.substring(1)
                 def done = false
                 while (!done) {
@@ -338,7 +337,7 @@ class RundeckLogFormat implements OutputLogFormat, LineLogFormat {
                 }
             }
         }
-        String rest = i < array.length - 1 ? new String(array, i, array.length - i) : null
+        String rest = i <= array.length - 1 ? new String(array, i, array.length - i) : null
 
         return [newline.toString(), doneDelimiter, rest]
     }

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/logging/RundeckLogFormatTest.groovy
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/logging/RundeckLogFormatTest.groovy
@@ -193,4 +193,23 @@ class RundeckLogFormatTest extends GroovyTestCase {
         assertUnescape2("abc123def", null, null, '\\' as char, "1234", ["123", "234"], "abc\\123def")
         assertUnescape2("abc123def12", null, null, '\\' as char, "1234", ["123", "234"], "abc\\123def12")
     }
+
+    /**
+     * Test what happens when there are no actual characters in the log line (occurs on multi-line logs lines
+     * where the first line is a new line)
+     *
+     * E.g.
+     * <pre>
+     * ^2013-09-24T18:15:49Z|log|ERROR|{command=3-NodeDispatch-salt-api-exec|node=somehost|step=3|user=vagrant}|
+     * Traceback (most recent call last):
+     * with open (source_file, "r") as file:
+     * ^
+     * </pre>
+     */
+    void testUnescapeEmptyLogLine() {
+        def (text, done, rest) = RundeckLogFormat.unescape("foo}|", '\\' as char, '=|}\\', ['|', '}'] as String[]);
+        assertEquals("foo", text);
+        assertEquals("}", done);
+        assertEquals("|", rest);
+    }
 }


### PR DESCRIPTION
Example log line that causes failure (paste this into an rdlog file)

^2013-09-24T18:15:49Z|log|VERBOSE|{command=3-NodeDispatch-salt-api-exec|node=ops-ppm1-1-piab.ops.sfdc.net|step=3|user=vagrant}|Using [SaltJsonReturnHandler [exitCodeKey=retcode, standardOutputKey=stdout, standardErrorKey=stderr]] as salt's response handler^
^2013-09-24T18:15:49Z|log|ERROR|{command=3-NodeDispatch-salt-api-exec|node=ops-ppm1-1-piab.ops.sfdc.net|step=3|user=vagrant}|
Traceback (most recent call last):
    with open (source_file, "r") as file:
^
