### PR TITLE
1378 : Compress .rdlog with gzip compression

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/LoggingService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LoggingService.groovy
@@ -30,7 +30,8 @@ import java.nio.charset.Charset
 
 class LoggingService implements ExecutionFileProducer {
 
-    public static final String LOG_FILE_FILETYPE = 'rdlog'
+    public static final String LOG_FILE_FILETYPE = 'rdlog.gz'
+    public static final String LOG_FILE_FILETYPE_UNCOMPRESSED = 'rdlog'
 
 
     FrameworkService frameworkService
@@ -210,7 +211,15 @@ class LoggingService implements ExecutionFileProducer {
         if (pluginName) {
             log.error("Falling back to local file storage log reader")
         }
-        return logFileStorageService.requestLogFileReader(execution, LOG_FILE_FILETYPE)
+
+        //get reader for compressed log
+        ExecutionLogReader logReader = logFileStorageService.requestLogFileReader(execution, LOG_FILE_FILETYPE)
+
+        //if compressed logs are not found, check for uncompressed logs
+        if(logReader.state == ExecutionLogState.NOT_FOUND) {
+            logReader = logFileStorageService.requestLogFileReader(execution, LOG_FILE_FILETYPE_UNCOMPRESSED)
+        }
+        return logReader
     }
 
     public OutputStream createLogOutputStream(

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/logging/FSFileLineIterator.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/logging/FSFileLineIterator.groovy
@@ -2,6 +2,8 @@ package com.dtolabs.rundeck.app.internal.logging
 
 import com.dtolabs.rundeck.core.logging.OffsetIterator
 
+import java.util.zip.GZIPInputStream
+
 /*
  * Copyright 2013 DTO Labs, Inc. (http://dtolabs.com)
  * 
@@ -31,6 +33,7 @@ import com.dtolabs.rundeck.core.logging.OffsetIterator
  */
 class FSFileLineIterator implements OffsetIterator<String>{
     private FileInputStream raf
+    private GZIPInputStream gzipInputStream
     private InputStreamReader read
     private long offset
     private Queue<String> buffer = new ArrayDeque<String>()
@@ -48,6 +51,19 @@ class FSFileLineIterator implements OffsetIterator<String>{
         }
         readNext()
     }
+
+    public FSFileLineIterator(GZIPInputStream gzipInputStream, String encoding, long offset){
+        this.encoding=encoding
+        this.gzipInputStream=gzipInputStream
+        this.offset=offset
+        if (encoding){
+            read = new InputStreamReader(gzipInputStream, encoding)
+        }else{
+            read = new InputStreamReader(gzipInputStream)
+        }
+        readNext()
+    }
+
     @Override
     boolean hasNext() {
         buffer.size()>0
@@ -60,6 +76,7 @@ class FSFileLineIterator implements OffsetIterator<String>{
         readNext()
         return s
     }
+	
     private void readNext(){
         if(closed){
             throw new IllegalStateException("Stream is closed")

--- a/rundeckapp/test/integration/rundeck/services/ProjectServiceTest.groovy
+++ b/rundeckapp/test/integration/rundeck/services/ProjectServiceTest.groovy
@@ -226,7 +226,7 @@ class ProjectServiceTest extends GroovyTestCase {
         assertTrue resultstatefile.delete()
         def files = [
                 "state.json":resultstatefile,
-                "rdlog":resultoutfile
+                "rdlog.gz":resultoutfile
         ]
         def errs=[]
         def result

--- a/rundeckapp/test/unit/ExecutionServiceSpec.groovy
+++ b/rundeckapp/test/unit/ExecutionServiceSpec.groovy
@@ -652,7 +652,7 @@ class ExecutionServiceSpec extends Specification {
 
 
         service.logFileStorageService = Mock(LogFileStorageService) {
-            1 * getFileForExecutionFiletype(execution, 'rdlog', true) >> file1
+            1 * getFileForExecutionFiletype(execution, 'rdlog.gz', true) >> file1
             1 * getFileForExecutionFiletype(execution, 'state.json', true) >> file2
             0 * _(*_)
         }
@@ -701,7 +701,7 @@ class ExecutionServiceSpec extends Specification {
         }
 
         service.logFileStorageService = Mock(LogFileStorageService) {
-            1 * getFileForExecutionFiletype(execution, 'rdlog', true) >> file1
+            1 * getFileForExecutionFiletype(execution, 'rdlog.gz', true) >> file1
             1 * getFileForExecutionFiletype(execution, 'state.json', true)
             0 * _(*_)
         }

--- a/rundeckapp/test/unit/rundeck/services/LogFileStorageServiceTests.groovy
+++ b/rundeckapp/test/unit/rundeck/services/LogFileStorageServiceTests.groovy
@@ -413,10 +413,10 @@ class LogFileStorageServiceTests  {
         grailsApplication.config.rundeck.execution.logs.fileStoragePlugin = "test2"
 
         def test = new testMultiStoragePlugin()
-        test.storeMultipleResponseSet=[rdlog:true]
+        test.storeMultipleResponseSet=['rdlog.gz':true]
 
         LogFileStorageService svc
-        Map task=performRunStorage(test, "rdlog", createExecution(), testLogFile1) { LogFileStorageService service ->
+        Map task=performRunStorage(test, "rdlog.gz", createExecution(), testLogFile1) { LogFileStorageService service ->
             svc = service
             assertFalse(test.storeMultipleCalled)
             assertNull(test.storeMultipleFiles)
@@ -424,7 +424,7 @@ class LogFileStorageServiceTests  {
 
         assertTrue(test.storeMultipleCalled)
         assertNotNull(test.storeMultipleFiles)
-        assertEquals(['rdlog'] as Set, test.storeMultipleFiles.availableFiletypes)
+        assertEquals(['rdlog.gz'] as Set, test.storeMultipleFiles.availableFiletypes)
 
         assertEquals(1,task.count)
         assertTrue(svc.executorService.executeCalled)
@@ -435,10 +435,10 @@ class LogFileStorageServiceTests  {
         grailsApplication.config.rundeck.execution.logs.fileStoragePlugin = "test2"
 
         def test = new testMultiStoragePlugin()
-        test.storeMultipleResponseSet=[rdlog:true,'state.json':true]
+        test.storeMultipleResponseSet=['rdlog.gz':true,'state.json':true]
 
         LogFileStorageService svc
-        Map task=performRunStorage(test, "rdlog,state.json", createExecution(), testLogFile1) { LogFileStorageService service ->
+        Map task=performRunStorage(test, "rdlog.gz,state.json", createExecution(), testLogFile1) { LogFileStorageService service ->
             svc = service
             assertFalse(test.storeMultipleCalled)
             assertNull(test.storeMultipleFiles)
@@ -446,7 +446,7 @@ class LogFileStorageServiceTests  {
 
         assertTrue(test.storeMultipleCalled)
         assertNotNull(test.storeMultipleFiles)
-        assertEquals(['rdlog','state.json'] as Set, test.storeMultipleFiles.availableFiletypes)
+        assertEquals(['rdlog.gz','state.json'] as Set, test.storeMultipleFiles.availableFiletypes)
 
         assertEquals(1,task.count)
         assertTrue(svc.executorService.executeCalled)
@@ -457,7 +457,7 @@ class LogFileStorageServiceTests  {
         grailsApplication.config.rundeck.execution.logs.fileStoragePlugin = "test2"
 
         def test = new testMultiStoragePlugin()
-        test.storeMultipleResponseSet=[rdlog:true,'state.json':true,'execution.xml':true]
+        test.storeMultipleResponseSet=['rdlog.gz':true,'state.json':true,'execution.xml':true]
 
         LogFileStorageService svc
         Map task=performRunStorage(test, '*', createExecution(), testLogFile1) { LogFileStorageService service ->
@@ -468,7 +468,7 @@ class LogFileStorageServiceTests  {
 
         assertTrue(test.storeMultipleCalled)
         assertNotNull(test.storeMultipleFiles)
-        assertEquals(['rdlog','state.json','execution.xml'] as Set, test.storeMultipleFiles.availableFiletypes)
+        assertEquals(['rdlog.gz','state.json','execution.xml'] as Set, test.storeMultipleFiles.availableFiletypes)
 
         assertEquals(1,task.count)
         assertTrue(svc.executorService.executeCalled)
@@ -480,10 +480,10 @@ class LogFileStorageServiceTests  {
         grailsApplication.config.rundeck.execution.logs.fileStorage.cancelOnStorageFailure = false
 
         def test = new testMultiStoragePlugin()
-        test.storeMultipleResponseSet=[rdlog:false]
+        test.storeMultipleResponseSet=['rdlog.gz':false]
 
         LogFileStorageService svc
-        Map task=performRunStorage(test, "rdlog", createExecution(), testLogFile1) { LogFileStorageService service ->
+        Map task=performRunStorage(test, "rdlog.gz", createExecution(), testLogFile1) { LogFileStorageService service ->
             svc = service
             assertFalse(test.storeMultipleCalled)
             assertNull(test.storeMultipleFiles)
@@ -491,7 +491,7 @@ class LogFileStorageServiceTests  {
 
         assertTrue(test.storeMultipleCalled)
         assertNotNull(test.storeMultipleFiles)
-        assertEquals(['rdlog'] as Set, test.storeMultipleFiles.availableFiletypes)
+        assertEquals(['rdlog.gz'] as Set, test.storeMultipleFiles.availableFiletypes)
 
         assertEquals(1,task.count)
         assertFalse(svc.executorService.executeCalled)
@@ -506,10 +506,10 @@ class LogFileStorageServiceTests  {
         grailsApplication.config.rundeck.execution.logs.fileStorage.cancelOnStorageFailure = false
 
         def test = new testMultiStoragePlugin()
-        test.storeMultipleResponseSet=[rdlog:true,'state.json':false]
+        test.storeMultipleResponseSet=['rdlog.gz':true,'state.json':false]
 
         LogFileStorageService svc
-        Map task=performRunStorage(test, "rdlog,state.json", createExecution(), testLogFile1) { LogFileStorageService service ->
+        Map task=performRunStorage(test, "rdlog.gz,state.json", createExecution(), testLogFile1) { LogFileStorageService service ->
             svc = service
             assertFalse(test.storeMultipleCalled)
             assertNull(test.storeMultipleFiles)
@@ -517,7 +517,7 @@ class LogFileStorageServiceTests  {
 
         assertTrue(test.storeMultipleCalled)
         assertNotNull(test.storeMultipleFiles)
-        assertEquals(['rdlog','state.json'] as Set, test.storeMultipleFiles.availableFiletypes)
+        assertEquals(['rdlog.gz','state.json'] as Set, test.storeMultipleFiles.availableFiletypes)
 
         assertEquals(1,task.count)
         assertFalse(svc.executorService.executeCalled)
@@ -542,10 +542,10 @@ class LogFileStorageServiceTests  {
         grailsApplication.config.rundeck.execution.logs.fileStorage.cancelOnStorageFailure = false
 
         def test = new testMultiStoragePlugin()
-        test.storeMultipleResponseSet=[rdlog:false,'state.json':false]
+        test.storeMultipleResponseSet=['rdlog.gz':false,'state.json':false]
 
         LogFileStorageService svc
-        Map task=performRunStorage(test, "rdlog,state.json", createExecution(), testLogFile1) { LogFileStorageService service ->
+        Map task=performRunStorage(test, "rdlog.gz,state.json", createExecution(), testLogFile1) { LogFileStorageService service ->
             svc = service
             assertFalse(test.storeMultipleCalled)
             assertNull(test.storeMultipleFiles)
@@ -553,7 +553,7 @@ class LogFileStorageServiceTests  {
 
         assertTrue(test.storeMultipleCalled)
         assertNotNull(test.storeMultipleFiles)
-        assertEquals(['rdlog','state.json'] as Set, test.storeMultipleFiles.availableFiletypes)
+        assertEquals(['rdlog.gz','state.json'] as Set, test.storeMultipleFiles.availableFiletypes)
 
         assertEquals(1,task.count)
         assertFalse(svc.executorService.executeCalled)
@@ -566,7 +566,7 @@ class LogFileStorageServiceTests  {
             request.refresh()
         }
 
-        assertEquals('rdlog,state.json', request.filetype)
+        assertEquals('rdlog.gz,state.json', request.filetype)
         assertFalse(request.completed)
     }
     /**
@@ -578,7 +578,7 @@ class LogFileStorageServiceTests  {
         grailsApplication.config.rundeck.execution.logs.fileStorage.cancelOnStorageFailure = false
 
         def test = new testMultiStoragePlugin()
-        test.storeMultipleResponseSet=[rdlog:true,'state.json':true,'execution.xml':false]
+        test.storeMultipleResponseSet=['rdlog.gz':true,'state.json':true,'execution.xml':false]
 
         LogFileStorageService svc
         Map task=performRunStorage(test, "*", createExecution(), testLogFile1) { LogFileStorageService service ->
@@ -589,7 +589,7 @@ class LogFileStorageServiceTests  {
 
         assertTrue(test.storeMultipleCalled)
         assertNotNull(test.storeMultipleFiles)
-        assertEquals(['rdlog','state.json','execution.xml'] as Set, test.storeMultipleFiles.availableFiletypes)
+        assertEquals(['rdlog.gz','state.json','execution.xml'] as Set, test.storeMultipleFiles.availableFiletypes)
 
         assertEquals(1,task.count)
         assertFalse(svc.executorService.executeCalled)
@@ -614,7 +614,7 @@ class LogFileStorageServiceTests  {
         grailsApplication.config.rundeck.execution.logs.fileStorage.cancelOnStorageFailure = false
 
         def test = new testMultiStoragePlugin()
-        test.storeMultipleResponseSet=[rdlog:true,'state.json':false,'execution.xml':false]
+        test.storeMultipleResponseSet=['rdlog.gz':true,'state.json':false,'execution.xml':false]
 
         LogFileStorageService svc
         Map task=performRunStorage(test, "*", createExecution(), testLogFile1) { LogFileStorageService service ->
@@ -625,7 +625,7 @@ class LogFileStorageServiceTests  {
 
         assertTrue(test.storeMultipleCalled)
         assertNotNull(test.storeMultipleFiles)
-        assertEquals(['rdlog','state.json','execution.xml'] as Set, test.storeMultipleFiles.availableFiletypes)
+        assertEquals(['rdlog.gz','state.json','execution.xml'] as Set, test.storeMultipleFiles.availableFiletypes)
 
         assertEquals(1,task.count)
         assertFalse(svc.executorService.executeCalled)
@@ -649,14 +649,14 @@ class LogFileStorageServiceTests  {
         def test = new testStoragePlugin()
         test.storeLogFileSuccess=true
         LogFileStorageService svc
-        Map task=performRunStorage(test, "rdlog", createExecution(), testLogFile1) { LogFileStorageService service ->
+        Map task=performRunStorage(test, "rdlog.gz", createExecution(), testLogFile1) { LogFileStorageService service ->
             svc = service
             assertFalse(test.storeLogFileCalled)
             assertNull(test.storeFiletype)
         }
 
         assertTrue(test.storeLogFileCalled)
-        assertEquals("rdlog", test.storeFiletype)
+        assertEquals("rdlog.gz", test.storeFiletype)
         assertEquals(testLogFile1.length(),test.storeLength)
         assertEquals(new Date(testLogFile1.lastModified()),test.storeLastModified)
 
@@ -672,14 +672,14 @@ class LogFileStorageServiceTests  {
         def test = new testStoragePlugin()
         test.storeLogFileSuccess=false
         LogFileStorageService svc
-        Map task=performRunStorage(test, "rdlog", createExecution(), testLogFile1) { LogFileStorageService service ->
+        Map task=performRunStorage(test, "rdlog.gz", createExecution(), testLogFile1) { LogFileStorageService service ->
             svc = service
             assertFalse(test.storeLogFileCalled)
             assertNull( test.storeFiletype)
         }
 
         assertTrue(test.storeLogFileCalled)
-        assertEquals("rdlog", test.storeFiletype)
+        assertEquals("rdlog.gz", test.storeFiletype)
         assertEquals(testLogFile1.length(),test.storeLength)
         assertEquals(new Date(testLogFile1.lastModified()),test.storeLastModified)
 
@@ -695,7 +695,7 @@ class LogFileStorageServiceTests  {
         def test = new testStoragePlugin()
         test.storeLogFileSuccess=false
         LogFileStorageService svc
-        Map task=performRunStorage(test, "rdlog", createExecution(), testLogFile1) { LogFileStorageService service ->
+        Map task=performRunStorage(test, "rdlog.gz", createExecution(), testLogFile1) { LogFileStorageService service ->
             //default to true fo cancelOnStorageFailure
             service.configurationService=mockWith(ConfigurationService){
                 getBoolean{String prop,boolean defval->true}
@@ -707,7 +707,7 @@ class LogFileStorageServiceTests  {
         }
 
         assertTrue(test.storeLogFileCalled)
-        assertEquals("rdlog", test.storeFiletype)
+        assertEquals("rdlog.gz", test.storeFiletype)
         assertEquals(testLogFile1.length(),test.storeLength)
         assertEquals(new Date(testLogFile1.lastModified()),test.storeLastModified)
 
@@ -726,7 +726,7 @@ class LogFileStorageServiceTests  {
         test.storeLogFileSuccess=false
         LogFileStorageService svc
         boolean queued=false
-        Map task=performRunStorage(test, "rdlog", createExecution(), testLogFile1) { LogFileStorageService service ->
+        Map task=performRunStorage(test, "rdlog.gz", createExecution(), testLogFile1) { LogFileStorageService service ->
             svc = service
             svc.metaClass.queueLogStorageRequest={ Map task, int delay ->
                 queued=true
@@ -738,7 +738,7 @@ class LogFileStorageServiceTests  {
         }
 
         assertTrue(test.storeLogFileCalled)
-        assertEquals("rdlog", test.storeFiletype)
+        assertEquals("rdlog.gz", test.storeFiletype)
         assertEquals(testLogFile1.length(),test.storeLength)
         assertEquals(new Date(testLogFile1.lastModified()),test.storeLastModified)
 
@@ -780,7 +780,7 @@ class LogFileStorageServiceTests  {
         service.executorService=emock
         def filetypes = filetype.split(',')
         if(filetype=='*'){
-            filetypes=['rdlog','state.json','execution.xml']
+            filetypes=['rdlog.gz','state.json','execution.xml']
         }
         Map<String,ExecutionFileProducer> loggingBeans=[:]
         for (String ftype : filetypes) {
@@ -1085,9 +1085,9 @@ class LogFileStorageServiceTests  {
         def test = null
 
         def e = createExecution()
-        e.outputfilepath = "/test/file/path.rdlog"
+        e.outputfilepath = "/test/file/path.rdlog.gz"
 
-        def file = service.getFileForExecutionFiletype(e, "rdlog", true)
+        def file = service.getFileForExecutionFiletype(e, "rdlog.gz", true)
         assertNotNull(file)
         assertEquals(file, new File(e.outputfilepath))
     }
@@ -1099,7 +1099,7 @@ class LogFileStorageServiceTests  {
         def test = null
 
         def e = createExecution()
-        e.outputfilepath = "/test/file/path.rdlog"
+        e.outputfilepath = "/test/file/path.rdlog.gz"
 
         def file = service.getFileForExecutionFiletype(e, "json.state", true)
         assertNotNull(file)
@@ -1112,7 +1112,7 @@ class LogFileStorageServiceTests  {
         def test = null
 
         def e = createExecution()
-        e.outputfilepath = "/test/file/path.rdlog"
+        e.outputfilepath = "/test/file/path.rdlog.gz"
         e.id=123
 
         def fwkMock = mockFor(FrameworkService)
@@ -1132,7 +1132,7 @@ class LogFileStorageServiceTests  {
         def test = null
 
         def e = createExecution()
-        e.outputfilepath = "/test/file/path.rdlog"
+        e.outputfilepath = "/test/file/path.rdlog.gz"
         e.id=123
 
         def fwkMock = mockFor(FrameworkService)
@@ -1141,9 +1141,9 @@ class LogFileStorageServiceTests  {
         }
         service.frameworkService=fwkMock.createMock()
 
-        def file = service.getFileForExecutionFiletype(e, "rdlog", false)
+        def file = service.getFileForExecutionFiletype(e, "rdlog.gz", false)
         assertNotNull(file)
-        assertEquals("/test2/logs/rundeck/${e.project}/run/logs/${e.id}.rdlog", file.absolutePath)
+        assertEquals("/test2/logs/rundeck/${e.project}/run/logs/${e.id}.rdlog.gz", file.absolutePath)
     }
 
     void testGetFileForExecutionFileLogFileForJob() {
@@ -1153,7 +1153,7 @@ class LogFileStorageServiceTests  {
         def test = null
 
         def e = createJobExecution()
-        e.outputfilepath = "/test/file/path.rdlog"
+        e.outputfilepath = "/test/file/path.rdlog.gz"
         e.id=123
 
         def fwkMock = mockFor(FrameworkService)
@@ -1162,9 +1162,9 @@ class LogFileStorageServiceTests  {
         }
         service.frameworkService=fwkMock.createMock()
 
-        def file = service.getFileForExecutionFiletype(e, "rdlog", false)
+        def file = service.getFileForExecutionFiletype(e, "rdlog.gz", false)
         assertNotNull(file)
-        assertEquals("/test2/logs/rundeck/${e.project}/job/test-uuid/logs/${e.id}.rdlog", file.absolutePath)
+        assertEquals("/test2/logs/rundeck/${e.project}/job/test-uuid/logs/${e.id}.rdlog.gz", file.absolutePath)
     }
 
     void testGetFileForExecutionFileStateFileForJob() {
@@ -1174,7 +1174,7 @@ class LogFileStorageServiceTests  {
         def test = null
 
         def e = createJobExecution()
-        e.outputfilepath = "/test/file/path.rdlog"
+        e.outputfilepath = "/test/file/path.rdlog.gz"
         e.id=123
 
         def fwkMock = mockFor(FrameworkService)
@@ -1197,7 +1197,7 @@ class LogFileStorageServiceTests  {
         def test = null
 
         def e = createJobExecution()
-        e.outputfilepath = "/test/file/path.rdlog"
+        e.outputfilepath = "/test/file/path.rdlog.gz"
         e.id=123
 
         def fwkMock = mockFor(FrameworkService)
@@ -1206,9 +1206,9 @@ class LogFileStorageServiceTests  {
         }
         service.frameworkService=fwkMock.createMock()
 
-        def file = service.getFileForExecutionFiletype(e, "rdlog", true)
+        def file = service.getFileForExecutionFiletype(e, "rdlog.gz", true)
         assertNotNull(file)
-        assertEquals("/test/file/path.rdlog", file.absolutePath)
+        assertEquals("/test/file/path.rdlog.gz", file.absolutePath)
     }
 
     void testGetFileForExecutionFileLegacyStateFileForJob() {
@@ -1218,7 +1218,7 @@ class LogFileStorageServiceTests  {
         def test = null
 
         def e = createJobExecution()
-        e.outputfilepath = "/test/file/path.rdlog"
+        e.outputfilepath = "/test/file/path.rdlog.gz"
         e.id=123
 
         def fwkMock = mockFor(FrameworkService)
@@ -1269,7 +1269,7 @@ class LogFileStorageServiceTests  {
         int useStoredNdx=0
         service.metaClass.getFileForExecutionFiletype = { Execution e2, String filetype, boolean useStored ->
             assert e == e2
-            assert "rdlog"==filetype
+            assert "rdlog.gz"==filetype
             assert useStored==useStoredValues[useStoredNdx]
             useStoredNdx++
             logfile

--- a/rundeckapp/test/unit/rundeck/services/LoggingServiceTests.groovy
+++ b/rundeckapp/test/unit/rundeck/services/LoggingServiceTests.groovy
@@ -117,7 +117,7 @@ class LoggingServiceTests  {
         }
         lfmock.demand.getFileForExecutionFiletype(1..1) { Execution e2, String filetype, boolean stored ->
             assertEquals(1, e2.id)
-            assertEquals("rdlog", filetype)
+            assertEquals("rdlog.gz", filetype)
             assertEquals(false, stored)
             new File("/test/file/path")
         }
@@ -190,7 +190,7 @@ class LoggingServiceTests  {
         }
         lfmock.demand.getFileForExecutionFiletype(1..1) { Execution e2, String filetype, boolean stored ->
             assertEquals(1, e2.id)
-            assertEquals("rdlog", filetype)
+            assertEquals("rdlog.gz", filetype)
             assertEquals(false, stored)
             new File("/test/file/path")
         }
@@ -229,7 +229,7 @@ class LoggingServiceTests  {
         }
         lfmock.demand.getFileForExecutionFiletype(1..1) { Execution e2, String filetype, boolean stored ->
             assertEquals(1, e2.id)
-            assertEquals("rdlog", filetype)
+            assertEquals("rdlog.gz", filetype)
             assertEquals(false, stored)
             new File("/test/file/path")
         }
@@ -265,7 +265,7 @@ class LoggingServiceTests  {
         }
         lfmock.demand.getFileForExecutionFiletype(1..1) { Execution e2, String filetype, boolean stored ->
             assertEquals(1, e2.id)
-            assertEquals("rdlog", filetype)
+            assertEquals("rdlog.gz", filetype)
             assertEquals(false, stored)
             new File("/test/file/path")
         }
@@ -307,7 +307,7 @@ class LoggingServiceTests  {
         }
         lfmock.demand.getFileForExecutionFiletype(1..1) { Execution e2, String filetype, boolean stored ->
             assertEquals(1, e2.id)
-            assertEquals("rdlog", filetype)
+            assertEquals("rdlog.gz", filetype)
             assertEquals(false, stored)
             new File("/test/file/path")
         }
@@ -396,7 +396,7 @@ class LoggingServiceTests  {
         def lfsvcmock = mockFor(LogFileStorageService)
         lfsvcmock.demand.requestLogFileReader(1..1){Execution e2, String key->
             assert e==e2
-            assert key=='rdlog'
+            assert key=='rdlog.gz'
             test
         }
         service.logFileStorageService=lfsvcmock.createMock()
@@ -421,7 +421,7 @@ class LoggingServiceTests  {
         def lfsvcmock = mockFor(LogFileStorageService)
         lfsvcmock.demand.requestLogFileReader(1..1) { Execution e2, String key ->
             assert e == e2
-            assert key == 'rdlog'
+            assert key == 'rdlog.gz'
             fail("should not be called")
         }
         def pmock = mockFor(PluginService)
@@ -467,7 +467,7 @@ class LoggingServiceTests  {
         def lfsvcmock = mockFor(LogFileStorageService)
         lfsvcmock.demand.requestLogFileReader(1..1) { Execution e2, String key ->
             assert e == e2
-            assert key == 'rdlog'
+            assert key == 'rdlog.gz'
             fail("should not be called")
         }
         def pmock = mockFor(PluginService)


### PR DESCRIPTION
Hi @gschueler @miguelantonio 

This is enhancement to Rundeck that compresses the .rdlog output file with gzip compression and stores it with .rdlog.gz

Please review.
