### PR TITLE
ScheduledExecutionService generic methods to use on plugin

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3076,4 +3076,20 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         )
     }
 
+     def listWorkflows(HashMap query) {
+        ScheduledExecutionQuery nquery = new ScheduledExecutionQuery()
+        nquery.setIdlist(query.idlist)
+        nquery.setGroupPath(query.groupPath)
+        nquery.setGroupPathExact(query.groupPathExact)
+        nquery.setMax(query.max)
+        nquery.setOffset(query.offset)
+        nquery.setSortBy(query.sortBy)
+        return listWorkflows(nquery)
+    }
+
+
+    def getScheduledExecutionByUUIDAndProject(String uuid, String project){
+        ScheduledExecution.findByUuidAndProject(uuid, project)
+    }
+
 }


### PR DESCRIPTION
Added two method, one overload listworkflows with a generic Hashmap  to populate the ScheduledExecutionQuery, the other helps find a ScheduledExecution with the uuid and the project without using the domain