### PR TITLE
Added support for the supplementalRoles option to the LDAP Module

### DIFF
--- a/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
+++ b/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
@@ -652,7 +652,7 @@ public class JettyCachingLdapLoginModule extends AbstractLoginModule {
         Object supplementalRoles = options.get("supplementalRoles");
         if (null != supplementalRoles) {
             this._supplementalRoles = new ArrayList<String>();
-            this._supplementalRoles.addAll(Arrays.asList(supplementalRoles.toString().split(", +")));
+            this._supplementalRoles.addAll(Arrays.asList(supplementalRoles.toString().split(", *")));
         }
 
         String cacheDurationSetting = (String) options.get("cacheDurationMillis");


### PR DESCRIPTION
I added a little bit of code to JettyCachingLdapLoginModule.java that implements the supplementalRoles option present in the recently added PAM Authentication modules. I essentially just lifted the code out of AbstractPamLoginModule.java and tweaked it a bit to conform to the existing style in JettyCachingLdapLoginModule.java. With this change I can add the "user" role to all LDAP users to solve the 403 !role issue documented in the FAQ (https://github.com/rundeck/rundeck/wiki/FAQ#i-get-an-error-logging-in-http-error-403--reason-role).

With the way Active Directory is setup at my company I have several groups that I need to allow access to Rundeck and with the current 2.0+ versions of Rundeck I could only allow one group by putting it into web.xml as Rundeck does not currently support nested AD groups. With this change I can allow accounts from multiple AD groups into Rundeck and control their access using ACL Policy files. I believe this change will help a lot of Rundeck users that need to integrate with Active Directory.

TL;DR Lifted code from Pam Login Modules to support supplementalRoles in the LDAP Login Module to solve the 403 !role issue that affects many users trying to integrate with Active Directory.
