### PR TITLE
Add ISO8601 timestamp to log4j ConsoleAppenders

### DIFF
--- a/core/src/main/resources/com/dtolabs/launcher/setup/templates/cli-log4j.properties.template
+++ b/core/src/main/resources/com/dtolabs/launcher/setup/templates/cli-log4j.properties.template
@@ -7,7 +7,7 @@ log4j.rootCategory=ERROR, stdout
 #
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%-5p %c{1}: %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}: %m%n
 
 #
 # plainStdout - ConsoleAppender which

--- a/packaging/debroot/etc/rundeck/cli-log4j.properties
+++ b/packaging/debroot/etc/rundeck/cli-log4j.properties
@@ -7,7 +7,7 @@ log4j.rootCategory=ERROR, stdout
 #
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%-5p %c{1}: %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}: %m%n
 
 #
 # plainStdout - ConsoleAppender which

--- a/packaging/debroot/etc/rundeck/log4j.properties
+++ b/packaging/debroot/etc/rundeck/log4j.properties
@@ -84,7 +84,7 @@ log4j.additivity.grails=false
 #
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%-5p %c{1}: %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}: %m%n
 
 #
 # cmd-logger - DailyRollingFileAppender

--- a/packaging/root/etc/rundeck/log4j.properties
+++ b/packaging/root/etc/rundeck/log4j.properties
@@ -84,7 +84,7 @@ log4j.additivity.grails=false
 #
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%-5p %c{1}: %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}: %m%n
 
 #
 # cmd-logger - DailyRollingFileAppender


### PR DESCRIPTION
Maybe this is  not needed for _all_ ConsoleAppenders; my intention is that the "main" logs that the init script redirects to service.log contain timestamps.