### PR TITLE
parallel execution continues after a node failure even if keepgoing is false

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/ParallelNodeDispatcher.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/ParallelNodeDispatcher.java
@@ -160,10 +160,11 @@ public class ParallelNodeDispatcher implements NodeDispatcher {
         return new Callable() {
             public Object call() throws Exception {
                 final NodeStepResult dispatch = toDispatch.dispatch(context, node);
+                resultMap.put(node.getNodename(), dispatch);
                 if (!dispatch.isSuccess()) {
                     failureMap.put(node.getNodename(), dispatch);
+                    throw new Exception();
                 }
-                resultMap.put(node.getNodename(), dispatch);
                 return dispatch;
             }
         };


### PR DESCRIPTION
Ran into an issue where rundeck continued to execute on nodes after a failure had occurred and keepgoing == false only if threadcount > 1.  Turns out since the dispatch callable task never throws an error on unsuccessful exit, the parallelTask continues to run through even with setFailOnAny(!keepgoing).
