### PR TITLE
Remove Join from  Execution table with LogFileStorageRequest

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -108,7 +108,6 @@ class Execution extends ExecutionContext {
         //mapping overrides superclass, so we need to relist these
         user column: "rduser"
         argString type: 'text'
-        logFileStorageRequest fetch: 'join'
 
         failedNodeList type: 'text'
         succeededNodeList type: 'text'


### PR DESCRIPTION
Remove Join from  Execution table with LogFileStorageRequest to increase query  performances