### PR TITLE
SSH AgentForwarding

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/ExtSSHExec.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/ExtSSHExec.java
@@ -391,6 +391,8 @@ public class ExtSSHExec extends SSHBase implements SSHTaskBuilder.SSHExecInterfa
             /* execute the command */
             channel = (ChannelExec) session.openChannel("exec");
             channel.setCommand(cmd);
+            // Enable AgentForwarding
+            channel.setAgentForwarding(true);
             channel.setOutputStream(tee);
             channel.setExtOutputStream(new KeepAliveOutputStream(System.err), true);
             if (istream != null) {


### PR DESCRIPTION
I've been playing around with deploying a project with rundeck, however getting the right SSH keys to the right paths is a pain. It seems like with this I could have my deploy keys be the same as my node keys at the various node/project/rundeck levels and not mess with copying SSH keys prior to running commands/scripts.

Is there a better way?
