### PR TITLE
Job Reference on another Project

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/jobedit.js
+++ b/rundeckapp/grails-app/assets/javascripts/jobedit.js
@@ -1070,7 +1070,7 @@ function jobChosen(name, group) {
     }
     hideJobChooser();
 }
-function loadJobChooser(elem, nameid, groupid) {
+function loadJobChooser(elem, nameid, groupid, projectid) {
     if (jQuery(elem).hasClass('active')) {
         hideJobChooser();
         return;
@@ -1078,10 +1078,15 @@ function loadJobChooser(elem, nameid, groupid) {
     jobNameFieldId = nameid;
     jobGroupFieldId = groupid;
     var project = selFrameworkProject;
+
+    if(projectid){
+        project = jQuery('#' + projectid).val();
+    }
     jQuery(elem).button('loading').addClass('active');
     jQuery.ajax({
-        url:_genUrl(appLinks.menuJobsPicker, {jobsjscallback: 'true', runAuthRequired: true}),
+        url:_genUrl(appLinks.menuJobsPicker, {jobsjscallback: 'true', runAuthRequired: true, projFilter: project}),
         success: function (resp, status, jqxhr){
+            jQuery(elem).popover('destroy');
             jQuery(elem).popover({html: true, container: 'body', placement: 'left', content: resp, trigger: 'manual'}).popover('show');
             jQuery(elem).button('reset');
         },

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -462,6 +462,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         if(query && !query.projFilter && params.project) {
             query.projFilter = params.project
             authContext = frameworkService.getAuthContextForSubjectAndProject(session.subject, params.project)
+        } else if(query && query.projFilter){
+            authContext = frameworkService.getAuthContextForSubjectAndProject(session.subject, query.projFilter)
         } else {
             authContext = frameworkService.getAuthContextForSubject(session.subject)
         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2064,6 +2064,7 @@ class ScheduledExecutionController  extends ControllerBase{
         def strategyPlugins = scheduledExecutionService.getWorkflowStrategyPluginDescriptions()
         def logFilterPlugins = pluginService.listPlugins(LogFilterPlugin)
         def globals = frameworkService.getProjectGlobals(scheduledExecution.project).keySet()
+        def fprojects = frameworkService.projectNames(authContext)
         render(
                 view: 'create',
                 model: [
@@ -2078,6 +2079,7 @@ class ScheduledExecutionController  extends ControllerBase{
                         notificationPlugins : notificationService.listNotificationPlugins(),
                         orchestratorPlugins : orchestratorPluginService.listDescriptions(),
                         logFilterPlugins    : logFilterPlugins,
+                        projectNames        : fprojects,
                         globalVars          : globals
                 ]
         )

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -1917,6 +1917,7 @@ class ScheduledExecutionController  extends ControllerBase{
         def orchestratorPlugins = orchestratorPluginService.listDescriptions()
         def globals=frameworkService.getProjectGlobals(scheduledExecution.project).keySet()
         def logFilterPlugins = pluginService.listPlugins(LogFilterPlugin)
+        def fprojects = frameworkService.projectNames(authContext)
         return [scheduledExecution  :scheduledExecution, crontab:crontab, params:params,
                 notificationPlugins : notificationPlugins,
                 orchestratorPlugins : orchestratorPlugins,
@@ -1926,7 +1927,9 @@ class ScheduledExecutionController  extends ControllerBase{
                 nodeStepDescriptions: nodeStepTypes,
                 stepDescriptions    : stepTypes,
                 logFilterPlugins    : logFilterPlugins,
-                globalVars          :globals]
+                projectNames        : fprojects,
+                globalVars          : globals
+        ]
     }
 
 
@@ -2209,13 +2212,15 @@ class ScheduledExecutionController  extends ControllerBase{
         def strategyPlugins = scheduledExecutionService.getWorkflowStrategyPluginDescriptions()
         def globals=frameworkService.getProjectGlobals(scheduledExecution.project).keySet()
         def logFilterPlugins = pluginService.listPlugins(LogFilterPlugin)
-        return ['scheduledExecution':scheduledExecution,params:params,crontab:[:],
+        def fprojects = frameworkService.projectNames(authContext)
+        return ['scheduledExecution':scheduledExecution, params:params, crontab:[:],
                 nodeStepDescriptions: nodeStepTypes, stepDescriptions: stepTypes,
-                notificationPlugins: notificationService.listNotificationPlugins(),
-                strategyPlugins:strategyPlugins,
-                orchestratorPlugins: orchestratorPluginService.listDescriptions(),
-                logFilterPlugins: logFilterPlugins,
-                globalVars:globals]
+                notificationPlugins : notificationService.listNotificationPlugins(),
+                strategyPlugins     :strategyPlugins,
+                orchestratorPlugins : orchestratorPluginService.listDescriptions(),
+                logFilterPlugins    : logFilterPlugins,
+                projectNames        : fprojects,
+                globalVars          :globals]
     }
 
     private clearEditSession(id='_new'){

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
@@ -1113,7 +1113,7 @@ class WorkflowController extends ControllerBase implements PluginListRequired {
      * @param exec the WorkflowStep
      * @param type type if specified in params
      */
-    public static boolean _validateCommandExec(WorkflowStep exec, String type = null, ArrayList authProjects = null) {
+    public static boolean _validateCommandExec(WorkflowStep exec, String type = null, List authProjects = null) {
         if (exec instanceof JobExec) {
             if (!exec.jobName) {
                 exec.errors.rejectValue('jobName', 'commandExec.jobName.blank.message')

--- a/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
@@ -30,6 +30,7 @@ public class JobExec extends WorkflowStep implements IWorkflowJobItem{
 
     String jobName
     String jobGroup
+    String jobProject
     String jobIdentifier
     String argString
     String nodeFilter
@@ -44,6 +45,7 @@ public class JobExec extends WorkflowStep implements IWorkflowJobItem{
     static constraints = {
         jobName(nullable: false, blank: false, maxSize: 1024)
         jobGroup(nullable: true, blank: true, maxSize: 2048)
+        jobProject(nullable: true, blank: true, maxSize: 2048)
         argString(nullable: true, blank: true)
         nodeStep(nullable: true)
         nodeKeepgoing(nullable: true)
@@ -58,12 +60,13 @@ public class JobExec extends WorkflowStep implements IWorkflowJobItem{
         argString type: 'text'
         jobName type: 'string'
         jobGroup type: 'string'
+        jobProject type: 'string'
         nodeFilter type: 'text'
         nodeRankAttribute type: 'text'
     }
 
     public String toString() {
-        return "jobref(name=\"${jobName}\" group=\"${jobGroup}\" argString=\"${argString}\" " +
+        return "jobref(name=\"${jobName}\" group=\"${jobGroup}\" project=\"${jobProject}\" argString=\"${argString}\" " +
                 "nodeStep=\"${nodeStep}\"" +
                 "nodeFilter=\"${nodeFilter}\"" +
                 "nodeKeepgoing=\"${nodeKeepgoing}\"" +
@@ -97,6 +100,9 @@ public class JobExec extends WorkflowStep implements IWorkflowJobItem{
      */
     public Map toMap(){
         final Map map = [jobref: [group: jobGroup ? jobGroup : '', name: jobName]]
+        if(jobProject){
+            map.project = jobProject
+        }
         if(argString){
             map.jobref.args=argString
         }
@@ -140,6 +146,9 @@ public class JobExec extends WorkflowStep implements IWorkflowJobItem{
         JobExec exec = new JobExec()
         exec.jobGroup=map.jobref.group
         exec.jobName=map.jobref.name
+        if(map.jobref.jobProject){
+            exec.jobProject = map.jobref.jobProject
+        }
         if(map.jobref.args){
             exec.argString=map.jobref.args
         }

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1468,3 +1468,5 @@ remove.filter=Remove Filter
 add=add
 global.log.filters=Global Log Filters:
 log.filters=Log Filters:
+scheduledExecution.projectPath.label=Another Project (Optional)
+commandExec.jobProject.unauth.message=Unauthorized Job Project

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1468,3 +1468,5 @@ remove.filter=Remove Filter
 add=add
 global.log.filters=Global Log Filters:
 log.filters=Log Filters:
+scheduledExecution.projectPath.label=Otro Projecto (Opcional)
+commandExec.jobProject.unauth.message=Projecto No autorizado

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -42,6 +42,7 @@ import com.dtolabs.rundeck.core.utils.NodeSet
 import com.dtolabs.rundeck.core.utils.OptsUtil
 import com.dtolabs.rundeck.core.utils.ThreadBoundOutputStream
 import com.dtolabs.rundeck.execution.JobExecutionItem
+import com.dtolabs.rundeck.execution.JobRefCommand
 import com.dtolabs.rundeck.execution.JobReferenceFailureReason
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
 import com.dtolabs.rundeck.plugins.scm.JobChangeEvent
@@ -3006,6 +3007,11 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     {
         def id
         def result
+        def project = null
+        if(jitem instanceof JobRefCommand){
+            JobRefCommand jitemRef = (JobRefCommand) jitem
+            project = jitemRef.project
+        }
 
         def group = null
         def name = null
@@ -3016,9 +3022,10 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         } else {
             name = jitem.jobIdentifier
         }
-        def schedlist = ScheduledExecution.findAllScheduledExecutions(group, name, executionContext.getFrameworkProject())
+        project = project?project:executionContext.getFrameworkProject()
+        def schedlist = ScheduledExecution.findAllScheduledExecutions(group, name, project)
         if (!schedlist || 1 != schedlist.size()) {
-            def msg = "Job [${jitem.jobIdentifier}] not found, project: ${executionContext.getFrameworkProject()}"
+            def msg = "Job [${jitem.jobIdentifier}] not found, project: ${project}"
             executionContext.getExecutionListener().log(0, msg)
             throw new StepException(msg, JobReferenceFailureReason.NotFound)
         }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
@@ -252,7 +252,8 @@ class ExecutionUtilService {
                     jobcmditem.nodeRankAttribute,
                     jobcmditem.nodeRankOrderAscending,
                     step.description,
-                    jobcmditem.nodeIntersect
+                    jobcmditem.nodeIntersect,
+                    jobcmditem.jobProject
             )
         }else if(step instanceof PluginStep || step.instanceOf(PluginStep)){
             final PluginStep stepitem = step as PluginStep

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1723,8 +1723,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
     }
 
-    def validateWorkflowStep(WorkflowStep step) {
-        WorkflowController._validateCommandExec(step)
+    def validateWorkflowStep(WorkflowStep step, List projects = []) {
+        WorkflowController._validateCommandExec(step, null, projects)
         if (step.errors.hasErrors()) {
             return false
         } else if (step instanceof PluginStep) {
@@ -1893,7 +1893,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 def failedlist = []
                 def i = 1;
                 wf.commands.each {WorkflowStep cexec ->
-                    if (!validateWorkflowStep(cexec,fprojects)) {
+                    if (!validateWorkflowStep(cexec, fprojects)) {
                         wfitemfailed = true
 
                         failedlist << "$i: " + cexec.errors.allErrors.collect {
@@ -1902,7 +1902,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                     }
 
                     if (cexec.errorHandler) {
-                        if (!validateWorkflowStep(cexec.errorHandler,fprojects)) {
+                        if (!validateWorkflowStep(cexec.errorHandler, fprojects)) {
                             wfitemfailed = true
                             failedlist << "$i: " + cexec.errorHandler.errors.allErrors.collect {
                                 messageSource.getMessage(it,Locale.default)
@@ -1943,7 +1943,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
                 cexec.properties = cmdparams
                 workflow.addToCommands(cexec)
-                if (!validateWorkflowStep(cexec,fprojects)) {
+                if (!validateWorkflowStep(cexec, fprojects)) {
                     wfitemfailed = true
                     failedlist << (i + 1)+ ": " + cexec.errors.allErrors.collect {
                         messageSource.getMessage(it,Locale.default)
@@ -1951,7 +1951,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
 
                 if (cmdparams.errorHandler) {
-                    if (!validateWorkflowStep(cmdparams.errorHandler,fprojects)) {
+                    if (!validateWorkflowStep(cmdparams.errorHandler, fprojects)) {
                         wfitemfailed = true
                         failedlist << (i + 1)+ ": " + cmdparams.errorHandler.errors.allErrors.collect {
                             messageSource.getMessage(it,Locale.default)

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1883,6 +1883,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
         def todiscard = []
         def wftodelete = []
+        def fprojects = frameworkService.projectNames(authContext)
 
         if (scheduledExecution.workflow && params['_sessionwf'] && params['_sessionEditWFObject']) {
             //load the session-stored modified workflow and replace the existing one
@@ -1892,7 +1893,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 def failedlist = []
                 def i = 1;
                 wf.commands.each {WorkflowStep cexec ->
-                    if (!validateWorkflowStep(cexec)) {
+                    if (!validateWorkflowStep(cexec,fprojects)) {
                         wfitemfailed = true
 
                         failedlist << "$i: " + cexec.errors.allErrors.collect {
@@ -1901,7 +1902,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                     }
 
                     if (cexec.errorHandler) {
-                        if (!validateWorkflowStep(cexec.errorHandler)) {
+                        if (!validateWorkflowStep(cexec.errorHandler,fprojects)) {
                             wfitemfailed = true
                             failedlist << "$i: " + cexec.errorHandler.errors.allErrors.collect {
                                 messageSource.getMessage(it,Locale.default)
@@ -1942,7 +1943,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
                 cexec.properties = cmdparams
                 workflow.addToCommands(cexec)
-                if (!validateWorkflowStep(cexec)) {
+                if (!validateWorkflowStep(cexec,fprojects)) {
                     wfitemfailed = true
                     failedlist << (i + 1)+ ": " + cexec.errors.allErrors.collect {
                         messageSource.getMessage(it,Locale.default)
@@ -1950,7 +1951,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
 
                 if (cmdparams.errorHandler) {
-                    if (!validateWorkflowStep(cmdparams.errorHandler)) {
+                    if (!validateWorkflowStep(cmdparams.errorHandler,fprojects)) {
                         wfitemfailed = true
                         failedlist << (i + 1)+ ": " + cmdparams.errorHandler.errors.allErrors.collect {
                             messageSource.getMessage(it,Locale.default)
@@ -2540,7 +2541,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
         def frameworkProject = frameworkService.getFrameworkProject(scheduledExecution.project)
         def projectProps = frameworkProject.getProperties()
-
+        def fprojects = frameworkService.projectNames(authContext)
         if (params.workflow) {
             //use the input params to define the workflow
             //create workflow and CommandExecs
@@ -2549,7 +2550,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             def wfitemfailed = false
             def failedlist = []
             workflow.commands.each { WorkflowStep cexec ->
-                if (!validateWorkflowStep(cexec)) {
+                if (!validateWorkflowStep(cexec, fprojects)) {
                     wfitemfailed = true
                     failedlist <<  "$i: " + cexec.errors.allErrors.collect {
                         messageSource.getMessage(it,Locale.default)
@@ -2557,7 +2558,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
 
                 if (cexec.errorHandler) {
-                    if (!validateWorkflowStep(cexec.errorHandler)) {
+                    if (!validateWorkflowStep(cexec.errorHandler, fprojects)) {
                         wfitemfailed = true
                         failedlist << "$i: " + cexec.errorHandler.errors.allErrors.collect {
                             messageSource.getMessage(it,Locale.default)
@@ -2905,6 +2906,10 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             scheduledExecution.description = ''
         }
 
+        def fprojects = new ArrayList()
+        if(userAndRoles instanceof AuthContext){
+            fprojects = frameworkService.projectNames((AuthContext)userAndRoles)
+        }
 
         def valid = scheduledExecution.validate()
         if (scheduledExecution.scheduled) {
@@ -2956,7 +2961,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 def i = 1
                 def failedlist = []
                 wf.commands.each {WorkflowStep cexec ->
-                    if (!validateWorkflowStep(cexec)) {
+                    if (!validateWorkflowStep(cexec, fprojects)) {
                         wfitemfailed = true
                         failedlist << "$i: " + cexec.errors.allErrors.collect {
                             messageSource.getMessage(it,Locale.default)
@@ -2964,7 +2969,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                     }
 
                     if (cexec.errorHandler) {
-                        if (!validateWorkflowStep(cexec.errorHandler)) {
+                        if (!validateWorkflowStep(cexec.errorHandler, fprojects)) {
                             wfitemfailed = true
                             failedlist << "$i: " + cexec.errorHandler.errors.allErrors.collect {
                                 messageSource.getMessage(it,Locale.default)
@@ -2991,7 +2996,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             def wfitemfailed = false
             def failedlist = []
             workflow.commands.each {WorkflowStep cexec ->
-                if (!validateWorkflowStep(cexec)) {
+                if (!validateWorkflowStep(cexec, fprojects)) {
                     wfitemfailed = true
                     failedlist << "$i: " + cexec.errors.allErrors.collect {
                         messageSource.getMessage(it,Locale.default)
@@ -2999,7 +3004,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
 
                 if (cexec.errorHandler) {
-                    if (!validateWorkflowStep(cexec.errorHandler)) {
+                    if (!validateWorkflowStep(cexec.errorHandler, fprojects)) {
                         wfitemfailed = true
                         failedlist << "$i: " + cexec.errorHandler.errors.allErrors.collect {
                             messageSource.getMessage(it,Locale.default)
@@ -3037,7 +3042,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
                 cexec.properties = cmdparams
                 workflow.addToCommands(cexec)
-                if (!validateWorkflowStep(cexec)) {
+                if (!validateWorkflowStep(cexec, fprojects)) {
                     wfitemfailed = true
                     failedlist << (i+1 )+ ": " + cexec.errors.allErrors.collect {
                         messageSource.getMessage(it,Locale.default)
@@ -3045,7 +3050,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
 
                 if (cmdparams.errorHandler) {
-                    if (!validateWorkflowStep(cmdparams.errorHandler)) {
+                    if (!validateWorkflowStep(cmdparams.errorHandler, fprojects)) {
                         wfitemfailed = true
                         failedlist << (i+1 )+ ": " + cmdparams.errorHandler.errors.allErrors.collect {
                             messageSource.getMessage(it,Locale.default)

--- a/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
@@ -129,7 +129,8 @@ class WorkflowService implements ApplicationContextAware,ExecutionFileProducer{
             if (step instanceof JobExec) {
 
                 JobExec jexec = (JobExec) step
-                def schedlist = ScheduledExecution.findAllScheduledExecutions(jexec.jobGroup, jexec.jobName, project)
+                def searchProject = jexec.jobProject? jexec.jobProject: project
+                def schedlist = ScheduledExecution.findAllScheduledExecutions(jexec.jobGroup, jexec.jobName, searchProject)
                 if (!schedlist || 1 != schedlist.size()) {
                     //skip
                     return

--- a/rundeckapp/grails-app/views/execution/_wfItemView.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfItemView.gsp
@@ -26,21 +26,20 @@
             <g:set var="pluginitem" value="${item.instanceOf(PluginStep)}"/>
             <span class="${edit?'autohilite autoedit':''} wfitem ${jobitem?'jobtype':pluginitem?'plugintype':'exectype'}" title="${edit?'Click to edit':''}">
             <g:if test="${jobitem}">
-
                 %{--Display job icon and name--}%
-                <g:set var="foundjob" value="${edit?null:ScheduledExecution.findScheduledExecution(item.jobGroup?item.jobGroup:null,item.jobName,project)}"/>
+                <g:set var="foundjob" value="${edit?null:ScheduledExecution.findScheduledExecution(item.jobGroup?item.jobGroup:null,item.jobName,item.jobProject?item.jobProject:project)}"/>
                 <g:if test="${foundjob}">
                 <g:link controller="scheduledExecution" action="show" id="${foundjob.extid}">
                     <g:if test="${!noimgs }">
                         <i class="glyphicon glyphicon-book"></i>
                     </g:if>
-                    <g:enc>${(item.jobGroup?item.jobGroup+'/':'')+item.jobName}</g:enc></g:link>
+                    <g:enc>${(item.jobGroup?item.jobGroup+'/':'')+item.jobName + (item.jobProject?' (' + item.jobProject+') ':'') }</g:enc></g:link>
                 </g:if>
                 <g:else>
                     <g:if test="${!noimgs }">
                         <i class="glyphicon glyphicon-book"></i>
                     </g:if>
-                    <g:enc>${(item.jobGroup?item.jobGroup+'/':'')+item.jobName}</g:enc>
+                    <g:enc>${(item.jobGroup?item.jobGroup+'/':'')+item.jobName + (item.jobProject?' (' + item.jobProject+') ':'') }</g:enc>
                 </g:else>
 
                 %{--display step description--}%

--- a/rundeckapp/grails-app/views/execution/_wfitemEdit.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfitemEdit.gsp
@@ -39,22 +39,36 @@
             <section >
                 <div class="form-group">
                     <label class="col-sm-2 control-label" for="jobNameField${rkey}"><g:message code="Workflow.Step.jobreference.name-group.label" /></label>
-                    <div class="col-sm-4">
+                    <div class="col-sm-3">
 
                         <input id="jobNameField${rkey}" type="text" name="jobName" value="${enc(attr: item?.jobName)}"
                                placeholder="${message(code:"scheduledExecution.jobName.label")}"
                                class="form-control"
                                size="100" autofocus/>
                     </div>
-                    <div class="col-sm-4">
+                    <div class="col-sm-3">
                         <input id="jobGroupField${rkey}"  type="text" name="jobGroup" value="${enc(attr:item?.jobGroup)}" size="100"
                                placeholder="${message(code:"scheduledExecution.groupPath.label")}"
                                class="form-control"
                         />
                     </div>
+                    <div class="col-sm-2">
+                        <input id="jobProjectField${rkey}"  type="text" name="jobProject" value="${enc(attr:item?.jobProject)}" size="100"
+                               placeholder="${message(code:"scheduledExecution.projectPath.label")}"
+                               class="form-control"
+                        />
+                        <g:javascript>
+                fireWhenReady('jobProjectField${rkey}',function(){
+                        var projectsArr = loadJsonData('projectNamesData');
+                        jQuery("#jobProjectField${rkey}").devbridgeAutocomplete({
+                                    lookup: projectsArr
+                        });
+                    });
+                        </g:javascript>
+                    </div>
 
                     <div class="col-sm-2">
-                        <span class="btn btn-sm btn-default act_choose_job" onclick="loadJobChooser(this, 'jobNameField${rkey}','jobGroupField${rkey}');"
+                        <span class="btn btn-sm btn-default act_choose_job" onclick="loadJobChooser(this, 'jobNameField${rkey}','jobGroupField${rkey}', 'jobProjectField${rkey}');"
                               id="jobChooseBtn${rkey}"
                               title="${message(code:"select.an.existing.job.to.use")}"
                               data-loading-text="Loading...">

--- a/rundeckapp/grails-app/views/scheduledExecution/create.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/create.gsp
@@ -32,6 +32,8 @@
         _onJobEdit(confirm.setNeedsConfirm);
     </g:javascript>
     <g:embedJSON data="${globalVars ?: []}" id="globalVarData"/>
+
+    <g:embedJSON data="${projectNames ?: []}" id="projectNamesData"/>
 </head>
 <body>
 

--- a/rundeckapp/grails-app/views/scheduledExecution/edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/edit.gsp
@@ -32,6 +32,8 @@
         _onJobEdit(confirm.setNeedsConfirm);
     </g:javascript>
     <g:embedJSON data="${globalVars ?: []}" id="globalVarData"/>
+
+    <g:embedJSON data="${projectNames ?: []}" id="projectNamesData"/>
 </head>
 <body>
 

--- a/rundeckapp/src/java/com/dtolabs/rundeck/execution/ExecutionItemFactory.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/execution/ExecutionItemFactory.java
@@ -361,7 +361,8 @@ public class ExecutionItemFactory {
                 null,
                 null,
                 label,
-                false
+                false,
+                null
         );
     }
 
@@ -388,7 +389,8 @@ public class ExecutionItemFactory {
             final String nodeRankAttribute,
             final Boolean nodeRankOrderAscending,
             final String label,
-            final Boolean nodeIntersect
+            final Boolean nodeIntersect,
+            final String project
     )
     {
         return new JobRefCommandBase() {
@@ -448,6 +450,10 @@ public class ExecutionItemFactory {
 
             @Override public Boolean getNodeIntersect() {
                 return nodeIntersect;
+            }
+
+            @Override public String getProject(){
+                return project;
             }
         };
     }

--- a/rundeckapp/src/java/com/dtolabs/rundeck/execution/JobRefCommand.java
+++ b/rundeckapp/src/java/com/dtolabs/rundeck/execution/JobRefCommand.java
@@ -36,6 +36,10 @@ public abstract class JobRefCommand extends BaseExecutionItem implements JobExec
         return isNodeStep() ? NodeDispatchStepExecutor.STEP_EXECUTION_TYPE : JobExecutionItem.STEP_EXECUTION_TYPE;
     }
 
+    public String getProject(){
+        return null;
+    }
+
     public String getNodeStepType() {
         return STEP_EXECUTION_TYPE;
     }

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/execution/ExecutionItemFactoryTest.groovy
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/execution/ExecutionItemFactoryTest.groovy
@@ -226,6 +226,7 @@ class ExecutionItemFactoryTest {
                 null,
                 null,
                 null,
+                null,
                 null
         )
         Assert.assertTrue(test instanceof JobExecutionItem)
@@ -274,6 +275,7 @@ class ExecutionItemFactoryTest {
                 null,
                 null,
                 null,
+                null,
                 null
         )
         Assert.assertTrue(test instanceof JobExecutionItem)
@@ -291,6 +293,7 @@ class ExecutionItemFactoryTest {
                 true,
                 null,
                 2,
+                null,
                 null,
                 null,
                 null,
@@ -316,6 +319,7 @@ class ExecutionItemFactoryTest {
                 null,
                 null,
                 null,
+                null,
                 null
         )
         Assert.assertTrue(test instanceof JobExecutionItem)
@@ -334,6 +338,7 @@ class ExecutionItemFactoryTest {
                 null,
                 null,
                 false,
+                null,
                 null,
                 null,
                 null,
@@ -358,6 +363,7 @@ class ExecutionItemFactoryTest {
                 'rank',
                 null,
                 null,
+                null,
                 null
         )
         Assert.assertTrue(test instanceof JobExecutionItem)
@@ -378,6 +384,7 @@ class ExecutionItemFactoryTest {
                 null,
                 null,
                 true,
+                null,
                 null,
                 null
         )
@@ -400,6 +407,7 @@ class ExecutionItemFactoryTest {
                 null,
                 false,
                 null,
+                null,
                 null
         )
         Assert.assertTrue(test instanceof JobExecutionItem)
@@ -417,6 +425,7 @@ class ExecutionItemFactoryTest {
                 false,
                 handler,
                 true,
+                null,
                 null,
                 null,
                 null,
@@ -448,6 +457,7 @@ class ExecutionItemFactoryTest {
                 null,
                 null,
                 null,
+                null,
                 null
         )
         Assert.assertTrue(test instanceof JobExecutionItem)
@@ -460,13 +470,14 @@ class ExecutionItemFactoryTest {
     @Test
     public void createJobRefNodeStep_withHandler(){
         StepExecutionItem handler = ExecutionItemFactory.createExecCommand(['a', 'b'] as String[], null, false,
-                                                                           null)
+                null)
         StepExecutionItem test = ExecutionItemFactory.createJobRef(
                 "monkey/piece",
                 ['args', 'args2'] as String[],
                 true,
                 handler,
                 true,
+                null,
                 null,
                 null,
                 null,
@@ -484,6 +495,29 @@ class ExecutionItemFactoryTest {
         Assert.assertTrue(test instanceof HasFailureHandler)
         HasFailureHandler handlered2 = (HasFailureHandler) test
         Assert.assertEquals(handler, handlered2.failureHandler)
+    }
+    @Test
+    public void createJobRef_from_AnotherProject(){
+        StepExecutionItem test = ExecutionItemFactory.createJobRef(
+                "monkey/piece",
+                ['args', 'args2'] as String[],
+                true,
+                null,
+                true,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                'anotherProject'
+        )
+        Assert.assertTrue(test instanceof JobRefCommand)
+        JobRefCommand testcommand=(JobRefCommand) test
+        Assert.assertEquals( 'monkey/piece',testcommand.jobIdentifier)
+        Assert.assertEquals( ['args','args2'],testcommand.args as List)
+        Assert.assertEquals('anotherProject',testcommand.project)
     }
     @Test
     public void createPluginStep(){

--- a/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerTests.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerTests.groovy
@@ -2057,6 +2057,7 @@ class ScheduledExecutionControllerTests  {
             fwkControl.demand.getNodeStepPluginDescriptions { [] }
             fwkControl.demand.getStepPluginDescriptions { [] }
             fwkControl.demand.getProjectGlobals { [:] }
+            fwkControl.demand.projectNames { [] }
             sec.frameworkService = fwkControl.createMock()
             def seServiceControl = mockFor(ScheduledExecutionService, true)
 

--- a/rundeckapp/test/unit/rundeck/controllers/WorkflowControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/WorkflowControllerSpec.groovy
@@ -42,6 +42,7 @@ class WorkflowControllerSpec extends Specification {
         wf.commands = new ArrayList()
         def inputparams = [(fieldname): 'blah']
         wf.commands << new CommandExec(inputparams)
+        controller.frameworkService = Mock(FrameworkService)
 
         when:
         def result = controller._applyWFEditAction(
@@ -66,6 +67,7 @@ class WorkflowControllerSpec extends Specification {
         given:
         Workflow wf = new Workflow(threadcount: 1, keepgoing: true)
         wf.commands = new ArrayList()
+        controller.frameworkService = Mock(FrameworkService)
 
         def inputparams = [(fieldname): 'blah']
         def cmd = new CommandExec(inputparams)
@@ -369,4 +371,73 @@ class WorkflowControllerSpec extends Specification {
         'abc' | [a: 'b'] | [c: 'd']
 
     }
+    def "insert jobexec type validation"() {
+        given:
+        Workflow wf = new Workflow(threadcount: 1, keepgoing: true)
+        wf.commands = new ArrayList()
+        def inputparams = [jobName: 'blah', jobGroup: 'test/test']
+        //wf.commands << new JobExec( inputparams)
+        controller.frameworkService = Mock(FrameworkService)
+
+        when:
+        def result = controller._applyWFEditAction(
+                wf, [action: 'insert', num: 0,
+                     params: [jobName: jobName, jobGroup: jobGroup,description:'desc1',newitemtype: 'job']]
+        )
+
+        then:
+        //assertEquals(expectedError,result.error)
+        if(!fieldname){
+            assertNull(result.error)
+        }else{
+            assertNotNull(result.error)
+            result.item.errors.hasFieldErrors(fieldname)
+        }
+        where:
+        jobName     | jobGroup | jobProject | fieldname
+        'blah'      | 'ble/ble'| null       | null
+        null        | 'ble/ble'| null       | 'jobName'
+        'blah'      | null     | null       | null
+        'blah'      | 'ble/ble'| 'proj'     | null
+
+    }
+
+    def "insert jobexec project validation"() {
+        given:
+        Workflow wf = new Workflow(threadcount: 1, keepgoing: true)
+        wf.commands = new ArrayList()
+        def inputparams = [jobName: 'blah', jobGroup: 'test/test']
+        //wf.commands << new JobExec( inputparams)
+        controller.frameworkService = Mock(FrameworkService)
+
+        when:
+        def result = controller._applyWFEditAction(
+                wf, [action: 'insert', num: 0,
+                     params: [jobName: jobName, jobGroup: jobGroup, jobProject: jobProject,
+                              description:'desc1',newitemtype: 'job']]
+        )
+
+        then:
+        //assertEquals(expectedError,result.error)
+        1 * controller.frameworkService.projectNames(_) >> ['proj','proj2']
+
+        if(!fieldname){
+            assertNull(result.error)
+        }else{
+            assertNotNull(result.error)
+            result.item.errors.hasFieldErrors(fieldname)
+        }
+
+
+
+        where:
+        jobName     | jobGroup | jobProject | fieldname
+        'blah'      | 'ble/ble'| null       | null
+        null        | 'ble/ble'| null       | 'jobName'
+        'blah'      | null     | null       | null
+        'blah'      | 'ble/ble'| 'proj'     | null
+        'blah'      | null     | 'projx'    | 'jobProject'
+
+    }
+
 }

--- a/rundeckapp/test/unit/rundeck/controllers/WorkflowControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/WorkflowControllerSpec.groovy
@@ -105,7 +105,7 @@ class WorkflowControllerSpec extends Specification {
         wf.addToCommands(item3)
         def origlist = [item1, item2, item3]
 
-
+        controller.frameworkService = Mock(FrameworkService)
         when:
 
 
@@ -141,7 +141,7 @@ class WorkflowControllerSpec extends Specification {
         wf.addToCommands(item3)
         def origlist = [item1, item2, item3]
 
-
+        controller.frameworkService = Mock(FrameworkService)
         when:
 
 

--- a/rundeckapp/test/unit/rundeck/services/ExecutionUtilServiceTests.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ExecutionUtilServiceTests.groovy
@@ -26,6 +26,7 @@ import com.dtolabs.rundeck.core.execution.workflow.steps.node.impl.ScriptFileCom
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.impl.ScriptURLCommandExecutionItem
 import com.dtolabs.rundeck.core.utils.ThreadBoundOutputStream
 import com.dtolabs.rundeck.execution.JobExecutionItem
+import com.dtolabs.rundeck.execution.JobRefCommand
 import grails.test.mixin.*
 import org.grails.plugins.metricsweb.MetricService
 import org.junit.*
@@ -432,5 +433,36 @@ class ExecutionUtilServiceTests {
         assertEquals('def', item.getNodeFilter())
         assertEquals(true, item.getNodeIntersect())
 
+    }
+
+    void testItemForWFCmdItem_jobref_externalProject() {
+        def testService = service
+        //file url script path
+        JobExec ce = new JobExec(jobName: 'abc', jobGroup: 'xyz', jobProject: 'anotherProject')
+        def res = testService.itemForWFCmdItem(ce)
+        assertNotNull(res)
+        assertTrue(res instanceof StepExecutionItem)
+        assertFalse(res instanceof ScriptURLCommandExecutionItem)
+        assertTrue(res instanceof JobRefCommand)
+        JobRefCommand item = (JobRefCommand) res
+        assertEquals('xyz/abc', item.getJobIdentifier())
+        assertNotNull(item.args)
+        assertEquals([], item.args as List)
+    }
+
+    void testItemForWFCmdItem_jobref_args_externalProject() {
+        def testService = service
+        //file url script path
+        JobExec ce = new JobExec(jobName: 'abc', jobGroup: 'xyz', jobProject: 'anotherProject')
+        def res = testService.itemForWFCmdItem(ce)
+        assertNotNull(res)
+        assertTrue(res instanceof StepExecutionItem)
+        assertFalse(res instanceof ScriptURLCommandExecutionItem)
+        assertTrue(res instanceof JobRefCommand)
+        JobRefCommand item = (JobRefCommand) res
+        assertEquals('xyz/abc', item.getJobIdentifier())
+        assertEquals('anotherProject', item.getProject())
+        assertNotNull(item.args)
+        assertEquals([], item.args as List)
     }
 }

--- a/rundeckapp/test/unit/rundeck/services/ScheduledExServiceTests.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ScheduledExServiceTests.groovy
@@ -190,6 +190,7 @@ class ScheduledExServiceTests {
                 assertEquals 'testProject', project
                 return projectMock
             }
+            projectNames{authContext -> []}
         }
     }
     def setupDoUpdateJob(sec){
@@ -462,6 +463,7 @@ class ScheduledExServiceTests {
                 assertEquals 'testProject', project
                 return projectMock
             }
+            projectNames{authContext -> []}
         }
         sec.frameworkService.metaClass.isClusterModeEnabled = {
             return false
@@ -600,6 +602,7 @@ class ScheduledExServiceTests {
             getFrameworkFromUserSession { session, request -> return null }
             getFrameworkFromUserSession { session, request -> return null }
             isClusterModeEnabled{->false}
+            projectNames{authContext -> []}
         }
 
 

--- a/rundeckapp/test/unit/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -66,6 +66,7 @@ class ScheduledExecutionServiceSpec extends Specification {
             isClusterModeEnabled()>>enabled
             getServerUUID()>>TEST_UUID1
             getFrameworkPropertyResolverWithProps(*_)>>Mock(PropertyResolver)
+            projectNames(*_)>>[]
         }
         service.pluginService=Mock(PluginService)
         service.executionServiceBean=Mock(ExecutionService)


### PR DESCRIPTION
Added capability to use Job Reference step referencing another project.
The current behavior is maintained leaving the field empty ensuring backward compatibility.

New create/edit GUI:
<img width="1094" alt="screenshot at may 18 13-51-57" src="https://cloud.githubusercontent.com/assets/2894508/26218013/7e4e4402-3bd7-11e7-8cb0-a2f3e45cd2b3.png">

Autocomplete of allowed projects:
<img width="1091" alt="screenshot at may 18 13-52-26" src="https://cloud.githubusercontent.com/assets/2894508/26218034/8ec72ed4-3bd7-11e7-9309-e62d17fd1068.png">
If the user has no permission to see another project will not be displayed on autocomplete.
Choose A Job... button will show the entered project jobs if the field is completed. On empty field, continue to show current project jobs.

If the project field is filled with an unauthorized project or a non existent one this error will be displayed:
<img width="1012" alt="screenshot at may 18 13-53-20" src="https://cloud.githubusercontent.com/assets/2894508/26218135/dab5c3d2-3bd7-11e7-934a-aaeb50bd30f5.png">

New text string representation on screen of Job reference from another project:
<img width="1057" alt="screenshot at may 18 13-54-09" src="https://cloud.githubusercontent.com/assets/2894508/26218152/f25d1346-3bd7-11e7-8be7-5141c1543de7.png">

See #561 