### PR TITLE
Added outputstream exception for Windows.

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/utils/ScriptExecUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/utils/ScriptExecUtil.java
@@ -226,7 +226,10 @@ public class ScriptExecUtil {
 
         final Runtime runtime = Runtime.getRuntime();
         final Process exec = runtime.exec(command, envarr, workingdir);
-        exec.getOutputStream().close();
+    	final String osName = System.getProperty("os.name");
+    	if (osName.toLowerCase().indexOf("windows") == -1) {
+    		exec.getOutputStream().close();
+    	}
         final Streams.StreamCopyThread errthread = Streams.copyStreamThread(exec.getErrorStream(), errorStream);
         final Streams.StreamCopyThread outthread = Streams.copyStreamThread(exec.getInputStream(), outputStream);
         errthread.start();
@@ -237,6 +240,9 @@ public class ScriptExecUtil {
         errorStream.flush();
         errthread.join();
         outthread.join();
+    	if (osName.toLowerCase().indexOf("windows") > -1) {
+    		exec.getOutputStream().close();
+    	}
         exec.getInputStream().close();
         exec.getErrorStream().close();
         if (null != outthread.getException()) {


### PR DESCRIPTION
The closing of outputstream is moved to after the process has terminated. This affects the localexec plugin execution which caused Windows legacy tools like winrs.exe to hang.