### PR TITLE
fix issue 1368: log output newlines

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/utils/ThreadBoundOutputStream.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/utils/ThreadBoundOutputStream.java
@@ -133,6 +133,15 @@ public class ThreadBoundOutputStream extends FilterOutputStream {
         }
     }
 
+    @Override
+    public void close() throws IOException {
+        final OutputStream out = getThreadLocalOutputStream();
+        if (out == null || out == this) {
+            super.close();
+        } else {
+            out.close();
+        }
+    }
 
     private static PrintStream origSystemOut;
     private static ThreadBoundPrintStream boundOutPrint;

--- a/rundeckapp/grails-app/conf/BootStrap.groovy
+++ b/rundeckapp/grails-app/conf/BootStrap.groovy
@@ -272,14 +272,9 @@ class BootStrap {
 
          //configure System.out and System.err so that remote command execution will write to a specific print stream
          if(Environment.getCurrent() != Environment.TEST){
-             PrintStream oldout = System.out;
-             PrintStream olderr = System.err;
 
-             def ThreadBoundOutputStream newOut = new ThreadBoundOutputStream(oldout)
-             def ThreadBoundOutputStream newErr = new ThreadBoundOutputStream(olderr)
-
-             System.setOut(new PrintStream(newOut));
-             System.setErr(new PrintStream(newErr));
+             def ThreadBoundOutputStream newOut = ThreadBoundOutputStream.bindSystemOut()
+             def ThreadBoundOutputStream newErr = ThreadBoundOutputStream.bindSystemErr()
 
              executionService.sysThreadBoundOut=newOut
              executionService.sysThreadBoundErr=newErr

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1,5 +1,6 @@
 package rundeck.services
 
+import com.dtolabs.rundeck.app.internal.logging.LogFlusher
 import com.dtolabs.rundeck.app.internal.workflow.MultiWorkflowExecutionListener
 import com.dtolabs.rundeck.app.support.*
 import com.dtolabs.rundeck.core.authorization.AuthContext
@@ -791,9 +792,19 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     execution,framework,authContext,jobcontext,extraParamsExposed)
 
             def wfEventListener = new WorkflowEventLoggerListener(executionListener)
-
-            def multiListener = MultiWorkflowExecutionListener.create(executionListener,
-                    [executionListener, wfEventListener,execStateListener, /*new EchoExecListener() */])
+            def logOutFlusher = new LogFlusher()
+            def logErrFlusher = new LogFlusher()
+            def multiListener = MultiWorkflowExecutionListener.create(
+                    executionListener, //delegate for ExecutionListener
+                    [
+                            executionListener, //manages context for logging
+                            wfEventListener, //emits state change events to log
+                            execStateListener, //updates WF execution state model
+                            logOutFlusher, //flushes stdout output after node steps
+                            logErrFlusher, //flush stderr output after node steps
+                            /*new EchoExecListener() */
+                    ]
+            )
 
             if(scheduledExecution) {
                 if(!extraParamsExposed){
@@ -824,8 +835,12 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             }
             //install custom outputstreams for System.out and System.err for this thread and any child threads
             //output will be sent to loghandler instead.
-            sysThreadBoundOut.installThreadStream(loggingService.createLogOutputStream(loghandler, LogLevel.NORMAL, executionListener));
-            sysThreadBoundErr.installThreadStream(loggingService.createLogOutputStream(loghandler, LogLevel.ERROR, executionListener));
+            sysThreadBoundOut.installThreadStream(
+                    loggingService.createLogOutputStream(loghandler, LogLevel.NORMAL, executionListener, logOutFlusher)
+            );
+            sysThreadBoundErr.installThreadStream(
+                    loggingService.createLogOutputStream(loghandler, LogLevel.ERROR, executionListener, logErrFlusher)
+            );
             //create service object for the framework and listener
             Thread thread = new WorkflowExecutionServiceThread(framework.getWorkflowExecutionService(),item, executioncontext)
             thread.start()
@@ -833,7 +848,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         }catch(Exception e) {
             log.error("Failed while starting execution: ${execution.id}", e)
             loghandler.logError('Failed to start execution: ' + e.getClass().getName() + ": " + e.message)
+            sysThreadBoundOut.close()
             sysThreadBoundOut.removeThreadStream()
+            sysThreadBoundErr.close()
             sysThreadBoundErr.removeThreadStream()
             loghandler.close()
             return null

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
@@ -78,9 +78,9 @@ class ExecutionUtilService {
                 log.info("Execution successful: " + execMap.execution.id)
             }
         } finally {
-            sysThreadBoundOut.flush()
+            sysThreadBoundOut.close()
             sysThreadBoundOut.removeThreadStream()
-            sysThreadBoundErr.flush()
+            sysThreadBoundErr.close()
             sysThreadBoundErr.removeThreadStream()
             loghandler.close()
         }

--- a/rundeckapp/grails-app/services/rundeck/services/LoggingService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LoggingService.groovy
@@ -1,5 +1,6 @@
 package rundeck.services
 
+import com.dtolabs.rundeck.app.internal.logging.LogFlusher
 import com.dtolabs.rundeck.app.internal.logging.ThreadBoundLogOutputStream
 import com.dtolabs.rundeck.core.execution.Contextual
 import com.dtolabs.rundeck.core.logging.LogLevel
@@ -205,7 +206,15 @@ class LoggingService implements ExecutionFileProducer {
         return logFileStorageService.requestLogFileReader(execution, LOG_FILE_FILETYPE)
     }
 
-    public OutputStream createLogOutputStream(StreamingLogWriter logWriter, LogLevel level, Contextual listener) {
-        return new ThreadBoundLogOutputStream(logWriter, level, listener)
+    public OutputStream createLogOutputStream(
+            StreamingLogWriter logWriter,
+            LogLevel level,
+            Contextual listener,
+            LogFlusher flusherWorkflowListener
+    )
+    {
+        def stream = new ThreadBoundLogOutputStream(logWriter, level, listener)
+        flusherWorkflowListener.logOut=stream
+        return stream
     }
 }

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/logging/LogEventBuffer.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/logging/LogEventBuffer.groovy
@@ -1,0 +1,76 @@
+package com.dtolabs.rundeck.app.internal.logging
+
+import com.dtolabs.rundeck.core.logging.LogEvent
+import com.dtolabs.rundeck.core.logging.LogLevel
+import com.dtolabs.rundeck.core.logging.LogUtil
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Buffer of log event data used by {@link ThreadBoundLogOutputStream}
+ */
+class LogEventBuffer implements Comparable {
+    Date time
+    Map<String, String> context
+    Boolean crchar
+    ByteArrayOutputStream baos
+    Long serial
+    final static AtomicLong counter = new AtomicLong(0)
+
+    LogEventBuffer(final Map<String, String> context) {
+        serial = counter.incrementAndGet()
+        reset(context)
+    }
+
+    boolean isEmpty() {
+        time == null
+    }
+
+    void clear() {
+        this.time = null
+        this.context = null
+        this.baos = new ByteArrayOutputStream()
+        this.crchar = false
+    }
+
+    void reset(final Map<String, String> context) {
+        this.time = new Date()
+        this.context = context
+        this.baos = new ByteArrayOutputStream()
+    }
+
+    LogEvent createEvent(LogLevel level) {
+        return new DefaultLogEvent(
+                loglevel: level,
+                metadata: context ?: [:],
+                message: baos ? new String(baos.toByteArray()) : '',
+                datetime: time ?: new Date(),
+                eventType: LogUtil.EVENT_TYPE_LOG
+        )
+    }
+
+    @Override
+    int compareTo(final Object o) {
+        if (!(o instanceof LogEventBuffer)) {
+            return -1;
+        }
+        LogEventBuffer other = (LogEventBuffer) o
+        def td = compareDates(time, other.time)
+        if (td != 0) {
+            return td
+        }
+        return serial.compareTo(other.serial)
+    }
+
+    static int compareDates(Date a, Date b) {
+        if (a == null && b == null) {
+            return 0;
+        }
+        if (a != null && b != null) {
+            return a.compareTo(b)
+        }
+
+        return a != null ? -1 : 1
+
+    }
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/logging/LogEventBufferManager.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/logging/LogEventBufferManager.groovy
@@ -1,0 +1,38 @@
+package com.dtolabs.rundeck.app.internal.logging
+
+import com.dtolabs.rundeck.core.logging.LogLevel
+import com.dtolabs.rundeck.core.logging.StreamingLogWriter
+
+/**
+ * Creates log event buffers, and retains references to them, so that they can be
+ * flushed later even if any thread-local references are lost when a thread finishes
+ */
+class LogEventBufferManager {
+    Set<LogEventBuffer> buffers = new TreeSet<>()
+
+    LogEventBuffer create(Map context) {
+        def buffer = new LogEventBuffer(context)
+        buffers.add(buffer)
+        return buffer
+    }
+
+    static LogEventBufferManager createManager() {
+        new LogEventBufferManager()
+    }
+
+    /**
+     * flush all incomplete event buffers in the appropriate order, then clear all buffers from the cache
+     * @param writer
+     * @param level
+     */
+    void flush(StreamingLogWriter writer, LogLevel level) {
+
+        for (def b : buffers) {
+            if (!b.isEmpty()) {
+                writer.addEvent(b.createEvent(level))
+            }
+            b.clear()
+        }
+        buffers.clear()
+    }
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/logging/LogFlusher.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/logging/LogFlusher.groovy
@@ -1,0 +1,64 @@
+package com.dtolabs.rundeck.app.internal.logging
+
+import com.dtolabs.rundeck.app.internal.workflow.BaseWorkflowExecutionListener
+import com.dtolabs.rundeck.core.common.INodeEntry
+import com.dtolabs.rundeck.core.execution.ExecutionContext
+import com.dtolabs.rundeck.core.execution.StatusResult
+import com.dtolabs.rundeck.core.execution.StepExecutionItem
+import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutor
+import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepExecutionItem
+import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepResult
+
+/**
+ * Manages cleanup for buffered log events, flushes the thread bound log output streams of any buffered events when a
+ * node or workflow step finishes
+ */
+class LogFlusher extends BaseWorkflowExecutionListener {
+    ThreadBoundLogOutputStream logOut
+
+    LogFlusher() {
+
+    }
+
+    LogFlusher(final ThreadBoundLogOutputStream logOut) {
+        this.logOut = logOut
+    }
+
+    @Override
+    void beginStepExecution(
+            final StepExecutor executor,
+            final StepExecutionContext context,
+            final StepExecutionItem item
+    )
+    {
+        logOut?.installManager()
+    }
+
+    @Override
+    void finishStepExecution(
+            final StepExecutor executor,
+            final StatusResult result,
+            final StepExecutionContext context,
+            final StepExecutionItem item
+    )
+    {
+        logOut?.flushBuffers()
+    }
+
+    @Override
+    void beginExecuteNodeStep(final ExecutionContext context, final NodeStepExecutionItem item, final INodeEntry node) {
+        logOut?.installManager()
+    }
+
+    @Override
+    void finishExecuteNodeStep(
+            final NodeStepResult result,
+            final ExecutionContext context,
+            final StepExecutionItem item,
+            final INodeEntry node
+    )
+    {
+        logOut?.flushBuffers()
+    }
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/workflow/BaseWorkflowExecutionListener.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/workflow/BaseWorkflowExecutionListener.groovy
@@ -1,0 +1,96 @@
+package com.dtolabs.rundeck.app.internal.workflow
+
+import com.dtolabs.rundeck.core.common.INodeEntry
+import com.dtolabs.rundeck.core.execution.ExecutionContext
+import com.dtolabs.rundeck.core.execution.StatusResult
+import com.dtolabs.rundeck.core.execution.StepExecutionItem
+import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext
+import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionItem
+import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionListener
+import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionResult
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutionResult
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutor
+import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepExecutionItem
+import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepResult
+
+/**
+ * Base listener for overriding
+ */
+abstract class BaseWorkflowExecutionListener implements WorkflowExecutionListener{
+    @Override
+    void beginWorkflowExecution(final StepExecutionContext executionContext, final WorkflowExecutionItem item) {
+
+    }
+
+    @Override
+    void finishWorkflowExecution(
+            final WorkflowExecutionResult result,
+            final StepExecutionContext executionContext,
+            final WorkflowExecutionItem item
+    )
+    {
+
+    }
+
+    @Override
+    void beginWorkflowItem(final int step, final StepExecutionItem item) {
+
+    }
+
+    @Override
+    void beginWorkflowItemErrorHandler(final int step, final StepExecutionItem item) {
+
+    }
+
+    @Override
+    void finishWorkflowItem(final int step, final StepExecutionItem item, final StepExecutionResult result) {
+
+    }
+
+    @Override
+    void finishWorkflowItemErrorHandler(
+            final int step,
+            final StepExecutionItem item,
+            final StepExecutionResult success
+    )
+    {
+
+    }
+
+    @Override
+    void beginStepExecution(
+            final StepExecutor executor,
+            final StepExecutionContext context,
+            final StepExecutionItem item
+    )
+    {
+
+    }
+
+    @Override
+    void finishStepExecution(
+            final StepExecutor executor,
+            final StatusResult result,
+            final StepExecutionContext context,
+            final StepExecutionItem item
+    )
+    {
+
+    }
+
+    @Override
+    void beginExecuteNodeStep(final ExecutionContext context, final NodeStepExecutionItem item, final INodeEntry node) {
+
+    }
+
+    @Override
+    void finishExecuteNodeStep(
+            final NodeStepResult result,
+            final ExecutionContext context,
+            final StepExecutionItem item,
+            final INodeEntry node
+    )
+    {
+
+    }
+}

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/logging/LogEventBufferManagerSpec.groovy
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/logging/LogEventBufferManagerSpec.groovy
@@ -1,0 +1,72 @@
+package com.dtolabs.rundeck.app.internal.logging
+
+import com.dtolabs.rundeck.core.logging.LogLevel
+import com.dtolabs.rundeck.core.logging.StreamingLogWriter
+import spock.lang.Specification
+
+/**
+ * Created by greg on 2/22/16.
+ */
+class LogEventBufferManagerSpec extends Specification {
+    def "create buffer"() {
+        given:
+        def manager = new LogEventBufferManager()
+
+        when:
+        def buffer = manager.create([abc: 'xyz'])
+
+        then:
+        buffer != null
+        !buffer.isEmpty()
+        buffer.context == [abc: 'xyz']
+        buffer.baos != null
+        buffer.baos.size() == 0
+        manager.buffers.size() == 1
+    }
+
+    def "create multiple buffers"() {
+        given:
+        def manager = new LogEventBufferManager()
+
+        when:
+        def buffer = manager.create([abc: 'xyz'])
+        def buffer2 = manager.create([abc: 'def'])
+        def buffer3 = manager.create([abc: 'ghi'])
+
+        then:
+        manager.buffers.size() == 3
+    }
+
+    def "flush buffers"() {
+        given:
+        def manager = new LogEventBufferManager()
+        def buffer = manager.create([abc: 'xyz'])
+        def buffer2 = manager.create([abc: 'def'])
+        def buffer3 = manager.create([abc: 'ghi'])
+        def writer = Mock(StreamingLogWriter)
+        when:
+        buffer.baos.write('abc'.bytes)
+
+        manager.flush(writer, LogLevel.DEBUG)
+        then:
+        3 * writer.addEvent(_)
+        manager.buffers.isEmpty()
+    }
+
+    def "flush buffers after clear"() {
+        given:
+        def manager = new LogEventBufferManager()
+        def buffer = manager.create([abc: 'xyz'])
+        def buffer2 = manager.create([abc: 'def'])
+        def buffer3 = manager.create([abc: 'ghi'])
+        def writer = Mock(StreamingLogWriter)
+        when:
+        buffer.clear()
+        buffer2.clear()
+        buffer3.clear()
+        manager.flush(writer, LogLevel.DEBUG)
+        then:
+        0 * writer.addEvent(_)
+        manager.buffers.isEmpty()
+    }
+}

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/logging/LogEventBufferSpec.groovy
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/logging/LogEventBufferSpec.groovy
@@ -1,0 +1,86 @@
+package com.dtolabs.rundeck.app.internal.logging
+
+import com.dtolabs.rundeck.core.logging.LogLevel
+import com.dtolabs.rundeck.core.logging.LogUtil
+import spock.lang.Specification
+
+/**
+ * Created by greg on 2/22/16.
+ */
+class LogEventBufferSpec extends Specification {
+
+    def "clear buffer is empty"() {
+        given:
+        def buff = new LogEventBuffer([:])
+        when:
+        buff.clear()
+        then:
+        null != buff.baos
+        0 == buff.baos.size()
+        null == buff.context
+        null == buff.time
+        !buff.crchar
+        buff.isEmpty()
+    }
+
+    def "new buffer not empty"() {
+        given:
+        def buff = new LogEventBuffer([:])
+        expect:
+        null != buff.baos
+        0 == buff.baos.size()
+        null != buff.context
+        null != buff.time
+        !buff.crchar
+        !buff.isEmpty()
+    }
+
+    def "clear after modify is empty"() {
+        given:
+        def buff = new LogEventBuffer([:])
+        buff.baos.write('abc'.bytes)
+        buff.crchar = true
+        when:
+        buff.clear()
+        then:
+        null != buff.baos
+        0 == buff.baos.size()
+        null == buff.context
+        null == buff.time
+        !buff.crchar
+        buff.isEmpty()
+    }
+
+    def "create event with data"() {
+
+        def buff = new LogEventBuffer([abc: 'xyz'])
+        buff.baos.write('abc'.bytes)
+
+        when:
+        def log = buff.createEvent(LogLevel.DEBUG)
+
+        then:
+        null != log
+        log.message == 'abc'
+        log.datetime != null
+        log.loglevel == LogLevel.DEBUG
+        log.metadata == [abc: 'xyz']
+        log.eventType == LogUtil.EVENT_TYPE_LOG
+
+    }
+
+    def "compare dates"() {
+        expect:
+
+        result == LogEventBuffer.compareDates(dateA, dateB)
+
+        where:
+        dateA         | dateB         | result
+        new Date(123) | new Date(125) | -1
+        new Date(123) | new Date(122) | 1
+        new Date(123) | new Date(123) | 0
+        null          | new Date(123) | 1
+        new Date(123) | null          | -1
+        null          | null          | 0
+    }
+}

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/logging/ThreadBoundLogOutputStreamSpec.groovy
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/logging/ThreadBoundLogOutputStreamSpec.groovy
@@ -1,0 +1,131 @@
+package com.dtolabs.rundeck.app.internal.logging
+
+import com.dtolabs.rundeck.core.execution.Contextual
+import com.dtolabs.rundeck.core.logging.LogLevel
+import com.dtolabs.rundeck.core.logging.StreamingLogWriter
+import com.dtolabs.rundeck.core.utils.ThreadBoundOutputStream
+import spock.lang.Specification
+
+/**
+ * Created by greg on 2/18/16.
+ */
+class ThreadBoundLogOutputStreamSpec extends Specification {
+    def "write without newline"() {
+        given:
+        StreamingLogWriter writer = Mock(StreamingLogWriter)
+        Contextual context = Mock(Contextual)
+        ThreadBoundLogOutputStream stream = new ThreadBoundLogOutputStream(writer, LogLevel.DEBUG, context)
+
+
+        when:
+        stream.write('abc no newline'.bytes)
+
+        then:
+        0 * writer.addEvent(_)
+        1 * context.getContext()
+
+    }
+
+    def "write multiple without newline"() {
+        given:
+        StreamingLogWriter writer = Mock(StreamingLogWriter)
+        Contextual context = Mock(Contextual)
+        ThreadBoundLogOutputStream stream = new ThreadBoundLogOutputStream(writer, LogLevel.DEBUG, context)
+
+
+        when:
+        stream.write('abc no newline'.bytes)
+        stream.write(' still not'.bytes)
+        stream.write(' more not'.bytes)
+
+        then:
+        0 * writer.addEvent(_)
+        1 * context.getContext()
+
+    }
+
+    def "write multiple with flush without newline"() {
+        given:
+        StreamingLogWriter writer = Mock(StreamingLogWriter)
+        Contextual context = Mock(Contextual)
+        ThreadBoundLogOutputStream stream = new ThreadBoundLogOutputStream(writer, LogLevel.DEBUG, context)
+
+
+        when:
+        stream.write('abc no newline'.bytes)
+        stream.flush()
+        stream.write(' still not'.bytes)
+        stream.flush()
+        stream.write(' more not'.bytes)
+        stream.flush()
+
+        then:
+        0 * writer.addEvent(_)
+        1 * context.getContext()
+
+    }
+
+    def "write with newline"() {
+        given:
+        StreamingLogWriter writer = Mock(StreamingLogWriter)
+        Contextual context = Mock(Contextual)
+        ThreadBoundLogOutputStream stream = new ThreadBoundLogOutputStream(writer, LogLevel.DEBUG, context)
+
+        when:
+        stream.write('abc yes newline\n'.bytes)
+
+        then:
+        1 * writer.addEvent(_)
+        1 * context.getContext()
+    }
+
+    def "write multi then newline"() {
+        given:
+        StreamingLogWriter writer = Mock(StreamingLogWriter)
+        Contextual context = Mock(Contextual)
+        ThreadBoundLogOutputStream stream = new ThreadBoundLogOutputStream(writer, LogLevel.DEBUG, context)
+
+        when:
+        stream.write('no newline'.bytes)
+        stream.write(' still not'.bytes)
+        stream.write(' more not'.bytes)
+        stream.write(' then\n'.bytes)
+
+        then:
+        1 * writer.addEvent(_)
+        1 * context.getContext()
+    }
+
+    def "write without newline then close"() {
+        given:
+        StreamingLogWriter writer = Mock(StreamingLogWriter)
+        Contextual context = Mock(Contextual)
+        ThreadBoundLogOutputStream stream = new ThreadBoundLogOutputStream(writer, LogLevel.DEBUG, context)
+
+        when:
+        stream.write('no newline'.bytes)
+        stream.close()
+
+        then:
+        1 * writer.addEvent(_)
+        1 * context.getContext()
+    }
+
+    def "write multi without newline then close"() {
+        given:
+        StreamingLogWriter writer = Mock(StreamingLogWriter)
+        Contextual context = Mock(Contextual)
+        ThreadBoundLogOutputStream stream = new ThreadBoundLogOutputStream(writer, LogLevel.DEBUG, context)
+
+        when:
+        stream.write('no newline'.bytes)
+        stream.write(' still not'.bytes)
+        stream.write(' more not'.bytes)
+        stream.close()
+
+        then:
+        1 * writer.addEvent(_)
+        1 * context.getContext()
+    }
+
+}

--- a/rundeckapp/test/unit/rundeck/services/ExecutionUtilServiceTests.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ExecutionUtilServiceTests.groovy
@@ -57,9 +57,9 @@ class ExecutionUtilServiceTests {
 
         def stbocontrol=mockFor(ThreadBoundOutputStream)
         def stbecontrol=mockFor(ThreadBoundOutputStream)
-        stbocontrol.demand.flush(1..1){->}
+        stbocontrol.demand.close(1..1){->}
         stbocontrol.demand.removeThreadStream(1..1){->}
-        stbecontrol.demand.flush(1..1){->}
+        stbecontrol.demand.close(1..1){->}
         stbecontrol.demand.removeThreadStream(1..1){->}
         executionUtilService.sysThreadBoundOut=stbocontrol.createMock()
         executionUtilService.sysThreadBoundErr=stbecontrol.createMock()
@@ -88,9 +88,9 @@ class ExecutionUtilServiceTests {
 
         def stbocontrol=mockFor(ThreadBoundOutputStream)
         def stbecontrol=mockFor(ThreadBoundOutputStream)
-        stbocontrol.demand.flush(1..1){->}
+        stbocontrol.demand.close(1..1){->}
         stbocontrol.demand.removeThreadStream(1..1){->}
-        stbecontrol.demand.flush(1..1){->}
+        stbecontrol.demand.close(1..1){->}
         stbecontrol.demand.removeThreadStream(1..1){->}
         executionUtilService.sysThreadBoundOut=stbocontrol.createMock()
         executionUtilService.sysThreadBoundErr=stbecontrol.createMock()
@@ -121,9 +121,9 @@ class ExecutionUtilServiceTests {
 
         def stbocontrol=mockFor(ThreadBoundOutputStream)
         def stbecontrol=mockFor(ThreadBoundOutputStream)
-        stbocontrol.demand.flush(1..1){->}
+        stbocontrol.demand.close(1..1){->}
         stbocontrol.demand.removeThreadStream(1..1){->}
-        stbecontrol.demand.flush(1..1){->}
+        stbecontrol.demand.close(1..1){->}
         stbecontrol.demand.removeThreadStream(1..1){->}
         executionUtilService.sysThreadBoundOut=stbocontrol.createMock()
         executionUtilService.sysThreadBoundErr=stbecontrol.createMock()
@@ -154,9 +154,9 @@ class ExecutionUtilServiceTests {
 
         def stbocontrol=mockFor(ThreadBoundOutputStream)
         def stbecontrol=mockFor(ThreadBoundOutputStream)
-        stbocontrol.demand.flush(1..1){->}
+        stbocontrol.demand.close(1..1){->}
         stbocontrol.demand.removeThreadStream(1..1){->}
-        stbecontrol.demand.flush(1..1){->}
+        stbecontrol.demand.close(1..1){->}
         stbecontrol.demand.removeThreadStream(1..1){->}
         executionUtilService.sysThreadBoundOut=stbocontrol.createMock()
         executionUtilService.sysThreadBoundErr=stbecontrol.createMock()


### PR DESCRIPTION
* does not flush all output when a flush() is sent
* flushes remaining output when child threads complete