### PR TITLE
Enhance project archive API: select only a set of executions for output

### DIFF
--- a/docs/en/api/rundeck-api.md
+++ b/docs/en/api/rundeck-api.md
@@ -3376,6 +3376,25 @@ Export a zip archive of the project.  Requires `export` authorization for the pr
 
 Response content type is `application/zip`
 
+Optional parameters:
+
+* `executionIds` a list (comma-separated) of execution IDs.  If this is specified then the archive will
+contain *only* executions that are specified, and will not contain Jobs, ACLs, or project configuration/readme files.
+    * optionally use `POST` method with with `application/x-www-form-urlencoded` content for large lists of execution IDs
+    * optionally, specify `executionIds` multiple times, with a single ID per entry.
+
+GET Examples:
+
+    GET /api/11/project/AlphaProject/export?executionIds=1,4,9
+    GET /api/11/project/AlphaProject/export?executionIds=1&executionIds=4&executionIds=9
+
+Post:
+
+    POST /api/11/project/AlphaProject/export
+    Content-Type: application/x-www-form-urlencoded
+
+    executionIds=1&executionIds=4&executionIds=9&...
+
 ### Project Archive Import ###
 
 **Request:** 

--- a/rundeckapp/test/unit/rundeck/controllers/ProjectControllerTest.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ProjectControllerTest.groovy
@@ -1585,7 +1585,7 @@ class ProjectControllerTest {
         controller.apiService.messageSource = mockWith(MessageSource) { getMessage { code, args, locale -> code } }
         controller.frameworkService = mockFrameworkServiceForProjectExport(true, true, 'export',true,true)
         controller.projectService=mockWith(ProjectService){
-            exportProjectToOutputStream{project,fwk,stream,l,aclperms->
+            exportProjectToOutputStream{project,fwk,stream,l,aclperms,opts->
                 assertEquals 'test1',project.name
                 assertTrue aclperms
                 stream<<'some data'
@@ -1605,7 +1605,7 @@ class ProjectControllerTest {
         controller.apiService.messageSource = mockWith(MessageSource) { getMessage { code, args, locale -> code } }
         controller.frameworkService = mockFrameworkServiceForProjectExport(true, true, 'export',true,false)
         controller.projectService=mockWith(ProjectService){
-            exportProjectToOutputStream{project,fwk,stream,l,aclperms->
+            exportProjectToOutputStream{project,fwk,stream,l,aclperms,opts->
                 assertEquals 'test1',project.name
                 assertFalse aclperms
                 stream<<'some data'

--- a/rundeckapp/test/unit/rundeck/services/ArchiveOptionsSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ArchiveOptionsSpec.groovy
@@ -1,0 +1,25 @@
+package rundeck.services
+
+import spock.lang.Specification
+
+/**
+ * Created by greg on 1/11/16.
+ */
+class ArchiveOptionsSpec extends Specification {
+    def "parseExecutionsIds single string"() {
+        given:
+        def opts = new ArchiveOptions()
+        when:
+        opts.parseExecutionsIds('123,456')
+        then:
+        opts.executionIds == ['123', '456'] as Set
+    }
+    def "parseExecutionsIds string list"() {
+        given:
+        def opts = new ArchiveOptions()
+        when:
+        opts.parseExecutionsIds(['123','456'])
+        then:
+        opts.executionIds == ['123', '456'] as Set
+    }
+}

--- a/test/api/include.sh
+++ b/test/api/include.sh
@@ -63,13 +63,13 @@ if [ -n "$DEBUG" ] ; then
 fi
 CURL="curl $CURLOPTS"
 docurl(){
-    if [ -n "$RDAUTH" ] ; then
-        if [ "true" == "$RDDEBUG" ] ; then
-            echo $CURL -H "$AUTHHEADER" "$@" 1>&2
+    if [ -n "${RDAUTH:-}" ] ; then
+        if [ "true" == "${RDDEBUG:-}" ] ; then
+            echo $CURL -H "${AUTHHEADER:-}" "$@" 1>&2
         fi
-        $CURL -H "$AUTHHEADER" "$@"
+        $CURL -H "${AUTHHEADER:-}" "$@"
     else    
-        if [ "true" == "$RDDEBUG" ] ; then
+        if [ "true" == "${RDDEBUG:-}" ] ; then
             echo $CURL "$@" 1>&2
         fi
         $CURL "$@"
@@ -91,19 +91,19 @@ api_request(){
     local ENDPOINT=$1
     local FILE=$2
     local H_ACCEPT=
-    if [ -n "$ACCEPT" ] ; then
+    if [ -n "${ACCEPT:-}" ] ; then
         H_ACCEPT="-H accept:$ACCEPT"
     fi
     local H_REQUEST_TYPE=
-    if [ -n "$TYPE" ] ; then
+    if [ -n "${TYPE:-}" ] ; then
         H_REQUEST_TYPE="-H content-type:$TYPE"
     fi
     local H_METHOD="-X GET"
-    if [ -n "$METHOD" ] ; then
+    if [ -n "${METHOD:-}" ] ; then
         H_METHOD="-X $METHOD"
     fi
     local H_UPLOAD=
-    if [ -n "$POSTFILE" ] ; then
+    if [ -n "${POSTFILE:-}" ] ; then
         H_UPLOAD="--data-binary @$POSTFILE"
         if [ -n "$DEBUG" ] ; then
             1>&2 echo "POSTFILE=$POSTFILE" 
@@ -113,11 +113,11 @@ api_request(){
         fi
     fi
     # get listing
-    docurl -D $DIR/headers.out $H_METHOD $H_UPLOAD $H_ACCEPT $H_REQUEST_TYPE ${ENDPOINT}?${PARAMS} > $FILE
+    docurl -D $DIR/headers.out $H_METHOD $H_UPLOAD $H_ACCEPT $H_REQUEST_TYPE ${ENDPOINT}?${PARAMS:-} > $FILE
     if [ 0 != $? ] ; then
         fail "ERROR: failed query request"
     fi
-    if [ -n "$DEBUG" ] ; then
+    if [ -n "${DEBUG:-}" ] ; then
             1>&2 echo "FILE=$FILE" 
             1>&2 echo "<<<<"
             1>&2 cat $FILE

--- a/test/api/test-project-export-executions.sh
+++ b/test/api/test-project-export-executions.sh
@@ -1,0 +1,247 @@
+#!/bin/bash
+
+
+#export API_XML_NO_WRAPPER=true
+
+DIR=$(cd `dirname $0` && pwd)
+source $DIR/include.sh
+
+set -euo pipefail
+
+#set -x
+
+create_project(){
+  local test_proj="$1"
+  # now submit req
+  local runurl="${APIURL}/projects"
+  local params=""
+
+  
+  
+  cat > $DIR/proj_create.post <<END
+  <project>
+      <name>$test_proj</name>
+      <description>test1</description>
+      
+  </project>
+END
+
+  # post
+  docurl -X POST -D $DIR/headers.out --data-binary @$DIR/proj_create.post -H Content-Type:application/xml ${runurl}?${params} > $DIR/curl.out
+  if [ 0 != $? ] ; then
+      errorMsg "ERROR: failed POST request"
+      exit 2
+  fi
+  assert_http_status 201 $DIR/headers.out
+}
+
+delete_project(){
+  local test_proj=$1;shift
+
+  # now delete the test project
+
+  runurl="${APIURL}/project/$test_proj"
+  docurl -X DELETE  ${runurl} > $DIR/curl.out
+  if [ 0 != $? ] ; then
+      errorMsg "ERROR: failed DELETE request"
+      exit 2
+  fi
+
+}
+
+
+uploadJob(){
+    local test_proj=$1;shift
+    local file=$1;shift
+
+    # now submit req
+    runurl="${APIURL}/project/$test_proj/jobs/import"
+
+    params="dupeOption=update"
+
+    # specify the file for upload with curl, named "xmlBatch"
+    ulopts="-F xmlBatch=@$file"
+
+    # get listing
+    docurl $ulopts  ${runurl}?${params} > $DIR/curl.out
+    if [ 0 != $? ] ; then
+        errorMsg "ERROR: failed query request"
+        exit 2
+    fi
+
+    $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
+
+    #result will contain list of failed and succeeded jobs, in this
+    #case there should only be 1 failed or 1 succeeded since we submit only 1
+
+    succount=$($XMLSTARLET sel -T -t -v "/result/succeeded/@count" $DIR/curl.out)
+    jobid=$($XMLSTARLET sel -T -t -v "/result/succeeded/job/id" $DIR/curl.out)
+
+    if [ "1" != "$succount" -o "" == "$jobid" ] ; then
+        $XMLSTARLET sel -T -t -v "//failed" $DIR/curl.out 1>&2
+        fail  "Expected 1 successful job upload, but it was not successful." 
+    fi
+
+    echo $jobid
+}
+
+
+runJob(){
+    local jobid=$1;shift
+    # now run the job
+    runurl="${APIURL}/job/${jobid}/run"
+    params=""
+    execargs="-opt2 a"
+
+    # get listing
+    docurl --data-urlencode "argString=${execargs}" ${runurl}?${params} > $DIR/curl.out || fail "failed request: ${runurl}"
+
+    $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
+
+    #get execid
+
+    execcount=$($XMLSTARLET sel -T -t -v "/result/executions/@count" $DIR/curl.out)
+    execid=$($XMLSTARLET sel -T -t -v "/result/executions/execution/@id" $DIR/curl.out)
+
+    if [ "1" != "${execcount}" -o "" == "${execid}" ] ; then
+        errorMsg "FAIL: expected run success message for execution id. (count: ${execcount}, id: ${execid})"
+        exit 2
+    fi
+    echo $execid
+}
+
+get_archive(){
+  local test_proj=$1;shift
+  local archive_file=$1;shift
+  local PARAMS=$1;shift
+  runurl="${APIURL}/project/$test_proj/export"
+
+  
+  ENDPOINT="${APIURL}/project/$test_proj/export"
+  
+
+  docurl -D $DIR/headers.out -o $archive_file  ${ENDPOINT}?${PARAMS:-} > $DIR/curl.out
+  if [ 0 != $? ] ; then
+      errorMsg "ERROR: failed query request"
+      exit 2
+  fi
+  assert_http_status 200 $DIR/headers.out
+
+  if [ ! -f $archive_file ] ; then
+      errorMsg "ERROR: output file does not exist"
+      exit 2
+  fi
+  file $archive_file | egrep -q 'archive data'
+  if [ $? != 0 ] ; then
+      file $archive_file 1>&2
+      errorMsg "Expected 'archive data' file contents"
+      exit 2
+  fi
+
+}
+assert_archive_contents(){
+  local archive_file=$1;shift
+  local count=$1;shift
+  local elist=$1;shift
+  local EID=
+  unzip -l $archive_file > $DIR/archive_list.output
+  for EID in $elist ; do
+    cat $DIR/archive_list.output | grep -q "executions/execution-$EID.xml" || fail "Archive missing expected file: execution-$EID.xml"
+    cat $DIR/archive_list.output | grep -q "executions/output-$EID.rdlog" || fail "Archive missing expected file: output-$EID.rdlog"
+    cat $DIR/archive_list.output | grep -q "executions/state-$EID.state.json" || fail "Archive missing expected file: state-$EID.state.json"
+  done
+  
+  local repcount=$(cat $DIR/archive_list.output | grep -e 'reports/report-.*.xml' | wc -l | cut -d' ' -f8)
+  if [ "$repcount" != "$count" ] ; then
+    fail "report xml expected $count files"
+  fi
+
+  local exmlcount=$(cat $DIR/archive_list.output | grep -e 'executions/execution-.*.xml' | wc -l | cut -d' ' -f8)
+  if [ "$exmlcount" != "$count" ] ; then
+    fail "execution xml expected $count files"
+  fi
+
+  # require project.properties not present
+  set +e
+  cat $DIR/archive_list.output | grep -q "files/etc/project.properties" && fail "Unexpected archive contents: files/etc/project.properties"
+  set -e
+}
+
+
+test_archive_executions(){
+  local test_proj=$1;shift
+
+  #produce job.xml content corresponding to the dispatch request
+  cat > $DIR/temp.out <<END
+  <joblist>
+     <job>
+        <name>cli job</name>
+        <group>api-test</group>
+        <description></description>
+        <loglevel>INFO</loglevel>
+        <dispatch>
+          <threadcount>1</threadcount>
+          <keepgoing>true</keepgoing>
+        </dispatch>
+        <sequence>
+          <command>
+          <exec>echo hi</exec>
+          </command>
+        </sequence>
+     </job>
+  </joblist>
+
+END
+  
+  JOBID=$(uploadJob "$test_proj" "$DIR/temp.out")
+
+  #run job to completion twice
+  EXECID=$(runJob $JOBID)
+  rd-queue follow -q -e $EXECID || fail "rd-queue failed to wait for job completion $EXECID"
+
+
+  #run job to completion twice
+  EXECID2=$(runJob $JOBID)
+  rd-queue follow -q -e $EXECID2 || fail "rd-queue failed to wait for job completion $EXECID2"
+  
+  echo "TEST: Export specifying executions, 2"
+  
+  get_archive $test_proj $DIR/test_archive.zip "executionIds=$EXECID,$EXECID2"
+
+  #Archive contents
+  assert_archive_contents "$DIR/test_archive.zip" "2" "$EXECID $EXECID2"
+  
+  echo "OK"
+  
+  echo "TEST: Export specifying executions, 1"
+  
+  get_archive $test_proj $DIR/test_archive.zip "executionIds=$EXECID"
+
+  #Archive contents
+  assert_archive_contents "$DIR/test_archive.zip" "1" "$EXECID"
+  
+  echo "OK"
+
+  echo "TEST: Export specifying executions, 1"
+  
+  get_archive $test_proj $DIR/test_archive.zip "executionIds=$EXECID2"
+
+  #Archive contents
+  assert_archive_contents "$DIR/test_archive.zip" "1" "$EXECID2"
+  
+  echo "OK"
+}
+
+
+main(){
+  create_project "Test_projectExportExecutions1"
+  test_archive_executions "Test_projectExportExecutions1"
+  delete_project "Test_projectExportExecutions1"
+}
+
+
+main
+
+rm $DIR/proj_create.post
+rm $DIR/curl.out
+rm $DIR/test_archive.zip


### PR DESCRIPTION
add `executionIds` parameter to the /project/export API:

* a list of execution IDs to include in the archive

If `executionIds` is specified, the archive only contains the execution definitions specified, an other archive contents, such as Jobs, ACLs, configuration, etc.

Future enhancement: more extensive selection of archive contents.