### PR TITLE
Added include and exclude node filters into execution data provided to notification plugins

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -13,6 +13,7 @@ class Execution extends ExecutionContext {
     Date dateCompleted 
     String status
     String outputfilepath
+    String matchedNodeList
     String failedNodeList
     String succeededNodeList
     String abortedby
@@ -57,6 +58,7 @@ class Execution extends ExecutionContext {
         nodeThreadcount(nullable:true)
         nodeRankOrderAscending(nullable: true)
         nodeRankAttribute(nullable: true)
+        matchedNodeList(nullable:true, blank:true)
         failedNodeList(nullable:true, blank:true)
         succeededNodeList(nullable:true, blank:true)
         abortedby(nullable:true, blank:true)
@@ -80,6 +82,7 @@ class Execution extends ExecutionContext {
         user column: "rduser"
         argString type: 'text'
 
+        matchedNodeList type: 'text'
         failedNodeList type: 'text'
         succeededNodeList type: 'text'
         outputfilepath type: 'text'
@@ -144,6 +147,7 @@ class Execution extends ExecutionContext {
         map.dateCompleted=dateCompleted
         map.status=status
         map.outputfilepath=outputfilepath
+        map.matchedNodeList = matchedNodeList
         map.failedNodeList = failedNodeList
         map.succeededNodeList = succeededNodeList
         map.abortedby=abortedby
@@ -196,6 +200,7 @@ class Execution extends ExecutionContext {
         exec.dateCompleted=data.dateCompleted
         exec.status=data.status
         exec.outputfilepath = data.outputfilepath
+        exec.matchedNodeList = data.matchedNodeList
         exec.failedNodeList = data.failedNodeList
         exec.succeededNodeList = data.succeededNodeList
         exec.abortedby = data.abortedby

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -153,6 +153,18 @@ class ExecutionJob implements InterruptableJob {
         return null;
     }
 
+    private static Set<String> extractMatchedNodes(Map execmap=null) {
+        if(null==execmap){
+            return null;
+        }
+        if(null!=execmap.noderecorder && execmap.noderecorder instanceof NodeRecorder){
+            final recorder = (NodeRecorder) execmap.noderecorder
+            def nodes = recorder.getMatchedNodes()
+            return nodes
+        }
+        return null;
+    }
+
     public void interrupt(){
         wasInterrupted=true;
     }
@@ -360,6 +372,7 @@ class ExecutionJob implements InterruptableJob {
                   boolean _interrupted,
                   boolean timedOut,
                   boolean isTemp, long scheduledExecutionId=-1, Map initMap, Map execmap) {
+        Set<String> matchedNodes = extractMatchedNodes(execmap)
         Map<String,Object> failedNodes=extractFailedNodes(execmap)
         Set<String> succeededNodes=extractSucceededNodes(execmap)
 
@@ -371,6 +384,7 @@ class ExecutionJob implements InterruptableJob {
                 cancelled: _interrupted && !timedOut,
                 timedOut: timedOut,
                 failedNodes: failedNodes?.keySet(),
+                matchedNodes: matchedNodes,
                 failedNodesMap: failedNodes,
                 succeededNodes: succeededNodes,
         ]

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -35,6 +35,7 @@ import com.dtolabs.rundeck.execution.JobExecutionItem
 import com.dtolabs.rundeck.execution.JobReferenceFailureReason
 import com.dtolabs.rundeck.server.authorization.AuthConstants
 import org.apache.commons.io.FileUtils
+import org.apache.commons.lang.StringUtils
 import org.apache.log4j.Logger
 import org.apache.log4j.MDC
 import org.hibernate.StaleObjectStateException
@@ -742,6 +743,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
             StepExecutionContext executioncontext = createContext(execution, null,framework, authContext,
                     execution.user, jobcontext, multiListener, null,extraParams, extraParamsExposed)
+
+            execution.matchedNodeList = StringUtils.join(executioncontext.getNodes().getNodeNames(), ",")
+            execution.save(flush:true)
 
             //ExecutionService handles Job reference steps
             final cis = StepExecutionService.getInstanceForFramework(framework);
@@ -1767,6 +1771,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         def ScheduledExecution scheduledExecution
         def Execution execution = Execution.get(exId)
         execution.properties=props
+        if (props.matchedNodes) {
+            execution.matchedNodeList = props.matchedNodes.join(",")
+        }
         if (props.failedNodes) {
             execution.failedNodeList = props.failedNodes.join(",")
         }

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -409,7 +409,9 @@ public class NotificationService implements ApplicationContextAware{
             failedNodeList: e.failedNodeList?.split(",") as List,
             succeededNodeListString: e.succeededNodeList,
             succeededNodeList: e.succeededNodeList?.split(",") as List,
-            loglevel: ExecutionService.textLogLevels[e.loglevel] ?: e.loglevel
+            loglevel: ExecutionService.textLogLevels[e.loglevel] ?: e.loglevel,
+            includeNodeFilters: e.asIncludeMap(),
+            excludeNodeFilters: e.asExcludeMap()
         ]
         if (null != e.dateCompleted) {
             emap.dateEnded = e.dateCompleted

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -405,6 +405,8 @@ public class NotificationService implements ApplicationContextAware{
             description: e.scheduledExecution.description?:'',
             argstring: e.argString,
             project: e.project,
+            matchedNodeListString: e.matchedNodeList,
+            matchedNodeList: e.matchedNodeList?.split(",") as List,
             failedNodeListString: e.failedNodeList,
             failedNodeList: e.failedNodeList?.split(",") as List,
             succeededNodeListString: e.succeededNodeList,

--- a/rundeckapp/test/unit/ProjectServiceTests.groovy
+++ b/rundeckapp/test/unit/ProjectServiceTests.groovy
@@ -48,6 +48,7 @@ class ProjectServiceTests  {
     <dateCompleted>1970-01-01T01:00:00Z</dateCompleted>
     <status>true</status>'''
     static String EXEC_XML_TEST1_DEF_END= '''
+    <matchedNodeList />
     <failedNodeList />
     <succeededNodeList />
     <abortedby />


### PR DESCRIPTION
Hi,

We'd like to be able to display any node filters (specifically, tags) used in a HipChat notification (via hipchat notification plugin) so I've added the include and exclude node filter maps to the execution data map that is passed to a notification plugin. I've also added the list of matched nodes to the execution data too.

Cheers,
Hayden
