### PR TITLE
Add job.executionType context variable

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2669,6 +2669,7 @@ class ScheduledExecutionController  extends ControllerBase{
             inputOpts.putAll(params.extra.subMap(['nodeIncludeName', 'loglevel',/*'argString',*/ 'optparams', 'option', '_replaceNodeFilters', 'filter']).findAll { it.value })
             inputOpts.putAll(params.extra.findAll{it.key.startsWith('option.')||it.key.startsWith('nodeInclude')|| it.key.startsWith('nodeExclude')}.findAll { it.value })
         }
+        inputOpts['executionType'] = "user"
         def result = executionService.executeJob(scheduledExecution, authContext,session.user, inputOpts)
 
         if (result.error){

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -20,6 +20,7 @@ class Execution extends ExecutionContext {
     boolean cancelled
     Boolean timedOut=false
     Workflow workflow
+    String executionType
     Integer retryAttempt=0
     Boolean willRetry=false
     Execution retryExecution
@@ -75,6 +76,7 @@ class Execution extends ExecutionContext {
         timeout(maxSize: 256, blank: true, nullable: true,)
         retry(maxSize: 256, blank: true, nullable: true,matches: /^\d+$/)
         timedOut(nullable: true)
+        executionType(nullable:true)
         retryAttempt(nullable: true)
         retryExecution(nullable: true)
         willRetry(nullable: true)
@@ -194,6 +196,9 @@ class Execution extends ExecutionContext {
         }
         map.id= this.id
         map.doNodedispatch= this.doNodedispatch
+        if(this.executionType) {
+            map.executionType=executionType
+        }
         if(this.retryAttempt){
             map.retryAttempt=retryAttempt
         }
@@ -244,6 +249,9 @@ class Execution extends ExecutionContext {
         exec.loglevel = data.loglevel
         exec.doNodedispatch = XmlParserUtil.stringToBool(data.doNodedispatch,false)
         exec.timeout = data.timeout
+        if(data.executionType) {
+            exec.executionType = data.executionType
+        }
         if(data.retryAttempt){
             exec.retryAttempt= XmlParserUtil.stringToInt(data.retryAttempt, 0)
         }

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -76,7 +76,7 @@ class Execution extends ExecutionContext {
         timeout(maxSize: 256, blank: true, nullable: true,)
         retry(maxSize: 256, blank: true, nullable: true,matches: /^\d+$/)
         timedOut(nullable: true)
-        executionType(nullable:true)
+        executionType(nullable: true)
         retryAttempt(nullable: true)
         retryExecution(nullable: true)
         willRetry(nullable: true)

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -210,6 +210,7 @@ class ExecutionJob implements InterruptableJob {
         if(initMap.isTemp){
             //an adhoc execution without associated job
             initMap.execution = Execution.get(initMap.executionId)
+            initMap.execution.executionType="adhoc"
             if (!initMap.execution) {
                 throw new RuntimeException("failed to lookup Exception object from job data map: id: ${initMap.executionId}")
             }
@@ -226,6 +227,7 @@ class ExecutionJob implements InterruptableJob {
             initMap.secureOpts=jobDataMap.get("secureOpts")
             initMap.secureOptsExposed=jobDataMap.get("secureOptsExposed")
             initMap.execution = Execution.get(initMap.executionId)
+            initMap.execution.executionType="user"
             //NOTE: Oracle/hibernate bug workaround: if session has not flushed we may have to wait until Execution.get
             //can return the right entity
             int retry=30
@@ -267,6 +269,7 @@ class ExecutionJob implements InterruptableJob {
             initMap.authContext = frameworkService.getAuthContextForUserAndRoles(initMap.scheduledExecution.user, rolelist)
             initMap.secureOptsExposed = initMap.executionService.selectSecureOptionInput(initMap.scheduledExecution,[:],true)
             initMap.execution = initMap.executionService.createExecution(initMap.scheduledExecution,initMap.authContext)
+            initMap.execution.executionType="scheduled"
         }
         if (!initMap.authContext) {
             throw new RuntimeException("authContext could not be determined")

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -210,7 +210,6 @@ class ExecutionJob implements InterruptableJob {
         if(initMap.isTemp){
             //an adhoc execution without associated job
             initMap.execution = Execution.get(initMap.executionId)
-            initMap.execution.executionType="adhoc"
             if (!initMap.execution) {
                 throw new RuntimeException("failed to lookup Exception object from job data map: id: ${initMap.executionId}")
             }
@@ -227,7 +226,6 @@ class ExecutionJob implements InterruptableJob {
             initMap.secureOpts=jobDataMap.get("secureOpts")
             initMap.secureOptsExposed=jobDataMap.get("secureOptsExposed")
             initMap.execution = Execution.get(initMap.executionId)
-            initMap.execution.executionType="user"
             //NOTE: Oracle/hibernate bug workaround: if session has not flushed we may have to wait until Execution.get
             //can return the right entity
             int retry=30
@@ -269,7 +267,6 @@ class ExecutionJob implements InterruptableJob {
             initMap.authContext = frameworkService.getAuthContextForUserAndRoles(initMap.scheduledExecution.user, rolelist)
             initMap.secureOptsExposed = initMap.executionService.selectSecureOptionInput(initMap.scheduledExecution,[:],true)
             initMap.execution = initMap.executionService.createExecution(initMap.scheduledExecution,initMap.authContext)
-            initMap.execution.executionType="scheduled"
         }
         if (!initMap.authContext) {
             throw new RuntimeException("authContext could not be determined")

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1592,7 +1592,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         input.retryAttempt = attempt
         try {
 
-            Map allowedOptions = input.subMap(['loglevel', 'argString', 'option','_replaceNodeFilters', 'filter', 'retryAttempt']).findAll { it.value != null }
+            Map allowedOptions = input.subMap(['loglevel', 'argString', 'option','_replaceNodeFilters', 'filter', 'executionType', 'retryAttempt']).findAll { it.value != null }
             allowedOptions.putAll(input.findAll { it.key.startsWith('option.') || it.key.startsWith('nodeInclude') || it.key.startsWith('nodeExclude') }.findAll { it.value != null })
             def Execution e = createExecution(scheduledExecution, authContext, allowedOptions,attempt>0,prevId)
             def timeout = 0
@@ -2022,6 +2022,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     execution.willRetry = true
                     def input = [
                             argString: execution.argString,
+                            executionType: execution.executionType,
                             loglevel : execution.loglevel,
                             filter   : execution.filter //TODO: failed nodes?
                     ]

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1482,6 +1482,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                                     nodeRankAttribute:params.nodeRankAttribute,
                                     workflow:params.workflow,
                                     argString:params.argString,
+                                    executionType: params.executionType?:"user",
                                     timeout:params.timeout?:null,
                                     retryAttempt:params.retryAttempt?:0,
                                     retry:params.retry?:null,
@@ -1644,6 +1645,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         propset.each{k->
             props.put(k,se[k])
         }
+        props.executionType="scheduled"
         props.user = authContext.username
         if (input && 'true' == input['_replaceNodeFilters']) {
             //remove all existing node filters to replace with input filters

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1482,7 +1482,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                                     nodeRankAttribute:params.nodeRankAttribute,
                                     workflow:params.workflow,
                                     argString:params.argString,
-                                    executionType: params.executionType?:"user",
+                                    executionType: params.executionType?:"scheduled",
                                     timeout:params.timeout?:null,
                                     retryAttempt:params.retryAttempt?:0,
                                     retry:params.retry?:null,
@@ -1645,7 +1645,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         propset.each{k->
             props.put(k,se[k])
         }
-        props.executionType="scheduled"
         props.user = authContext.username
         if (input && 'true' == input['_replaceNodeFilters']) {
             //remove all existing node filters to replace with input filters
@@ -1659,6 +1658,12 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         if (input) {
             props.putAll(input.subMap(['argString','filter','loglevel','retryAttempt','doNodedispatch']).findAll{it.value!=null})
             props.putAll(input.findAll{it.key.startsWith('option.') && it.value!=null})
+        }
+
+        if (input && input['executionType']) {
+            props.executionType = input['executionType']
+        } else {
+            props.executionType="scheduled"
         }
 
         //evaluate embedded Job options for validation

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -776,6 +776,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             jobcontext.id = execution.scheduledExecution.extid
         }
         jobcontext.execid = execution.id.toString()
+        jobcontext.executionType = execution.executionType
         jobcontext.serverUrl = generateServerURL(grailsLinkGenerator)
         jobcontext.url = generateExecutionURL(execution,grailsLinkGenerator)
         jobcontext.serverUUID = execution.serverNodeUUID

--- a/rundeckapp/test/unit/ExecutionServiceTests.groovy
+++ b/rundeckapp/test/unit/ExecutionServiceTests.groovy
@@ -135,6 +135,37 @@ class ExecutionServiceTests  {
         assertNotNull(e2.dateStarted)
         assertNull(e2.dateCompleted)
         assertEquals('user1', e2.user)
+        assertEquals('scheduled', e2.executionType)
+        def execs = se.executions
+        assertNotNull(execs)
+        assertTrue(execs.contains(e2))
+    }
+    void testCreateExecutionSimpleUserExecutionType(){
+
+        ScheduledExecution se = new ScheduledExecution(
+            jobName: 'blue',
+            project: 'AProject',
+            groupPath: 'some/where',
+            description: 'a job',
+            argString: '-a b -c d',
+            workflow: new Workflow(keepgoing: true, commands: [new CommandExec([adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle'])]),
+        )
+        se.save()
+
+
+        ExecutionService svc = new ExecutionService()
+        FrameworkService fsvc = new FrameworkService()
+        svc.frameworkService=fsvc
+
+        Execution e2=svc.createExecution(se,createAuthContext("user1"),['executionType':'user'])
+
+        assertNotNull(e2)
+        assertEquals('-a b -c d', e2.argString)
+        assertEquals(se, e2.scheduledExecution)
+        assertNotNull(e2.dateStarted)
+        assertNull(e2.dateCompleted)
+        assertEquals('user1', e2.user)
+        assertEquals('user', e2.executionType)
         def execs = se.executions
         assertNotNull(execs)
         assertTrue(execs.contains(e2))


### PR DESCRIPTION
Currently there's no way to differentiate whether a job was ran by a user
and a job ran by the scheduler by looking at the job context variables.

With this change, we'll have a job.executionType context variable that will
indicate what invoked the job.

Possible values of job.executionType:
  adhoc = adhoc command
  user = job initiated by a user
  scheduled = job triggered by the scheduler

This is a first stab at this problem to get the ball rolling.

Please review for correctness and let me know if anything
else is needed.

Addresses issue https://github.com/rundeck/rundeck/issues/1811

Signed-off-by: Rene Fragoso ctrlrsf@gmail.com
