### PR TITLE
Job State Conditional check logs warning if not a failure

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ServiceThreadBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ServiceThreadBase.java
@@ -30,11 +30,11 @@ import java.util.*;
  *
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
-public class ServiceThreadBase extends Thread {
+public class ServiceThreadBase<T> extends Thread {
     volatile boolean success = false;
     private volatile boolean aborted = false;
     volatile Throwable thrown;
-    volatile Object resultObject;
+    volatile T resultObject;
 
     public void abort() {
         if (isAlive()) {
@@ -55,7 +55,7 @@ public class ServiceThreadBase extends Thread {
         return aborted;
     }
 
-    public Object getResultObject() {
+    public T getResultObject() {
         return resultObject;
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/WorkflowExecutionServiceThread.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/WorkflowExecutionServiceThread.java
@@ -34,7 +34,7 @@ import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutor;
  *
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
-public class WorkflowExecutionServiceThread extends ServiceThreadBase {
+public class WorkflowExecutionServiceThread extends ServiceThreadBase<WorkflowExecutionResult> {
     WorkflowExecutionService weservice;
     WorkflowExecutionItem weitem;
     private StepExecutionContext context;

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/EngineWorkflowExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/EngineWorkflowExecutor.java
@@ -6,12 +6,12 @@ import com.dtolabs.rundeck.core.dispatcher.DataContextUtils;
 import com.dtolabs.rundeck.core.execution.ExecutionListener;
 import com.dtolabs.rundeck.core.execution.StepExecutionItem;
 import com.dtolabs.rundeck.core.execution.service.ExecutionServiceException;
-import com.dtolabs.rundeck.core.execution.workflow.steps.*;
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepException;
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutionResult;
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutionResultImpl;
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepFailureReason;
 import com.dtolabs.rundeck.core.rules.*;
 import com.dtolabs.rundeck.plugins.ServiceNameConstants;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.collect.FluentIterable;
 import org.apache.log4j.Logger;
 
 import java.util.*;
@@ -319,6 +319,7 @@ public class EngineWorkflowExecutor extends BaseWorkflowExecutor {
                 stepExecutionResults.put(success.stepNum, success.result);
                 if (!success.result.isSuccess()) {
                     stepFailures.put(success.stepNum, success.result);
+                    workflowSuccess = false;
                 }
                 stepResults.add(success.result);
                 if (success.controlBehavior != null && success.controlBehavior != ControlBehavior.Continue) {
@@ -363,17 +364,6 @@ public class EngineWorkflowExecutor extends BaseWorkflowExecutor {
                         )
                 );
             }
-        }
-        // fail if there is any result is not successful
-        Predicate<StepExecutionResult> resultSuccess = new Predicate<StepExecutionResult>() {
-            @Override
-            public boolean apply(final StepExecutionResult stepExecutionResult) {
-                return stepExecutionResult.isSuccess();
-            }
-        };
-
-        if (FluentIterable.from(stepExecutionResults.values()).anyMatch(Predicates.not(resultSuccess))) {
-            workflowSuccess = false;
         }
 
         WorkflowStatusResult workflowResult = workflowResult(

--- a/plugins/job-state-plugin/build.gradle
+++ b/plugins/job-state-plugin/build.gradle
@@ -21,7 +21,15 @@
 ext.pluginClassNames = 'org.rundeck.plugin.jobstate.JobStateWorkflowStep'
 ext.pluginName = 'Job State Conditional'
 ext.pluginDescription = 'Evaluate state of another Job'
+apply plugin: 'groovy'
+dependencies{
 
+    testCompile 'junit:junit:4.8.1',
+                'org.mockito:mockito-all:1.8.5'
+
+    testCompile "org.codehaus.groovy:groovy-all:2.3.7"
+    testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
+}
 jar {
     manifest {
         attributes 'Rundeck-Plugin-Classnames': pluginClassNames

--- a/plugins/job-state-plugin/src/main/java/org/rundeck/plugin/jobstate/JobStateWorkflowStep.java
+++ b/plugins/job-state-plugin/src/main/java/org/rundeck/plugin/jobstate/JobStateWorkflowStep.java
@@ -165,10 +165,7 @@ public class JobStateWorkflowStep implements StepPlugin {
             throws StepException
     {
         if(result!=equality) {
-            //for now fail
-//            String message = "Condition not met: " + stringBuilder;
-//            throw new StepException(message, Failures.ConditionNotMet);
-            context.getLogger().log(0, message);
+            context.getLogger().log(halt && fail ? 0 : 1, message);
             haltConditionally(context);
         }else{
             context.getLogger().log(2, message);

--- a/plugins/job-state-plugin/src/test/groovy/org/rundeck/plugin/jobstate/JobStateWorkflowStepSpec.groovy
+++ b/plugins/job-state-plugin/src/test/groovy/org/rundeck/plugin/jobstate/JobStateWorkflowStepSpec.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.plugin.jobstate
+
+import com.dtolabs.rundeck.core.execution.ExecutionContext
+import com.dtolabs.rundeck.core.execution.workflow.FlowControl
+import com.dtolabs.rundeck.core.jobs.JobReference
+import com.dtolabs.rundeck.core.jobs.JobService
+import com.dtolabs.rundeck.core.jobs.JobState
+import com.dtolabs.rundeck.plugins.PluginLogger
+import com.dtolabs.rundeck.plugins.step.PluginStepContext
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * @author greg
+ * @since 4/12/17
+ */
+class JobStateWorkflowStepSpec extends Specification {
+    @Unroll
+    def "state check #rightstate halt #halt and fail #fail should log at #loglevel"() {
+        given:
+        def step = new JobStateWorkflowStep()
+        step.halt = halt
+        step.fail = fail
+        def actualState = 'failed'
+        step.executionState = rightstate ? actualState : 'wrongstate'
+        step.jobUUID = 'auuid'
+
+
+        def context = Mock(PluginStepContext)
+        def config = [:]
+
+        when:
+        step.executeStep(context, config)
+        then:
+        1 * context.getFrameworkProject() >> 'projectName'
+        1 * context.getExecutionContext() >> Mock(ExecutionContext) {
+            getJobService() >> Mock(JobService) {
+                1 * jobForID('auuid', _) >> Mock(JobReference)
+                1 * getJobState(_) >> Mock(JobState) {
+                    getPreviousExecutionState() >> actualState
+                }
+            }
+        }
+        1 * context.getLogger() >> Mock(PluginLogger) {
+            1 * log(loglevel, _)
+        }
+        if (!rightstate) {
+            if (halt) {
+                context.getFlowControl() >> Mock(FlowControl) {
+                    1 * Halt(!fail)
+                }
+            } else {
+                context.getFlowControl() >> Mock(FlowControl) {
+                    1 * Continue()
+                }
+            }
+        }
+
+
+        where:
+        halt  | fail  | rightstate | loglevel
+        true  | false | false      | 1
+        true  | true  | false      | 0
+        false | true  | false      | 1
+        false | true  | true       | 2
+
+
+    }
+}

--- a/rundeckapp/grails-app/assets/stylesheets/rundeck.less
+++ b/rundeckapp/grails-app/assets/stylesheets/rundeck.less
@@ -1175,8 +1175,11 @@ section{
     }
 
 
-    td.data.log_warn, td.data.log_error {
+    td.data.log_error {
       color: #800;
+    }
+    td.data.log_warn {
+      color: #a80;
     }
 
     table.execoutput.collapse_stepnum {

--- a/rundeckapp/test/unit/rundeck/services/ExecutionUtilServiceTests.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ExecutionUtilServiceTests.groovy
@@ -18,6 +18,9 @@ package rundeck.services
 
 import com.dtolabs.rundeck.core.execution.ServiceThreadBase
 import com.dtolabs.rundeck.core.execution.StepExecutionItem
+import com.dtolabs.rundeck.core.execution.workflow.ControlBehavior
+import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionResult
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutionResult
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.impl.ExecCommandExecutionItem
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.impl.ScriptFileCommandExecutionItem
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.impl.ScriptURLCommandExecutionItem
@@ -69,7 +72,7 @@ class ExecutionUtilServiceTests {
     void testFinishExecutionLoggingNoMessage(){
 
         def executionUtilService = new ExecutionUtilService()
-        def thread = new ServiceThreadBase()
+        def thread = new ServiceThreadBase<WorkflowExecutionResult>()
         thread.success = false
         def logcontrol = mockFor(ExecutionLogWriter)
         logcontrol.demand.logError(1..1){String value->
@@ -96,9 +99,49 @@ class ExecutionUtilServiceTests {
     void testFinishExecutionLoggingNoMessageWithResult(){
 
         def executionUtilService = new ExecutionUtilService()
-        def thread = new ServiceThreadBase()
+        def thread = new ServiceThreadBase<WorkflowExecutionResult>()
         thread.success = false
-        thread.resultObject="abcd"
+        thread.resultObject=new WorkflowExecutionResult(){
+            @Override
+            String getStatusString() {
+                return null
+            }
+
+            @Override
+            ControlBehavior getControlBehavior() {
+                return null
+            }
+
+            @Override
+            boolean isSuccess() {
+                return false
+            }
+
+            @Override
+            Throwable getException() {
+                return null
+            }
+
+            @Override
+            List<StepExecutionResult> getResultSet() {
+                return null
+            }
+
+            @Override
+            Map<String, Collection<StepExecutionResult>> getNodeFailures() {
+                return null
+            }
+
+            @Override
+            Map<Integer, StepExecutionResult> getStepFailures() {
+                return null
+            }
+
+            @Override
+            String toString() {
+                "abcd"
+            }
+        }
         def logcontrol = mockFor(ExecutionLogWriter)
         logcontrol.demand.logVerbose(1..1){String value->
             assertEquals("abcd",value)
@@ -127,9 +170,9 @@ class ExecutionUtilServiceTests {
     void testFinishExecutionLoggingCausedByException(){
 
         def executionUtilService = new ExecutionUtilService()
-        def thread = new ServiceThreadBase()
+        def thread = new ServiceThreadBase<WorkflowExecutionResult>()
         thread.success = false
-        thread.resultObject="abcd123"
+        thread.resultObject=null
         thread.thrown=new Exception("exceptionTest1")
         def logcontrol = mockFor(ExecutionLogWriter)
         logcontrol.demand.logError(1..1){String value->
@@ -160,9 +203,9 @@ class ExecutionUtilServiceTests {
     void testFinishExecutionLoggingCausedByExceptionWithCause(){
 
         def executionUtilService = new ExecutionUtilService()
-        def thread = new ServiceThreadBase()
+        def thread = new ServiceThreadBase<WorkflowExecutionResult>()
         thread.success = false
-        thread.resultObject="abcd123"
+        thread.resultObject=null
         def cause=new Exception("exceptionCause1")
         thread.thrown=new Exception("exceptionTest1",cause)
         def logcontrol = mockFor(ExecutionLogWriter)


### PR DESCRIPTION
* If Job State Conditional  causes Halt without a failure: log a warning level instead of error
* Log execution result status not as "failed" if flow control caused a halt that was not a failure
* Log execution result status as succeeded if flow control caused a halt that was a success
* fix #2116 