### PR TITLE
Add expect fork to upstart config

### DIFF
--- a/packaging/debroot/etc/init/rundeckd.conf
+++ b/packaging/debroot/etc/init/rundeckd.conf
@@ -12,6 +12,9 @@ stop on runlevel [!2345]
 # Give up if restart occurs 10 times in 30 seconds.
 respawn limit 10 30
 
+# Let Upstart know that the script will fork, so it can keep track of RunDeck properly
+expect fork
+
 script
 	. /etc/rundeck/profile
 	cd /var/log/rundeck


### PR DESCRIPTION
Without an "expect fork", upstart loses track of the RunDeck process, so you have to manually kill it.
