### PR TITLE
Feature - override node filter (GUI enhancement)

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
@@ -326,8 +326,8 @@ class ReportService  {
             }
 
             if(query.execnodeFilter){
-                if(query.execnodeFilter.startsWith('name:')){
-                    def node = (query.execnodeFilter.split("name:")[1]).stripIndent()
+                if(query.execnodeFilter.startsWith('name:') || !query.execnodeFilter.contains(":")){
+                    def node = query.execnodeFilter.startsWith('name:')?(query.execnodeFilter.split("name:")[1]).stripIndent():query.execnodeFilter;
                     or {
                         ilike("failedNodeList", '%' + node + '%')
                         ilike("succeededNodeList", '%' + node + '%')

--- a/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
@@ -326,7 +326,7 @@ class ReportService  {
             }
 
             if(query.execnodeFilter){
-                if(query.execnodeFilter.startsWith('name:') || !query.execnodeFilter.contains(":")){
+                if(query.execnodeFilter.startsWith('name:') || !(query.execnodeFilter.contains(":") || query.execnodeFilter.contains(".*"))){
                     def node = query.execnodeFilter.startsWith('name:')?(query.execnodeFilter.split("name:")[1]).stripIndent():query.execnodeFilter;
                     or {
                         ilike("failedNodeList", '%' + node + '%')

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -2965,10 +2965,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             }
         }
         if (scheduledExecution.doNodedispatch) {
-            if (!scheduledExecution.asFilter()) {
-                scheduledExecution.errors.rejectValue('filter', 'scheduledExecution.filter.blank.message')
-                failed = true
-            } else if (!scheduledExecution.nodeThreadcount) {
+            if (!scheduledExecution.nodeThreadcount) {
                 scheduledExecution.nodeThreadcount = 1
             }
         }

--- a/rundeckapp/grails-app/views/framework/_nodeFilterInputGroup.gsp
+++ b/rundeckapp/grails-app/views/framework/_nodeFilterInputGroup.gsp
@@ -51,7 +51,7 @@
 
 
 <span class="input-group-btn">
-    <a class="btn btn-default" data-toggle='popover-for' data-target="#${filterFieldId ? enc(attr: filterFieldId) : 'schedJobNodeFilter'}">
+    <a class="btn btn-default" data-toggle='popover-for' data-target="#${filterFieldId ? enc(attr: filterFieldId) : 'schedJobNodeFilter'}" onclick="jQuery('#${filterFieldId ? enc(attr: filterFieldId) : 'schedJobNodeFilter'}').popover('toggle')">
         <i class="glyphicon glyphicon-question-sign"></i>
     </a>
     <a class="btn btn-default" data-bind="click: $data.newFilterText, css: {disabled: !filter()}" href="#">

--- a/rundeckapp/grails-app/views/reports/_baseReport.gsp
+++ b/rundeckapp/grails-app/views/reports/_baseReport.gsp
@@ -140,9 +140,9 @@
 
 
             <td class="  user autoclickable" style="white-space: nowrap">
-                <g:if test="${it?.nodeList}">
+                <g:if test="${it?.filterApplied}">
                     <em><g:message code="activity.jobs.executed.node"/>:</em>
-                    ${it?.nodeList}
+                    ${it?.filterApplied}
                 </g:if>
                 <g:else>
                     <em><g:message code="activity.jobs.executed.local"/></em>

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -85,6 +85,11 @@
     }
     jQuery(document).ready(init);
 </script>
+    <div class=" collapse" id="queryFilterHelp">
+        <div class="help-block">
+            <g:render template="/common/nodefilterStringHelp"/>
+        </div>
+    </div>
 <div class="list-group list-group-tab-content">
 <div class="list-group-item">
 <div class="row">

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -57,7 +57,7 @@
 <div class="row">
 <div class="${hideHead?'col-sm-9':'col-sm-12'}">
     <g:render template="editOptions" model="${[scheduledExecution:scheduledExecution, selectedoptsmap:selectedoptsmap, selectedargstring:selectedargstring,authorized:authorized,jobexecOptionErrors:jobexecOptionErrors, optiondependencies: optiondependencies, dependentoptions: dependentoptions, optionordering: optionordering]}"/>
-    <g:if test="${scheduledExecution.nodeFilterEditable}">
+
     <div class="form-group" style="${wdgt.styleVisible(if: nodesetvariables && !failedNodes || nodesetempty || nodes)}">
     <div class="col-sm-2 control-label text-form-label">
         Nodes
@@ -109,7 +109,7 @@
                 --%>
                 <g:if test="${!nodesetvariables && nodes}">
                 <g:if test="${namegroups}">
-                    <label for="cherrypickradio">
+                    <label for=" ">
                     <div class=" group_select_control" style="${wdgt.styleVisible(if: selectedNodes !=null)}">
                         <input id="cherrypickradio"
                                type="radio"
@@ -198,6 +198,7 @@
                     </g:each>
                 </g:else>
                 </g:if>
+                <g:if test="${scheduledExecution.nodeFilterEditable || nodefilter == ''}">
                 <div class="subfields nodeFilterFields ">
                     %{-- filter text --}%
                     <div class="">
@@ -208,7 +209,7 @@
                            name="extra.nodeoverride"
                            value="filter"
                     />
-                        <spans>
+                        <span>
                     <g:if test="${!nodesetvariables && nodes}"><g:message code="or"/> </g:if>
                             <g:message code="job.run.override.node"/>: </span>
                     <g:if test="${session.user && User.findByLogin(session.user)?.nodefilters}">
@@ -228,6 +229,7 @@
 
 
                 </div>
+                    </g:if>
             </div>
             <g:javascript>
                 var updateSelectCount = function (evt) {
@@ -342,7 +344,7 @@
 
     </div>
     </div>
-    </g:if>
+
     <div class="error note" id="formerror" style="display:none">
 
     </div>

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/support/ExecutionContext.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/support/ExecutionContext.groovy
@@ -41,6 +41,6 @@ abstract class ExecutionContext extends BaseNodeFilters{
     Integer nodeThreadcount=1
     String nodeRankAttribute
     Boolean nodeRankOrderAscending=true
-    Boolean nodeFilterEditable = true
+    Boolean nodeFilterEditable = false
 }
 

--- a/rundeckapp/test/integration/ReportServiceTests.groovy
+++ b/rundeckapp/test/integration/ReportServiceTests.groovy
@@ -70,7 +70,7 @@ class ReportServiceTests extends GroovyTestCase {
         assertQueryResult([reportIdFilter: 'blah4'], [])
     }
     void testgetExecNodeFilterReportIdFilter(){
-        def r1,r2,r3
+        def r1,r2,r3, r4
 
         ExecReport.withNewSession {
             r1=proto(reportId:'blah', jcExecId: '123', succeededNodeList:'test')
@@ -84,23 +84,29 @@ class ReportServiceTests extends GroovyTestCase {
             r3 = proto(reportId: 'blah3', jcExecId: '125', filterApplied:'tags: monkey')
             assert r3.validate()
             println r3.save(flush: true)
+            r4 = proto(reportId: 'blah4', jcExecId: '126', filterApplied:'.*',succeededNodeList:'test')
+            assert r4.validate()
+            println r4.save(flush: true)
 
             sessionFactory.currentSession.flush()
         }
         r1=r1.refresh()
         r2=r2.refresh()
         r3=r3.refresh()
-        assertEquals(3,ExecReport.count())
+        r4=r4.refresh()
+        assertEquals(4,ExecReport.count())
         def query = new ExecQuery(execnodeFilter: 'name: test')
 
         def result=reportService.getExecutionReports(query,true)
-        assert result.total==2
-        assert result.reports.size()==2
+        assert result.total==3
+        assert result.reports.size()==3
         assert result.reports.contains(r1)
 
-        assertQueryResult([execnodeFilter: 'name: test'], [r1,r2])
+        assertQueryResult([execnodeFilter: 'name: test'], [r1,r2,r4])
+        assertQueryResult([execnodeFilter: 'test'], [r1,r2,r4])
         assertQueryResult([execnodeFilter: 'tags: monkey'], [r3])
         assertQueryResult([execnodeFilter: 'tags: test'], [])
+        assertQueryResult([execnodeFilter: '.*'], [r4])
     }
 
     void testgetExecReportsProjFilterIsExact(){


### PR DESCRIPTION
## New GUI and new behavior for the Override Node Filter on execution.

If you enter a default node filter you can set the "Editable filter" to false so no one can edit it on the run. I you leave the node filter field empty, any user can edit it on the run job screen regardless of the "Editable Filter" value. 

The new execution screen looks like this:
<img width="1024" alt="runscreen" src="https://cloud.githubusercontent.com/assets/2894508/19313155/e981d92c-906b-11e6-8ddd-865f3e35c6a1.png">


On the Activity screen, if you search by filter, you can use the name of the searched node, and it will assume "name: "