### PR TITLE
Feature/api job info

### DIFF
--- a/docs/en/api/rundeck-api.md
+++ b/docs/en/api/rundeck-api.md
@@ -2289,9 +2289,9 @@ The list of succeeded/failed will contain objects of this form:
 }
 ~~~~~~
 
-### Get Job Metdata
+### Get Job Metadata
 
-Get metadata about a job.
+Get metadata about a specific job.
 
 **Request:**
 
@@ -2299,7 +2299,37 @@ Get metadata about a job.
 
 **Response:**
 
-An Item List of `jobs` with a single `job`.  See [Listing Jobs](#listing-jobs).
+`Content-Type: application/xml`: A single `job` element in the same format as [Listing Jobs](#listing-jobs):
+
+~~~~~~~~~~ {.xml}
+<job id="ID" href="[API url]" permalink="[GUI URL]" scheduled="true/false" scheduleEnabled="true/false"
+   enabled="true/false"
+   >
+    <name>Job Name</name>
+    <group>Job Name</group>
+    <project>Project Name</project>
+    <description>...</description>
+</job>
+~~~~~~~~~~~~
+
+`Content-Type: application/json`
+
+A single object:
+
+~~~~~~~~~~ {.json}
+{
+    "id": "[UUID]",
+    "name": "[name]",
+    "group": "[group]",
+    "project": "[project]",
+    "description": "...",
+    "href": "[API url]",
+    "permalink": "[GUI url]",
+    "scheduled": true/false,
+    "scheduleEnabled": true/false,
+    "enabled": true/false
+}
+~~~~~~~~~~~~
 
 ## Executions
 
@@ -5361,6 +5391,10 @@ Same response as [Setup SCM Plugin for a Project](#setup-scm-plugin-for-a-projec
 
 * `POST` [Disable Executions for a Job](#disable-executions-for-a-job)
 
+[/api/V/job/[ID]/info][]
+
+* `GET` [Get Job Metadata](#get-job-metadata)
+
 [/api/V/job/[ID]/run][]
 
 * `POST` [Running a Job](#running-a-job)
@@ -5645,6 +5679,8 @@ Same response as [Setup SCM Plugin for a Project](#setup-scm-plugin-for-a-projec
 [POST /api/V/job/[ID]/executions]:#running-a-job
 [DELETE /api/V/job/[ID]/executions]:#delete-all-executions-for-a-job
 
+[/api/V/job/[ID]/info]:#get-job-metadata
+[GET /api/V/job/[ID]/info]:#get-job-metadata
 
 [/api/V/job/[ID]/schedule/enable]:#enable-scheduling-for-a-job
 

--- a/docs/en/api/rundeck-api.md
+++ b/docs/en/api/rundeck-api.md
@@ -57,6 +57,9 @@ Changes introduced by API Version number:
 
 **Version 18**:
 
+* New Endpoints.
+    - [`GET /api/18/job/[ID]/info`][/api/V/job/[ID]/info] - Get metadata about a Job: Project name and scheduling info.
+
 **Version 17**:
 
 * New Endpoints.
@@ -2285,6 +2288,18 @@ The list of succeeded/failed will contain objects of this form:
   "message": "(success or failure message)"
 }
 ~~~~~~
+
+### Get Job Metdata
+
+Get metadata about a job.
+
+**Request:**
+
+    GET /api/18/job/[ID]/info
+
+**Response:**
+
+An Item List of `jobs` with a single `job`.  See [Listing Jobs](#listing-jobs).
 
 ## Executions
 

--- a/docs/en/api/rundeck-api.md
+++ b/docs/en/api/rundeck-api.md
@@ -220,7 +220,6 @@ In this version, all new and updated endpoints support XML or JSON request and r
 - For API clients that expect to see the `<result>` element, a request header of `X-Rundeck-API-XML-Response-Wrapper: true` will restore it.
 - For endpoint requests for API version 10 and earlier, the `<result>` element will be sent as it has been (described in [Response Format][])
 
-[Response Format]: #response-format
 
 **Version 11**:
 
@@ -1817,7 +1816,7 @@ If you specify `format=xml`, then the output will be in [job-xml](../man5/job-xm
 
 If you specify `format=yaml`, then the output will be in [job-yaml](../man5/job-yaml.html) format.
 
-If an error occurs, then the output will be in XML format, using the common `result` element described in the [Response Format](#response-format) section.
+If an error occurs, then the output will be in XML format, using the common `result` element described in the [Response Format][] section.
 
 ### Importing Jobs ###
 
@@ -1928,7 +1927,7 @@ If you specify `format=xml`, then the output will be in [job-xml](../man5/job-xm
 
 If you specify `format=yaml`, then the output will be in [job-yaml](../man5/job-yaml.html) format.
 
-If an error occurs, then the output will be in XML format, using the common `result` element described in the [Response Format](#response-format) section.
+If an error occurs, then the output will be in XML format, using the common `result` element described in the [Response Format][] section.
 
 ### Deleting a Job Definition ###
 
@@ -1974,7 +1973,7 @@ Note: you can combine `ids` with `idlist`
 
 `application/xml` response:
 
-The common `result` element described in the [Response Format](#response-format) section, indicating success or failure and any messages.
+The common `result` element described in the [Response Format][] section, indicating success or failure and any messages.
 
 If successful, then the `result` will contain a `deleteJobs` element with two sections of results, `succeeded` and `failed`:
 
@@ -3225,7 +3224,7 @@ E.g.:
 The result will contain a set of data values reflecting the execution's status, as well as the status and read location in the output file.
 
 * In JSON, there will be an object containing these entries.
-* In XML, within the standard [Response Format](#response-format) `result` there will be an `output` element, containing these sub-elements, each with a text value.
+* In XML, within the standard [Response Format][] `result` there will be an `output` element, containing these sub-elements, each with a text value.
 
 Entries:
 
@@ -4145,7 +4144,7 @@ Resource Model definition in [resource-xml](../man5/resource-xml.html) or [resou
 
 **Since API version 3**: You can also POST data using a content type supported by a Resource Format Parser plugin.  This requires using API version `3`.
 
-POST Result: A success or failure API response. (See [Response Format](#response-format)).
+POST Result: A success or failure API response. (See [Response Format][]).
 
 Example POST request:
 
@@ -5631,6 +5630,8 @@ Same response as [Setup SCM Plugin for a Project](#setup-scm-plugin-for-a-projec
 * `GET` [Get a token](#get-a-token)
 * `DELETE` [Delete a token](#delete-a-token)
 
+
+[Response Format]:#xml-response-format
 
 
 [/api/V/project/[PROJECT]/scm/[INTEGRATION]/plugins]:#list-scm-plugins

--- a/docs/en/api/rundeck-api.md
+++ b/docs/en/api/rundeck-api.md
@@ -2302,7 +2302,7 @@ Get metadata about a specific job.
 
 ~~~~~~~~~~ {.xml}
 <job id="ID" href="[API url]" permalink="[GUI URL]" scheduled="true/false" scheduleEnabled="true/false"
-   enabled="true/false"
+   enabled="true/false" averageDuration="[ms]"
    >
     <name>Job Name</name>
     <group>Job Name</group>
@@ -2326,7 +2326,8 @@ A single object:
     "permalink": "[GUI url]",
     "scheduled": true/false,
     "scheduleEnabled": true/false,
-    "enabled": true/false
+    "enabled": true/false,
+    "averageDuration": long (milliseconds)
 }
 ~~~~~~~~~~~~
 

--- a/docs/en/api/rundeck-api.md
+++ b/docs/en/api/rundeck-api.md
@@ -57,10 +57,6 @@ Changes introduced by API Version number:
 
 **Version 18**:
 
-* Updated Endpoints:
-    - [`/api/18/job/[ID]/run`][/api/V/job/[ID]/run] 
-        - new `runAtTime` parameter to run once at a certain time.
-
 **Version 17**:
 
 * New Endpoints.

--- a/rundeckapp/grails-app/conf/BootStrap.groovy
+++ b/rundeckapp/grails-app/conf/BootStrap.groovy
@@ -18,6 +18,7 @@ import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.health.HealthCheck
 import com.codahale.metrics.health.HealthCheckRegistry
 import com.dtolabs.launcher.Setup
+import com.dtolabs.rundeck.app.api.ApiMarshallerRegistrar
 import com.dtolabs.rundeck.core.Constants
 import com.dtolabs.rundeck.core.VersionConstants
 import com.dtolabs.rundeck.core.utils.ThreadBoundOutputStream
@@ -55,6 +56,7 @@ class BootStrap {
     def scmService
     HealthCheckRegistry healthCheckRegistry
     def dataSource
+    ApiMarshallerRegistrar apiMarshallerRegistrar
 
     def timer(String name,Closure clos){
         long bstart=System.currentTimeMillis()
@@ -71,6 +73,7 @@ class BootStrap {
              grailsApplication.mainContext.profilerLog.appenderNames = ["loggingAppender", 'miniProfilerAppender']
          }
          long bstart=System.currentTimeMillis()
+         apiMarshallerRegistrar.registerApiMarshallers()
          //version info
          servletContext.setAttribute("version.build",VersionConstants.BUILD)
          servletContext.setAttribute("version.date",VersionConstants.DATE)

--- a/rundeckapp/grails-app/conf/UrlMappings.groovy
+++ b/rundeckapp/grails-app/conf/UrlMappings.groovy
@@ -45,6 +45,8 @@ class UrlMappings {
         "/api/$api_version/job/$id"(controller: 'scheduledExecution') {
             action = [GET: 'apiJobExport', DELETE: 'apiJobDelete', PUT: 'apiJobUpdateSingle', POST: 'apiJobCreateSingle']
         }
+        "/api/$api_version/job/$id/info"(controller: 'menu', action: 'apiJobDetail')
+
 
         "/api/$api_version/job/$id/execution/enable"(controller: 'scheduledExecution') {
             action = [POST: 'apiFlipExecutionEnabled']

--- a/rundeckapp/grails-app/conf/rundeck/filters/ApiRequestFilters.groovy
+++ b/rundeckapp/grails-app/conf/rundeck/filters/ApiRequestFilters.groovy
@@ -17,6 +17,8 @@
 package rundeck.filters
 
 import com.codahale.metrics.MetricRegistry
+import grails.converters.JSON
+import grails.converters.XML
 import org.apache.log4j.Logger
 import org.apache.log4j.MDC
 import org.codehaus.groovy.grails.web.util.WebUtils
@@ -161,6 +163,10 @@ public class ApiRequestFilters {
                 }
                 request.api_version = VersionMap[params.api_version]
                 request['ApiRequestFilters.request.parameters.project']=params.project?:request.project?:''
+                if (request.api_version >= V18) {
+                    XML.use('v' + request.api_version)
+                    JSON.use('v' + request.api_version)
+                }
                 return true
             }
             after = {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -86,6 +86,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     static allowedMethods = [
             deleteJobfilter:'POST',
             storeJobfilter:'POST',
+            apiJobDetail:'GET',
             apiResumeIncompleteLogstorage:'POST',
             cleanupIncompleteLogStorageAjax:'POST',
             resumeIncompleteLogStorageAjax: 'POST',
@@ -1802,6 +1803,10 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         if (clusterModeEnabled && scheduledExecution.scheduled) {
             extra.serverNodeUUID = scheduledExecution.serverNodeUUID
             extra.serverOwner = scheduledExecution.serverNodeUUID == serverNodeUUID
+        }
+        if (scheduledExecution.totalTime >= 0 && scheduledExecution.execCount > 0) {
+            def long avg = Math.floor(scheduledExecution.totalTime / scheduledExecution.execCount)
+            extra.averageDuration = avg
         }
         respond(
 

--- a/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
@@ -180,6 +180,12 @@ class ApiService {
     def renderSuccessXmlUnwrapped(Closure recall){
         return renderXml(recall)
     }
+    /**
+     * TODO: remove "result" wrapper from API responses after Rundeck 2.6
+     * @param recall
+     * @return
+     * @deprecated
+     */
     def renderSuccessXml(Closure recall){
         return renderSuccessXmlUnwrapped {
             result(success: "true", apiversion: ApiRequestFilters.API_CURRENT_VERSION) {

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/jobs/info/JobInfo.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/jobs/info/JobInfo.groovy
@@ -69,6 +69,11 @@ class JobInfo {
     @XmlAttribute
     Boolean serverOwner
 
+    @ApiVersion(18)
+    @Ignore(onlyIfNull = true)
+    @XmlAttribute
+    Long averageDuration
+
 //    Map blah=[
 //            z:'x'
 //    ]
@@ -91,7 +96,7 @@ class JobInfo {
                      scheduled      : se.scheduled,
                      scheduleEnabled: se.scheduleEnabled,
                      enabled        : se.executionEnabled
-                    ] + extra?.subMap('serverNodeUUID', 'serverOwner')
+                    ] + extra?.subMap('serverNodeUUID', 'serverOwner','averageDuration')
         )
     }
 }

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/jobs/info/JobInfo.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/jobs/info/JobInfo.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.api.jobs.info
+
+import com.dtolabs.rundeck.app.api.marshall.ApiVersion
+import com.dtolabs.rundeck.app.api.marshall.ElementName
+import com.dtolabs.rundeck.app.api.marshall.Ignore
+import com.dtolabs.rundeck.app.api.marshall.ApiResource
+import com.dtolabs.rundeck.app.api.marshall.XmlAttribute
+import grails.validation.Validateable
+import rundeck.ScheduledExecution
+
+/**
+ * Resource view used by /project/jobs listing, and /job/[id]/info, and /scheduler
+ */
+@ApiResource
+@ElementName('job')
+class JobInfo {
+    @XmlAttribute
+    String id
+
+    String name
+    String group
+    String project
+    String description
+
+    @XmlAttribute
+    String href
+
+    @XmlAttribute
+    String permalink
+
+    @ApiVersion(17)
+    @Ignore(onlyIfNull = true)
+    @XmlAttribute
+    Boolean scheduled
+
+    @ApiVersion(17)
+    @Ignore(onlyIfNull = true)
+    @XmlAttribute
+    Boolean scheduleEnabled
+
+    @ApiVersion(17)
+    @Ignore(onlyIfNull = true)
+    @XmlAttribute
+    Boolean enabled
+
+    @ApiVersion(17)
+    @Ignore(onlyIfNull = true)
+    @XmlAttribute
+    String serverNodeUUID
+
+    @ApiVersion(17)
+    @Ignore(onlyIfNull = true)
+    @XmlAttribute
+    Boolean serverOwner
+
+//    Map blah=[
+//            z:'x'
+//    ]
+//    renders as: <blah z="x"/>
+//
+//    @SubElement
+//    List<Map> submap = [
+//            [a: 'b']
+//    ]
+//    renders as: <map><entry key="a">b</entry></map>
+
+    static JobInfo from(ScheduledExecution se, href, permalink, Map extra = [:]) {
+        new JobInfo([id             : se.extid,
+                     name           : (se.jobName),
+                     group          : (se.groupPath),
+                     project        : (se.project),
+                     description    : (se.description),
+                     href           : href,
+                     permalink      : permalink,
+                     scheduled      : se.scheduled,
+                     scheduleEnabled: se.scheduleEnabled,
+                     enabled        : se.executionEnabled
+                    ] + extra?.subMap('serverNodeUUID', 'serverOwner')
+        )
+    }
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/jobs/info/JobInfoList.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/jobs/info/JobInfoList.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.api.jobs.info
+
+import com.dtolabs.rundeck.app.api.marshall.ApiResource
+import com.dtolabs.rundeck.app.api.marshall.ElementName
+import com.dtolabs.rundeck.app.api.marshall.SubElement
+import com.dtolabs.rundeck.app.api.marshall.XmlAttribute
+import grails.validation.Validateable
+
+/**
+ * Created by greg on 8/19/16.
+ */
+@ApiResource
+@ElementName('jobs')
+class JobInfoList {
+    JobInfoList(final List<JobInfo> jobs) {
+        this.jobs = jobs
+        this.count = jobs.size()
+    }
+    @XmlAttribute
+    Integer count
+
+    @SubElement
+    List<JobInfo> jobs
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/ApiMarshaller.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/ApiMarshaller.groovy
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.api.marshall
+
+import org.springframework.beans.factory.config.BeanDefinition
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.type.filter.AnnotationTypeFilter
+
+import java.lang.reflect.Field
+
+/**
+ * Scans all classes in a package for {@link ApiResource} annotations, and can introspect annotations on those classes.
+ */
+class ApiMarshaller {
+    String packageName
+    List<Class> clazzes
+    protected Map<Class, Map<String, ResourceField>> classFields = [:]
+
+    ApiMarshaller(String packageName) {
+        clazzes = null
+        this.packageName = packageName
+    }
+
+    /**
+     * @param object
+     * @return true if the object's class is one of the ApiResource types
+     */
+    boolean supports(final Object object) {
+        if (null == clazzes) {
+            clazzes = scanPackageForAnnotatedTypes(packageName, ApiResource)
+        }
+        return object.class in clazzes
+    }
+
+    def Map<String, ResourceField> getFieldDefsForClass(Class clazz) {
+        if (null == classFields[clazz]) {
+            classFields[clazz] = introspectFields(clazz)
+        }
+        return classFields[clazz]
+    }
+
+
+    private static ArrayList<Class> scanPackageForAnnotatedTypes(String pkgName, Class annotation) {
+        def apiResourceTypes = []
+        def scanner = new ClassPathScanningCandidateComponentProvider(false)
+        scanner.addIncludeFilter(new AnnotationTypeFilter(annotation))
+        scanner.findCandidateComponents(pkgName).each { BeanDefinition bd ->
+            apiResourceTypes << Class.forName(bd.beanClassName)
+        }
+        apiResourceTypes
+    }
+
+    private static ArrayList<Class> scanPackageForAllTypes(String pkgName) {
+        def apiResourceTypes = []
+        def scanner = new ClassPathScanningCandidateComponentProvider(false)
+        scanner.findCandidateComponents(pkgName).each { BeanDefinition bd ->
+            apiResourceTypes << Class.forName(bd.beanClassName)
+        }
+        apiResourceTypes
+    }
+
+    private static Map<String, ResourceField> introspectFields(Class clazz) {
+        def Map<String, ResourceField> fieldDefs = [:]
+        clazz.getDeclaredFields().each { Field f ->
+            def fieldDef = new ResourceField(name: f.name)
+            fieldDefs.put(f.name, fieldDef)
+
+            ApiVersion apiVersionCheck = f.getAnnotation(ApiVersion)
+            if (null != apiVersionCheck) {
+                fieldDef.apiVersionMin = apiVersionCheck.value()
+                fieldDef.apiVersionMax = apiVersionCheck.max()
+            }
+            Ignore ignore = f.getAnnotation(Ignore)
+            if (null != ignore) {
+                fieldDef.ignoreOnlyIfNull = ignore.onlyIfNull()
+                fieldDef.ignore = !ignore.onlyIfNull()
+            }
+            def attr = f.getAnnotation(XmlAttribute)
+            if (attr) {
+                fieldDef.xmlAttr = attr.value() ?: f.name
+            }
+
+            def subElement = f.getAnnotation(SubElement)
+            if (subElement != null) {
+                fieldDef.subElement = true
+
+            }
+            def elemName = f.getAnnotation(ElementName)
+            if (elemName) {
+                fieldDef.elementName = elemName.value()
+            }
+        }
+        return fieldDefs
+    }
+
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/ApiResource.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/ApiResource.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.api.marshall
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * Identify a type marshalled by {@link CustomXmlMarshaller} and {@link CustomJsonMarshaller}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.TYPE])
+@interface ApiResource {
+
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/ApiVersion.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/ApiVersion.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.api.marshall
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * Require a min and/or max api version to include the field.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.TYPE, ElementType.FIELD, ElementType.METHOD])
+@interface ApiVersion {
+    int value() default 1
+
+    int max() default -1
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/BaseCustomMarshaller.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/BaseCustomMarshaller.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.api.marshall
+/**
+ * Base for json/xml custom marshaller
+ */
+class BaseCustomMarshaller {
+    ApiMarshaller marshaller
+    int apiVersion
+
+    BaseCustomMarshaller(ApiMarshaller marshaller, int apiVersion) {
+        this.marshaller = marshaller
+        this.apiVersion = apiVersion
+    }
+
+    boolean supports(final Object object) {
+        return marshaller.supports(object)
+    }
+
+    /**
+     * Scan fields of the object based on the ApiMarshaller introspection, and return
+     * the maps to use for XML Attributes, fields, and direct subelements.
+     * @param object
+     * @return [attrs, fields, subelements]
+     */
+    protected List introspect(object) {
+        //determine attributes and fields to included
+        def attrs = [:]
+        def fields = [:]
+        def subelements = [:]
+        def fieldDefs = marshaller.getFieldDefsForClass(object.class)
+
+        object.properties.keySet().each { String k ->
+            ResourceField resField = fieldDefs[k]
+            if (!resField) {
+                return
+            }
+            if (resField.apiVersionMin > 1 && apiVersion < resField.apiVersionMin) {
+                return
+            }
+            if (resField.apiVersionMax > 0 && apiVersion > resField.apiVersionMax) {
+                return
+            }
+
+            if (resField.ignore) {
+                return
+            }
+            if (resField.ignoreOnlyIfNull && null == object[k]) {
+                return
+            }
+            if (resField.xmlAttr) {
+                attrs[resField.xmlAttr] = object[k]
+                return
+            }
+
+            if (resField.subElement) {
+                subelements[k] = object[k]
+                return
+            }
+            if (resField.elementName) {
+                fields[resField.elementName] = object[k]
+            } else {
+                fields[k] = object[k]
+            }
+        }
+        [attrs, fields, subelements]
+    }
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/CustomJsonMarshaller.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/CustomJsonMarshaller.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.api.marshall
+
+import grails.converters.JSON
+import grails.converters.XML
+import grails.util.GrailsNameUtils
+import org.codehaus.groovy.grails.web.converters.exceptions.ConverterException
+import org.codehaus.groovy.grails.web.converters.marshaller.NameAwareMarshaller
+import org.codehaus.groovy.grails.web.converters.marshaller.ObjectMarshaller
+
+/**
+ * Custom JSON marshaller which handles "wrapper" objects. If a {@link ApiResource} class defines
+ * a single field with {@link SubElement}, that object will be marshalled in place of the parent.
+ * If any other non-ignored fields are defined, then the subelement will be treated as a simple field.
+ */
+class CustomJsonMarshaller extends BaseCustomMarshaller implements ObjectMarshaller<JSON> {
+
+    CustomJsonMarshaller(ApiMarshaller marshaller, int apiVersion) {
+        super(marshaller, apiVersion)
+    }
+
+    @Override
+    boolean supports(final Object object) {
+        return super.supports(object)
+    }
+
+    @Override
+    void marshalObject(final Object object, final JSON converter) throws ConverterException {
+        def (Map attrs, Map fields, Map subelements) = introspect(object)
+
+        //if only one subelement, simply apply that
+        if (subelements.size() == 1 && !fields) {
+            converter.convertAnother(subelements.values().first())
+            return
+        }
+        converter.convertAnother(attrs + fields + subelements)
+    }
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/CustomXmlMarshaller.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/CustomXmlMarshaller.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.api.marshall
+
+import grails.converters.XML
+import grails.util.GrailsNameUtils
+import groovy.inspect.Inspector
+import org.codehaus.groovy.grails.web.converters.exceptions.ConverterException
+import org.codehaus.groovy.grails.web.converters.marshaller.NameAwareMarshaller
+import org.codehaus.groovy.grails.web.converters.marshaller.ObjectMarshaller
+
+/**
+ * Custom XMl marshaller, uses annotations on fields/class to convert to XML.
+ * Fields annotated with {@link XmlAttribute} will be used as attributes of the root element.
+ * If the type is annotated with {@link ElementName} that value will be used as the root element name.
+ * Any fields annotated with {@link SubElement} will be inlined in the root element, instead of wrapped
+ * with the field name.
+ *
+ * TODO: better handling of embedded object types
+ */
+class CustomXmlMarshaller extends BaseCustomMarshaller implements ObjectMarshaller<XML>, NameAwareMarshaller {
+    CustomXmlMarshaller(ApiMarshaller marshaller, int apiVersion) {
+        super(marshaller, apiVersion)
+    }
+    @Override
+    boolean supports(final Object object) {
+        return super.supports(object)
+    }
+
+    @Override
+    String getElementName(final Object o) {
+        def annotation = o.getClass().getAnnotation(ElementName)
+        if (annotation) {
+            return annotation.value()
+        }
+        return GrailsNameUtils.getPropertyName(o.class)
+    }
+
+
+    @Override
+    void marshalObject(final Object object, final XML xml) throws ConverterException {
+        def (Map attrs, Map fields, Map subelements) = introspect(object)
+
+        attrs.each { String k, Object v ->
+            xml.attribute(k, v?.toString() ?: '')
+        }
+        xml.build {
+            def xmld = delegate
+            fields.each { k, v ->
+                xmld."$k"(v)
+            }
+        }
+        subelements.each { k, v ->
+            xml.convertAnother(v)
+        }
+
+    }
+
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/ElementName.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/ElementName.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.api.marshall
+
+import groovy.transform.AnnotationCollector
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+
+/**
+ * Define the name of the an XML element for a field or type
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.TYPE, ElementType.FIELD, ElementType.METHOD])
+@interface ElementName {
+    String value()
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/Ignore.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/Ignore.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.api.marshall
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * The field should not be included in rendered output, optionally only if it is null
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.FIELD, ElementType.METHOD])
+@interface Ignore {
+    /**
+     * If true, ignore this field when the value is null
+     * @return
+     */
+    boolean onlyIfNull() default false
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/ResourceField.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/ResourceField.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.api.marshall
+
+/**
+ * Annotation information for a field in a resource
+ */
+class ResourceField {
+    String name
+    /**
+     * Minimum API version for the field to be included
+     */
+    int apiVersionMin = 1
+    /**
+     * Maximum API version for the field to be included
+     */
+    int apiVersionMax = -1
+    /**
+     * The field should be ignored
+     */
+    boolean ignore
+    /**
+     * The field should be ignored in marshalling if its value is null
+     */
+    boolean ignoreOnlyIfNull
+    /**
+     * The name to use for this field as an XML attribute
+     */
+    String xmlAttr
+    /**
+     * True if the field should be marshalled as a direct subelement of the parent XML element,
+     * instead of within an element using the field name.
+     */
+    boolean subElement
+    /**
+     * The name of the element to marshall for the value of this field, instead of the field name.
+     */
+    String elementName
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/SubElement.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/SubElement.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.api.marshall
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * The field value should not be contained in another element. For XML, this means
+ * inline the value of the field in the parent element, eliding the field name.
+ * For JSON, if this field is the only available field, replace the parent
+ * object with this one.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.FIELD])
+@interface SubElement {
+
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/XmlAttribute.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/api/marshall/XmlAttribute.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.api.marshall
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * Field should be a XML attribute with given name, or using field name if value is not set
+ */
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.FIELD, ElementType.METHOD])
+@interface XmlAttribute {
+    String value() default ''
+}

--- a/rundeckapp/test/unit/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/MenuControllerSpec.groovy
@@ -33,7 +33,7 @@ import spock.lang.Specification
 @TestFor(MenuController)
 @Mock([ScheduledExecution, CommandExec, Workflow])
 class MenuControllerSpec extends Specification {
-    def "api job detail"() {
+    def "api job detail xml"() {
         given:
         def testUUID = UUID.randomUUID().toString()
         def testUUID2 = UUID.randomUUID().toString()
@@ -42,6 +42,8 @@ class MenuControllerSpec extends Specification {
         controller.scheduledExecutionService = Mock(ScheduledExecutionService)
         ScheduledExecution job1 = new ScheduledExecution(createJobParams(jobName: 'job1', uuid:testUUID))
         job1.serverNodeUUID = testUUID2
+        job1.totalTime=200*1000
+        job1.execCount=100
         job1.save()
 
         when:
@@ -66,6 +68,45 @@ class MenuControllerSpec extends Specification {
         response.xml.group  == 'some/where'
         response.xml.href  == 'api/href'
         response.xml.permalink  == 'gui/href'
+        response.xml.averageDuration  == '2000'
+    }
+    def "api job detail json"() {
+        given:
+        def testUUID = UUID.randomUUID().toString()
+        def testUUID2 = UUID.randomUUID().toString()
+        controller.apiService = Mock(ApiService)
+        controller.frameworkService = Mock(FrameworkService)
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService)
+        ScheduledExecution job1 = new ScheduledExecution(createJobParams(jobName: 'job1', uuid:testUUID))
+        job1.serverNodeUUID = testUUID2
+        job1.totalTime=200*1000
+        job1.execCount=100
+        job1.save()
+
+        when:
+        params.id=testUUID
+        response.format='json'
+        def result = controller.apiJobDetail()
+
+        then:
+        1 * controller.apiService.requireVersion(_, _, 18) >> true
+        1 * controller.apiService.requireParameters(_, _, ['id']) >> true
+        1 * controller.scheduledExecutionService.getByIDorUUID(testUUID) >> job1
+        1 * controller.apiService.requireExists(_, job1, _) >> true
+        1 * controller.frameworkService.getAuthContextForSubjectAndProject(_, 'AProject') >>
+                Mock(UserAndRolesAuthContext)
+        1 * controller.frameworkService.authorizeProjectJobAll(_, job1, ['read'], 'AProject') >> true
+        1 * controller.apiService.apiHrefForJob(job1) >> 'api/href'
+        1 * controller.apiService.guiHrefForJob(job1) >> 'gui/href'
+
+        response.json != null
+        response.json.id  == testUUID
+        response.json.description  == 'a job'
+        response.json.name  == 'job1'
+        response.json.group  == 'some/where'
+        response.json.href  == 'api/href'
+        response.json.permalink  == 'gui/href'
+        response.json.averageDuration  == 2000
     }
 
     def "scheduler list jobs invalid uuid"() {

--- a/rundeckapp/test/unit/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/MenuControllerSpec.groovy
@@ -24,14 +24,50 @@ import rundeck.ScheduledExecution
 import rundeck.Workflow
 import rundeck.services.ApiService
 import rundeck.services.FrameworkService
+import rundeck.services.ScheduledExecutionService
 import spock.lang.Specification
 
 /**
  * Created by greg on 3/15/16.
  */
 @TestFor(MenuController)
-@Mock([ScheduledExecution,CommandExec,Workflow])
+@Mock([ScheduledExecution, CommandExec, Workflow])
 class MenuControllerSpec extends Specification {
+    def "api job detail"() {
+        given:
+        def testUUID = UUID.randomUUID().toString()
+        def testUUID2 = UUID.randomUUID().toString()
+        controller.apiService = Mock(ApiService)
+        controller.frameworkService = Mock(FrameworkService)
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService)
+        ScheduledExecution job1 = new ScheduledExecution(createJobParams(jobName: 'job1', uuid:testUUID))
+        job1.serverNodeUUID = testUUID2
+        job1.save()
+
+        when:
+        params.id=testUUID
+        def result = controller.apiJobDetail()
+
+        then:
+        1 * controller.apiService.requireVersion(_, _, 18) >> true
+        1 * controller.apiService.requireParameters(_, _, ['id']) >> true
+        1 * controller.scheduledExecutionService.getByIDorUUID(testUUID) >> job1
+        1 * controller.apiService.requireExists(_, job1, _) >> true
+        1 * controller.frameworkService.getAuthContextForSubjectAndProject(_, 'AProject') >>
+                Mock(UserAndRolesAuthContext)
+        1 * controller.frameworkService.authorizeProjectJobAll(_, job1, ['read'], 'AProject') >> true
+        1 * controller.apiService.apiHrefForJob(job1) >> 'api/href'
+        1 * controller.apiService.guiHrefForJob(job1) >> 'gui/href'
+
+        response.xml != null
+        response.xml.id  == testUUID
+        response.xml.description  == 'a job'
+        response.xml.name  == 'job1'
+        response.xml.group  == 'some/where'
+        response.xml.href  == 'api/href'
+        response.xml.permalink  == 'gui/href'
+    }
+
     def "scheduler list jobs invalid uuid"() {
         given:
         def paramUUID = "not a uuid"

--- a/test/api/include.sh
+++ b/test/api/include.sh
@@ -45,7 +45,6 @@ API_CURRENT_VERSION=18
 
 API_VERSION=${API_VERSION:-$API_CURRENT_VERSION}
 
-
 # curl opts to use a cookie jar, and follow redirects, showing only errors
 if [ -n "$RDAUTH" ] ; then 
     AUTHHEADER="X-RunDeck-Auth-Token: $RDAUTH"

--- a/test/api/test-jobs.sh
+++ b/test/api/test-jobs.sh
@@ -3,6 +3,7 @@
 #test output from /api/jobs
 
 DIR=$(cd `dirname $0` && pwd)
+export API_XML_NO_WRAPPER=1
 source $DIR/include.sh
 
 proj="test"
@@ -24,7 +25,7 @@ fi
 $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
 
 #Check projects list
-itemcount=$($XMLSTARLET sel -T -t -v "/result/jobs/@count" $DIR/curl.out)
+itemcount=$($XMLSTARLET sel -T -t -v "/jobs/@count" $DIR/curl.out)
 
 if [ "" == "$itemcount" ] ; then
     errorMsg "Wrong count: $itemcount"
@@ -66,7 +67,10 @@ if [ 0 != $? ] ; then
     exit 2
 fi
 
+#wrapper expected in job import response
+export API_XML_NO_WRAPPER=
 $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
+export API_XML_NO_WRAPPER=1
 
 cat > $DIR/temp.out <<END
 - 
@@ -97,7 +101,10 @@ if [ 0 != $? ] ; then
     exit 2
 fi
 
+#wrapper expected in job import response
+export API_XML_NO_WRAPPER=
 $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
+export API_XML_NO_WRAPPER=1
 
 # load a top-level job not in a group
 cat > $DIR/temp.out <<END
@@ -128,7 +135,10 @@ if [ 0 != $? ] ; then
     exit 2
 fi
 
+#wrapper expected in job import response
+export API_XML_NO_WRAPPER=
 $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
+export API_XML_NO_WRAPPER=1
 
 ###
 # test query with match filter and exact filter
@@ -150,7 +160,7 @@ fi
 $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
 
 #Check projects list
-itemcount=$($XMLSTARLET sel -T -t -v "/result/jobs/@count" $DIR/curl.out)
+itemcount=$($XMLSTARLET sel -T -t -v "/jobs/@count" $DIR/curl.out)
 
 if [ "2" != "$itemcount" ] ; then
     errorMsg "Wrong count: $itemcount"
@@ -177,7 +187,7 @@ fi
 $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
 
 #Check projects list
-itemcount=$($XMLSTARLET sel -T -t -v "/result/jobs/@count" $DIR/curl.out)
+itemcount=$($XMLSTARLET sel -T -t -v "/jobs/@count" $DIR/curl.out)
 
 if [ "1" != "$itemcount" ] ; then
     errorMsg "Wrong count: $itemcount"
@@ -204,7 +214,7 @@ fi
 $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
 
 #Check projects list
-itemcount=$($XMLSTARLET sel -T -t -v "/result/jobs/@count" $DIR/curl.out)
+itemcount=$($XMLSTARLET sel -T -t -v "/jobs/@count" $DIR/curl.out)
 
 if [ "1" != "$itemcount" ] ; then
     errorMsg "Wrong count: $itemcount"
@@ -231,7 +241,7 @@ fi
 $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
 
 #Check projects list
-itemcount=$($XMLSTARLET sel -T -t -v "/result/jobs/@count" $DIR/curl.out)
+itemcount=$($XMLSTARLET sel -T -t -v "/jobs/@count" $DIR/curl.out)
 
 if [ "2" != "$itemcount" ] ; then
     errorMsg "Wrong count: $itemcount"
@@ -257,7 +267,7 @@ fi
 $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
 
 #Check projects list
-itemcount=$($XMLSTARLET sel -T -t -v "/result/jobs/@count" $DIR/curl.out)
+itemcount=$($XMLSTARLET sel -T -t -v "/jobs/@count" $DIR/curl.out)
 
 if [ "1" != "$itemcount" ] ; then
     errorMsg "Wrong count: $itemcount"
@@ -283,7 +293,7 @@ fi
 $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
 
 #Check projects list
-itemcount=$($XMLSTARLET sel -T -t -v "/result/jobs/@count" $DIR/curl.out)
+itemcount=$($XMLSTARLET sel -T -t -v "/jobs/@count" $DIR/curl.out)
 
 if [ "1" != "$itemcount" ] ; then
     errorMsg "Wrong count: $itemcount"
@@ -310,7 +320,7 @@ fi
 $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
 
 #Check projects list
-itemcount=$($XMLSTARLET sel -T -t -v "/result/jobs/@count" $DIR/curl.out)
+itemcount=$($XMLSTARLET sel -T -t -v "/jobs/@count" $DIR/curl.out)
 
 if [ "1" != "$itemcount" ] ; then
     errorMsg "Wrong count: $itemcount"
@@ -336,7 +346,7 @@ fi
 $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
 
 #Check projects list
-itemcount=$($XMLSTARLET sel -T -t -v "/result/jobs/@count" $DIR/curl.out)
+itemcount=$($XMLSTARLET sel -T -t -v "/jobs/@count" $DIR/curl.out)
 
 if [ "0" != "$itemcount" ] ; then
     errorMsg "Wrong count: $itemcount"
@@ -362,7 +372,7 @@ fi
 $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
 
 #Check projects list
-itemcount=$($XMLSTARLET sel -T -t -v "/result/jobs/@count" $DIR/curl.out)
+itemcount=$($XMLSTARLET sel -T -t -v "/jobs/@count" $DIR/curl.out)
 
 if [ "0" != "$itemcount" ] ; then
     errorMsg "Wrong count: $itemcount"
@@ -388,7 +398,7 @@ fi
 $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
 
 #Check projects list
-itemcount=$($XMLSTARLET sel -T -t -v "/result/jobs/@count" $DIR/curl.out)
+itemcount=$($XMLSTARLET sel -T -t -v "/jobs/@count" $DIR/curl.out)
 
 if [ "1" != "$itemcount" ] ; then
     errorMsg "Wrong count: $itemcount"


### PR DESCRIPTION
Add a new endpoint `/api/18/job/[ID]/info`, returns metadata about the job, including `project` and other info already returned in job list and scheduler list info.

Fix issue: no way to know a Job's project based on ID