### PR TITLE
Changing wording of project global variable override.

### DIFF
--- a/docs/en/administration/03-configuration.md
+++ b/docs/en/administration/03-configuration.md
@@ -97,7 +97,7 @@ The token_strings can be used as Authentication tokens to the [API](../api/index
 
 Entries in `framework.properties` in the form `framework.globals.X=Y` Adds a variable `X` available in all execution contexts as `${globals.X}`.
 
-Values can be overridden in the [`project.properties`](#project.properties) configuration for a project.
+Global variables can be overridden in the [`project.properties`](#project.properties) by adding a line in the form of `project.globals.X=Y` and then accessing it as `${globals.X}`.
 
 
 ## log4j.properties


### PR DESCRIPTION
On reading this page as part of making this change, I see that it links
to the project config docs where project.globals are mentioned and that
links to further documentation on project globals that fully explains
it.  But I looked at this top level a couple times and missed this
wording and the link.  I'm thinking this wording might have helped,
but perhaps this is more my problem than a docs problem.  :-)