### PR TITLE
Disable Compatiblity Mode in Internet Explorer: Set X-UA-Compatible

### DIFF
--- a/rundeckapp/grails-app/views/layouts/base.gsp
+++ b/rundeckapp/grails-app/views/layouts/base.gsp
@@ -9,6 +9,7 @@
         <g:layoutTitle default="${g.appTitle()}"/>
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="SHORTCUT" href="${g.resource(dir: 'images', file: 'favicon-152.png')}"/>
     <link rel="favicon" href="${g.resource(dir: 'images', file: 'favicon-152.png')}"/>
     <link rel="shortcut icon" href="${g.resource(dir: 'images', file: 'favicon.ico')}"/>


### PR DESCRIPTION
Rundeck does not work well with Compatibility Mode in Internet Explorer.

This tag is to force disable of Compatiblity Mode