### PR TITLE
External Job State Conditional plugin.

### DIFF
--- a/plugins/job-state-plugin/src/main/java/org/rundeck/plugin/jobstate/JobStateWorkflowStep.java
+++ b/plugins/job-state-plugin/src/main/java/org/rundeck/plugin/jobstate/JobStateWorkflowStep.java
@@ -64,6 +64,10 @@ public class JobStateWorkflowStep implements StepPlugin {
     public static final String EXEC_STATE_FAILED_WITH_RETRY = "Failed-with-retry";
     public static final String PROVIDER_NAME = "job-state-conditional";
 
+    @PluginProperty(title = "Job Project",
+            description = "The project name (needed only if is an external project).")
+    String jobProject;
+
     @PluginProperty(title = "Job Name",
                     description = "Group and Name for the Job in the form \"group/name\".")
     String jobName;
@@ -129,11 +133,15 @@ public class JobStateWorkflowStep implements StepPlugin {
         final JobState jobState;
         final JobReference jobReference;
         try {
+            String project = context.getFrameworkProject();
+            if(null != jobProject){
+                project = jobProject;
+            }
 
             if (null != jobUUID) {
-                jobReference = jobService.jobForID(jobUUID, context.getFrameworkProject());
+                jobReference = jobService.jobForID(jobUUID, project);
             } else {
-                jobReference = jobService.jobForName(jobName, context.getFrameworkProject());
+                jobReference = jobService.jobForName(jobName, project);
             }
             jobState = jobService.getJobState(jobReference);
         } catch (JobNotFound jobNotFound) {


### PR DESCRIPTION
Add *Job Project* property to the  Job State Plugin to search projects outside the actual project.
Actual jobs maintains his functionality and any job created with project empty use the actual project as usual.
Works with UUID and job name.

![image](https://cloud.githubusercontent.com/assets/2894508/26316303/cfbc5bfa-3ee1-11e7-8c24-db4996a90131.png)

Similar to #2519 enhancement.