### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -16,7 +16,7 @@ dependencies {
         'log4j:log4j:1.2.17',
         'commons-codec:commons-codec:1.5',
         'commons-beanutils:commons-beanutils:1.8.3',
-        'commons-collections:commons-collections:3.2.1',
+        'commons-collections:commons-collections:3.2.2',
         'commons-logging:commons-logging:1.1.1',
         'commons-lang:commons-lang:2.6',
         'dom4j:dom4j:1.6.1',


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/