### PR TITLE
Add text/plain MIME type for YAML files

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/format/ResourceYamlFormatParser.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/format/ResourceYamlFormatParser.java
@@ -49,7 +49,7 @@ public class ResourceYamlFormatParser implements ResourceFormatParser,Describabl
 
     public static final Set<String> EXTENSIONS = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList("yaml","yml")));
     public static final Set<String> MIME_TYPES = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
-        "text/plain")));
+        "*/yaml", "*/x-yaml", "text/plain")));
 
     public Set<String> getFileExtensions() {
         return EXTENSIONS;

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/format/ResourceYamlFormatParser.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/format/ResourceYamlFormatParser.java
@@ -49,7 +49,7 @@ public class ResourceYamlFormatParser implements ResourceFormatParser,Describabl
 
     public static final Set<String> EXTENSIONS = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList("yaml","yml")));
     public static final Set<String> MIME_TYPES = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
-        "*/yaml", "*/x-yaml")));
+        "text/plain")));
 
     public Set<String> getFileExtensions() {
         return EXTENSIONS;


### PR DESCRIPTION
The currently specified MIME types "*/yaml", "*/x-yaml" are not generally found on any popular web server. See http://www.iana.org/assignments/media-types/media-types.xhtml . Consequentially, the MIME type returned for a YAML file hosted via a common web server is text/plain . This change shouldn't affect XML files served since they do have a globally accepted MIME type and will be served with that in the header.

Facing issues with being able to serve such a file off a shared service. Seeing...

```
ERROR ExceptionCatchingResourceModelSource: [ResourceModelSource: 1.url (URL Source), project: XYZ] 
com.dtolabs.rundeck.core.resources.ResourceModelSourceException: Error requesting URL Resource Model Source: http://f.q.d.n/xyz.yaml: Response content type is not supported: text/plain

Caused by: com.dtolabs.rundeck.core.resources.format.UnsupportedFormatException: No provider available to parse MIME type: text/plain
        at com.dtolabs.rundeck.core.resources.format.ResourceFormatParserService.getParserForMIMEType(ResourceFormatParserService.java:193)
        at com.dtolabs.rundeck.core.resources.URLResourceModelSource.getNodes(URLResourceModelSource.java:309)
```

...in the logs.