### PR TITLE
 Fix LDAP nested groups for Active Directory

### DIFF
--- a/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
+++ b/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
@@ -433,14 +433,14 @@ public class JettyCachingLdapLoginModule extends AbstractLoginModule {
             }
         }
 
+        if(_nestedGroups) {
+            roleList = getNestedRoles(dirContext, roleList);
+        }
+
         if (roleList.size() < 1) {
             LOG.warn("JettyCachingLdapLoginModule: User '" + username + "' has no role membership; role query configuration may be incorrect");
         }else{
             LOG.debug("JettyCachingLdapLoginModule: User '" + username + "' has roles: " + roleList);
-        }
-
-        if(_nestedGroups) {
-            roleList = getNestedRoles(dirContext, roleList);
         }
 
         return roleList;

--- a/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
+++ b/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
@@ -99,7 +99,7 @@ public class JettyCachingLdapLoginModule extends AbstractLoginModule {
 
     private static final Logger LOG = Log.getLogger(JettyCachingLdapLoginModule.class);
 
-    private static final Pattern rolePattern = Pattern.compile("^cn=([^,]+)");
+    private static final Pattern rolePattern = Pattern.compile("^cn=([^,]+)", Pattern.CASE_INSENSITIVE);
 
     protected final String _roleMemberFilter = "member=*";
     /**


### PR DESCRIPTION
fixes #748 
caused by case-sensitivity bug in regexp pattern that failed for
ActiveDirectory but worked for openldap