### PR TITLE
add a job option to disable the automatic selection of all nodes

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -95,7 +95,7 @@ class ScheduledExecutionController  extends ControllerBase{
     def ApiService apiService
     def UserService userService
 
- 
+
     def index = { redirect(controller:'menu',action:'jobs',params:params) }
 
     // the delete, save and update actions only
@@ -1747,6 +1747,10 @@ class ScheduledExecutionController  extends ControllerBase{
                 model.nodemap=[:]
                 model.tagsummary=[:]
                 model.grouptags=[:]
+                model.nodesSelectedByDefault=scheduledExecution.nodesSelectedByDefault
+                if (!model.nodesSelectedByDefault) {
+                    model.selectedNodes = ""
+                }
                 //summarize node groups
                 def namegroups=[other: new TreeList()]
                 nodes.each{INodeEntry node->

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -26,6 +26,7 @@ class ScheduledExecution extends ExecutionContext {
 
     Date nextExecution
     boolean scheduled = false
+    Boolean nodesSelectedByDefault = true
     Long totalTime=0
     Long execCount=0
     String adhocExecutionType
@@ -105,6 +106,7 @@ class ScheduledExecution extends ExecutionContext {
             }
         })
         crontabString(bindable: true,nullable: true)
+        nodesSelectedByDefault(nullable: true)
     }
 
     static mapping = {
@@ -186,6 +188,7 @@ class ScheduledExecution extends ExecutionContext {
             map.multipleExecutions=true
         }
         if(doNodedispatch){
+            map.nodesSelectedByDefault = nodesSelectedByDefault == null || nodesSelectedByDefault
             map.nodefilters=[dispatch:[threadcount:null!=nodeThreadcount?nodeThreadcount:1,keepgoing:nodeKeepgoing?true:false,excludePrecedence:nodeExcludePrecedence?true:false]]
             if(nodeRankAttribute){
                 map.nodefilters.dispatch.rankAttribute= nodeRankAttribute
@@ -295,6 +298,7 @@ class ScheduledExecution extends ExecutionContext {
             se.multipleExecutions=data.multipleExecutions?true:false
         }
         if(data.nodefilters){
+            se.nodesSelectedByDefault = data.nodesSelectedByDefault?true:false
             if(data.nodefilters.dispatch){
                 se.nodeThreadcount = data.nodefilters.dispatch.threadcount ?: 1
                 if(data.nodefilters.dispatch.containsKey('keepgoing')){

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -444,6 +444,9 @@ scheduledExecution.property.nodeThreadcount.description=Maximum number of parall
 scheduledExecution.property.nodeThreadcount.label=Thread Count
 scheduledExecution.property.doNodedispatch.description=Choose whether the Job will run on filtered nodes or only on \
   the local node.
+scheduledExecution.property.nodesSelectedByDefault.label=Node selection
+scheduledExecution.property.nodesSelectedByDefault.true.description=Target nodes are selected by default
+scheduledExecution.property.nodesSelectedByDefault.false.description=The user has to explicitly select target nodes
 no=No
 yes=Yes
 true=True

--- a/rundeckapp/grails-app/views/execution/_execDetails.gsp
+++ b/rundeckapp/grails-app/views/execution/_execDetails.gsp
@@ -153,7 +153,17 @@
                         order.
                     </span>
                     </div>
-
+                    <g:if test="${execdata instanceof ScheduledExecution}">
+                    <div>
+                        <span class="text-muted text-em">
+                            <g:message code="scheduledExecution.property.nodesSelectedByDefault.label" />:
+                            <strong>
+                                <g:message
+                                        code="scheduledExecution.property.nodesSelectedByDefault.${!!execdata?.nodesSelectedByDefault}.description"/>
+                            </strong>
+                        </span>
+                    </div>
+                    </g:if>
                 </td>
 
             </tr>

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -729,7 +729,33 @@ function getCurSEID(){
                 </div>
             </div>
         </div>
-	        
+
+        <div class="form-group">
+            <label class="${labelColClass}"><g:message code="scheduledExecution.property.nodesSelectedByDefault.label"/></label>
+
+            <div class="${fieldColSize}">
+                <div class="radio">
+                    <label>
+                        <g:radio
+                                name="nodesSelectedByDefault"
+                                value="true"
+                                checked="${scheduledExecution.nodesSelectedByDefault}"
+                                id="nodesSelectedByDefaultTrue"/>
+                        <g:message code="scheduledExecution.property.nodesSelectedByDefault.true.description"/>
+                    </label>
+                </div>
+                <div class="radio">
+                    <label>
+                        <g:radio name="nodesSelectedByDefault"
+                                 value="false"
+                                 checked="${!scheduledExecution.nodesSelectedByDefault}"
+                                 id="nodesSelectedByDefaultFalse"/>
+                        <g:message code="scheduledExecution.property.nodesSelectedByDefault.false.description"/>
+                    </label>
+                </div>
+            </div>
+        </div>
+
         %{--orchestrator--}%
         <g:render template="editOrchestratorForm" model="[scheduledExecution:scheduledExecution, orchestratorPlugins: orchestratorPlugins,adminauth:adminauth]"/>
         %{--//orchestrator--}%

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -41,7 +41,7 @@
         </g:elseif>
         <g:elseif test="${nodes}">
             <g:set var="selectedNodes"
-                   value="${failedNodes? failedNodes.split(','):selectedNodes? selectedNodes.split(','):null}"/>
+                   value="${failedNodes? failedNodes.split(','):selectedNodes!=null? selectedNodes.split(','):null}"/>
             <div class="container">
             <div class="row">
                 <div class="col-sm-12 checkbox">
@@ -49,22 +49,22 @@
                     <input name="extra._replaceNodeFilters" value="true" type="checkbox"
                            data-toggle="collapse"
                            data-target="#nodeSelect"
-                        ${selectedNodes?'checked':''}
+                        ${selectedNodes!=null?'checked':''}
                            id="doReplaceFilters"/>
                     Change the Target Nodes
-                (<span class="nodeselectcount"><g:enc>${selectedNodes?selectedNodes.size():nodes.size()}</g:enc></span>)</label>
+                (<span class="nodeselectcount"><g:enc>${selectedNodes!=null?selectedNodes.size():nodes.size()}</g:enc></span>)</label>
                 </div>
 
             </div>
             </div>
-            <div class=" matchednodes embed jobmatchednodes group_section collapse ${selectedNodes ? 'in' : ''}" id="nodeSelect">
+            <div class=" matchednodes embed jobmatchednodes group_section collapse ${selectedNodes!=null? 'in' : ''}" id="nodeSelect">
                 <%--
                  split node names into groups, in several patterns
                   .*\D(\d+)
                   (\d+)\D.*
                 --%>
                 <g:if test="${namegroups}">
-                    <div class=" group_select_control" style="${wdgt.styleVisible(if: selectedNodes)}">
+                    <div class=" group_select_control" style="${wdgt.styleVisible(if: selectedNodes !=null)}">
                         Select:
                         <span class="textbtn textbtn-default textbtn-on-hover selectall">All</span>
                         <span class="textbtn textbtn-default textbtn-on-hover selectnone">None</span>
@@ -77,7 +77,7 @@
                         <div class="panel panel-default">
                       <div class="panel-heading">
                           <g:set var="expkey" value="${g.rkey()}"/>
-                            <g:expander key="${expkey}" open="${selectedNodes?'true':'false'}">
+                            <g:expander key="${expkey}" open="${selectedNodes!=null?'true':'false'}">
                                 <g:if test="${group!='other'}">
                                     <span class="prompt">
                                     <g:enc>${namegroups[group][0]}</g:enc></span>
@@ -92,7 +92,7 @@
                                 <g:enc>(${namegroups[group].size()})</g:enc>
                             </g:expander>
                         </div>
-                        <div id="${enc(attr:expkey)}" style="${wdgt.styleVisible(if: selectedNodes)}" class="group_section panel-body">
+                        <div id="${enc(attr:expkey)}" style="${wdgt.styleVisible(if: selectedNodes!=null)}" class="group_section panel-body">
                                 <g:if test="${namegroups.size()>1}">
                                 <div class="group_select_control" style="display:none">
                                     Select:
@@ -113,7 +113,7 @@
                                                    type="checkbox"
                                                    name="extra.nodeIncludeName"
                                                    value="${enc(attr:node.nodename)}"
-                                                   ${selectedNodes ? '':'disabled' }
+                                                   ${selectedNodes!=null ? '':'disabled' }
                                                    data-tag="${enc(attr:node.tags?.join(' '))}"
                                                     ${(null== selectedNodes||selectedNodes.contains(node.nodename))?'checked':''}
                                                    /><g:enc>${node.nodename}</g:enc></label>
@@ -248,6 +248,11 @@
                 });
 
             </g:javascript>
+            <g:if test="${nodesSelectedByDefault != null && !nodesSelectedByDefault}">
+                <g:javascript>
+                    Event.fire($('nodeSelect'), 'nodeset:change');
+                </g:javascript>
+            </g:if>
         </g:elseif>
     </div>
     </div>

--- a/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerTests.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerTests.groovy
@@ -1847,6 +1847,7 @@ class ScheduledExecutionControllerTests  {
         assertEquals([:],model.dependentoptions)
         assertEquals([:],model.optiondependencies)
         assertEquals(null,model.optionordering)
+        assertEquals(null,model.nodesSelectedByDefault)
         assertEquals([:],model.remoteOptionData)
     }
     /**
@@ -1861,6 +1862,7 @@ class ScheduledExecutionControllerTests  {
                 project: 'project1',
                 groupPath: 'testgroup',
                 doNodedispatch: true,
+                nodesSelectedByDefault: false,
                 filter:'name: nodea,nodeb',
                 workflow: new Workflow(
                         keepgoing: true,
@@ -1927,14 +1929,14 @@ class ScheduledExecutionControllerTests  {
         assertNull sec.response.redirectedUrl
         assertNotNull model
         assertNotNull(model.scheduledExecution)
-        assertNull(model.selectedNodes)
+        assertEquals("", model.selectedNodes)
         assertEquals('fwnode',model.localNodeName)
         assertEquals('name: nodea,nodeb',model.nodefilter)
         assertEquals(null,model.nodesetvariables)
         assertEquals(null,model.failedNodes)
         assertEquals(null,model.nodesetempty)
+        assertEquals(false,model.nodesSelectedByDefault)
         assertEquals(testNodeSet.nodes,model.nodes)
-        assertEquals(null,model.selectedNodes)
         assertEquals([:],model.grouptags)
         assertEquals(null,model.selectedoptsmap)
         assertEquals([:],model.dependentoptions)
@@ -2030,6 +2032,7 @@ class ScheduledExecutionControllerTests  {
         assertEquals(null,model.selectedNodes)
         assertEquals(null,model.grouptags)
         assertEquals(null,model.selectedoptsmap)
+        assertEquals(null,model.nodesSelectedByDefault)
         assertEquals([:],model.dependentoptions)
         assertEquals([:],model.optiondependencies)
         assertEquals(null,model.optionordering)
@@ -2149,6 +2152,7 @@ class ScheduledExecutionControllerTests  {
         assertEquals('nodea',model.selectedNodes)
         assertEquals([:],model.grouptags)
         assertEquals(null,model.selectedoptsmap)
+        assertEquals(true,model.nodesSelectedByDefault)
         assertEquals([:],model.dependentoptions)
         assertEquals([:],model.optiondependencies)
         assertEquals(null,model.optionordering)


### PR DESCRIPTION
Nowadays when a user wants to run a predefined job all nodes are automatically selected. Thus the user only need to click on "Run Job Now" to run the job on all those nodes.
In our case we are running jobs on business critical machines and we want to force the user to explicitly select nodes before running the job.

This commit add an option in the job definition to disable this automatic selection of nodes:
![scheduled_execution_form](https://cloud.githubusercontent.com/assets/3679481/7678461/febcdcfe-fd5c-11e4-9ee4-98cd300f120d.png)

This feature is also visible in the "Definition" tab:
![run_job_definition](https://cloud.githubusercontent.com/assets/3679481/7678438/c6beb0d4-fd5c-11e4-8331-bad6739db93d.png)

When this feature is enable for a job, the user has to select node explicitly:
![run_job_no_node_selected](https://cloud.githubusercontent.com/assets/3679481/7678490/2c10e16e-fd5d-11e4-94f4-4cd81fb709cc.png)
