### PR TITLE
Add documentation to configure Rundeck with PostgreSQL DB

### DIFF
--- a/docs/en/administration/07-relational-database.md
+++ b/docs/en/administration/07-relational-database.md
@@ -114,6 +114,54 @@ Else:
 
 Finally you can start rundeck.  If you see a startup error about database access, make sure that the hostname that the Mysql server sees from the client is the same one you granted access to.
 
+# PostgreSQL setup guide
+
+This is a simple guide for setting up PostgreSQL for use with Rundeck.
+
+## Install PostgreSQL
+
+You can "yum install" or "apt-get install" the server, or you can download rpms manually if you like. See [PostgreSQL installation](https://wiki.postgresql.org/wiki/Detailed_installation_guides)
+
+## Setup Rundeck Database
+
+We have to create the database and user for Rundeck.
+
+If it is not running, start Postgres (with "service postgresql-<version> start" or similar).
+
+Switch to 'postgres' user and use the 'psql' commandline tool to access the db:
+
+    $ su postgres
+    $ psql
+
+Once you have the 'postgres=#'' prompt, enter the following commands to create the rundeck database:
+
+    postgres=# create database rundeck;
+
+Now, create a user and grant privileges to connect to this DB.
+
+    postgres=# create user rundeckuser with password 'rundeckpassword';
+    postgres=# grant ALL privileges on database rundeck to rundeckuser;
+
+You can then exit the psql prompt.
+
+You may also have to add a pg_hba.conf entry for this user. See [pg_hba.conf documentation](https://www.postgresql.org/docs/9.5/static/auth-pg-hba-conf.html)
+
+## Configure Rundeck
+
+Now you need to configure Rundeck to connect to this DB as described earlier in this document: [Customize the Datasource](#customize-the-datasource).
+
+Update your `rundeck-config.properties` and configure the datasource:
+
+    dataSource.driverClassName = org.postgresql.Driver
+    dataSource.url = jdbc:postgresql://myserver/rundeck
+    dataSource.username=rundeckuser
+    dataSource.password=rundeckpassword
+
+With recent Rundeck versions, PostgreSQL connector is bundled.
+You can check if present in this path: `$RDECK_BASE/exp/webapp/WEB-INF/lib/`
+
+Now, you can start Rundeck.
+
 # Mysql migration guide
 
 This section describes how to migrate a set of Rundeck projects from


### PR DESCRIPTION
Postgres support for Rundeck is currently undocumented.

This PR includes these steps to set up Rundeck with a Postgres DB:
* Creating Postgres database for Rundeck
* Creating Postgres user, granting privileges
* Configuring Rundeck to connect to this database

This resolves #1405.