### PR TITLE
Add missing context to execution data

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -307,8 +307,9 @@ public class NotificationService implements ApplicationContextAware{
                     def Execution exec = content.execution
                     def execMap = generateExecutionData(exec,content)
                     def jobMap = exportJobdata(source)
-                    execMap.job=jobMap
                     Map context=generateContextData(exec,content)
+                    execMap.job=jobMap
+                    execMap.context=context
                     Map config= n.configuration
                     if (context && config) {
                         config = DataContextUtils.replaceDataReferences(config, context)


### PR DESCRIPTION
fix regression with missing 'context' in execution data for #764 
