### PR TITLE
fix #1938 allow default encoding of command output to be specified

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContext.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContext.java
@@ -112,6 +112,12 @@ public interface ExecutionContext {
     int getLoglevel();
 
     /**
+     *
+     * @return the charset encoding to use for handling output, or null for default
+     */
+    String getCharsetEncoding();
+
+    /**
      * Return data context set
      *
      * @return map of data contexts keyed by name

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContextImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContextImpl.java
@@ -59,6 +59,7 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
     private int threadCount;
     private boolean keepgoing;
     private int loglevel;
+    private String charsetEncoding;
     private Map<String, Map<String, String>> dataContext;
     private Map<String, Map<String, String>> privateDataContext;
     private Map<String, Map<String, Map<String, String>>> nodeDataContext;
@@ -113,6 +114,15 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
         return flowControl;
     }
 
+    @Override
+    public String getCharsetEncoding() {
+        return charsetEncoding;
+    }
+
+    public void setCharsetEncoding(String charsetEncoding) {
+        this.charsetEncoding = charsetEncoding;
+    }
+
     public static class Builder {
         private ExecutionContextImpl ctx;
 
@@ -129,6 +139,7 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
                 ctx.nodeSet = original.getNodeSelector();
                 ctx.nodes = original.getNodes();
                 ctx.loglevel = original.getLoglevel();
+                ctx.charsetEncoding = original.getCharsetEncoding();
                 ctx.dataContext = original.getDataContext();
                 ctx.privateDataContext = original.getPrivateDataContext();
                 ctx.executionListener = original.getExecutionListener();
@@ -243,6 +254,11 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
 
         public Builder loglevel(int loglevel) {
             ctx.loglevel = loglevel;
+            return this;
+        }
+
+        public Builder charsetEncoding(String charsetEncoding) {
+            ctx.charsetEncoding = charsetEncoding;
             return this;
         }
 

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/impl/local/LocalNodeExecutorSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/impl/local/LocalNodeExecutorSpec.groovy
@@ -1,0 +1,47 @@
+package com.dtolabs.rundeck.core.execution.impl.local
+
+import com.dtolabs.rundeck.core.common.INodeEntry
+import com.dtolabs.rundeck.core.execution.script.ExecTaskParameterGeneratorImpl
+import org.apache.tools.ant.Project
+import org.apache.tools.ant.taskdefs.ExecTask
+import org.apache.tools.ant.types.RedirectorElement
+import spock.lang.Specification
+
+/**
+ * Created by greg on 7/7/16.
+ */
+class LocalNodeExecutorSpec extends Specification {
+    class TExecTask extends ExecTask {
+        RedirectorElement getTestRedirectorElement() {
+            return this.redirectorElement
+        }
+    }
+
+    def "build exec task uses input encoding"() {
+        given:
+        def task = new TExecTask()
+        def project = new Project()
+        def node = Mock(INodeEntry)
+        def params = new ExecTaskParameterGeneratorImpl().generate(
+                node, true, null, ['a', 'command'] as String[]
+        )
+        when:
+        def result = LocalNodeExecutor.buildExecTask(project, params, [:], encoding, task)
+
+        then:
+        result == task
+        if (encoding) {
+            task.testRedirectorElement != null
+            task.testRedirectorElement.inputEncoding == encoding
+        } else {
+            task.testRedirectorElement == null
+        }
+
+        where:
+
+        encoding     | _
+        null         | _
+        'UTF-8'      | _
+        'ISO-8859-2' | _
+    }
+}

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -45,6 +45,7 @@ import rundeck.services.logging.LoggingThreshold
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import javax.servlet.http.HttpSession
+import java.nio.charset.Charset
 import java.text.MessageFormat
 import java.text.SimpleDateFormat
 import java.util.regex.Pattern
@@ -861,9 +862,11 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 }
                 loadSecureOptionStorageDefaults(scheduledExecution, extraParamsExposed, extraParams, authContext,true)
             }
+            String inputCharset=frameworkService.getDefaultInputCharsetForProject(execution.project)
+            log.error("using charset: "+inputCharset)
 
             StepExecutionContext executioncontext = createContext(execution, null,framework, authContext,
-                    execution.user, jobcontext, multiListener, null,extraParams, extraParamsExposed)
+                    execution.user, jobcontext, multiListener, null,extraParams, extraParamsExposed,inputCharset)
 
             //ExecutionService handles Job reference steps
             final cis = StepExecutionService.getInstanceForFramework(framework);
@@ -882,10 +885,10 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             //install custom outputstreams for System.out and System.err for this thread and any child threads
             //output will be sent to loghandler instead.
             sysThreadBoundOut.installThreadStream(
-                    loggingService.createLogOutputStream(loghandler, LogLevel.NORMAL, executionListener, logOutFlusher)
+                    loggingService.createLogOutputStream(loghandler, LogLevel.NORMAL, executionListener, logOutFlusher, inputCharset?Charset.forName(inputCharset):null)
             );
             sysThreadBoundErr.installThreadStream(
-                    loggingService.createLogOutputStream(loghandler, LogLevel.ERROR, executionListener, logErrFlusher)
+                    loggingService.createLogOutputStream(loghandler, LogLevel.ERROR, executionListener, logErrFlusher, inputCharset?Charset.forName(inputCharset):null)
             );
             //create service object for the framework and listener
             Thread thread = new WorkflowExecutionServiceThread(framework.getWorkflowExecutionService(),item, executioncontext)
@@ -1156,7 +1159,20 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     /**
      * Return an StepExecutionItem instance for the given workflow Execution, suitable for the ExecutionService layer
      */
-    public StepExecutionContext createContext(ExecutionContext execMap, StepExecutionContext origContext, Framework framework, AuthContext authContext, String userName = null, Map<String, String> jobcontext, ExecutionListener listener, String[] inputargs=null, Map extraParams=null, Map extraParamsExposed=null) {
+    public StepExecutionContext createContext(
+            ExecutionContext execMap,
+            StepExecutionContext origContext,
+            Framework framework,
+            AuthContext authContext,
+            String userName = null,
+            Map<String, String> jobcontext,
+            ExecutionListener listener,
+            String[] inputargs = null,
+            Map extraParams = null,
+            Map extraParamsExposed = null,
+            String charsetEncoding = null
+    )
+    {
         if (!userName) {
             userName=execMap.user
         }
@@ -1232,6 +1248,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             .nodeSelector(nodeselector)
             .nodes(nodeSet)
             .loglevel(logLevelIntValue(execMap.loglevel))
+            .charsetEncoding(charsetEncoding)
             .dataContext(datacontext)
             .privateDataContext(privatecontext)
             .executionListener(listener)

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -44,6 +44,7 @@ import rundeck.PluginStep
 import rundeck.ScheduledExecution
 
 import javax.security.auth.Subject
+import java.nio.charset.Charset
 
 /**
  * Interfaces with the core Framework object
@@ -51,6 +52,7 @@ import javax.security.auth.Subject
 class FrameworkService implements ApplicationContextAware {
 
     static transactional = false
+    public static final String REMOTE_CHARSET = 'remote.charset.default'
 
     boolean initialized = false
     private String serverUUID
@@ -1079,5 +1081,16 @@ class FrameworkService implements ApplicationContextAware {
 
     Map<String, String> getProjectGlobals(final String project) {
         rundeckFramework.getProjectGlobals(project)
+    }
+
+    String getDefaultInputCharsetForProject(final String project) {
+        def config = rundeckFramework.getFrameworkProjectMgr().loadProjectConfig(project)
+        String charsetname
+        if(config.hasProperty("project.$REMOTE_CHARSET")) {
+            charsetname=config.getProperty("project.${REMOTE_CHARSET}")
+        }else if (config.hasProperty("framework.$REMOTE_CHARSET")) {
+            charsetname=config.getProperty("framework.$REMOTE_CHARSET")
+        }
+        return charsetname
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/LoggingService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LoggingService.groovy
@@ -26,6 +26,8 @@ import rundeck.services.logging.NodeCountingLogWriter
 import rundeck.services.logging.ProducedExecutionFile
 import rundeck.services.logging.ThresholdLogWriter
 
+import java.nio.charset.Charset
+
 class LoggingService implements ExecutionFileProducer {
 
     public static final String LOG_FILE_FILETYPE = 'rdlog'
@@ -215,10 +217,11 @@ class LoggingService implements ExecutionFileProducer {
             StreamingLogWriter logWriter,
             LogLevel level,
             Contextual listener,
-            LogFlusher flusherWorkflowListener
+            LogFlusher flusherWorkflowListener,
+            Charset charset=null
     )
     {
-        def stream = new ThreadBoundLogOutputStream(logWriter, level, listener)
+        def stream = new ThreadBoundLogOutputStream(logWriter, level, listener, charset)
         flusherWorkflowListener.logOut=stream
         return stream
     }

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/logging/LogEventBuffer.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/logging/LogEventBuffer.groovy
@@ -4,6 +4,7 @@ import com.dtolabs.rundeck.core.logging.LogEvent
 import com.dtolabs.rundeck.core.logging.LogLevel
 import com.dtolabs.rundeck.core.logging.LogUtil
 
+import java.nio.charset.Charset
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -16,10 +17,12 @@ class LogEventBuffer implements Comparable {
     ByteArrayOutputStream baos
     Long serial
     final static AtomicLong counter = new AtomicLong(0)
+    private Charset charset
 
-    LogEventBuffer(final Map<String, String> context) {
+    LogEventBuffer(final Map<String, String> context, Charset charset = null) {
         serial = counter.incrementAndGet()
         reset(context)
+        this.charset = charset
     }
 
     boolean isEmpty() {
@@ -40,10 +43,11 @@ class LogEventBuffer implements Comparable {
     }
 
     LogEvent createEvent(LogLevel level) {
+        def string = baos?(charset?new String(baos.toByteArray(), (Charset) charset):new String(baos.toByteArray())):''
         return new DefaultLogEvent(
                 loglevel: level,
                 metadata: context ?: [:],
-                message: baos ? new String(baos.toByteArray()) : '',
+                message: string,
                 datetime: time ?: new Date(),
                 eventType: LogUtil.EVENT_TYPE_LOG
         )

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/logging/LogEventBufferManager.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/logging/LogEventBufferManager.groovy
@@ -3,21 +3,24 @@ package com.dtolabs.rundeck.app.internal.logging
 import com.dtolabs.rundeck.core.logging.LogLevel
 import com.dtolabs.rundeck.core.logging.StreamingLogWriter
 
+import java.nio.charset.Charset
+
 /**
  * Creates log event buffers, and retains references to them, so that they can be
  * flushed later even if any thread-local references are lost when a thread finishes
  */
 class LogEventBufferManager {
     Set<LogEventBuffer> buffers = new TreeSet<>()
+    Charset charset
 
-    LogEventBuffer create(Map context) {
-        def buffer = new LogEventBuffer(context)
+    LogEventBuffer create(Map context, Charset charset = null) {
+        def buffer = new LogEventBuffer(context, charset ?: this.charset)
         buffers.add(buffer)
         return buffer
     }
 
-    static LogEventBufferManager createManager() {
-        new LogEventBufferManager()
+    static LogEventBufferManager createManager(Charset charset = null) {
+        new LogEventBufferManager(charset: charset)
     }
 
     /**

--- a/rundeckapp/test/unit/ExecutionServiceSpec.groovy
+++ b/rundeckapp/test/unit/ExecutionServiceSpec.groovy
@@ -544,6 +544,42 @@ class ExecutionServiceSpec extends Specification {
         !val.executionListener
         val.dataContext.globals == [a:'b',c:'d']
     }
+    def "Create execution context with charset"() {
+        given:
+
+        service.frameworkService = Mock(FrameworkService) {
+            1 * filterNodeSet(null, 'testproj')
+            1 * filterAuthorizedNodes(*_)
+            1 * getProjectGlobals(*_) >> [:]
+            0 * _(*_)
+        }
+        service.storageService = Mock(StorageService) {
+            1 * storageTreeWithContext(_)
+        }
+        service.jobStateService = Mock(JobStateService) {
+            1 * jobServiceWithAuthContext(_)
+        }
+
+        Execution se = new Execution(
+                argString: "-test args",
+                user: "testuser",
+                project: "testproj",
+                loglevel: 'WARN',
+                doNodedispatch: false
+        )
+
+        when:
+        def val = service.createContext(se, null, null, null, null, null, null,null,null,null,charset)
+        then:
+        val!=null
+        val.charsetEncoding==charset
+
+        where:
+        charset      | _
+        null         | _
+        'UTF-8'      | _
+        'ISO-8859-1' | _
+    }
 
     def "delete execution unauthorized"() {
         given:


### PR DESCRIPTION
project.remote.charset.default
framework.remote.charset.default