### PR TITLE
Do not fail when property does not exist

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1878,9 +1878,9 @@ class ScheduledExecutionService implements ApplicationContextAware{
         }
         if (!params.jobName) {
             //TODO: finalize format
-            if (params.adhocRemoteString) {
+            if (params.metaClass.hasProperty(params, 'adhocRemoteString') && params.adhocRemoteString) {
                 params.jobName = "Remote Script Job"
-            } else if (params.adhocLocalString) {
+            } else if (params.metaClass.hasProperty(params, 'adhocLocalString') && params.adhocLocalString) {
                 params.jobName = "Inline Script Job"
             }
         }


### PR DESCRIPTION
Fixes validation message during job import described in #1009 

Case:  'name' parameter missing in the job description 

Old behavior: import failed with error message displaying internal exception :
"groovy.lang.MissingPropertyException: No such property: adhocRemoteString for class:   rundeck.services.ScheduledExecutionService" 

New behavior: gracefully process missing properties and returns proper validation message: "Resource definition cannot contain null value.  Corresponding key: name"

Not sure but maybe this part can be removed at all ( https://github.com/rundeck/rundeck/blob/development/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy#L1879 ), can not find where it's used:

```
        if (!params.jobName) {
            //TODO: finalize format
            if (params.adhocRemoteString) {
                params.jobName = "Remote Script Job"
            } else if (params.adhocLocalString) {
                params.jobName = "Inline Script Job"
            }
        }
```
