### PR TITLE
Gradle build can't find quartz in the classpath during a fresh/clean build

### DIFF
--- a/rundeckapp/grails-app/conf/BuildConfig.groovy
+++ b/rundeckapp/grails-app/conf/BuildConfig.groovy
@@ -73,11 +73,11 @@ grails.project.dependency.resolution = {
     println "Application Version: ${rundeckVersion}"
     plugins {
         runtime ":hibernate:$grailsVersion"
-        compile ":code-coverage:1.2.6"
-        build ':jetty:2.0.3'
-        compile ":twitter-bootstrap:3.0.3"
-        compile ":asset-pipeline:1.3.3"
-        compile ":less-asset-pipeline:1.2.1"
+        compile ':code-coverage:1.2.6'
+        build   ':jetty:2.0.3'
+        compile ':twitter-bootstrap:3.0.3'
+        compile ':asset-pipeline:1.3.3'
+        compile ':less-asset-pipeline:1.2.1'
     }
     dependencies {
         
@@ -93,7 +93,7 @@ grails.project.dependency.resolution = {
                 'com.jcraft:jsch:0.1.50','log4j:log4j:1.2.16','commons-collections:commons-collections:3.2.1',
                 'commons-codec:commons-codec:1.5', 'com.fasterxml.jackson.core:jackson-databind:2.0.2',
                 'com.codahale.metrics:metrics-core:3.0.1',
-                'com.google.guava:guava:15.0','org.owasp.encoder:encoder:1.1.1'
+                'com.google.guava:guava:15.0','org.owasp.encoder:encoder:1.1.1', 'org.quartz-scheduler:quartz:1.7.3'
         compile("org.rundeck:rundeck-core:${rundeckVersion}") {
             changing = true
             excludes("xalan")


### PR DESCRIPTION
As mentioned [here](https://groups.google.com/forum/#!topic/rundeck-discuss/BoiP7zC4xTQ), the Gradle build can't find quartz in the classpath during a fresh/clean build.

0) Clean caches
`$ rm -fr ~/.m2 ~/.gradle ~/.grails`

1) Fresh clone
`$ git clone https://github.com/rundeck/rundeck.git`

2) First build fails with a cold cache

```
$ ./gradlew build

=====<SNIP>=====

| Compiling 46 source files.
| Error Fatal error during compilation java.lang.NoClassDefFoundError: org/quartz/listeners/JobListenerSupport (Use --stacktrace to see the full trace)
:rundeckapp:grailsWar FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':rundeckapp:grailsWar'.
> Process 'command '/home/jli/tmp/rundeck/local/grails-2.2.4/bin/grails'' finished with non-zero exit value 1

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED
Total time: 3 mins 31.707 secs
```

3) Second build succeeds with a primed cache

```
$ ./gradlew build

=====<SNIP>=====

:rundeck-storage:rundeck-storage-filesys:build

BUILD SUCCESSFUL
Total time: 3 mins 41.674 secs
```
