### PR TITLE
add RUNDECK_WITH_SSL env var to uncomment

### DIFF
--- a/packaging/debroot/etc/rundeck/profile
+++ b/packaging/debroot/etc/rundeck/profile
@@ -52,7 +52,7 @@ RDECK_JVM="-Djava.security.auth.login.config=$JAAS_CONF \
 RDECK_JVM="$RDECK_JVM $RDECK_JVM_SETTINGS"
 #
 # SSL Configuration - Uncomment the following to enable.  Check SSL.properties for details.
-#
+# RUNDECK_WITH_SSL=true
 if [ -n "$RUNDECK_WITH_SSL" ] ; then
   RDECK_JVM="$RDECK_JVM -Drundeck.ssl.config=$RDECK_SERVER_CONFIG/ssl/ssl.properties -Dserver.https.port=${RDECK_HTTPS_PORT}"
   RDECK_SSL_OPTS="${RDECK_SSL_OPTS:- -Djavax.net.ssl.trustStore=$RDECK_TRUSTSTORE_FILE -Djavax.net.ssl.trustStoreType=$RDECK_TRUSTSTORE_TYPE -Djava.protocol.handler.pkgs=com.sun.net.ssl.internal.www.protocol}"

--- a/packaging/debroot/etc/rundeck/profile
+++ b/packaging/debroot/etc/rundeck/profile
@@ -52,7 +52,7 @@ RDECK_JVM="-Djava.security.auth.login.config=$JAAS_CONF \
 RDECK_JVM="$RDECK_JVM $RDECK_JVM_SETTINGS"
 #
 # SSL Configuration - Uncomment the following to enable.  Check SSL.properties for details.
-# RUNDECK_WITH_SSL=true
+#RUNDECK_WITH_SSL=true
 if [ -n "$RUNDECK_WITH_SSL" ] ; then
   RDECK_JVM="$RDECK_JVM -Drundeck.ssl.config=$RDECK_SERVER_CONFIG/ssl/ssl.properties -Dserver.https.port=${RDECK_HTTPS_PORT}"
   RDECK_SSL_OPTS="${RDECK_SSL_OPTS:- -Djavax.net.ssl.trustStore=$RDECK_TRUSTSTORE_FILE -Djavax.net.ssl.trustStoreType=$RDECK_TRUSTSTORE_TYPE -Djava.protocol.handler.pkgs=com.sun.net.ssl.internal.www.protocol}"

--- a/packaging/root/etc/rundeck/profile
+++ b/packaging/root/etc/rundeck/profile
@@ -52,7 +52,7 @@ RDECK_JVM="-Djava.security.auth.login.config=$JAAS_CONF \
 RDECK_JVM="$RDECK_JVM $RDECK_JVM_SETTINGS"
 #
 # SSL Configuration - Uncomment the following to enable.  Check SSL.properties for details.
-#
+#RUNDECK_WITH_SSL=true
 if [ -n "$RUNDECK_WITH_SSL" ] ; then
   RDECK_JVM="$RDECK_JVM -Drundeck.ssl.config=$RDECK_SERVER_CONFIG/ssl/ssl.properties -Dserver.https.port=${RDECK_HTTPS_PORT}"
   RDECK_SSL_OPTS="${RDECK_SSL_OPTS:- -Djavax.net.ssl.trustStore=$RDECK_TRUSTSTORE_FILE -Djavax.net.ssl.trustStoreType=$RDECK_TRUSTSTORE_TYPE -Djava.protocol.handler.pkgs=com.sun.net.ssl.internal.www.protocol}"


### PR DESCRIPTION
Maybe I missed where RUNDECK_WITH_SSL is set elsewhere, but it appears the profile is missing an example line to set the RUNDECK_WITH_SSL environment variable in order to trigger SSL flags.

related issue report: #2256 