### PR TITLE
Add destfilename expansion which contains the destinitation filename

### DIFF
--- a/plugins/script-plugin/src/main/java/com/dtolabs/rundeck/plugin/script/ScriptFileCopier.java
+++ b/plugins/script-plugin/src/main/java/com/dtolabs/rundeck/plugin/script/ScriptFileCopier.java
@@ -272,9 +272,15 @@ public class ScriptFileCopier implements DestinationFileCopier, Describable {
         final HashMap<String, String> scptexec = new HashMap<String, String>(){{
             //set filename of source file
             put("filename", srcFile.getName());
+            put("destfilename", srcFile.getName());
             put("file", srcFile.getAbsolutePath());
             //add file, dir, destination to the file-copy data
         }};
+	
+	if(null != remotePath && !remotePath.endsWith("/")) {
+	    scptexec.put("destfilename", new File(remotePath).getName());
+	}
+
         if (null != workingdir) {
             //set up the data context to include the working dir
             scptexec.put("dir", workingdir.getAbsolutePath());


### PR DESCRIPTION
Currently the only filename available in paths is the source filename.  However, If a file copy renames a file, the is no way to grab just the filename.  This commit adds that expansion.
