### PR TITLE
Fix .deb install directory permissions

### DIFF
--- a/packaging/debroot/DEBIAN/postinst
+++ b/packaging/debroot/DEBIAN/postinst
@@ -69,6 +69,10 @@ case "$1" in
     setperm rundeck rundeck 0750 /var/rundeck
     setperm rundeck rundeck 0750 /var/rundeck/projects
     setperm rundeck adm 2751 /var/log/rundeck
+    setperm rundeck rundeck 0750 /var/lib/rundeck/bootstrap
+    setperm rundeck rundeck 0750 /var/lib/rundeck/cli
+    setperm rundeck rundeck 0750 /var/lib/rundeck/exp
+    setperm rundeck rundeck 0750 /var/lib/rundeck/libext
     find /etc/rundeck -maxdepth 2 -type f -print0 | xargs -0 chown rundeck:rundeck
     find /etc/rundeck -maxdepth 2 -type f -print0 | xargs -0 chmod 0640
     ;;


### PR DESCRIPTION
Looks like a few new subdirectories of /var/lib/rundeck have turned up in the two years since this file was last maintained. Let's fix that (we were bitten just now when trying to set up a new rundeck server)
