### PR TITLE
Allow "ns:name" attributes in xml node attributes, if namespace specified

### DIFF
--- a/core/src/main/java/com/dtolabs/shared/resources/ResourceXMLParser.java
+++ b/core/src/main/java/com/dtolabs/shared/resources/ResourceXMLParser.java
@@ -215,7 +215,11 @@ public class ResourceXMLParser {
         //load all element attributes as properties
         for (final Object o : node1.attributes()) {
             final Attribute attr = (Attribute) o;
-            ent.properties.setProperty(attr.getName(), attr.getStringValue());
+            if (attr.getNamespace() != null) {
+                ent.properties.setProperty(attr.getQualifiedName(), attr.getStringValue());
+            } else {
+                ent.properties.setProperty(attr.getName(), attr.getStringValue());
+            }
         }
     }
 

--- a/core/src/test/java/com/dtolabs/shared/resources/TestResourceXMLParser.java
+++ b/core/src/test/java/com/dtolabs/shared/resources/TestResourceXMLParser.java
@@ -35,6 +35,7 @@ public class TestResourceXMLParser extends TestCase {
     File dnefile1;
     File testfile1;
     File testfile2;
+    File testfile3;
     File invalidfile1;
     File invalidfile2;
 
@@ -50,6 +51,7 @@ public class TestResourceXMLParser extends TestCase {
         dnefile1 = new File("test-does-not-exist.xml");
         testfile1 = new File("src/test/resources/com/dtolabs/shared/resources/test-resources1.xml");
         testfile2 = new File("src/test/resources/com/dtolabs/shared/resources/test-resources2.xml");
+        testfile3 = new File("src/test/resources/com/dtolabs/shared/resources/test-resources3.xml");
         invalidfile1 = new File("src/test/resources/com/dtolabs/shared/resources/test-resources-invalid1.xml");
         invalidfile2 = new File("src/test/resources/com/dtolabs/shared/resources/test-resources-invalid2.xml");
     }
@@ -165,5 +167,37 @@ public class TestResourceXMLParser extends TestCase {
         }
 
 
+    }
+
+    /**
+     * Node attributes using xml namespaces
+     * @throws Exception
+     */
+    public void testParseXMLNs() throws Exception {
+        ResourceXMLParser resourceXMLParser = new ResourceXMLParser(testfile3);
+        final ArrayList<ResourceXMLParser.Entity> items = new ArrayList<ResourceXMLParser.Entity>();
+        final boolean[] resourceParsedCalled = new boolean[]{false};
+        final boolean[] resourcesParsed = new boolean[]{false};
+        resourceXMLParser.setReceiver(new ResourceXMLReceiver() {
+            public boolean resourceParsed(ResourceXMLParser.Entity entity) {
+                items.add(entity);
+                resourceParsedCalled[0] = true;
+                return true;
+            }
+
+            public void resourcesParsed(ResourceXMLParser.EntitySet entities) {
+                resourcesParsed[0] = true;
+            }
+        });
+        resourceXMLParser.parse();
+        assertTrue(resourceParsedCalled[0]);
+        assertTrue(resourcesParsed[0]);
+        assertEquals("Wrong size", 1, items.size());
+        final ResourceXMLParser.Entity entity = items.get(0);
+        assertEquals("wrong node type", "node", entity.getResourceType());
+        assertEquals("wrong name", "node1", entity.getName());
+        assertEquals("wrong value", "testvalue", entity.getProperty("testattribute"));
+        assertEquals("wrong value", "test value2", entity.getProperty("test:attribute2"));
+        assertEquals("wrong value", "test value3", entity.getProperty("test:attribute3"));
     }
 }

--- a/core/src/test/resources/com/dtolabs/shared/resources/test-resources3.xml
+++ b/core/src/test/resources/com/dtolabs/shared/resources/test-resources3.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright 2010 DTO Labs, Inc. (http://dtolabs.com)
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<project xmlns:test="http://blah/test">
+    <node name="node1" description="description1" tags="tag1,tag2"
+          hostname="hostname1"
+          osName="osName1"
+          osFamily="osFamily1"
+          osArch="osArch1"
+          osVersion="osVersion1"
+          username="username1"
+          editUrl="EditURL"
+          remoteUrl="RemoteURL"
+          testattribute="testvalue"
+          test:attribute2="test value2"
+          test:attribute3="test value3"
+            >
+    </node>
+</project>


### PR DESCRIPTION
allow xml node definitions to use xml namespaces, and parse attributes using the namespace prefix:

``` .xml
<project xmlns:myns="http://blah">
<node name="mynode" myns:something="asdf" myns:something-else="wombat"/>
</project>
```

result:

![screen shot 2014-05-12 at 3 47 44 pm](https://cloud.githubusercontent.com/assets/55603/2951430/90a60b2c-da27-11e3-9494-a265a7822af9.png)
