### PR TITLE
Fix default parameter location for debian packaging

### DIFF
--- a/packaging/debroot/etc/init.d/rundeckd
+++ b/packaging/debroot/etc/init.d/rundeckd
@@ -21,7 +21,7 @@
 
 prog="rundeckd"
 
-[ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+[ -e /etc/default/$prog ] && . /etc/default/$prog
 
 . /etc/rundeck/profile
 

--- a/packaging/debroot/etc/init/rundeckd.conf
+++ b/packaging/debroot/etc/init/rundeckd.conf
@@ -21,7 +21,7 @@ chdir /var/log/rundeck
 script
     prog="rundeckd"
 
-    [ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+    [ -e /etc/default/$prog ] && . /etc/default/$prog
 
     . /etc/rundeck/profile
 


### PR DESCRIPTION
For debian, the equivalent of /etc/sysconfig is /etc/default - see
https://www.debian.org/doc/manuals/debian-reference/ch03.en.html#_the_default_parameter_for_each_init_script