### PR TITLE
Job Reference on another Project (Fixes)

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
@@ -99,7 +99,8 @@ class WorkflowController extends ControllerBase implements PluginListRequired {
                 origitemtype=item.adhocLocalString?'script':item.adhocRemoteString?'command':'scriptfile'
             }
         }
-
+        AuthContext auth = frameworkService.getAuthContextForSubject(request.subject)
+        def fprojects = frameworkService.projectNames(auth)
         [
                 item                : item,
                 key                 : params.key,
@@ -111,7 +112,8 @@ class WorkflowController extends ControllerBase implements PluginListRequired {
                 pluginNotFound      : null == newitemDescription,
                 edit                : true,
                 isErrorHandler      : isErrorHandler,
-                newitemnodestep     : params.newitemnodestep
+                newitemnodestep     : params.newitemnodestep,
+                fprojects           : fprojects
         ]
     }
     /**
@@ -418,13 +420,15 @@ class WorkflowController extends ControllerBase implements PluginListRequired {
         def item
         def numi
         def wfEditAction = 'true' == params.newitem ? 'insert' : 'modify'
+        AuthContext auth = frameworkService.getAuthContextForSubject(request.subject)
+        def fprojects = frameworkService.projectNames(auth)
         if (null != params.num) {
             try {
                 numi = Integer.parseInt(params.num)
             } catch (NumberFormatException e) {
                 log.error("num parameter is invalid: " + params.num)
                 flash.'error' = "num parameter is invalid: " + params.num
-                return render(template: "/execution/wfitemEdit", model: [item: null, num: numi, scheduledExecutionId: params.scheduledExecutionId, newitemtype: params['newitemtype'], edit: true])
+                return render(template: "/execution/wfitemEdit", model: [item: null, num: numi, scheduledExecutionId: params.scheduledExecutionId, newitemtype: params['newitemtype'], edit: true, fprojects: fprojects])
             }
         } else {
             numi = editwf.commands ? editwf.commands.size() : 0
@@ -454,7 +458,8 @@ class WorkflowController extends ControllerBase implements PluginListRequired {
                             edit                : true,
                             isErrorHandler      : isErrorHandler,
                             newitemDescription  : itemDescription,
-                            report              : result.report
+                            report              : result.report,
+                            fprojects           : fprojects
                     ]
             )
         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
@@ -100,7 +100,7 @@ class WorkflowController extends ControllerBase implements PluginListRequired {
             }
         }
         AuthContext auth = frameworkService.getAuthContextForSubject(request.subject)
-        def fprojects = frameworkService.projectNames(auth)
+        def fprojects = frameworkService.projectNames(auth).findAll{it != params.project}
         [
                 item                : item,
                 key                 : params.key,
@@ -421,7 +421,7 @@ class WorkflowController extends ControllerBase implements PluginListRequired {
         def numi
         def wfEditAction = 'true' == params.newitem ? 'insert' : 'modify'
         AuthContext auth = frameworkService.getAuthContextForSubject(request.subject)
-        def fprojects = frameworkService.projectNames(auth)
+        def fprojects = frameworkService.projectNames(auth).findAll{it != params.project}
         if (null != params.num) {
             try {
                 numi = Integer.parseInt(params.num)

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -719,7 +719,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             def map=step.toMap()
             if(step instanceof JobExec) {
                 ScheduledExecution refjob = ScheduledExecution.findByProjectAndJobNameAndGroupPath(
-                        project,
+                        step.jobProject?step.jobProject:project,
                         step.jobName,
                         step.jobGroup
                 )
@@ -739,7 +739,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
             if(eh instanceof JobExec) {
                 ScheduledExecution refjob = ScheduledExecution.findByProjectAndJobNameAndGroupPath(
-                        project,
+                        eh.jobProject?eh.jobProject:project,
                         eh.jobName,
                         eh.jobGroup
                 )

--- a/rundeckapp/grails-app/views/execution/_wfitemEdit.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfitemEdit.gsp
@@ -53,18 +53,8 @@
                         />
                     </div>
                     <div class="col-sm-2">
-                        <input id="jobProjectField${rkey}"  type="text" name="jobProject" value="${enc(attr:item?.jobProject)}" size="100"
-                               placeholder="${message(code:"scheduledExecution.projectPath.label")}"
-                               class="form-control"
-                        />
-                        <g:javascript>
-                fireWhenReady('jobProjectField${rkey}',function(){
-                        var projectsArr = loadJsonData('projectNamesData');
-                        jQuery("#jobProjectField${rkey}").devbridgeAutocomplete({
-                                    lookup: projectsArr
-                        });
-                    });
-                        </g:javascript>
+                        <g:select name="jobProject" from="${fprojects}" id="jobProjectField${rkey}" value="${enc(attr:item?.jobProject)}" noSelection="${['':message(code:'scheduledExecution.projectPath.label')]}"
+                                  class="form-control input-sm"/>
                     </div>
 
                     <div class="col-sm-2">

--- a/rundeckapp/grails-app/views/scheduledExecution/create.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/create.gsp
@@ -32,8 +32,6 @@
         _onJobEdit(confirm.setNeedsConfirm);
     </g:javascript>
     <g:embedJSON data="${globalVars ?: []}" id="globalVarData"/>
-
-    <g:embedJSON data="${projectNames ?: []}" id="projectNamesData"/>
 </head>
 <body>
 

--- a/rundeckapp/grails-app/views/scheduledExecution/edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/edit.gsp
@@ -32,8 +32,6 @@
         _onJobEdit(confirm.setNeedsConfirm);
     </g:javascript>
     <g:embedJSON data="${globalVars ?: []}" id="globalVarData"/>
-
-    <g:embedJSON data="${projectNames ?: []}" id="projectNamesData"/>
 </head>
 <body>
 


### PR DESCRIPTION
UI fixes for #2519 

- The project selector now is a select instead of autocomplete. (User now can't select a bad project name)
- Corrected job show/execution page in the UI steps section.