### PR TITLE
fix #1611

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -750,9 +750,12 @@ class ExecutionController extends ControllerBase{
      * tailExecutionOutput action, used by execution/show.gsp view to display output inline
      * Also used by apiExecutionOutput for API response
      */
-    def tailExecutionOutput = {
+    def tailExecutionOutput () {
         log.debug("tailExecutionOutput: ${params}, format: ${request.format}")
         Execution e = Execution.get(Long.parseLong(params.id))
+        if(!apiService.requireExists(response,e,['Execution',params.id])){
+            return
+        }
         AuthContext authContext = frameworkService.getAuthContextForSubjectAndProject(session.subject,e.project)
         def reqError=false
 
@@ -1207,18 +1210,17 @@ class ExecutionController extends ControllerBase{
             return
         }
         def Execution e = Execution.get(params.id)
-        AuthContext authContext = frameworkService.getAuthContextForSubjectAndProject(session.subject,e.project)
-        if (!e) {
-            return apiService.renderErrorFormat(response,
-                    [status: HttpServletResponse.SC_NOT_FOUND,code: "api.error.item.doesnotexist", args: ['Execution ID', params.id]])
-        } else if (!frameworkService.authorizeProjectExecutionAll(authContext,e,[AuthConstants.ACTION_READ])){
-            return apiService.renderErrorFormat(response,
-                    [
-                            status: HttpServletResponse.SC_FORBIDDEN,
-                            code: "api.error.item.unauthorized",
-                            args: [AuthConstants.ACTION_READ, "Execution", params.id]
-                    ])
+        if(!apiService.requireExists(response,e,['Execution ID',params.id])){
+            return
         }
+        AuthContext authContext = frameworkService.getAuthContextForSubjectAndProject(session.subject,e.project)
+        if(!apiService.requireAuthorized(
+                frameworkService.authorizeProjectExecutionAll(authContext,e,[AuthConstants.ACTION_READ]),
+                response,
+                [AuthConstants.ACTION_READ, "Execution", params.id] as Object[])){
+            return
+        }
+
         if (request.api_version < ApiRequestFilters.V14 && !(response.format in ['all','xml'])) {
             return apiService.renderErrorFormat(response,[
                     status:HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE,
@@ -1238,35 +1240,23 @@ class ExecutionController extends ControllerBase{
     /**
      * API: /api/execution/{id}/state , version 10
      */
-    def apiExecutionState= {
+    def apiExecutionState(){
         if (!apiService.requireVersion(request, response, ApiRequestFilters.V10)) {
             return
         }
         def Execution e = Execution.get(params.id)
-        AuthContext authContext = frameworkService.getAuthContextForSubjectAndProject(session.subject,e.project)
-        if (!e) {
-            def errormap= [status: HttpServletResponse.SC_NOT_FOUND, code: "api.error.item.doesnotexist", args: ['Execution ID', params.id]]
-            withFormat {
-                json{
-                    return apiService.renderErrorJson(response, errormap)
-                }
-                xml{
-                    return apiService.renderErrorXml(response, errormap)
-                }
-            }
 
-        } else if (!frameworkService.authorizeProjectExecutionAll(authContext, e, [AuthConstants.ACTION_READ])) {
-            def errormap = [status: HttpServletResponse.SC_FORBIDDEN,
-                    code: "api.error.item.unauthorized", args: [AuthConstants.ACTION_READ, "Execution", params.id]]
-            withFormat {
-                json {
-                    return apiService.renderErrorJson(response, errormap)
-                }
-                xml {
-                    return apiService.renderErrorXml(response, errormap)
-                }
-            }
+        if(!apiService.requireExists(response,e,['Execution ID',params.id])){
+            return
         }
+        AuthContext authContext = frameworkService.getAuthContextForSubjectAndProject(session.subject,e.project)
+        if(!apiService.requireAuthorized(
+                frameworkService.authorizeProjectExecutionAll(authContext,e,[AuthConstants.ACTION_READ]),
+                response,
+                [AuthConstants.ACTION_READ, "Execution", params.id] as Object[])){
+            return
+        }
+
 
         def loader = workflowService.requestState(e)
         def state= loader.workflowState
@@ -1372,22 +1362,17 @@ class ExecutionController extends ControllerBase{
             return
         }
         def Execution e = Execution.get(params.id)
-        AuthContext authContext = frameworkService.getAuthContextForSubjectAndProject(session.subject,e.project)
-        if (!e) {
-            return apiService.renderErrorFormat(response,
-                        [
-                                status: HttpServletResponse.SC_NOT_FOUND,
-                                code: "api.error.item.doesnotexist",
-                                args: ['Execution ID', params.id]
-                        ])
-        } else if (!frameworkService.authorizeProjectExecutionAll(authContext,e,[AuthConstants.ACTION_KILL])){
-            return apiService.renderErrorFormat(response,
-                    [
-                            status: HttpServletResponse.SC_FORBIDDEN,
-                            code: "api.error.item.unauthorized",
-                            args: [AuthConstants.ACTION_KILL, "Execution", params.id]
-                    ])
+        if(!apiService.requireExists(response,e,['Execution ID',params.id])){
+            return
         }
+        AuthContext authContext = frameworkService.getAuthContextForSubjectAndProject(session.subject,e.project)
+        if(!apiService.requireAuthorized(
+                frameworkService.authorizeProjectExecutionAll(authContext,e,[AuthConstants.ACTION_KILL]),
+                response,
+                [AuthConstants.ACTION_KILL, "Execution", params.id] as Object[])){
+            return
+        }
+
         def ScheduledExecution se = e.scheduledExecution
         def user=session.user
         def killas=null
@@ -1446,32 +1431,22 @@ class ExecutionController extends ControllerBase{
             return
         }
         def Execution e = Execution.get(params.id)
-        AuthContext authContext = frameworkService.getAuthContextForSubjectAndProject(session.subject,e.project)
-        def respFormat = apiService.extractResponseFormat(request, response, ['xml', 'json'])
-        if (!e) {
-            return apiService.renderErrorFormat(response,
-                    [
-                            status: HttpServletResponse.SC_NOT_FOUND,
-                            code: "api.error.item.doesnotexist",
-                            args: ['Execution ID', params.id],
-                            format: respFormat
-                    ])
+        if(!apiService.requireExists(response,e,['Execution ID',params.id])){
+            return
         }
-        if (
-                !frameworkService.authorizeApplicationResourceAny(
+        AuthContext authContext = frameworkService.getAuthContextForSubjectAndProject(session.subject,e.project)
+        if(!apiService.requireAuthorized(
+                frameworkService.authorizeApplicationResourceAny(
                         authContext,
                         frameworkService.authResourceForProject(e.project),
                         [AuthConstants.ACTION_DELETE_EXECUTION, AuthConstants.ACTION_ADMIN]
-                )
-        ) {
-            return apiService.renderErrorFormat(response,
-                    [
-                            status: HttpServletResponse.SC_FORBIDDEN,
-                            code: "api.error.item.unauthorized",
-                            args: [AuthConstants.ACTION_DELETE_EXECUTION, "Project", e.project],
-                            format: respFormat
-                    ])
+                ),
+                response,
+                [AuthConstants.ACTION_DELETE_EXECUTION, "Project", e.project] as Object[])){
+            return
         }
+        def respFormat = apiService.extractResponseFormat(request, response, ['xml', 'json'])
+
         def result = executionService.deleteExecution(e, authContext,session.user)
         if(!result.success){
             log.error("Failed to delete execution: ${result.message}")

--- a/rundeckapp/test/unit/rundeck/controllers/ExecutionControllerTests.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ExecutionControllerTests.groovy
@@ -410,6 +410,8 @@ class ExecutionControllerTests  {
 
         def svcMock = mockFor(ApiService, false)
         svcMock.demand.requireApi { req, resp -> true }
+        svcMock.demand.requireExists { resp,e,args -> true }
+        svcMock.demand.requireAuthorized { test,resp,args -> true }
         svcMock.demand.renderSuccessXml { response, Closure clos ->
             return true
         }
@@ -443,13 +445,8 @@ class ExecutionControllerTests  {
 
         def svcMock = mockFor(ApiService, false)
         svcMock.demand.requireApi { req, resp -> true }
-        svcMock.demand.renderErrorFormat { response, Map args ->
-            assertEquals('api.error.item.unauthorized',args.code)
-            assertEquals(403,args.status)
-            assertEquals([AuthConstants.ACTION_KILL, "Execution", execs[2].id.toString()],args.args)
-            response.status=403
-            return true
-        }
+        svcMock.demand.requireExists { resp,e,args -> true }
+        svcMock.demand.requireAuthorized { test,resp,args -> resp.status=403;false }
         controller.apiService = svcMock.createMock()
         controller.apiExecutionAbort()
 
@@ -482,13 +479,8 @@ class ExecutionControllerTests  {
 
         def svcMock = mockFor(ApiService, false)
         svcMock.demand.requireApi { req, resp -> true }
-        svcMock.demand.renderErrorFormat { response, Map args ->
-            assertEquals('api.error.item.unauthorized', args.code)
-            assertEquals(403, args.status)
-            assertEquals([AuthConstants.ACTION_KILL, "Execution", execs[2].id.toString()], args.args)
-            response.status = 403
-            return true
-        }
+        svcMock.demand.requireExists { resp,e,args -> true }
+        svcMock.demand.requireAuthorized { test,resp,args -> resp.status=403;false }
         controller.apiService = svcMock.createMock()
         controller.apiExecutionAbort()
 
@@ -521,6 +513,8 @@ class ExecutionControllerTests  {
 
         def svcMock = mockFor(ApiService, false)
         svcMock.demand.requireApi { req, resp -> true }
+        svcMock.demand.requireExists { resp,e,args -> true }
+        svcMock.demand.requireAuthorized { test,resp,args -> true }
         svcMock.demand.requireVersion { request,response,int min ->
             assertEquals(5,min)
             return true
@@ -559,6 +553,9 @@ class ExecutionControllerTests  {
 
         def svcMock = mockFor(ApiService, false)
         svcMock.demand.requireApi { req, resp -> true }
+        svcMock.demand.requireExists { resp,e,args -> true }
+        svcMock.demand.requireAuthorized { test,resp,args -> true }
+
         svcMock.demand.requireVersion { request, response, int min ->
             assertEquals(5, min)
             return true
@@ -574,9 +571,9 @@ class ExecutionControllerTests  {
     }
 
     /**
-     * Test get execution output as user
+     * Test get execution unauthorized
      */
-    public void testApiExecutionAsUserUnauthorized() {
+    public void testApiExecutionUnauthorized() {
         def controller = new ExecutionController()
         def execs = createTestExecs()
         def fwkControl = mockFor(FrameworkService, false)
@@ -593,13 +590,8 @@ class ExecutionControllerTests  {
 
         def svcMock = mockFor(ApiService, false)
         svcMock.demand.requireApi { req, resp -> true }
-        svcMock.demand.renderErrorFormat{ response, Map args ->
-            assertEquals('api.error.item.unauthorized', args.code)
-            assertEquals(403, args.status)
-            assertEquals([AuthConstants.ACTION_READ, "Execution", execs[2].id.toString()], args.args)
-            response.status = 403
-            return true
-        }
+        svcMock.demand.requireExists { resp,e,args -> true }
+        svcMock.demand.requireAuthorized { test,resp,args -> resp.status=403;false }
         controller.apiService = svcMock.createMock()
         controller.apiExecution()
 

--- a/test/api/test-execution-404.sh
+++ b/test/api/test-execution-404.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+#test output from /api/execution/{id}
+# test 404 response
+
+DIR=$(cd `dirname $0` && pwd)
+source $DIR/include.sh
+
+execid="000"
+
+test_execution_notfound_xml(){
+
+	####
+	# Test: request with 404 response
+	####
+
+
+	ENDPOINT="$APIURL/execution/$execid"
+	ACCEPT=application/xml
+	EXPECT_STATUS=404
+
+	test_begin "GET execution not found (xml)"
+
+	api_request $ENDPOINT $DIR/curl.out
+
+	assert_xml_valid $DIR/curl.out
+
+	test_succeed
+
+}
+
+test_execution_notfound_json(){
+
+	ENDPOINT="$APIURL/execution/$execid"
+	ACCEPT=application/json
+	EXPECT_STATUS=404
+
+	test_begin "GET execution not found (json)"
+
+	api_request $ENDPOINT $DIR/curl.out
+
+	assert_json_value "api.error.item.doesnotexist" ".errorCode" $DIR/curl.out
+
+	test_succeed
+}
+
+main(){
+	test_execution_notfound_xml
+	test_execution_notfound_json
+}
+main

--- a/test/api/test-execution-abort-404.sh
+++ b/test/api/test-execution-abort-404.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+#test output from /api/execution/{id}/abort
+# test 404 response
+
+DIR=$(cd `dirname $0` && pwd)
+source $DIR/include.sh
+
+execid="000"
+TITLE="execution/ID/abort not found"
+
+test_execution_notfound_xml(){
+
+	####
+	# Test: request with 404 response
+	####
+
+
+	ENDPOINT="$APIURL/execution/$execid/abort"
+	ACCEPT=application/xml
+	EXPECT_STATUS=404
+
+	test_begin "$TITLE (xml)"
+
+	api_request $ENDPOINT $DIR/curl.out
+
+	assert_xml_valid $DIR/curl.out
+
+	test_succeed
+
+}
+
+test_execution_notfound_json(){
+
+	ENDPOINT="$APIURL/execution/$execid/abort"
+	ACCEPT=application/json
+	EXPECT_STATUS=404
+
+	test_begin "$TITLE (json)"
+
+	api_request $ENDPOINT $DIR/curl.out
+
+	assert_json_value "api.error.item.doesnotexist" ".errorCode" $DIR/curl.out
+
+	test_succeed
+}
+
+main(){
+	test_execution_notfound_xml
+	test_execution_notfound_json
+}
+main

--- a/test/api/test-execution-delete-404.sh
+++ b/test/api/test-execution-delete-404.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+#test output from /api/execution/{id}/abort
+# test 404 response
+
+DIR=$(cd `dirname $0` && pwd)
+source $DIR/include.sh
+
+execid="000"
+TITLE="DELETE execution/ID not found"
+
+test_execution_notfound_xml(){
+
+	####
+	# Test: request with 404 response
+	####
+
+
+	ENDPOINT="$APIURL/execution/$execid"
+	ACCEPT=application/xml
+	METHOD=DELETE
+	EXPECT_STATUS=404
+
+	test_begin "$TITLE (xml)"
+
+	api_request $ENDPOINT $DIR/curl.out
+
+	assert_xml_valid $DIR/curl.out
+
+	test_succeed
+
+}
+
+test_execution_notfound_json(){
+
+	ENDPOINT="$APIURL/execution/$execid"
+	ACCEPT=application/json
+	METHOD=DELETE
+	EXPECT_STATUS=404
+
+	test_begin "$TITLE (json)"
+
+	api_request $ENDPOINT $DIR/curl.out
+
+	assert_json_value "api.error.item.doesnotexist" ".errorCode" $DIR/curl.out
+
+	test_succeed
+}
+
+main(){
+	test_execution_notfound_xml
+	test_execution_notfound_json
+}
+main

--- a/test/api/test-execution-output-404.sh
+++ b/test/api/test-execution-output-404.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+#test output from /api/execution/{id}/output
+# test 404 response
+
+DIR=$(cd `dirname $0` && pwd)
+source $DIR/include.sh
+
+execid="000"
+TITLE="execution/ID/output not found"
+
+test_execution_notfound_xml(){
+
+	####
+	# Test: request with 404 response
+	####
+
+
+	ENDPOINT="$APIURL/execution/$execid/output"
+	ACCEPT=application/xml
+	EXPECT_STATUS=404
+
+	test_begin "$TITLE (xml)"
+
+	api_request $ENDPOINT $DIR/curl.out
+
+	assert_xml_valid $DIR/curl.out
+
+	test_succeed
+
+}
+
+test_execution_notfound_json(){
+
+	ENDPOINT="$APIURL/execution/$execid/output"
+	ACCEPT=application/json
+	EXPECT_STATUS=404
+
+	test_begin "$TITLE (json)"
+
+	api_request $ENDPOINT $DIR/curl.out
+
+	assert_json_value "api.error.item.doesnotexist" ".errorCode" $DIR/curl.out
+
+	test_succeed
+}
+
+main(){
+	test_execution_notfound_xml
+	test_execution_notfound_json
+}
+main

--- a/test/api/test-execution-state-404.sh
+++ b/test/api/test-execution-state-404.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+#test output from /api/execution/{id}/state
+# test 404 response
+
+DIR=$(cd `dirname $0` && pwd)
+source $DIR/include.sh
+
+execid="000"
+TITLE="execution/state not found"
+
+test_execution_notfound_xml(){
+
+	####
+	# Test: request with 404 response
+	####
+
+
+	ENDPOINT="$APIURL/execution/$execid/state"
+	ACCEPT=application/xml
+	EXPECT_STATUS=404
+
+	test_begin "$TITLE (xml)"
+
+	api_request $ENDPOINT $DIR/curl.out
+
+	assert_xml_valid $DIR/curl.out
+
+	test_succeed
+
+}
+
+test_execution_notfound_json(){
+
+	ENDPOINT="$APIURL/execution/$execid/state"
+	ACCEPT=application/json
+	EXPECT_STATUS=404
+
+	test_begin "$TITLE (json)"
+
+	api_request $ENDPOINT $DIR/curl.out
+
+	assert_json_value "api.error.item.doesnotexist" ".errorCode" $DIR/curl.out
+
+	test_succeed
+}
+
+main(){
+	test_execution_notfound_xml
+	test_execution_notfound_json
+}
+main


### PR DESCRIPTION
API Execution endpoints for missing ID should respond with 404 correctly, for #1611 