### PR TITLE
Update postgresql connector to 42.0.0

### DIFF
--- a/rundeckapp/grails-app/conf/BuildConfig.groovy
+++ b/rundeckapp/grails-app/conf/BuildConfig.groovy
@@ -123,7 +123,7 @@ grails.project.dependency.resolution = {
         compile("org.rundeck:rundeck-core:${rundeckVersion}")
         compile("org.rundeck:rundeck-storage-filesys:${rundeckVersion}")
 
-        runtime 'postgresql:postgresql:9.1-901.jdbc4'
+        runtime 'postgresql:postgresql:42.0.0'
         runtime 'mysql:mysql-connector-java:5.1.35'
 
         //BEGIN fix hibernate4 bug with dateCreated auto timestamp, see: https://jira.grails.org/browse/GPHIB-30

--- a/rundeckapp/grails-app/conf/BuildConfig.groovy
+++ b/rundeckapp/grails-app/conf/BuildConfig.groovy
@@ -123,7 +123,7 @@ grails.project.dependency.resolution = {
         compile("org.rundeck:rundeck-core:${rundeckVersion}")
         compile("org.rundeck:rundeck-storage-filesys:${rundeckVersion}")
 
-        runtime 'postgresql:postgresql:42.0.0'
+        runtime 'org.postgresql:postgresql:42.0.0'
         runtime 'mysql:mysql-connector-java:5.1.35'
 
         //BEGIN fix hibernate4 bug with dateCreated auto timestamp, see: https://jira.grails.org/browse/GPHIB-30


### PR DESCRIPTION
postgresql is very very very old (PostgreSQL 9.1). It's not compatible with postgresql 9.6, update to a postgresql 9.6 version with JDK 8 support.

See https://jdbc.postgresql.org/download.html