### PR TITLE
Fix 2472

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContextImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContextImpl.java
@@ -210,7 +210,7 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
             this((ExecutionContext) original);
             if (null != original) {
                 ctx.stepNumber = original.getStepNumber();
-                ctx.stepContext = original.getStepContext();
+                ctx.stepContext = null != original.getStepContext() ? new ArrayList<>(original.getStepContext()) : null;
                 ctx.flowControl = original.getFlowControl();
             }
         }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/NodeDispatcherService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/NodeDispatcherService.java
@@ -46,10 +46,9 @@ public class NodeDispatcherService extends BaseProviderRegistryService<NodeDispa
         registry.put("orchestrator", OrchestratorNodeDispatcher.class);
     }
 
-    public  NodeDispatcher getNodeDispatcher(ExecutionContext context) throws ExecutionServiceException {
+    public NodeDispatcher getNodeDispatcher(ExecutionContext context) throws ExecutionServiceException {
         //this gets called for each node as well if we already have data then the parent orchestrator has fired
-        if(context.getOrchestrator() != null && 
-                !context.getDataContext().containsKey(OrchestratorNodeDispatcher.ORCHESTRATOR_DATA)){
+        if (context.getOrchestrator() != null) {
             return providerOfType("orchestrator");
         }
         if (context.getThreadCount() > 1 && context.getNodes().getNodeNames().size() > 1) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/OrchestratorNodeDispatcher.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/OrchestratorNodeDispatcher.java
@@ -54,8 +54,6 @@ import com.dtolabs.rundeck.plugins.util.DescriptionBuilder;
  * @author Ashley Taylor
  */
 public class OrchestratorNodeDispatcher implements NodeDispatcher {
-    public static final String ORCHESTRATOR_DATA = "orchestratorData";
-    
     private Framework framework;
 
     public OrchestratorNodeDispatcher(Framework framework) {
@@ -119,8 +117,7 @@ public class OrchestratorNodeDispatcher implements NodeDispatcher {
             + context.getThreadCount()
             + ")");
         //to not have 2 orchestrator within one run when it processed the inner node
-        Map<String,String> orchestratorData = new HashMap<>();
-        context.getDataContext().put(ORCHESTRATOR_DATA, orchestratorData);
+
         boolean success = false;
         final HashMap<String, NodeStepResult> resultMap = new HashMap<>();
         final HashMap<String, NodeStepResult> failureMap = new HashMap<>();

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/WorkflowExecutionService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/WorkflowExecutionService.java
@@ -73,12 +73,7 @@ public class WorkflowExecutionService extends ChainedProviderService<WorkflowExe
                 registry
         );
 
-//        final ProviderService<WorkflowExecutor> pluginService =
-//                ServiceFactory.pluginService(SERVICE_NAME, framework, WorkflowExecutor.class);
-
-
         serviceList.add(primaryService);
-//        serviceList.add(pluginService);
     }
 
     @Override

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/ExecutionContextImplSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/ExecutionContextImplSpec.groovy
@@ -1,0 +1,30 @@
+package com.dtolabs.rundeck.core.execution
+
+import spock.lang.Specification
+
+/**
+ * @author greg
+ * @since 8/1/17
+ */
+class ExecutionContextImplSpec extends Specification {
+    def "original step context not modified"() {
+        given:
+        def orig = ExecutionContextImpl.builder()
+                                       .stepContext([1, 2])
+                                       .stepNumber(3)
+                                       .build()
+
+
+        when:
+        def newctx = ExecutionContextImpl.builder(orig)
+                                         .pushContextStep(4)
+                                         .build()
+
+        then:
+        orig.stepContext == [1, 2]
+        orig.stepNumber == 3
+
+        newctx.stepContext == [1, 2, 3]
+        newctx.stepNumber == 4
+    }
+}

--- a/plugins/orchestrator-plugin/src/main/java/org/rundeck/plugin/example/MaxPercentageOrchestator.java
+++ b/plugins/orchestrator-plugin/src/main/java/org/rundeck/plugin/example/MaxPercentageOrchestator.java
@@ -36,7 +36,7 @@ public class MaxPercentageOrchestator implements Orchestrator {
 
 
     public MaxPercentageOrchestator(StepExecutionContext context, Collection<INodeEntry> nodes, int percentage) {
-        this.list = new ArrayList<INodeEntry>(nodes);
+        this.list = new ArrayList<>(nodes);
         percentage = validPercentage(percentage);
         this.max = calculateMax(nodes.size(), percentage);
         if (context != null) {

--- a/plugins/orchestrator-plugin/src/main/java/org/rundeck/plugin/example/RandomSubsetOrchestrator.java
+++ b/plugins/orchestrator-plugin/src/main/java/org/rundeck/plugin/example/RandomSubsetOrchestrator.java
@@ -31,11 +31,19 @@ import java.util.Random;
  */
 public class RandomSubsetOrchestrator implements Orchestrator {
 
-    Random random = new Random(System.currentTimeMillis());
+    Random random;
+    long seed;
     final int count;
     List<INodeEntry> nodes;
 
-    public RandomSubsetOrchestrator(int count, StepExecutionContext context, Collection<INodeEntry> nodes) {
+    public RandomSubsetOrchestrator(
+            int count,
+            StepExecutionContext context,
+            Collection<INodeEntry> nodes, final long seed
+    )
+    {
+        this.seed = seed;
+        this.random = new Random(seed);
         this.count = count;
         this.nodes = select(count, nodes);
     }


### PR DESCRIPTION
- orchestrator config is applied to each node dispatch step/section
- random subset orchestrator deterministically generates seed to use within the same workflow layer so that independent node dispatches will use the same random set of nodes