### PR TITLE
Using option value in key storage path

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1045,13 +1045,13 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     !(secureOpts?.containsKey(it.name))
         }
         if (found) {
-
             //load secure option defaults from key storage
             def keystore = storageService.storageTreeWithContext(authContext)
             found?.each {
                 try {
                     def defStoragePath = it.defaultStoragePath
-                    if (args && defStoragePath?.contains('${')) {
+                    //search and replace ${option.
+                    if (args && defStoragePath?.contains('${option.')) {
                         defStoragePath = DataContextUtils.replaceDataReferences(defStoragePath, DataContextUtils.addContext("option", args, null)).trim()
                     }
                     def password = keystore.readPassword(defStoragePath)


### PR DESCRIPTION
Adds the possibility to relate and option value with a key storage path for secure option, in order to select the key storage path depending on the option value selected, for example:

`keys/${option.enviroment}/password`

It only replaces option values, and in case the option doesn't exist or doesn't match a valid keystorage path, it just use a default empty value.

Fixes  #1822

Example of job using this feature:
```
- description: 'test for issue 1822 '
  executionEnabled: true
  group: issue
  id: d32cb0d7-2c41-4456-8a7a-ca2ac7dcdbb2
  loglevel: INFO
  name: '1822'
  nodeFilterEditable: false
  options:
  - description: develop,production,qa
    enforced: true
    name: environment
    required: true
    value: develop
    values:
    - develop
    - production
    - qa
  - name: dbpassenv
    secure: true
    storagePath: keys/${option.environment}/storage/db.pass
    valueExposed: true
  scheduleEnabled: true
  sequence:
    commands:
    - exec: echo "${option.environment} ${option.dbpassenv}"
    keepgoing: false
    pluginConfig:
      WorkflowStrategy:
        node-first: null
    strategy: node-first
  uuid: d32cb0d7-2c41-4456-8a7a-ca2ac7dcdbb2
```