### PR TITLE
Preauthentication filter

### DIFF
--- a/rundeck-launcher/launcher/src/main/resources/templates/config/rundeck-config.properties.template
+++ b/rundeck-launcher/launcher/src/main/resources/templates/config/rundeck-config.properties.template
@@ -7,3 +7,8 @@ rss.enabled=false
 grails.serverURL=http://${server.hostname}:${server.http.port}${server.web.context}
 dataSource.dbCreate = update
 dataSource.url = jdbc:h2:file:${server.datastore.path};MVCC=true;TRACE_LEVEL_FILE=4
+
+# Pre Auth mode settings
+rundeck.security.authorization.preauthenticated.enabled=false
+rundeck.security.authorization.preauthenticated.attributeName=REMOTE_USER_GROUPS
+rundeck.security.authorization.preauthenticated.delimiter=,

--- a/rundeck-launcher/launcher/src/main/resources/templates/config/rundeck-config.properties.template
+++ b/rundeck-launcher/launcher/src/main/resources/templates/config/rundeck-config.properties.template
@@ -12,3 +12,10 @@ dataSource.url = jdbc:h2:file:${server.datastore.path};MVCC=true;TRACE_LEVEL_FIL
 rundeck.security.authorization.preauthenticated.enabled=false
 rundeck.security.authorization.preauthenticated.attributeName=REMOTE_USER_GROUPS
 rundeck.security.authorization.preauthenticated.delimiter=,
+# Redirect to upstream logout url
+rundeck.security.authorization.preauthenticated.redirectLogout=false
+rundeck.security.authorization.preauthenticated.redirectUrl=/oauth2/sign_in
+
+dataSource.url = jdbc:mysql://localhost:3306/rundeck?autoReconnect=true
+dataSource.username=rundeckuser
+dataSource.password=rundeckpassword

--- a/rundeck-launcher/launcher/src/main/resources/templates/config/rundeck-config.properties.template
+++ b/rundeck-launcher/launcher/src/main/resources/templates/config/rundeck-config.properties.template
@@ -15,7 +15,3 @@ rundeck.security.authorization.preauthenticated.delimiter=,
 # Redirect to upstream logout url
 rundeck.security.authorization.preauthenticated.redirectLogout=false
 rundeck.security.authorization.preauthenticated.redirectUrl=/oauth2/sign_in
-
-dataSource.url = jdbc:mysql://localhost:3306/rundeck?autoReconnect=true
-dataSource.username=rundeckuser
-dataSource.password=rundeckpassword

--- a/rundeck-launcher/launcher/src/main/resources/templates/config/rundeck-config.properties.template
+++ b/rundeck-launcher/launcher/src/main/resources/templates/config/rundeck-config.properties.template
@@ -12,6 +12,10 @@ dataSource.url = jdbc:h2:file:${server.datastore.path};MVCC=true;TRACE_LEVEL_FIL
 rundeck.security.authorization.preauthenticated.enabled=false
 rundeck.security.authorization.preauthenticated.attributeName=REMOTE_USER_GROUPS
 rundeck.security.authorization.preauthenticated.delimiter=,
+# Header from which to obtain user name
+rundeck.security.authorization.preauthenticated.userNameHeader=X-Forwarded-Uuid
+# Header from which to obtain list of roles
+rundeck.security.authorization.preauthenticated.userRolesHeader=X-Forwarded-Roles
 # Redirect to upstream logout url
 rundeck.security.authorization.preauthenticated.redirectLogout=false
 rundeck.security.authorization.preauthenticated.redirectUrl=/oauth2/sign_in

--- a/rundeckapp/authfilter/AuthFilterGrailsPlugin.groovy
+++ b/rundeckapp/authfilter/AuthFilterGrailsPlugin.groovy
@@ -1,0 +1,85 @@
+
+class AuthFilterGrailsPlugin {
+    // the plugin version
+    def version = "2.0.0-SNAPSHOT"
+    // the version or versions of Grails the plugin is designed for
+    def grailsVersion = "2.2 > *"
+    // resources that are excluded from plugin packaging
+    def pluginExcludes = [
+        "grails-app/views",
+        "web-app/**"
+    ]
+
+    def title = "Auth Filter Plugin" // Headline display name of the plugin
+    def author = "John Stoltenborg"
+    def authorEmail = ""
+    def description = '''\
+Adds auth filter to web.xml
+'''
+
+    // URL to the plugin's documentation
+    def documentation = "http://rundeck.org"
+
+    // Extra (optional) plugin metadata
+
+    // License: one of 'APACHE', 'GPL2', 'GPL3'
+    def license = "APACHE"
+
+    // Details of company behind the plugin (if there is one)
+    def organization = [ name: "SimplifyOps", url: "http://www.simplifyops.com/" ]
+
+    // Any additional developers beyond the author specified above.
+    def developers = [ [ name: "Greg Schueler", email: "greg@simplifyops.com" ]]
+
+    // Location of the plugin's issue tracker.
+    def issueManagement = [ system: "Github", url: "http://github.com/dtolabs/rundeck/issues" ]
+
+    // Online location of the plugin's browseable source code.
+    def scm = [ url: "http://github.com/dtolabs/rundeck" ]
+
+    def doWithWebDescriptor = { xml ->
+            addFilters(application.config,xml)
+    }
+
+
+    def addFilters(ConfigObject config,def xml) {
+        def filterNodes = xml.'context-param'
+        if (filterNodes.size() > 0) {
+
+            def filterElement = filterNodes[filterNodes.size() - 1]
+            filterElement + {
+                'filter' {
+                    'filter-name'("AuthFilter")
+                    'filter-class'("com.dtolabs.rundeck.server.filters.AuthFilter")
+                }
+            }
+
+
+            def mappingNodes = xml.'filter'
+            if (mappingNodes.size() > 0) {
+
+                def mappingElement = mappingNodes[mappingNodes.size() - 1]
+                mappingElement + {
+                    'filter-mapping' {
+                        'filter-name'("AuthFilter")
+                        'url-pattern'("/*")
+                    }
+                }
+            }
+        }
+    }
+    def onChange = { event ->
+        // TODO Implement code that is executed when any artefact that this plugin is
+        // watching is modified and reloaded. The event contains: event.source,
+        // event.application, event.manager, event.ctx, and event.plugin.
+    }
+
+    def onConfigChange = { event ->
+        // TODO Implement code that is executed when the project configuration changes.
+        // The event is the same as for 'onChange'.
+    }
+
+    def onShutdown = { event ->
+        // TODO Implement code that is executed when the application shuts down (optional)
+    }
+}

--- a/rundeckapp/authfilter/application.properties
+++ b/rundeckapp/authfilter/application.properties
@@ -1,0 +1,5 @@
+#Grails Metadata file
+#Tue Aug 27 19:22:41 PDT 2013
+app.grails.version=2.2.4
+app.name=auth-filter
+app.version=2.1.0-SNAPSHOT

--- a/rundeckapp/authfilter/scripts/_Install.groovy
+++ b/rundeckapp/authfilter/scripts/_Install.groovy
@@ -1,0 +1,10 @@
+//
+// This script is executed by Grails after plugin was installed to project.
+// This script is a Gant script so you can use all special variables provided
+// by Gant (such as 'baseDir' which points on project base dir). You can
+// use 'ant' to access a global instance of AntBuilder
+//
+// For example you can create directory under project tree:
+//
+//    ant.mkdir(dir:"${basedir}/grails-app/jobs")
+//

--- a/rundeckapp/authfilter/scripts/_Uninstall.groovy
+++ b/rundeckapp/authfilter/scripts/_Uninstall.groovy
@@ -1,0 +1,5 @@
+//
+// This script is executed by Grails when the plugin is uninstalled from project.
+// Use this script if you intend to do any additional clean-up on uninstall, but
+// beware of messing up SVN directories!
+//

--- a/rundeckapp/authfilter/scripts/_Upgrade.groovy
+++ b/rundeckapp/authfilter/scripts/_Upgrade.groovy
@@ -1,0 +1,10 @@
+//
+// This script is executed by Grails during application upgrade ('grails upgrade'
+// command). This script is a Gant script so you can use all special variables
+// provided by Gant (such as 'baseDir' which points on project base dir). You can
+// use 'ant' to access a global instance of AntBuilder
+//
+// For example you can create directory under project tree:
+//
+//    ant.mkdir(dir:"${basedir}/grails-app/jobs")
+//

--- a/rundeckapp/grails-app/conf/BootStrap.groovy
+++ b/rundeckapp/grails-app/conf/BootStrap.groovy
@@ -228,6 +228,13 @@ class BootStrap {
          }else{
              log.info("RSS feeds disabled")
          }
+
+         if('true' == grailsApplication.config.rundeck.security.authorization.preauthenticated.enabled){
+             log.info("Preauthentication is enabled")
+         } else {
+             log.info("Preauthentication is disabled")
+         }
+
          if(grailsApplication.config.execution.follow.buffersize){
              servletContext.setAttribute("execution.follow.buffersize",grailsApplication.config.execution.follow.buffersize)
          }else{

--- a/rundeckapp/grails-app/conf/BuildConfig.groovy
+++ b/rundeckapp/grails-app/conf/BuildConfig.groovy
@@ -42,6 +42,7 @@ if(System.properties['disable.grails.central']) {
 
 grails.plugin.location.webrealms = 'webrealms'
 grails.plugin.location.metricsweb = 'metricsweb'
+grails.plugin.location.authfilter = 'authfilter'
 
 grails.project.dependency.resolution = {
     inherits 'global' // inherit Grails' default dependencies

--- a/rundeckapp/grails-app/conf/rundeck/filters/AuthorizationFilters.groovy
+++ b/rundeckapp/grails-app/conf/rundeck/filters/AuthorizationFilters.groovy
@@ -52,20 +52,24 @@ public class AuthorizationFilters implements ApplicationContextAware{
          */
         loginCheck(controller: 'user', action: '(logout|login|error)', invert: true) {
             before = {
-                if(request.api_version && request.remoteUser && !(grailsApplication.config.rundeck?.security?.apiCookieAccess?.enabled in ['true',true])){
+                if (request.api_version && request.remoteUser && !(grailsApplication.config.rundeck?.security?.apiCookieAccess?.enabled in ['true',true])){
                     //disallow api access via normal login
                     request.invalidApiAuthentication=true
                     return
                 }
                 if (request.remoteUser && session.user!=request.remoteUser) {
                     session.user = request.remoteUser
-                    
 
                     Subject subject=createAuthSubject(request)
                     
                     request.subject = subject
                     session.subject = subject
-                }else if(request.remoteUser && session.subject){
+                } else if(request.remoteUser && session.subject && grailsApplication.config.rundeck.security.authorization.preauthenticated.enabled in ['true',true]){
+                    // Preauthenticated mode is enabled, handle upstream role changes
+                    Subject subject = createAuthSubject(request)
+                    request.subject = subject
+                    session.subject = subject
+                } else if(request.remoteUser && session.subject && !grailsApplication.config.rundeck.security.authorization.preauthenticated.enabled in ['true',true])  {
                     request.subject = session.subject
                 } else if (request.api_version && !session.user ) {
                     //allow authentication token to be used 

--- a/rundeckapp/grails-app/conf/rundeck/filters/AuthorizationFilters.groovy
+++ b/rundeckapp/grails-app/conf/rundeck/filters/AuthorizationFilters.groovy
@@ -69,7 +69,7 @@ public class AuthorizationFilters implements ApplicationContextAware{
                     Subject subject = createAuthSubject(request)
                     request.subject = subject
                     session.subject = subject
-                } else if(request.remoteUser && session.subject && !grailsApplication.config.rundeck.security.authorization.preauthenticated.enabled in ['true',true])  {
+                } else if(request.remoteUser && session.subject && grailsApplication.config.rundeck.security.authorization.preauthenticated.enabled in ['false',false]) {
                     request.subject = session.subject
                 } else if (request.api_version && !session.user ) {
                     //allow authentication token to be used 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -40,7 +40,9 @@ class UserController extends ControllerBase{
     }
 
     def loggedout(){
-        return redirect(url: grailsApplication.config.grails.serverURL + '/oauth2/sign_in')
+        if(grailsApplication.config.rundeck.security.authorization.preauthenticated.redirectLogout in ['true',true]) {
+            return redirect(url: grailsApplication.config.grails.serverURL + grailsApplication.config.rundeck.security.authorization.preauthenticated.redirectUrl)
+        }
     }
 
     def login = {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -40,7 +40,9 @@ class UserController extends ControllerBase{
     }
 
     def loggedout(){
-
+        URL url = new URL(grailsApplication.config.grails.serverURL)
+        def hostname = url.getHost()
+        return redirect(url: 'http://' + hostname + ':4180/oauth2/sign_in')
     }
 
     def login = {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -40,9 +40,7 @@ class UserController extends ControllerBase{
     }
 
     def loggedout(){
-        URL url = new URL(grailsApplication.config.grails.serverURL)
-        def hostname = url.getHost()
-        return redirect(url: 'http://' + hostname + ':4180/oauth2/sign_in')
+        return redirect(url: grailsApplication.config.grails.serverURL + '/oauth2/sign_in')
     }
 
     def login = {

--- a/rundeckapp/src/java/com/dtolabs/rundeck/server/filters/AuthFilter.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/server/filters/AuthFilter.java
@@ -18,7 +18,7 @@ import java.util.Enumeration;
  */
 public class AuthFilter implements Filter {
 
-    private static final transient Logger LOG = Logger.getLogger(GrailsServiceInjectorJobListener.class);
+    private static final transient Logger LOG = Logger.getLogger(AuthFilter.class);
 
 
     public void init(FilterConfig filterConfig) throws ServletException {

--- a/rundeckapp/src/java/com/dtolabs/rundeck/server/filters/AuthFilter.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/server/filters/AuthFilter.java
@@ -31,8 +31,11 @@ public class AuthFilter implements Filter {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         Enumeration<String> headerNames = httpRequest.getHeaderNames();
 
-        final String forwardedUser = httpRequest.getHeader("X-Forwarded-User");
+        // Todo remove stdout debugs
+        System.out.println("Debug: Spring auth filter");
 
+        final String forwardedUser = httpRequest.getHeader("X-Forwarded-User");
+        System.out.println("User received " + forwardedUser);
         ServletRequest requestModified =
                 new HttpServletRequestWrapper((HttpServletRequest) request) {
                     @Override
@@ -56,6 +59,7 @@ public class AuthFilter implements Filter {
         // Get the roles sent by the proxy and add them onto the request as an attribute for
         // PreauthenticatedAttributeRoleSource
         final String forwardedRoles = httpRequest.getHeader("X-Forwarded-Roles");
+        System.out.println("Roles received: " + forwardedRoles);
         requestModified.setAttribute("REMOTE_USER_GROUPS", forwardedRoles);
 
         filterChain.doFilter(requestModified, response);

--- a/rundeckapp/src/java/com/dtolabs/rundeck/server/filters/AuthFilter.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/server/filters/AuthFilter.java
@@ -2,67 +2,82 @@ package com.dtolabs.rundeck.server.filters;
 
 import com.dtolabs.rundeck.core.utils.GrailsServiceInjectorJobListener;
 import org.apache.log4j.Logger;
-
-import javax.management.relation.RoleList;
+import org.codehaus.groovy.grails.commons.GrailsApplication;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.Enumeration;
+import java.util.Map;
 
 /**
  * Filter interrogates headers and modifies the request object to be passed down the filter chain
  *
  * @author John Stoltenborg
  */
+
 public class AuthFilter implements Filter {
 
+    String preauthentication;
+    String rolesAttribute;
     private static final transient Logger LOG = Logger.getLogger(AuthFilter.class);
 
 
     public void init(FilterConfig filterConfig) throws ServletException {
+
+        WebApplicationContext springContext = WebApplicationContextUtils.getWebApplicationContext(filterConfig.getServletContext());
+        GrailsApplication grailsApplication = springContext.getBean(GrailsApplication.class);
+
+        if (grailsApplication.equals(null)) {
+            throw new IllegalStateException("grailsApplication not found in context");
+        }
+
+        Map map = grailsApplication.getFlatConfig();
+        preauthentication = (String) map.get("rundeck.security.authorization.preauthenticated.enabled");
+        rolesAttribute = (String) map.get("rundeck.security.authorization.preauthenticated.attributeName");
     }
 
     public void doFilter(ServletRequest request, ServletResponse response,
                          FilterChain filterChain)
             throws IOException, ServletException {
 
-        HttpServletRequest httpRequest = (HttpServletRequest) request;
-        Enumeration<String> headerNames = httpRequest.getHeaderNames();
+        if(preauthentication.equals("true")) {
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            Enumeration<String> headerNames = httpRequest.getHeaderNames();
 
-        // Todo remove stdout debugs
-        System.out.println("Debug: Spring auth filter");
+            final String forwardedUser = httpRequest.getHeader("X-Forwarded-User");
+            ServletRequest requestModified =
+                    new HttpServletRequestWrapper((HttpServletRequest) request) {
+                        @Override
+                        public String getRemoteUser() {
+                            return forwardedUser;
+                        }
 
-        final String forwardedUser = httpRequest.getHeader("X-Forwarded-User");
-        System.out.println("User received " + forwardedUser);
-        ServletRequest requestModified =
-                new HttpServletRequestWrapper((HttpServletRequest) request) {
-                    @Override
-                    public String getRemoteUser() {
-                        return forwardedUser;
-                    }
+                        @Override
+                        public Principal getUserPrincipal() {
+                            Principal principle = new Principal() {
+                                @Override
+                                public String getName() {
+                                    return forwardedUser;
+                                }
+                            };
+                            return principle;
+                        }
+                    };
 
-                    @Override
-                    public Principal getUserPrincipal() {
-                        Principal principle = new Principal() {
-                            @Override
-                            public String getName() {
-                                return forwardedUser;
-                            }
-                        };
-                        return principle;
-                    }
-                };
+            //
+            // Get the roles sent by the proxy and add them onto the request as an attribute for
+            // PreauthenticatedAttributeRoleSource
+            final String forwardedRoles = httpRequest.getHeader("X-Forwarded-Roles");
+            requestModified.setAttribute(rolesAttribute, forwardedRoles);
+            filterChain.doFilter(requestModified, response);
 
-        //
-        // Get the roles sent by the proxy and add them onto the request as an attribute for
-        // PreauthenticatedAttributeRoleSource
-        final String forwardedRoles = httpRequest.getHeader("X-Forwarded-Roles");
-        System.out.println("Roles received: " + forwardedRoles);
-        requestModified.setAttribute("REMOTE_USER_GROUPS", forwardedRoles);
-
-        filterChain.doFilter(requestModified, response);
+        } else {
+            filterChain.doFilter(request, response);
+        }
     }
 
     public void destroy() {

--- a/rundeckapp/src/java/com/dtolabs/rundeck/server/filters/AuthFilter.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/server/filters/AuthFilter.java
@@ -1,0 +1,66 @@
+package com.dtolabs.rundeck.server.filters;
+
+import com.dtolabs.rundeck.core.utils.GrailsServiceInjectorJobListener;
+import org.apache.log4j.Logger;
+
+import javax.management.relation.RoleList;
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Enumeration;
+
+/**
+ * Filter interrogates headers and modifies the request object to be passed down the filter chain
+ *
+ * @author John Stoltenborg
+ */
+public class AuthFilter implements Filter {
+
+    private static final transient Logger LOG = Logger.getLogger(GrailsServiceInjectorJobListener.class);
+
+
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    public void doFilter(ServletRequest request, ServletResponse response,
+                         FilterChain filterChain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        Enumeration<String> headerNames = httpRequest.getHeaderNames();
+
+        final String forwardedUser = httpRequest.getHeader("X-Forwarded-User");
+
+        ServletRequest requestModified =
+                new HttpServletRequestWrapper((HttpServletRequest) request) {
+                    @Override
+                    public String getRemoteUser() {
+                        return forwardedUser;
+                    }
+
+                    @Override
+                    public Principal getUserPrincipal() {
+                        Principal principle = new Principal() {
+                            @Override
+                            public String getName() {
+                                return forwardedUser;
+                            }
+                        };
+                        return principle;
+                    }
+                };
+
+        //
+        // Get the roles sent by the proxy and add them onto the request as an attribute for
+        // PreauthenticatedAttributeRoleSource
+        final String forwardedRoles = httpRequest.getHeader("X-Forwarded-Roles");
+        requestModified.setAttribute("REMOTE_USER_GROUPS", forwardedRoles);
+
+        filterChain.doFilter(requestModified, response);
+    }
+
+    public void destroy() {
+    }
+}


### PR DESCRIPTION
Hi,

Thanks to the team for all of the work you’ve put into this project. 

Here is a contribution towards preauthenticating with a reverse proxy, works towards resolving #1229 - Feedback is appreciated.

We are currently using https://github.com/bitly/oauth2_proxy to auth with Github and send a remote user and roles (as defined by teams) along to Rundeck. I’ve written a Spring filter that intercepts the request object at the beginning of the filter chain and modifies it to be sent along. 

There are a number of manual configuration changes. Here are the steps we take for `rundeck-launcher`

* Set `rundeck.security.authorization.preauthenticated.enabled=true`
* Build the project
  `$ ./gradlew clean build` 
* Run jar with install option on (default)
 `$ java -jar rundeck-launcher/launcher/build/libs/rundeck-launcher-2.6.8-SNAPSHOT.jar --install-only` 

* Modify `rundeck-launcher/launcher/build/libs/server/exp/webapp/WEB-INF/web.xml` 

 * Add the filter to the top of the filter chain.
    
```
<filter>
    <filter-name>AuthFilter</filter-name>
    <filter-class>com.dtolabs.rundeck.server.filters.AuthFilter</filter-class>
</filter>
<filter-mapping>
    <filter-name>AuthFilter</filter-name>
    <url-pattern>/*</url-pattern>
</filter-mapping>
``` 
  
 *  Remove the `auth-constraint` element
  
```
<auth-constraint>
    <role-name>*</role-name>
</auth-constraint>
```  
  
* Run the jar again, this time use --skip-install to avoid overwriting the new web.xml

 `$ java -jar rundeck-launcher/launcher/build/libs/rundeck-launcher-2.6.8-SNAPSHOT.jar --skipinstall` 


Improvements / todo,

* Automate some of the manual configuration of web.xml above (we are doing it with our provisioning scripts).
* Access `preauthenticated.attributeName` value to be set from config in `AuthFilter`.
* Understanding and support of other use cases.
