### PR TITLE
Fix #2024 can't reload remote job option value

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/menu/job-remote-options.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/job-remote-options.js
@@ -130,12 +130,14 @@ function RemoteOptionController(data) {
 
         // reload iff: all of its required dependencies have a value
         var missing = [];
-        for (var j = 0; j < self.dependencies[name].length; j++) {
-            var dependencyName = self.dependencies[name][j];
-            var option = self.options[dependencyName];
-            if (!option.value() && option.required()) {
-                skip = true;
-                missing.push(dependencyName);
+        if(self.dependencies[name]) {
+            for (var j = 0; j < self.dependencies[name].length; j++) {
+                var dependencyName = self.dependencies[name][j];
+                var option = self.options[dependencyName];
+                if (!option.value() && option.required()) {
+                    skip = true;
+                    missing.push(dependencyName);
+                }
             }
         }
         if (!skip) {

--- a/rundeckapp/grails-app/assets/javascripts/menu/job-remote-options.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/job-remote-options.js
@@ -278,11 +278,11 @@ function RemoteOptionLoader(data) {
             type: 'json',
             url: _genUrl(self.url, params),
             success: function (data, status, jqxhr) {
-                // self.addReloadRemoteOptionValues(opt,data);
-                opt.loading(false);
+                //show loading spinner at least for a little while
+                setTimeout(opt.loading.curry(false),200);
             },
             error: function (jqxhr, status, message) {
-                opt.loading(false);
+                setTimeout(opt.loading.curry(false),200);
                 opt.remoteError({error: "ERROR loading result from Rundeck server: " + status + ": " + message});
             }
         });

--- a/rundeckapp/grails-app/assets/javascripts/menu/job-remote-optionsTest.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/job-remote-optionsTest.js
@@ -232,6 +232,64 @@ jQuery(function () {
                 this.assert("should load option", ['opt3'], toload);
                 this.assert("should do callback", true, didcallback);
             },
+        reloadOptionIfRequirementsMet_nullDeps_Test: function (pref) {
+            var opts = new JobOptions({});
+            var opt1 = mkopt({name: 'opt1', required: true, value: 'zzz'});
+            var opt2 = mkopt({name: 'opt2', required: true, value: 'xyz'});
+            var opt3 = mkopt({name: 'opt3', hasRemote: true, value: ''});
+            opts.options([
+                opt1,
+                opt2,
+                opt3
+            ]);
+            var toload = [];
+            var didcallback = false;
+            var loader = {
+                loadRemoteOptionValues: function (option, opts) {
+                    toload.push(option.name());
+                    return {
+                        then: function (func) {
+                            didcallback = true;
+                        }
+                    };
+                }
+            };
+            var control = new RemoteOptionController({loader: loader});
+            control.setupOptions(opts);
+            var optConfig = {
+                options: {
+                    opt1: {
+                        //optionDependencies: [],
+                        optionDeps: ['opt3'],
+                        optionAutoReload: false,
+                        loadonstart: true,
+                        hasUrl: false
+                    },
+                    opt2: {
+                        optionDependencies: [],
+                        optionDeps: ['opt3'],
+                        optionAutoReload: false,
+                        loadonstart: true,
+                        hasUrl: false
+                    },
+                    opt3: {
+                        optionDependencies: ['opt1', 'opt2'],
+                        optionDeps: [],
+                        optionAutoReload: true,
+                        loadonstart: true,
+                        hasUrl: true
+                    }
+                }
+            };
+            control.loadData(optConfig);
+
+            this.assert("expect undefined dependencies", undefined, control.dependencies['opt1']);
+            
+            control.reloadOptionIfRequirementsMet('opt1');
+            //opt2 should have error
+            this.assert("should load option", ['opt1'], toload);
+            this.assert("should do callback", true, didcallback);
+        },
             optionValueChanged_Test: function (pref) {
                 var self = this;
                 this.testMatrix("optionValueChanged({0})", [

--- a/rundeckapp/grails-app/assets/javascripts/menu/joboptions.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/joboptions.js
@@ -44,12 +44,14 @@ function OptionVal(data) {
         return sel || val ? "" : null;
     });
 }
+var _option_uid=0;
 function Option(data) {
     "use strict";
 
     var self = this;
     self.remoteLoadCallback = null;
     self.name = ko.observable(data.name);
+    self.uid = ko.observable(data.uid||(++_option_uid+'_opt'));
     self.description = ko.observable(data.description);
     self.descriptionHtml = ko.observable(data.descriptionHtml);
     self.loading = ko.observable(false);

--- a/rundeckapp/grails-app/views/framework/_jobOptionsKO.gsp
+++ b/rundeckapp/grails-app/views/framework/_jobOptionsKO.gsp
@@ -98,9 +98,9 @@ data for configuring remote option cascading/dependencies
     css: { 'has-warning': hasError, 'remote': hasRemote }
     ">
             <label class="remoteoptionfield col-sm-2 control-label"
-                   data-bind="attr: { for: fieldId }">
-                <span data-bind="if: hasRemote(), click: reloadRemoteValues">
-                    <span data-bind="if: loading()">
+                   data-bind="attr: { for: fieldId }, click: reloadRemoteValues">
+                <span data-bind="if: hasRemote()">
+                    <span data-bind="if: loading() ">
                         <g:img file="spinner-gray.gif" width="16px" height="16px"/>
                     </span>
                     <span class="remotestatus"

--- a/rundeckapp/grails-app/views/framework/_optionValuesSelectKO.gsp
+++ b/rundeckapp/grails-app/views/framework/_optionValuesSelectKO.gsp
@@ -180,7 +180,7 @@
                 <a class="textbtn textbtn-warning "
                    data-toggle="collapse"
                    href="#"
-                   data-bind="attr: {href: '#rerr_'+option.name() }">
+                   data-bind="attr: {href: '#rerr_'+option.uid() }">
                    <span data-bind="text: remoteError().message"></span>
                     <i class="auto-caret"></i>
                 </a>
@@ -189,7 +189,7 @@
                 <span class="text-warning" data-bind="text: remoteError().message"></span>
             </div>
 
-            <div class="alert alert-warning collapse collapse-expandable" data-bind="attr: {id: 'rerr_'+option.name() }">
+            <div class="alert alert-warning collapse collapse-expandable" data-bind="attr: {id: 'rerr_'+option.uid() }">
                 <span data-bind="if: remoteError().exception">
                     <div>Exception: <span data-bind="text: remoteError().exception"></span></div>
                 </span>

--- a/rundeckapp/grails-app/views/scheduledExecution/_editOptions.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editOptions.gsp
@@ -34,7 +34,7 @@
     </div>
 </g:hasErrors>
 <div id="optionSelect">
-    <g:render template="/framework/commandOptionsKO"
+    <g:render template="/framework/jobOptionsKO"
               model="[
                       paramsPrefix        : 'extra.',
                       selectedargstring   : selectedargstring,


### PR DESCRIPTION
fix two issues: 

1. If a job option has a URL, but no dependencies on other options, it won't reload correctly when the reload button is clicked
2. if a job option has a `.` in the name, remote url loading error messages won't be shown correctly
