### PR TITLE
Feature: Asynchronous nodes cache

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkFactory.java
@@ -217,6 +217,29 @@ public class FrameworkFactory {
     }
 
     /**
+     *
+     * @param projectName
+     * @param baseDir project base directory
+     * @param filesystemFramework
+     * @param properties
+     * @return
+     */
+    public static FrameworkProjectConfig loadFrameworkProjectConfig(
+            final String projectName,
+            final File baseDir,
+            final FilesystemFramework filesystemFramework,
+            final Properties properties
+    )
+    {
+        return FrameworkProjectConfig.create(
+                projectName,
+                FrameworkProject.getProjectPropertyFile(baseDir),
+                properties,
+                filesystemFramework
+        );
+    }
+
+    /**
      * Return true if the config has values for each config
      * @param config config
      * @return true if valid values are found

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProject.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProject.java
@@ -75,8 +75,6 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
 
     private final IFrameworkProjectMgr projectResourceMgr;
 
-    private final File propertyFile;
-
     /**
      * reference to PropertyLookup object providing access to project.properties
      */
@@ -84,11 +82,13 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
     /**
      * Direct projec properties
      */
-    private PropertyLookup projectLookup;
     private FilesystemFramework filesystemFramework;
     private Framework framework;
     private IProjectNodes projectNodes;
     private Authorization projectAuthorization;
+    private IRundeckProjectConfig projectConfig;
+    private IRundeckProjectConfigModifier projectConfigModifier;
+
 
     /**
      * Constructor
@@ -96,32 +96,15 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
      * @param name        Name of the project
      * @param basedir     the base directory for the Depot
      * @param resourceMgr manager
-     */
-    public FrameworkProject(
-            final String name,
-            final File basedir,
-            final FilesystemFramework filesystemFramework,
-            final IFrameworkProjectMgr resourceMgr
-    )
-    {
-
-        this(name, basedir, filesystemFramework, resourceMgr, null);
-    }
-
-    /**
-     * Constructor
-     *
-     * @param name        Name of the project
-     * @param basedir     the base directory for the Depot
-     * @param resourceMgr manager
-     * @param properties  properties
+     * @param projectConfig  config
      */
     public FrameworkProject(
             final String name,
             final File basedir,
             final FilesystemFramework filesystemFramework,
             final IFrameworkProjectMgr resourceMgr,
-            final Properties properties
+            final IRundeckProjectConfig projectConfig,
+            final IRundeckProjectConfigModifier projectConfigModifier
     )
     {
 
@@ -139,138 +122,49 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
             }
         }
 
-        propertyFile = getProjectPropertyFile(getBaseDir());
-        if (!propertyFile.exists()) {
-            generateProjectPropertiesFile(false, properties, true);
-        }
-        loadProperties();
-
-
+        this.projectConfig=projectConfig;
+        this.projectConfigModifier=projectConfigModifier;
         initialize();
     }
 
     /**
      * Get the etc dir from the basedir
      */
-    private static File getProjectEtcDir(File baseDir) {
+    public static File getProjectEtcDir(File baseDir) {
         return new File(baseDir, ETC_DIR_NAME);
     }
 
     /**
      * Get the project property file from the basedir
      */
-    private static File getProjectPropertyFile(File baseDir) {
+    public static File getProjectPropertyFile(File baseDir) {
         return new File(getProjectEtcDir(baseDir), PROP_FILENAME);
     }
 
-    private long propertiesLastReload=0L;
-    private synchronized void checkReloadProperties(){
-        if (needsPropertiesReload()) {
-            loadProperties();
-        }
+    @Override
+    public String getProperty(final String name) {
+        return projectConfig.getProperty(name);
     }
 
-    private boolean needsPropertiesReload() {
-        final File fwkProjectPropertyFile = getFrameworkPropertyFile();
-        final long fwkPropsLastModified = fwkProjectPropertyFile.lastModified();
-        if (propertyFile.exists()) {
-            return propertyFile.lastModified() > propertiesLastReload || fwkPropsLastModified > propertiesLastReload;
-        } else {
-            return fwkPropsLastModified > propertiesLastReload;
-        }
-    }
-    private synchronized void loadProperties() {
-        //generic framework properties for a project
-        final File fwkProjectPropertyFile = getFrameworkPropertyFile();
-
-        lookup = createProjectPropertyLookup(
-                filesystemFramework,
-                getName()
-        );
-        projectLookup = createDirectProjectPropertyLookup(
-                filesystemFramework,
-                getName()
-        );
-
-        if (propertyFile.exists()) {
-            getLogger().debug("loading existing project.properties: " + propertyFile.getAbsolutePath());
-            final long fwkPropsLastModified = fwkProjectPropertyFile.lastModified();
-            final long propsLastMod = propertyFile.lastModified();
-            propertiesLastReload = propsLastMod > fwkPropsLastModified ? propsLastMod : fwkPropsLastModified;
-        } else {
-            getLogger().debug("loading instance-level project.properties: " + propertyFile.getAbsolutePath());
-            propertiesLastReload = fwkProjectPropertyFile.lastModified();
-        }
+    @Override
+    public boolean hasProperty(final String key) {
+        return projectConfig.hasProperty(key);
     }
 
-    private File getFrameworkPropertyFile() {
-        return new File(
-                    filesystemFramework.getConfigDir(),
-                    PROP_FILENAME
-            );
+    @Override
+    public Map<String, String> getProperties() {
+        return projectConfig.getProperties();
     }
 
-    /**
-     * Create PropertyLookup for a project from the framework basedir
-     *
-     * @param filesystemFramework the filesystem
-     */
-    private static PropertyLookup createProjectPropertyLookup(FilesystemFramework filesystemFramework, String projectName) {
-        PropertyLookup lookup;
-        final Properties ownProps = new Properties();
-        ownProps.setProperty("project.name", projectName);
-
-        File baseDir=filesystemFramework.getBaseDir();
-        File projectsBaseDir=filesystemFramework.getFrameworkProjectsBaseDir();
-        //generic framework properties for a project
-        final File fwkProjectPropertyFile = FilesystemFramework.getPropertyFile(filesystemFramework.getConfigDir());
-        final Properties nodeWideDepotProps = PropertyLookup.fetchProperties(fwkProjectPropertyFile);
-        nodeWideDepotProps.putAll(ownProps);
-
-        final File propertyFile = getProjectPropertyFile(new File(projectsBaseDir, projectName));
-
-        if (propertyFile.exists()) {
-            lookup = PropertyLookup.create(propertyFile,
-                    nodeWideDepotProps, FilesystemFramework.createPropertyLookupFromBasedir(baseDir));
-        } else {
-            lookup = PropertyLookup.create(fwkProjectPropertyFile,
-                    ownProps, FilesystemFramework.createPropertyLookupFromBasedir(baseDir));
-        }
-        lookup.expand();
-        return lookup;
-    }
-    /**
-     * Create PropertyLookup for a project from the framework basedir
-     *
-     * @param filesystemFramework the filesystem
-     */
-    private static PropertyLookup createDirectProjectPropertyLookup(FilesystemFramework filesystemFramework, String projectName) {
-        PropertyLookup lookup;
-        final Properties ownProps = new Properties();
-        ownProps.setProperty("project.name", projectName);
-
-        File projectsBaseDir=filesystemFramework.getFrameworkProjectsBaseDir();
-        //generic framework properties for a project
-
-        final File propertyFile = getProjectPropertyFile(new File(projectsBaseDir, projectName));
-        final Properties projectProps = PropertyLookup.fetchProperties(propertyFile);
-
-        lookup = PropertyLookup.create(projectProps, PropertyLookup.create(ownProps));
-        lookup.expand();
-        return lookup;
+    @Override
+    public Map<String, String> getProjectProperties() {
+        return projectConfig.getProjectProperties();
     }
 
-    /**
-     * @return Create a property retriever for a project given the framework basedir
-     *
-     * @param filesystemFramework filesystem
-     * @param projectName name of project
-     */
-    public static PropertyRetriever createProjectPropertyRetriever(FilesystemFramework filesystemFramework, String projectName) {
-        return createProjectPropertyLookup(filesystemFramework, projectName).safe();
+    @Override
+    public Date getConfigLastModifiedTime() {
+        return projectConfig.getConfigLastModifiedTime();
     }
-
-
 
     /**
      * list the configurations of resource model providers.
@@ -348,9 +242,6 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
     }
 
 
-    public File getPropertyFile() {
-        return propertyFile;
-    }
 
     public IFrameworkProjectMgr getFrameworkProjectMgr() {
         return projectResourceMgr;
@@ -429,42 +320,6 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
        projectNodes.updateNodesResourceFile(nodeset,ProjectNodeSupport.getNodesResourceFilePath(this, framework));
     }
 
-
-
-    /**
-     * @return the property value by name
-     * @param name property name
-     */
-    @Override
-    public synchronized String getProperty(final String name) {
-        checkReloadProperties();
-        return lookup.getProperty(name);
-    }
-
-
-    @Override
-    public synchronized boolean hasProperty(final String key) {
-        checkReloadProperties();
-        return lookup.hasProperty(key);
-    }
-    @Override
-    public Map<String,String> getProperties() {
-        return lookup.getPropertiesMap();
-    }
-
-    @Override
-    public Map<String,String> getProjectProperties() {
-        return projectLookup.getPropertiesMap();
-    }
-
-
-    /**
-     * @return a PropertyRetriever interface for project-scoped properties
-     */
-    public synchronized PropertyRetriever getPropertyRetriever() {
-        checkReloadProperties();
-        return lookup.safe();
-    }
 
 
    /**
@@ -546,117 +401,8 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
         }
     }
 
-    /**
-     * Create project.properties file based on $RDECK_BASE/etc/project.properties
-     * @param overwrite Overwrite existing properties file
-     */
-    protected void generateProjectPropertiesFile(final boolean overwrite) {
-        generateProjectPropertiesFile(overwrite, null, false);
-    }
-
-    /**
-     * Create project.properties file based on $RDECK_BASE/etc/project.properties
-     *
-     * @param overwrite Overwrite existing properties file
-     * @param properties properties
-     * @param addDefaultProps true to add default properties
-     */
-    protected void generateProjectPropertiesFile(final boolean overwrite, final Properties properties, boolean
-            addDefaultProps) {
-        generateProjectPropertiesFile(overwrite, properties, false, null, addDefaultProps);
-    }
-
-    /**
-     * Create project.properties file based on $RDECK_BASE/etc/project.properties
-     *
-     * @param overwrite Overwrite existing properties file
-     * @param properties properties to use
-     * @param merge if true, merge existing properties that are not replaced
-     * @param removePrefixes set of property prefixes to remove from original
-     * @param addDefaultProps true to add default properties
-     */
-    protected void generateProjectPropertiesFile(final boolean overwrite, final Properties properties,
-            final boolean merge, final Set<String> removePrefixes, boolean addDefaultProps) {
-        final File destfile = getPropertyFile();
-        if (destfile.exists() && !overwrite) {
-            return;
-        }
-        final Properties newProps = new Properties();
-        newProps.setProperty("project.name", getName());
-
-        //TODO: improve default configuration generation
-        if(addDefaultProps){
-            if (null == properties || !properties.containsKey("resources.source.1.type") ) {
-                //add default file source
-                newProps.setProperty("resources.source.1.type", "file");
-                newProps.setProperty("resources.source.1.config.file", new File(getEtcDir(), "resources.xml").getAbsolutePath());
-                newProps.setProperty("resources.source.1.config.includeServerNode", "true");
-                newProps.setProperty("resources.source.1.config.generateFileAutomatically", "true");
-            }
-            if(null==properties || !properties.containsKey("service.NodeExecutor.default.provider")) {
-                newProps.setProperty("service.NodeExecutor.default.provider", "jsch-ssh");
-            }
-            if(null==properties || !properties.containsKey("service.FileCopier.default.provider")) {
-                newProps.setProperty("service.FileCopier.default.provider", "jsch-scp");
-            }
-            if (null == properties || !properties.containsKey("project.ssh-keypath")) {
-                newProps.setProperty("project.ssh-keypath", new File(System.getProperty("user.home"),
-                        ".ssh/id_rsa").getAbsolutePath());
-            }
-            if(null==properties || !properties.containsKey("project.ssh-authentication")) {
-                newProps.setProperty("project.ssh-authentication", "privateKey");
-            }
-        }
-        if(merge) {
-            final Properties orig = new Properties();
-
-            if(destfile.exists()){
-                try {
-                    final FileInputStream fileInputStream = new FileInputStream(destfile);
-                    try {
-                        orig.load(fileInputStream);
-                    } finally {
-                        fileInputStream.close();
-                    }
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-            //add all original properties that are not in the incoming  properties, and are not
-            //matched by one of the remove prefixes
-            entry: for (final Object o : orig.entrySet()) {
-                Map.Entry entry=(Map.Entry) o;
-                //determine if
-                final String key = (String) entry.getKey();
-                if (null != removePrefixes) {
-                    for (final String replacePrefix : removePrefixes) {
-                        if (key.startsWith(replacePrefix)) {
-                            //skip this key
-                            continue entry;
-                        }
-                    }
-                }
-                newProps.put(entry.getKey(), entry.getValue());
-            }
-        }
-        //overwrite original with the input properties
-        if (null != properties) {
-            newProps.putAll(properties);
-        }
-
-        try {
-            final FileOutputStream fileOutputStream = new FileOutputStream(destfile);
-            try {
-                newProps.store(fileOutputStream, "Project " + getName() + " configuration, generated");
-            } finally {
-                fileOutputStream.close();
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
-        loadProperties();
-        getLogger().debug("generated project.properties: " + destfile.getAbsolutePath());
+    protected void generateProjectPropertiesFile(boolean overwrite, Properties properties, boolean addDefault){
+        projectConfigModifier.generateProjectPropertiesFile(overwrite, properties, addDefault);
     }
     /**
      * Update the project properties file by setting updating the given properties, and removing
@@ -666,7 +412,7 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
      */
     @Override
     public void mergeProjectProperties(final Properties properties, final Set<String> removePrefixes) {
-        generateProjectPropertiesFile(true, properties, true, removePrefixes, false);
+        projectConfigModifier.mergeProjectProperties(properties, removePrefixes);
     }
     /**
      * Set the project properties file contents exactly
@@ -674,13 +420,9 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
      */
     @Override
     public void setProjectProperties(final Properties properties) {
-        generateProjectPropertiesFile(true, properties, false, null, false);
+        projectConfigModifier.setProjectProperties(properties);
     }
 
-    @Override
-    public Date getConfigLastModifiedTime() {
-        return new Date(getPropertyFile().lastModified());
-    }
 
     /**
      * Checks if project is installed by checking if it's basedir directory exists.

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProject.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProject.java
@@ -84,7 +84,7 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
      */
     private FilesystemFramework filesystemFramework;
     private Framework framework;
-    private IProjectNodes projectNodes;
+    private IProjectNodesFactory projectNodesFactory;
     private Authorization projectAuthorization;
     private IRundeckProjectConfig projectConfig;
     private IRundeckProjectConfigModifier projectConfigModifier;
@@ -176,33 +176,53 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
      */
     @Override
     public synchronized List<Map<String, Object>> listResourceModelConfigurations(){
-        return projectNodes.listResourceModelConfigurations();
+        return getProjectNodes().listResourceModelConfigurations();
     }
 
     /**
-     * @return Create a new Project object at the specified projects.directory
-     * @param name project name
+     * @param name        project name
      * @param projectsDir projects dir
      * @param resourceMgr resourcemanager
+     *
+     * @return Create a new Project object at the specified projects.directory
      */
-    public static FrameworkProject create(final String name, final File projectsDir,final FilesystemFramework filesystemFramework, final IFrameworkProjectMgr resourceMgr) {
-        return FrameworkFactory.createFrameworkProject(name,new File(projectsDir, name),filesystemFramework,resourceMgr,null);
+    public static FrameworkProject create(
+            final String name,
+            final File projectsDir,
+            final FilesystemFramework filesystemFramework,
+            final IFrameworkProjectMgr resourceMgr,
+            IProjectNodesFactory nodesFactory
+    )
+    {
+        return FrameworkFactory.createFrameworkProject(name,
+                                                       new File(projectsDir, name),
+                                                       filesystemFramework,
+                                                       resourceMgr,
+                                                       nodesFactory,
+                                                       null);
     }
+
     /**
-     * @return Create a new Project object at the specified projects.directory
-     * @param name project name
+     * @param name        project name
      * @param projectsDir projects dir
      * @param resourceMgr resourcemanager
-     * @param properties project properties
+     *
+     * @return Create a new Project object at the specified projects.directory
      */
-    public static FrameworkProject create(final String name, final File projectsDir,final FilesystemFramework filesystemFramework, final IFrameworkProjectMgr resourceMgr, final Properties properties) {
-
+    public static FrameworkProject create(
+            final String name,
+            final File projectsDir,
+            final FilesystemFramework filesystemFramework,
+            final IFrameworkProjectMgr resourceMgr
+    )
+    {
         return FrameworkFactory.createFrameworkProject(
                 name,
                 new File(projectsDir, name),
                 filesystemFramework,
                 resourceMgr,
-                properties
+                FrameworkFactory.createNodesFactory(filesystemFramework),
+                null
         );
     }
 
@@ -268,7 +288,7 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
      */
     @Override
     public INodeSet getNodeSet() throws NodeFileParserException {
-        return projectNodes.getNodeSet();
+        return getProjectNodes().getNodeSet();
     }
 
     /**
@@ -281,7 +301,7 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
      */
     @Override
     public boolean updateNodesResourceFile() throws UpdateUtils.UpdateException {
-        return projectNodes.updateNodesResourceFile(ProjectNodeSupport.getNodesResourceFilePath(this, framework));
+        return getProjectNodes().updateNodesResourceFile(ProjectNodeSupport.getNodesResourceFilePath(this, framework));
     }
 
     /**
@@ -298,7 +318,7 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
             final String password
     ) throws UpdateUtils.UpdateException
     {
-        projectNodes.updateNodesResourceFileFromUrl(
+        getProjectNodes().updateNodesResourceFileFromUrl(
                 providerURL,
                 username,
                 password,
@@ -317,7 +337,7 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
      */
     @Override
     public void updateNodesResourceFile(final INodeSet nodeset) throws UpdateUtils.UpdateException {
-       projectNodes.updateNodesResourceFile(nodeset,ProjectNodeSupport.getNodesResourceFilePath(this, framework));
+       getProjectNodes().updateNodesResourceFile(nodeset,ProjectNodeSupport.getNodesResourceFilePath(this, framework));
     }
 
 
@@ -437,7 +457,7 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
      * @return the set of exceptions produced by the last attempt to invoke all node providers
      */
     public ArrayList<Exception> getResourceModelSourceExceptions() {
-        return projectNodes.getResourceModelSourceExceptions();
+        return getProjectNodes().getResourceModelSourceExceptions();
     }
 
     public Framework getFramework() {
@@ -448,13 +468,10 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
         this.framework = framework;
     }
 
+
     @Override
     public IProjectNodes getProjectNodes() {
-        return projectNodes;
-    }
-
-    public void setProjectNodes(final IProjectNodes projectNodes) {
-        this.projectNodes = projectNodes;
+        return projectNodesFactory.getNodes(getName());
     }
 
     @Override
@@ -464,5 +481,9 @@ public class FrameworkProject extends FrameworkResourceParent implements IRundec
 
     public void setProjectAuthorization(Authorization projectAuthorization) {
         this.projectAuthorization = projectAuthorization;
+    }
+
+    public void setProjectNodesFactory(IProjectNodesFactory projectNodesFactory) {
+        this.projectNodesFactory = projectNodesFactory;
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProjectConfig.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProjectConfig.java
@@ -1,0 +1,414 @@
+package com.dtolabs.rundeck.core.common;
+
+import com.dtolabs.rundeck.core.utils.PropertyLookup;
+import org.apache.log4j.Logger;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Date;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Config interface
+ */
+public class FrameworkProjectConfig implements IRundeckProjectConfig, IRundeckProjectConfigModifier {
+    public static final String PROP_FILENAME = "project.properties";
+    public static final String ETC_DIR_NAME = "etc";
+    public static final Logger logger = Logger.getLogger(FrameworkProjectConfig.class);
+    private String name;
+    /**
+     * reference to PropertyLookup object providing access to project.properties
+     */
+    private PropertyLookup lookup;
+    /**
+     * Direct projec properties
+     */
+    private PropertyLookup projectLookup;
+    private File propertyFile;
+    private FilesystemFramework filesystemFramework;
+
+    private long propertiesLastReload = 0L;
+
+    public FrameworkProjectConfig(
+            final String name,
+            final File propertyFile,
+            final FilesystemFramework filesystemFramework
+    )
+    {
+        this.name = name;
+        this.propertyFile = propertyFile;
+        this.filesystemFramework = filesystemFramework;
+        loadProperties();
+    }
+
+    /**
+     * Create from existing file
+     * @param name
+     * @param propertyFile
+     * @param filesystemFramework
+     * @return
+     */
+    public static FrameworkProjectConfig create(
+            final String name,
+            final File propertyFile,
+            final FilesystemFramework filesystemFramework
+    )
+    {
+        return new FrameworkProjectConfig(name, propertyFile, filesystemFramework);
+    }
+
+    /**
+     * Create and generate file with the given properties if not null
+     * @param name
+     * @param propertyFile
+     * @param properties
+     * @param filesystemFramework
+     * @return
+     */
+    public static FrameworkProjectConfig create(
+            final String name,
+            final File propertyFile,
+            final Properties properties,
+            final FilesystemFramework filesystemFramework
+    )
+    {
+
+        if (!propertyFile.exists() ) {
+            generateProjectPropertiesFile(name, propertyFile, false, properties, true);
+        }
+        return create(name, propertyFile, filesystemFramework);
+    }
+
+    /**
+     * Create project.properties file based on $RDECK_BASE/etc/project.properties
+     *
+     * @param overwrite       Overwrite existing properties file
+     * @param properties      properties
+     * @param addDefaultProps true to add default properties
+     */
+    static void generateProjectPropertiesFile(
+            final String name,
+            final File destfile,
+            final boolean overwrite,
+            final Properties properties,
+            boolean addDefaultProps
+    )
+    {
+
+        generateProjectPropertiesFile(name, destfile, overwrite, properties, false, null, addDefaultProps);
+    }
+
+    /**
+     * Update the project properties file by setting updating the given properties, and removing
+     * any properties that have a prefix in the removePrefixes set
+     *
+     * @param properties     new properties to put in the file
+     * @param removePrefixes prefixes of properties to remove from the file
+     */
+    public void mergeProjectProperties(final Properties properties, final Set<String> removePrefixes) {
+        generateProjectPropertiesFile(getName(), propertyFile, true, properties, true, removePrefixes, false);
+        loadProperties();
+    }
+
+    /**
+     * Set the project properties file contents exactly
+     *
+     * @param properties new properties to use in the file
+     */
+    public void setProjectProperties(final Properties properties) {
+        generateProjectPropertiesFile(getName(), propertyFile, true, properties, false, null, false);
+        loadProperties();
+    }
+
+    @Override
+    public void generateProjectPropertiesFile(boolean overwrite, Properties properties, boolean addDefault){
+        generateProjectPropertiesFile(getName(), propertyFile, overwrite, properties, false, null, addDefault);
+        loadProperties();
+    }
+    /**
+     * Create project.properties file based on $RDECK_BASE/etc/project.properties
+     *
+     * @param overwrite       Overwrite existing properties file
+     * @param properties      properties to use
+     * @param merge           if true, merge existing properties that are not replaced
+     * @param removePrefixes  set of property prefixes to remove from original
+     * @param addDefaultProps true to add default properties
+     */
+    static void generateProjectPropertiesFile(
+            final String name,
+            final File destfile,
+            final boolean overwrite,
+            final Properties properties,
+            final boolean merge,
+            final Set<String> removePrefixes,
+            boolean addDefaultProps
+    )
+    {
+        if (destfile.exists() && !overwrite) {
+            return;
+        }
+        final Properties newProps = new Properties();
+        newProps.setProperty("project.name", name);
+
+        //TODO: improve default configuration generation
+        if (addDefaultProps) {
+            if (null == properties || !properties.containsKey("resources.source.1.type")) {
+                //add default file source
+                newProps.setProperty("resources.source.1.type", "file");
+                newProps.setProperty(
+                        "resources.source.1.config.file",
+                        new File(destfile.getParentFile(), "resources.xml").getAbsolutePath()
+                );
+                newProps.setProperty("resources.source.1.config.includeServerNode", "true");
+                newProps.setProperty("resources.source.1.config.generateFileAutomatically", "true");
+            }
+            if (null == properties || !properties.containsKey("service.NodeExecutor.default.provider")) {
+                newProps.setProperty("service.NodeExecutor.default.provider", "jsch-ssh");
+            }
+            if (null == properties || !properties.containsKey("service.FileCopier.default.provider")) {
+                newProps.setProperty("service.FileCopier.default.provider", "jsch-scp");
+            }
+            if (null == properties || !properties.containsKey("project.ssh-keypath")) {
+                newProps.setProperty("project.ssh-keypath", new File(
+                        System.getProperty("user.home"),
+                        ".ssh/id_rsa"
+                ).getAbsolutePath());
+            }
+            if (null == properties || !properties.containsKey("project.ssh-authentication")) {
+                newProps.setProperty("project.ssh-authentication", "privateKey");
+            }
+        }
+        if (merge) {
+            final Properties orig = new Properties();
+
+            if (destfile.exists()) {
+                try {
+                    final FileInputStream fileInputStream = new FileInputStream(destfile);
+                    try {
+                        orig.load(fileInputStream);
+                    } finally {
+                        fileInputStream.close();
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            //add all original properties that are not in the incoming  properties, and are not
+            //matched by one of the remove prefixes
+            entry:
+            for (final Object o : orig.entrySet()) {
+                Map.Entry entry = (Map.Entry) o;
+                //determine if
+                final String key = (String) entry.getKey();
+                if (null != removePrefixes) {
+                    for (final String replacePrefix : removePrefixes) {
+                        if (key.startsWith(replacePrefix)) {
+                            //skip this key
+                            continue entry;
+                        }
+                    }
+                }
+                newProps.put(entry.getKey(), entry.getValue());
+            }
+        }
+        //overwrite original with the input properties
+        if (null != properties) {
+            newProps.putAll(properties);
+        }
+
+        try {
+            if(!destfile.getParentFile().exists()){
+                destfile.getParentFile().mkdirs();
+            }
+            final FileOutputStream fileOutputStream = new FileOutputStream(destfile);
+            try {
+                newProps.store(fileOutputStream, "Project " + name + " configuration, generated");
+            } finally {
+                fileOutputStream.close();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        logger.debug("generated project.properties: " + destfile.getAbsolutePath());
+    }
+
+    public File getPropertyFile() {
+        return propertyFile;
+    }
+
+    private synchronized void checkReloadProperties() {
+        if (needsPropertiesReload()) {
+            loadProperties();
+        }
+    }
+
+    private boolean needsPropertiesReload() {
+        final File fwkProjectPropertyFile = getFrameworkPropertyFile();
+        final long fwkPropsLastModified = fwkProjectPropertyFile.lastModified();
+        if (propertyFile.exists()) {
+            return propertyFile.lastModified() > propertiesLastReload || fwkPropsLastModified > propertiesLastReload;
+        } else {
+            return fwkPropsLastModified > propertiesLastReload;
+        }
+    }
+
+    private File getFrameworkPropertyFile() {
+        return new File(
+                filesystemFramework.getConfigDir(),
+                PROP_FILENAME
+        );
+    }
+
+
+    /**
+     * Create PropertyLookup for a project from the framework basedir
+     *
+     * @param filesystemFramework the filesystem
+     */
+    private static PropertyLookup createDirectProjectPropertyLookup(
+            FilesystemFramework filesystemFramework,
+            String projectName
+    )
+    {
+        PropertyLookup lookup;
+        final Properties ownProps = new Properties();
+        ownProps.setProperty("project.name", projectName);
+
+        File projectsBaseDir = filesystemFramework.getFrameworkProjectsBaseDir();
+        //generic framework properties for a project
+
+        final File propertyFile = getProjectPropertyFile(new File(projectsBaseDir, projectName));
+        final Properties projectProps = PropertyLookup.fetchProperties(propertyFile);
+
+        lookup = PropertyLookup.create(projectProps, PropertyLookup.create(ownProps));
+        lookup.expand();
+        return lookup;
+    }
+
+    private synchronized void loadProperties() {
+        //generic framework properties for a project
+        final File fwkProjectPropertyFile = getFrameworkPropertyFile();
+
+        loadProperties(fwkProjectPropertyFile);
+    }
+
+    private synchronized void loadProperties(final File fwkProjectPropertyFile) {
+        //generic framework properties for a project
+        lookup = createProjectPropertyLookup(
+                filesystemFramework,
+                getName()
+        );
+        projectLookup = createDirectProjectPropertyLookup(
+                filesystemFramework,
+                getName()
+        );
+
+        if (propertyFile.exists()) {
+            logger.debug("loading existing project.properties: " + propertyFile.getAbsolutePath());
+            final long fwkPropsLastModified = fwkProjectPropertyFile.lastModified();
+            final long propsLastMod = propertyFile.lastModified();
+            propertiesLastReload = propsLastMod > fwkPropsLastModified ? propsLastMod : fwkPropsLastModified;
+        } else {
+            logger.debug("loading instance-level project.properties: " + propertyFile.getAbsolutePath());
+            propertiesLastReload = fwkProjectPropertyFile.lastModified();
+        }
+    }
+
+
+    @Override
+    public Date getConfigLastModifiedTime() {
+        return new Date(getPropertyFile().lastModified());
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return lookup.getPropertiesMap();
+    }
+
+    @Override
+    public Map<String, String> getProjectProperties() {
+        return projectLookup.getPropertiesMap();
+    }
+
+    /**
+     * @param name property name
+     *
+     * @return the property value by name
+     */
+    @Override
+    public synchronized String getProperty(final String name) {
+        checkReloadProperties();
+        return lookup.getProperty(name);
+    }
+
+
+    /**
+     * Create PropertyLookup for a project from the framework basedir
+     *
+     * @param filesystemFramework the filesystem
+     */
+    private static PropertyLookup createProjectPropertyLookup(
+            FilesystemFramework filesystemFramework,
+            String projectName
+    )
+    {
+        PropertyLookup lookup;
+        final Properties ownProps = new Properties();
+        ownProps.setProperty("project.name", projectName);
+
+        File baseDir = filesystemFramework.getBaseDir();
+        File projectsBaseDir = filesystemFramework.getFrameworkProjectsBaseDir();
+        //generic framework properties for a project
+        final File fwkProjectPropertyFile = FilesystemFramework.getPropertyFile(filesystemFramework.getConfigDir());
+        final Properties nodeWideDepotProps = PropertyLookup.fetchProperties(fwkProjectPropertyFile);
+        nodeWideDepotProps.putAll(ownProps);
+
+        final File propertyFile = getProjectPropertyFile(new File(projectsBaseDir, projectName));
+
+        if (propertyFile.exists()) {
+            lookup = PropertyLookup.create(
+                    propertyFile,
+                    nodeWideDepotProps,
+                    FilesystemFramework.createPropertyLookupFromBasedir(baseDir)
+            );
+        } else {
+            lookup = PropertyLookup.create(fwkProjectPropertyFile,
+                                           ownProps, FilesystemFramework.createPropertyLookupFromBasedir(baseDir)
+            );
+        }
+        lookup.expand();
+        return lookup;
+    }
+
+
+    /**
+     * Get the etc dir from the basedir
+     */
+    private static File getProjectEtcDir(File baseDir) {
+        return new File(baseDir, ETC_DIR_NAME);
+    }
+
+    /**
+     * Get the project property file from the basedir
+     */
+    private static File getProjectPropertyFile(File baseDir) {
+        return new File(getProjectEtcDir(baseDir), PROP_FILENAME);
+    }
+
+
+    @Override
+    public synchronized boolean hasProperty(final String key) {
+        checkReloadProperties();
+        return lookup.hasProperty(key);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProjectMgr.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProjectMgr.java
@@ -160,6 +160,16 @@ public class FrameworkProjectMgr extends FrameworkResourceParent implements IFra
         }
     }
 
+    @Override
+    public IRundeckProjectConfig loadProjectConfig(final String projectName) {
+        return FrameworkFactory.loadFrameworkProjectConfig(
+                projectName,
+                new File(getBaseDir(), projectName),
+                filesystemFramework,
+                null
+        );
+    }
+
     /**
      * @return true if project exists in framework.
      *

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProjectMgr.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProjectMgr.java
@@ -30,22 +30,36 @@ public class FrameworkProjectMgr extends FrameworkResourceParent implements IFra
     public static final Logger log = Logger.getLogger(FrameworkProjectMgr.class);
 
     private final FilesystemFramework filesystemFramework;
-
+    private IProjectNodesFactory nodesFactory;
 
 
     /**
      * Base constructor
      *
-     * @param name       Name of manager. informational purposes
-     * @param baseDir    Basedir where child resources live
-     * @param filesystemFramework  Framework instance
+     * @param name                Name of manager. informational purposes
+     * @param baseDir             Basedir where child resources live
+     * @param filesystemFramework Framework instance
      */
-    FrameworkProjectMgr(final String name, final File baseDir, final FilesystemFramework filesystemFramework) {
+    FrameworkProjectMgr(
+            final String name,
+            final File baseDir,
+            final FilesystemFramework filesystemFramework,
+            final IProjectNodesFactory nodesFactory
+    )
+    {
         super(name, baseDir, null);
         this.filesystemFramework = filesystemFramework;
+        this.nodesFactory=nodesFactory;
     }
-    static FrameworkProjectMgr create(final String name, final File baseDir, final Framework framework) {
-        return FrameworkFactory.createProjectManager(baseDir, framework.getFilesystemFramework());
+
+    static FrameworkProjectMgr create(
+            final String name,
+            final File baseDir,
+            final Framework framework,
+            final IProjectNodesFactory nodesFactory
+    )
+    {
+        return FrameworkFactory.createProjectManager(baseDir, framework.getFilesystemFramework(), nodesFactory);
     }
 
 
@@ -120,6 +134,7 @@ public class FrameworkProjectMgr extends FrameworkResourceParent implements IFra
                     new File(getBaseDir(), projectName),
                     filesystemFramework,
                     this,
+                    nodesFactory,
                     properties
             );
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/IProjectNodesFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/IProjectNodesFactory.java
@@ -1,0 +1,8 @@
+package com.dtolabs.rundeck.core.common;
+
+/**
+ * Construct Project nodes for a project
+ */
+public interface IProjectNodesFactory {
+    IProjectNodes getNodes(final String name);
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/IProjectNodesFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/IProjectNodesFactory.java
@@ -5,4 +5,5 @@ package com.dtolabs.rundeck.core.common;
  */
 public interface IProjectNodesFactory {
     IProjectNodes getNodes(final String name);
+    void refreshProjectNodes(String name);
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/IRundeckProject.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/IRundeckProject.java
@@ -10,7 +10,7 @@ import java.util.*;
 /**
  * Interface for a project
  */
-public interface IRundeckProject {
+public interface IRundeckProject extends IRundeckProjectConfig {
     /**
      * @return project name
      */

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/IRundeckProjectConfig.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/IRundeckProjectConfig.java
@@ -1,0 +1,41 @@
+package com.dtolabs.rundeck.core.common;
+
+import java.util.Date;
+import java.util.Map;
+
+/**
+ * definition of a project's configuration
+ */
+public interface IRundeckProjectConfig {
+    /**
+     * @return project name
+     */
+    public String getName();
+    /**
+     * @param name property name
+     *
+     * @return the property value by name
+     */
+    String getProperty(String name);
+
+    /**
+     *
+     * @param key property name
+     * @return true if present, false otherwise
+     */
+    boolean hasProperty(String key);
+
+    /**
+     * @return the merged properties available for the project
+     */
+    Map<String,String> getProperties();
+
+    /**
+     * @return the direct properties set for the project
+     */
+    Map<String,String> getProjectProperties();
+    /**
+     * @return last modified time for configuration in epoch time
+     */
+    Date getConfigLastModifiedTime();
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/IRundeckProjectConfigModifier.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/IRundeckProjectConfigModifier.java
@@ -1,0 +1,28 @@
+package com.dtolabs.rundeck.core.common;
+
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Created by greg on 2/2/16.
+ */
+public interface IRundeckProjectConfigModifier {
+
+    /**
+     * Update the project properties file by setting updating the given properties, and removing
+     * any properties that have a prefix in the removePrefixes set
+     *
+     * @param properties     new properties to put in the file
+     * @param removePrefixes prefixes of properties to remove from the file
+     */
+    void mergeProjectProperties(Properties properties, Set<String> removePrefixes);
+
+    /**
+     * Set the project properties file contents exactly
+     *
+     * @param properties new properties to use in the file
+     */
+    void setProjectProperties(Properties properties);
+
+    void generateProjectPropertiesFile(boolean overwrite, Properties properties, boolean addDefault);
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/ProjectManager.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/ProjectManager.java
@@ -23,6 +23,8 @@ public interface ProjectManager {
      */
     IRundeckProject getFrameworkProject(String name);
 
+    IRundeckProjectConfig loadProjectConfig(final String project);
+
     /**
      * Checks if project by that name exists
      *

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/ProjectNodeSupport.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/ProjectNodeSupport.java
@@ -31,7 +31,7 @@ public class ProjectNodeSupport implements IProjectNodes {
     public static final String PROJECT_RESOURCES_ALLOWED_URL_PREFIX = "project.resources.allowedURL.";
     public static final String FRAMEWORK_RESOURCES_ALLOWED_URL_PREFIX = "framework.resources.allowedURL.";
 
-    private IRundeckProject project;
+    private IRundeckProjectConfig projectConfig;
     private ArrayList<Exception> nodesSourceExceptions;
     private long nodesSourcesLastReload = -1L;
     private List<ResourceModelSource> nodesSourceList;
@@ -39,12 +39,12 @@ public class ProjectNodeSupport implements IProjectNodes {
     private ResourceModelSourceService resourceModelSourceService;
 
     public ProjectNodeSupport(
-            final IRundeckProject project,
+            final IRundeckProjectConfig projectConfig,
             final ResourceFormatGeneratorService resourceFormatGeneratorService,
             final ResourceModelSourceService resourceModelSourceService
     )
     {
-        this.project = project;
+        this.projectConfig = projectConfig;
         this.resourceFormatGeneratorService = resourceFormatGeneratorService;
         this.resourceModelSourceService = resourceModelSourceService;
     }
@@ -65,8 +65,8 @@ public class ProjectNodeSupport implements IProjectNodes {
      * @return a NodeSetMerge
      */
     private NodeSetMerge getNodeSetMerge() {
-        if (project.hasProperty(PROJECT_RESOURCES_MERGE_NODE_ATTRIBUTES) && "false".equals(
-                project.getProperty
+        if (projectConfig.hasProperty(PROJECT_RESOURCES_MERGE_NODE_ATTRIBUTES) && "false".equals(
+                projectConfig.getProperty
                         (PROJECT_RESOURCES_MERGE_NODE_ATTRIBUTES))) {
             return new AdditiveListNodeSet();
         }
@@ -128,7 +128,7 @@ public class ProjectNodeSupport implements IProjectNodes {
 
     private synchronized Collection<ResourceModelSource> getResourceModelSources() {
         //determine if sources need to be reloaded
-        final long lastMod = project.getConfigLastModifiedTime()!=null?project.getConfigLastModifiedTime().getTime():0;
+        final long lastMod = projectConfig.getConfigLastModifiedTime()!=null? projectConfig.getConfigLastModifiedTime().getTime():0;
         if (lastMod > nodesSourcesLastReload) {
             nodesSourceList = new ArrayList<ResourceModelSource>();
             loadResourceModelSources();
@@ -139,7 +139,7 @@ public class ProjectNodeSupport implements IProjectNodes {
     private void loadResourceModelSources() {
         nodesSourceExceptions = new ArrayList<Exception>();
         //generate Configuration for file source
-        if (project.hasProperty(PROJECT_RESOURCES_FILE_PROPERTY)) {
+        if (projectConfig.hasProperty(PROJECT_RESOURCES_FILE_PROPERTY)) {
             try {
                 final Properties config = createFileSourceConfiguration();
                 logger.info("Source (project.resources.file): loading with properties: " + config);
@@ -149,7 +149,7 @@ public class ProjectNodeSupport implements IProjectNodes {
                 nodesSourceExceptions.add(e);
             }
         }
-        if (project.hasProperty(PROJECT_RESOURCES_URL_PROPERTY)) {
+        if (projectConfig.hasProperty(PROJECT_RESOURCES_URL_PROPERTY)) {
             try {
                 final Properties config = createURLSourceConfiguration();
                 logger.info("Source (project.resources.url): loading with properties: " + config);
@@ -181,21 +181,21 @@ public class ProjectNodeSupport implements IProjectNodes {
             i++;
         }
 
-        Date configLastModifiedTime = project.getConfigLastModifiedTime();
+        Date configLastModifiedTime = projectConfig.getConfigLastModifiedTime();
         nodesSourcesLastReload = configLastModifiedTime!=null?configLastModifiedTime.getTime():-1;
     }
 
     private Properties createURLSourceConfiguration() {
         final URLResourceModelSource.Configuration build = URLResourceModelSource.Configuration.build();
-        build.url(project.getProperty(PROJECT_RESOURCES_URL_PROPERTY));
-        build.project(project.getName());
+        build.url(projectConfig.getProperty(PROJECT_RESOURCES_URL_PROPERTY));
+        build.project(projectConfig.getName());
 
         return build.getProperties();
     }
 
     private File getResourceModelSourceFileCacheForType(String ident) {
-        String varDir = project.getProperty("framework.var.dir");
-        File file = new File(varDir, "resourceModelSourceCache/" + project.getName() + "/" + ident + ".xml");
+        String varDir = projectConfig.getProperty("framework.var.dir");
+        File file = new File(varDir, "resourceModelSourceCache/" + projectConfig.getName() + "/" + ident + ".xml");
         if (!file.getParentFile().exists() && !file.getParentFile().mkdirs()) {
             logger.warn("Failed to create cache dirs for source file cache");
         }
@@ -222,7 +222,7 @@ public class ProjectNodeSupport implements IProjectNodes {
             ResourceFormatGenerator generatorForFormat = resourceFormatGeneratorService.getGeneratorForFormat
                     (ResourceXMLFormatGenerator.SERVICE_PROVIDER_TYPE);
 
-            String ident1 = "[ResourceModelSource: " + descr + ", project: " + project.getName() + "]";
+            String ident1 = "[ResourceModelSource: " + descr + ", project: " + projectConfig.getName() + "]";
             return new CachingResourceModelSource(
                     sourceForConfiguration,
                     ident1,
@@ -255,7 +255,7 @@ public class ProjectNodeSupport implements IProjectNodes {
 
         final ResourceModelSourceService nodesSourceService =
                 getResourceModelSourceService();
-        configuration.put("project",project.getName());
+        configuration.put("project", projectConfig.getName());
         ResourceModelSource sourceForConfiguration = nodesSourceService.getSourceForConfiguration(type, configuration);
 
         if (useCache) {
@@ -282,7 +282,7 @@ public class ProjectNodeSupport implements IProjectNodes {
         if (null != format) {
             build.format(format);
         }
-        build.project(project.getName());
+        build.project(projectConfig.getName());
         build.generateFileAutomatically(generate);
         build.includeServerNode(includeServerNode);
 
@@ -292,11 +292,11 @@ public class ProjectNodeSupport implements IProjectNodes {
 
     private Properties createFileSourceConfiguration() {
         String format = null;
-        if (project.hasProperty(PROJECT_RESOURCES_FILEFORMAT_PROPERTY)) {
-            format = project.getProperty(PROJECT_RESOURCES_FILEFORMAT_PROPERTY);
+        if (projectConfig.hasProperty(PROJECT_RESOURCES_FILEFORMAT_PROPERTY)) {
+            format = projectConfig.getProperty(PROJECT_RESOURCES_FILEFORMAT_PROPERTY);
         }
         return generateFileSourceConfigurationProperties(
-                project.getProperty(PROJECT_RESOURCES_FILE_PROPERTY), format, true,
+                projectConfig.getProperty(PROJECT_RESOURCES_FILE_PROPERTY), format, true,
                 true
         );
     }
@@ -310,7 +310,7 @@ public class ProjectNodeSupport implements IProjectNodes {
      */
     @Override
     public synchronized List<Map<String, Object>> listResourceModelConfigurations(){
-        Map propertiesMap = project.getProperties();
+        Map propertiesMap = projectConfig.getProperties();
         Properties properties = new Properties();
         properties.putAll(propertiesMap);
         return listResourceModelConfigurations(properties);
@@ -373,7 +373,7 @@ public class ProjectNodeSupport implements IProjectNodes {
      *
      */
     private boolean shouldUpdateNodesResourceFile() {
-        return project.hasProperty(PROJECT_RESOURCES_URL_PROPERTY);
+        return projectConfig.hasProperty(PROJECT_RESOURCES_URL_PROPERTY);
     }
     /**
      * Conditionally update the nodes resources file if a URL source is defined for it and return
@@ -387,7 +387,7 @@ public class ProjectNodeSupport implements IProjectNodes {
     @Override
     public boolean updateNodesResourceFile(final String nodesResourcesFilePath) throws UpdateUtils.UpdateException {
         if (shouldUpdateNodesResourceFile()) {
-            updateNodesResourceFileFromUrl(project.getProperty(PROJECT_RESOURCES_URL_PROPERTY), null, null,nodesResourcesFilePath);
+            updateNodesResourceFileFromUrl(projectConfig.getProperty(PROJECT_RESOURCES_URL_PROPERTY), null, null,nodesResourcesFilePath);
             return true;
         }
         return false;
@@ -441,7 +441,7 @@ public class ProjectNodeSupport implements IProjectNodes {
      */
     boolean isAllowedProviderURL(final String providerURL) {
         //whitelist the configured providerURL
-        if (project.hasProperty(PROJECT_RESOURCES_URL_PROPERTY) && project.getProperty(PROJECT_RESOURCES_URL_PROPERTY).equals(
+        if (projectConfig.hasProperty(PROJECT_RESOURCES_URL_PROPERTY) && projectConfig.getProperty(PROJECT_RESOURCES_URL_PROPERTY).equals(
                 providerURL)) {
             return true;
         }
@@ -449,9 +449,9 @@ public class ProjectNodeSupport implements IProjectNodes {
         int i = 0;
         boolean projpass = false;
         boolean setproj = false;
-        while (project.hasProperty(PROJECT_RESOURCES_ALLOWED_URL_PREFIX + i)) {
+        while (projectConfig.hasProperty(PROJECT_RESOURCES_ALLOWED_URL_PREFIX + i)) {
             setproj = true;
-            final String regex = project.getProperty(PROJECT_RESOURCES_ALLOWED_URL_PREFIX + i);
+            final String regex = projectConfig.getProperty(PROJECT_RESOURCES_ALLOWED_URL_PREFIX + i);
             final Pattern pat = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
             final Matcher matcher = pat.matcher(providerURL);
             if (matcher.matches()) {
@@ -469,7 +469,7 @@ public class ProjectNodeSupport implements IProjectNodes {
         //check framework props
         i = 0;
 
-        final boolean setframework = project.hasProperty(FRAMEWORK_RESOURCES_ALLOWED_URL_PREFIX + i);
+        final boolean setframework = projectConfig.hasProperty(FRAMEWORK_RESOURCES_ALLOWED_URL_PREFIX + i);
         if (!setframework && projpass) {
             //unset in framework.props, allowed by project.props
             return true;
@@ -478,8 +478,8 @@ public class ProjectNodeSupport implements IProjectNodes {
             //unset in both
             return false;
         }
-        while (project.hasProperty(FRAMEWORK_RESOURCES_ALLOWED_URL_PREFIX + i)) {
-            final String regex = project.getProperty(FRAMEWORK_RESOURCES_ALLOWED_URL_PREFIX + i);
+        while (projectConfig.hasProperty(FRAMEWORK_RESOURCES_ALLOWED_URL_PREFIX + i)) {
+            final String regex = projectConfig.getProperty(FRAMEWORK_RESOURCES_ALLOWED_URL_PREFIX + i);
             final Pattern pat = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
             final Matcher matcher = pat.matcher(providerURL);
             if (matcher.matches()) {
@@ -542,7 +542,7 @@ public class ProjectNodeSupport implements IProjectNodes {
             throw new UpdateUtils.UpdateException("Unable to generate resources file: " + e.getMessage(), e);
         }
 
-        updateNodesResourceFile(resfile,nodesResourceFilePath);
+        updateNodesResourceFile(resfile, nodesResourceFilePath);
         if (!resfile.delete()) {
             logger.warn("failed to remove temp file: " + resfile);
         }
@@ -562,5 +562,7 @@ public class ProjectNodeSupport implements IProjectNodes {
     }
 
 
-
+    public IRundeckProjectConfig getProjectConfig() {
+        return projectConfig;
+    }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/ProjectNodeSupport.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/ProjectNodeSupport.java
@@ -91,14 +91,7 @@ public class ProjectNodeSupport implements IProjectNodes {
                 } else {
                     list.addNodeSet(nodes);
                 }
-            } catch (ResourceModelSourceException e) {
-                logger.error("Cannot get nodes from [" + nodesSource.toString() + "]: " + e.getMessage(), e);
-                nodesSourceExceptions.add(
-                        new ResourceModelSourceException(
-                                "Cannot get nodes from [" + nodesSource.toString() + "]: " + e.getMessage(), e
-                        )
-                );
-            } catch (RuntimeException e) {
+            } catch (ResourceModelSourceException | RuntimeException e) {
                 logger.error("Cannot get nodes from [" + nodesSource.toString() + "]: " + e.getMessage(), e);
                 nodesSourceExceptions.add(
                         new ResourceModelSourceException(

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/Validator.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/Validator.java
@@ -103,8 +103,20 @@ public class Validator {
      * @return the validation report
      */
     public static Report validate(final Properties props, final Description desc) {
-        final Report report = new Report();
         final List<Property> properties = desc.getProperties();
+        return validate(props, properties);
+    }
+
+    /**
+     * Validate a set of properties for a description, and return a report.
+     *
+     * @param props the input properties
+     * @param properties  the properties
+     *
+     * @return the validation report
+     */
+    public static Report validate(final Properties props, final List<Property> properties) {
+        final Report report = new Report();
         validate(props, report, properties, null);
         return report;
     }
@@ -235,7 +247,7 @@ public class Validator {
      * @param mapping map to convert key names
      * @param skip if true, ignore input entries when the key is not present in the mapping
      */
-    private static Map<String, String> performMapping(final Map<String, String> input,
+    public static Map<String, String> performMapping(final Map<String, String> input,
                                                       final Map<String, String> mapping, final boolean skip) {
 
         final Map<String, String> props = new HashMap<String, String>();
@@ -260,6 +272,23 @@ public class Validator {
      */
     public static Map<String, String> demapProperties(final Map<String, String> input, final Description desc) {
         final Map<String, String> mapping = desc.getPropertiesMapping();
+        return demapProperties(input, mapping, true);
+    }
+
+    /**
+     * Reverses a set of properties mapped using the specified property mapping, or the same input
+     * if the description has no mapping
+     * @param input input map
+     * @param mapping key value mapping
+     * @param skip if true, ignore input entries when the key is not present in the mapping
+     * @return mapped values
+     */
+    public static Map<String, String> demapProperties(
+            final Map<String, String> input,
+            final Map<String, String> mapping,
+            final boolean skip
+    )
+    {
         if (null == mapping) {
             return input;
         }
@@ -267,6 +296,6 @@ public class Validator {
         for (final Map.Entry<String, String> entry : mapping.entrySet()) {
             rev.put(entry.getValue(), entry.getKey());
         }
-        return performMapping(input, rev, true);
+        return performMapping(input, rev, skip);
     }
 }

--- a/core/src/test/java/com/dtolabs/rundeck/core/common/ProjectNodeSupportTest.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/common/ProjectNodeSupportTest.java
@@ -103,7 +103,8 @@ public class ProjectNodeSupportTest extends AbstractBaseTest {
         FrameworkProject project = FrameworkProject.create(PROJECT_NAME,
                                                            new File(getFrameworkProjectsBase()),
                                                            getFrameworkInstance().getFilesystemFramework(),
-                                                           getFrameworkInstance().getFilesystemFrameworkProjectManager());
+                                                           getFrameworkInstance().getFilesystemFrameworkProjectManager(),
+                                                           FrameworkFactory.createNodesFactory(getFrameworkInstance().getFilesystemFramework()));
 
         //set project providerURL and allowed URL regexes
         Properties orig = new Properties();

--- a/core/src/test/java/com/dtolabs/rundeck/core/common/TestFrameworkProject.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/common/TestFrameworkProject.java
@@ -604,34 +604,7 @@ public class TestFrameworkProject extends AbstractBaseTest {
         assertEquals("value3.else",project.getProperty("test3.somethingelse"));
     }
 
-    public void testCreateProjectPropertyRetriever() throws IOException {
-        final FrameworkProject project = FrameworkProject.create(PROJECT_NAME,
-                new File(getFrameworkProjectsBase()),
-                getFrameworkInstance().getFilesystemFramework(),getFrameworkInstance().getFilesystemFrameworkProjectManager());
-        final Properties testprops = new Properties();
-        testprops.setProperty("test1", "value1");
-        testprops.setProperty("test2", "value2");
-        testprops.setProperty("test3.something", "value3");
-        testprops.setProperty("test3.somethingelse", "value3.else");
-        boolean overwrite = true;
-        project.generateProjectPropertiesFile(overwrite, testprops, false);
 
-        final File propFile = new File(project.getEtcDir(), "project.properties");
-        assertTrue("project.properties file was not generated",
-                propFile.exists());
-
-        final FilesystemFramework fsframework=new FilesystemFramework(new File
-                                                                              (getBaseDir()), new File(getFrameworkProjectsBase()));
-        PropertyRetriever projectPropertyRetriever = FrameworkProject.createProjectPropertyRetriever(fsframework, PROJECT_NAME);
-        assertNotNull(projectPropertyRetriever);
-
-        assertNull(projectPropertyRetriever.getProperty("project.resources.file"));
-        assertEquals("value1", projectPropertyRetriever.getProperty("test1"));
-        assertEquals("value2", projectPropertyRetriever.getProperty("test2"));
-        assertEquals("value3", projectPropertyRetriever.getProperty("test3.something"));
-        assertEquals("value3.else", projectPropertyRetriever.getProperty("test3.somethingelse"));
-        assertNull(projectPropertyRetriever.getProperty("blah.does.not.exist"));
-    }
     static class testSource implements ResourceModelSource {
         INodeSet returnNodes;
         int called=0;

--- a/core/src/test/java/com/dtolabs/rundeck/core/common/TestFrameworkProjectMgr.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/common/TestFrameworkProjectMgr.java
@@ -75,8 +75,11 @@ public class TestFrameworkProjectMgr extends AbstractBaseTest {
 
     public void testConstruction() {
         final FrameworkProjectMgr mgr = FrameworkProjectMgr.create("projectMgr",
-                                                             new File(getFrameworkProjectsBase()),
-                                                             getFrameworkInstance() );
+                                                                   new File(getFrameworkProjectsBase()),
+                                                                   getFrameworkInstance(),
+                                                                   FrameworkFactory.createNodesFactory(
+                                                                           getFrameworkInstance().getFilesystemFramework())
+        );
         assertEquals("mgr.getBaseDir() did not match exepcted", mgr.getBaseDir(), new File(getFrameworkProjectsBase()));
 
         assertEquals("expected 1 projects listed. number found: " + mgr.listFrameworkProjects().size()
@@ -86,8 +89,11 @@ public class TestFrameworkProjectMgr extends AbstractBaseTest {
 
     public void testChildCouldBeLoaded() throws IOException {
         final FrameworkProjectMgr mgr = FrameworkProjectMgr.create("projectMgr",
-                                                             new File(getFrameworkProjectsBase()),
-                                                             getFrameworkInstance());
+                                                                   new File(getFrameworkProjectsBase()),
+                                                                   getFrameworkInstance(),
+                                                                   FrameworkFactory.createNodesFactory(
+                                                                           getFrameworkInstance().getFilesystemFramework())
+        );
         assertTrue(mgr.childCouldBeLoaded(PROJECT_NAME));
         assertFalse(mgr.childCouldBeLoaded(PROJECT_NAME2));
         assertFalse(mgr.childCouldBeLoaded(PROJECT_NAME2));
@@ -111,8 +117,11 @@ public class TestFrameworkProjectMgr extends AbstractBaseTest {
 
     public void testListChildNames() throws IOException {
         final FrameworkProjectMgr mgr = FrameworkProjectMgr.create("projectMgr",
-                                                             new File(getFrameworkProjectsBase()),
-                                                             getFrameworkInstance());
+                                                                   new File(getFrameworkProjectsBase()),
+                                                                   getFrameworkInstance(),
+                                                                   FrameworkFactory.createNodesFactory(
+                                                                           getFrameworkInstance().getFilesystemFramework())
+        );
         assertTrue(mgr.listChildNames().contains(PROJECT_NAME));
         assertFalse(mgr.listChildNames().contains(PROJECT_NAME2));
         final File projectDir2 = new File(mgr.getBaseDir(), PROJECT_NAME2);
@@ -124,8 +133,11 @@ public class TestFrameworkProjectMgr extends AbstractBaseTest {
 
     public void testLoadChild() throws IOException {
         final FrameworkProjectMgr mgr = FrameworkProjectMgr.create("projectMgr",
-                                                             new File(getFrameworkProjectsBase()),
-                                                             getFrameworkInstance());
+                                                                   new File(getFrameworkProjectsBase()),
+                                                                   getFrameworkInstance(),
+                                                                   FrameworkFactory.createNodesFactory(
+                                                                           getFrameworkInstance().getFilesystemFramework())
+        );
         try {
             IFrameworkResource res = mgr.loadChild(PROJECT_NAME);
             assertNotNull(res);
@@ -161,8 +173,11 @@ public class TestFrameworkProjectMgr extends AbstractBaseTest {
 
     public void testCreateRemoveDepot() {
         final IFrameworkProjectMgr mgr = FrameworkProjectMgr.create("projectMgr",
-                                                      new File(getFrameworkProjectsBase()),
-                                                      getFrameworkInstance());
+                                                                    new File(getFrameworkProjectsBase()),
+                                                                    getFrameworkInstance(),
+                                                                    FrameworkFactory.createNodesFactory(
+                                                                            getFrameworkInstance().getFilesystemFramework())
+        );
         final IRundeckProject d1 = mgr.createFrameworkProject("Depot1");
         assertEquals("exected two listed FrameworkProject after the addDepot call", 2, mgr.listFrameworkProjects().size());
         assertTrue("expected existsFrameworkProject to be true after it was added", mgr.existsFrameworkProject("Depot1"));
@@ -178,7 +193,7 @@ public class TestFrameworkProjectMgr extends AbstractBaseTest {
     public void testAddRemoveFrameworkProject() {
         final FrameworkProjectMgr mgr = FrameworkProjectMgr.create("projectMgr",
                                                              new File(getFrameworkProjectsBase()),
-                                                             getFrameworkInstance());
+                                                             getFrameworkInstance(),FrameworkFactory.createNodesFactory(getFrameworkInstance().getFilesystemFramework()) );
         final FrameworkProject d1 = mgr.createFSFrameworkProject("Depot1");
         assertTrue("existsFrameworkProject did not return true for a type that should exist",
                    mgr.existsFrameworkProject("Depot1"));

--- a/plugins/stub-plugin/src/main/java/com/dtolabs/rundeck/plugin/stub/StubResourceModelSource.java
+++ b/plugins/stub-plugin/src/main/java/com/dtolabs/rundeck/plugin/stub/StubResourceModelSource.java
@@ -22,9 +22,9 @@ import com.dtolabs.rundeck.core.common.NodeSetImpl;
 import com.dtolabs.rundeck.core.resources.ResourceModelSource;
 import com.dtolabs.rundeck.core.resources.ResourceModelSourceException;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Properties;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * StubResourceModelSource is ...
@@ -38,6 +38,8 @@ public class StubResourceModelSource implements ResourceModelSource {
     String prefix;
     String suffix;
     String tags;
+    Map<String, String> attrs;
+    int delayMin, delayMax;
 
     public StubResourceModelSource(Properties configuration) {
         this.configuration = configuration;
@@ -45,20 +47,95 @@ public class StubResourceModelSource implements ResourceModelSource {
         prefix = configuration.getProperty("prefix");
         suffix = configuration.getProperty("suffix");
         tags = configuration.getProperty("tags");
+        attrs = attrsMap(configuration.getProperty("attrs"));
+        delayMin = minDelay(configuration.getProperty("delay"));
+        delayMax = maxDelay(configuration.getProperty("delay"));
+    }
+
+    Pattern pattern = Pattern.compile("^(\\d+)(-(\\d+))?$");
+    private int maxDelay(final String delay) {
+        int[] matches = parseDelay(delay);
+        return matches[1];
+    }
+
+    private int[] parseDelay(final String delay) {
+        int[] results = new int[2];
+        results[0] = -1;
+        results[1] = -1;
+        if(delay==null){
+            return results;
+        }
+
+        Matcher matcher = pattern.matcher(delay);
+        if (matcher.matches()) {
+            String g0 = matcher.group(1);
+            String g3 = matcher.group(3);
+            if(null!=g0){
+                try{
+                    results[0] = Integer.parseInt(g0);
+                }catch (NumberFormatException e){
+
+                }
+            }
+            if(null!=g3){
+                try{
+                    results[1] = Integer.parseInt(g3);
+                }catch (NumberFormatException e){
+
+                }
+            }
+        }
+        return results;
+    }
+
+    private int minDelay(final String delay) {
+        int[] matches = parseDelay(delay);
+        return matches[0];
+    }
+
+    private Map<String, String> attrsMap(final String attrs) {
+        Map<String, String> result = new HashMap<>();
+        if(null!=attrs) {
+            for (String x : attrs.split(",")) {
+                String[] vals = x.split("=", 2);
+                if (vals.length == 2 && !"".equals(vals[0]) && !"".equals(vals[1])) {
+                    result.put(vals[0], vals[1]);
+                }
+            }
+        }
+        return result;
     }
 
     @Override
     public INodeSet getNodes() throws ResourceModelSourceException {
+        if(delayMin>=0){
+            int delay;
+            if (delayMax > delayMin) {
+                delay = (int) Math.floor(delayMin + Math.random() * (delayMax - delayMin));
+            } else {
+                delay = delayMin;
+            }
+            if(delay>0) {
+                try {
+                    Thread.sleep(delay * 1000);
+                } catch (InterruptedException e) {
+
+                }
+            }
+        }
         NodeSetImpl iNodeEntries = new NodeSetImpl();
-        for(int i=0;i<count;i++){
+        for (int i = 0; i < count; i++) {
             NodeEntryImpl nodeEntry = new NodeEntryImpl();
-            nodeEntry.setNodename((prefix != null ? prefix : "node") + "-" + i  + (suffix != null ? suffix : ""));
+            nodeEntry.setNodename((prefix != null ? prefix : "node") + "-" + i + (suffix != null ? suffix : ""));
             nodeEntry.setHostname((prefix != null ? prefix : "") + "host" + (suffix != null ? suffix : ""));
             nodeEntry.setUsername((prefix != null ? prefix : "") + "user" + (suffix != null ? suffix : ""));
             nodeEntry.setAttribute("node-executor", "stub");
             nodeEntry.setAttribute("file-copier", "stub");
-            if(null!=tags){
+            if (null != tags) {
                 nodeEntry.setTags(new HashSet(Arrays.asList(tags.split("\\s*,\\s*"))));
+            }
+            if(null!=attrs && attrs.size()>0){
+                nodeEntry.getAttributes().putAll(attrs);
             }
 
             iNodeEntries.putNode(nodeEntry);

--- a/plugins/stub-plugin/src/main/java/com/dtolabs/rundeck/plugin/stub/StubResourceModelSourceFactory.java
+++ b/plugins/stub-plugin/src/main/java/com/dtolabs/rundeck/plugin/stub/StubResourceModelSourceFactory.java
@@ -63,11 +63,19 @@ public class StubResourceModelSourceFactory implements ResourceModelSourceFactor
         builder.property(PropertyUtil.string("tags", "Tags",
                 "Comma separated tags to add to all nodes",
                 false, "stub"));
+        builder.property(PropertyUtil.string("attrs", "Attributes",
+                "Comma separated key=val to add to all nodes",
+                false, null));
+        builder.property(PropertyUtil.string("delay", "Delay",
+                "Seconds of delay to introduce, or range.\n\nCan be, e.g. `0-10` (random between 0 and 10 seconds)",
+                false, "0"));
 
         builder.mapping("prefix", "plugin.ResourceModelSource.stub.prefix");
         builder.mapping("suffix", "plugin.ResourceModelSource.stub.suffix");
         builder.mapping("count", "plugin.ResourceModelSource.stub.count");
         builder.mapping("tags", "plugin.ResourceModelSource.stub.tags");
+        builder.mapping("attrs", "plugin.ResourceModelSource.stub.attrs");
+        builder.mapping("delay", "plugin.ResourceModelSource.stub.delay");
 
         DESC = builder.build();
     }

--- a/rundeckapp/grails-app/conf/Config.groovy
+++ b/rundeckapp/grails-app/conf/Config.groovy
@@ -176,6 +176,9 @@ rundeck.projectsStorageType='filesystem'
 rundeck.ajax.compression='gzip'
 rundeck.ajax.executionState.compression.nodeThreshold=500
 
+rundeck.nodeService.nodeCache.spec='refreshAfterWrite=30s'
+rundeck.nodeService.nodeCache.enabled=true
+
 grails.assets.less.compile = 'less4j'
 grails.assets.plugin."twitter-bootstrap".excludes = ["**/*.less"]
 grails.assets.plugin."twitter-bootstrap".includes = ["bootstrap.less"]

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -80,7 +80,7 @@ beans={
     frameworkFilesystem(FrameworkFactory,rdeckBase){ bean->
         bean.factoryMethod='createFilesystemFramework'
     }
-    filesystemProjectManager(FrameworkFactory,frameworkFilesystem){ bean->
+    filesystemProjectManager(FrameworkFactory,frameworkFilesystem,ref('nodeService')){ bean->
         bean.factoryMethod='createProjectManager'
     }
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -303,9 +303,9 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def project = framework.getFrameworkProjectMgr().getFrameworkProject(query.project)
         def INodeSet nodeset
 
+        long mark=System.currentTimeMillis()
         INodeSet nodes1 = project.getNodeSet()
 
-//        System.err.println("nodesData getNodeSet: ${System.currentTimeMillisentTimeMillis()-mark}ms")
 //        allcount=nodes1.nodes.size()
         if(params.localNodeOnly){
             nodeset=new NodeSetImpl()
@@ -315,7 +315,6 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             //match using nodeset unless all filters are blank
             try {
                 nodeset = com.dtolabs.rundeck.core.common.NodeFilter.filterNodes(nset, nodes1)
-//                System.err.println("nodesData filter: ${System.currentTimeMillis()-mark}ms")
             } catch (PatternSyntaxException e) {
                 filterErrors['filter']=e.getMessage()
                 nodeset=new NodeSetImpl()
@@ -331,8 +330,12 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 //            nodes = nodes.sort { INodeEntry a, INodeEntry b -> return a.nodename.compareTo(b.nodename) }
         //filter nodes by read authorization
 
+        mark=System.currentTimeMillis()
         def readnodes = frameworkService.filterAuthorizedNodes(query.project, ['read'] as Set, nodeset, authContext)
+        log.debug("nodesData filterAuthorizedNodes[read]: ${System.currentTimeMillis()-mark}ms")
+        mark=System.currentTimeMillis()
         def runnodes = frameworkService.filterAuthorizedNodes(query.project, ['run'] as Set, readnodes, authContext)
+        log.debug("nodesData filterAuthorizedNodes[run]: ${System.currentTimeMillis()-mark}ms")
         def noderunauthmap = [:]
 
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -488,10 +488,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
     def nodesFragmentData(ExtNodeFilters query) {
         long start = System.currentTimeMillis()
         if (query.hasErrors()) {
-            response.setStatus(HttpServletResponse.SC_BAD_REQUEST)
-            return renderErrorFragment(
-                    g.message(error: query.errors.allErrors.collect { g.message(error: it) }.join("; "))
-            )
+            return null
         }
 
         Framework framework = frameworkService.getRundeckFramework()
@@ -556,6 +553,12 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
      * nodesFragment renders a set of nodes in HTML snippet, for ajax
      */
     def nodesFragment(ExtNodeFilters query) {
+        if (query.hasErrors()) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST)
+            return renderErrorFragment(
+                    g.message(error: query.errors.allErrors.collect { g.message(error: it) }.join("; "))
+            )
+        }
         def result= nodesFragmentData(query)
         render(template:"allnodes",model: result)
     }
@@ -563,6 +566,12 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
      * nodesFragment renders a set of nodes in HTML snippet, for ajax
      */
     def nodesQueryAjax(ExtNodeFilters query) {
+        if (query.hasErrors()) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST)
+            return renderErrorFragment(
+                    g.message(error: query.errors.allErrors.collect { g.message(error: it) }.join("; "))
+            )
+        }
         Map result= nodesFragmentData(query)
         result.remove('selectedProject')
         result.remove('query')

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1132,3 +1132,5 @@ filters=Filters
 all.nodes=All Nodes
 set.all.nodes.as.default.filter=Set All Nodes as Default Filter
 remove.all.nodes.as.default.filter=Remove All Nodes as Default Filter
+resource.model=Project Nodes
+additional.configuration.for.the.resource.model.for.this.project=Additional configuration for the Nodes for this project

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1130,3 +1130,5 @@ filters=Filters
 all.nodes=All Nodes
 set.all.nodes.as.default.filter=Set All Nodes as Default Filter
 remove.all.nodes.as.default.filter=Remove All Nodes as Default Filter
+resource.model=Project Nodes
+additional.configuration.for.the.resource.model.for.this.project=Additional configuration for the Nodes for this project

--- a/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
@@ -21,9 +21,11 @@ class ConfigurationService {
         getAppConfig()?."${service}"?."${cache}"?.spec ?: defval
     }
     boolean getCacheEnabledFor(String service, String cache, boolean defval) {
-        getAppConfig()?."${service}"?."${cache}"?.enabled ?: defval
-    }
-    boolean getIncubatorEnabled(String feature){
-        getAppConfig()?.incubator?."${feature}"
+        def val=getAppConfig()?."${service}"?."${cache}"?.enabled
+        if(null!=val){
+            return val in [true,'true']
+        }else{
+            return defval
+        }
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
@@ -6,9 +6,24 @@ class ConfigurationService {
     def grailsApplication
 
     boolean isExecutionModeActive() {
-        grailsApplication.config?.rundeck?.executionMode=='active'
+        getAppConfig()?.executionMode=='active'
     }
+
+    private ConfigObject getAppConfig() {
+        grailsApplication.config?.rundeck
+    }
+
     void setExecutionModeActive(boolean active){
-        grailsApplication.config.rundeck.executionMode=(active?'active':'passive')
+        getAppConfig().executionMode=(active?'active':'passive')
+    }
+
+    String getCacheSpecFor(String service, String cache, String defval) {
+        getAppConfig()?."${service}"?."${cache}"?.spec ?: defval
+    }
+    boolean getCacheEnabledFor(String service, String cache, boolean defval) {
+        getAppConfig()?."${service}"?."${cache}"?.enabled ?: defval
+    }
+    boolean getIncubatorEnabled(String feature){
+        getAppConfig()?.incubator?."${feature}"
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
@@ -1,0 +1,190 @@
+package rundeck.services
+
+import com.codahale.metrics.MetricRegistry
+import com.dtolabs.rundeck.core.common.IProjectNodes
+import com.dtolabs.rundeck.core.common.IProjectNodesFactory
+import com.dtolabs.rundeck.core.common.IRundeckProjectConfig
+import com.dtolabs.rundeck.core.common.ProjectNodeSupport
+import com.dtolabs.rundeck.core.plugins.configuration.Property
+import com.dtolabs.rundeck.plugins.util.PropertyBuilder
+import com.google.common.cache.CacheBuilder
+import com.google.common.cache.CacheLoader
+import com.google.common.cache.LoadingCache
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.ListenableFutureTask
+import org.springframework.beans.factory.InitializingBean
+import rundeck.Project
+import rundeck.services.framework.RundeckProjectConfigurable
+import rundeck.services.nodes.CachedProjectNodes
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Provides asynchronous loading and caching of nodesets for projects
+ */
+class NodeService implements InitializingBean, RundeckProjectConfigurable,IProjectNodesFactory {
+    public static final String PROJECT_NODECACHE_DELAY = 'project.nodeCache.delay'
+    public static final String PROJECT_NODECACHE_ENABLED = 'project.nodeCache.enabled'
+    static transactional = false
+    def grailsApplication
+    def metricService
+    def frameworkService
+
+    String category='resourceModelSource'
+
+    @Override
+    List<Property> getProjectConfigProperties() {
+        [
+                PropertyBuilder.builder().with {
+                    booleanType 'enabled'
+                    title 'Use Asynchronous Cache'
+                    description 'Use asynchronous cache for all Resource Model Source results in this project'
+                    required(false)
+                    defaultValue 'true'
+                }.build(),
+                PropertyBuilder.builder().with {
+                    integer 'delay'
+                    title 'Cache Delay'
+                    description 'Delay in seconds.\n\nRefresh results after this many seconds have passed. (Results may be this many seconds old.)'
+                    required(false)
+                    defaultValue '30'
+                }.build()
+        ]
+    }
+
+    @Override
+    Map<String, String> getPropertiesMapping() {
+        ['delay': PROJECT_NODECACHE_DELAY, 'enabled': PROJECT_NODECACHE_ENABLED]
+    }
+    /**
+     * Scheduled executor for retries
+     */
+    private ExecutorService executor = Executors.newFixedThreadPool(2)
+
+    //basic creation, created via spec string in afterPropertiesSet()
+    private LoadingCache<String, CachedProjectNodes> nodeCache =
+            CacheBuilder.newBuilder()
+                        .refreshAfterWrite(30, TimeUnit.SECONDS)
+                        .build(
+                    new CacheLoader<String, CachedProjectNodes>() {
+                        public CachedProjectNodes load(String key) {
+                            return loadNodes(key);
+                        }
+                    }
+            );
+
+    @Override
+    void afterPropertiesSet() throws Exception {
+        def spec = grailsApplication.config.rundeck?.nodeService?.nodeCache?.spec ?:
+                "refreshAfterWrite=30s"
+
+        log.debug("nodeCache: creating from spec: ${spec}")
+
+        nodeCache = CacheBuilder.from(spec)
+                                .recordStats()
+                                .build(
+                new CacheLoader<String, CachedProjectNodes>() {
+                    public CachedProjectNodes load(String key) {
+                        return loadNodes(key);
+                    }
+
+                    @Override
+                    ListenableFuture<CachedProjectNodes> reload(final String key, final CachedProjectNodes oldValue)
+                            throws Exception
+                    {
+                        if (needsReload(key, oldValue)) {
+                            ListenableFutureTask<CachedProjectNodes> task = ListenableFutureTask.create{ loadNodes(key) }
+                            executor.execute(task);
+                            return task;
+                        } else {
+                            return Futures.immediateFuture(oldValue)
+                        }
+                    }
+                }
+        )
+
+        MetricRegistry registry = metricService?.getMetricRegistry()
+        Util.addCacheMetrics(this.class.name + ".nodeCache", registry, nodeCache)
+    }
+    boolean isCacheEnabled(IRundeckProjectConfig projectConfig){
+        def globalEnabled = grailsApplication.config.rundeck?.nodeService?.nodeCache?.enabled || grailsApplication.config.feature?.incubator?.nodeCache
+        return globalEnabled && projectNodeCacheEnabledConfig(projectConfig)
+    }
+
+    boolean needsReload(String project, CachedProjectNodes oldNodes) {
+        def framework = frameworkService.getRundeckFramework()
+        def rdprojectconfig = framework.projectManager.loadProjectConfig(project)
+        def now = new Date()
+        if(now.time - oldNodes.cacheTime.time < projectNodeCacheDelayConfig(rdprojectconfig)){
+            return false
+        }
+        Project.withNewSession {
+            Project rdproject = Project.findByName(project)
+            boolean needsReload = rdproject == null ||
+                    oldNodes.projectConfig.configLastModifiedTime == null ||
+                    rdprojectconfig.getConfigLastModifiedTime() > oldNodes.projectConfig.configLastModifiedTime
+            needsReload
+        }
+    }
+
+    /**
+     * Return project config for node cache delay
+     * @param project
+     * @return
+     */
+    long projectNodeCacheDelayConfig(final IRundeckProjectConfig projectConfig) {
+        projectConfig.hasProperty(PROJECT_NODECACHE_DELAY)?
+                Long.parseLong(projectConfig.getProperty(PROJECT_NODECACHE_DELAY)) :
+        (30*1000)
+    }
+    /**
+     * Return project config for node cache delay
+     * @param project
+     * @param s @return
+     */
+    boolean projectNodeCacheEnabledConfig(final IRundeckProjectConfig projectConfig) {
+        projectConfig.hasProperty(PROJECT_NODECACHE_ENABLED)?
+                Boolean.parseBoolean(projectConfig.getProperty(PROJECT_NODECACHE_ENABLED)) :
+        true
+    }
+
+    CachedProjectNodes loadNodes(final String project) {
+        def framework = frameworkService.getRundeckFramework()
+        def rdprojectconfig = framework.getProjectManager().loadProjectConfig(project)
+        log.debug("loadNodes for ${project}... (cacheEnabled: ${isCacheEnabled(rdprojectconfig)})")
+
+
+        def nodeSupport = new ProjectNodeSupport(
+                rdprojectconfig,
+                framework.getResourceFormatGeneratorService(),
+                framework.getResourceModelSourceService()
+        )
+        def cachedNodes = new CachedProjectNodes(
+                cacheTime: new Date(),
+                nodeSupport: nodeSupport,
+                doCache: isCacheEnabled(rdprojectconfig)
+        )
+        metricService.withTimer(this.class.name,"project.${project}.loadNodes"){
+            cachedNodes.reloadNodeSet()
+        }
+        cachedNodes
+    }
+    def expireProjectNodes(String name){
+        nodeCache.invalidate(name)
+    }
+
+    IProjectNodes getNodes(final String name) {
+        def framework = frameworkService.getRundeckFramework()
+        if (!framework.projectManager.existsFrameworkProject(name)) {
+            throw new IllegalArgumentException("Project does not exist: " + name)
+        }
+        def result = nodeCache.get(name)
+        if (!result) {
+            throw new IllegalArgumentException("Project does not exist: " + name)
+        }
+        result
+    }
+}

--- a/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
@@ -29,9 +29,9 @@ class NodeService implements InitializingBean, RundeckProjectConfigurable,IProje
     public static final String PROJECT_NODECACHE_DELAY = 'project.nodeCache.delay'
     public static final String PROJECT_NODECACHE_ENABLED = 'project.nodeCache.enabled'
     static transactional = false
-    def grailsApplication
     def metricService
     def frameworkService
+    def configurationService
 
     String category='resourceModelSource'
 
@@ -78,8 +78,7 @@ class NodeService implements InitializingBean, RundeckProjectConfigurable,IProje
 
     @Override
     void afterPropertiesSet() throws Exception {
-        def spec = grailsApplication.config.rundeck?.nodeService?.nodeCache?.spec ?:
-                "refreshAfterWrite=30s"
+        def spec = configurationService.getCacheSpecFor('nodeService','nodeCache', "refreshAfterWrite=30s")
 
         log.debug("nodeCache: creating from spec: ${spec}")
 
@@ -110,7 +109,7 @@ class NodeService implements InitializingBean, RundeckProjectConfigurable,IProje
         Util.addCacheMetrics(this.class.name + ".nodeCache", registry, nodeCache)
     }
     boolean isCacheEnabled(IRundeckProjectConfig projectConfig){
-        def globalEnabled = grailsApplication.config.rundeck?.nodeService?.nodeCache?.enabled || grailsApplication.config.feature?.incubator?.nodeCache
+        def globalEnabled = configurationService.getCacheEnabledFor('nodeService','nodeCache', true)
         return globalEnabled && projectNodeCacheEnabledConfig(projectConfig)
     }
 

--- a/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
@@ -173,6 +173,12 @@ class NodeService implements InitializingBean, RundeckProjectConfigurable,IProje
 
         cachedNodes
     }
+
+    @Override
+    void refreshProjectNodes(final String name) {
+        expireProjectNodes(name)
+    }
+
     def expireProjectNodes(String name){
         nodeCache.invalidate(name)
     }

--- a/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
@@ -138,7 +138,7 @@ class NodeService implements InitializingBean, RundeckProjectConfigurable,IProje
      */
     long projectNodeCacheDelayConfig(final IRundeckProjectConfig projectConfig) {
         projectConfig.hasProperty(PROJECT_NODECACHE_DELAY)?
-                Long.parseLong(projectConfig.getProperty(PROJECT_NODECACHE_DELAY)) :
+                Long.parseLong(projectConfig.getProperty(PROJECT_NODECACHE_DELAY))*1000 :
         (30*1000)
     }
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -105,7 +105,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
     }
 
     //basic creation, created via spec string in afterPropertiesSet()
-    private LoadingCache<String, IRundeckProject> projectCache =
+    def LoadingCache<String, IRundeckProject> projectCache =
             CacheBuilder.newBuilder()
                         .expireAfterAccess(10, TimeUnit.MINUTES)
                         .refreshAfterWrite(1, TimeUnit.MINUTES)
@@ -464,8 +464,6 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
         def oldprops = res.config
         Properties newprops = mergeProperties(removePrefixes, oldprops, properties)
         Map newres=storeProjectConfig(projectName, newprops)
-        projectCache.invalidate(projectName)
-        nodeService.expireProjectNodes(projectName)
         newres
     }
 
@@ -507,8 +505,6 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
             throw new IllegalArgumentException("project does not exist: " + projectName)
         }
         Map resource=storeProjectConfig(projectName, properties)
-        projectCache.invalidate(projectName)
-        nodeService.expireProjectNodes(projectName)
         resource
     }
     //basic creation, created via spec string in afterPropertiesSet()

--- a/rundeckapp/grails-app/services/rundeck/services/framework/RundeckProjectConfigurable.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/framework/RundeckProjectConfigurable.groovy
@@ -1,0 +1,25 @@
+package rundeck.services.framework
+
+import com.dtolabs.rundeck.core.plugins.configuration.Property
+
+/**
+ * defines a set of project-level configuration properties for a grails service/spring bean
+ */
+interface RundeckProjectConfigurable {
+    /**
+     * Project configuration category
+     * @return
+     */
+    String getCategory()
+
+    /**
+     * List of properties
+     * @return
+     */
+    List<Property> getProjectConfigProperties()
+
+    /**
+     * @return a map of config prop names to project config property names
+     */
+    public Map<String, String> getPropertiesMapping();
+}

--- a/rundeckapp/grails-app/services/rundeck/services/nodes/CachedProjectNodes.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/nodes/CachedProjectNodes.groovy
@@ -1,0 +1,27 @@
+package rundeck.services.nodes
+
+import com.dtolabs.rundeck.core.common.INodeSet
+import com.dtolabs.rundeck.core.common.IProjectNodes
+import com.dtolabs.rundeck.core.common.ProjectNodeSupport
+
+/**
+ * Created by greg on 1/15/16.
+ */
+class CachedProjectNodes implements IProjectNodes {
+    @Delegate
+    ProjectNodeSupport nodeSupport
+    INodeSet nodes
+    boolean doCache
+    Date cacheTime
+
+
+    @Override
+    INodeSet getNodeSet() {
+        return doCache?nodes:reloadNodeSet()
+    }
+
+    INodeSet reloadNodeSet() {
+        nodes = nodeSupport.getNodeSet()
+        nodes
+    }
+}

--- a/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
@@ -115,6 +115,37 @@
 
 </g:if>
 
+    <g:if test="${extraConfig}">
+       <div class="list-group-item">
+           <span class="h4 ">
+                <g:message code="resource.model" />
+            </span>
+
+            <div class="help-block">
+                <g:message code="additional.configuration.for.the.resource.model.for.this.project" />
+            </div>
+
+            <div class="form-horizontal">
+                <g:each in="${extraConfig.keySet()}" var="configService">
+                    <g:set var="configurable" value="${extraConfig[configService].configurable}"/>
+                    <g:if test="${configurable.category == 'resourceModelSource'}">
+
+                        <g:set var="pluginprefix" value="${extraConfig[configService].get('prefix')}"/>
+                        <g:render template="/framework/pluginConfigPropertiesInputs" model="${[
+                                properties:configurable.projectConfigProperties,
+                                report:extraConfig[configService].get('report'),
+                                prefix:pluginprefix,
+                                values:extraConfig[configService].get('values')?:[:],
+                                fieldnamePrefix:pluginprefix,
+                                origfieldnamePrefix:'orig.' + pluginprefix,
+                                allowedScope:PropertyScope.Project
+                        ]}"/>
+                    </g:if>
+                </g:each>
+            </div>
+       </div>
+    </g:if>
+
 <g:if test="${nodeExecDescriptions}">
     <div class="list-group-item">
     <span class="h4">Default <g:message code="framework.service.NodeExecutor.label" /></span>

--- a/rundeckapp/grails-app/views/menu/admin.gsp
+++ b/rundeckapp/grails-app/views/menu/admin.gsp
@@ -188,6 +188,38 @@
             </ol>
         </li>
 
+             <g:if test="${extraConfig}">
+                 <div class="list-group-item">
+                     <h4 class="list-group-item-heading ">
+                         <g:message code="resource.model" />
+                     </h4>
+
+                     <span class="text-muted">
+                         <g:message code="additional.configuration.for.the.resource.model.for.this.project" />
+                     </span>
+
+                     <div class="inpageconfig">
+                         <g:each in="${extraConfig.keySet()}" var="configService">
+                             <g:set var="configurable" value="${extraConfig[configService].configurable}"/>
+                             <g:if test="${configurable.category == 'resourceModelSource'}">
+
+                                 <g:set var="pluginprefix" value="${extraConfig[configService].get('prefix')}"/>
+
+                                 <g:each in="${configurable.projectConfigProperties}" var="prop">
+                                     <g:render template="/framework/pluginConfigPropertySummaryValue"
+                                               model="${[
+                                                       prop:prop,
+                                                       prefix:pluginprefix,
+                                                         values:extraConfig[configService].get('values')?:[:],
+                                               ]}"/>
+                                 </g:each>
+                                 
+                             </g:if>
+                         </g:each>
+                     </div>
+                 </div>
+             </g:if>
+
         <li class="list-group-item">
             <h4 class="list-group-item-heading">
                 <g:message code="framework.service.NodeExecutor.default.label" />

--- a/rundeckapp/src/java/com/dtolabs/rundeck/server/projects/RundeckProject.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/server/projects/RundeckProject.java
@@ -14,35 +14,25 @@ import java.util.*;
  * Created by greg on 2/23/15.
  */
 public class RundeckProject implements IRundeckProject{
-    private String name;
     private ProjectManagerService projectService;
     private IProjectNodes projectNodes;
-    private Authorization projectAuthorization;
-    private Date lastModifiedTime;
-    private IPropertyLookup lookup;
-    private IPropertyLookup projectLookup;
+    private IRundeckProjectConfig projectConfig;
 
     public RundeckProject(
-            final String name,
-            final IPropertyLookup lookup,
-            final IPropertyLookup projectLookup,
-            final ProjectManagerService projectService,
-            final Date lastModifiedTime
+            final IRundeckProjectConfig projectConfig,
+            final ProjectManagerService projectService
     )
     {
-        this.name = name;
-        this.setLookup(lookup);
-        this.setProjectLookup(projectLookup);
+        this.projectConfig=projectConfig;
         this.projectService = projectService;
-        this.setLastModifiedTime(lastModifiedTime);
 
     }
 
     public String getName(){
-        return name;
+        return projectConfig.getName();
     }
     public String getProperty(final String property) {
-        return getLookup().getProperty(property);
+        return projectConfig.getProperty(property);
     }
 
     @Override
@@ -57,28 +47,16 @@ public class RundeckProject implements IRundeckProject{
 
     @Override
     public boolean hasProperty(final String key) {
-        return getProperties().containsKey(key);
+        return projectConfig.hasProperty(key);
     }
 
     @Override
     public Map<String, String> getProperties() {
-        HashMap<String, String> result = new HashMap<>();
-        if(null!= getLookup()){
-            for(Object key: getLookup().getPropertiesMap().keySet()) {
-                result.put(key.toString(), getLookup().getProperty(key.toString()));
-            }
-        }
-        return result;
+        return projectConfig.getProperties();
     }
     @Override
     public Map<String, String> getProjectProperties() {
-        HashMap<String, String> result = new HashMap<>();
-        if(null!= getProjectLookup()){
-            for(Object key: getProjectLookup().getPropertiesMap().keySet()) {
-                result.put(key.toString(), getProjectLookup().getProperty(key.toString()));
-            }
-        }
-        return result;
+        return projectConfig.getProjectProperties();
     }
 
     @Override
@@ -93,39 +71,39 @@ public class RundeckProject implements IRundeckProject{
 
     @Override
     public boolean existsFileResource(final String path) {
-        return projectService.existsProjectFileResource(name, path);
+        return projectService.existsProjectFileResource(getName(), path);
     }
 
     @Override
     public boolean existsDirResource(final String path) {
-        return projectService.existsProjectDirResource(name, path);
+        return projectService.existsProjectDirResource(getName(), path);
     }
 
     @Override
     public List<String> listDirPaths(final String path) {
-        return projectService.listProjectDirPaths(name, path);
+        return projectService.listProjectDirPaths(getName(), path);
     }
 
     @Override
     public boolean deleteFileResource(final String path) {
-        return projectService.deleteProjectFileResource(name, path);
+        return projectService.deleteProjectFileResource(getName(), path);
     }
 
     @Override
     public long storeFileResource(final String path, final InputStream input) throws IOException {
-        return projectService.writeProjectFileResource(name, path, input, new HashMap<String, String>())
+        return projectService.writeProjectFileResource(getName(), path, input, new HashMap<String, String>())
                              .getContents()
                              .getContentLength();
     }
 
     @Override
     public long loadFileResource(final String path, final OutputStream output) throws IOException {
-        return projectService.readProjectFileResource(name,path,output);
+        return projectService.readProjectFileResource(getName(),path,output);
     }
 
     @Override
     public Date getConfigLastModifiedTime() {
-        return getLastModifiedTime();
+        return projectConfig.getConfigLastModifiedTime();
     }
 
     @Override
@@ -156,36 +134,20 @@ public class RundeckProject implements IRundeckProject{
     @Override
     public String toString() {
         return "RundeckProject{" +
-               "name='" + name + '\'' +
-               ", lastModifiedTime=" + getLastModifiedTime() +
+               "config='" + projectConfig + '\'' +
                '}';
     }
 
-    public IPropertyLookup getLookup() {
-        return lookup;
-    }
-
-    public void setLookup(final IPropertyLookup lookup) {
-        this.lookup = lookup;
-    }
-
-    public IPropertyLookup getProjectLookup() {
-        return projectLookup;
-    }
-
-    public void setProjectLookup(final IPropertyLookup projectLookup) {
-        this.projectLookup = projectLookup;
-    }
-
-    public Date getLastModifiedTime() {
-        return lastModifiedTime;
-    }
-
-    public void setLastModifiedTime(final Date lastModifiedTime) {
-        this.lastModifiedTime = lastModifiedTime;
-    }
 
     public Authorization getProjectAuthorization() {
-        return projectService.getProjectAuthorization(name);
+        return projectService.getProjectAuthorization(getName());
+    }
+
+    public IRundeckProjectConfig getProjectConfig() {
+        return projectConfig;
+    }
+
+    public void setProjectConfig(IRundeckProjectConfig projectConfig) {
+        this.projectConfig = projectConfig;
     }
 }

--- a/rundeckapp/src/java/com/dtolabs/rundeck/server/projects/RundeckProjectConfig.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/server/projects/RundeckProjectConfig.java
@@ -1,0 +1,101 @@
+package com.dtolabs.rundeck.server.projects;
+
+import com.dtolabs.rundeck.core.common.IRundeckProjectConfig;
+import com.dtolabs.rundeck.core.utils.IPropertyLookup;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * project config implementation using property lookup
+ */
+public class RundeckProjectConfig implements IRundeckProjectConfig {
+    private String name;
+    private Date lastModifiedTime;
+    private IPropertyLookup lookup;
+    private IPropertyLookup projectLookup;
+
+    public RundeckProjectConfig(
+            final String name,
+            final IPropertyLookup lookup,
+            final IPropertyLookup projectLookup,
+            final Date lastModifiedTime
+    )
+    {
+        this.name = name;
+        this.setLookup(lookup);
+        this.setProjectLookup(projectLookup);
+        this.setLastModifiedTime(lastModifiedTime);
+
+    }
+
+    public String getName(){
+        return name;
+    }
+    public String getProperty(final String property) {
+        return getLookup().getProperty(property);
+    }
+
+
+    public boolean hasProperty(final String key) {
+        return getProperties().containsKey(key);
+    }
+
+    public Map<String, String> getProperties() {
+        HashMap<String, String> result = new HashMap<>();
+        if(null!= getLookup()){
+            for(Object key: getLookup().getPropertiesMap().keySet()) {
+                result.put(key.toString(), getLookup().getProperty(key.toString()));
+            }
+        }
+        return result;
+    }
+    public Map<String, String> getProjectProperties() {
+        HashMap<String, String> result = new HashMap<>();
+        if(null!= getProjectLookup()){
+            for(Object key: getProjectLookup().getPropertiesMap().keySet()) {
+                result.put(key.toString(), getProjectLookup().getProperty(key.toString()));
+            }
+        }
+        return result;
+    }
+
+
+    public Date getConfigLastModifiedTime() {
+        return getLastModifiedTime();
+    }
+
+
+    public String toString() {
+        return "RundeckProjectConfig{" +
+               "name='" + name + '\'' +
+               ", lastModifiedTime=" + getLastModifiedTime() +
+               '}';
+    }
+
+    public IPropertyLookup getLookup() {
+        return lookup;
+    }
+
+    public void setLookup(final IPropertyLookup lookup) {
+        this.lookup = lookup;
+    }
+
+    public IPropertyLookup getProjectLookup() {
+        return projectLookup;
+    }
+
+    public void setProjectLookup(final IPropertyLookup projectLookup) {
+        this.projectLookup = projectLookup;
+    }
+
+    public Date getLastModifiedTime() {
+        return lastModifiedTime;
+    }
+
+    public void setLastModifiedTime(final Date lastModifiedTime) {
+        this.lastModifiedTime = lastModifiedTime;
+    }
+
+}

--- a/rundeckapp/test/unit/rundeck/services/NodeServiceSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/services/NodeServiceSpec.groovy
@@ -1,0 +1,69 @@
+package rundeck.services
+
+import com.dtolabs.rundeck.core.common.Framework
+import com.dtolabs.rundeck.core.common.INodeSet
+import com.dtolabs.rundeck.core.common.IRundeckProjectConfig
+import com.dtolabs.rundeck.core.common.NodeEntryImpl
+import com.dtolabs.rundeck.core.common.NodeSetImpl
+import com.dtolabs.rundeck.core.common.ProjectManager
+import com.dtolabs.rundeck.core.resources.ResourceModelSource
+import com.dtolabs.rundeck.core.resources.ResourceModelSourceFactory
+import com.dtolabs.rundeck.core.resources.ResourceModelSourceService
+import grails.test.mixin.TestFor
+import spock.lang.Specification
+
+/**
+ * Created by greg on 2/3/16.
+ */
+@TestFor(NodeService)
+class NodeServiceSpec extends Specification {
+    def "get nodes project DNE"(){
+        given:
+        service.frameworkService=Mock(FrameworkService)
+        when:
+        def result = service.getNodes('test1')
+
+
+        then:
+        1*service.frameworkService.getRundeckFramework()>>Mock(Framework){
+            1*getProjectManager()>>Mock(ProjectManager){
+                1*existsFrameworkProject('test1')>>false
+            }
+        }
+        IllegalArgumentException e = thrown()
+        e.message=='Project does not exist: test1'
+    }
+    def "get nodes project exists"(){
+        given:
+        service.frameworkService=Mock(FrameworkService)
+        service.configurationService=Mock(ConfigurationService){
+            getCacheEnabledFor('nodeService','nodeCache', true)>>true
+        }
+        INodeSet nodeSet = new NodeSetImpl()
+        nodeSet.putNode(new NodeEntryImpl('anode'))
+        def properties = ['project.resources.file': '/tmp/test.xml']
+        when:
+        def result = service.getNodes('test1')
+
+
+        then:
+        service.frameworkService.getRundeckFramework()>>Mock(Framework){
+            getProjectManager()>>Mock(ProjectManager){
+                existsFrameworkProject('test1')>>true
+                loadProjectConfig('test1')>>Mock(IRundeckProjectConfig){
+                    getName()>>'test1'
+                    hasProperty(_)>>{args-> properties.containsKey(args[0])}
+                    getProperty(_)>>{args-> properties.get(args[0])}
+                    getProperties()>> properties
+                }
+            }
+            getResourceModelSourceService()>>Mock(ResourceModelSourceService){
+                1 * getSourceForConfiguration('file',_)>>Mock(ResourceModelSource){
+                    getNodes()>>nodeSet
+                }
+            }
+        }
+        null != result.nodeSet.getNode('anode')
+        result.nodeSet.nodeNames as List==['anode']
+    }
+}

--- a/rundeckapp/test/unit/rundeck/services/NodeServiceSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/services/NodeServiceSpec.groovy
@@ -11,59 +11,136 @@ import com.dtolabs.rundeck.core.resources.ResourceModelSourceFactory
 import com.dtolabs.rundeck.core.resources.ResourceModelSourceService
 import grails.test.mixin.TestFor
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  * Created by greg on 2/3/16.
  */
 @TestFor(NodeService)
 class NodeServiceSpec extends Specification {
-    def "get nodes project DNE"(){
+    def "get nodes project DNE"() {
         given:
-        service.frameworkService=Mock(FrameworkService)
+        service.frameworkService = Mock(FrameworkService)
         when:
         def result = service.getNodes('test1')
 
 
         then:
-        1*service.frameworkService.getRundeckFramework()>>Mock(Framework){
-            1*getProjectManager()>>Mock(ProjectManager){
-                1*existsFrameworkProject('test1')>>false
+        1 * service.frameworkService.getRundeckFramework() >> Mock(Framework) {
+            1 * getProjectManager() >> Mock(ProjectManager) {
+                1 * existsFrameworkProject('test1') >> false
             }
         }
         IllegalArgumentException e = thrown()
-        e.message=='Project does not exist: test1'
+        e.message == 'Project does not exist: test1'
     }
-    def "get nodes project exists"(){
+
+    def "get nodes project exists"() {
         given:
-        service.frameworkService=Mock(FrameworkService)
-        service.configurationService=Mock(ConfigurationService){
-            getCacheEnabledFor('nodeService','nodeCache', true)>>true
+        service.frameworkService = Mock(FrameworkService)
+        service.configurationService = Mock(ConfigurationService) {
+            getCacheEnabledFor('nodeService', 'nodeCache', true) >> true
         }
         INodeSet nodeSet = new NodeSetImpl()
         nodeSet.putNode(new NodeEntryImpl('anode'))
         def properties = ['project.resources.file': '/tmp/test.xml']
+
+        def projConfig = new PropsConfig(
+                projectProperties: properties,
+                properties: properties,
+                name: 'test1',
+                configLastModifiedTime: new Date()
+        )
+        def modelSource=Mock(ResourceModelSource) {
+            getNodes() >> nodeSet
+        }
         when:
         def result = service.getNodes('test1')
+        def nodes1 = result.getNodeSet()
 
 
         then:
-        service.frameworkService.getRundeckFramework()>>Mock(Framework){
-            getProjectManager()>>Mock(ProjectManager){
-                existsFrameworkProject('test1')>>true
-                loadProjectConfig('test1')>>Mock(IRundeckProjectConfig){
-                    getName()>>'test1'
-                    hasProperty(_)>>{args-> properties.containsKey(args[0])}
-                    getProperty(_)>>{args-> properties.get(args[0])}
-                    getProperties()>> properties
-                }
+        service.frameworkService.getRundeckFramework() >> Mock(Framework) {
+            getProjectManager() >> Mock(ProjectManager) {
+                existsFrameworkProject('test1') >> true
+                loadProjectConfig('test1') >> projConfig
             }
-            getResourceModelSourceService()>>Mock(ResourceModelSourceService){
-                1 * getSourceForConfiguration('file',_)>>Mock(ResourceModelSource){
-                    getNodes()>>nodeSet
-                }
+            getResourceModelSourceService() >> Mock(ResourceModelSourceService) {
+                1 * getSourceForConfiguration('file', _) >> modelSource
             }
         }
-        null != result.nodeSet.getNode('anode')
-        result.nodeSet.nodeNames as List==['anode']
+        _ * modelSource.getNodes() >> nodeSet
+        null != nodes1.getNode('anode')
+        nodes1.nodeNames as List == ['anode']
+    }
+    class PropsConfig implements IRundeckProjectConfig{
+        Map<String,String> properties
+        Map<String,String> projectProperties
+        String name
+        Date configLastModifiedTime
+
+
+        @Override
+        boolean hasProperty(final String key) {
+            projectProperties.containsKey(key)
+        }
+
+        @Override
+        String getProperty(final String property) {
+            projectProperties.get(property)
+        }
+    }
+    @Unroll
+    def "get nodes when project cache #isenabled"(String isenabled, int expectedCount) {
+        given:
+        service.frameworkService = Mock(FrameworkService)
+        service.configurationService = Mock(ConfigurationService) {
+            getCacheEnabledFor('nodeService', 'nodeCache', true) >> true
+        }
+        INodeSet nodeSet = new NodeSetImpl()
+        nodeSet.putNode(new NodeEntryImpl('anode'))
+        def properties = [
+                'project.resources.file': '/tmp/test.xml',
+
+        ]
+        if(null!=isenabled){
+            properties['project.nodeCache.enabled']= isenabled
+        }
+        def projConfig = new PropsConfig(
+                projectProperties: properties,
+                properties: properties,
+                name: 'test1',
+                configLastModifiedTime: new Date()
+        )
+        def modelSource = Mock(ResourceModelSource)
+
+        service.frameworkService.getRundeckFramework() >> Mock(Framework) {
+            getProjectManager() >> Mock(ProjectManager) {
+                existsFrameworkProject('test1') >> true
+                1*loadProjectConfig('test1') >> projConfig
+            }
+            getResourceModelSourceService() >> Mock(ResourceModelSourceService) {
+                _ * getSourceForConfiguration('file', _) >> modelSource
+            }
+        }
+        when:
+        def result1 = service.getNodes('test1')
+        def nodes1 = result1.getNodeSet()
+        def result2 = service.getNodes('test1')
+        def nodes2 = result2.getNodeSet()
+
+        then:
+        null != nodes1.getNode('anode')
+        null != nodes2.getNode('anode')
+        nodes1.nodeNames as List == ['anode']
+        nodes2.nodeNames as List == ['anode']
+        result1.doCache==('false'!=isenabled)
+        expectedCount * modelSource.getNodes() >> nodeSet
+
+        where:
+        isenabled | expectedCount
+        'true'    | 1
+        'false'   | 3
+        null      | 1
     }
 }

--- a/rundeckapp/test/unit/rundeck/services/ProjectManagerServiceSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ProjectManagerServiceSpec.groovy
@@ -8,6 +8,8 @@ import com.dtolabs.rundeck.core.storage.ResourceMeta
 import com.dtolabs.rundeck.core.storage.StorageTree
 import com.dtolabs.rundeck.core.storage.StorageUtil
 import com.dtolabs.rundeck.core.utils.PropertyLookup
+import com.google.common.cache.Cache
+import com.google.common.cache.LoadingCache
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import org.apache.commons.fileupload.util.Streams
@@ -72,10 +74,13 @@ class ProjectManagerServiceSpec extends Specification {
                 getPropertyLookup() >> PropertyLookup.create(properties)
             }
         }
+        service.nodeService=Mock(NodeService)
         when:
         def result=service.getFrameworkProject('test1')
 
         then:
+
+        1*service.nodeService.getNodes('test1')
         result!=null
         'test1'==result.name
         'fwkvalue'==result.getProperty('fwkprop')
@@ -107,10 +112,12 @@ class ProjectManagerServiceSpec extends Specification {
                 getPropertyLookup() >> PropertyLookup.create(properties)
             }
         }
+        service.nodeService=Mock(NodeService)
         when:
         def result=service.getFrameworkProject('test1')
 
         then:
+        1*service.nodeService.getNodes('test1')
         result!=null
         'test1'==result.name
         'fwkvalue'==result.getProperty('fwkprop')
@@ -145,10 +152,12 @@ class ProjectManagerServiceSpec extends Specification {
                 getPropertyLookup() >> PropertyLookup.create(properties)
             }
         }
+        service.nodeService=Mock(NodeService)
         when:
         def result=service.getFrameworkProject('test1')
 
         then:
+        1*service.nodeService.getNodes('test1')
         result!=null
         'test1'==result.name
         'fwkvalue'==result.getProperty('fwkprop')
@@ -187,12 +196,17 @@ class ProjectManagerServiceSpec extends Specification {
                 getPropertyLookup() >> PropertyLookup.create(properties)
             }
         }
+        service.nodeService=Mock(NodeService)
+        service.projectCache=Mock(LoadingCache)
 
         when:
 
         def result = service.createFrameworkProject('test1',props)
 
         then:
+        1*service.projectCache.invalidate('test1')
+        1*service.nodeService.expireProjectNodes('test1')
+        1*service.nodeService.getNodes('test1')
 
         result.name=='test1'
         2==result.getProjectProperties().size()
@@ -247,12 +261,18 @@ class ProjectManagerServiceSpec extends Specification {
             }
         }
 
+        service.nodeService=Mock(NodeService)
+        service.projectCache=Mock(LoadingCache)
         when:
 
         def result = service.createFrameworkProjectStrict('test1',props)
 
         then:
+        1*service.projectCache.invalidate('test1')
+        1*service.nodeService.expireProjectNodes('test1')
+        1*service.nodeService.getNodes('test1')
 
+        0*service.nodeService._(*_)
         result.name=='test1'
         2==result.getProjectProperties().size()
         'test1'==result.getProjectProperties().get('project.name')
@@ -268,6 +288,7 @@ class ProjectManagerServiceSpec extends Specification {
         service.removeFrameworkProject('test1')
 
         then:
+        0*service.nodeService._(*_)
         IllegalArgumentException e = thrown()
         e.message.contains('does not exist')
     }
@@ -282,11 +303,15 @@ class ProjectManagerServiceSpec extends Specification {
             1*hasDirectory({it.path=="projects/test1"}) >> true
             1*listDirectory({it.path=="projects/test1"}) >> []
         }
+        service.nodeService=Mock(NodeService)
+        service.projectCache=Mock(LoadingCache)
         when:
 
         service.removeFrameworkProject('test1')
 
         then:
+        1*service.projectCache.invalidate('test1')
+        1*service.nodeService.expireProjectNodes('test1')
         null==Project.findByName('test1')
 
     }
@@ -327,11 +352,15 @@ class ProjectManagerServiceSpec extends Specification {
             }
         }
 
+        service.nodeService=Mock(NodeService)
+        service.projectCache=Mock(LoadingCache)
 
         when:
         def res=service.mergeProjectProperties('test1',props1,[] as Set)
 
         then:
+        1*service.projectCache.invalidate('test1')
+        1*service.nodeService.expireProjectNodes('test1')
 
         res!=null
         res.config.size()==3
@@ -362,12 +391,16 @@ class ProjectManagerServiceSpec extends Specification {
             }
         }
 
+        service.nodeService=Mock(NodeService)
+        service.projectCache=Mock(LoadingCache)
 
         when:
         def res=service.setProjectProperties('test1',props1)
 
         then:
 
+        1*service.projectCache.invalidate('test1')
+        1*service.nodeService.expireProjectNodes('test1')
         res!=null
         res.config.size()==2
         null==res.config['abc']
@@ -400,11 +433,15 @@ class ProjectManagerServiceSpec extends Specification {
         }
 
 
+        service.nodeService=Mock(NodeService)
+        service.projectCache=Mock(LoadingCache)
         when:
         def res=service.setProjectProperties('test1',props1)
 
         then:
 
+        1*service.projectCache.invalidate('test1')
+        1*service.nodeService.expireProjectNodes('test1')
         res!=null
         res.config.size()==2
         null==res.config['abc']
@@ -1047,10 +1084,15 @@ class ProjectManagerServiceSpec extends Specification {
                 getPropertyLookup() >> PropertyLookup.create(properties)
             }
         }
+        service.nodeService=Mock(NodeService)
+        service.projectCache=Mock(LoadingCache)
         when:
         service.importProjectsFromProjectManager(pm1)
 
         then:
+        1*service.nodeService.expireProjectNodes('abc')
+        1*service.nodeService.getNodes('abc')
+        1*service.projectCache.invalidate('abc')
         Project.findByName('abc')!=null
     }
 }

--- a/test/api/test-resource.sh
+++ b/test/api/test-resource.sh
@@ -7,6 +7,26 @@ set -- -
 
 source $DIR/include.sh
 
+
+project="test"
+proj_config_url="${APIURL}/project/${project}/config"
+set_url_config(){
+    prop=$1
+    value=$2
+
+    docurl -X PUT --data-binary "${value}" -H 'Content-Type:text/plain' "${proj_config_url}/${prop}" > $DIR/curl.out
+    if [ 0 != $? ] ; then
+        errorMsg "ERROR: failed PUT request"
+        exit 2
+    fi
+    #echo "project.resources.url=http://invalid.domain:1235/resources.xml" >> $TPROPS
+}
+
+
+#disable node caching
+set_url_config "project.nodeCache.enabled" "false"
+
+
 file=$DIR/curl.out
 
 ###

--- a/test/api/test-resources.sh
+++ b/test/api/test-resources.sh
@@ -7,6 +7,21 @@ source $DIR/include.sh
 
 file=$DIR/curl.out
 
+project="test"
+proj_config_url="${APIURL}/project/${project}/config"
+set_url_config(){
+    prop=$1
+    value=$2
+
+    docurl -X PUT --data-binary "${value}" -H 'Content-Type:text/plain' "${proj_config_url}/${prop}" > $DIR/curl.out
+    if [ 0 != $? ] ; then
+        errorMsg "ERROR: failed PUT request"
+        exit 2
+    fi
+    #echo "project.resources.url=http://invalid.domain:1235/resources.xml" >> $TPROPS
+}
+
+
 ###
 # Setup: acquire local server name from RDECK_ETC/framework.properties#server.name
 ####
@@ -17,12 +32,14 @@ if [ -z "${localnode}" ] ; then
     exit 2
 fi
 
+#disable node caching
+set_url_config "project.nodeCache.enabled" "false"
+
 # now submit req
 runurl="${APIURL}/resources"
 
 echo "TEST: /api/resources, basic XML response with all nodes: >0 result"
 
-project="test"
 params="project=${project}"
 
 # get listing


### PR DESCRIPTION
Provides projects with asynchronous cache for nodes:

* slow resource model sources will now not affect the GUI
* can be disabled on a per-project or global basis if needed
* can configure per-project cache delay (default 30 seconds)
* works with file or db based project config
* configuration via GUI or project config

This will supplant the need for Resource Model Source plugins (such as ec2) to do their own asynchronous responses

Configuration:

Disable globally in `rundeck-config.properties`:

~~~{.properties}
rundeck.nodeService.nodeCache.enabled=true
~~~

Project settings:

~~~{.properties}
#  if not specified is treated as true
project.nodeCache.enabled=true/false
# delay in seconds
project.nodeCache.delay=30
~~~