### PR TITLE
Feature/auth

### DIFF
--- a/rundeck-launcher/launcher/src/main/resources/templates/config/rundeck-config.properties.template
+++ b/rundeck-launcher/launcher/src/main/resources/templates/config/rundeck-config.properties.template
@@ -7,3 +7,8 @@ rss.enabled=false
 grails.serverURL=http://${server.hostname}:${server.http.port}${server.web.context}
 dataSource.dbCreate = update
 dataSource.url = jdbc:h2:file:${server.datastore.path};MVCC=true;TRACE_LEVEL_FILE=4
+
+# Pre Auth mode settings
+rundeck.security.authorization.preauthenticated.enabled=false
+rundeck.security.authorization.preauthenticated.attributeName=REMOTE_USER_GROUPS
+rundeck.security.authorization.preauthenticated.delimiter=,

--- a/rundeckapp/grails-app/conf/BootStrap.groovy
+++ b/rundeckapp/grails-app/conf/BootStrap.groovy
@@ -228,6 +228,13 @@ class BootStrap {
          }else{
              log.info("RSS feeds disabled")
          }
+
+         if('true' == grailsApplication.config.rundeck.security.authorization.preauthenticated.enabled){
+             log.info("Preauthentication is enabled")
+         } else {
+             log.info("Preauthentication is disabled")
+         }
+
          if(grailsApplication.config.execution.follow.buffersize){
              servletContext.setAttribute("execution.follow.buffersize",grailsApplication.config.execution.follow.buffersize)
          }else{

--- a/rundeckapp/src/java/com/dtolabs/rundeck/server/filters/AuthFilter.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/server/filters/AuthFilter.java
@@ -1,0 +1,66 @@
+package com.dtolabs.rundeck.server.filters;
+
+import com.dtolabs.rundeck.core.utils.GrailsServiceInjectorJobListener;
+import org.apache.log4j.Logger;
+
+import javax.management.relation.RoleList;
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Enumeration;
+
+/**
+ * Filter interrogates headers and modifies the request object to be passed down the filter chain
+ *
+ * @author John Stoltenborg
+ */
+public class AuthFilter implements Filter {
+
+    private static final transient Logger LOG = Logger.getLogger(GrailsServiceInjectorJobListener.class);
+
+
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    public void doFilter(ServletRequest request, ServletResponse response,
+                         FilterChain filterChain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        Enumeration<String> headerNames = httpRequest.getHeaderNames();
+
+        final String forwardedUser = httpRequest.getHeader("X-Forwarded-User");
+
+        ServletRequest requestModified =
+                new HttpServletRequestWrapper((HttpServletRequest) request) {
+                    @Override
+                    public String getRemoteUser() {
+                        return forwardedUser;
+                    }
+
+                    @Override
+                    public Principal getUserPrincipal() {
+                        Principal principle = new Principal() {
+                            @Override
+                            public String getName() {
+                                return forwardedUser;
+                            }
+                        };
+                        return principle;
+                    }
+                };
+
+        //
+        // Get the roles sent by the proxy and add them onto the request as an attribute for
+        // PreauthenticatedAttributeRoleSource
+        final String forwardedRoles = httpRequest.getHeader("X-Forwarded-Roles");
+        requestModified.setAttribute("REMOTE_USER_GROUPS", forwardedRoles);
+
+        filterChain.doFilter(requestModified, response);
+    }
+
+    public void destroy() {
+    }
+}


### PR DESCRIPTION
Hi,

Thanks to the team for all of the work you’ve put into this project. 

Here is a contribution towards preauthenticating with a reverse proxy, works towards resolving #1229 - Feedback is appreciated.

We are currently using https://github.com/bitly/oauth2_proxy to auth with Github and send a remote user and roles (as defined by teams) along to Rundeck. I’ve written a Spring filter that intercepts the request object at the beginning of the filter chain and modifies it to be sent along. 

There are a number of manual configuration changes. Here are the steps we take for `rundeck-launcher`

* Set `rundeck.security.authorization.preauthenticated.enabled=true`
* Build the project
  `$ ./gradlew clean build` 
* Run jar with install option on (default)
 `$ java -jar rundeck-launcher/launcher/build/libs/rundeck-launcher-2.6.8-SNAPSHOT.jar --install-only` 

* Modify `rundeck-launcher/launcher/build/libs/server/exp/webapp/WEB-INF/web.xml` 

 * Add the filter to the top of the filter chain.
    
```
<filter>
    <filter-name>AuthFilter</filter-name>
    <filter-class>com.dtolabs.rundeck.server.filters.AuthFilter</filter-class>
</filter>
<filter-mapping>
    <filter-name>AuthFilter</filter-name>
    <url-pattern>/*</url-pattern>
</filter-mapping>
``` 
  
 *  Remove the `auth-constraint` element
  
```
<auth-constraint>
    <role-name>*</role-name>
</auth-constraint>
```  
  
* Run the jar again, this time use --skip-install to avoid overwriting the new web.xml

 `$ java -jar rundeck-launcher/launcher/build/libs/rundeck-launcher-2.6.8-SNAPSHOT.jar --skipinstall` 


Improvements / todo,

* Automate some of the manual configuration of web.xml above (we are doing it with our provisioning scripts).
* Access `preauthenticated.attributeName` value to be set from config in `AuthFilter`.
* Understanding and support of other use cases.
