### PR TITLE
fix #1898  avoid file writing contention

### DIFF
--- a/core/src/test/java/com/dtolabs/rundeck/core/plugins/TestJarPluginProviderLoader.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/plugins/TestJarPluginProviderLoader.java
@@ -38,7 +38,6 @@ import java.util.jar.Manifest;
 
 import junit.framework.Assert;
 
-import com.dtolabs.rundeck.core.Constants;
 import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.execution.service.ProviderCreationException;
 import com.dtolabs.rundeck.core.execution.service.ProviderLoaderException;
@@ -409,7 +408,7 @@ public class TestJarPluginProviderLoader extends AbstractBaseTest {
 
         final JarPluginProviderLoader jarPluginProviderLoader = new JarPluginProviderLoader(testJar11, testPluginJarCacheDirectory, testCachedir);
         // Create test jar in pluginCache
-        File otherJar = new File(testPluginJarCacheDirectory, "20120301121249123-" + testJar11.getName());
+        File otherJar = new File(testPluginJarCacheDirectory, "20120301121249123-00-" + testJar11.getName());
         otherJar.createNewFile();
         otherJar.deleteOnExit();
         
@@ -423,12 +422,148 @@ public class TestJarPluginProviderLoader extends AbstractBaseTest {
         final JarTestType1 test2 = jarPluginProviderLoader.load(service, "test2");
         assertNotNull(test2);
         assertTrue(test2 instanceof testProvider2);
-        
-        Assert.assertFalse("Expected existing cached jar to be deleted", otherJar.exists());
-        Assert.assertFalse("Expected dependency jar to be deleted", dependency.exists());
+
+        Assert.assertTrue("Expected dependency jar to be deleted", dependency.exists());
         File[] files = testPluginJarCacheDirectory.listFiles();
         Assert.assertEquals("Expected single cached jar in plugin jar cache", 1, files.length);
-        Assert.assertTrue("Expected cached jar to meet requirements for equivalency against original jar", jarPluginProviderLoader.isEquivalentPluginJar(files[0]));
+        Assert.assertTrue(
+                "Expected cached jar to meet requirements for equivalency against original jar",
+                jarPluginProviderLoader.isEquivalentPluginJar(files[0])
+        );
+    }
+
+    public void testExpireRemovesExistingCachedJars() throws Exception {
+        testService1 service = new testService1() {
+            @Override
+            public boolean isValidProviderClass(Class clazz) {
+                return JarTestType1.class.isAssignableFrom(clazz);
+            }
+        };
+        service.name = "TestService";
+        service.isvalid = true;
+        service.createInstance = new testProvider2();
+
+        final Class[] classes = {testProvider2.class};
+
+        final Map<String, String> entries = new HashMap<>();
+        entries.put(JarPluginProviderLoader.RUNDECK_PLUGIN_ARCHIVE, "true");
+        entries.put(JarPluginProviderLoader.RUNDECK_PLUGIN_VERSION, CURRENT_PLUGIN_VERSION);
+        entries.put(JarPluginProviderLoader.RUNDECK_PLUGIN_CLASSNAMES, classnameString(classes));
+
+        final File testJar11 = createTestJar(entries, null, classes);
+
+        FileUtils.deleteDir(testPluginJarCacheDirectory);
+        testPluginJarCacheDirectory.mkdirs();
+
+        final JarPluginProviderLoader jarPluginProviderLoader = new JarPluginProviderLoader(
+                testJar11,
+                testPluginJarCacheDirectory,
+                testCachedir
+        );
+
+
+        //valid
+        JarTestType1 test2 = jarPluginProviderLoader.load(service, "test2");
+        assertNotNull(test2);
+        assertTrue(test2 instanceof testProvider2);
+
+        File[] files = testCachedir.listFiles();
+        Assert.assertEquals("Expected single cached jar in plugin jar cache", 1, files.length);
+        Assert.assertTrue(files[0].isDirectory());
+        File[] files2 = files[0].listFiles();
+        Assert.assertEquals("Expected single cached jar in plugin jar cache", 1, files2.length);
+        Assert.assertTrue("Jar dir should be ident stamp: "+files2[0].getName(), files2[0].getName().matches("^\\d+-\\d+$"));
+        Assert.assertTrue(files2[0].isDirectory());
+        File[] files3 = files2[0].listFiles();
+        Assert.assertEquals("Expected single cached jar in plugin jar cache", 1, files3.length);
+        Assert.assertTrue("Jar dir should be cache jar file name: "+files3[0].getName(), files3[0].getName().matches("^\\d+-\\d+.*"));
+        Assert.assertTrue(
+                "Jar dir should be cache jar file name: " + files3[0].getName(),
+                files3[0].getName().endsWith(testJar11.getName())
+        );
+        Assert.assertTrue(files3[0].isFile());
+
+        Assert.assertTrue(
+                "Expected cached jar to meet requirements for equivalency against original jar",
+                jarPluginProviderLoader.isEquivalentPluginJar(files3[0])
+        );
+        test2=null;
+        jarPluginProviderLoader.expire();
+
+        //all files should be removed
+        files = testCachedir.listFiles();
+        Assert.assertEquals("Expected single cached jar in plugin jar cache", 0, files.length);
+    }
+    public void testExpireRemovesExistingCachedJarsAndLibs() throws Exception {
+        testService1 service = new testService1() {
+            @Override
+            public boolean isValidProviderClass(Class clazz) {
+                return JarTestType1.class.isAssignableFrom(clazz);
+            }
+        };
+        service.name = "TestService";
+        service.isvalid = true;
+        service.createInstance = new testProvider2();
+
+        final Class[] classes = {testProvider2.class};
+
+        final Map<String, String> entries = new HashMap<>();
+        entries.put(JarPluginProviderLoader.RUNDECK_PLUGIN_ARCHIVE, "true");
+        entries.put(JarPluginProviderLoader.RUNDECK_PLUGIN_VERSION, CURRENT_PLUGIN_VERSION);
+        entries.put(JarPluginProviderLoader.RUNDECK_PLUGIN_CLASSNAMES, classnameString(classes));
+        entries.put(JarPluginProviderLoader.RUNDECK_PLUGIN_LIBS, "lib/fakejar.jar");
+        File[] libs = new File[1];
+        libs[0] = new File("fakejar.jar");
+        final File testJar11 = createTestJar(entries, null, classes,libs);
+
+        FileUtils.deleteDir(testPluginJarCacheDirectory);
+        testPluginJarCacheDirectory.mkdirs();
+
+        final JarPluginProviderLoader jarPluginProviderLoader = new JarPluginProviderLoader(
+                testJar11,
+                testPluginJarCacheDirectory,
+                testCachedir
+        );
+
+
+        //valid
+        JarTestType1 test2 = jarPluginProviderLoader.load(service, "test2");
+        assertNotNull(test2);
+        assertTrue(test2 instanceof testProvider2);
+
+        File[] files = testCachedir.listFiles();
+        Assert.assertEquals("Expected single cached jar in plugin jar cache", 1, files.length);
+        Assert.assertTrue(files[0].isDirectory());
+        File[] files2 = files[0].listFiles();
+        Assert.assertEquals("Expected single cached jar in plugin jar cache", 1, files2.length);
+        Assert.assertTrue("Jar dir should be ident stamp: "+files2[0].getName(), files2[0].getName().matches("^\\d+-\\d+$"));
+        Assert.assertTrue(files2[0].isDirectory());
+        File[] files3 = files2[0].listFiles();
+        Assert.assertEquals("Expected single cached jar in plugin jar cache", 2, files3.length);
+        Assert.assertTrue("Jar dir should be cache jar file name: "+files3[0].getName(), files3[0].getName().matches("^\\d+-\\d+.*"));
+        Assert.assertTrue(
+                "Jar dir should be cache jar file name: " + files3[0].getName(),
+                files3[0].getName().endsWith(testJar11.getName())
+        );
+        Assert.assertTrue(files3[0].isFile());
+
+        Assert.assertTrue(
+                "Expected cached jar to meet requirements for equivalency against original jar",
+                jarPluginProviderLoader.isEquivalentPluginJar(files3[0])
+        );
+        Assert.assertEquals("Jar dir should be lib dir: " + files3[1].getName(), "lib", files3[1].getName());
+        Assert.assertTrue(files3[1].isDirectory());
+        File[] files4 = files3[1].listFiles();
+        Assert.assertEquals("Expected single cached jar in plugin jar cache", 1, files4.length);
+        Assert.assertEquals("Expected fakarjar dep: " + files4[0].getName(), "fakejar.jar", files4[0].getName());
+
+
+        test2=null;
+        jarPluginProviderLoader.expire();
+
+        //all files should be removed
+        files = testCachedir.listFiles();
+        Assert.assertEquals("Expected single cached jar in plugin jar cache", 0, files.length);
     }
 
     public void testCreateProviderForClass() throws Exception {
@@ -537,9 +672,12 @@ public class TestJarPluginProviderLoader extends AbstractBaseTest {
         File testJar = createTestJar(null, null);
         JarPluginProviderLoader jarPluginProviderLoader = new JarPluginProviderLoader(testJar,
                 testPluginJarCacheDirectory, testCachedir);
-        
-        File otherJar = new File(testPluginJarCacheDirectory, "20120301121249123-" + testJar.getName());
-        Assert.assertTrue("Expected jar names to be the same without timestamp", jarPluginProviderLoader.isEquivalentPluginJar(otherJar));
+
+        File otherJar = new File(testPluginJarCacheDirectory, "20120301121249123-00-" + testJar.getName());
+        Assert.assertTrue(
+                "Expected jar names to be the same without timestamp",
+                jarPluginProviderLoader.isEquivalentPluginJar(otherJar)
+        );
     }
     
     public void testIsEquivalentPluginJarDifferentNames() throws IOException {
@@ -555,8 +693,12 @@ public class TestJarPluginProviderLoader extends AbstractBaseTest {
         File testJar = createTestJar(null, null);
         JarPluginProviderLoader jarPluginProviderLoader = new JarPluginProviderLoader(testJar,
                 testPluginJarCacheDirectory, testCachedir);
-        String cachedName = jarPluginProviderLoader.generateCachedJarName();
-        Assert.assertTrue("Expected cached name - mtime to be the same as original jar name", cachedName.substring(18).equals(testJar.getName()));
+        String ident = jarPluginProviderLoader.generateCachedJarIdentity();
+        String cachedName = jarPluginProviderLoader.generateCachedJarName(ident);
+        Assert.assertTrue(
+                "Expected cached name - mtime to be the same as original jar name",
+                cachedName.replaceFirst("\\d+-\\d+-", "").equals(testJar.getName())
+        );
     }
     
     public void testCreateCachedJar() throws Exception {
@@ -568,16 +710,19 @@ public class TestJarPluginProviderLoader extends AbstractBaseTest {
         final JarPluginProviderLoader jarPluginProviderLoader = new JarPluginProviderLoader(testJar, testPluginJarCacheDirectory, testCachedir);
         
         // Create test jar in pluginCache
-        File otherJar = new File(testPluginJarCacheDirectory, "20120301121249123-" + testJar.getName());
+        File otherJar = new File(testPluginJarCacheDirectory, "20120301121249123-00-" + testJar.getName());
         otherJar.createNewFile();
         otherJar.deleteOnExit();
-        
-        jarPluginProviderLoader.createCachedJar();
-        
-        Assert.assertFalse("Expected existing cached jar to be deleted", otherJar.exists());
+        String ident = jarPluginProviderLoader.generateCachedJarIdentity();
+        jarPluginProviderLoader.createCachedJar(testPluginJarCacheDirectory,jarPluginProviderLoader.generateCachedJarName(ident));
+
+//        Assert.assertFalse("Expected existing cached jar to be deleted", otherJar.exists());
         File[] files = testPluginJarCacheDirectory.listFiles();
-        Assert.assertEquals("Expected single cached jar in plugin jar cache", 1, files.length);
-        Assert.assertTrue("Expected cached jar to meet requirements for equivalency against original jar", jarPluginProviderLoader.isEquivalentPluginJar(files[0]));
+        Assert.assertEquals("Expected single cached jar in plugin jar cache", 2, files.length);
+        Assert.assertTrue(
+                "Expected cached jar to meet requirements for equivalency against original jar",
+                jarPluginProviderLoader.isEquivalentPluginJar(files[0])
+        );
     }
     public void testCreateCachedJarInvalidDir() throws Exception {
         File testJar = createTestJar(null, null);
@@ -591,9 +736,9 @@ public class TestJarPluginProviderLoader extends AbstractBaseTest {
         invalidCacheDir.deleteOnExit();
 
         final JarPluginProviderLoader jarPluginProviderLoader = new JarPluginProviderLoader(testJar, invalidCacheDir, testCachedir);
-
+        String ident = jarPluginProviderLoader.generateCachedJarIdentity();
         try {
-            jarPluginProviderLoader.createCachedJar();
+            jarPluginProviderLoader.createCachedJar(invalidCacheDir,jarPluginProviderLoader.generateCachedJarName(ident));
             fail("Should fail to create cached jar");
         } catch (PluginException e) {
             e.printStackTrace();
@@ -633,6 +778,13 @@ public class TestJarPluginProviderLoader extends AbstractBaseTest {
      */
     static File createTestJar(final Map<String, String> entries, final File test, final Class[] classes) throws
         IOException {
+        return createTestJar(entries, test, classes, null);
+    }
+    /**
+     * Create test jar file with manifest entries
+     */
+    static File createTestJar(final Map<String, String> entries, final File test, final Class[] classes, final File[] libs) throws
+        IOException {
         final File file = null != test ? test : File.createTempFile("createTestJar", ".jar");
         if (null == test) {
             file.deleteOnExit();
@@ -651,9 +803,21 @@ public class TestJarPluginProviderLoader extends AbstractBaseTest {
         for (final Class aClass : classes) {
             writeClassEntry(jarstream, aClass);
         }
+        if(null!=libs){
+            for (File lib : libs) {
+                writeJarFileEntry(jarstream, lib);
+            }
+        }
         jarstream.flush();
         jarstream.close();
         return file;
+    }
+
+    private static void writeJarFileEntry(final JarOutputStream jarstream, final File lib) throws IOException {
+        final JarEntry jarEntry = new JarEntry("lib/" + lib.getName());
+        jarstream.putNextEntry(jarEntry);
+        //no content
+        jarstream.closeEntry();
     }
 
     private static void writeClassEntry(JarOutputStream jarstream, Class aClass) throws IOException {

--- a/core/src/test/java/com/dtolabs/rundeck/core/plugins/TestJarPluginProviderLoader.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/plugins/TestJarPluginProviderLoader.java
@@ -540,20 +540,30 @@ public class TestJarPluginProviderLoader extends AbstractBaseTest {
         Assert.assertTrue(files2[0].isDirectory());
         File[] files3 = files2[0].listFiles();
         Assert.assertEquals("Expected single cached jar in plugin jar cache", 2, files3.length);
-        Assert.assertTrue("Jar dir should be cache jar file name: "+files3[0].getName(), files3[0].getName().matches("^\\d+-\\d+.*"));
+
+        File cachejarfile = files3[0];
+        File libDir = files3[1];
+        if(files3[0].isDirectory()){
+            libDir = files3[0];
+            cachejarfile = files3[1];
+        }
+
+        Assert.assertTrue("Jar dir should be cache jar file name: " + cachejarfile.getName(), cachejarfile.getName().matches("^\\d+-\\d+.*"));
         Assert.assertTrue(
-                "Jar dir should be cache jar file name: " + files3[0].getName(),
-                files3[0].getName().endsWith(testJar11.getName())
+                "Jar dir should be cache jar file name: " + cachejarfile.getName(),
+                cachejarfile.getName().endsWith(testJar11.getName())
         );
-        Assert.assertTrue(files3[0].isFile());
+        Assert.assertTrue(cachejarfile.isFile());
+
 
         Assert.assertTrue(
                 "Expected cached jar to meet requirements for equivalency against original jar",
-                jarPluginProviderLoader.isEquivalentPluginJar(files3[0])
+                jarPluginProviderLoader.isEquivalentPluginJar(cachejarfile)
         );
-        Assert.assertEquals("Jar dir should be lib dir: " + files3[1].getName(), "lib", files3[1].getName());
-        Assert.assertTrue(files3[1].isDirectory());
-        File[] files4 = files3[1].listFiles();
+        Assert.assertEquals("Jar dir should be lib dir: " + libDir.getName(), "lib", libDir.getName());
+        Assert.assertTrue(libDir.isDirectory());
+
+        File[] files4 = libDir.listFiles();
         Assert.assertEquals("Expected single cached jar in plugin jar cache", 1, files4.length);
         Assert.assertEquals("Expected fakarjar dep: " + files4[0].getName(), "fakejar.jar", files4[0].getName());
 


### PR DESCRIPTION
fix jar plugin loader to avoid contention
with overwriting the same file if multiple threads
attempt to load classes from the same jar:
* use unique string in cached file name
* only use one cached file/libset per loader
* clean up all cached files