### PR TITLE
docs: fix ssh-agent settings typo in changelog

### DIFF
--- a/docs/en/history/changelog.md
+++ b/docs/en/history/changelog.md
@@ -1341,13 +1341,13 @@ This release has bug fixes and new features, including some GUI improvements.
     - this can be enabled per node, project, or server
         framework.properties:
 
-            framework.local.ssh-agent=<true|false>
-            framework.local.ttl-ssh-agent=<time in sec>
+            framework.local-ssh-agent=<true|false>
+            framework.local-ttl-ssh-agent=<time in sec>
 
         project.properties:
 
-            project.local.ssh-agent=<true|false>
-            project.local.ttl-ssh-agent=<time in sec>
+            project.local-ssh-agent=<true|false>
+            project.local-ttl-ssh-agent=<time in sec>
 
         Node properties:
 


### PR DESCRIPTION
There was a typo in the docs, it was cleaned up in most places in #1093 but `changelog.md` was missed.