### PR TITLE
Copy job to another project

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -234,6 +234,20 @@ class ExecutionController extends ControllerBase{
         def workflowTree = scheduledExecutionService.getWorkflowDescriptionTree(e.project, e.workflow, 0)
         def inputFiles = fileUploadService.findRecords(e, FileUploadService.RECORD_TYPE_OPTION_INPUT)
         def inputFilesMap = inputFiles.collectEntries { [it.uuid, it] }
+
+        def projectNames = frameworkService.projectNames(authContext)
+        def authProjectsToCreate = []
+        projectNames.each{
+            if(it != params.project && frameworkService.authorizeProjectResource(
+                    authContext,
+                    AuthConstants.RESOURCE_TYPE_JOB,
+                    AuthConstants.ACTION_CREATE,
+                    it
+            )){
+                authProjectsToCreate.add(it)
+            }
+        }
+
         return [
                 scheduledExecution    : e.scheduledExecution ?: null,
                 execution             : e,
@@ -247,7 +261,8 @@ class ExecutionController extends ControllerBase{
                 enext                 : enext,
                 eprev                 : eprev,
                 stepPluginDescriptions: pluginDescs,
-                inputFilesMap         : inputFilesMap
+                inputFilesMap         : inputFilesMap,
+                projectNames          : authProjectsToCreate
         ]
     }
     def delete = {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -271,7 +271,23 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         def framework = frameworkService.getRundeckFramework()
         def rdprojectconfig = framework.projectManager.loadProjectConfig(params.project)
         results.jobExpandLevel = scheduledExecutionService.getJobExpandLevel(rdprojectconfig)
-
+        AuthContext authContext = frameworkService.getAuthContextForSubjectAndProject(
+                session.subject,
+                params.project
+        )
+        def projectNames = frameworkService.projectNames(authContext)
+        def authProjectstoCreate = []
+        projectNames.each{
+            if(it != attrs.project && frameworkService.authorizeProjectResource(
+                    authContext,
+                    AuthConstants.RESOURCE_TYPE_JOB,
+                    AuthConstants.ACTION_CREATE,
+                    it
+            )){
+                authProjectstoCreate.add(it)
+            }
+        }
+        results.projectNames = authProjectstoCreate
         withFormat{
             html {
                 results

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -276,7 +276,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 params.project
         )
         def projectNames = frameworkService.projectNames(authContext)
-        def authProjectstoCreate = []
+        def authProjectsToCreate = []
         projectNames.each{
             if(it != params.project && frameworkService.authorizeProjectResource(
                     authContext,
@@ -284,10 +284,10 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     AuthConstants.ACTION_CREATE,
                     it
             )){
-                authProjectstoCreate.add(it)
+                authProjectsToCreate.add(it)
             }
         }
-        results.projectNames = authProjectstoCreate
+        results.projectNames = authProjectsToCreate
         withFormat{
             html {
                 results

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -278,7 +278,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         def projectNames = frameworkService.projectNames(authContext)
         def authProjectstoCreate = []
         projectNames.each{
-            if(it != attrs.project && frameworkService.authorizeProjectResource(
+            if(it != params.project && frameworkService.authorizeProjectResource(
                     authContext,
                     AuthConstants.RESOURCE_TYPE_JOB,
                     AuthConstants.ACTION_CREATE,

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -429,6 +429,20 @@ class ScheduledExecutionController  extends ControllerBase{
                 dataMap.scmImportStatus = scmService.importStatusForJobs([scheduledExecution])
             }
         }
+
+        def projectNames = frameworkService.projectNames(authContext)
+        def authProjectsToCreate = []
+        projectNames.each{
+            if(it != params.project && frameworkService.authorizeProjectResource(
+                    authContext,
+                    AuthConstants.RESOURCE_TYPE_JOB,
+                    AuthConstants.ACTION_CREATE,
+                    it
+            )){
+                authProjectsToCreate.add(it)
+            }
+        }
+        dataMap.projectNames = authProjectsToCreate
         withFormat{
             html{
                 dataMap

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1450,3 +1450,4 @@ form.option.multivalueAllSelected.label=Select All Values by Default
 project.configuration.extra.category.gui.description=Additional configuration for the user interface for this project
 project.configuration.extra.category.gui.title=User Interface
 api.error.project.archive.failure=Project export request {0} failed: {1}
+scheduledExecution.action.duplicate.other.button.label=Duplicate this Job to other Project&hellip;

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1446,3 +1446,4 @@ form.option.multivalueAllSelected.label=Select All Values by Default
 project.configuration.extra.category.gui.description=Additional configuration for the Jobs for this project
 project.configuration.extra.category.gui.title=User Interface
 api.error.project.archive.failure=Project export request {0} failed: {1}
+scheduledExecution.action.duplicate.other.button.label=Duplicar TRabajo a otro Projecto&hellip;

--- a/rundeckapp/grails-app/taglib/rundeck/AuthTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/AuthTagLib.groovy
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.core.authorization.Attribute;
 import com.dtolabs.rundeck.core.authorization.Authorization
 import com.dtolabs.rundeck.core.authorization.Decision
 import com.dtolabs.rundeck.core.authorization.providers.EnvironmentalContext
+import com.dtolabs.rundeck.server.authorization.AuthConstants
 import rundeck.services.FrameworkService;
 
 class AuthTagLib {
@@ -137,6 +138,8 @@ class AuthTagLib {
     def resourceAllowedTest = {attrs, body ->
         boolean has = (null == attrs.has || attrs.has == "true")
         boolean anyCheck = ((null != attrs.any) && (attrs.any in [true,"true"]))
+        boolean other = ((null != attrs.others) && (attrs.others in [true,"true"]))
+
         boolean auth = false
         if (!attrs.action) {
             throw new Exception("action attribute required: " + attrs.action + ": " + attrs.name)
@@ -167,14 +170,27 @@ class AuthTagLib {
         tagattrs.remove('has')
         tagattrs.remove('context')
         tagattrs.remove('any')
+        tagattrs.remove('others')
         def attributes = attrs.attributes ?: tagattrs
         if (attributes) {
             resource.putAll(attributes)
         }
-        def Set resources = [resource]
+        Set resources = [resource]
 
         def authContext = appContext?frameworkService.getAuthContextForSubject(request.subject):
                 frameworkService.getAuthContextForSubjectAndProject(request.subject,attrs.project)
+
+        if(other){
+            boolean isAuth = false
+            def projectNames = frameworkService.projectNames(authContext)
+            projectNames.each{
+                env = Collections.singleton(new Attribute(URI.create(EnvironmentalContext.URI_BASE +"project"), it))
+                if(it != attrs.project && authContext.evaluate(resources, tests as Set, env)){
+                    isAuth = true
+                }
+            }
+            return isAuth
+        }
 
         if(anyCheck){
             return tests.any { authContext.evaluate(resources, [it] as Set, env).any{has==it.authorized} }

--- a/rundeckapp/grails-app/taglib/rundeck/AuthTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/AuthTagLib.groovy
@@ -185,8 +185,11 @@ class AuthTagLib {
             def projectNames = frameworkService.projectNames(authContext)
             projectNames.each{
                 env = Collections.singleton(new Attribute(URI.create(EnvironmentalContext.URI_BASE +"project"), it))
-                if(it != attrs.project && authContext.evaluate(resources, tests as Set, env)){
-                    isAuth = true
+                if(it != attrs.project){
+                    def decision=  authContext.evaluate(resources, tests as Set, env)
+                    if(!decision.find{has^it.authorized}){
+                        isAuth = true
+                    }
                 }
             }
             return isAuth

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -218,6 +218,11 @@
                 _applyAce(this);
             });
             followControl.bindActions('outputappendform');
+
+            PageActionHandlers.registerHandler('copy_other_project',function(el){
+                jQuery('#jobid').val(el.data('jobId'));
+                jQuery('#selectProject').modal();
+            });
         }
         jQuery(init);
       </g:javascript>
@@ -766,6 +771,8 @@
             </div>
         </div>
     </g:if>
+<g:render template="/menu/copyModal"
+          model="[projectNames: projectNames]"/>
 
   <!--[if (gt IE 8)|!(IE)]><!--> <g:javascript library="ace/ace"/><!--<![endif]-->
 

--- a/rundeckapp/grails-app/views/menu/_copyModal.gsp
+++ b/rundeckapp/grails-app/views/menu/_copyModal.gsp
@@ -1,0 +1,29 @@
+<div class="modal fade" id="selectProject" role="dialog" aria-labelledby="selectProjectLabel" aria-hidden="true">
+    <div class="modal-dialog modal-sm">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title" id="selectProjectLabel"><g:message code="select.project" /></h4>
+            </div>
+            <g:form controller="scheduledExecution">
+                <div class="modal-body" id="selectProjectContent">
+
+                    <input type="hidden" id="jobid" name="id"/>
+                    <g:select name="project" from="${projectNames}" id="jobProject" value=""
+                              class="form-control input-sm"/>
+                </div>
+                <div class="modal-footer">
+                    <button type="button"
+                            class="btn btn-danger"
+                            data-bind="click: cancel"
+                            data-dismiss="modal" ><g:message code="cancel"/></button>
+
+                    <g:actionSubmit action="copy"
+                                    value="${message(code:'yes')}"
+                                    id="submittbn"
+                                    class="btn btn-default"/>
+                </div>
+            </g:form>
+        </div>
+    </div>
+</div>

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -26,12 +26,10 @@
     <g:javascript library="pagehistory"/>
     <g:javascript library="prototype/effects"/>
     <asset:javascript src="menu/jobs.js"/>
-    <asset:javascript src="jquery.autocomplete.min.js"/>
     <g:if test="${grails.util.Environment.current==grails.util.Environment.DEVELOPMENT}">
         <asset:javascript src="menu/joboptionsTest.js"/>
         <asset:javascript src="menu/job-remote-optionsTest.js"/>
     </g:if>
-    <g:embedJSON id="pageParams" data="${[project:params.project?:request.project]}"/>
     <g:embedJSON data="${projectNames ?: []}" id="projectNamesData"/>
     <g:jsMessages code="Node,Node.plural,job.starting.execution,job.scheduling.execution,option.value.required,options.remote.dependency.missing.required,,option.default.button.title,option.default.button.text,option.select.choose.text"/>
     <!--[if (gt IE 8)|!(IE)]><!--> <g:javascript library="ace/ace"/><!--<![endif]-->
@@ -611,49 +609,8 @@
 </div>
 </div>
 
-<div class="modal fade" id="selectProject" role="dialog" aria-labelledby="selectProjectLabel" aria-hidden="true">
-    <div class="modal-dialog modal-sm">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title" id="selectProjectLabel"><g:message code="select.project" /></h4>
-            </div>
-            <g:form controller="scheduledExecution">
-                <div class="modal-body" id="selectProjectContent">
-
-                    <input type="hidden" id="jobid" name="id"/>
-                    <input id="jobProject"  type="text" name="project" value="" size="100"
-                                              placeholder="${message(code:"select.project")}"
-                                              class="form-control"
-                                       />
-                    <g:javascript>
-                    fireWhenReady('jobProject',function(){
-                         var projectsArr = loadJsonData('projectNamesData');
-                         jQuery("#jobProject").devbridgeAutocomplete({
-                                     lookup: projectsArr
-                         });
-                        jQuery("#jobProject").on('keyup blur', function(){
-                            jQuery('#submittbn').prop('disabled', this.value.trim().length == 0);
-                        });
-                     });
-                    </g:javascript>
-                </div>
-                <div class="modal-footer">
-                    <button type="button"
-                            class="btn btn-danger"
-                            data-bind="click: cancel"
-                            data-dismiss="modal" ><g:message code="cancel"/></button>
-
-                    <g:actionSubmit action="copy"
-                                    value="${message(code:'yes')}"
-                                    id="submittbn"
-                                    disabled="disabled"
-                                    class="btn btn-default"/>
-                </div>
-            </g:form>
-        </div>
-    </div>
-</div>
+<g:render template="/menu/copyModal"
+          model="[projectNames: projectNames]"/>
 
 <div class="row row-space" id="activity_section">
     <div class="col-sm-12 ">

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -632,6 +632,9 @@
                          jQuery("#jobProject").devbridgeAutocomplete({
                                      lookup: projectsArr
                          });
+                        jQuery("#jobProject").on('keyup blur', function(){
+                            jQuery('#submittbn').prop('disabled', this.value.trim().length == 0);
+                        });
                      });
                     </g:javascript>
                 </div>
@@ -643,6 +646,8 @@
 
                     <g:actionSubmit action="copy"
                                     value="${message(code:'yes')}"
+                                    id="submittbn"
+                                    disabled="disabled"
                                     class="btn btn-default"/>
                 </div>
             </g:form>

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -26,11 +26,13 @@
     <g:javascript library="pagehistory"/>
     <g:javascript library="prototype/effects"/>
     <asset:javascript src="menu/jobs.js"/>
+    <asset:javascript src="jquery.autocomplete.min.js"/>
     <g:if test="${grails.util.Environment.current==grails.util.Environment.DEVELOPMENT}">
         <asset:javascript src="menu/joboptionsTest.js"/>
         <asset:javascript src="menu/job-remote-optionsTest.js"/>
     </g:if>
     <g:embedJSON id="pageParams" data="${[project:params.project?:request.project]}"/>
+    <g:embedJSON data="${projectNames ?: []}" id="projectNamesData"/>
     <g:jsMessages code="Node,Node.plural,job.starting.execution,job.scheduling.execution,option.value.required,options.remote.dependency.missing.required,,option.default.button.title,option.default.button.text,option.select.choose.text"/>
     <!--[if (gt IE 8)|!(IE)]><!--> <g:javascript library="ace/ace"/><!--<![endif]-->
     <script type="text/javascript">
@@ -396,6 +398,12 @@
                 bulkeditor.activateActionForJob(bulkeditor.ENABLE_SCHEDULE,el.data('jobId'));
             });
 
+            PageActionHandlers.registerHandler('copy_other_project',function(el){
+                jQuery('#jobid').val(el.data('jobId'));
+                jQuery('#selectProject').modal();
+            });
+
+
             Event.observe(document.body,'click',function(evt){
                 //click outside of popup bubble hides it
                 doMouseout();
@@ -601,6 +609,45 @@
             </div>
 </div>
 </div>
+</div>
+
+<div class="modal fade" id="selectProject" role="dialog" aria-labelledby="selectProjectLabel" aria-hidden="true">
+    <div class="modal-dialog modal-sm">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title" id="selectProjectLabel"><g:message code="select.project" /></h4>
+            </div>
+            <g:form controller="scheduledExecution">
+                <div class="modal-body" id="selectProjectContent">
+
+                    <input type="hidden" id="jobid" name="id"/>
+                    <input id="jobProject"  type="text" name="project" value="" size="100"
+                                              placeholder="${message(code:"select.project")}"
+                                              class="form-control"
+                                       />
+                    <g:javascript>
+                    fireWhenReady('jobProject',function(){
+                         var projectsArr = loadJsonData('projectNamesData');
+                         jQuery("#jobProject").devbridgeAutocomplete({
+                                     lookup: projectsArr
+                         });
+                     });
+                    </g:javascript>
+                </div>
+                <div class="modal-footer">
+                    <button type="button"
+                            class="btn btn-danger"
+                            data-bind="click: cancel"
+                            data-dismiss="modal" ><g:message code="cancel"/></button>
+
+                    <g:actionSubmit action="copy"
+                                    value="${message(code:'yes')}"
+                                    class="btn btn-default"/>
+                </div>
+            </g:form>
+        </div>
+    </div>
 </div>
 
 <div class="row row-space" id="activity_section">

--- a/rundeckapp/grails-app/views/scheduledExecution/_jobActionButtonMenuContent.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_jobActionButtonMenuContent.gsp
@@ -36,6 +36,7 @@
 <g:set var="authEnableDisableSchedule" value="${auth.jobAllowedTest(job: scheduledExecution, action: [AuthConstants.ACTION_TOGGLE_SCHEDULE])}"/>
 <g:set var="authEnableDisableExecution" value="${auth.jobAllowedTest(job: scheduledExecution, action: [AuthConstants.ACTION_TOGGLE_EXECUTION])}"/>
 <g:set var="authJobCreate" value="${auth.resourceAllowedTest(kind: 'job', action: AuthConstants.ACTION_CREATE, project: scheduledExecution.project)}"/>
+<g:set var="authOtherProject" value="${auth.resourceAllowedTest(kind: 'job', action: AuthConstants.ACTION_CREATE, project: scheduledExecution.project, others: true)}"/>
 <g:set var="authJobDelete" value="${auth.resourceAllowedTest(kind: 'job', action: AuthConstants.ACTION_DELETE, project: scheduledExecution.project)}"/>
 <g:set var="authProjectExport" value="${auth.resourceAllowedTest(
         context: 'application',
@@ -67,6 +68,21 @@
             <g:message
                     code="scheduledExecution.action.duplicate.button.label"/>
         </g:link>
+    </li>
+</g:if>
+<g:if test="${authRead && authOtherProject}">
+    <li>
+        <g:link controller="scheduledExecution"
+                title="${g.message(code:'scheduledExecution.action.duplicate.button.tooltip')}"
+                action="copyanother"
+                data-job-id="${enc(attr: scheduledExecution.extid)}"
+                data-action="copy_other_project"
+                class="page_action">
+            <i class="glyphicon glyphicon-plus"></i>
+            <g:message
+                    code="scheduledExecution.action.duplicate.other.button.label"/>
+        </g:link>
+
     </li>
 </g:if>
 

--- a/rundeckapp/grails-app/views/scheduledExecution/show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/show.gsp
@@ -25,6 +25,7 @@
     <asset:javascript src="menu/joboptions.js"/>
     <asset:javascript src="menu/jobs.js"/>
     <asset:javascript src="util/markdeep.js"/>
+    <asset:javascript src="jquery.autocomplete.min.js"/>
     <g:embedJSON id="jobParams"
                  data="${[filter: scheduledExecution?.filter, doNodeDispatch: scheduledExecution?.doNodedispatch, project: params.project
                          ?:
@@ -93,6 +94,11 @@
                     document.location.hash = t.attr('href');
                 }
             });
+
+            PageActionHandlers.registerHandler('copy_other_project',function(el){
+                jQuery('#jobid').val(el.data('jobId'));
+                jQuery('#selectProject').modal();
+            });
         }
         jQuery(init);
     </script>
@@ -100,6 +106,8 @@
 
 <body>
 <tmpl:show scheduledExecution="${scheduledExecution}" crontab="${crontab}"/>
+<g:render template="/menu/copyModal"
+          model="[projectNames: projectNames]"/>
 </body>
 </html>
 

--- a/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerTests.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerTests.groovy
@@ -2120,6 +2120,7 @@ class ScheduledExecutionControllerTests  {
             isClusterModeEnabled{-> false }
             authResourceForProject{p->null}
             authorizeApplicationResourceAny(2..2){AuthContext authContext, Map resource, List actions->false}
+            projectNames { _ -> return []}
             projects { return [] }
             authorizeProjectResourceAll { framework, resource, actions, project -> return true }
             authorizeProjectJobAll { framework, resource, actions, project -> return true }
@@ -2218,6 +2219,7 @@ class ScheduledExecutionControllerTests  {
             }
             authResourceForProject{p->null}
             authorizeApplicationResourceAny(2..2){AuthContext authContext, Map resource, List actions->false}
+            projectNames { _ -> return []}
             projects { return [] }
             authorizeProjectResourceAll { framework, resource, actions, project -> return true }
             authorizeProjectJobAll { framework, resource, actions, project -> return true }
@@ -2316,6 +2318,7 @@ class ScheduledExecutionControllerTests  {
             }
             authResourceForProject{p->null}
             authorizeApplicationResourceAny(2..2){AuthContext authContext, Map resource, List actions->false}
+            projectNames { _ -> return []}
             projects { return [] }
             authorizeProjectResourceAll { framework, resource, actions, project -> return true }
             authorizeProjectJobAll { framework, resource, actions, project -> return true }
@@ -2414,6 +2417,7 @@ class ScheduledExecutionControllerTests  {
             }
             authResourceForProject{p->null}
             authorizeApplicationResourceAny(2..2){AuthContext authContext, Map resource, List actions->false}
+            projectNames { _ -> return []}
             projects { return [] }
             authorizeProjectResourceAll { framework, resource, actions, project -> return true }
             authorizeProjectJobAll { framework, resource, actions, project -> return true }
@@ -2511,6 +2515,7 @@ class ScheduledExecutionControllerTests  {
             }
             authResourceForProject{p->null}
             authorizeApplicationResourceAny(2..2){AuthContext authContext, Map resource, List actions->false}
+            projectNames { _ -> return []}
             projects { return [] }
             authorizeProjectResourceAll { framework, resource, actions, project -> return true }
             authorizeProjectJobAll { framework, resource, actions, project -> return true }
@@ -2635,6 +2640,7 @@ class ScheduledExecutionControllerTests  {
             }
             authResourceForProject{p->null}
             authorizeApplicationResourceAny(2..2){AuthContext authContext, Map resource, List actions->false}
+            projectNames { _ -> return []}
             projects { return [] }
             authorizeProjectResourceAll { framework, resource, actions, project -> return true }
             authorizeProjectJobAll { framework, resource, actions, project -> return true }


### PR DESCRIPTION
GUI enhancement to allow copy a job to another project, only if the user is authorized to create in the other project, uses the same copy method only overwriting the project for the selected one

**New item in dropdown menu "Duplicate this job to other Project":**
<img width="378" alt="1_dropdown_menu" src="https://cloud.githubusercontent.com/assets/2894508/26787606/a0d39428-49d8-11e7-9e58-f9ed10e603e3.png">

**Popup asking to choose the project in the autocomplete list:**
<img width="507" alt="2_select_project" src="https://cloud.githubusercontent.com/assets/2894508/26787612/a6950c2a-49d8-11e7-9907-e66bb3c2eb8d.png">

**If the user can't create in any other project, the user don't get the option on the menu:** 
<img width="415" alt="3_dropdown_menu_wo_perm" src="https://cloud.githubusercontent.com/assets/2894508/26787631/b7528466-49d8-11e7-92d9-a87fa94958e5.png">

**This is how it looks if the user can create in other project but only can read on the actual:**
<img width="423" alt="4_dropdown_other_not_this" src="https://cloud.githubusercontent.com/assets/2894508/26787636/ba76e3d0-49d8-11e7-966e-789ee24578f9.png">

**If the user tries to duplicate to a project he can't see:**
<img width="402" alt="5_error_cant_see_pr" src="https://cloud.githubusercontent.com/assets/2894508/26787645/c031cb0a-49d8-11e7-9f7f-257e8291ef0f.png">

**If the user tries to duplicate to a project he can see but cant create:**
<img width="371" alt="6_error_noauth_create" src="https://cloud.githubusercontent.com/assets/2894508/26787652/c42262c4-49d8-11e7-9a24-7e200b189792.png">


