### PR TITLE
Refactor authorization into components, add preauth attribute role

### DIFF
--- a/docs/en/administration/10-authorization.md
+++ b/docs/en/administration/10-authorization.md
@@ -1,5 +1,16 @@
 % Access Control Policy
 
+Based on the [Authentication](authenticating-users.html) mechanism,
+the Container provides Rundeck
+with a list of "group" or "role" names
+that the user belongs to.
+Rundeck uses this list to determine what access rights the user has.
+(For more about the role list,
+refer to [Authenticating Users - Container authentication and authorization][1].)
+
+[1]: authenticating-users.html#container-authentication-and-authorization
+
+
 A Rundeck *access control policy* grants users
 and user groups certain
 privileges to perform actions against rundeck resources

--- a/rundeckapp/grails-app/conf/Config.groovy
+++ b/rundeckapp/grails-app/conf/Config.groovy
@@ -149,6 +149,11 @@ rundeck.gui.execution.tail.lines.max = 500
 rundeck.mail.template.subject='${notification.eventStatus} [${execution.project}] ${job.group}/${job.name} ${execution.argstring}'
 rundeck.security.useHMacRequestTokens=true
 rundeck.security.apiCookieAccess.enabled=true
+rundeck.security.authorization.containerPrincipal.enabled=true
+rundeck.security.authorization.container.enabled=true
+rundeck.security.authorization.preauthenticated.enabled=false
+rundeck.security.authorization.preauthenticated.attributeName=null
+rundeck.security.authorization.preauthenticated.delimiter=','
 
 rundeck.web.metrics.servlets.metrics.enabled = true
 rundeck.web.metrics.servlets.ping.enabled = true

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -15,8 +15,11 @@ import com.dtolabs.rundeck.server.plugins.services.StreamingLogReaderPluginProvi
 import com.dtolabs.rundeck.server.plugins.services.StreamingLogWriterPluginProviderService
 import com.dtolabs.rundeck.server.plugins.storage.DbStoragePluginFactory
 import com.dtolabs.rundeck.server.storage.StorageTreeFactory
+import org.rundeck.web.infosec.ContainerPrincipalRoleSource
+import org.rundeck.web.infosec.ContainerRoleSource
 import org.rundeck.web.infosec.HMacSynchronizerTokensManager
 import groovy.io.FileType
+import org.rundeck.web.infosec.PreauthenticatedAttributeRoleSource
 import org.springframework.core.task.SimpleAsyncTaskExecutor
 import rundeck.services.PasswordFieldsService
 
@@ -104,6 +107,17 @@ beans={
 
     storageConverterPluginProviderService(StorageConverterPluginProviderService) {
         rundeckServerServiceProviderLoader = ref('rundeckServerServiceProviderLoader')
+    }
+    containerPrincipalRoleSource(ContainerPrincipalRoleSource){
+        enabled=grailsApplication.config.rundeck?.security?.authorization?.containerPrincipal?.enabled in [true,'true']
+    }
+    containerRoleSource(ContainerRoleSource){
+        enabled=grailsApplication.config.rundeck?.security?.authorization?.container?.enabled in [true,'true']
+    }
+    preauthenticatedAttributeRoleSource(PreauthenticatedAttributeRoleSource){
+        enabled=grailsApplication.config.rundeck?.security?.authorization?.preauthenticated?.enabled in [true,'true']
+        attributeName=grailsApplication.config.rundeck?.security?.authorization?.preauthenticated?.attributeName
+        delimiter=grailsApplication.config.rundeck?.security?.authorization?.preauthenticated?.delimiter
     }
 
     def storageDir= new File(varDir, 'storage')

--- a/rundeckapp/src/groovy/org/rundeck/web/infosec/AuthorizationRoleSource.groovy
+++ b/rundeckapp/src/groovy/org/rundeck/web/infosec/AuthorizationRoleSource.groovy
@@ -1,0 +1,19 @@
+package org.rundeck.web.infosec
+
+import javax.servlet.http.HttpServletRequest
+
+/**
+ * Created by greg on 2/17/15.
+ */
+interface AuthorizationRoleSource {
+    /**
+     * @param username
+     * @param request
+     * @return collection of user role names
+     */
+    public Collection<String> getUserRoles(String username, HttpServletRequest request)
+    /**
+     * @return true if this source is enabled
+     */
+    public boolean isEnabled()
+}

--- a/rundeckapp/src/groovy/org/rundeck/web/infosec/ContainerPrincipalRoleSource.groovy
+++ b/rundeckapp/src/groovy/org/rundeck/web/infosec/ContainerPrincipalRoleSource.groovy
@@ -1,0 +1,48 @@
+package org.rundeck.web.infosec
+
+import com.dtolabs.rundeck.core.authentication.Group
+
+import javax.security.auth.Subject
+import javax.servlet.http.HttpServletRequest
+
+/**
+ * Return a list of roles by introspecting the userPrincipal object
+ */
+class ContainerPrincipalRoleSource implements AuthorizationRoleSource {
+    boolean enabled
+    @Override
+    Collection<String> getUserRoles(final String username, final HttpServletRequest request) {
+        def roles=new ArrayList<String>()
+        def principal = request.userPrincipal
+        if (principal.hasProperty('subject')) {
+            Subject osubject = (Subject) principal.subject
+            osubject.getPrincipals().each { p ->
+                if (p.class.name.equals('org.eclipse.jetty.plus.jaas.JAASRole') || p.class.name.contains('Role')) {
+                    roles<<p.name
+                }
+            }
+        } else if (principal.hasProperty('roles')) {
+            if (principal.roles instanceof Iterator) {
+                def Iterator iter = principal.roles
+                while (iter.hasNext()) {
+                    def role = iter.next()
+                    if (role.rolename) {
+                        roles<<role.rolename
+                    } else if (role instanceof String) {
+                        roles<<role
+                    }
+
+                }
+            } else if (principal.roles instanceof Collection || principal.roles instanceof Object[]) {
+                principal.roles?.each { name ->
+                    roles<<name
+                }
+            } else {
+                principal.roles?.members.each { group ->
+                    roles<<group.name
+                }
+            }
+        }
+        roles
+    }
+}

--- a/rundeckapp/src/groovy/org/rundeck/web/infosec/ContainerRoleSource.groovy
+++ b/rundeckapp/src/groovy/org/rundeck/web/infosec/ContainerRoleSource.groovy
@@ -1,0 +1,26 @@
+package org.rundeck.web.infosec
+
+import org.springframework.beans.factory.annotation.Autowired
+import rundeck.services.FrameworkService
+
+import javax.servlet.http.HttpServletRequest
+
+/**
+ * Returns list of known roles that user is in via {@link HttpServletRequest#isUserInRole(java.lang.String)}
+ */
+class ContainerRoleSource implements AuthorizationRoleSource {
+    boolean enabled
+    @Autowired
+    def FrameworkService frameworkService
+    @Override
+    Collection<String> getUserRoles(final String username, final HttpServletRequest request) {
+        def roles=new ArrayList<String>()
+        //try to determine roles based on aclpolicy group definitions
+        frameworkService.getFrameworkRoles().each { rolename ->
+            if (request.isUserInRole(rolename)) {
+                roles<<rolename
+            }
+        }
+        roles
+    }
+}

--- a/rundeckapp/src/groovy/org/rundeck/web/infosec/PreauthenticatedAttributeRoleSource.groovy
+++ b/rundeckapp/src/groovy/org/rundeck/web/infosec/PreauthenticatedAttributeRoleSource.groovy
@@ -1,0 +1,24 @@
+package org.rundeck.web.infosec
+
+import javax.servlet.http.HttpServletRequest
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+/**
+ * Returns list of roles defined in a request attribute
+ */
+class PreauthenticatedAttributeRoleSource implements AuthorizationRoleSource {
+    String attributeName
+    String delimiter=','
+    boolean enabled
+    @Override
+    Collection<String> getUserRoles(final String username, final HttpServletRequest request) {
+        if(enabled && attributeName){
+            def value=request.getAttribute(attributeName)
+            if(value && value instanceof String){
+                return value.split(" *${Pattern.quote(delimiter)} *").collect{it.trim()} as List<String>
+            }
+        }
+        []
+    }
+}


### PR DESCRIPTION
Add ability to use pre-authenticated and authorized proxied requests, e.g. from Apache httpd.

* Requires disabling the container authentication mechanism (remove the `<auth-constraint>` from web.xml)
* Accepts the remote_user as username, and a list of roles defined in a request attribute, the name and delimiter can be configured.