### PR TITLE
More redhatcompliance init file, more easier to use profile file

### DIFF
--- a/packaging/root/etc/rc.d/init.d/rundeckd
+++ b/packaging/root/etc/rc.d/init.d/rundeckd
@@ -7,14 +7,17 @@
 # pidfile: /var/run/rundeckd.pid
 
 # Source function library
-. /etc/rc.d/init.d/functions
-. /etc/rundeck/profile
 
 prog="rundeckd"
-rundeckd="${JAVA_HOME:-/usr}/bin/java ${RDECK_JVM} -cp ${BOOTSTRAP_CP} com.dtolabs.rundeck.RunServer /var/lib/rundeck ${RDECK_HTTP_PORT}"
 RETVAL=0
 PID_FILE=/var/run/${prog}.pid
 servicelog=/var/log/rundeck/service.log
+
+. /etc/rc.d/init.d/functions
+
+[ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+
+. /etc/rundeck/profile
 
 start() {
 	echo -n $"Starting $prog: "
@@ -24,11 +27,11 @@ start() {
 		echo
 		return 1
 	fi
-        nohup runuser -s /bin/bash -l rundeck -c "$rundeckd" >>$servicelog 2>&1 &
- 	RETVAL=$?	
+	nohup runuser -s /bin/bash -l rundeck -c "$rundeckd" >>$servicelog 2>&1 &
+	RETVAL=$?	
 	PID=$!
 	echo $PID > $PID_FILE
-	if [ $RETVAL -eq 0 ]; then 
+	if [ $RETVAL -eq 0 ]; then
 		touch /var/lock/subsys/$prog
 		echo_success
 	else
@@ -44,15 +47,6 @@ stop() {
 	RETVAL=$?
 	echo
 	[ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/$prog
-	return $RETVAL
-}
-
-### NOT USED
-reload() {
-	echo -n $"Reloading $prog: "
-	killproc -p $PID_FILE "$rundeckd" -HUP
-	RETVAL=$?
-	echo
 	return $RETVAL
 }
 

--- a/packaging/root/etc/rundeck/profile
+++ b/packaging/root/etc/rundeck/profile
@@ -1,58 +1,70 @@
-RDECK_BASE=/var/lib/rundeck
-export RDECK_BASE
+RDECK_INSTALL="${RDECK_INSTALL:-/var/lib/rundeck}"
+RDECK_BASE="${RDECK_BASE:-/var/lib/rundeck}"
+RDECK_CONFIG="${RDECK_CONFIG:-/etc/rundeck}"
+RDECK_SERVER_BASE="${RDECK_SERVER_BASE:-$RDECK_BASE}"
+RDECK_SERVER_CONFIG="${RDECK_SERVER_CONFIG:-$RDECK_CONFIG}"
+RDECK_SERVER_DATA="${RDECK_SERVER_DATA:-$RDECK_BASE/data}"
+RDECK_PROJECTS="${RDECK_PROJECTS:-$RDECK_BASE/projects}"
+RUNDECK_TEMPDIR="${RUNDECK_TEMPDIR:-/tmp/rundeck}"
+RUNDECK_WORKDIR="${RUNDECK_TEMPDIR:-$RDECK_BASE/work}"
+RUNDECK_LOGDIR="${RUNDECK_LOGDIR:-$RDECK_BASE/logs}"
+RDECK_JVM_SETTINGS="${RDECK_JVM_SETTINGS:- -Xmx1024m -Xms256m -XX:MaxPermSize=256m -server}"
+RDECK_TRUSTSTORE_FILE="${RDECK_TRUSTSTORE_FILE:-$RDECK_CONFIG/ssl/truststore}"
+RDECK_TRUSTSTORE_TYPE="${RDECK_TRUSTSTORE_TYPE:-jks}"
+JAAS_CONF="${JAAS_CONF:-$RDECK_CONFIG/jaas-loginmodule.conf}"
+LOGIN_MODULE="${LOGIN_MODULE:-RDpropertyfilelogin}"
+RDECK_HTTP_PORT=${RDECK_HTTP_PORT:-4440}
+RDECK_HTTPS_PORT=${RDECK_HTTP_PORT:-4443}
 
-JAVA_CMD=java
-RUNDECK_TEMPDIR=/tmp/rundeck
 
-RDECK_HTTP_PORT=4440
-RDECK_HTTPS_PORT=4443
-
-#
-# If JAVA_HOME is set, then add it to home and set JAVA_CMD to use the version specified in that
-# path.  JAVA_HOME can be set in the rundeck profile.  Or set in this file.
-#JAVA_HOME=<path/to/JDK or JRE/install>
-
-if [ ! -z $JAVA_HOME ]; then
-	PATH=$PATH:$JAVA_HOME/bin
-	export PATH
-	JAVA_CMD=$JAVA_HOME/bin/java
+# If no JAVA_CMD, try to find it in $JAVA_HOME
+if [ -z "$JAVA_CMD" -a -n "$JAVA_HOME" -a -x $(command -v $JAVA_HOME/bin/java) ] ; then
+  JAVA_CMD=$JAVA_HOME/bin/java
+  PATH=$PATH:$JAVA_HOME/bin
+  export JAVA_HOME
+elif [ -z "$JAVA_CMD" ] ; then
+  JAVA_CMD=java
 fi
 
+# build classpath without lone : that includes .
+for jar in $(find $RDECK_INSTALL/cli -name '*.jar') ; do
+  CLI_CP=${CLI_CP:+$CLI_CP:}$jar
+done
+for jar in $(find $RDECK_INSTALL/bootstrap -name '*.jar') ; do
+  BOOTSTRAP_CP=${BOOTSTRAP_CP:+$BOOTSTRAP_CP:}$jar
+done
 
-
-export CLI_CP=$(find /var/lib/rundeck/cli -name \*.jar -printf %p:)
-export BOOTSTRAP_CP=$(find /var/lib/rundeck/bootstrap -name \*.jar -printf %p:)
-export RDECK_JVM="-Djava.security.auth.login.config=/etc/rundeck/jaas-loginmodule.conf \
-	-Dloginmodule.name=RDpropertyfilelogin \
-	-Drdeck.config=/etc/rundeck \
-	-Drdeck.base=/var/lib/rundeck \
-	-Drundeck.server.configDir=/etc/rundeck \
-	-Dserver.datastore.path=/var/lib/rundeck/data \
-	-Drundeck.server.serverDir=/var/lib/rundeck \
-	-Drdeck.projects=/var/rundeck/projects \
-	-Drdeck.runlogs=/var/lib/rundeck/logs \
-	-Drundeck.config.location=/etc/rundeck/rundeck-config.properties \
-	-Djava.io.tmpdir=$RUNDECK_TEMPDIR"
+RDECK_JVM="-Djava.security.auth.login.config=$JAAS_CONF \
+           -Dloginmodule.name=$LOGIN_MODULE \
+           -Drdeck.config=$RDECK_CONFIG \
+           -Drundeck.server.configDir=$RDECK_SERVER_CONFIG \
+           -Dserver.datastore.path=$RDECK_SERVER_DATA/rundeck \
+           -Drundeck.server.serverDir=$RDECK_INSTALL \
+           -Drdeck.projects=$RDECK_PROJECTS \
+           -Drdeck.runlogs=$RUNDECK_LOGDIR \
+           -Drundeck.config.location=$RDECK_CONFIG/rundeck-config.properties \
+           -Djava.io.tmpdir=$RUNDECK_TEMPDIR \
+           -Drundeck.server.workDir=$RUNDECK_WORKDIR \
+           -Dserver.http.port=$RDECK_HTTP_PORT"
 #
 # Set min/max heap size
 #
-RDECK_JVM="$RDECK_JVM -Xmx1024m -Xms256m -XX:MaxPermSize=256m -server"
+RDECK_JVM="$RDECK_JVM $RDECK_JVM_SETTINGS"
 #
 # SSL Configuration - Uncomment the following to enable.  Check SSL.properties for details.
 #
-#export RDECK_JVM="$RDECK_JVM -Drundeck.ssl.config=/etc/rundeck/ssl/ssl.properties -Dserver.https.port=${RDECK_HTTPS_PORT}"
+if [ -n "$RUNDECK_WITH_SSL" ] ; then
+  RDECK_JVM="$RDECK_JVM -Drundeck.ssl.config=$RDECK_SERVER_CONFIG/ssl.properties -Dserver.https.port=${RDECK_HTTPS_PORT}"
+  RDECK_SSL_OPTS="${RDECK_SSL_OPTS:- -Djavax.net.ssl.trustStore=$RDECK_TRUSTSTORE_FILE -Djavax.net.ssl.trustStoreType=$RDECK_TRUSTSTORE_TYPE -Djava.protocol.handler.pkgs=com.sun.net.ssl.internal.www.protocol}"
+fi
 
-export RDECK_SSL_OPTS="-Djavax.net.ssl.trustStore=/etc/rundeck/ssl/truststore -Djavax.net.ssl.trustStoreType=jks -Djava.protocol.handler.pkgs=com.sun.net.ssl.internal.www.protocol"
-
-if test -t 0 -a -z "$RUNDECK_CLI_TERSE"
-then
+if [ -t 0 -a -z "$RUNDECK_CLI_TERSE" ] ; then 
   RUNDECK_CLI_TERSE=true
   export RUNDECK_CLI_TERSE
 fi
 
-if test -n "$JRE_HOME"
-then
-   unset JRE_HOME
-fi
+unset JRE_HOME
 
 umask 002
+
+rundeckd="$JAVA_CMD $RDECK_JVM $RDECK_JVM_OPTS -cp $BOOTSTRAP_CP com.dtolabs.rundeck.RunServer $RDECK_BASE"


### PR DESCRIPTION
Default init script for redhat can be improved:

It looks for configuration in /etc/rundeck/profile. But service configurations should be in /etc/sysconfig/$service instead in redhat.

The profile script was not optimum. It needed a lot of editing. Many useless export where used. This new one add a lot of variable that can be used in a sysconfig configuration. It also remove the system property rdeck.base because it's overridden in com.dtolabs.rundeck.RunServer:

        if (null != basedir) {
            System.setProperty("rdeck.base", basedir.getAbsolutePath());
        }

and

        if (args.length > 0) {
            basedir = new File(args[0]);
        } else {
            throw new RuntimeException("Basedir argument required");
        }

So the `-Drdeck.base=/var/lib/rundeck` as no effect.

