### PR TITLE
Escape HTML characters in ExecutionController.renderOutput

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,27 @@
+# Bug report
+
+(Note: Please fill in the blank `___` about your rundeck installation below. You can remove this line.)
+
+**My Rundeck detail**
+
+* Rundeck version: ___
+* install type: ___ (rpm,deb,war,launcher)
+* OS Name/version: ___
+
+**Expected Behavior**
+
+___
+
+**Actual Behavior**
+
+___
+
+**How to reproduce Behavior**
+
+___
+
+# Enhancement request
+
+(*For enhancements*: Please search the existing Issues and look at the [Trello board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.)
+
+...

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.github
 !.gitignore
 *~
 *.swp

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -648,7 +648,7 @@ class ExecutionController extends ControllerBase{
                 return
             }
             def message = msgbuf.message
-            def msghtml=message
+            def msghtml=message.encodeAsHTML()
             if (message.contains('\033[')) {
                 try {
                     msghtml = message.decodeAnsiColor()
@@ -659,7 +659,7 @@ class ExecutionController extends ControllerBase{
             def css="log_line" + (csslevel?" level_${msgbuf.loglevel.toString().toLowerCase()}":'')
 
             response.outputStream << "<div class=\"$css\" >"
-            response.outputStream << msghtml.encodeAsHTML()
+            response.outputStream << msghtml
             response.outputStream << '</div>'
 
             response.outputStream<<lineSep

--- a/rundeckapp/grails-app/utils/rundeck/codecs/AnsiColorCodec.groovy
+++ b/rundeckapp/grails-app/utils/rundeck/codecs/AnsiColorCodec.groovy
@@ -75,7 +75,7 @@ class AnsiColorCodec {
                 return
             }
             if (!coded) {
-                sb << str.encodeAsHTMLElement()
+                sb << str.encodeAsHTML()
                 coded = true
                 return
             }
@@ -111,12 +111,12 @@ class AnsiColorCodec {
                                 }
                             }
                         } catch (NumberFormatException e) {
-                            sb << matcher.group(1).encodeAsHTMLElement()
+                            sb << matcher.group(1).encodeAsHTML()
                         }
                     }
                 }
                 if (!cols) {
-                    sb << matcher.group(1).encodeAsHTMLElement()
+                    sb << matcher.group(1).encodeAsHTML()
                 } else {
                     //256 col ansi
                     def ncols=[]
@@ -155,9 +155,9 @@ class AnsiColorCodec {
 
                     sb << (rvals ? '<span class="' + rvals + '">' : '')
                 }
-                str = str.substring(len).encodeAsHTMLElement()
+                str = str.substring(len).encodeAsHTML()
             }
-            sb << str.encodeAsHTMLElement()
+            sb << str.encodeAsHTML()
         }
         sb << ('' + (ctx ? ctx.collect { '</span>' }.join('') : ''))
         sb.toString()


### PR DESCRIPTION
renderOutput was not sanitizing task logs correctly for an HTML view. If
an attacker controlled a node, they could send Javascript code in the
response, which would be executed in the user's browser upon viewing the
page.