### PR TITLE
[fix] IllegalArgumentException at job start on storage dirs creation

### DIFF
--- a/rundeck-storage/rundeck-storage-filesys/src/main/java/org/rundeck/storage/data/file/DirectFilepathMapper.java
+++ b/rundeck-storage/rundeck-storage-filesys/src/main/java/org/rundeck/storage/data/file/DirectFilepathMapper.java
@@ -33,16 +33,8 @@ public class DirectFilepathMapper implements FilepathMapper {
         this.rootDir = rootDir;
         this.contentDir = new File(rootDir, "content");
         this.metaDir = new File(rootDir, "meta");
-        if (!contentDir.exists()) {
-            if (!contentDir.mkdirs()) {
-                throw new IllegalArgumentException("Unable to create root dir: " + rootDir);
-            }
-        }
-        if (!metaDir.exists()) {
-            if (!metaDir.mkdirs()) {
-                throw new IllegalArgumentException("Unable to create meta dir: " + metaDir);
-            }
-        }
+        contentDir.mkdirs();
+        metaDir.mkdirs();
     }
 
     /**


### PR DESCRIPTION
Let mkdirs() create directories only if they don't exist
(instead of testing first) to avoid any race condition.

fixes #2400