### PR TITLE
Fix #2547 deprecate framework.ssh.timeout

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/Constants.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/Constants.java
@@ -181,6 +181,5 @@ public final class Constants {
     public static final String SSH_KEYPATH_PROP = "framework.ssh.keypath";
     public static final String SSH_KEYRESOURCE_PROP = "framework.ssh.key.resource";
     public static final String SSH_USER_PROP = "framework.ssh.user";
-    public static final String SSH_TIMEOUT_PROP = "framework.ssh.timeout";
 
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutor.java
@@ -26,8 +26,6 @@ package com.dtolabs.rundeck.core.execution.impl.jsch;
 import com.dtolabs.rundeck.core.cli.CLIUtils;
 import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.common.INodeEntry;
-import com.dtolabs.rundeck.core.common.IRundeckProject;
-import com.dtolabs.rundeck.core.dispatcher.DataContextUtils;
 import com.dtolabs.rundeck.core.execution.ExecutionContext;
 import com.dtolabs.rundeck.core.execution.ExecutionListener;
 import com.dtolabs.rundeck.core.execution.impl.common.AntSupport;
@@ -136,9 +134,28 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
     public static final boolean DEFAULT_SUDO_SUCCESS_ON_PROMPT_THRESHOLD = true;
     public static final String PROJECT_SSH_USER = PROJ_PROP_PREFIX + "ssh.user";
 
+    /**
+     * deprecated Global command & connection timeout framework property
+     */
+    public static final String SSH_TIMEOUT_PROP = "framework.ssh.timeout";
+
+    public static final String NODE_ATTR_SSH_COMMAND_TIMEOUT_PROP = "ssh-command-timeout";
+    public static final String FRAMEWORK_SSH_COMMAND_TIMEOUT_PROP = "framework.ssh.command.timeout";
+
+    public static final String NODE_ATTR_SSH_CONNECT_TIMEOUT_PROP = "ssh-connect-timeout";
+    public static final String FRAMEWORK_SSH_CONNECT_TIMEOUT_PROP = "framework.ssh.connect.timeout";
+
+
+    public static final String PROJ_PROP_CON_TIMEOUT = PROJ_PROP_PREFIX + NODE_ATTR_SSH_CONNECT_TIMEOUT_PROP;
+    public static final String FWK_PROP_CON_TIMEOUT = FWK_PROP_PREFIX + NODE_ATTR_SSH_CONNECT_TIMEOUT_PROP;
+
+    public static final String PROJ_PROP_COMMAND_TIMEOUT = PROJ_PROP_PREFIX + NODE_ATTR_SSH_COMMAND_TIMEOUT_PROP;
+    public static final String FWK_PROP_COMMAND_TIMEOUT = FWK_PROP_PREFIX + NODE_ATTR_SSH_COMMAND_TIMEOUT_PROP;
+
     public static final String SSH_CONFIG_PREFIX = "ssh-config-";
     public static final String FWK_SSH_CONFIG_PREFIX = FWK_PROP_PREFIX + SSH_CONFIG_PREFIX;
     public static final String PROJ_SSH_CONFIG_PREFIX = PROJ_PROP_PREFIX + SSH_CONFIG_PREFIX;
+
     private Framework framework;
 
     public JschNodeExecutor(final Framework framework) {
@@ -151,6 +168,8 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
     public static final String CONFIG_SUDO_PASSSTORE_PATH = "sudopasswordstoragepath";
     public static final String CONFIG_AUTHENTICATION = "authentication";
     public static final String CONFIG_SET_PTY = "always-set-pty";
+    public static final String CONFIG_CON_TIMEOUT = "ssh-connection-timeout";
+    public static final String CONFIG_COMMAND_TIMEOUT = "ssh-command-timeout";
 
     static final Description DESC ;
 
@@ -188,6 +207,21 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
             "Always force use of new pty",
             false, "false");
 
+    public static final Property PROP_CON_TIMEOUT = PropertyUtil.longProp(CONFIG_CON_TIMEOUT, "Connection Timeout",
+                                                                          "SSH Connection timeout in milliseconds. (0" +
+                                                                          " for no timeout)",
+                                                                          false, "0"
+    );
+
+    public static final Property PROP_COMMAND_TIMEOUT = PropertyUtil.longProp(
+            CONFIG_COMMAND_TIMEOUT,
+            "Command Timeout",
+            "Maximum duration of commands: timeout " +
+            "in milliseconds. (0 for no timeout)",
+            false,
+            "0"
+    );
+
     static {
         DescriptionBuilder builder = DescriptionBuilder.builder();
         builder.name(SERVICE_PROVIDER_TYPE)
@@ -200,6 +234,8 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
         builder.property(SSH_PASSWORD_STORAGE_PROP);
         builder.property(SSH_AUTH_TYPE_PROP);
         builder.property(ALWAYS_SET_PTY);
+        builder.property(PROP_CON_TIMEOUT);
+        builder.property(PROP_COMMAND_TIMEOUT);
 
         builder.mapping(CONFIG_KEYPATH, PROJ_PROP_SSH_KEYPATH);
         builder.frameworkMapping(CONFIG_KEYPATH, FWK_PROP_SSH_KEYPATH);
@@ -209,8 +245,15 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
         builder.frameworkMapping(CONFIG_PASSSTORE_PATH, FWK_PROP_SSH_PASSWORD_STORAGE_PATH);
         builder.mapping(CONFIG_AUTHENTICATION, PROJ_PROP_SSH_AUTHENTICATION);
         builder.frameworkMapping(CONFIG_AUTHENTICATION, FWK_PROP_SSH_AUTHENTICATION);
+
         builder.mapping(CONFIG_SET_PTY, PROJ_PROP_SET_PTY);
         builder.frameworkMapping(CONFIG_SET_PTY, FWK_PROP_SET_PTY);
+
+        builder.mapping(CONFIG_CON_TIMEOUT, PROJ_PROP_CON_TIMEOUT);
+        builder.frameworkMapping(CONFIG_CON_TIMEOUT, FWK_PROP_CON_TIMEOUT);
+
+        builder.mapping(CONFIG_COMMAND_TIMEOUT, PROJ_PROP_COMMAND_TIMEOUT);
+        builder.frameworkMapping(CONFIG_COMMAND_TIMEOUT, FWK_PROP_COMMAND_TIMEOUT);
 
         DESC=builder.build();
     }
@@ -242,7 +285,6 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
         //perform jsch sssh command
         final NodeSSHConnectionInfo nodeAuthentication = new NodeSSHConnectionInfo(node, framework,
                                                                                    context);
-        final int timeout = nodeAuthentication.getSSHTimeout();
         try {
 
             sshexec = SSHTaskBuilder.build(node, command, project, context.getDataContext(),
@@ -299,7 +341,7 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
             //first sudo prompt responder
             ResponderTask responder = new ResponderTask(sudoResponder, responderInput, responderOutput, resultHandler);
 
-            /**
+            /*
              * Callable will be executed by the ExecutorService
              */
             final Callable<ResponderTask.ResponderResult> responderResultCallable;
@@ -376,6 +418,8 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
         }
         String errormsg = null;
         FailureReason failureReason=null;
+        final long contimeout = nodeAuthentication.getConnectTimeout();
+        final long commandtimeout = nodeAuthentication.getCommandTimeout();
         try {
             if(forceNewPty) {
                 sshexec.setAllocatePty(true);
@@ -383,7 +427,7 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
             sshexec.execute();
             success = true;
         } catch (BuildException e) {
-            final ExtractFailure extractJschFailure = extractFailure(e,node, timeout, framework);
+            final ExtractFailure extractJschFailure = extractFailure(e, node, commandtimeout, contimeout, framework);
             errormsg = extractJschFailure.getErrormsg();
             failureReason = extractJschFailure.getReason();
             context.getExecutionListener().log(0, errormsg);
@@ -445,18 +489,30 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
         SSHProtocolFailure
     }
 
-    static ExtractFailure extractFailure(BuildException e, INodeEntry node, int timeout, Framework framework) {
+    static ExtractFailure extractFailure(
+            BuildException e,
+            INodeEntry node,
+            long commandTimeout,
+            long connectTimeout,
+            Framework framework
+    )
+    {
         String errormsg;
         FailureReason failureReason;
 
-        if (e.getMessage().contains("Timeout period exceeded, connection dropped")) {
+        if (e.getMessage().contains(ExtSSHExec.COMMAND_TIMEOUT_MESSAGE)) {
             errormsg =
-                "Failed execution for node: " + node.getNodename() + ": Execution Timeout period exceeded (after "
-                + timeout + "ms), connection dropped";
+                    "Failed execution for node: " + node.getNodename() + ": Execution Timeout period exceeded (after "
+                    + commandTimeout + "ms), connection dropped";
+            failureReason = NodeStepFailureReason.ConnectionTimeout;
+        } else if (e.getMessage().contains(ExtSSHExec.CON_TIMEOUT_MESSAGE)) {
+            errormsg =
+                    "Failed execution for node: " + node.getNodename() + ": Connection Timeout period exceeded (after "
+                    + connectTimeout + "ms).";
             failureReason = NodeStepFailureReason.ConnectionTimeout;
         } else if (null != e.getCause() && e.getCause() instanceof JSchException) {
             JSchException jSchException = (JSchException) e.getCause();
-            return extractJschFailure(node, timeout, jSchException, framework);
+            return extractJschFailure(node, commandTimeout, connectTimeout, jSchException, framework);
         } else if (e.getMessage().contains("Remote command failed with exit status")) {
             errormsg = e.getMessage();
             failureReason = NodeStepFailureReason.NonZeroResultCode;
@@ -468,7 +524,8 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
     }
 
     static ExtractFailure extractJschFailure(final INodeEntry node,
-                                             final int timeout,
+                                             final long commandTimeout,
+                                             final long connectionTimeout,
                                              final JSchException jSchException, final Framework framework) {
         String errormsg;
         FailureReason reason;
@@ -501,7 +558,7 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
             } else if (cause instanceof UnknownHostException) {
                 reason = NodeStepFailureReason.HostNotFound;
             } else if (cause instanceof SocketTimeoutException) {
-                errormsg = "Connection Timeout (after " + timeout + "ms): " + cause.getMessage();
+                errormsg = "Connection Timeout (after " + connectionTimeout + "ms): " + cause.getMessage();
                 reason = NodeStepFailureReason.ConnectionTimeout;
             } else if (cause instanceof SocketException) {
                 reason = NodeStepFailureReason.ConnectionFailure;

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschScpFileCopier.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschScpFileCopier.java
@@ -29,7 +29,6 @@ import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.execution.ExecutionContext;
 import com.dtolabs.rundeck.core.execution.impl.common.BaseFileCopier;
 import com.dtolabs.rundeck.core.execution.script.ScriptfileUtils;
-import com.dtolabs.rundeck.core.execution.service.FileCopier;
 import com.dtolabs.rundeck.core.execution.service.FileCopierException;
 import com.dtolabs.rundeck.core.execution.service.MultiFileCopier;
 import com.dtolabs.rundeck.core.execution.workflow.steps.FailureReason;
@@ -37,7 +36,6 @@ import com.dtolabs.rundeck.core.execution.workflow.steps.StepFailureReason;
 import com.dtolabs.rundeck.core.plugins.configuration.Describable;
 import com.dtolabs.rundeck.core.plugins.configuration.Description;
 import com.dtolabs.rundeck.core.tasks.net.SSHTaskBuilder;
-import com.dtolabs.rundeck.core.utils.FileUtils;
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
@@ -268,7 +266,8 @@ public class JschScpFileCopier extends BaseFileCopier implements MultiFileCopier
         JschNodeExecutor.ExtractFailure failure = JschNodeExecutor.extractFailure(
                 e,
                 node,
-                nodeAuthentication.getSSHTimeout(),
+                nodeAuthentication.getCommandTimeout(),
+                nodeAuthentication.getConnectTimeout(),
                 framework
         );
         final String errormsg = failure.getErrormsg();

--- a/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/ExtScp.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/ExtScp.java
@@ -40,6 +40,8 @@ public class ExtScp extends Scp implements SSHTaskBuilder.SCPInterface {
     private String              knownhosts;
     private InputStream         sshKeyData;
     private long                timeout;
+    private long connectTimeout;
+    private long commandTimeout;
     private Map<String, String> sshConfig;
     private PluginLogger        pluginLogger;
     private String toDir;
@@ -143,5 +145,25 @@ public class ExtScp extends Scp implements SSHTaskBuilder.SCPInterface {
 
     public List<FileSet> getIfaceFileSets() {
         return fileSets;
+    }
+
+    @Override
+    public long getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    @Override
+    public void setConnectTimeout(long connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    @Override
+    public long getCommandTimeout() {
+        return commandTimeout;
+    }
+
+    @Override
+    public void setCommandTimeout(long commandTimeout) {
+        this.commandTimeout = commandTimeout;
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/SSHTaskBuilder.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/SSHTaskBuilder.java
@@ -156,9 +156,13 @@ public class SSHTaskBuilder {
         }
 
         Session session = jsch.getSession(base.getUserInfo().getName(), base.getHost(), base.getPort());
-        session.setTimeout((int) base.getTimeout());
+        long conTimeout = base.getConnectTimeout();
+        if(conTimeout<1){
+            conTimeout = base.getTimeout();
+        }
+        session.setTimeout((int) conTimeout);
         if (base.getVerbose()) {
-            base.getPluginLogger().log(Project.MSG_DEBUG, "Set timeout to " + base.getTimeout());
+            base.getPluginLogger().log(Project.MSG_DEBUG, "Set timeout to " + conTimeout);
         }
 
         session.setUserInfo(base.getUserInfo());
@@ -239,9 +243,17 @@ public class SSHTaskBuilder {
 
         void setUsername(String username);
 
-        public void setTimeout(long sshTimeout);
+        void setTimeout(long sshTimeout);
 
         long getTimeout();
+
+        void setConnectTimeout(long sshTimeout);
+
+        long getConnectTimeout();
+
+        void setCommandTimeout(long sshTimeout);
+
+        long getCommandTimeout();
 
         void setKeyfile(String sshKeypath);
 
@@ -281,8 +293,6 @@ public class SSHTaskBuilder {
     static interface SSHExecInterface extends SSHBaseInterface, DataContextUtils.EnvironmentConfigurable {
 
         void setCommand(String commandString);
-
-        void setTimeout(long sshTimeout);
 
         void setOutputproperty(String s);
     }
@@ -338,6 +348,26 @@ public class SSHTaskBuilder {
 
         public void setTimeout(long sshTimeout) {
             instance.setTimeout(sshTimeout);
+        }
+
+        @Override
+        public void setConnectTimeout(final long sshTimeout) {
+            instance.setConnectTimeout(sshTimeout);
+        }
+
+        @Override
+        public long getConnectTimeout() {
+            return instance.getConnectTimeout();
+        }
+
+        @Override
+        public void setCommandTimeout(final long sshTimeout) {
+            instance.setCommandTimeout(sshTimeout);
+        }
+
+        @Override
+        public long getCommandTimeout() {
+            return instance.getCommandTimeout();
         }
 
         public void setKeyfile(String sshKeypath) {
@@ -544,7 +574,9 @@ public class SSHTaskBuilder {
         //nb: args are already quoted as necessary
         final String commandString = StringUtils.join(args, " ");
         sshexecTask.setCommand(commandString);
-        sshexecTask.setTimeout(sshConnectionInfo.getSSHTimeout());
+        sshexecTask.setTimeout(sshConnectionInfo.getTimeout());
+        sshexecTask.setCommandTimeout(sshConnectionInfo.getCommandTimeout());
+        sshexecTask.setConnectTimeout(sshConnectionInfo.getConnectTimeout());
 
         DataContextUtils.addEnvVars(sshexecTask, dataContext);
     }
@@ -560,7 +592,7 @@ public class SSHTaskBuilder {
 
         sshexecTask.setLocalFile(localFile);
         sshexecTask.setRemoteFile(remoteFile);
-        sshexecTask.setTimeout(sshConnectionInfo.getSSHTimeout());
+        sshexecTask.setTimeout(sshConnectionInfo.getConnectTimeout());
 
         DataContextUtils.addEnvVars(sshexecTask, dataContext);
     }
@@ -918,7 +950,11 @@ public class SSHTaskBuilder {
 
         public String getPassword();
 
-        public int getSSHTimeout();
+        public long getTimeout();
+
+        public long getCommandTimeout();
+
+        public long getConnectTimeout();
 
         public String getUsername();
         

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/impl/jsch/NodeSSHConnectionInfoSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/impl/jsch/NodeSSHConnectionInfoSpec.groovy
@@ -21,12 +21,14 @@ import com.dtolabs.rundeck.core.common.FrameworkProject
 import com.dtolabs.rundeck.core.common.INodeEntry
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import com.dtolabs.rundeck.core.execution.ExecutionContext
+import com.dtolabs.rundeck.core.execution.ExecutionListener
 import com.dtolabs.rundeck.core.storage.ResourceMeta
 import com.dtolabs.rundeck.core.storage.StorageTree
 import com.dtolabs.rundeck.core.tasks.net.SSHTaskBuilder
 import com.dtolabs.rundeck.core.tools.AbstractBaseTest
 import org.rundeck.storage.api.Resource
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  * Created by greg on 3/18/15.
@@ -548,8 +550,137 @@ class NodeSSHConnectionInfoSpec extends Specification {
         'wrong-attribute'                 | '/some/file2.password' | 'testpassword'  | null
 
     }
+    static String fwkSSHTimeoutPropA = JschNodeExecutor.FRAMEWORK_SSH_CONNECT_TIMEOUT_PROP
+    static String fwkSSHTimeoutPropB = JschNodeExecutor.SSH_TIMEOUT_PROP
 
-    private  NodeSSHConnectionInfo setupStorageVal(
+    @Unroll
+    def "ssh connection timeout config"() {
+
+
+        setup:
+        def context = Mock(ExecutionContext) {
+            getFrameworkProject() >> 'NodeSSHConnectionInfoTest'
+        }
+        def propName = JschNodeExecutor.NODE_ATTR_SSH_CONNECT_TIMEOUT_PROP
+        def projectPropName = JschNodeExecutor.PROJ_PROP_CON_TIMEOUT
+        def frameworkPropName = JschNodeExecutor.FWK_PROP_CON_TIMEOUT
+//        def frameworkPropName2 = JschNodeExecutor.FRAMEWORK_SSH_CONNECT_TIMEOUT_PROP
+
+        NodeEntryImpl node = setupProps(
+                propName,
+                nodepropval,
+                projectPropName,
+                projectpropval,
+                [
+                        (frameworkPropName)                                  : fwkpropval,
+                        (JschNodeExecutor.FRAMEWORK_SSH_CONNECT_TIMEOUT_PROP): !useDeprecated ? fwkpropval2 : null,
+                        (JschNodeExecutor.SSH_TIMEOUT_PROP)                  : useDeprecated ? fwkpropval2 : null
+                ],
+                )
+        when:
+        NodeSSHConnectionInfo info = new NodeSSHConnectionInfo(node, framework, context)
+
+        then:
+        info.getConnectTimeout() == expected
+
+        where:
+
+        nodepropval | projectpropval | fwkpropval | fwkpropval2 | useDeprecated | expected
+        null        | null           | null       | null        | false         | 0l
+        '123'       | null           | null       | null        | false         | 123l
+        '123'       | '321'          | null       | null        | false         | 123l
+        '123'       | '321'          | '456'      | null        | false         | 123l
+        '123'       | '321'          | '456'      | '789'       | false         | 123l
+        null        | '321'          | '456'      | '789'       | false         | 321L
+        null        | null           | '456'      | '789'       | false         | 456L
+        null        | null           | null       | '789'       | false         | 789L
+        null        | null           | null       | null        | true          | 0l
+        '123'       | null           | null       | null        | true          | 123l
+        '123'       | '321'          | null       | null        | true          | 123l
+        '123'       | '321'          | '456'      | null        | true          | 123l
+        '123'       | '321'          | '456'      | '789'       | true          | 123l
+        null        | '321'          | '456'      | '789'       | true          | 321L
+        null        | null           | '456'      | '789'       | true          | 456L
+        null        | null           | null       | '789'       | true          | 789L
+
+    }
+
+    private NodeEntryImpl setupProps(
+            String propName,
+            String nodepropval,
+            String projectPropName,
+            String projectpropval,
+            Map<String, String> fwkProps
+    )
+    {
+        INodeEntry node = new NodeEntryImpl("test1");
+        if (nodepropval) {
+            node.getAttributes().put(propName, nodepropval)
+        }
+        if (projectpropval) {
+            def projprops = new Properties()
+            projprops.put(projectPropName, projectpropval)
+            def testProject = framework.getFrameworkProjectMgr().getFrameworkProject('NodeSSHConnectionInfoTest')
+            testProject.mergeProjectProperties(projprops, [] as Set)
+            testProject.hasProperty(projectPropName)//trigger refresh
+        }
+        removeProps(
+                new File(framework.getBaseDir(), "etc/framework.properties"),
+                fwkProps.keySet()
+        )
+        if (fwkProps) {
+            def pfwkProps = new Properties()
+            fwkProps.each { k, v ->
+                if (v) {
+                    pfwkProps.setProperty(k, v)
+                }
+            }
+            mergeProps(new File(framework.getBaseDir(), "etc/framework.properties"), pfwkProps)
+        }
+        node
+    }
+
+    @Unroll
+    def "ssh command timeout config"() {
+        setup:
+        def context = Mock(ExecutionContext) {
+            getFrameworkProject() >> 'NodeSSHConnectionInfoTest'
+        }
+        def propName = JschNodeExecutor.NODE_ATTR_SSH_COMMAND_TIMEOUT_PROP
+        def projectPropName = JschNodeExecutor.PROJ_PROP_COMMAND_TIMEOUT
+        def frameworkPropName = JschNodeExecutor.FWK_PROP_COMMAND_TIMEOUT
+        def frameworkPropName2 = JschNodeExecutor.FRAMEWORK_SSH_COMMAND_TIMEOUT_PROP
+
+        NodeEntryImpl node = setupProps(
+                propName,
+                nodepropval,
+                projectPropName,
+                projectpropval,
+                [
+                        (frameworkPropName) : fwkpropval,
+                        (frameworkPropName2): fwkpropval2
+                ],
+                )
+        when:
+        NodeSSHConnectionInfo info = new NodeSSHConnectionInfo(node, framework, context)
+
+        then:
+        info.getCommandTimeout() == expected
+
+        where:
+        nodepropval | projectpropval | fwkpropval | fwkpropval2 | expected
+        null        | null           | null       | null        | 0l
+        '123'       | null           | null       | null        | 123l
+        '123'       | '321'          | null       | null        | 123l
+        '123'       | '321'          | '456'      | null        | 123l
+        '123'       | '321'          | '456'      | '789'       | 123l
+        null        | '321'          | '456'      | '789'       | 321L
+        null        | null           | '456'      | '789'       | 456L
+        null        | null           | null       | '789'       | 789L
+
+    }
+
+    private NodeSSHConnectionInfo setupStorageVal(
             String propname,
             String path,
             String storageVal

--- a/core/src/test/java/com/dtolabs/rundeck/core/tasks/net/TestSSHTaskBuilder.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/tasks/net/TestSSHTaskBuilder.java
@@ -59,6 +59,8 @@ public class TestSSHTaskBuilder extends TestCase {
         private String host;
         private int port;
         private long timeout;
+        private long connectTimeout;
+        private long commandTimeout;
         private SSHUserInfo userInfo;
         String username;
         private String keyfile;
@@ -204,6 +206,26 @@ public class TestSSHTaskBuilder extends TestCase {
         public Integer getTtlSSHAgent(){
           return this.ttlSSHAgent;
         }
+
+        @Override
+        public long getConnectTimeout() {
+            return connectTimeout;
+        }
+
+        @Override
+        public void setConnectTimeout(long connectTimeout) {
+            this.connectTimeout = connectTimeout;
+        }
+
+        @Override
+        public long getCommandTimeout() {
+            return commandTimeout;
+        }
+
+        @Override
+        public void setCommandTimeout(long commandTimeout) {
+            this.commandTimeout = commandTimeout;
+        }
     }
 
     static class testSCPInterface extends testSSHBaseInterface implements SSHTaskBuilder.SCPInterface {
@@ -261,7 +283,9 @@ public class TestSSHTaskBuilder extends TestCase {
         String privateKeyResourcePath;
         String passwordStoragePath;
         String password;
-        int SSHTimeout;
+        long timeout;
+        private long connectTimeout;
+        private long commandTimeout;
         Boolean localSSHAgent;
         Integer localTtlSSHAgent;
         String username;
@@ -289,8 +313,8 @@ public class TestSSHTaskBuilder extends TestCase {
             return password;
         }
 
-        public int getSSHTimeout() {
-            return SSHTimeout;
+        public long getTimeout() {
+            return timeout;
         }
 
         public String getUsername() {
@@ -365,6 +389,24 @@ public class TestSSHTaskBuilder extends TestCase {
         @Override
         public byte[] getPrivateKeyPassphraseStorageData() throws IOException {
             return privateKeyPassphraseStorageData;
+        }
+
+        @Override
+        public long getConnectTimeout() {
+            return connectTimeout;
+        }
+
+        public void setConnectTimeout(long connectTimeout) {
+            this.connectTimeout = connectTimeout;
+        }
+
+        @Override
+        public long getCommandTimeout() {
+            return commandTimeout;
+        }
+
+        public void setCommandTimeout(long commandTimeout) {
+            this.commandTimeout = commandTimeout;
         }
     }
 
@@ -460,7 +502,7 @@ public class TestSSHTaskBuilder extends TestCase {
         final testSSHExecInterface test = new testSSHExecInterface();
 
         state.node.setHostname("hostname:33");
-        state.sshConnectionInfo.SSHTimeout = 600;
+        state.sshConnectionInfo.timeout = 600;
         state.sshConnectionInfo.username = "usernameValue";
 
         runBuildSSH(state, test, testLogger);
@@ -483,7 +525,7 @@ public class TestSSHTaskBuilder extends TestCase {
         final testSSHExecInterface test = new testSSHExecInterface();
 
         state.node.setHostname("hostname:33");
-        state.sshConnectionInfo.SSHTimeout = 600;
+        state.sshConnectionInfo.timeout = 600;
         state.sshConnectionInfo.username = "usernameValue";
         state.sshConnectionInfo.privateKeyPassphrase = "passphraseValue";
 

--- a/docs/en/administration/03-configuration.md
+++ b/docs/en/administration/03-configuration.md
@@ -68,11 +68,12 @@ Some important settings:
 * `framework.rundeck.url`: Base URL for Rundeck server.
 
 
-SSH Connection settings:
+SSH Connection settings (See [Plugins User Guide > SSH Plugins](../plugins-user-guide/ssh-plugins.html)):
 
 * `framework.ssh.keypath`: Path to the SSH private key file used for SSH connections
 * `framework.ssh.user`: Default username for SSH Connections, if not overridden by Node specific value.
-* `framework.ssh.timeout`: timeout in milliseconds for SSH connections and executions. The default is "0" (no timeout).  You can modify this to change the maximum time allowed for SSH connections.
+* `framework.ssh-connect-timeout`: timeout in milliseconds for SSH connections. The default is "0" (no timeout).  You can modify this to change the connect/socket timeout. (Deprecated: `framework.ssh.timeout`.)
+* `framework.ssh-command-timeout`: timeout in milliseconds for SSH commands. The default is "0" (no timeout).  You can modify this to change the maximum time allowed for SSH commands to run.
 
 Other settings:
 

--- a/docs/en/plugins-user-guide/ssh-plugins.md
+++ b/docs/en/plugins-user-guide/ssh-plugins.md
@@ -98,6 +98,30 @@ SSH config options can be specified by setting the following properties:
 2. **Project level**: `project.ssh-config-KEY` property in `project.properties`.  Applies to any project node by default.
 3. **Rundeck level**: `framework.ssh-config-KEY` property in `framework.properties`. Applies to all projects by default.
 
+### Specifying SSH Timeout options
+
+SSH timeout options can be specified.  The timeout values are in milliseconds.  
+A value of 0 means the timeout will be indefinite.
+The precedence level is Node > Project > Rundeck.  
+
+1. **Node level**: attribute on the Node. Applies only to the target node.
+    
+    * `ssh-connection-timeout` connection timeout
+    * `ssh-command-timeout` command timeout
+
+2. **Project level**:  Applies to any project node by default. Set property in Project Config (`project.properties`).
+
+    * `project.ssh-connection-timeout`  connection timeout
+    * `project.ssh-command-timeout` command timeout
+    
+3. **Rundeck level**: Applies to all projects by default. Set property in `framework.properties`. 
+
+    * `framework.ssh-connection-timeout` connection timeout 
+    * `framework.ssh-command-timeout` command timeout 
+
+
+Deprecated: The framework property `framework.ssh.timeout` will also be used for Connection timeout if set.
+
 ### SSH Private Keys
 
 Choose either:


### PR DESCRIPTION
define separate connection and command timeout configs for SSH plugins