### PR TITLE
Rundeck-853: Override option list by providing options in URL

### DIFF
--- a/rundeckapp/grails-app/views/framework/_optionValuesSelectKO.gsp
+++ b/rundeckapp/grails-app/views/framework/_optionValuesSelectKO.gsp
@@ -133,7 +133,7 @@
 
                 <div data-bind="if:!multivalued()">
                     <select class="optionvalues form-control"
-                            data-bind="attr: {name: !hasTextfield()?fieldName():'', id: !hasTextfield()?fieldId():'' },
+                            data-bind="attr: {name: !hasTextfield()?fieldName():'', id: !hasTextfield()?fieldId():fieldName() },
                          options: selectOptions,
                          optionsText: 'label',
                          optionsValue: 'value',

--- a/rundeckapp/grails-app/views/scheduledExecution/show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/show.gsp
@@ -67,7 +67,51 @@
 
             jQuery('input').on('keydown', function (evt) {
                 return noenter(evt);
-            });
+            })
+
+            //Rundeck-853 Override option list by providing options in URL (https://github.com/rundeck/rundeck/issues/853)
+            setTimeout(function () {
+                overrideOptions(window.location.href);
+            }, 200);
+        }
+
+        function overrideOptions(href) {
+            var data = parseUrlParams(href)
+            for (var key in data){
+
+                //1. when option is not strict and allowed to enter any values other then drop downs
+                var element = document.getElementsByName("extra.option."+key);
+                if(jQuery(element).is(":text")) {
+                    element[0].value = data[key];
+                }
+
+                var selectElement = document.getElementById("extra.option."+key);
+                if(jQuery(selectElement).is("select")) {
+                    if(selectElement == undefined || selectElement == null) {
+                        selectElement = document.getElementsByName("extra.option."+key)[0];
+                    }
+                    selectElement.value = data[key];
+                }
+
+                //2. when option is strict
+                var selectElementStrict = document.getElementsByName("extra.option."+key)[0];
+                if(jQuery(selectElementStrict).is("select")) {
+                    selectElementStrict.value = data[key];
+                }
+
+                //3. when options are multivalued
+                var checkboxeElements = document.getElementsByName("extra.option."+key);
+                if(jQuery(checkboxeElements).is(":checkbox")) {
+                    var elementValues = data[key].split(",");
+                    if(elementValues.length > 0) {
+                        jQuery('input[name="extra.option.'+key+'"]').prop('checked', false);
+                    }
+                    for(i = 0; i<elementValues.length; i++) {
+                        jQuery('input[name="extra.option.'+key+'"][value='+elementValues[i]+']').prop('checked', true);
+                    }
+                }
+
+            }
         }
         jQuery(init);
     </script>


### PR DESCRIPTION
@miguelantonio @gschueler As mentioned in the ticket, now values in the URL will override the options in the job. 

For ex.https://myrundeckserver/project/myproject/job/show/21d9cea5-b1fb-4240-88a9-3ff095f0a45f?opt1=value1&opt2=value2 
would open up the Job with opt1 and opt2 populated with value1 and value2.

Providing these in the link allows someone to review the job prior to running it.
