### PR TITLE
Adding the first api token

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -265,7 +265,7 @@ class UserController extends ControllerBase{
             )
             result = [result: true, /*apitoken: token.token, */ tokenid: token.uuid]
         } catch (Exception e) {
-            result = [result: false, error: e.message]
+            result = [result: false, error: e.getCause().message]
         }
         return renderTokenGenerateResult(result, params.login)
     }

--- a/rundeckapp/grails-app/views/user/_user.gsp
+++ b/rundeckapp/grails-app/views/user/_user.gsp
@@ -301,9 +301,7 @@
                        value="${(tokenAdmin) ? rundeck.AuthToken.findAll() :
                                rundeck.AuthToken.findAllByCreator(user.login)}"/>
 
-                <g:if test="${tokens}">
                     <g:render template="tokenList" model="${[user:user, tokenList:tokens,flashToken:flash.newtoken]}"/>
-                </g:if>
 
 
                 <div style="display:none" class="gentokenerror alert alert-danger alert-dismissable">


### PR DESCRIPTION
Small fix for #2525
In the actual behavior if the user don't have tokens the template with the token list isn't rendered  causing a javascript error creating the first one. 

Removing the validation for tokens on start the headers appears with a empty list to be filled.

![image](https://cloud.githubusercontent.com/assets/2894508/26317437/721c4f4c-3ee5-11e7-8511-1598f486b8e5.png)
