### PR TITLE
JettyPamLoginModule: supplementalRoles split regex requires whitespace

### DIFF
--- a/rundeck-launcher/rundeck-jetty-server/src/main/java/org/rundeck/jaas/pam/AbstractPamLoginModule.java
+++ b/rundeck-launcher/rundeck-jetty-server/src/main/java/org/rundeck/jaas/pam/AbstractPamLoginModule.java
@@ -63,7 +63,7 @@ public abstract class AbstractPamLoginModule extends AbstractSharedLoginModule {
         Object supplementalRoles1 = options.get("supplementalRoles");
         if (null != supplementalRoles1) {
             this.supplementalRoles = new ArrayList<String>();
-            this.supplementalRoles.addAll(Arrays.asList(supplementalRoles1.toString().split(", +")));
+            this.supplementalRoles.addAll(Arrays.asList(supplementalRoles1.toString().split(", *")));
         }
     }
 


### PR DESCRIPTION
" +" matches "one or more whitespace".

Correctly it should be " *" which matches "zero or more whitespace"