### PR TITLE
Make moving/renaming of files more robust

### DIFF
--- a/core/src/main/java/com/dtolabs/launcher/Setup.java
+++ b/core/src/main/java/com/dtolabs/launcher/Setup.java
@@ -220,6 +220,7 @@ public class Setup implements CLIToolLogger {
             throw new RuntimeException("Unable to load required template: " + resource);
         }
         templateFile = File.createTempFile("temp", filename);
+        templateFile.deleteOnExit();
         try {
             return copyToNativeLineEndings(is, templateFile);
         } finally {

--- a/core/src/test/java/com/dtolabs/rundeck/core/cli/jobs/TestJobsTool.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/cli/jobs/TestJobsTool.java
@@ -394,6 +394,7 @@ public class TestJobsTool extends AbstractBaseTest {
         centralDispatcher1.loadJobsResult = new ArrayList<IStoredJobLoadResult>();
 
         File test = File.createTempFile("blah", ".xml");
+        test.deleteOnExit();
         tool.run(new String[]{"load", "-f", test.getAbsolutePath()});
         assertFalse("list action was not called", centralDispatcher1.listStoredJobsCalled);
         assertTrue("load action should be called", centralDispatcher1.loadJobsCalled);
@@ -416,6 +417,7 @@ public class TestJobsTool extends AbstractBaseTest {
         centralDispatcher1.loadJobsResult = new ArrayList<IStoredJobLoadResult>();
 
         File test = File.createTempFile("blah", ".xml");
+        test.deleteOnExit();
         tool.run(new String[]{"load", "-f", test.getAbsolutePath(), "-p", "project1"});
         assertFalse("list action was not called", centralDispatcher1.listStoredJobsCalled);
         assertTrue("load action should be called", centralDispatcher1.loadJobsCalled);
@@ -438,6 +440,7 @@ public class TestJobsTool extends AbstractBaseTest {
         centralDispatcher1.loadJobsResult = new ArrayList<IStoredJobLoadResult>();
 
         File test = File.createTempFile("blah", ".xml");
+        test.deleteOnExit();
         tool.run(new String[]{"load", "-f", test.getAbsolutePath(), "-p", "project1", "-r"});
         assertFalse("list action was not called", centralDispatcher1.listStoredJobsCalled);
         assertTrue("load action should be called", centralDispatcher1.loadJobsCalled);
@@ -461,6 +464,7 @@ public class TestJobsTool extends AbstractBaseTest {
         centralDispatcher1.loadJobsResult = new ArrayList<IStoredJobLoadResult>();
 
         File test = File.createTempFile("blah", ".xml");
+        test.deleteOnExit();
         tool.run(new String[]{"load", "-f", test.getAbsolutePath(), "-p", "project1"});
         assertFalse("list action was not called", centralDispatcher1.listStoredJobsCalled);
         assertTrue("load action should be called", centralDispatcher1.loadJobsCalled);

--- a/core/src/test/java/com/dtolabs/rundeck/core/common/TestFrameworkProject.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/common/TestFrameworkProject.java
@@ -370,6 +370,7 @@ public class TestFrameworkProject extends AbstractBaseTest {
         
         final File filesrc = new File("src/test/resources/com/dtolabs/rundeck/core/common/test-nodes2.xml");
         final File tempfile = File.createTempFile("test", ".xml");
+        tempfile.deleteOnExit();
         FileUtils.copyFileStreams(filesrc, tempfile);
         final String providerURL = tempfile.toURI().toURL().toExternalForm();
         

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/impl/local/LocalFileCopierTest.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/impl/local/LocalFileCopierTest.java
@@ -59,6 +59,7 @@ public class LocalFileCopierTest {
     public void testCopyString() throws IOException, FileCopierException {
         LocalFileCopier localFileCopier = new LocalFileCopier(getFramework());
         File temp = File.createTempFile("string-copy", "tmp");
+        temp.deleteOnExit();
         String script = "my script\n";
         String s = localFileCopier.copyScriptContent(null, script, null, temp.getAbsolutePath());
         Assert.assertEquals(temp.getAbsolutePath(), s);
@@ -69,6 +70,7 @@ public class LocalFileCopierTest {
     public void testCopyInputStream() throws IOException, FileCopierException {
         LocalFileCopier localFileCopier = new LocalFileCopier(getFramework());
         File temp = File.createTempFile("string-copy", "tmp");
+        temp.deleteOnExit();
         String script = "my script\n";
         ByteArrayInputStream inputStream = new ByteArrayInputStream(script.getBytes());
         String s = localFileCopier.copyFileStream(null, inputStream, null, temp.getAbsolutePath());
@@ -80,11 +82,13 @@ public class LocalFileCopierTest {
     public void testCopyFile() throws IOException, FileCopierException {
         LocalFileCopier localFileCopier = new LocalFileCopier(getFramework());
         File temp = File.createTempFile("string-copy", "tmp");
+        temp.deleteOnExit();
         String script = "my script\n";
         File inputFile = File.createTempFile(
                 "input",
                 "tmp"
         );
+        inputFile.deleteOnExit();
         FileOutputStream fileOutputStream = new FileOutputStream( inputFile);
         fileOutputStream.write(script.getBytes());
         fileOutputStream.close();

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/service/TestScriptPluginFileCopier.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/service/TestScriptPluginFileCopier.java
@@ -311,7 +311,9 @@ public class TestScriptPluginFileCopier {
         final File scriptFile = File.createTempFile("test-scriptfile", "tmp");
         scriptFile.deleteOnExit();
         testProvider.setScriptFile(scriptFile);
-        testProvider.setContentsBasedir(File.createTempFile("test-basedir", "tmp"));
+        final File baseDir = File.createTempFile("test-basedir", "tmp");
+        baseDir.deleteOnExit();
+        testProvider.setContentsBasedir(baseDir);
         testProvider.setMetadata(new HashMap<String, Object>());
         testProvider.setName("test-plugin");
         testProvider.setScriptArgs("");
@@ -385,7 +387,9 @@ public class TestScriptPluginFileCopier {
         final File scriptFile = File.createTempFile("test-scriptfile", "tmp");
         scriptFile.deleteOnExit();
         testProvider.setScriptFile(scriptFile);
-        testProvider.setContentsBasedir(File.createTempFile("test-basedir", "tmp"));
+        final File baseDir = File.createTempFile("test-basedir", "tmp");
+        baseDir.deleteOnExit();
+        testProvider.setContentsBasedir(baseDir);
         testProvider.setMetadata(new HashMap<String, Object>());
         testProvider.setName("test-plugin");
         testProvider.setScriptArgs("");
@@ -460,7 +464,9 @@ public class TestScriptPluginFileCopier {
         final File scriptFile = File.createTempFile("test-scriptfile", "tmp");
         scriptFile.deleteOnExit();
         testProvider.setScriptFile(scriptFile);
-        testProvider.setContentsBasedir(File.createTempFile("test-basedir", "tmp"));
+        final File baseDir = File.createTempFile("test-basedir", "tmp");
+        baseDir.deleteOnExit();
+        testProvider.setContentsBasedir(baseDir);
         testProvider.setMetadata(new HashMap<String, Object>());
         testProvider.setName("test-plugin");
         testProvider.setScriptArgs("");

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptFileNodeStepExecutor.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptFileNodeStepExecutor.java
@@ -777,6 +777,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             )
             .build();
         final File testScriptFile = File.createTempFile("Testfile", "tmp");
+        testScriptFile.deleteOnExit();
 
         final String testScript =
                 "a script\n" +

--- a/core/src/test/java/com/dtolabs/rundeck/core/plugins/BaseScriptPluginTest.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/plugins/BaseScriptPluginTest.java
@@ -60,7 +60,9 @@ public class BaseScriptPluginTest {
         final Map<String, Object> data = new HashMap<String, Object>();
         data.put("script-file", "myfile.sh");
         File archiveFile = File.createTempFile("test", "zip");
+        archiveFile.deleteOnExit();
         File basedir = File.createTempFile("test", "dir");
+        basedir.deleteOnExit();
 
         test1 test = new test1(
                 scriptPluginProvider(new PluginMeta(),data, archiveFile, basedir), null);
@@ -76,7 +78,9 @@ public class BaseScriptPluginTest {
         final Map<String, Object> data = new HashMap<String, Object>();
         data.put("script-file", "myfile.sh");
         File archiveFile = File.createTempFile("test", "zip");
+        archiveFile.deleteOnExit();
         File basedir = File.createTempFile("test", "dir");
+        basedir.deleteOnExit();
 
         test1 test = new test1(
                 scriptPluginProvider(new PluginMeta(),data, archiveFile, basedir), null);

--- a/core/src/test/java/com/dtolabs/rundeck/core/resources/TestDirectoryResourceModelSource.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/resources/TestDirectoryResourceModelSource.java
@@ -121,6 +121,7 @@ public class TestDirectoryResourceModelSource extends AbstractBaseTest {
         }
 
         File testfile = File.createTempFile("testfile", "test");
+        testfile.deleteOnExit();
         //set directory to point to a file instead of a directory
         props.setProperty("directory", testfile.getAbsolutePath());
 

--- a/core/src/test/java/com/dtolabs/rundeck/core/resources/TestFileResourceModelSource.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/resources/TestFileResourceModelSource.java
@@ -381,7 +381,12 @@ public class TestFileResourceModelSource extends AbstractBaseTest {
         assertEquals(1, nodes.getNodes().size());
         assertNotNull(nodes.getNode(getFrameworkInstance().getFrameworkNodeName()));
         assertTrue(testfile.exists());
+
+        // clean up
         testfile.delete();
+        new File(testfile2, "sub/dir").delete();
+        new File(testfile2, "sub").delete();
+        testfile2.delete();
     }
     public void testGetNodesGenerateFileAutomaticallyWithFormatXml() throws Exception {
 
@@ -456,6 +461,7 @@ public class TestFileResourceModelSource extends AbstractBaseTest {
         assertNotNull(iNodeSet.getNode("testnode2"));
 
         File testfile2 = File.createTempFile("testParseFile", ".yaml");
+        testfile2.deleteOnExit();
         //create yaml file
         final BufferedWriter bufferedWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(
             (testfile2))));

--- a/core/src/test/java/com/dtolabs/rundeck/core/tools/AbstractBaseTest.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/tools/AbstractBaseTest.java
@@ -73,12 +73,11 @@ public abstract class AbstractBaseTest extends TestCase {
 
     public static void generateProjectResourcesFile(final File source, final IRundeckProject frameworkProject){
         //copy test nodes to resources file
-        File resourcesfile=null;
+        File resourcesfile = null;
         try {
             resourcesfile = File.createTempFile("resources", ".xml");
-            FileUtils.copyFileStreams(
-                    source,
-                                      resourcesfile);
+            resourcesfile.deleteOnExit();
+            FileUtils.copyFileStreams(source, resourcesfile);
         } catch (IOException e) {
             throw new RuntimeException("Caught Setup exception: " + e.getMessage(), e);
         }
@@ -95,12 +94,11 @@ public abstract class AbstractBaseTest extends TestCase {
     }
     public static Properties generateProjectResourcesFile(final File source){
         //copy test nodes to resources file
-        File resourcesfile=null;
+        File resourcesfile = null;
         try {
             resourcesfile = File.createTempFile("resources", ".xml");
-            FileUtils.copyFileStreams(
-                    source,
-                                      resourcesfile);
+            resourcesfile.deleteOnExit();
+            FileUtils.copyFileStreams(source, resourcesfile);
         } catch (IOException e) {
             throw new RuntimeException("Caught Setup exception: " + e.getMessage(), e);
         }

--- a/core/src/test/java/com/dtolabs/rundeck/core/utils/TestFileUtils.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/utils/TestFileUtils.java
@@ -82,4 +82,41 @@ public class TestFileUtils extends TestCase {
          // clean up
          infile2.delete(); destfile.delete();         
      }
+
+    public void testCreateParentDirForRelativeFile() throws Exception {
+        final File tmpFile = File.createTempFile("test", "rel");
+        tmpFile.delete();
+        final File file = new File(tmpFile, "testDir/tmp");
+        assertFalse("test setup error: file already exists", file.exists());
+        assertFalse("test setup error: directory already exists",
+                file.getAbsoluteFile().getParentFile().exists());
+        FileUtils.mkParentDirs(file);
+        assertFalse("created file as directory",
+                file.getAbsoluteFile().isDirectory());
+        assertTrue("failed to create directory: " +
+                file.getAbsoluteFile().getParentFile().getAbsolutePath(),
+                file.getAbsoluteFile().getParentFile().isDirectory());
+        assertEquals("testDir", file.getAbsoluteFile().getParentFile().getName());
+        // Remove again as it was re-created as a directory
+        file.delete();
+        new File(tmpFile, "testDir").delete();
+        tmpFile.delete();
+    }
+
+    public void testCreateParentDirForAbsoluteFile() throws Exception {
+        final File file = new File("/tmp/testDir/test");
+        assertFalse("test setup error: file already exists", file.exists());
+        assertFalse("test setup error: directory already exists",
+                file.getParentFile().exists());
+        FileUtils.mkParentDirs(file);
+        assertFalse("created file as directory",
+                file.getAbsoluteFile().isDirectory());
+        assertTrue("failed to create directory: " +
+                file.getParentFile().getAbsolutePath(),
+                file.getParentFile().isDirectory());
+        assertEquals("testDir", file.getAbsoluteFile().getParentFile().getName());
+        // clean up
+        file.delete();
+        new File("/tmp/testDir").delete();
+    }
 }

--- a/core/src/test/java/com/dtolabs/rundeck/core/utils/TestPropertyLookup.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/utils/TestPropertyLookup.java
@@ -36,6 +36,7 @@ public class TestPropertyLookup extends TestCase {
     public TestPropertyLookup(final String name) throws IOException {
         super(name);
         propertyFile = File.createTempFile("prop1", "properties");
+        propertyFile.deleteOnExit();
         properties1 = new Properties();
         properties1.put("foo", "shizzle");
         properties1.put("bar", "madizzle");
@@ -68,6 +69,7 @@ public class TestPropertyLookup extends TestCase {
 
     public void testExpand() throws IOException {
         final File pFile = File.createTempFile("myprops", "properties");
+        pFile.deleteOnExit();
         final Properties p = new Properties();
         p.put("foo", "shizzler");
         p.put("bar", "${foo}-madizzler");
@@ -81,6 +83,7 @@ public class TestPropertyLookup extends TestCase {
 
     public void testConstructionWithDefaults() throws IOException {
         final File pFile = File.createTempFile("myprops", "properties");
+        pFile.deleteOnExit();
         final Properties p = new Properties();
         p.put("foo", "shizzler");
         p.put("bar", "bizzle");

--- a/core/src/test/java/com/dtolabs/rundeck/core/utils/TestPropertyUtil.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/utils/TestPropertyUtil.java
@@ -36,6 +36,7 @@ public class TestPropertyUtil extends TestCase {
     public TestPropertyUtil(final String name) throws IOException {
         super(name);
         propertyFile = File.createTempFile("prop1", "properties");
+        propertyFile.deleteOnExit();
         properties = new Properties();
         properties.put("foo", "shizzle");
         properties.put("bar", "madizzle");

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/BaseGitPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/BaseGitPluginSpec.groovy
@@ -175,6 +175,7 @@ class BaseGitPluginSpec extends Specification {
         def base = new BaseGitPlugin(config)
 
         def tempdir = File.createTempFile("BaseGitPluginSpec", "-test")
+        tempdir.deleteOnExit()
         tempdir.delete()
         def gitdir = new File(tempdir, 'scm')
         def origindir = new File(tempdir, 'origin')
@@ -203,6 +204,7 @@ class BaseGitPluginSpec extends Specification {
         base.branch = 'master'
 
         def tempdir = File.createTempFile("BaseGitPluginSpec", "-test")
+        tempdir.deleteOnExit()
         tempdir.delete()
         def gitdir = new File(tempdir, 'scm')
         gitdir.mkdir()

--- a/rundeckapp/test/unit/ProjectServiceTests.groovy
+++ b/rundeckapp/test/unit/ProjectServiceTests.groovy
@@ -217,6 +217,7 @@ class ProjectServiceTests  {
 
         def outfilename = "blahfile.xml"
         File tempoutfile = File.createTempFile("tempout",".txt")
+        tempoutfile.deleteOnExit()
 
         def zipmock=mockFor(ZipBuilder)
         def outwriter = new StringWriter()
@@ -272,7 +273,9 @@ class ProjectServiceTests  {
 
         def outfilename = "blahfile.xml"
         File tempoutfile = File.createTempFile("tempout",".txt")
+        tempoutfile.deleteOnExit()
         File tempoutfile2 = File.createTempFile("tempout",".state.json")
+        tempoutfile2.deleteOnExit()
 
         def zipmock=mockFor(ZipBuilder)
         def outwriter = new StringWriter()

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/logging/RundeckLogFormatTest.groovy
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/logging/RundeckLogFormatTest.groovy
@@ -253,6 +253,7 @@ class RundeckLogFormatTest  {
     void testSeekBackSimple(){
         RundeckLogFormat format = new RundeckLogFormat()
         def f = File.createTempFile("log-format-test", ".rdlog")
+        f.deleteOnExit()
 
         def line1 = '^2015-05-15T16:50:57Z|||{node=madmartigan.local|step=1|stepctx=1|user=greg}|testing execution output api-plain line 1^\n'
         def line2 = '^2015-05-15T16:50:57Z|||{node=madmartigan.local|step=1|stepctx=1|user=greg}|line 2^\n'
@@ -276,6 +277,7 @@ class RundeckLogFormatTest  {
     void testSeekBackMeta(){
         RundeckLogFormat format = new RundeckLogFormat()
         def f = File.createTempFile("log-format-test", ".rdlog")
+        f.deleteOnExit()
 
         def line1 = '^2015-05-15T16:50:57Z|||{node=madmartigan.local|step=1|stepctx=1|user=greg}|testing execution output api-plain line 1^\n'
         def line2 = '^2015-05-15T16:50:57Z|nodebegin||{node=madmartigan.local|step=1|stepctx=1|user=greg}|^\n'
@@ -288,6 +290,7 @@ class RundeckLogFormatTest  {
     void testSeekBackFull(){
         RundeckLogFormat format = new RundeckLogFormat()
         def f = File.createTempFile("log-format-test", ".rdlog")
+        f.deleteOnExit()
 
         def part1 = '^text/x-rundeck-log-v2.0^\n' +
                 '^2015-05-15T16:50:57Z|stepbegin||{node=madmartigan.local|step=1|stepctx=1|user=admin}|^\n' +


### PR DESCRIPTION
- Fix #1702 by replacing `File.renameTo` with `Files.move`, which handles moving between different filesystems; use the JDK 7 `Files.copy` for copy operations.
- When creating temporary files, check the parent directory structure exists and create it if needed.
- Tidy up temporary files on exit to reduce clutter in `/tmp` after running tests.