### PR TITLE
Run ssh-keygen after home directory is installed

### DIFF
--- a/packaging/rundeck.spec
+++ b/packaging/rundeck.spec
@@ -26,11 +26,11 @@ Rundeck provides a single console for dispatching commands across many resources
 %pre
 getent group rundeck >/dev/null || groupadd rundeck
 getent passwd rundeck >/dev/null || useradd -d /var/lib/rundeck -m -g rundeck rundeck
+
+%post
 if [ ! -e ~rundeck/.ssh/id_rsa ]; then
 	su -c "ssh-keygen -q -t rsa -C '' -N '' -f ~rundeck/.ssh/id_rsa" rundeck
 fi
-
-%post
 /sbin/chkconfig --add rundeckd
 
 %preun


### PR DESCRIPTION
The useradd command will not create the home directory,
and consequently the ssh-keygen command fails.
Moving the ssh-keygen command after the package is installed
ensures that the home directory is in place.

Issue: rundeck/rundeck#631
