### PR TITLE
fix: runAtTime does not support "Z" timezone indicator in iso8601 format

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1775,14 +1775,10 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             Date now        = java.util.Calendar.getInstance().getTime()
             Date startTime
             try {
-                if (input.runAtTime.length() == 25 || input.runAtTime.length() == 24) {
+                try{
                     startTime   = ISO_8601_DATE_FORMAT.get().parse(input.runAtTime)
-                } else if (input.runAtTime.length() == 29 || input.runAtTime.length() == 28) {
+                }catch (ParseException e1){
                     startTime	= ISO_8601_DATE_FORMAT_WITH_MS.get().parse(input.runAtTime)
-                } else {
-                    return [success: false, failed: true, error: 'failed',
-                            message: 'Invalid date/time format, not the expected length',
-                            options: input.option]
                 }
             } catch (ParseException | IllegalArgumentException e) {
                 return [success: false, failed: true, error: 'failed',

--- a/rundeckapp/test/unit/ExecutionServiceSpec.groovy
+++ b/rundeckapp/test/unit/ExecutionServiceSpec.groovy
@@ -1778,7 +1778,9 @@ class ExecutionServiceSpec extends Specification {
         where:
         runAtTime                       | executionsAreActive | scheduleEnabled | executionEnabled | hasSchedule | expectScheduled
         "2200-01-01T12:43:10.000+00:00" | true                | true            | true             | true        | true
+        "2200-01-01T12:43:10.000Z"      | true                | true            | true             | true        | true
         "2200-01-01T12:43:10+00:00"     | true                | true            | true             | true        | true
+        "2200-01-01T12:43:10Z"          | true                | true            | true             | true        | true
     }
 
     @Unroll
@@ -1818,6 +1820,6 @@ class ExecutionServiceSpec extends Specification {
         time                               | executionsAreActive | scheduleEnabled | executionEnabled | hasSchedule | expectScheduled
         "01/01/2001 10:11:12.000000 +0000" | true                | true            | true             | true        | true
         "0000-00-00 00:00:00.000+0000"     | true                | true            | true             | true        | true
-        "2080-01-01T01:00:01.000+0000    " | true                | true            | true             | true        | true
+        "2080-01-01T01:00:01.000"          | true                | true            | true             | true        | true
     }
 }


### PR DESCRIPTION
for #1987 