### PR TITLE
Plugin resources and icons

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginManagerService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginManagerService.java
@@ -144,6 +144,17 @@ public class PluginManagerService implements FrameworkSupportService, ServicePro
         return null;
     }
 
+    @Override
+    public PluginMetadata getPluginMetadata(final String service, final String provider)
+            throws ProviderLoaderException
+    {
+        ProviderLoader loaderForIdent = getCache().getLoaderForIdent(new ProviderIdent(service, provider));
+        if (null != loaderForIdent && loaderForIdent instanceof PluginMetadata) {
+            return (PluginMetadata) loaderForIdent;
+        }
+        return null;
+    }
+
     public File getExtdir() {
         return extdir;
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginManagerService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginManagerService.java
@@ -135,6 +135,14 @@ public class PluginManagerService implements FrameworkSupportService, ServicePro
         }
     }
 
+    @Override
+    public PluginResourceLoader getResourceLoader(String service, String provider) throws ProviderLoaderException {
+        ProviderLoader loaderForIdent = getCache().getLoaderForIdent(new ProviderIdent(service, provider));
+        if (null != loaderForIdent && loaderForIdent instanceof PluginResourceLoader) {
+            return (PluginResourceLoader) loaderForIdent;
+        }
+        return null;
+    }
 
     public File getExtdir() {
         return extdir;

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginMetadata.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginMetadata.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.core.plugins;
+
+import java.io.File;
+import java.util.Date;
+
+/**
+ * Provides metadata about plugin files
+ */
+public interface PluginMetadata {
+    /**
+     * @return Name of file on disk
+     */
+    String getFilename();
+
+    /**
+     * @return Source file on disk
+     */
+    File getFile();
+
+    /**
+     * @return author metadata
+     */
+    String getPluginAuthor();
+
+    /**
+     * @return plugin file version
+     */
+    String getPluginFileVersion();
+
+    /**
+     * @return rundeck plugin format version
+     */
+    String getPluginVersion();
+
+    /**
+     * @return plugin URL
+     */
+    String getPluginUrl();
+
+    /**
+     * @return build date of plugin
+     */
+    Date getPluginDate();
+
+    /**
+     * @return date loaded
+     */
+    Date getDateLoaded();
+
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginResourceLoader.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginResourceLoader.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.core.plugins;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * List and load resources from a plugin
+ */
+public interface PluginResourceLoader {
+
+    /**
+     * @return the list of resources available
+     */
+    public List<String> listResources() throws PluginException, IOException;
+
+    /**
+     * Open a stream to load a resource
+     *
+     * @param name resource path and name
+     *
+     * @return input stream for the resources, must be closed when finished, or null if the plugin does not support
+     * resources
+     *
+     * @throws PluginException if a path is requested that was not in the plugin
+     * @throws IOException     if an error occurs
+     */
+    InputStream openResourceStreamFor(String name) throws PluginException, IOException;
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/ScriptPluginProviderImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/ScriptPluginProviderImpl.java
@@ -46,7 +46,11 @@ class ScriptPluginProviderImpl implements ScriptPluginProvider {
         this.plugindef = plugindef;
         this.archiveFile = archiveFile;
         this.contentsBasedir=basedir;
-        scriptFile = new File(basedir, plugindef.getScriptFile());
+        if (plugindef.getPluginType().equals("script")) {
+            scriptFile = new File(basedir, plugindef.getScriptFile());
+        } else {
+            scriptFile = null;
+        }
     }
 
     public String getName() {

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/ScriptPluginProviderLoader.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/ScriptPluginProviderLoader.java
@@ -37,6 +37,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -48,7 +50,7 @@ import static com.dtolabs.rundeck.core.plugins.JarPluginProviderLoader.RESOURCES
  *
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
-class ScriptPluginProviderLoader implements ProviderLoader, FileCache.Expireable, PluginResourceLoader {
+class ScriptPluginProviderLoader implements ProviderLoader, FileCache.Expireable, PluginResourceLoader, PluginMetadata {
 
     private static final Logger log = Logger.getLogger(ScriptPluginProviderLoader.class.getName());
     public static final String VERSION_1_0 = "1.0";
@@ -173,6 +175,7 @@ class ScriptPluginProviderLoader implements ProviderLoader, FileCache.Expireable
         return null;
     }
 
+    private Date dateLoaded = null;
 
     /**
      * Get the plugin metadata, loading from the file if necessary
@@ -186,6 +189,7 @@ class ScriptPluginProviderLoader implements ProviderLoader, FileCache.Expireable
             return metadata;
         }
         metadata = loadMeta(file);
+        dateLoaded = new Date();
         return metadata;
     }
 
@@ -614,5 +618,73 @@ class ScriptPluginProviderLoader implements ProviderLoader, FileCache.Expireable
     public static String getResourcesBasePath(PluginMeta metadata) throws IOException {
         String resourcesDir = metadata.getResourcesDir();
         return null != resourcesDir ? resourcesDir : RESOURCES_DIR_DEFAULT;
+    }
+
+    @Override
+    public String getFilename() {
+        return file.getName();
+    }
+
+    @Override
+    public File getFile() {
+        return file;
+    }
+
+    @Override
+    public String getPluginAuthor() {
+        try {
+            return getPluginMeta().getAuthor();
+        } catch (IOException e) {
+
+        }
+        return null;
+    }
+
+    @Override
+    public String getPluginFileVersion() {
+        try {
+            return getPluginMeta().getVersion();
+        } catch (IOException e) {
+
+        }
+        return null;
+    }
+
+    @Override
+    public String getPluginVersion() {
+        try {
+            return getPluginMeta().getRundeckPluginVersion();
+        } catch (IOException e) {
+
+        }
+        return null;
+    }
+
+    @Override
+    public String getPluginUrl() {
+        try {
+            return getPluginMeta().getUrl();
+        } catch (IOException e) {
+
+        }
+        return null;
+    }
+
+    @Override
+    public Date getPluginDate() {
+        try {
+            String date = getPluginMeta().getDate();
+            return new SimpleDateFormat().parse(date);
+        } catch (IOException e) {
+
+        } catch (ParseException e) {
+
+        }
+        return null;
+    }
+
+    @Override
+    public Date getDateLoaded() {
+        return dateLoaded;
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/ServiceProviderLoader.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/ServiceProviderLoader.java
@@ -47,6 +47,8 @@ public interface ServiceProviderLoader {
     public <T> T loadProvider(PluggableService<T> service, String providerName) throws
         ProviderLoaderException;
 
+    public PluginResourceLoader getResourceLoader(String service, String provider) throws ProviderLoaderException;
+
     /**
      * @return the available providers
      */

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/ServiceProviderLoader.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/ServiceProviderLoader.java
@@ -49,6 +49,8 @@ public interface ServiceProviderLoader {
 
     public PluginResourceLoader getResourceLoader(String service, String provider) throws ProviderLoaderException;
 
+    public PluginMetadata getPluginMetadata(String service, String provider) throws ProviderLoaderException;
+
     /**
      * @return the available providers
      */

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/ZipResourceLoader.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/ZipResourceLoader.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.core.plugins;
+
+import com.dtolabs.rundeck.core.utils.ZipUtil;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.jar.JarInputStream;
+import java.util.zip.ZipEntry;
+
+/**
+ * Created by greg on 8/26/16.
+ */
+public class ZipResourceLoader implements PluginResourceLoader {
+    File cacheDir;
+    File zipFile;
+    List<String> resourcesList;
+    String resourcesBasedir;
+    List<String> basedirListing;
+
+    public ZipResourceLoader(
+            final File cacheDir,
+            final File zipFile,
+            final List<String> resourcesList,
+            final String resourcesBasedir
+    )
+    {
+        this.cacheDir = cacheDir;
+        this.zipFile = zipFile;
+        this.resourcesList = resourcesList;
+        this.resourcesBasedir = resourcesBasedir;
+    }
+
+    public List<String> listResources() {
+        return Arrays.asList(getResourceNames());
+    }
+
+    /**
+     * Get the list of resources in the jar
+     */
+    public String[] getResourceNames() {
+        if (null != resourcesList) {
+            return resourcesList.toArray(new String[resourcesList.size()]);
+        }
+        if (null != basedirListing) {
+            return basedirListing.toArray(new String[basedirListing.size()]);
+        }
+        String[] list = listZipPath(zipFile, resourcesBasedir);
+        if (null != list) {
+            basedirListing = Arrays.asList(list);
+            return list;
+        }
+        return null;
+    }
+
+    /**
+     * Get the main attributes for the jar file
+     */
+    private static String[] listZipPath(final File file, String path) {
+        //debug("listJarPath: " + file + ", " + path);
+        ArrayList<String> strings = new ArrayList<>();
+        try {
+            try (final JarInputStream jarInputStream = new JarInputStream(new FileInputStream(file))) {
+                ZipEntry nextJarEntry = jarInputStream.getNextEntry();
+                while (nextJarEntry != null) {
+                    if (nextJarEntry.getName().startsWith(path + "/")) {
+                        if (!nextJarEntry.getName().endsWith("/")) {
+                            strings.add(nextJarEntry.getName().substring(path.length() + 1));
+                        }
+                    }
+                    nextJarEntry=jarInputStream.getNextEntry();
+                }
+            }
+        } catch (IOException e) {
+            return null;
+        }
+
+        return strings.toArray(new String[strings.size()]);
+    }
+
+    public InputStream openResourceStreamFor(final String path) throws PluginException, IOException {
+        if (null == cacheDir) {
+            throw new PluginException(String.format(
+                    "Resource path %s was not found in the file: %s",
+                    path,
+                    zipFile.getAbsolutePath()
+            ));
+        }
+        File resfile = new File(cacheDir, path);
+        if (!resfile.isFile()) {
+            throw new PluginException(String.format(
+                    "Resource path %s did not exist in the file: %s",
+                    path,
+                    zipFile.getAbsolutePath()
+            ));
+        }
+        return new FileInputStream(resfile);
+    }
+
+    /**
+     * Extract resources return the extracted files
+     *
+     * @return the collection of extracted files
+     */
+    public void extractResources() throws IOException {
+        if (!cacheDir.isDirectory()) {
+            if (!cacheDir.mkdirs()) {
+                //debug("Failed to create cachedJar dir for dependent resources: " + cachedir);
+            }
+        }
+        if (null != resourcesList) {
+            //debug("jar manifest lists resources: " + resourcesList + " for file: " + pluginJar);
+
+            extractJarContents(resourcesList, cacheDir);
+            for (final String s : resourcesList) {
+                File libFile = new File(cacheDir, s);
+                libFile.deleteOnExit();
+            }
+        } else {
+            //debug("using resources dir: " + resDir + " for file: " + pluginJar);
+            ZipUtil.extractZip(zipFile.getAbsolutePath(), cacheDir, resourcesBasedir, resourcesBasedir);
+        }
+    }
+
+    /**
+     * Extract specific entries from the jar to a destination directory. Creates the
+     * destination directory if it does not exist
+     *
+     * @param entries the entries to extract
+     * @param destdir destination directory
+     */
+    private void extractJarContents(final List<String> entries, final File destdir) throws IOException {
+        if (!destdir.exists()) {
+            if (!destdir.mkdir()) {
+                //log.warn("Unable to create cache dir for plugin: " + destdir.getAbsolutePath());
+            }
+        }
+
+        //debug("extracting lib files from jar: " + pluginJar);
+        for (final String path : entries) {
+            //debug("Expand zip " + pluginJar.getAbsolutePath() + " to dir: " + destdir + ", file: " + path);
+            ZipUtil.extractZipFile(zipFile.getAbsolutePath(), destdir, path);
+        }
+
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/metadata/PluginMeta.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/metadata/PluginMeta.java
@@ -36,6 +36,7 @@ public class PluginMeta {
     private String date;
     private String version;
     private String rundeckPluginVersion;
+    private String url;
     private List<String> resourcesList;
     private String resourcesDir;
     private List<Map<String, Object>> providers;
@@ -125,5 +126,13 @@ public class PluginMeta {
 
     public void setResourcesDir(String resourcesDir) {
         this.resourcesDir = resourcesDir;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/metadata/PluginMeta.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/metadata/PluginMeta.java
@@ -36,6 +36,8 @@ public class PluginMeta {
     private String date;
     private String version;
     private String rundeckPluginVersion;
+    private List<String> resourcesList;
+    private String resourcesDir;
     private List<Map<String, Object>> providers;
     private List<ProviderDef> pluginDefs;
 
@@ -107,5 +109,21 @@ public class PluginMeta {
 
     public void setRundeckPluginVersion(final String rundeckPluginVersion) {
         this.rundeckPluginVersion = rundeckPluginVersion;
+    }
+
+    public List<String> getResourcesList() {
+        return resourcesList;
+    }
+
+    public void setResourcesList(List<String> resourcesList) {
+        this.resourcesList = resourcesList;
+    }
+
+    public String getResourcesDir() {
+        return resourcesDir;
+    }
+
+    public void setResourcesDir(String resourcesDir) {
+        this.resourcesDir = resourcesDir;
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/ServiceNameConstants.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/ServiceNameConstants.java
@@ -58,5 +58,5 @@ public class ServiceNameConstants {
     public static final String Orchestrator = "Orchestrator";
     public static final String ScmExport = "ScmExport";
     public static final String ScmImport = "ScmImport";
-    public static final String Application = "Application";
+    public static final String UI = "UI";
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/ServiceNameConstants.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/ServiceNameConstants.java
@@ -58,4 +58,5 @@ public class ServiceNameConstants {
     public static final String Orchestrator = "Orchestrator";
     public static final String ScmExport = "ScmExport";
     public static final String ScmImport = "ScmImport";
+    public static final String Application = "Application";
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/ServiceTypes.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/ServiceTypes.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.plugins;
+
+import com.dtolabs.rundeck.core.execution.dispatch.NodeDispatcher;
+import com.dtolabs.rundeck.core.execution.service.FileCopier;
+import com.dtolabs.rundeck.core.execution.service.NodeExecutor;
+import com.dtolabs.rundeck.core.resources.ResourceModelSourceFactory;
+import com.dtolabs.rundeck.core.resources.format.ResourceFormatGenerator;
+import com.dtolabs.rundeck.core.resources.format.ResourceFormatParser;
+import com.dtolabs.rundeck.plugins.logging.ExecutionFileStoragePlugin;
+import com.dtolabs.rundeck.plugins.logging.LogFileStoragePlugin;
+import com.dtolabs.rundeck.plugins.logging.StreamingLogReaderPlugin;
+import com.dtolabs.rundeck.plugins.logging.StreamingLogWriterPlugin;
+import com.dtolabs.rundeck.plugins.notification.NotificationPlugin;
+import com.dtolabs.rundeck.plugins.orchestrator.OrchestratorPlugin;
+import com.dtolabs.rundeck.plugins.rundeck.UIPlugin;
+import com.dtolabs.rundeck.plugins.scm.ScmExportPluginFactory;
+import com.dtolabs.rundeck.plugins.scm.ScmImportPluginFactory;
+import com.dtolabs.rundeck.plugins.step.NodeStepPlugin;
+import com.dtolabs.rundeck.plugins.step.RemoteScriptNodeStepPlugin;
+import com.dtolabs.rundeck.plugins.step.StepPlugin;
+import com.dtolabs.rundeck.plugins.storage.StorageConverterPlugin;
+import com.dtolabs.rundeck.plugins.storage.StoragePlugin;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Static list of java interfaces associated with plugin service names, see {@link ServiceNameConstants}
+ */
+public class ServiceTypes {
+    /**
+     * Map of Service name to Class
+     */
+    public static final Map<String, Class> TYPES;
+
+    static {
+        HashMap<String, Class> map = new HashMap<>();
+        map.put(ServiceNameConstants.RemoteScriptNodeStep, RemoteScriptNodeStepPlugin.class);
+        map.put(ServiceNameConstants.WorkflowNodeStep, NodeStepPlugin.class);
+        map.put(ServiceNameConstants.WorkflowStep, StepPlugin.class);
+        map.put(ServiceNameConstants.NodeExecutor, NodeExecutor.class);
+        map.put(ServiceNameConstants.FileCopier, FileCopier.class);
+        map.put(ServiceNameConstants.NodeDispatcher, NodeDispatcher.class);
+        map.put(ServiceNameConstants.ResourceModelSource, ResourceModelSourceFactory.class);
+        map.put(ServiceNameConstants.ResourceFormatParser, ResourceFormatParser.class);
+        map.put(ServiceNameConstants.ResourceFormatGenerator, ResourceFormatGenerator.class);
+        map.put(ServiceNameConstants.Notification, NotificationPlugin.class);
+        map.put(ServiceNameConstants.StreamingLogReader, StreamingLogReaderPlugin.class);
+        map.put(ServiceNameConstants.StreamingLogWriter, StreamingLogWriterPlugin.class);
+        map.put(ServiceNameConstants.LogFileStorage, LogFileStoragePlugin.class);
+        map.put(ServiceNameConstants.ExecutionFileStorage, ExecutionFileStoragePlugin.class);
+        map.put(ServiceNameConstants.StorageConverter, StorageConverterPlugin.class);
+        map.put(ServiceNameConstants.Storage, StoragePlugin.class);
+        map.put(ServiceNameConstants.Orchestrator, OrchestratorPlugin.class);
+        map.put(ServiceNameConstants.ScmExport, ScmExportPluginFactory.class);
+        map.put(ServiceNameConstants.ScmImport, ScmImportPluginFactory.class);
+        map.put(ServiceNameConstants.UI, UIPlugin.class);
+
+
+        TYPES = Collections.unmodifiableMap(map);
+    }
+
+}

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/rundeck/ApplicationPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/rundeck/ApplicationPlugin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.plugins.rundeck;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generic plugin which can provide other plugin types, and behaviors
+ */
+public interface ApplicationPlugin {
+
+//    boolean hasPluginProviders(String serviceName);
+//
+//    List<Object> getProvidersFor(String serviceName);
+//
+    boolean supportsCallback(String name);
+
+    Object performCallback(String name, Map data);
+}

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/rundeck/BaseApplicationPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/rundeck/BaseApplicationPlugin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.plugins.rundeck;
+
+import java.util.Map;
+
+/**
+ * Created by greg on 8/26/16.
+ */
+public class BaseApplicationPlugin implements ApplicationPlugin {
+    @Override
+    public boolean supportsCallback(final String name) {
+        return false;
+    }
+
+    @Override
+    public Object performCallback(final String name, final Map data) {
+        return null;
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/rundeck/ProvidesResources.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/rundeck/ProvidesResources.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.plugins.rundeck;
+
+import java.io.OutputStream;
+
+/**
+ * Created by greg on 8/26/16.
+ */
+public interface ProvidesResources {
+    static interface PluginResource {
+        String getName();
+
+        String getMimeType();
+
+        String getGroup();
+    }
+
+    void provideResource(String name, OutputStream outputStream);
+
+}

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/rundeck/UIPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/rundeck/UIPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.plugins.rundeck;
+
+import java.util.List;
+
+/**
+ * Created by greg on 8/26/16.
+ */
+public interface UIPlugin {
+    boolean doesApply(String path);
+
+    List<String> resourcesForPath(String path);
+}

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/rundeck/UIPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/rundeck/UIPlugin.java
@@ -19,10 +19,34 @@ package com.dtolabs.rundeck.plugins.rundeck;
 import java.util.List;
 
 /**
- * Created by greg on 8/26/16.
+ *
  */
 public interface UIPlugin {
+    /**
+     * @param path
+     *
+     * @return true if this plugin applies at the path
+     */
     boolean doesApply(String path);
 
+    /**
+     *
+     * @param path
+     * @return list of resources available at the path
+     */
     List<String> resourcesForPath(String path);
+
+    /**
+     * @param path
+     *
+     * @return list of javascript resources to load at the path
+     */
+    List<String> scriptResourcesForPath(String path);
+
+    /**
+     * @param path
+     *
+     * @return list of css stylesheets to load at the path
+     */
+    List<String> styleResourcesForPath(String path);
 }

--- a/core/src/test/java/com/dtolabs/rundeck/core/plugins/BaseScriptPluginTest.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/plugins/BaseScriptPluginTest.java
@@ -75,6 +75,7 @@ public class BaseScriptPluginTest {
     public void testCreateScriptArgsEmptyProvider() throws IOException {
         final Map<String, Object> data = new HashMap<String, Object>();
         data.put("script-file", "myfile.sh");
+        data.put("plugin-type", "script");
         File archiveFile = File.createTempFile("test", "zip");
         archiveFile.deleteOnExit();
         File basedir = File.createTempFile("test", "dir");
@@ -93,6 +94,7 @@ public class BaseScriptPluginTest {
     public void testCreateScriptArgsListEmptyProvider() throws IOException {
         final Map<String, Object> data = new HashMap<String, Object>();
         data.put("script-file", "myfile.sh");
+        data.put("plugin-type", "script");
         File archiveFile = File.createTempFile("test", "zip");
         archiveFile.deleteOnExit();
         File basedir = File.createTempFile("test", "dir");

--- a/plugins/flow-control-plugin/build.gradle
+++ b/plugins/flow-control-plugin/build.gradle
@@ -24,6 +24,7 @@ ext.pluginDescription = 'Control execution flow'
 
 jar {
     manifest {
+        attributes 'Rundeck-Plugin-Version': '1.2'
         attributes 'Rundeck-Plugin-Classnames': pluginClassNames
         attributes 'Rundeck-Plugin-Name': pluginName
         attributes 'Rundeck-Plugin-Description': pluginDescription

--- a/rundeckapp/grails-app/assets/javascripts/global/uiplugins.js
+++ b/rundeckapp/grails-app/assets/javascripts/global/uiplugins.js
@@ -22,36 +22,62 @@ function RundeckPage(data) {
     var self = this;
     self.project = ko.observable(data.project);
     self.path = ko.observable(data.path);
-    self.pageLoad = [];
     self.onPageLoad = function () {
 
     };
+    function supports_html5_storage() {
+        try {
+            return 'localStorage' in window && window['localStorage'] !== null;
+        } catch (e) {
+            return false;
+        }
+    }
     self.persistUserSetting = function (key, val) {
-        return jQuery.ajax({
-            url: _genUrl(appLinks.userAddFilterPref, {filterpref: key + "=" + val}),
-            method: 'POST',
-            beforeSend: _ajaxSendTokens.curry('uiplugin_tokens'),
-            success: function () {
-                console.log("saved successful for project " );
-            },
-            error: function () {
-                console.log("save failed for project " );
-            }
-        }).success(_ajaxReceiveTokens.curry('uiplugin_tokens'));
+        if (supports_html5_storage()) {
+            localStorage[key] = val;
+        }
+        // return jQuery.ajax({
+        //     url: _genUrl(appLinks.userAddFilterPref, {filterpref: key + "=" + val}),
+        //     method: 'POST',
+        //     beforeSend: _ajaxSendTokens.curry('uiplugin_tokens'),
+        //     success: function () {
+        //         console.log("saved successful for project " );
+        //     },
+        //     error: function () {
+        //         console.log("save failed for project " );
+        //     }
+        // }).success(_ajaxReceiveTokens.curry('uiplugin_tokens'));
+    };
+    self.removeUserSetting = function (key) {
+        if (supports_html5_storage()) {
+            localStorage.removeItem(key);
+        }
     };
     self.loadUserSetting=function (key) {
-        return jQuery.ajax({
-            url: _genUrl(appLinks.userLoadUserPrefAll, key && {key: key } || {}),
-            method: 'GET',
-            success: function (data) {
-                console.log("load data pref  " + data);
-            },
-            error: function () {
-                console.log("load failed for user pref ");
-            }
-        })
+        if (supports_html5_storage()) {
+            return localStorage[key];
+        }
+        // return jQuery.ajax({
+        //     url: _genUrl(appLinks.userLoadUserPrefAll, key && {key: key } || {}),
+        //     method: 'GET',
+        //     success: function (data) {
+        //         console.log("load data pref  " + data);
+        //     },
+        //     error: function () {
+        //         console.log("load failed for user pref ");
+        //     }
+        // })
+    };
+    /**
+     * Called last at end of page load
+     */
+    self.onPageLoad = function () {
+        jQuery(document).trigger(
+            jQuery.Event('load.rundeck.page', {
+                relatedTarget: self
+            }));
     }
 }
 jQuery(function () {
-    window.rundeckPage = new RundeckPage(loadJsonData('pageData'));
+    window.rundeckPage = new RundeckPage(loadJsonData('uipluginData'));
 });

--- a/rundeckapp/grails-app/assets/javascripts/global/uiplugins.js
+++ b/rundeckapp/grails-app/assets/javascripts/global/uiplugins.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//= require knockout.min
+//= require knockout-mapping
+
+function RundeckPage(data) {
+    "use strict";
+    var self = this;
+    self.project = ko.observable(data.project);
+    self.path = ko.observable(data.path);
+    self.pageLoad = [];
+    self.onPageLoad = function () {
+
+    };
+    self.persistUserSetting = function (key, val) {
+        return jQuery.ajax({
+            url: _genUrl(appLinks.userAddFilterPref, {filterpref: key + "=" + val}),
+            method: 'POST',
+            beforeSend: _ajaxSendTokens.curry('uiplugin_tokens'),
+            success: function () {
+                console.log("saved successful for project " );
+            },
+            error: function () {
+                console.log("save failed for project " );
+            }
+        }).success(_ajaxReceiveTokens.curry('uiplugin_tokens'));
+    };
+    self.loadUserSetting=function (key) {
+        return jQuery.ajax({
+            url: _genUrl(appLinks.userLoadUserPrefAll, key && {key: key } || {}),
+            method: 'GET',
+            success: function (data) {
+                console.log("load data pref  " + data);
+            },
+            error: function () {
+                console.log("load failed for user pref ");
+            }
+        })
+    }
+}
+jQuery(function () {
+    window.rundeckPage = new RundeckPage(loadJsonData('pageData'));
+});

--- a/rundeckapp/grails-app/assets/stylesheets/rundeck.less
+++ b/rundeckapp/grails-app/assets/stylesheets/rundeck.less
@@ -82,11 +82,11 @@
     .glyphicon();
     .glyphicon-chevron-down();
   }
-  .auto-caret{
+  .auto-caret, .accordion-toggle.collapsed .auto-caret{
     .glyphicon();
     .glyphicon-chevron-right();
   }
-  .auto-caret-container{
+  .auto-caret-container, .accordion-toggle{
     .auto-caret, .auto-caret-left {
       .glyphicon();
       .glyphicon-chevron-down();

--- a/rundeckapp/grails-app/conf/UrlMappings.groovy
+++ b/rundeckapp/grails-app/conf/UrlMappings.groovy
@@ -231,6 +231,9 @@ class UrlMappings {
         "/storage/download/keys/$resourcePath**"(controller: 'storage', action: 'keyStorageDownload')
         "/job/show/$id"(controller: 'scheduledExecution',action: 'show')
         "/execution/show/$id"(controller: 'execution',action: 'show')
+        "/plugin/icon/$service/$name"(controller: 'plugin', action: 'pluginIcon')
+        "/plugin/file/$service/$name/$path**"(controller: 'plugin', action: 'pluginFile')
+
         "404"(view: '/404')
         "500"(view: '/error')
     }

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -203,7 +203,7 @@ beans={
         rundeckServerServiceProviderLoader = ref('rundeckServerServiceProviderLoader')
     }
 
-    uiPluginProviderService(UIPluginProviderService) {
+    uiPluginProviderService(UIPluginProviderService,rundeckFramework) {
         rundeckServerServiceProviderLoader = ref('rundeckServerServiceProviderLoader')
     }
 

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -38,6 +38,7 @@ import com.dtolabs.rundeck.server.plugins.services.StoragePluginProviderService
 import com.dtolabs.rundeck.server.plugins.services.StorageConverterPluginProviderService
 import com.dtolabs.rundeck.server.plugins.services.StreamingLogReaderPluginProviderService
 import com.dtolabs.rundeck.server.plugins.services.StreamingLogWriterPluginProviderService
+import com.dtolabs.rundeck.server.plugins.services.UIPluginProviderService
 import com.dtolabs.rundeck.server.plugins.storage.DbStoragePluginFactory
 import com.dtolabs.rundeck.server.storage.StorageTreeFactory
 import org.rundeck.web.infosec.ContainerPrincipalRoleSource
@@ -199,6 +200,10 @@ beans={
     }
 
     scmImportPluginProviderService(ScmImportPluginProviderService) {
+        rundeckServerServiceProviderLoader = ref('rundeckServerServiceProviderLoader')
+    }
+
+    uiPluginProviderService(UIPluginProviderService) {
         rundeckServerServiceProviderLoader = ref('rundeckServerServiceProviderLoader')
     }
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ControllerBase.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ControllerBase.groovy
@@ -34,29 +34,38 @@ import java.util.zip.GZIPOutputStream
  * @since 2014-03-12
  */
 class ControllerBase {
+    public static final ArrayList<String> UIPLUGIN_PAGES = [
+            'menu/jobs',
+            'menu/home',
+            'menu/executionMode',
+            'menu/admin',
+            "menu/logStorage",
+            "menu/securityConfig",
+            "menu/systemInfo",
+            "menu/systemConfig",
+            "menu/metrics",
+            "menu/plugins",
+            "menu/welcome",
+            "menu/storage",
+            "scheduledExecution/show",
+            "scheduledExecution/edit",
+            "scheduledExecution/delete",
+            "scheduledExecution/create",
+            "execution/show",
+            "framework/nodes",
+            "framework/adhoc",
+            "framework/createProject",
+            "framework/editProject",
+            "framework/editProjectConfig",
+            "scm/index",
+            "reports/index",
+    ]
     def grailsApplication
     UiPluginService uiPluginService
 
     protected def loadUiPlugins(path) {
         def uiplugins = [:]
-        if ((path in [
-                'menu/jobs',
-                'menu/home',
-                'menu/executionMode',
-                'menu/admin',
-                "menu/logStorage",
-                "menu/securityConfig",
-                "menu/systemInfo",
-                "menu/metrics",
-                "menu/plugins",
-                "menu/welcome",
-                "scheduledExecution/show",
-                "scheduledExecution/edit",
-                "scheduledExecution/delete",
-                "scheduledExecution/create",
-                "execution/show",
-        ])) {
-
+        if ((path in UIPLUGIN_PAGES)) {
             uiPluginService.pluginsForPage(path).each { name, inst ->
                 uiplugins[name] = [
                         scripts: inst.scriptResourcesForPath(path),

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ControllerBase.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ControllerBase.groovy
@@ -69,6 +69,7 @@ class ControllerBase {
 
     def afterInterceptor = { model ->
         model.uiplugins = loadUiPlugins(controllerName + "/" + actionName)
+        model.uipluginsPath = controllerName + "/" + actionName
     }
     protected def withHmacToken(Closure valid){
         GrailsWebRequest request= (GrailsWebRequest) RequestContextHolder.currentRequestAttributes()

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -1223,6 +1223,14 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             it.value.description
         }.sort { a, b -> a.name <=> b.name }
 
+
+        def uiPluginProfiles = [:]
+        pluginDescs.each { svc, list ->
+            list.each { desc ->
+                uiPluginProfiles[svc + ":" + desc.name] = uiPluginService.getProfileFor(svc, desc.name)
+            }
+        }
+
         def defaultScopes=[
                 (framework.getNodeStepExecutorService().name) : PropertyScope.InstanceOnly,
                 (framework.getStepExecutionService().name) : PropertyScope.InstanceOnly,
@@ -1268,7 +1276,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 serviceDefaultScopes: defaultScopes,
                 bundledPlugins      : bundledPlugins,
                 specialConfiguration: specialConfiguration,
-                specialScoping      : specialScoping
+                specialScoping      : specialScoping,
+                uiPluginProfiles    : uiPluginProfiles
         ]
     }
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -58,6 +58,7 @@ import rundeck.services.NotificationService
 import rundeck.services.PluginService
 import rundeck.services.ScheduledExecutionService
 import rundeck.services.ScmService
+import rundeck.services.UiPluginService
 import rundeck.services.UserService
 import rundeck.services.framework.RundeckProjectConfigurable
 
@@ -75,6 +76,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     StoragePluginProviderService storagePluginProviderService
     StorageConverterPluginProviderService storageConverterPluginProviderService
     PluginService pluginService
+    UiPluginService uiPluginService
     def configurationService
     ScmService scmService
     def quartzScheduler
@@ -231,7 +233,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     def clearJobsFilter = { ScheduledExecutionQuery query ->
         return redirect(action: 'jobs', params: [project: params.project])
     }
-    def jobs = {ScheduledExecutionQuery query ->
+    def jobs (ScheduledExecutionQuery query ){
         
         def User u = userService.findOrCreateUser(session.user)
         if(params.size()<1 && !params.filterName && u ){
@@ -253,7 +255,10 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
 
         withFormat{
             html {
-                results
+
+                def plugins = uiPluginService.pluginsForPage("menu/jobs")
+
+                results + [uiPlugins: plugins]
             }
             yaml{
                 final def encoded = JobsYAMLCodec.encode(results.nextScheduled as List)
@@ -269,8 +274,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             }
         }
     }
-    
-    def jobsFragment = {ScheduledExecutionQuery query ->
+
+    def jobsFragment(ScheduledExecutionQuery query) {
         long start=System.currentTimeMillis()
         UserAndRolesAuthContext authContext
         def usedFilter=null

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -257,8 +257,15 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             html {
 
                 def plugins = uiPluginService.pluginsForPage("menu/jobs")
+                def uiplugins=[:]
+                plugins.each{name,inst->
+                    uiplugins[name]=[
+                            scripts:inst.scriptResourcesForPath("menu/jobs"),
+                            styles:inst.styleResourcesForPath("menu/jobs"),
+                    ]
+                }
 
-                results + [uiPlugins: plugins]
+                results + [uiplugins:uiplugins]
             }
             yaml{
                 final def encoded = JobsYAMLCodec.encode(results.nextScheduled as List)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -76,7 +76,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     StoragePluginProviderService storagePluginProviderService
     StorageConverterPluginProviderService storageConverterPluginProviderService
     PluginService pluginService
-    UiPluginService uiPluginService
+
     def configurationService
     ScmService scmService
     def quartzScheduler
@@ -255,17 +255,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
 
         withFormat{
             html {
-
-                def plugins = uiPluginService.pluginsForPage("menu/jobs")
-                def uiplugins=[:]
-                plugins.each{name,inst->
-                    uiplugins[name]=[
-                            scripts:inst.scriptResourcesForPath("menu/jobs"),
-                            styles:inst.styleResourcesForPath("menu/jobs"),
-                    ]
-                }
-
-                results + [uiplugins:uiplugins]
+                results
             }
             yaml{
                 final def encoded = JobsYAMLCodec.encode(results.nextScheduled as List)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
@@ -1,22 +1,43 @@
 package rundeck.controllers
 
-import org.apache.commons.fileupload.util.Streams
+import com.dtolabs.rundeck.app.support.PluginResourceReq
 import rundeck.services.UiPluginService
 
 class PluginController {
     def UiPluginService uiPluginService
 
-    def pluginIcon(String service, String name) {
-        def profile = uiPluginService.getProfileFor(service, name)
+    def pluginIcon(PluginResourceReq resourceReq) {
+        if (resourceReq.hasErrors()) {
+            request.errors = resourceReq.errors
+            response.status = 400
+            return render(view: '/common/error')
+        }
+        def profile = uiPluginService.getProfileFor(resourceReq.service, resourceReq.name)
         if (!profile.icon) {
             return respond([status: 404])
         }
-        def istream = uiPluginService.openResourceForPlugin(service, name, profile.icon)
+        resourceReq.path = profile.icon
+        pluginFile(resourceReq)
+    }
+
+    def pluginFile(PluginResourceReq resourceReq) {
+        if (!resourceReq.path) {
+            resourceReq.errors.rejectValue('path', 'blank')
+        }
+        if (resourceReq.hasErrors()) {
+            request.errors = resourceReq.errors
+            response.status = 400
+            return render(view: '/common/error')
+        }
+        def istream = uiPluginService.openResourceForPlugin(resourceReq.service, resourceReq.name, resourceReq.path)
         if (null == istream) {
             return respond([status: 404])
         }
-        response.contentType = 'image/png'
-        Streams.copy(istream, response.outputStream, true)
+        def format = servletContext.getMimeType(resourceReq.path)
+
+        response.contentType = format
+        response.outputStream << istream.bytes
         istream.close()
+        response.flushBuffer()
     }
 }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
@@ -1,0 +1,22 @@
+package rundeck.controllers
+
+import org.apache.commons.fileupload.util.Streams
+import rundeck.services.UiPluginService
+
+class PluginController {
+    def UiPluginService uiPluginService
+
+    def pluginIcon(String service, String name) {
+        def profile = uiPluginService.getProfileFor(service, name)
+        if (!profile.icon) {
+            return respond([status: 404])
+        }
+        def istream = uiPluginService.openResourceForPlugin(service, name, profile.icon)
+        if (null == istream) {
+            return respond([status: 404])
+        }
+        response.contentType = 'image/png'
+        Streams.copy(istream, response.outputStream, true)
+        istream.close()
+    }
+}

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -26,8 +26,10 @@ import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.INodeEntry
+import com.dtolabs.rundeck.core.plugins.configuration.Description
 import com.dtolabs.rundeck.core.utils.NodeSet
 import com.dtolabs.rundeck.core.utils.OptsUtil
+import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.converters.JSON
 import groovy.xml.MarkupBuilder
@@ -99,6 +101,7 @@ class ScheduledExecutionController  extends ControllerBase{
     def ApiService apiService
     def UserService userService
     def ScmService scmService
+    def UiPluginService uiPluginService
 
 
     def index = { redirect(controller:'menu',action:'jobs',params:params) }
@@ -1865,6 +1868,19 @@ class ScheduledExecutionController  extends ControllerBase{
         }
         def nodeStepTypes = frameworkService.getNodeStepPluginDescriptions()
         def stepTypes = frameworkService.getStepPluginDescriptions()
+        def uiPluginProfiles = [:]
+//        nodeStepTypes.each{ Description desc->
+//            uiPluginProfiles[ServiceNameConstants.WorkflowNodeStep+":"+desc.name] =
+//            uiPluginService.getProfileFor(ServiceNameConstants.WorkflowNodeStep,
+//                                          desc.name
+//            )
+//        }
+        stepTypes.each {
+            def profile = uiPluginService.getProfileFor(ServiceNameConstants.WorkflowStep, it.name)
+            uiPluginProfiles[ServiceNameConstants.WorkflowStep+":"+it.name]=profile
+        }
+
+        System.err.println("profiles: $uiPluginProfiles")
         def crontab = scheduledExecution.timeAndDateAsBooleanMap()
         return [ scheduledExecution:scheduledExecution, crontab:crontab,params:params,
                 notificationPlugins: notificationService.listNotificationPlugins(),
@@ -1872,7 +1888,8 @@ class ScheduledExecutionController  extends ControllerBase{
                 nextExecutionTime:scheduledExecutionService.nextExecutionTime(scheduledExecution),
                 authorized:scheduledExecutionService.userAuthorizedForJob(request,scheduledExecution,authContext),
                 nodeStepDescriptions: nodeStepTypes,
-                stepDescriptions:stepTypes]
+                stepDescriptions:stepTypes,
+                 uiPluginProfiles:uiPluginProfiles]
     }
 
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -101,7 +101,6 @@ class ScheduledExecutionController  extends ControllerBase{
     def ApiService apiService
     def UserService userService
     def ScmService scmService
-    def UiPluginService uiPluginService
 
 
     def index = { redirect(controller:'menu',action:'jobs',params:params) }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -1869,18 +1869,15 @@ class ScheduledExecutionController  extends ControllerBase{
         def nodeStepTypes = frameworkService.getNodeStepPluginDescriptions()
         def stepTypes = frameworkService.getStepPluginDescriptions()
         def uiPluginProfiles = [:]
-//        nodeStepTypes.each{ Description desc->
-//            uiPluginProfiles[ServiceNameConstants.WorkflowNodeStep+":"+desc.name] =
-//            uiPluginService.getProfileFor(ServiceNameConstants.WorkflowNodeStep,
-//                                          desc.name
-//            )
-//        }
+        nodeStepTypes.each{ Description desc->
+            def profile = uiPluginService.getProfileFor(ServiceNameConstants.WorkflowNodeStep, desc.name)
+            uiPluginProfiles[ServiceNameConstants.WorkflowNodeStep+":"+desc.name]=profile
+        }
         stepTypes.each {
             def profile = uiPluginService.getProfileFor(ServiceNameConstants.WorkflowStep, it.name)
             uiPluginProfiles[ServiceNameConstants.WorkflowStep+":"+it.name]=profile
         }
 
-        System.err.println("profiles: $uiPluginProfiles")
         def crontab = scheduledExecution.timeAndDateAsBooleanMap()
         return [ scheduledExecution:scheduledExecution, crontab:crontab,params:params,
                 notificationPlugins: notificationService.listNotificationPlugins(),

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1328,5 +1328,6 @@ edit=edit
 really.delete.option.0=Really delete option {0}?
 execution.log.no.output=Execution has no log output
 request.authentication.required=Authentication is required
+com.dtolabs.rundeck.app.support.PluginResourceReq.path.matches.invalid.path=Invalid path: {2}
 scheduledExecution.property.notified.label.text=Send Notification?
 notification.plugin.configuration.noproperties.message=No configuration properties for {0}

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1328,5 +1328,6 @@ edit=edit
 really.delete.option.0=Really delete option {0}?
 execution.log.no.output=Execution has no log output
 request.authentication.required=Authentication is required
+com.dtolabs.rundeck.app.support.PluginResourceReq.path.matches.invalid.path=Invalid path: {2}
 scheduledExecution.property.notified.label.text=Send Notification?
 notification.plugin.configuration.noproperties.message=No configuration properties for {0}

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -90,6 +90,27 @@ class FrameworkService implements ApplicationContextAware {
      * @param grailsApplication
      * @return
      */
+    def listEmbeddedPlugins(GrailsApplication grailsApplication) {
+        def loader = new ApplicationContextPluginFileSource(grailsApplication.mainContext, '/WEB-INF/rundeck/plugins/')
+        def result = [success: true, logs: []]
+        def pluginsDir = getRundeckFramework().getLibextDir()
+        def pluginList
+        try {
+            pluginList = loader.listManifests()
+        } catch (IOException e) {
+            log.error("Could not load plugins: ${e}", e)
+            result.message = "Could not load plugins: ${e}"
+            result.success = false
+            return result
+        }
+        result.pluginList=pluginList
+        return result
+    }
+    /**
+     * Install all the embedded plugins, will not overwrite existing plugin files with the same name
+     * @param grailsApplication
+     * @return
+     */
     def extractEmbeddedPlugins(GrailsApplication grailsApplication){
         def loader = new ApplicationContextPluginFileSource(grailsApplication.mainContext, '/WEB-INF/rundeck/plugins/')
         def result=[success:true,logs:[]]

--- a/rundeckapp/grails-app/services/rundeck/services/UiPluginService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/UiPluginService.groovy
@@ -36,29 +36,19 @@ class UiPluginService {
         loaded
     }
 
-    final Map providerProfiles = [:]
 
     def getProfileFor(String service, String name) {
-        def profile = providerProfiles[service + ':' + name]
-        if (null == profile) {
-            synchronized (providerProfiles) {
-                if (null == profile) {
-                    profile = [:]
-                    def reslist = resourcesForPlugin(service, name)
-                    if (reslist) {
-                        def testlist = ['png', 'gif'].inject([]) { list, ext ->
-                            list + ["${service}.${name}.icon.", 'icon.'].collect { prefix ->
-                                prefix + ext
-                            }
-                        }
-                        profile['icon'] = testlist.find { reslist?.contains(it.toString()) }
-                    }
-                    profile['metadata'] = metadataForPlugin(service, name)
-                    providerProfiles[service + ':' + name] = profile
+        def profile = [:]
+        def reslist = resourcesForPlugin(service, name)
+        if (reslist) {
+            def testlist = ['png', 'gif'].inject([]) { list, ext ->
+                list + ["${service}.${name}.icon.", 'icon.'].collect { prefix ->
+                    prefix + ext
                 }
             }
+            profile['icon'] = testlist.find { reslist?.contains(it.toString()) }
         }
-
+        profile['metadata'] = metadataForPlugin(service, name)
         profile
     }
 

--- a/rundeckapp/grails-app/services/rundeck/services/UiPluginService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/UiPluginService.groovy
@@ -11,14 +11,21 @@ class UiPluginService {
     def PluginRegistry rundeckPluginRegistry
     def PluginService pluginService
     def UIPluginProviderService uiPluginProviderService
-    Map loadingCache = [:]
+    Map<String, Map<String, UIPlugin>> loadingCache = [:]
+    List<String> loadedPlugins = []
 
-    def pluginsForPage(String path) {
-        if (loadingCache[path] != null) {
+    Map<String, UIPlugin> pluginsForPage(String path) {
+        def reload = false
+        def plugins = pluginService.listPlugins(UIPlugin, uiPluginProviderService)
+        if (plugins.values()*.name.sort() != loadedPlugins) {
+            loadedPlugins = plugins.values()*.name.sort()
+            reload = true
+        }
+        if (!reload && loadingCache[path] != null) {
             return loadingCache[path]
         }
+
         def loaded = [:]
-        def plugins = pluginService.listPlugins(UIPlugin, uiPluginProviderService)
         plugins.each { String name, DescribedPlugin<UIPlugin> plugin ->
             UIPlugin inst = pluginService.getPlugin(plugin.name, uiPluginProviderService)
             if (inst.doesApply(path)) {

--- a/rundeckapp/grails-app/services/rundeck/services/UiPluginService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/UiPluginService.groovy
@@ -53,6 +53,7 @@ class UiPluginService {
                         }
                         profile['icon'] = testlist.find { reslist?.contains(it.toString()) }
                     }
+                    profile['metadata'] = metadataForPlugin(service, name)
                     providerProfiles[service + ':' + name] = profile
                 }
             }
@@ -71,6 +72,9 @@ class UiPluginService {
         rundeckPluginRegistry.getResourceLoader(service, name)?.listResources()
     }
 
+    def metadataForPlugin(String service, String name) {
+        rundeckPluginRegistry.getPluginMetadata(service, name)
+    }
     /**
      * open input stream for the resource
      * @param service

--- a/rundeckapp/grails-app/services/rundeck/services/UiPluginService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/UiPluginService.groovy
@@ -1,0 +1,70 @@
+package rundeck.services
+
+import com.dtolabs.rundeck.core.plugins.PluginException
+import com.dtolabs.rundeck.core.plugins.ProviderIdent
+import com.dtolabs.rundeck.plugins.rundeck.UIPlugin
+import com.dtolabs.rundeck.server.plugins.DescribedPlugin
+import com.dtolabs.rundeck.server.plugins.PluginRegistry
+import com.dtolabs.rundeck.server.plugins.services.UIPluginProviderService
+import grails.transaction.Transactional
+
+class UiPluginService {
+    static boolean transactional = false
+    def PluginRegistry rundeckPluginRegistry
+    def PluginService pluginService
+    def UIPluginProviderService uiPluginProviderService
+    Map loadingCache = [:]
+
+    def pluginsForPage(String path) {
+        if (loadingCache[path] != null) {
+            return loadingCache[path]
+        }
+        def loaded = []
+        def plugins = pluginService.listPlugins(UIPlugin, uiPluginProviderService)
+        plugins.each { String name, DescribedPlugin<UIPlugin> plugin ->
+            UIPlugin inst = pluginService.getPlugin(plugin.name, uiPluginProviderService)
+            if (inst.doesApply(path)) {
+                loaded << inst
+            }
+        }
+        loadingCache[path] = loaded
+    }
+
+    Map providerProfiles = [:]
+
+    def getProfileFor(String service, String name) {
+        def profile = [:]
+        def reslist = resourcesForPlugin(service, name)
+        if (reslist?.contains("$service:$name:icon.png".toString())) {
+            profile['icon'] = "$service:$name:icon.png"
+        } else if (reslist?.contains('icon.png')) {
+            profile['icon'] = "icon.png"
+        }
+        profile
+    }
+
+    /**
+     * List of resource names for the given plugin, or null
+     * @param service
+     * @param name
+     * @return
+     */
+    def resourcesForPlugin(String service, String name) {
+        rundeckPluginRegistry.getResourceLoader(service, name)?.listResources()
+    }
+
+    /**
+     * open input stream for the resource
+     * @param service
+     * @param name
+     * @param path
+     * @return
+     */
+    def openResourceForPlugin(String service, String name, String path) {
+        try {
+            return rundeckPluginRegistry.getResourceLoader(service, name)?.openResourceStreamFor(path)
+        } catch (IOException | PluginException e) {
+            return null
+        }
+    }
+}

--- a/rundeckapp/grails-app/taglib/rundeck/PluginTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/PluginTagLib.groovy
@@ -31,6 +31,7 @@ class PluginTagLib {
                     template: "/framework/renderPluginConfig",
                     model: [
                             type: step.type,
+                            serviceName:step.nodeStep?'WorkflowNodeStep':'WorkflowStep',
                             values: step?.configuration,
                             description: description
                     ] + attrs.subMap(['showPluginIcon','showNodeIcon','prefix', 'includeFormFields'])

--- a/rundeckapp/grails-app/views/execution/_execDetailsNotification.gsp
+++ b/rundeckapp/grails-app/views/execution/_execDetailsNotification.gsp
@@ -32,7 +32,7 @@
         <g:expander key="notificationplugin${ukey}"><g:enc>${desc.title}</g:enc> </g:expander>
         <span class="" id="notificationplugin${ukey}" style="display:none;" title="">
             <g:render template="/framework/renderPluginConfig"
-                      model="${[values: notification.configuration, description: desc, hideTitle: true]}"/>
+                      model="${[serviceName:'Notification',values: notification.configuration, description: desc, hideTitle: true]}"/>
         </span>
     </g:if>
     <g:elseif test="${!notificationPlugins?.get(notification.type)}">

--- a/rundeckapp/grails-app/views/execution/_execDetailsOrchestrator.gsp
+++ b/rundeckapp/grails-app/views/execution/_execDetailsOrchestrator.gsp
@@ -21,7 +21,7 @@
     <g:expander key="orchestratorplugin${orchestrator.type}">${desc.title.encodeAsHTML()} </g:expander>
     <span class="" id="orchestratorplugin${orchestrator.type}" style="display:none;" title="">
         <g:render template="/framework/renderPluginConfig"
-                  model="${[values: orchestrator.configuration, description: desc, hideTitle: true]}"/>
+                  model="${[serviceName:'Orchestrator',values: orchestrator.configuration, description: desc, hideTitle: true]}"/>
     </span>
 </g:if>
 <g:elseif test="${!orchestratorPlugins?.getDescription(orchestrator.type)}">

--- a/rundeckapp/grails-app/views/execution/_wfAddStep.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfAddStep.gsp
@@ -72,7 +72,16 @@
 
                         <a  class="list-group-item textbtn  add_node_step_type" data-node-step-type="${enc(attr:typedesc.name)}"
                             href="#">
-                            <i class="rdicon icon-small plugin"></i>
+                            <g:if test="${uiPluginProfiles?.get('WorkflowNodeStep:'+typedesc.name)?.icon}">
+                                <img src="${createLink(
+                                        controller: 'plugin',
+                                        action: 'pluginIcon',
+                                        params: [service: 'WorkflowNodeStep', name: typedesc.name]
+                                )}" width="24px" height="24px"/>
+                            </g:if>
+                            <g:else>
+                                <i class="rdicon icon-small plugin"></i>
+                            </g:else>
                             <g:enc>${typedesc.title}</g:enc>
                             <span class="text-info">-
                             <g:render template="/scheduledExecution/description"
@@ -102,7 +111,16 @@
                     </div>
                     <g:each in="${stepDescriptions.sort{a,b->a.name<=>b.name}}" var="typedesc">
                         <a class="list-group-item textbtn  add_step_type" data-step-type="${enc(attr:typedesc.name)}" href="#">
-                            <i class="rdicon icon-small plugin"></i>
+                            <g:if test="${uiPluginProfiles?.get('WorkflowStep:'+typedesc.name)?.icon}">
+                                <img src="${createLink(
+                                        controller: 'plugin',
+                                        action: 'pluginIcon',
+                                        params: [service: 'WorkflowStep', name: typedesc.name]
+                                )}" width="24px" height="24px"/>
+                            </g:if>
+                            <g:else>
+                                <i class="rdicon icon-small plugin"></i>
+                            </g:else>
                             <g:enc>${typedesc.title}</g:enc>
                             <span class="text-info">-
                                 <g:render template="/scheduledExecution/description"

--- a/rundeckapp/grails-app/views/execution/_wfAddStep.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfAddStep.gsp
@@ -77,7 +77,7 @@
                                         controller: 'plugin',
                                         action: 'pluginIcon',
                                         params: [service: 'WorkflowNodeStep', name: typedesc.name]
-                                )}" width="24px" height="24px"/>
+                                )}" width="16px" height="16px"/>
                             </g:if>
                             <g:else>
                                 <i class="rdicon icon-small plugin"></i>
@@ -116,7 +116,7 @@
                                         controller: 'plugin',
                                         action: 'pluginIcon',
                                         params: [service: 'WorkflowStep', name: typedesc.name]
-                                )}" width="24px" height="24px"/>
+                                )}" width="16px" height="16px"/>
                             </g:if>
                             <g:else>
                                 <i class="rdicon icon-small plugin"></i>

--- a/rundeckapp/grails-app/views/execution/_wfItemView.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfItemView.gsp
@@ -83,7 +83,16 @@
             </g:if>
             <g:elseif test="${pluginitem}">
                 <g:if test="${!noimgs && item.description}">
-                    <i class="rdicon icon-small plugin"></i>
+                    <g:if test="${uiPluginProfiles?.get("Workflow${item.nodeStep?'Node':''}Step:"+item.type)?.icon}">
+                        <img src="${createLink(
+                                controller: 'plugin',
+                                action: 'pluginIcon',
+                                params: [service: "Workflow${item.nodeStep?'Node':''}Step:", name: item.type]
+                        )}" width="16px" height="16px"/>
+                    </g:if>
+                    <g:else>
+                        <i class="rdicon icon-small plugin"></i>
+                    </g:else>
                     <g:if test="${item && item.nodeStep}">
                         <i class="rdicon icon-small node"></i>
                     </g:if>

--- a/rundeckapp/grails-app/views/framework/_renderPluginConfig.gsp
+++ b/rundeckapp/grails-app/views/framework/_renderPluginConfig.gsp
@@ -25,7 +25,16 @@
     <div class="row">
     <div class="col-sm-12">
         <g:if test="${showPluginIcon}">
-            <i class="rdicon icon-small plugin"></i>
+            <g:if test="${uiPluginProfiles?.get(serviceName+":"+description.name)?.icon}">
+                <img src="${createLink(
+                        controller: 'plugin',
+                        action: 'pluginIcon',
+                        params: [service: serviceName, name: description.name]
+                )}" width="16px" height="16px"/>
+            </g:if>
+            <g:else>
+                <i class="rdicon icon-small plugin"></i>
+            </g:else>
         </g:if>
         <g:if test="${showNodeIcon}">
             <i class="rdicon icon-small node"></i>

--- a/rundeckapp/grails-app/views/framework/_viewResourceModelConfig.gsp
+++ b/rundeckapp/grails-app/views/framework/_viewResourceModelConfig.gsp
@@ -23,4 +23,4 @@
  --%>
 
 <%@ page contentType="text/html;charset=UTF-8" %>
-<g:render template="/framework/renderPluginConfig" model="${[project:project,prefix:prefix,includeFormFields:includeFormFields,values:values,description:description,type:type]}"/>
+<g:render template="/framework/renderPluginConfig" model="${[serviceName:'ResourceModelSource',project:project,prefix:prefix,includeFormFields:includeFormFields,values:values,description:description,type:type]}"/>

--- a/rundeckapp/grails-app/views/layouts/base.gsp
+++ b/rundeckapp/grails-app/views/layouts/base.gsp
@@ -72,7 +72,46 @@
             <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="${pageProperty(name:'meta.rssfeed')}"/>
         </g:ifServletContextAttribute>
     </g:if>
+
+    <g:if test="${uiplugins && uipluginsPath && params.uiplugins!='false'}">
+
+        <g:embedJSON id="uipluginData" data="${[path: uipluginsPath, project: params.project ?: request.project]}"/>
+        <g:if test="${uiplugins}">
+            <asset:javascript src="global/uiplugins.js"/>
+            <g:jsonToken id="uiplugin_tokens" url="${request.forwardURI}"/>
+        </g:if>
+        <g:each in="${uiplugins?.keySet()}" var="pluginname">
+            <!-- BEGIN UI plugin scripts for ${pluginname} -->
+            <g:each in="${uiplugins[pluginname].scripts}" var="scriptPath">
+                <script src="${createLink(
+                        controller: 'plugin',
+                        action: 'pluginFile',
+                        params: [service: 'UI', name: pluginname, path: scriptPath]
+                )}" type="text/javascript"></script>
+            </g:each>
+            <!-- END UI Plugin scripts for ${pluginname} -->
+        </g:each>
+
+        <g:each in="${uiplugins?.keySet()}" var="pluginname">
+            <!-- BEGIN UI plugin css for ${pluginname} -->
+            <g:each in="${uiplugins[pluginname].styles}" var="scriptPath">
+                <link rel="stylesheet" href="${createLink(
+                        controller: 'plugin',
+                        action: 'pluginFile',
+                        params: [service: 'UI', name: pluginname, path: scriptPath]
+                )}"/>
+            </g:each>
+            <!-- END UI Plugin css for ${pluginname} -->
+        </g:each>
+
+    </g:if>
     <g:layoutHead/>
+    <g:if test="${uiplugins && uipluginsPath && params.uiplugins!='false'}">
+        <g:javascript>
+            //call after gsp page has loaded javascript
+            jQuery(function(){window.rundeckPage.onPageLoad();});
+        </g:javascript>
+    </g:if>
 </head>
 <body>
 <g:render template="/common/topbar"/>

--- a/rundeckapp/grails-app/views/menu/_jobslist.gsp
+++ b/rundeckapp/grails-app/views/menu/_jobslist.gsp
@@ -45,7 +45,11 @@
                         %{-- select job view --}%
                         <g:if test="${jobsjscallback}">
                             <tr class=" expandComponentHolder expanded" id="jobrow_${scheduledExecution.id}">
-                               <td class="jobname" style="overflow:hidden; text-overflow: ellipsis; white-space: nowrap; overflow-x: hidden">
+                               <td class="jobname"
+                                   data-job-id="${scheduledExecution.extid}"
+                                   data-job-name="${scheduledExecution.jobName}"
+                                   data-job-group="${scheduledExecution.groupPath}"
+                                   style="overflow:hidden; text-overflow: ellipsis; white-space: nowrap; overflow-x: hidden">
                                        <g:set var="jstext" value="jobChosen('${enc(js: scheduledExecution.jobName)}','${enc(js: scheduledExecution.groupPath)}')"/>
                                        <span class="textbtn textbtn-success" title="Choose this job" onclick="${enc(attr:jstext)}">
                                            <i class="glyphicon glyphicon-book"></i>
@@ -60,7 +64,11 @@
                         <g:else>
                             %{--normal view--}%
                         <tr class="sectionhead expandComponentHolder ${paginateParams?.idlist==scheduledExecution.id.toString()?'expanded':''}" id="jobrow_${scheduledExecution.id}">
-                            <td class="jobname" data-job-id="${scheduledExecution.extid}">
+                            <td class="jobname"
+                                data-job-id="${scheduledExecution.extid}"
+                                data-job-name="${scheduledExecution.jobName}"
+                                data-job-group="${scheduledExecution.groupPath}"
+                            >
                                 <span class="jobbulkeditfield" style="display: none" data-bind="visible: enabled">
                                 <input type="checkbox"
                                        name="ids"

--- a/rundeckapp/grails-app/views/menu/_jobslist.gsp
+++ b/rundeckapp/grails-app/views/menu/_jobslist.gsp
@@ -60,7 +60,7 @@
                         <g:else>
                             %{--normal view--}%
                         <tr class="sectionhead expandComponentHolder ${paginateParams?.idlist==scheduledExecution.id.toString()?'expanded':''}" id="jobrow_${scheduledExecution.id}">
-                            <td class="jobname">
+                            <td class="jobname" data-job-id="${scheduledExecution.extid}">
                                 <span class="jobbulkeditfield" style="display: none" data-bind="visible: enabled">
                                 <input type="checkbox"
                                        name="ids"

--- a/rundeckapp/grails-app/views/menu/_workflowsFull.gsp
+++ b/rundeckapp/grails-app/views/menu/_workflowsFull.gsp
@@ -136,7 +136,7 @@
 
                 <div class="jobscontent head">
     <g:if test="${!params.compact}">
-        <div class=" pull-right" >
+        <div class=" pull-right" id="jobpageactionbuttons">
 
             <g:if test="${scmExportEnabled && scmExportStatus || scmImportEnabled  && scmImportStatus}">
             %{--SCM synch status--}%

--- a/rundeckapp/grails-app/views/menu/admin.gsp
+++ b/rundeckapp/grails-app/views/menu/admin.gsp
@@ -247,7 +247,7 @@
                     <g:if test="${desc}">
 
                         <g:render template="/framework/renderPluginConfig"
-                                  model="${[values: nodeexecconfig.config, description: desc]}"/>
+                                  model="${[serviceName:'NodeExecutor',values: nodeexecconfig.config, description: desc]}"/>
                     </g:if>
                     <g:else>
                         <span
@@ -274,7 +274,7 @@
                     <g:if test="${desc}">
 
                         <g:render template="/framework/renderPluginConfig"
-                                  model="${[values: fcopyconfig.config, description: desc]}"/>
+                                  model="${[serviceName:'FileCopier',values: fcopyconfig.config, description: desc]}"/>
                     </g:if>
                     <g:else>
                         <span

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -550,6 +550,35 @@
             width:100%;
         }
     </style>
+    <g:embedJSON id="pageData" data="${[path: 'menu/jobs', project: params.project ?: request.project]}"/>
+    <g:if test="${uiplugins}">
+        <asset:javascript src="global/uiplugins.js"/>
+        <g:jsonToken id="uiplugin_tokens"  url="${request.forwardURI}"/>
+    </g:if>
+    <g:each in="${uiplugins?.keySet()}" var="pluginname">
+        <!-- BEGIN UI plugin scripts for ${pluginname} -->
+        <g:each in="${uiplugins[pluginname].scripts}" var="scriptPath">
+            <script src="${createLink(
+                    controller: 'plugin',
+                    action: 'pluginFile',
+                    params: [service: 'UI', name: pluginname, path: scriptPath]
+            )}" type="text/javascript"></script>
+        </g:each>
+        <!-- END UI Plugin scripts for ${pluginname} -->
+    </g:each>
+
+    <g:each in="${uiplugins?.keySet()}" var="pluginname">
+        <!-- BEGIN UI plugin css for ${pluginname} -->
+        <g:each in="${uiplugins[pluginname].styles}" var="scriptPath">
+            <link rel="stylesheet" href="${createLink(
+                    controller: 'plugin',
+                    action: 'pluginFile',
+                    params: [service: 'UI', name: pluginname, path: scriptPath]
+            )}"/>
+        </g:each>
+        <!-- END UI Plugin css for ${pluginname} -->
+    </g:each>
+
 </head>
 <body>
 
@@ -598,7 +627,6 @@
 </div>
 </div>
 </div>
-
 
 <div class="row row-space" id="activity_section">
     <div class="col-sm-12 ">

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -550,35 +550,6 @@
             width:100%;
         }
     </style>
-    <g:embedJSON id="pageData" data="${[path: 'menu/jobs', project: params.project ?: request.project]}"/>
-    <g:if test="${uiplugins}">
-        <asset:javascript src="global/uiplugins.js"/>
-        <g:jsonToken id="uiplugin_tokens"  url="${request.forwardURI}"/>
-    </g:if>
-    <g:each in="${uiplugins?.keySet()}" var="pluginname">
-        <!-- BEGIN UI plugin scripts for ${pluginname} -->
-        <g:each in="${uiplugins[pluginname].scripts}" var="scriptPath">
-            <script src="${createLink(
-                    controller: 'plugin',
-                    action: 'pluginFile',
-                    params: [service: 'UI', name: pluginname, path: scriptPath]
-            )}" type="text/javascript"></script>
-        </g:each>
-        <!-- END UI Plugin scripts for ${pluginname} -->
-    </g:each>
-
-    <g:each in="${uiplugins?.keySet()}" var="pluginname">
-        <!-- BEGIN UI plugin css for ${pluginname} -->
-        <g:each in="${uiplugins[pluginname].styles}" var="scriptPath">
-            <link rel="stylesheet" href="${createLink(
-                    controller: 'plugin',
-                    action: 'pluginFile',
-                    params: [service: 'UI', name: pluginname, path: scriptPath]
-            )}"/>
-        </g:each>
-        <!-- END UI Plugin css for ${pluginname} -->
-    </g:each>
-
 </head>
 <body>
 

--- a/rundeckapp/grails-app/views/menu/plugins.gsp
+++ b/rundeckapp/grails-app/views/menu/plugins.gsp
@@ -70,8 +70,8 @@
     <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#${ukey}" title="${serviceName}">
-                        <i class="glyphicon glyphicon-chevron-down"></i>
+                    <a class="accordion-toggle collapsed" data-toggle="collapse" data-parent="#accordion" href="#${ukey}" title="${serviceName}">
+                        <i class="auto-caret text-muted"></i>
     <g:message code="framework.service.${serviceName}.label.plural" default="${serviceName}"/></a>
 
                     <g:if test="${pluginDescList.size()>0}">

--- a/rundeckapp/grails-app/views/menu/plugins.gsp
+++ b/rundeckapp/grails-app/views/menu/plugins.gsp
@@ -105,9 +105,14 @@
                 <g:set var="ukeyx" value="${g.rkey()}"/>
     <div class="panel panel-default">
             <div class="panel-heading">
-                <h4 class="panel-title">
-                    <a class="accordion-toggle link-bare collapsed" data-toggle="collapse" data-parent="#accordion${enc(attr:ukey)}" href="#${enc(attr:ukeyx)}" title="${pluginName}">
+                <div class=" panel-title row">
+                    <div class="col-sm-8">
+
+                        <a class="accordion-toggle link-bare collapsed" data-toggle="collapse"
+                           data-parent="#accordion${enc(attr: ukey)}" href="#${enc(attr: ukeyx)}" title="${pluginName}">
                         <i class="auto-caret text-muted"></i>
+                            <g:set var="pluginFileMetadata"
+                                   value="${uiPluginProfiles?.get(serviceName + ":" + pluginName)?.metadata}"/>
                     <g:if test="${uiPluginProfiles?.get(serviceName+":"+pluginName)?.icon}">
                         <img src="${createLink(
                                 controller: 'plugin',
@@ -125,13 +130,67 @@
                                   model="[description: pluginDesc, textCss: 'text-muted',
                                           mode: 'hidden', rkey: g.rkey()]"/>
                     </g:if>
-                    <g:if test="${bundledPlugins&& bundledPlugins[serviceName] && bundledPlugins[serviceName].contains(pluginName)}">
-                        <span class="label label-default pull-right">bundled</span>
-                    </g:if>
-                    <g:else>
-                        <span class="label label-info pull-right">plugin</span>
-                    </g:else>
-                </h4>
+                    </div>
+
+                    <g:set var="source" value="${
+                        pluginFileMetadata?.filename && embeddedFilenames &&
+                                embeddedFilenames.contains(pluginFileMetadata?.filename) ?
+                                'embed' :
+
+                                bundledPlugins && bundledPlugins[serviceName] &&
+                                        bundledPlugins[serviceName].contains(pluginName) ?
+                                        'builtin' :
+                                        'file'
+                    }"/>
+
+                    <g:set var="metaInfo" value="${
+                        (pluginFileMetadata?.pluginDate ? '\n Date: ' + pluginFileMetadata?.pluginDate : '') +
+                                'Source: ' + (
+                                source == 'embed' ? 'This plugin file was included with Rundeck.' :
+                                        source == 'builtin' ? 'This provider is built in to Rundeck.' :
+                                                'This plugin was installed with a file.'
+                        )
+                    }"/>
+                    <g:set var="linkInfo" value="${
+                        (pluginFileMetadata?.pluginUrl ? "Website: " + pluginFileMetadata?.pluginUrl : '') +
+                                (pluginFileMetadata?.pluginAuthor ? '\nAuthor: ' + pluginFileMetadata?.pluginAuthor :
+                                        '')
+                    }"/>
+                    <div class="col-sm-4 text-right">
+                        <g:if test="${pluginFileMetadata?.pluginUrl}">
+                            <a class="textbtn small textbtn-info has_tooltip "
+                               title="${enc(attr: linkInfo)}"
+                               href="${g.enc(attr: pluginFileMetadata?.pluginUrl)}">
+                                ${pluginFileMetadata?.pluginAuthor ?: 'site'}
+                            </a> &nbsp;
+                        </g:if>
+                        <g:elseif test="${pluginFileMetadata?.pluginAuthor}">
+                            <span class="text-muted small has_tooltip"
+                                  title="Author">
+                                ${pluginFileMetadata?.pluginAuthor}
+                            </span>
+                        </g:elseif>
+
+                        <span class=" ${source == 'file' ? 'label label-info' : 'text-muted small'} has_tooltip "
+                              data-container="body"
+                              title="${metaInfo}">${pluginFileMetadata?.pluginFileVersion ?: ''}
+
+                        <g:if test="${source == 'embed'}">
+                            <g:icon name="file"/>
+                        </g:if>
+                        <g:elseif test="${source == 'builtin'}">
+
+                            <g:icon name="briefcase"/>
+                        </g:elseif>
+                        <g:else>
+
+                            <g:icon name="file"/>
+                        </g:else>
+                        </span>
+
+                    </div>
+
+                </div>
             </div>
 
             <div id="${enc(attr:ukeyx)}" class="panel-collapse collapse">

--- a/rundeckapp/grails-app/views/menu/plugins.gsp
+++ b/rundeckapp/grails-app/views/menu/plugins.gsp
@@ -106,9 +106,18 @@
     <div class="panel panel-default">
             <div class="panel-heading">
                 <h4 class="panel-title">
-                    <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion${enc(attr:ukey)}" href="#${enc(attr:ukeyx)}" title="${pluginName}">
-                        <i class="glyphicon glyphicon-chevron-down"></i>
-                    <i class="rdicon icon-small plugin"></i>
+                    <a class="accordion-toggle link-bare collapsed" data-toggle="collapse" data-parent="#accordion${enc(attr:ukey)}" href="#${enc(attr:ukeyx)}" title="${pluginName}">
+                        <i class="auto-caret text-muted"></i>
+                    <g:if test="${uiPluginProfiles?.get(serviceName+":"+pluginName)?.icon}">
+                        <img src="${createLink(
+                                controller: 'plugin',
+                                action: 'pluginIcon',
+                                params: [service: serviceName, name: pluginName]
+                        )}" width="16px" height="16px"/>
+                    </g:if>
+                    <g:else>
+                        <i class="rdicon icon-small plugin"></i>
+                    </g:else>
                     <g:enc>${pluginTitle?:pluginName}</g:enc></a>
 
                     <g:if test="${pluginDesc}">

--- a/rundeckapp/grails-app/views/scm/_pluginConfigList.gsp
+++ b/rundeckapp/grails-app/views/scm/_pluginConfigList.gsp
@@ -148,6 +148,7 @@
 
                     <g:render template="/framework/renderPluginConfig"
                               model="${[
+                                      serviceName:integration=='export'?'ScmExport':'ScmImport',
                                       values     : isConfigured ? pluginConfig.config : [:],
                                       description: plugins[pluginName].description,
                                       hideTitle  : true

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/support/PluginResourceReq.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/support/PluginResourceReq.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.support
+
+import grails.validation.Validateable
+
+/**
+ * Created by greg on 8/27/16.
+ */
+@Validateable
+class PluginResourceReq {
+    String service
+    String name
+    String path
+    static constraints = {
+        service(nullable: false, blank: false, matches: /^[-a-zA-Z0-9\.]+$/)
+        name(nullable: false, blank: false, matches: /^[-a-zA-Z0-9\.]+$/)
+        path(nullable: true, blank: true, matches: /^(((?!\.)[-a-zA-Z0-9+_\.]+)(\/((?!\.)[-a-zA-Z0-9+_\.]+))*)*$/)
+    }
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/PluginRegistry.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/PluginRegistry.groovy
@@ -17,7 +17,10 @@
 package com.dtolabs.rundeck.server.plugins
 
 import com.dtolabs.rundeck.core.common.Framework
+import com.dtolabs.rundeck.core.execution.service.ProviderLoaderException
 import com.dtolabs.rundeck.core.plugins.PluggableProviderService
+import com.dtolabs.rundeck.core.plugins.PluginResourceLoader
+import com.dtolabs.rundeck.core.plugins.ProviderIdent
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolver
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
 import com.dtolabs.rundeck.core.utils.IPropertyLookup
@@ -154,4 +157,7 @@ public interface PluginRegistry {
      * @return
      */
     public <T> Map<String, DescribedPlugin<T>> listPluginDescriptors(Class groovyPluginType, PluggableProviderService<T> service) ;
+
+
+    public PluginResourceLoader getResourceLoader(String service, String provider) throws ProviderLoaderException;
 }

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/PluginRegistry.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/PluginRegistry.groovy
@@ -19,6 +19,7 @@ package com.dtolabs.rundeck.server.plugins
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.execution.service.ProviderLoaderException
 import com.dtolabs.rundeck.core.plugins.PluggableProviderService
+import com.dtolabs.rundeck.core.plugins.PluginMetadata
 import com.dtolabs.rundeck.core.plugins.PluginResourceLoader
 import com.dtolabs.rundeck.core.plugins.ProviderIdent
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolver
@@ -158,6 +159,21 @@ public interface PluginRegistry {
      */
     public <T> Map<String, DescribedPlugin<T>> listPluginDescriptors(Class groovyPluginType, PluggableProviderService<T> service) ;
 
-
+    /**
+     * Return plugin resource loader
+     * @param service
+     * @param provider
+     * @return
+     * @throws ProviderLoaderException
+     */
     public PluginResourceLoader getResourceLoader(String service, String provider) throws ProviderLoaderException;
+
+    /**
+     * Return plugin metadata
+     * @param service
+     * @param provider
+     * @return
+     * @throws ProviderLoaderException
+     */
+    public PluginMetadata getPluginMetadata(String service, String provider) throws ProviderLoaderException;
 }

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.execution.service.ExecutionServiceException
 import com.dtolabs.rundeck.core.execution.service.MissingProviderException
 import com.dtolabs.rundeck.core.execution.service.ProviderLoaderException
+import com.dtolabs.rundeck.core.plugins.PluginResourceLoader
 import com.dtolabs.rundeck.core.plugins.configuration.PluginAdapterUtility
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolver
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolverFactory
@@ -369,5 +370,11 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry {
         }
 
         list
+    }
+
+    @Override
+    PluginResourceLoader getResourceLoader(String service, String provider) throws ProviderLoaderException {
+        //TODO: check groovy plugins
+        rundeckServerServiceProviderLoader.getResourceLoader(service,provider)
     }
 }

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.execution.service.ExecutionServiceException
 import com.dtolabs.rundeck.core.execution.service.MissingProviderException
 import com.dtolabs.rundeck.core.execution.service.ProviderLoaderException
+import com.dtolabs.rundeck.core.plugins.PluginMetadata
 import com.dtolabs.rundeck.core.plugins.PluginResourceLoader
 import com.dtolabs.rundeck.core.plugins.configuration.PluginAdapterUtility
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolver
@@ -375,6 +376,11 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry {
     @Override
     PluginResourceLoader getResourceLoader(String service, String provider) throws ProviderLoaderException {
         //TODO: check groovy plugins
-        rundeckServerServiceProviderLoader.getResourceLoader(service,provider)
+        rundeckServerServiceProviderLoader.getResourceLoader service, provider
+    }
+
+    @Override
+    PluginMetadata getPluginMetadata(final String service, final String provider) throws ProviderLoaderException {
+        rundeckServerServiceProviderLoader.getPluginMetadata service, provider
     }
 }

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/ExecutionFileStoragePluginBuilder.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/ExecutionFileStoragePluginBuilder.groovy
@@ -31,8 +31,8 @@ class ExecutionFileStoragePluginBuilder extends ScriptPluginBuilder implements P
     static Logger logger = Logger.getLogger(StreamingLogWriterPluginBuilder)
     Map<String, Closure> handlers = [:]
 
-    ExecutionFileStoragePluginBuilder(String name) {
-        super(name)
+    ExecutionFileStoragePluginBuilder(Class clazz,String name) {
+        super(clazz,name)
     }
 
     @Override

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/ScriptNotificationPluginBuilder.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/ScriptNotificationPluginBuilder.groovy
@@ -34,8 +34,8 @@ import org.codehaus.groovy.runtime.InvokerHelper
 class ScriptNotificationPluginBuilder extends ScriptPluginBuilder implements PluginBuilder<NotificationPlugin>{
     static Logger logger = Logger.getLogger(ScriptNotificationPluginBuilder)
     Map<String, Closure> triggers=[:]
-    ScriptNotificationPluginBuilder(String name) {
-        super(name)
+    ScriptNotificationPluginBuilder(Class clazz,String name) {
+        super(clazz,name)
     }
 
     @Override

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/StreamingLogReaderPluginBuilder.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/StreamingLogReaderPluginBuilder.groovy
@@ -31,8 +31,8 @@ class StreamingLogReaderPluginBuilder extends ScriptPluginBuilder implements Plu
     static Logger logger = Logger.getLogger(StreamingLogReaderPluginBuilder)
     Map<String, Closure> handlers = [:]
 
-    StreamingLogReaderPluginBuilder(String name) {
-        super(name)
+    StreamingLogReaderPluginBuilder(Class clazz,String name) {
+        super(clazz,name)
     }
 
     @Override

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/StreamingLogWriterPluginBuilder.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/StreamingLogWriterPluginBuilder.groovy
@@ -30,8 +30,8 @@ import org.codehaus.groovy.runtime.InvokerHelper
 class StreamingLogWriterPluginBuilder extends ScriptPluginBuilder implements PluginBuilder<StreamingLogWriterPlugin>{
     static Logger logger = Logger.getLogger(StreamingLogWriterPluginBuilder)
     Map<String, Closure> handlers = [:]
-    StreamingLogWriterPluginBuilder(String name) {
-        super(name)
+    StreamingLogWriterPluginBuilder(Class clazz,String name) {
+        super(clazz,name)
     }
 
     @Override

--- a/rundeckapp/src/java/com/dtolabs/rundeck/server/plugins/services/PluginBuilder.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/server/plugins/services/PluginBuilder.java
@@ -24,4 +24,5 @@ package com.dtolabs.rundeck.server.plugins.services;
  */
 public interface PluginBuilder<T> {
     public T buildPlugin();
+    public Class<T> getPluginClass();
 }

--- a/rundeckapp/src/java/com/dtolabs/rundeck/server/plugins/services/ScriptUIPlugin.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/server/plugins/services/ScriptUIPlugin.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.server.plugins.services;
+
+import com.dtolabs.rundeck.core.common.Framework;
+import com.dtolabs.rundeck.core.plugins.AbstractDescribableScriptPlugin;
+import com.dtolabs.rundeck.core.plugins.PluginException;
+import com.dtolabs.rundeck.core.plugins.ScriptPluginProvider;
+import com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException;
+import com.dtolabs.rundeck.plugins.rundeck.UIPlugin;
+import com.dtolabs.rundeck.plugins.util.DescriptionBuilder;
+
+import java.util.*;
+
+/**
+ * Created by greg on 8/30/16.
+ */
+public class ScriptUIPlugin extends AbstractDescribableScriptPlugin implements UIPlugin {
+    List<String> paths;
+    Map<String, List<String>> pathResources = new HashMap<>();
+    Map<String, List<String>> pathScripts = new HashMap<>();
+    Map<String, List<String>> pathStyles = new HashMap<>();
+
+    public ScriptUIPlugin(
+            final ScriptPluginProvider provider,
+            final Framework framework
+    )
+    {
+        super(provider, framework);
+        loadProviderDefs(provider);
+    }
+
+    private void loadResourcesFromMap(Map uimap) {
+        //pages,styles,scripts, each a string or list of strings
+        List<String> pages = asStringList(uimap.get("pages"));
+        List<String> styles = asStringList(uimap.get("styles"));
+        List<String> scripts = asStringList(uimap.get("scripts"));
+        if (null == pages) {
+            throw new IllegalArgumentException(
+                    "in provider metadata: 'ui: pages:' not found, or not a String or String list");
+        }
+        for (String page : pages) {
+            if (styles != null) {
+                for (String resource : styles) {
+                    addResource(page, resource, pathResources);
+                    addResource(page, resource, pathStyles);
+                }
+            }
+            if (scripts != null) {
+                for (String resource : scripts) {
+                    addResource(page, resource, pathResources);
+                    addResource(page, resource, pathScripts);
+                }
+            }
+        }
+    }
+
+    private void addResource(final String page, final String resource, final Map<String, List<String>> dataSet) {
+        if (null == dataSet.get(page)) {
+            dataSet.put(page, new ArrayList<String>());
+        }
+        dataSet.get(page).add(resource);
+    }
+
+    private static List<String> asStringList(final Object pages) {
+        if (pages instanceof String) {
+            return Collections.singletonList((String) pages);
+        } else if (pages instanceof Collection) {
+            ArrayList<String> strings = new ArrayList<>();
+            for (Object o : ((Collection) pages)) {
+                if (o instanceof String) {
+                    strings.add((String) o);
+                }
+            }
+            return strings;
+        }
+        return null;
+    }
+
+    private void loadProviderDefs(final ScriptPluginProvider provider) {
+        Map<String, Object> metadata = provider.getMetadata();
+        Object ui = metadata.get("ui");
+        if (ui instanceof Map) {
+            Map uimap = (Map) ui;
+            loadResourcesFromMap(uimap);
+        } else if (ui instanceof Collection) {
+            for (Object o : ((Collection) ui)) {
+                if (o instanceof Map) {
+                    loadResourcesFromMap((Map) o);
+                }
+            }
+        } else {
+            throw new IllegalArgumentException("in provider metadata: 'ui:' was not a Map or a List");
+        }
+
+    }
+
+    static void validateScriptPlugin(final ScriptPluginProvider plugin) throws PluginException {
+        try {
+            createDescription(plugin, true, DescriptionBuilder.builder());
+        } catch (ConfigurationException e) {
+            throw new PluginException(e);
+        }
+        Map<String, Object> metadata = plugin.getMetadata();
+        Object ui = metadata.get("ui");
+        if (ui instanceof Map) {
+            Map uimap = (Map) ui;
+            List<String> pages = asStringList(uimap.get("pages"));
+            if (pages == null) {
+                throw new IllegalArgumentException(
+                        "in provider metadata: 'ui: pages:' not found, or not a String or String list");
+            }
+        } else if (ui instanceof Collection) {
+            for (Object o : ((Collection) ui)) {
+                if (o instanceof Map) {
+                    Map uimap = (Map) o;
+                    List<String> pages = asStringList(uimap.get("pages"));
+                    if (pages == null) {
+                        throw new IllegalArgumentException(
+                                "in provider metadata: 'ui: - pages:' not found, or not a String or String list");
+                    }
+                }
+            }
+        } else {
+            throw new IllegalArgumentException("in provider metadata: 'ui:' was not a Map or a List");
+        }
+    }
+
+    private List<String> keyAppliedForPath(String path, Map<String, List<String>> map) {
+
+        for (String s : map.keySet()) {
+            if ("*".equals(s) || s.equals(path) || path.matches(s)) {
+                return map.get(s);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean doesApply(final String path) {
+        return keyAppliedForPath(path, pathResources) != null;
+    }
+
+    @Override
+    public List<String> resourcesForPath(final String path) {
+        return keyAppliedForPath(path, pathResources);
+    }
+
+    @Override
+    public List<String> scriptResourcesForPath(final String path) {
+        return keyAppliedForPath(path, pathScripts);
+    }
+
+    @Override
+    public List<String> styleResourcesForPath(final String path) {
+        return keyAppliedForPath(path, pathStyles);
+    }
+
+    @Override
+    public boolean isAllowCustomProperties() {
+        return false;
+    }
+}

--- a/rundeckapp/src/java/com/dtolabs/rundeck/server/plugins/services/UIPluginProviderService.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/server/plugins/services/UIPluginProviderService.java
@@ -16,21 +16,21 @@
 
 package com.dtolabs.rundeck.server.plugins.services;
 
-import com.dtolabs.rundeck.core.plugins.BasePluggableProviderService;
-import com.dtolabs.rundeck.core.plugins.ServiceProviderLoader;
+import com.dtolabs.rundeck.core.common.Framework;
+import com.dtolabs.rundeck.core.plugins.*;
 import com.dtolabs.rundeck.plugins.ServiceNameConstants;
 import com.dtolabs.rundeck.plugins.rundeck.UIPlugin;
+import com.dtolabs.rundeck.plugins.storage.StoragePlugin;
 
 /**
  * Created by greg on 8/26/16.
  */
-public class UIPluginProviderService extends BasePluggableProviderService<UIPlugin> {
+public class UIPluginProviderService extends FrameworkPluggableProviderService<UIPlugin> {
     public static final String SERVICE_NAME = "UI";
     private ServiceProviderLoader rundeckServerServiceProviderLoader;
 
-    public UIPluginProviderService()
-    {
-        super(SERVICE_NAME, UIPlugin.class);
+    public UIPluginProviderService(final Framework framework) {
+        super(SERVICE_NAME, framework, UIPlugin.class);
     }
 
     @Override
@@ -48,6 +48,14 @@ public class UIPluginProviderService extends BasePluggableProviderService<UIPlug
 
     @Override
     public boolean isScriptPluggable() {
-        return false;
+        return true;
+    }
+
+    @Override
+    public UIPlugin createScriptProviderInstance(ScriptPluginProvider provider) throws
+            PluginException
+    {
+        ScriptUIPlugin.validateScriptPlugin(provider);
+        return new ScriptUIPlugin(provider, getFramework());
     }
 }

--- a/rundeckapp/src/java/com/dtolabs/rundeck/server/plugins/services/UIPluginProviderService.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/server/plugins/services/UIPluginProviderService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.server.plugins.services;
+
+import com.dtolabs.rundeck.core.plugins.BasePluggableProviderService;
+import com.dtolabs.rundeck.core.plugins.ServiceProviderLoader;
+import com.dtolabs.rundeck.plugins.ServiceNameConstants;
+import com.dtolabs.rundeck.plugins.rundeck.UIPlugin;
+
+/**
+ * Created by greg on 8/26/16.
+ */
+public class UIPluginProviderService extends BasePluggableProviderService<UIPlugin> {
+    public static final String SERVICE_NAME = "UI";
+    private ServiceProviderLoader rundeckServerServiceProviderLoader;
+
+    public UIPluginProviderService()
+    {
+        super(SERVICE_NAME, UIPlugin.class);
+    }
+
+    @Override
+    public ServiceProviderLoader getPluginManager() {
+        return rundeckServerServiceProviderLoader;
+    }
+
+    public ServiceProviderLoader getRundeckServerServiceProviderLoader() {
+        return rundeckServerServiceProviderLoader;
+    }
+
+    public void setRundeckServerServiceProviderLoader(ServiceProviderLoader rundeckServerServiceProviderLoader) {
+        this.rundeckServerServiceProviderLoader = rundeckServerServiceProviderLoader;
+    }
+
+    @Override
+    public boolean isScriptPluggable() {
+        return false;
+    }
+}

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/server/plugins/services/ScriptUIPluginSpec.groovy
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/server/plugins/services/ScriptUIPluginSpec.groovy
@@ -73,6 +73,28 @@ class ScriptUIPluginSpec extends Specification {
 
     }
 
+    def "create missing pages: scripts or styles"() {
+        given:
+        def provider = Mock(ScriptPluginProvider) {
+            getMetadata() >> [
+                    ui: invalidContent
+            ]
+        }
+        when:
+        def plugin = new ScriptUIPlugin(provider, Mock(Framework))
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message =~ /either 'scripts' or 'styles' was expected/
+
+        where:
+        invalidContent                                       | _
+        [pages: 'test',]                                     | _
+        [[pages: 'test']]                                    | _
+        [[pages: 'test'], [pages: 'test2', scripts: 'asdf']] | _
+        [[pages: 'test'], [pages: 'test2', styles: 'asdf']]  | _
+    }
+
     def "validate missing pages:"() {
         given:
 

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/server/plugins/services/ScriptUIPluginSpec.groovy
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/server/plugins/services/ScriptUIPluginSpec.groovy
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.server.plugins.services
+
+import com.dtolabs.rundeck.core.common.Framework
+import com.dtolabs.rundeck.core.plugins.ScriptPluginProvider
+import spock.lang.Specification
+
+/**
+ * Created by greg on 8/30/16.
+ */
+class ScriptUIPluginSpec extends Specification {
+
+    def "validate missing ui:"() {
+        given:
+
+        def provider = Mock(ScriptPluginProvider) {
+            getMetadata() >> [
+                    :
+            ]
+        }
+        when:
+        ScriptUIPlugin.validateScriptPlugin(provider)
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message =~ /ui:/
+    }
+
+    def "create missing ui:"() {
+        given:
+        def provider = Mock(ScriptPluginProvider) {
+            getMetadata() >> [
+                    :
+            ]
+        }
+        when:
+        def plugin = new ScriptUIPlugin(provider, Mock(Framework))
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message =~ /ui:/
+
+    }
+
+    def "create missing pages:"() {
+        given:
+        def provider = Mock(ScriptPluginProvider) {
+            getMetadata() >> [
+                    ui: [:]
+            ]
+        }
+        when:
+        def plugin = new ScriptUIPlugin(provider, Mock(Framework))
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message =~ /ui: pages:/
+
+    }
+
+    def "validate missing pages:"() {
+        given:
+
+        def provider = Mock(ScriptPluginProvider) {
+            getMetadata() >> [
+                    ui: [:]
+            ]
+        }
+        when:
+        ScriptUIPlugin.validateScriptPlugin(provider)
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message =~ /ui:/
+    }
+
+    def "create with metadata"() {
+        given:
+        def provider = Mock(ScriptPluginProvider) {
+            getMetadata() >> [
+                    ui: [
+                            pages  : pages,
+                            scripts: scripts,
+                            styles : styles,
+                    ]
+
+            ]
+        }
+        when:
+        def plugin = new ScriptUIPlugin(provider, Mock(Framework))
+
+        then:
+        plugin.doesApply('a/test')
+        plugin.resourcesForPath('a/test') == expectAll
+        plugin.scriptResourcesForPath('a/test') == (scripts == null ? null : ['a/b'])
+        plugin.styleResourcesForPath('a/test') == (styles == null ? null : ['a/c'])
+
+
+        where:
+        pages      | scripts | styles  | expectAll
+        'a/test'   | 'a/b'   | null    | ['a/b']
+        'a/test'   | null    | 'a/c'   | ['a/c']
+        ['a/test'] | 'a/b'   | null    | ['a/b']
+        ['a/test'] | null    | 'a/c'   | ['a/c']
+        'a/test'   | ['a/b'] | null    | ['a/b']
+        'a/test'   | null    | ['a/c'] | ['a/c']
+    }
+
+    def "create with multiple entries"() {
+        given:
+        def provider = Mock(ScriptPluginProvider) {
+            getMetadata() >> [
+                    ui: [
+                            [pages  : pages,
+                             scripts: scripts,
+                             styles : styles
+                            ],
+                            [pages  : pages2,
+                             scripts: scripts2,
+                             styles : styles2
+                            ],
+                    ]
+
+            ]
+        }
+        when:
+        def plugin = new ScriptUIPlugin(provider, Mock(Framework))
+
+        then:
+        plugin.doesApply('a/test')
+        plugin.resourcesForPath('a/test') == expectA
+        plugin.scriptResourcesForPath('a/test') == (scripts == null ? null : ['a/b'])
+        plugin.styleResourcesForPath('a/test') == (styles == null ? null : ['a/c'])
+        plugin.resourcesForPath('b/test') == expectB
+        plugin.scriptResourcesForPath('b/test') == (scripts2 == null ? null : ['b/c'])
+        plugin.styleResourcesForPath('b/test') == (styles2 == null ? null : ['b/d'])
+
+
+        where:
+        pages      | scripts | styles  | expectA | pages2     | scripts2 | styles2 | expectB
+        'a/test'   | 'a/b'   | null    | ['a/b'] | 'b/test'   | 'b/c'    | null    | ['b/c']
+        'a/test'   | null    | 'a/c'   | ['a/c'] | 'b/test'   | null     | 'b/d'   | ['b/d']
+        ['a/test'] | 'a/b'   | null    | ['a/b'] | ['b/test'] | 'b/c'    | null    | ['b/c']
+        ['a/test'] | null    | 'a/c'   | ['a/c'] | ['b/test'] | null     | 'b/d'   | ['b/d']
+        'a/test'   | ['a/b'] | null    | ['a/b'] | 'b/test'   | ['b/c']  | null    | ['b/c']
+        'a/test'   | null    | ['a/c'] | ['a/c'] | 'b/test'   | null     | ['b/d'] | ['b/d']
+    }
+
+    def "create with multiple pages"() {
+        given:
+        def provider = Mock(ScriptPluginProvider) {
+            getMetadata() >> [
+                    ui: [
+                            pages  : pages,
+                            scripts: scripts,
+                            styles : styles
+
+                    ]
+
+            ]
+        }
+        when:
+        def plugin = new ScriptUIPlugin(provider, Mock(Framework))
+
+        then:
+        plugin.doesApply('a/test')
+        plugin.resourcesForPath('a/test') == expectA
+        plugin.scriptResourcesForPath('a/test') == (scripts == null ? null : ['a/b'])
+        plugin.styleResourcesForPath('a/test') == (styles == null ? null : ['a/c'])
+        plugin.resourcesForPath('b/test') == expectA
+
+
+        where:
+        pages                | scripts | styles  | expectA
+        ['a/test', 'b/test'] | 'a/b'   | null    | ['a/b']
+        ['a/test', 'b/test'] | null    | 'a/c'   | ['a/c']
+        ['a/test', 'b/test'] | ['a/b'] | null    | ['a/b']
+        ['a/test', 'b/test'] | null    | ['a/c'] | ['a/c']
+    }
+
+}

--- a/rundeckapp/test/unit/rundeck/controllers/PluginControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/PluginControllerSpec.groovy
@@ -1,0 +1,20 @@
+package rundeck.controllers
+
+import grails.test.mixin.TestFor
+import spock.lang.Specification
+
+/**
+ * See the API for {@link grails.test.mixin.web.ControllerUnitTestMixin} for usage instructions
+ */
+@TestFor(PluginController)
+class PluginControllerSpec extends Specification {
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "test something"() {
+    }
+}

--- a/rundeckapp/test/unit/rundeck/services/PluginServiceTests.groovy
+++ b/rundeckapp/test/unit/rundeck/services/PluginServiceTests.groovy
@@ -17,7 +17,9 @@
 package rundeck.services
 
 import com.dtolabs.rundeck.core.common.Framework
+import com.dtolabs.rundeck.core.execution.service.ProviderLoaderException
 import com.dtolabs.rundeck.core.plugins.PluggableProviderService
+import com.dtolabs.rundeck.core.plugins.PluginResourceLoader
 import com.dtolabs.rundeck.core.plugins.ProviderIdent
 import com.dtolabs.rundeck.core.plugins.ScriptPluginProvider
 import com.dtolabs.rundeck.core.plugins.configuration.Description
@@ -200,6 +202,13 @@ class PluginServiceTests extends GrailsUnitTestCase {
         Map getPluginConfigurationByName(String name, PluggableProviderService service, PropertyResolver resolver, PropertyScope defaultScope) {
             getPluginConfigurationByNameCalled=true
             return allConfiguration
+        }
+
+        @Override
+        PluginResourceLoader getResourceLoader(final String service, final String provider)
+                throws ProviderLoaderException
+        {
+            return null
         }
     }
 

--- a/rundeckapp/test/unit/rundeck/services/PluginServiceTests.groovy
+++ b/rundeckapp/test/unit/rundeck/services/PluginServiceTests.groovy
@@ -19,6 +19,7 @@ package rundeck.services
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.execution.service.ProviderLoaderException
 import com.dtolabs.rundeck.core.plugins.PluggableProviderService
+import com.dtolabs.rundeck.core.plugins.PluginMetadata
 import com.dtolabs.rundeck.core.plugins.PluginResourceLoader
 import com.dtolabs.rundeck.core.plugins.ProviderIdent
 import com.dtolabs.rundeck.core.plugins.ScriptPluginProvider
@@ -208,6 +209,11 @@ class PluginServiceTests extends GrailsUnitTestCase {
         PluginResourceLoader getResourceLoader(final String service, final String provider)
                 throws ProviderLoaderException
         {
+            return null
+        }
+
+        @Override
+        PluginMetadata getPluginMetadata(final String service, final String provider) throws ProviderLoaderException {
             return null
         }
     }

--- a/rundeckapp/test/unit/rundeck/services/UiPluginServiceSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/services/UiPluginServiceSpec.groovy
@@ -1,0 +1,20 @@
+package rundeck.services
+
+import grails.test.mixin.TestFor
+import spock.lang.Specification
+
+/**
+ * See the API for {@link grails.test.mixin.services.ServiceUnitTestMixin} for usage instructions
+ */
+@TestFor(UiPluginService)
+class UiPluginServiceSpec extends Specification {
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "test something"() {
+    }
+}


### PR DESCRIPTION
jar or zip plugins can contain a `resources/` subdirectory, and `resources/icon.png` will be used as the icon for the plugin.  Specific providers can have different icons using `resources/${service}.${provider}.icon.png`. e.g for a WorkflowStep plugin named 'my-plugin' `resources/WorkflowStep.my-plugin.icon.png`. 