### PR TITLE
Interpret ${PWD} in the shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 SHELL=/bin/bash
 
-VNUMBER=$(shell grep version.number= ${PWD}/version.properties | cut -d= -f 2)
+VNUMBER=$(shell grep version.number= $${PWD}/version.properties | cut -d= -f 2)
 ifndef TAG
-TAG=$(shell grep version.tag= ${PWD}/version.properties | cut -d= -f 2)
+TAG=$(shell grep version.tag= $${PWD}/version.properties | cut -d= -f 2)
 endif
 VERSION=${VNUMBER}-${TAG}
 ifeq ($(strip $(TAG)),GA)
 VERSION=${VNUMBER}
 endif
-RELEASE=$(shell grep version.release.number= ${PWD}/version.properties | cut -d= -f 2)
+RELEASE=$(shell grep version.release.number= $${PWD}/version.properties | cut -d= -f 2)
 
 PROXY_DEFS=
 ifdef http_proxy


### PR DESCRIPTION
This works correctly, even if PWD isn't set in the environment of the
process that calls make.

Issue: dtolabs/rundeck#624
