### PR TITLE
Fix next execution time on non-scheduled cluster member

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -787,7 +787,7 @@ class ScheduledExecutionService implements ApplicationContextAware{
      */
     def Date tempNextExecutionTime(ScheduledExecution se){
         def trigger = createTrigger(se)
-        return trigger.nextFireTime
+        return trigger.getFireTimeAfter(new Date())
     }
 
     /**


### PR DESCRIPTION
In a clustered rundeck installation, the cluster member that isn't the assigned node for a job will display "never" for the next scheduled execution time.

This turns out to be because `trigger.getNextFireTime()` returns `null` if the trigger hasn't been added to a schedule (or more precisely, if the start time hasn't been set yet). Using `trigger.getFireTimeAfter(new Date())` will properly calculate the next execution. 