### PR TITLE
Fix some i18n error messages

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2035,7 +2035,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 if (opt.required && !optparams[opt.name]) {
 
                     if (!opt.defaultStoragePath) {
-                        invalidOpt opt,lookupMessage("domain.Option.validation.required",[opt.name].toArray())
+                        invalidOpt opt,lookupMessage("domain.Option.validation.required",[opt.name])
                         return
                     }
                     try {
@@ -2048,7 +2048,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                         if (!canread) {
                             invalidOpt opt, lookupMessage(
                                     "domain.Option.validation.required.storageDefault",
-                                    [opt.name, opt.defaultStoragePath].toArray()
+                                    [opt.name, opt.defaultStoragePath]
                             )
                             return
                         }
@@ -2056,7 +2056,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
                         invalidOpt opt, lookupMessage(
                                 "domain.Option.validation.required.storageDefault.reason",
-                                [opt.name, opt.defaultStoragePath, e1.cause.message].toArray()
+                                [opt.name, opt.defaultStoragePath, e1.cause.message]
 
                         )
                         return
@@ -2096,7 +2096,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     if (opt.regex && !opt.enforced && optparams[opt.name]) {
                         if (!(optparams[opt.name] ==~ opt.regex)) {
                             invalidOpt opt, opt.secureInput ?
-                                    lookupMessage("domain.Option.validation.secure.invalid",[opt.name].toArray())
+                                    lookupMessage("domain.Option.validation.secure.invalid",[opt.name])
                                     : lookupMessage("domain.Option.validation.regex.invalid",[opt.name,optparams[opt.name],opt.regex])
 
                             return
@@ -2107,7 +2107,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                             optparams[opt.name] instanceof String &&
                             !opt.values.contains(optparams[opt.name])) {
                         invalidOpt opt,  opt.secureInput ?
-                                lookupMessage("domain.Option.validation.secure.invalid",[opt.name].toArray())
+                                lookupMessage("domain.Option.validation.secure.invalid",[opt.name])
                                 : lookupMessage("domain.Option.validation.allowed.invalid",[opt.name,optparams[opt.name],opt.values])
                         return
                     }
@@ -2448,19 +2448,19 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
        * @parameter key
        * @returns corresponding value from messages.properties
        */
-      def lookupMessage(String theKey, Object[] data, String defaultMessage=null) {
+      def lookupMessage(String theKey, List<Object> data, String defaultMessage=null) {
           def locale = getLocale()
           def theValue = null
           MessageSource messageSource = messageSource?:applicationContext.getBean("messageSource")
           try {
-              theValue =  messageSource.getMessage(theKey,data,locale )
+              theValue =  messageSource.getMessage(theKey,data as Object[],locale )
           } catch (org.springframework.context.NoSuchMessageException e){
           } catch (java.lang.NullPointerException e) {
               log.error "Expression does not exist."
           }
           if(null==theValue && defaultMessage){
               MessageFormat format = new MessageFormat(defaultMessage);
-              theValue=format.format(data)
+              theValue=format.format(data as Object[])
           }
           return theValue
       }
@@ -2468,12 +2468,12 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
        * @parameter key
        * @returns corresponding value from messages.properties
        */
-      def lookupMessage(String[] theKeys, Object[] data, String defaultMessage=null) {
+      def lookupMessage(String[] theKeys, List<Object> data, String defaultMessage=null) {
           def locale = getLocale()
           def theValue = null
           theKeys.any{key->
               try {
-                  theValue =  messageSource.getMessage(key,data,locale )
+                  theValue =  messageSource.getMessage(key,data as Object[],locale )
                   return true
               } catch (org.springframework.context.NoSuchMessageException e){
               } catch (java.lang.NullPointerException e) {
@@ -2482,7 +2482,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
           }
           if(null==theValue && defaultMessage){
               MessageFormat format = new MessageFormat(defaultMessage);
-              theValue=format.format(data)
+              theValue=format.format(data as Object[])
           }
           return theValue
       }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -800,7 +800,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         def ScheduledExecution scheduledExecution = getByIDorUUID(jobid)
         if (!scheduledExecution) {
             def err = [
-                    message: lookupMessage( "api.error.item.doesnotexist",  ['Job ID', jobid] as Object[]),
+                    message: lookupMessage( "api.error.item.doesnotexist",  ['Job ID', jobid]),
                     errorCode: 'notfound',
                     id: jobid
             ]
@@ -822,7 +822,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 scheduledExecution.project
         )) {
             def err = [
-                    message: lookupMessage('api.error.item.unauthorized', ['Delete', 'Job ID', scheduledExecution.extid] as Object[]),
+                    message: lookupMessage('api.error.item.unauthorized', ['Delete', 'Job ID', scheduledExecution.extid]),
                     errorCode: 'unauthorized',
                     id: scheduledExecution.extid,
                     job: scheduledExecution
@@ -837,7 +837,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             return [success:false,error:  [message: result.error, job: scheduledExecution, errorCode: 'failed', id: scheduledExecution.extid]]
         } else {
             logJobChange(changeinfo, jobdata)
-            return [success: [message: lookupMessage('api.success.job.delete.message', [jobtitle] as Object[]), job: scheduledExecution]]
+            return [success: [message: lookupMessage('api.success.job.delete.message', [jobtitle]), job: scheduledExecution]]
         }
     }
     /**
@@ -1226,12 +1226,12 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
      * @parameter key
      * @returns corresponding value from messages.properties
      */
-    def lookupMessage(String theKey, Object[] data, String defaultMessage = null) {
+    def lookupMessage(String theKey, List<Object> data, String defaultMessage = null) {
         def locale = getLocale()
         def theValue = null
 //        MessageSource messageSource = applicationContext.getBean("messageSource")
         try {
-            theValue = messageSource.getMessage(theKey, data, locale)
+            theValue = messageSource.getMessage(theKey, data as Object[], locale)
         } catch (org.springframework.context.NoSuchMessageException e) {
             log.error "Missing message ${theKey}"
 //        } catch (java.lang.NullPointerException e) {
@@ -1239,7 +1239,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
         if (null == theValue && defaultMessage) {
             MessageFormat format = new MessageFormat(defaultMessage);
-            theValue = format.format(data)
+            theValue = format.format(data as Object[])
         }
         return theValue
     }
@@ -1588,8 +1588,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 return [success     : false, scheduledExecution: scheduledExecution,
                         message     : lookupMessage(
                                 'api.error.item.unauthorized',
-                                [AuthConstants.ACTION_TOGGLE_SCHEDULE, 'Job ID', scheduledExecution.extid].toArray()
-
+                                [AuthConstants.ACTION_TOGGLE_SCHEDULE, 'Job ID', scheduledExecution.extid]
                         ),
                         errorCode   : 'api.error.item.unauthorized',
                         unauthorized: true]
@@ -1608,8 +1607,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 return [success          : false, scheduledExecution: scheduledExecution,
                         message          : lookupMessage(
                                 'api.error.item.unauthorized',
-                                [AuthConstants.ACTION_TOGGLE_EXECUTION, 'Job ID', scheduledExecution.extid].toArray()
-
+                                [AuthConstants.ACTION_TOGGLE_EXECUTION, 'Job ID', scheduledExecution.extid]
                         ),
                         errorCode   : 'api.error.item.unauthorized',
                         unauthorized: true]


### PR DESCRIPTION
Some messages would appear similar to:
>    Option [endDate, 2016-01-01 00:00:001, ^[0-9]{4}-[0-1][0-9]-[0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9]$] value: {1} doesnt match regular expression: {2}

Instead of the expected:
>    Option endDate value: 2016-01-01 00:00:001 doesnt match regular expression: ^[0-9]{4}-[0-1][0-9]-[0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9]$

Also, improve lookupMessage's usability.