### PR TITLE
fix #1744 first node load is synchronous

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/common/IProjectNodes.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/IProjectNodes.java
@@ -21,6 +21,11 @@ public interface IProjectNodes {
     ArrayList<Exception> getResourceModelSourceExceptions();
 
     /**
+     * @return the set of exceptions produced by source name
+     */
+    Map<String,Exception> getResourceModelSourceExceptionsMap();
+
+    /**
      * list the configurations of resource model providers.
      *
      * @return a list of maps containing:

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/ProjectNodeSupport.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/ProjectNodeSupport.java
@@ -302,7 +302,7 @@ public class ProjectNodeSupport implements IProjectNodes {
         final ResourceFormatGeneratorService resourceFormatGeneratorService = getResourceFormatGeneratorService();
         final Properties fileSourceConfig = generateFileSourceConfigurationProperties(
                 file.getAbsolutePath(),
-                ResourceXMLFormatGenerator.SERVICE_PROVIDER_TYPE, true, false
+                ResourceXMLFormatGenerator.SERVICE_PROVIDER_TYPE, false, false
         );
         try {
             ResourceModelSource fileSource = nodesSourceService.getSourceForConfiguration("file", fileSourceConfig);

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/ProjectNodeSupport.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/ProjectNodeSupport.java
@@ -280,13 +280,15 @@ public class ProjectNodeSupport implements IProjectNodes {
             String descr
     )
     {
-        return createCachingSource(origin, ident, descr, SourceFactory.CacheType.BOTH);
+        return createCachingSource(origin, ident, descr, SourceFactory.CacheType.BOTH, true);
     }
 
     /**
+     * @param logging
      * @param origin origin source
      * @param ident  unique identity for this cached source, used in filename
      * @param descr  description of the source, used in logging
+     * @param logging if true, log cache access
      *
      * @return new source
      */
@@ -294,7 +296,8 @@ public class ProjectNodeSupport implements IProjectNodes {
             ResourceModelSource origin,
             String ident,
             String descr,
-            SourceFactory.CacheType type
+            SourceFactory.CacheType type,
+            final boolean logging
     )
     {
         final File file = getResourceModelSourceFileCacheForType(ident);
@@ -312,14 +315,19 @@ public class ProjectNodeSupport implements IProjectNodes {
 
             String ident1 = "[ResourceModelSource: " + descr + ", project: " + projectConfig.getName() + "]";
             StoreExceptionHandler handler = new StoreExceptionHandler(ident);
+            ResourceModelSourceCache cache = new FileResourceModelSourceCache(
+                    file,
+                    generatorForFormat,
+                    fileSource
+            );
+            if(logging) {
+                cache = new LoggingResourceModelSourceCache(cache, ident1);
+            }
             return SourceFactory.cachedSource(
                     origin,
                     ident1,
                     handler,
-                    new LoggingResourceModelSourceCache(
-                            new FileResourceModelSourceCache(file, generatorForFormat, fileSource),
-                            ident1
-                    ),
+                    cache,
                     type
             );
         } catch (UnsupportedFormatException | ExecutionServiceException e) {
@@ -341,7 +349,7 @@ public class ProjectNodeSupport implements IProjectNodes {
             String descr
     )
     {
-        return createCachingSource(origin, ident, descr, SourceFactory.CacheType.LOAD_ONLY);
+        return createCachingSource(origin, ident, descr, SourceFactory.CacheType.LOAD_ONLY, true);
     }
 
     /**
@@ -357,7 +365,7 @@ public class ProjectNodeSupport implements IProjectNodes {
             String descr
     )
     {
-        return createCachingSource(origin, ident, descr, SourceFactory.CacheType.STORE_ONLY);
+        return createCachingSource(origin, ident, descr, SourceFactory.CacheType.STORE_ONLY, true);
     }
 
     private ResourceFormatGeneratorService getResourceFormatGeneratorService() {

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/CachingResourceModelSource.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/CachingResourceModelSource.java
@@ -37,6 +37,17 @@ public class CachingResourceModelSource extends ExceptionCatchingResourceModelSo
         this.cache = cache;
     }
 
+    public CachingResourceModelSource(
+            final ResourceModelSource delegate,
+            final String identity,
+            final ExceptionHandler handler,
+            final ResourceModelSourceCache cache
+    )
+    {
+        super(delegate, identity, handler);
+        this.cache = cache;
+    }
+
     @Override
     INodeSet returnResultNodes(INodeSet nodes) throws ResourceModelSourceException {
         if (null != nodes) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/CachingResourceModelSource.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/CachingResourceModelSource.java
@@ -17,15 +17,20 @@
 package com.dtolabs.rundeck.core.resources;
 
 import com.dtolabs.rundeck.core.common.INodeSet;
-import org.apache.log4j.Logger;
 
 /**
  * Abstract caching model source. calls to getNodes will attempt to use the delegate to get nodes.  If successful the
- * nodes will be stored in the cache with a call to {@link ResourceModelSourceCache#storeNodesInCache(com.dtolabs.rundeck.core.common.INodeSet)}.
- * If any exception is thrown it will be caught.  finally getNodes returns the result of {@link ResourceModelSourceCache#loadCachedNodes()}
+ * nodes will be stored in the cache with a call to
+ * {@link ResourceModelSourceCache#storeNodesInCache(com.dtolabs.rundeck.core.common.INodeSet)}.
+ * If any exception is thrown it will be caught.  finally getNodes returns the result of {@link
+ * ResourceModelSourceCache#loadCachedNodes()}.
+ *
+ * The behavior can be changed using the {@link com.dtolabs.rundeck.core.resources.SourceFactory.CacheType} parameter
  */
-public class CachingResourceModelSource extends ExceptionCatchingResourceModelSource  {
+public class CachingResourceModelSource extends ExceptionCatchingResourceModelSource {
     private ResourceModelSourceCache cache;
+    private SourceFactory.CacheType type = SourceFactory.CacheType.BOTH;
+
 
     public CachingResourceModelSource(ResourceModelSource delegate, ResourceModelSourceCache cache) {
         super(delegate);
@@ -44,17 +49,31 @@ public class CachingResourceModelSource extends ExceptionCatchingResourceModelSo
             final ResourceModelSourceCache cache
     )
     {
+        this(delegate, identity, handler, cache, SourceFactory.CacheType.BOTH);
+    }
+
+    public CachingResourceModelSource(
+            final ResourceModelSource delegate,
+            final String identity,
+            final ExceptionHandler handler,
+            final ResourceModelSourceCache cache,
+            final SourceFactory.CacheType type
+    )
+    {
         super(delegate, identity, handler);
         this.cache = cache;
+        this.type = type;
     }
 
     @Override
     INodeSet returnResultNodes(INodeSet nodes) throws ResourceModelSourceException {
-        if (null != nodes) {
+        if (null != nodes && type.isStoreType()) {
             cache.storeNodesInCache(nodes);
-            return nodes;
         }
-        return cache.loadCachedNodes();
+        if (null == nodes && type.isLoadType()) {
+            return cache.loadCachedNodes();
+        }
+        return nodes;
     }
 
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/SourceFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/SourceFactory.java
@@ -1,0 +1,96 @@
+package com.dtolabs.rundeck.core.resources;
+
+import com.dtolabs.rundeck.core.common.INodeSet;
+
+/**
+ * Utils for creating ResourceModelSources
+ */
+public class SourceFactory {
+
+    /**
+     * @return A source which always returns the given data
+     */
+    public static ResourceModelSource staticSource(final INodeSet data) {
+        return new ResourceModelSource() {
+            @Override
+            public INodeSet getNodes() throws ResourceModelSourceException {
+                return data;
+            }
+        };
+    }
+
+    public static ResourceModelSource cachedSource(
+            final ResourceModelSource delegate,
+            final String identity,
+            final ExceptionCatchingResourceModelSource.ExceptionHandler handler,
+            final ResourceModelSourceCache cache
+    )
+    {
+        return cachedSource(delegate, identity, handler, cache, CacheType.BOTH);
+    }
+
+    public static ResourceModelSource cacheWritingSource(
+            final ResourceModelSource delegate,
+            final String identity,
+            final ExceptionCatchingResourceModelSource.ExceptionHandler handler,
+            final ResourceModelSourceCache cache
+    )
+    {
+        return cachedSource(delegate, identity, handler, cache, CacheType.STORE_ONLY);
+    }
+
+    public static ResourceModelSource cacheLoadingSource(
+            final ResourceModelSource delegate,
+            final String identity,
+            final ExceptionCatchingResourceModelSource.ExceptionHandler handler,
+            final ResourceModelSourceCache cache
+    )
+    {
+        return cachedSource(delegate, identity, handler, cache, CacheType.LOAD_ONLY);
+    }
+
+    public static ResourceModelSource cachedSource(
+            final ResourceModelSource delegate,
+            final String identity,
+            final ExceptionCatchingResourceModelSource.ExceptionHandler handler,
+            final ResourceModelSourceCache cache,
+            final CacheType type
+    )
+    {
+        return new CachingResourceModelSource(delegate, identity, handler, cache, type);
+    }
+
+    /**
+     * behavior of the cache
+     */
+    public static enum CacheType {
+        /**
+         * Only load data
+         */
+        LOAD_ONLY(true, false),
+        /**
+         * only store data
+         */
+        STORE_ONLY(false, true),
+        /**
+         * Store and load data
+         */
+        BOTH(true, true);
+
+        private final boolean storeType;
+        private final boolean loadType;
+
+        CacheType(boolean load, boolean store) {
+            this.loadType = load;
+            this.storeType = store;
+        }
+
+        public boolean isStoreType() {
+            return storeType;
+        }
+
+        public boolean isLoadType() {
+            return loadType;
+        }
+    }
+}

--- a/core/src/main/java/com/dtolabs/shared/resources/ResourceXMLGenerator.java
+++ b/core/src/main/java/com/dtolabs/shared/resources/ResourceXMLGenerator.java
@@ -132,6 +132,10 @@ public class ResourceXMLGenerator implements NodesFileGenerator {
                 ent.setProperty(setName, value);
             }
         }
+        if(null!=node.getTags()){
+            ent.setProperty("tags", joinStrings(node.getTags(), ", "));
+        }
+
 
 
         return ent;
@@ -146,8 +150,11 @@ public class ResourceXMLGenerator implements NodesFileGenerator {
      * @return joined string
      */
     private static String joinStrings(final Set tags, final String delim) {
+        ArrayList<String> strings = new ArrayList<String>(tags);
+        String[] objects = strings.toArray(new String[strings.size()]);
+        Arrays.sort(objects);
         final StringBuffer sb = new StringBuffer();
-        for (final Object tag : tags) {
+        for (final String tag : objects) {
             if (sb.length() > 0) {
                 sb.append(delim);
             }

--- a/core/src/test/java/com/dtolabs/shared/resources/TestResourceXMLGenerator.java
+++ b/core/src/test/java/com/dtolabs/shared/resources/TestResourceXMLGenerator.java
@@ -28,6 +28,7 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.dom4j.Document;
+import org.dom4j.DocumentException;
 import org.dom4j.Element;
 import org.dom4j.Node;
 import org.dom4j.io.SAXReader;
@@ -218,6 +219,43 @@ public class TestResourceXMLGenerator extends TestCase {
             assertEquals("-asdf", root.selectSingleNode("node/attribute/@name").getStringValue());
             assertEquals("test value", root.selectSingleNode("node/attribute/@value").getStringValue());
         }
+    }
+    public void testTags() throws Exception {
+        final ResourceXMLGenerator gen = new ResourceXMLGenerator(test1);
+        //add a node
+        final NodeEntryImpl node = new NodeEntryImpl("test1", "test1name");
+        node.setDescription("test desc");
+        node.setOsArch("test arch");
+        node.setOsFamily("test fam");
+        node.setOsName("test osname");
+        node.setOsVersion("test vers");
+        final HashSet<String> tags = new HashSet<String>();
+        tags.add("a");
+        tags.add("b");
+        node.setTags(tags);
+        node.getTags().add("c");
+        node.setUsername("test user");
+
+        gen.addNode(node);
+        gen.generate();
+        assertTrue(test1.exists());
+        assertTrue(test1.isFile());
+        //assert contents
+        final Document d = reader.read(test1);
+        assertNotNull(d);
+        final Element root = d.getRootElement();
+        assertEquals("project", root.getName());
+        assertEquals(1, root.selectNodes("/project/*").size());
+        assertEquals(1, root.selectNodes("node").size());
+        assertEquals("test1name", root.selectSingleNode("node/@name").getStringValue());
+        assertEquals("test1", root.selectSingleNode("node/@hostname").getStringValue());
+        assertEquals("a, b, c", root.selectSingleNode("node/@tags").getStringValue());
+        assertEquals("test desc", root.selectSingleNode("node/@description").getStringValue());
+        assertEquals("test arch", root.selectSingleNode("node/@osArch").getStringValue());
+        assertEquals("test fam", root.selectSingleNode("node/@osFamily").getStringValue());
+        assertEquals("test osname", root.selectSingleNode("node/@osName").getStringValue());
+        assertEquals("test vers", root.selectSingleNode("node/@osVersion").getStringValue());
+        assertEquals("test user", root.selectSingleNode("node/@username").getStringValue());
     }
 
 

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -160,6 +160,12 @@ beans={
     nodeTaskExecutor(SimpleAsyncTaskExecutor,"NodeService-SourceLoader") {
         concurrencyLimit = (application.config.rundeck?.nodeService?.concurrencyLimit ?: 25) //-1 for unbounded
     }
+    //alternately use ThreadPoolTaskExecutor ...
+//    nodeTaskExecutor(ThreadPoolTaskExecutor) {
+//        threadNamePrefix="NodeService-SourceLoader"
+//        corePoolSize= (application.config.rundeck?.nodeService?.corePoolSize ?: 5)
+//        maxPoolSize= (application.config.rundeck?.nodeService?.maxPoolSize ?: 40)
+//    }
 
     pluggableStoragePluginProviderService(PluggableStoragePluginProviderService) {
         rundeckServerServiceProviderLoader = ref('rundeckServerServiceProviderLoader')

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -157,6 +157,9 @@ beans={
     logFileTaskExecutor(SimpleAsyncTaskExecutor,"LogFileStorage"){
         concurrencyLimit= 2 + (application.config.rundeck?.execution?.logs?.fileStorage?.concurrencyLimit ?: 5)
     }
+    nodeTaskExecutor(SimpleAsyncTaskExecutor,"NodeService-SourceLoader") {
+        concurrencyLimit = (application.config.rundeck?.nodeService?.concurrencyLimit ?: 25) //-1 for unbounded
+    }
 
     pluggableStoragePluginProviderService(PluggableStoragePluginProviderService) {
         rundeckServerServiceProviderLoader = ref('rundeckServerServiceProviderLoader')

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -602,6 +602,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             def project= params.project
             def fproject = frameworkService.getFrameworkProject(project)
             def configs = fproject.projectNodes.listResourceModelConfigurations()
+            def nodeErrorsMap = fproject.projectNodes.getResourceModelSourceExceptionsMap()
 
             final service = framework.getResourceModelSourceService()
             final descriptions = service.listDescriptions()
@@ -649,6 +650,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             ]
         }
             return [configs:configs,
+                    nodeErrorsMap:nodeErrorsMap,
                 resourceModelConfigDescriptions:descriptions,
                 nodeexecconfig:nodeexec,
                 fcopyconfig:fcopy,

--- a/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
@@ -9,12 +9,48 @@ class ConfigurationService {
         getAppConfig()?.executionMode=='active'
     }
 
-    private ConfigObject getAppConfig() {
+    public ConfigObject getAppConfig() {
         grailsApplication.config?.rundeck
     }
 
     void setExecutionModeActive(boolean active){
         getAppConfig().executionMode=(active?'active':'passive')
+    }
+    /**
+     * Lookup boolean config value, rundeck.some.property.name, evaluate true/false.
+     * @param property property name
+     * @param defval default value
+     * @return
+     */
+    boolean getBoolean(String property, boolean defval) {
+        def strings = property.split('\\.')
+        def val = appConfig
+        strings.each{
+            val = val?."${it}"
+        }
+        booleanValue(defval,val)
+    }
+    /**
+     * Lookup boolean config value, rundeck.service.component.property, evaluate true/false.
+     * @param service service name
+     * @param name component name
+     * @param property property name
+     * @param defval default value
+     * @return
+     */
+    boolean getBoolean(String service, String name, String property, boolean defval) {
+        def val = appConfig."${service}"?."${name}"?."${property}"
+        return booleanValue(defval, val)
+    }
+
+    private boolean booleanValue(boolean defval, val) {
+        if (defval) {
+            //not found implies true
+            return !(val in [false, 'false'])
+        } else {
+            //not found implies false
+            return val in [true, 'true']
+        }
     }
 
     String getCacheSpecFor(String service, String cache, String defval) {

--- a/rundeckapp/grails-app/services/rundeck/services/nodes/CachedProjectNodes.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/nodes/CachedProjectNodes.groovy
@@ -3,6 +3,7 @@ package rundeck.services.nodes
 import com.dtolabs.rundeck.core.common.INodeSet
 import com.dtolabs.rundeck.core.common.IProjectNodes
 import com.dtolabs.rundeck.core.common.ProjectNodeSupport
+import com.dtolabs.rundeck.core.resources.ResourceModelSource
 
 /**
  * Created by greg on 1/15/16.
@@ -10,6 +11,7 @@ import com.dtolabs.rundeck.core.common.ProjectNodeSupport
 class CachedProjectNodes implements IProjectNodes {
     @Delegate
     ProjectNodeSupport nodeSupport
+    ResourceModelSource source
     INodeSet nodes
     boolean doCache
     Date cacheTime
@@ -21,7 +23,7 @@ class CachedProjectNodes implements IProjectNodes {
     }
 
     INodeSet reloadNodeSet() {
-        nodes = nodeSupport.getNodeSet()
+        nodes = source.getNodes()
         nodes
     }
 }

--- a/rundeckapp/grails-app/views/menu/admin.gsp
+++ b/rundeckapp/grails-app/views/menu/admin.gsp
@@ -179,8 +179,20 @@
                                 </g:if>
                                 <g:else>
                                     <span
-                                        class="warn note"><g:message code="invalid.resource.model.source.configuration.provider.not.found"  args="${[config.type]}"/></span>
+                                        class="text-warning"><g:message code="invalid.resource.model.source.configuration.provider.not.found"  args="${[config.type]}"/></span>
                                 </g:else>
+                                <g:if test="${nodeErrorsMap && nodeErrorsMap[(n+1)+'.'+config.type]}">
+                                    <div class="row row-space">
+                                    <div class="col-sm-12">
+                                        <g:set var="arkey" value="${g.rkey()}"/>
+                                        <div class=" well well-embed text-danger " id="srcerr_${arkey}">
+                                            <g:icon name="warning-sign"/>
+                                            Error:
+                                            ${nodeErrorsMap[(n+1)+'.'+config.type].message}
+                                        </div>
+                                    </div>
+                                    </div>
+                                </g:if>
                             </div>
                         </li>
                     </g:each>


### PR DESCRIPTION
Asynch nodes cache new behavior:

* If a project nodes cache file exists, initial load of project nodes will preload using this file
* Otherwise initial load of project nodes is *asynchronous*, meaning you may see 0 nodes until they are loaded
    * this makes UI responsive after creating/saving project, and at startup
    * can force this to be synchronous using rundeck-config value: `rundeck.nodeService.nodeCache.firstLoadAsynch=false`
    * "Why would I want to force it to be synchronous?" If you deploy Rundeck with predefined jobs (e.g. new cluster node pointing at existing DB), this will force Rundeck to load all nodes prior to any jobs being executed, and may prevent spuriously failing jobs due to "no matched nodes" 
* Anytime the asynch cache successfully loads project nodes, it will write results to the local project nodes cache file, similar to existing cache files for individual model sources

bonus feature:

* resource model source errors now shown in project config page