### PR TITLE
disable LDAP login with empty password

### DIFF
--- a/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
+++ b/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
@@ -543,9 +543,10 @@ public class JettyCachingLdapLoginModule extends AbstractLoginModule {
 
         Log.info("Attempting authentication: " + userDn);
 
+        String pass = (String) password;
         Hashtable environment = getEnvironment();
         environment.put(Context.SECURITY_PRINCIPAL, userDn);
-        environment.put(Context.SECURITY_CREDENTIALS, password);
+        environment.put(Context.SECURITY_CREDENTIALS, (pass.trim().isEmpty() ? "password_that_would_be never_used" : pass));
 
         DirContext dirContext = new InitialDirContext(environment);
 


### PR DESCRIPTION
(http://rundeck.lighthouseapp.com/projects/59277/tickets/475)

LDAP login with empty password

Reported by Alexei Bratuhin | November 15th, 2011 @ 08:21 AM

If LDAP servers supports anonymous sessions, then a login with an username (existing in LDAP) and empty password becomes possible.
The problem is that call to InitialDirContext constructor doesn't require an AD bind and if Context.SECURITY_CREDENTIALS contains empty string authentication method 'none' (anonymous) is used.

Affected: Rundeck 1.3+ with implemented
http://rundeck.lighthouseapp.com/projects/59277-development/tickets/474-feature-request-hybrid-ldapproperties-login-module
See commit https://github.com/coiouhkc/rundeck/commit/a8f999efc66d2131800fd53eb568892b24ead75e

Possible workaround is:
JettyCachingLdapLoginModule.java, ll.528-534

String pass = (String) password;

Hashtable environment = getEnvironment();
environment.put(Context.SECURITY_PRINCIPAL, userDn);
environment.put(Context.SECURITY_CREDENTIALS, (pass.trim().isEmpty() ? "password_that_would_be never_used" : pass));

DirContext dirContext = new InitialDirContext(environment);
