### PR TITLE
Fix: Add a missing space in example

### DIFF
--- a/docs/en/administration/09-authentication.md
+++ b/docs/en/administration/09-authentication.md
@@ -579,7 +579,7 @@ Configuration properties:
 
 * `serviceName` - name of the PAM service configuration to use. (Required). Example: "sshd".
 * `useUnixGroups` - true/false. If true, the unix Groups defined for the user will be included as authorization roles. Default: false.
-* `supplementalRoles` - a comma-separated list of additional user roles to add to any authenticated user. Example: 'user,readonly'
+* `supplementalRoles` - a comma-separated list of additional user roles to add to any authenticated user. Example: `'user, readonly'` Note: you must use comma **and a space** for this to work.
 
 
 ### JettyRolePropertyFileLoginModule


### PR DESCRIPTION
The example as given would add a single group with name `"user,readonly"` rather than two groups: `"user"` and `"readonly"`. Adding the space after the comma fixes this problem.
