### PR TITLE
Fix rundeckd init script

### DIFF
--- a/packaging/root/etc/rc.d/init.d/rundeckd
+++ b/packaging/root/etc/rc.d/init.d/rundeckd
@@ -74,7 +74,7 @@ case "$1" in
 		fi
 		;;
 	status)
-		status -p $PID_FILE $rundeckd
+		status -p $PID_FILE $prog
 		RETVAL=$?
 		;;
 	*)


### PR DESCRIPTION
Made changes to display rundeckd when checking status of rundeckd daemon. Please, review.

```shell
# /etc/init.d/rundeckd status
java (pid  24682) is running...
```
__Fix:__
```shell
# /etc/init.d/rundeckd status
rundeckd (pid  24682) is running...
```