### PR TITLE
Fix ssh-agent variable names in documentation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,13 +32,13 @@ This release has bug fixes and new features, including some GUI improvements.
     - this can be enabled per node, project, or server
         framework.properties:
 
-            framework.local.ssh-agent=<true|false>
-            framework.local.ttl-ssh-agent=<time in sec>
+            framework.local-ssh-agent=<true|false>
+            framework.local-ttl-ssh-agent=<time in sec>
 
         project.properties:
 
-            project.local.ssh-agent=<true|false>
-            project.local.ttl-ssh-agent=<time in sec>
+            project.local-ssh-agent=<true|false>
+            project.local-ttl-ssh-agent=<time in sec>
 
         Node properties:
 

--- a/docs/en/history/version-2.4.0.md
+++ b/docs/en/history/version-2.4.0.md
@@ -36,13 +36,13 @@ This release has bug fixes and new features, including some GUI improvements.
     - this can be enabled per node, project, or server
         framework.properties:
 
-            framework.local.ssh-agent=<true|false>
-            framework.local.ttl-ssh-agent=<time in sec>
+            framework.local-ssh-agent=<true|false>
+            framework.local-ttl-ssh-agent=<time in sec>
 
         project.properties:
 
-            project.local.ssh-agent=<true|false>
-            project.local.ttl-ssh-agent=<time in sec>
+            project.local-ssh-agent=<true|false>
+            project.local-ttl-ssh-agent=<time in sec>
 
         Node properties:
 

--- a/docs/en/plugins-user-guide/ssh-plugins.md
+++ b/docs/en/plugins-user-guide/ssh-plugins.md
@@ -411,15 +411,15 @@ New variables are:
 **framework.properties:**
 
 ~~~~
-framework.local.ssh-agent=<true|false>
-framework.local.ttl-ssh-agent=<time in sec>
+framework.local-ssh-agent=<true|false>
+framework.local-ttl-ssh-agent=<time in sec>
 ~~~~
 
 **project.properties:**
 
 ~~~~
-project.local.ssh-agent=<true|false>
-project.local.ttl-ssh-agent=<time in sec>
+project.local-ssh-agent=<true|false>
+project.local-ttl-ssh-agent=<time in sec>
 ~~~~
 
 **Node attributes:**


### PR DESCRIPTION
Hi,

The documentation and the release notes for Rundeck 2.4.0 use a wrong name for the two new ssh-agent variables. I noticed that ssh-agent forwarding did not work after upgrading to 2.4.0 and realized that the documentation was wrong.
