### PR TITLE
Prevent csrf attacks

### DIFF
--- a/rundeckapp/grails-app/conf/RefererFilters.groovy
+++ b/rundeckapp/grails-app/conf/RefererFilters.groovy
@@ -2,7 +2,7 @@ class RefererFilters {
     def grailsApplication
 
     def filters = {
-        checkReferer(controller: '*', action: '*') {
+        checkReferer(controller: 'user', action: 'login',invert: true) {
             before = {
                 def csrf = grailsApplication.config.rundeck.security.csrf
                 if(csrf && csrf != 'NONE'){
@@ -16,12 +16,8 @@ class RefererFilters {
                     }else if(csrf == '*'){
                         def validRefererPrefix = "^${grailsApplication.config.grails.serverURL}".replace("http", "https?")
                         def referer = request.getHeader('Referer')
-                        if(request.method.toUpperCase() == 'GET' && (referer == null || referer.endsWith("user/login"))) {
-                            //excluding the user/login screen
-                            return true
-                        }else{
-                            return referer && referer =~ validRefererPrefix
-                        }
+                        return referer && referer =~ validRefererPrefix
+
                     }
                 }
 

--- a/rundeckapp/grails-app/conf/RefererFilters.groovy
+++ b/rundeckapp/grails-app/conf/RefererFilters.groovy
@@ -1,7 +1,4 @@
-import org.codehaus.groovy.grails.commons.GrailsApplication
-
 class RefererFilters {
-    // referer must match serverURL, optionally https
     def grailsApplication
 
     def filters = {
@@ -9,22 +6,18 @@ class RefererFilters {
             before = {
                 def csrf = grailsApplication.config.rundeck.security.csrf
                 if(csrf && csrf != 'NONE'){
-                    println(csrf)
-                    //grailsApplication.config.rundeck.clusterMode.enabled
                     if(csrf == 'POST') {
                         if (request.method.toUpperCase() == "POST") {
-                            println('filter post')
+                            // referer must match serverURL, optionally https
                             def validRefererPrefix = "^${grailsApplication.config.grails.serverURL}".replace("http", "https?")
                             def referer = request.getHeader('Referer')
                             return referer && referer =~ validRefererPrefix
                         }
                     }else if(csrf == '*'){
-                        println('filter anything')
                         def validRefererPrefix = "^${grailsApplication.config.grails.serverURL}".replace("http", "https?")
                         def referer = request.getHeader('Referer')
                         if(request.method.toUpperCase() == 'GET' && (referer == null || referer.endsWith("user/login"))) {
                             //excluding the user/login screen
-                            println('return true')
                             return true
                         }else{
                             return referer && referer =~ validRefererPrefix

--- a/rundeckapp/grails-app/conf/RefererFilters.groovy
+++ b/rundeckapp/grails-app/conf/RefererFilters.groovy
@@ -1,0 +1,38 @@
+import org.codehaus.groovy.grails.commons.GrailsApplication
+
+class RefererFilters {
+    // referer must match serverURL, optionally https
+    def grailsApplication
+
+    def filters = {
+        checkReferer(controller: '*', action: '*') {
+            before = {
+                def csrf = grailsApplication.config.rundeck.security.csrf
+                if(csrf && csrf != 'NONE'){
+                    println(csrf)
+                    //grailsApplication.config.rundeck.clusterMode.enabled
+                    if(csrf == 'POST') {
+                        if (request.method.toUpperCase() == "POST") {
+                            println('filter post')
+                            def validRefererPrefix = "^${grailsApplication.config.grails.serverURL}".replace("http", "https?")
+                            def referer = request.getHeader('Referer')
+                            return referer && referer =~ validRefererPrefix
+                        }
+                    }else if(csrf == '*'){
+                        println('filter anything')
+                        def validRefererPrefix = "^${grailsApplication.config.grails.serverURL}".replace("http", "https?")
+                        def referer = request.getHeader('Referer')
+                        if(request.method.toUpperCase() == 'GET' && (referer == null || referer.endsWith("user/login"))) {
+                            //excluding the user/login screen
+                            println('return true')
+                            return true
+                        }else{
+                            return referer && referer =~ validRefererPrefix
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
By default, preserve the actual state without CSRF filter, to activate the administrator need to add a property on _rundeck-config.properties_:
"rundeck.security.csrf"

It accepts the values: 
**_POST_**: recommended, only filter the POST methods, verifies Refer and url.
**_*_**: applies the filter to any type of request, including POST and GET, except the login screen wich need to be accesible without refer or with a redirect from another url (case of localhost resolved to hostname)
_**NONE**_: don't applies any filter.
Any other string or the absence of the property, resolves as NONE.

i.e.:
rundeck.security.csrf=POST