### PR TITLE
Fix #2228

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/ExecReport.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ExecReport.groovy
@@ -32,6 +32,9 @@ class ExecReport extends BaseReport{
 
     static mapping = {
         adhocScript type: 'text'
+        filterApplied type: 'text'
+        succeededNodeList type: 'text'
+        failedNodeList type: 'text'
     }
 
     static constraints = {


### PR DESCRIPTION
Applied text column type to filterApplied, succeededNodeList and failedNodeList, convert the data type to long text instead of varchar 255