### PR TITLE
Job Notification for jobs exceeding average duration

### DIFF
--- a/docs/en/developer/05-notification-plugins.md
+++ b/docs/en/developer/05-notification-plugins.md
@@ -11,6 +11,7 @@ Currently there are three conditions that can trigger notifications:
 * `onstart` - the Job started
 * `onsuccess` - the Job completed without error
 * `onfailure` - the Job failed or was aborted
+* `onavgduration` - The Execution exceed the average duration of the Job
 
 Rundeck has two built-in notification types that can be configured for Jobs:
 
@@ -288,7 +289,7 @@ The user is presented with any `Instance` scoped properties in the Rundeck GUI w
 
 ### Notification handlers
 
-For a `NotificationPlugin`, you can define custom handlers for each of the notification triggers (`onsuccess`, `onfailure`, and `onstart`).
+For a `NotificationPlugin`, you can define custom handlers for each of the notification triggers (`onsuccess`, `onfailure`, `onstart` and `onavgduration`).
 
 Simply define a closure with the given trigger name, and return a true value if your action was successful:
 
@@ -306,6 +307,11 @@ onsuccess{ Map execution, Map configuration ->
 onfailure{ Map execution, Map configuration ->
     //perform an action using the execution and configuration
     println "Oh No! Job ${execution.job.name} didn't work out."
+    return true
+}
+onavgduration{ Map execution, Map configuration ->
+    //perform an action using the execution and configuration
+    println "Job ${execution.job.name} exceeded Average Duration!."
     return true
 }
 ~~~~~~~~
@@ -334,6 +340,10 @@ rundeckPlugin(NotificationPlugin){
  
     onsuccess {
         println("success: data ${execution}")
+        true
+    }
+    onavgduration{
+        println("exceeded average duration: data ${execution}")
         true
     }
 }
@@ -399,6 +409,11 @@ rundeckPlugin(NotificationPlugin) {
     onsuccess {
         //with no args, there is a "configuration" and an "execution" variable in the context
         println("script, success: data ${execution}, test1: ${configuration.test1}, test2: ${configuration.test2} test3: ${configuration.test3}")
+        true
+    }
+
+    onavgduration { Map executionData,Map config ->
+        println("script, exceeded average duration: data ${executionData}, config: ${config}")
         true
     }
 }

--- a/docs/en/manpages/man5/job-v20.md
+++ b/docs/en/manpages/man5/job-v20.md
@@ -1184,6 +1184,10 @@ Defines email, webhook or plugin notifications for Job success and failure, with
 
 :    define notifications for job start
 
+[onavgduration][]
+
+:    define notifications when exceed average duration
+
 *Example*
 
 ~~~~~~~~ {.xml}
@@ -1202,6 +1206,10 @@ Defines email, webhook or plugin notifications for Job success and failure, with
           </configuration>
         </plugin>
    </onstart>
+   <onavgduration>
+        <email recipients='test@example.com' subject='Job Exceeded average duration' />
+        <plugin type='MinimalNotificationPlugin' />
+      </onavgduration>
 </notification>      
 ~~~~~~~~ 
 
@@ -1239,9 +1247,20 @@ Embed an [webhook](#webhook) element to perform a HTTP POST to some URLs, within
 Embed an [plugin](#plugin) element to perform a custom action, within
 [notification](#notification).
 
+### onavgduration 
+
+Embed an [email](#email) element to send email on success, within
+[notification](#notification).
+
+Embed an [webhook](#webhook) element to perform a HTTP POST to some URLs, within
+[notification](#notification).
+
+Embed an [plugin](#plugin) element to perform a custom action, within
+[notification](#notification).
+
 ### email 
 
-Define email recipients for Job execution result, within [onsuccess][], [onfailure][] or [onstart][].
+Define email recipients for Job execution result, within [onsuccess][], [onfailure][], [onstart][] or [onavgduration][].
 
 *Attributes*
 
@@ -1255,7 +1274,7 @@ recipients
 
 ### webhook
 
-Define URLs to submit a HTTP POST to containing the job execution result, within [onsuccess][], [onfailure][] or [onstart][].
+Define URLs to submit a HTTP POST to containing the job execution result, within [onsuccess][], [onfailure][], [onstart][] or [onavgduration][].
 
 
 *Attributes*
@@ -1275,7 +1294,7 @@ urls
 
 ### plugin
 
-Defines a configuration for a plugin to perform a Notification, within [onsuccess][], [onfailure][] or [onstart][].
+Defines a configuration for a plugin to perform a Notification, within [onsuccess][], [onfailure][], [onstart][] or [onavgduration][].
 
 *Attributes*
 
@@ -1339,3 +1358,4 @@ The Rundeck source code and all documentation may be downloaded from
 [onsuccess]: #onsuccess
 [onfailure]: #onfailure
 [onstart]: #onstart
+[onavgduration]: #onavgduration

--- a/docs/en/manpages/man5/job-yaml-v12.md
+++ b/docs/en/manpages/man5/job-yaml-v12.md
@@ -828,10 +828,10 @@ Deprecated Example:
 
 ### Notification
 
-Defines a notification for the job.  You can include any of `onsuccess`, `onfailure` or `onstart` notifications. Each type of notification can define any of the built in notifications, or define plugin notifications.
+Defines a notification for the job.  You can include any of `onsuccess`, `onfailure`, `onstart` or `onavgduration` notifications. Each type of notification can define any of the built in notifications, or define plugin notifications.
 
 
-`onsuccess`/`onfailure`/`onstart`
+`onsuccess`/`onfailure`/`onstart`/`onavgduration`
 
 :    A Map containing either or both of:
 
@@ -868,6 +868,13 @@ Example:
           type: otherplugin
           configuration:
             a: b
+    onavgduration:
+      email:
+        recipients: test@example.com
+        subject: Job Exceeded average duration
+      plugin:
+        configuration: {}
+        type: MinimalNotificationPlugin
 ~~~~~~~~ 
 
 * For more information about the Webhook mechanism used, see the chapter [Integration - Webhooks](../manual/jobs.html#webhooks).

--- a/docs/en/plugins-user-guide/configuring.md
+++ b/docs/en/plugins-user-guide/configuring.md
@@ -199,6 +199,7 @@ currently available triggers:
 * `onstart` - the Job started
 * `onsuccess` - the Job succeeded
 * `onfailure` - the Job failed
+* `onavgduration` - the Execution exceed the average duration of the Job
 
 When you define the Job in the GUI or via [XML](../man5/job-v20.html#notification) or
 [Yaml](../man5/job-yaml-v12.html#notification), you can add any of the available Notification plugin types to happen for

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -87,6 +87,7 @@ class ScheduledExecutionController  extends ControllerBase{
     public static final String ONSUCCESS_TRIGGER_NAME = 'onsuccess'
     public static final String ONFAILURE_TRIGGER_NAME = 'onfailure'
     public static final String ONSTART_TRIGGER_NAME = 'onstart'
+    public static final String OVERAVGDURATION_TRIGGER_NAME = 'avgduration'
     public static final String EMAIL_NOTIFICATION_TYPE = 'email'
     public static final String WEBHOOK_NOTIFICATION_TYPE = 'url'
     public static final ArrayList<String> NOTIFICATION_ENABLE_FIELD_NAMES = [

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -87,7 +87,13 @@ class ScheduledExecutionController  extends ControllerBase{
     public static final String ONSUCCESS_TRIGGER_NAME = 'onsuccess'
     public static final String ONFAILURE_TRIGGER_NAME = 'onfailure'
     public static final String ONSTART_TRIGGER_NAME = 'onstart'
-    public static final String OVERAVGDURATION_TRIGGER_NAME = 'avgduration'
+    public static final String OVERAVGDURATION_TRIGGER_NAME = 'onavgduration'
+    public static final String NOTIFY_OVERAVGDURATION_EMAIL = 'notifyAvgDurationEmail'
+    public static final String NOTIFY_OVERAVGDURATION_URL = 'notifyAvgDurationUrl'
+    public static final String NOTIFY_ONOVERAVGDURATION_URL = 'notifyOnAvgDurationUrl'
+    public static final String NOTIFY_OVERAVGDURATION_RECIPIENTS = 'notifyAvgDurationRecipients'
+    public static final String NOTIFY_OVERAVGDURATION_SUBJECT = 'notifyAvgDurationSubject'
+
     public static final String EMAIL_NOTIFICATION_TYPE = 'email'
     public static final String WEBHOOK_NOTIFICATION_TYPE = 'url'
     public static final ArrayList<String> NOTIFICATION_ENABLE_FIELD_NAMES = [
@@ -96,7 +102,9 @@ class ScheduledExecutionController  extends ControllerBase{
             NOTIFY_ONSUCCESS_EMAIL,
             NOTIFY_ONSUCCESS_URL,
             NOTIFY_ONSTART_EMAIL,
-            NOTIFY_ONSTART_URL
+            NOTIFY_ONSTART_URL,
+            NOTIFY_OVERAVGDURATION_EMAIL,
+            NOTIFY_ONOVERAVGDURATION_URL
     ]
 
     def Scheduler quartzScheduler

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -61,6 +61,8 @@ class ScheduledExecution extends ExecutionContext {
     String notifySuccessUrl
     String notifyFailureUrl
     String notifyStartUrl
+    String notifyAvgDurationRecipients
+    String notifyAvgDurationUrl
     Boolean multipleExecutions = false
     Orchestrator orchestrator
 
@@ -71,7 +73,7 @@ class ScheduledExecution extends ExecutionContext {
 
     static transients = ['userRoles','adhocExecutionType','notifySuccessRecipients','notifyFailureRecipients',
                          'notifyStartRecipients', 'notifySuccessUrl', 'notifyFailureUrl', 'notifyStartUrl',
-                         'crontabString','averageDuration']
+                         'crontabString','averageDuration','notifyAvgDurationRecipients','notifyAvgDurationUrl']
 
     static constraints = {
         project(nullable:false, blank: false, matches: FrameworkResource.VALID_RESOURCE_NAME_REGEX)

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -322,7 +322,7 @@ node.metadata.OsArch.defaults=i386,i686,ppc,sparc,x86,x86_64
 notification.event.onfailure=On Failure
 notification.event.onsuccess=On Success
 notification.event.onstart=On Start
-notification.event.avgduration=Average Duration Exceeded
+notification.event.onavgduration=Average Duration Exceeded
 
 #metadata for resources
 resource.metadata.entity.deployment-install-root=Install Root

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -322,6 +322,7 @@ node.metadata.OsArch.defaults=i386,i686,ppc,sparc,x86,x86_64
 notification.event.onfailure=On Failure
 notification.event.onsuccess=On Success
 notification.event.onstart=On Start
+notification.event.avgduration=Average Duration Exceeded
 
 #metadata for resources
 resource.metadata.entity.deployment-install-root=Install Root

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -322,6 +322,7 @@ node.metadata.OsArch.defaults=i386,i686,ppc,sparc,x86,x86_64
 notification.event.onfailure=Por Fracaso
 notification.event.onsuccess=Por Éxito
 notification.event.onstart=Al Inicio
+notification.event.onavgduration=Cuando excede la duración promedio
 
 #metadata for resources
 resource.metadata.entity.deployment-install-root=Instalar Raíz

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -306,6 +306,7 @@ node.metadata.OsArch.defaults=i386,i686,ppc,sparc,x86,x86_64
 notification.event.onfailure=On Failure
 notification.event.onsuccess=On Success
 notification.event.onstart=On Start
+notification.event.onavgduration=Average Duration Exceeded
 
 #metadata for resources
 resource.metadata.entity.deployment-install-root=Install Root

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -361,10 +361,7 @@ class ExecutionJob implements InterruptableJob {
         def killLimit = 100
         def WorkflowExecutionServiceThread thread = execmap.thread
         def ThresholdValue threshold = execmap.threshold
-        def jobAverageDuration = 0
-        if(execmap.scheduledExecution?.execCount){
-            jobAverageDuration= execmap.scheduledExecution.totalTime/execmap.scheduledExecution.execCount
-        }
+        def jobAverageDuration = execmap.scheduledExecution?execmap.scheduledExecution.averageDuration:0
         def boolean avgNotificationSent = false
         def boolean stop=false
         boolean never=true
@@ -377,7 +374,7 @@ class ExecutionJob implements InterruptableJob {
             }
             if(!avgNotificationSent && jobAverageDuration>0){
                 if((System.currentTimeMillis() - startTime) > jobAverageDuration){
-                    def res = executionService.notificationService.triggerJobNotification('avgduration', execmap.scheduledExecution.id,
+                    def res = executionService.avgDurationExceeded(execmap.scheduledExecution.id,
                             [execution: execmap.execution, context:execmap])
                     avgNotificationSent=true
                 }

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -375,7 +375,6 @@ class ExecutionJob implements InterruptableJob {
             } catch (InterruptedException e) {
                 //do nada
             }
-            //TODO send notification avg duration
             if(!avgNotificationSent && jobAverageDuration>0){
                 if((System.currentTimeMillis() - startTime) > jobAverageDuration){
                     def res = executionService.notificationService.triggerJobNotification('avgduration', execmap.scheduledExecution.id,

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3461,4 +3461,10 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         ISO_8601_DATE_FORMAT_WITH_MS.remove()
         ISO_8601_DATE_FORMAT.remove()
     }
+
+
+
+    boolean avgDurationExceeded(schedId, Map content){
+        notificationService.triggerJobNotification('avgduration',schedId, content)
+    }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1712,10 +1712,32 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                     type: ScheduledExecutionController.WEBHOOK_NOTIFICATION_TYPE,
                     content: params[ScheduledExecutionController.NOTIFY_START_URL]]
         }
+
+        if ('true' == params[ScheduledExecutionController.NOTIFY_OVERAVGDURATION_EMAIL]) {
+            def config = [
+                    recipients: params[ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS],
+            ]
+            if (params[ScheduledExecutionController.NOTIFY_OVERAVGDURATION_SUBJECT]) {
+                config.subject = params[ScheduledExecutionController.NOTIFY_OVERAVGDURATION_SUBJECT]
+            }
+            nots << [eventTrigger: ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME,
+                     type: ScheduledExecutionController.EMAIL_NOTIFICATION_TYPE,
+                     configuration: config
+            ]
+        }
+        if ('true' == params[ScheduledExecutionController.NOTIFY_ONOVERAVGDURATION_URL]) {
+            nots << [eventTrigger: ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME,
+                     type: ScheduledExecutionController.WEBHOOK_NOTIFICATION_TYPE,
+                     content: params[ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL]]
+        }
+
+
+
         //notifyOnsuccessPlugin
         if (params.notifyPlugin) {
             [ScheduledExecutionController.ONSUCCESS_TRIGGER_NAME, ScheduledExecutionController
-                    .ONFAILURE_TRIGGER_NAME, ScheduledExecutionController.ONSTART_TRIGGER_NAME].each { trig ->
+                    .ONFAILURE_TRIGGER_NAME, ScheduledExecutionController.ONSTART_TRIGGER_NAME,
+             ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME].each { trig ->
 //                params.notifyPlugin.each { trig, plug ->
                 def plugs = params.notifyPlugin[trig]
                 if (plugs) {
@@ -2366,7 +2388,9 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 (ScheduledExecutionController.ONFAILURE_TRIGGER_NAME):
                         ScheduledExecutionController.NOTIFY_FAILURE_RECIPIENTS,
                 (ScheduledExecutionController.ONSTART_TRIGGER_NAME):
-                        ScheduledExecutionController.NOTIFY_START_RECIPIENTS
+                        ScheduledExecutionController.NOTIFY_START_RECIPIENTS,
+                (ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME):
+                        ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS,
         ]
         def conf = notif.configuration
         def arr = (conf?.recipients?: notif.content)?.split(",")
@@ -2414,7 +2438,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         def fieldNamesUrl = [
                 (ScheduledExecutionController.ONSUCCESS_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_SUCCESS_URL,
                 (ScheduledExecutionController.ONFAILURE_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_FAILURE_URL,
-                (ScheduledExecutionController.ONSTART_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_START_URL
+                (ScheduledExecutionController.ONSTART_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_START_URL,
+                (ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL,
         ]
         def arr = notif.content.split(",")
         def validCount=0
@@ -2467,12 +2492,15 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 (ScheduledExecutionController.ONFAILURE_TRIGGER_NAME):
                         ScheduledExecutionController.NOTIFY_FAILURE_RECIPIENTS,
                 (ScheduledExecutionController.ONSTART_TRIGGER_NAME):
-                        ScheduledExecutionController.NOTIFY_START_RECIPIENTS
+                        ScheduledExecutionController.NOTIFY_START_RECIPIENTS,
+                (ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME):
+                        ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS,
         ]
         def fieldNamesUrl = [
                 (ScheduledExecutionController.ONSUCCESS_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_SUCCESS_URL,
                 (ScheduledExecutionController.ONFAILURE_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_FAILURE_URL,
                 (ScheduledExecutionController.ONSTART_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_START_URL,
+                (ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL,
         ]
         
         def addedNotifications=[]

--- a/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsForm.gsp
@@ -32,6 +32,15 @@
 <g:set var="defStartUrl" value="${scheduledExecution.findNotification(ScheduledExecutionController.ONSTART_TRIGGER_NAME, ScheduledExecutionController.WEBHOOK_NOTIFICATION_TYPE)}"/>
 <g:set var="isStartUrl"
        value="${'true' == params[ScheduledExecutionController.NOTIFY_ONSTART_URL] || null == params[ScheduledExecutionController.NOTIFY_ONSTART_URL] && defStartUrl}"/>
+<g:set var="defAvg" value="${scheduledExecution.findNotification(ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME, ScheduledExecutionController.EMAIL_NOTIFICATION_TYPE)}"/>
+<g:set var="isAvg"
+       value="${'true' == params[ScheduledExecutionController.NOTIFY_OVERAVGDURATION_EMAIL] || null == params[ScheduledExecutionController.NOTIFY_OVERAVGDURATION_EMAIL] && defAvg}"/>
+<g:set var="defAvgUrl" value="${scheduledExecution.findNotification(ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME, ScheduledExecutionController.WEBHOOK_NOTIFICATION_TYPE)}"/>
+<g:set var="isAvgUrl"
+       value="${'true' == params[ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL] || null == params[ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL] && defAvgUrl}"/>
+
+
+
 <div class="form-group">
     <div class="col-sm-2 control-label text-form-label">
         <g:message code="scheduledExecution.property.notified.label.text" />
@@ -120,16 +129,16 @@
           model="${[
                   isVisible: (notifications|| params.notified == 'true'),
                   trigger: ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME,
-                  triggerEmailCheckboxName: ScheduledExecutionController.NOTIFY_ONSTART_EMAIL,
-                  triggerEmailRecipientsName: ScheduledExecutionController.NOTIFY_START_RECIPIENTS,
-                  triggerEmailSubjectName: ScheduledExecutionController.NOTIFY_START_SUBJECT,
-                  triggerUrlCheckboxName: ScheduledExecutionController.NOTIFY_ONSTART_URL,
-                  triggerUrlFieldName: ScheduledExecutionController.NOTIFY_START_URL,
-                  isEmail: isStart,
-                  isUrl: isStartUrl,
-                  defEmail: defStart,
-                  defUrl: defStartUrl,
-                  definedNotifications: scheduledExecution.notifications?.findAll { it.eventTrigger == ScheduledExecutionController.ONSTART_TRIGGER_NAME },
+                  triggerEmailCheckboxName: ScheduledExecutionController.NOTIFY_OVERAVGDURATION_EMAIL,
+                  triggerEmailRecipientsName: ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS,
+                  triggerEmailSubjectName: ScheduledExecutionController.NOTIFY_OVERAVGDURATION_SUBJECT,
+                  triggerUrlCheckboxName: ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL,
+                  triggerUrlFieldName: ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL,
+                  isEmail: isAvg,
+                  isUrl: isAvgUrl,
+                  defEmail: defAvg,
+                  defUrl: defAvgUrl,
+                  definedNotifications: scheduledExecution.notifications?.findAll { it.eventTrigger == ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME },
                   adminauth: adminauth,
                   serviceName: ServiceNameConstants.Notification
           ]}"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsForm.gsp
@@ -116,3 +116,20 @@
                   adminauth: adminauth,
                   serviceName: ServiceNameConstants.Notification
           ]}"/>
+<g:render template="/scheduledExecution/editNotificationsTriggerForm"
+          model="${[
+                  isVisible: (notifications|| params.notified == 'true'),
+                  trigger: ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME,
+                  triggerEmailCheckboxName: ScheduledExecutionController.NOTIFY_ONSTART_EMAIL,
+                  triggerEmailRecipientsName: ScheduledExecutionController.NOTIFY_START_RECIPIENTS,
+                  triggerEmailSubjectName: ScheduledExecutionController.NOTIFY_START_SUBJECT,
+                  triggerUrlCheckboxName: ScheduledExecutionController.NOTIFY_ONSTART_URL,
+                  triggerUrlFieldName: ScheduledExecutionController.NOTIFY_START_URL,
+                  isEmail: isStart,
+                  isUrl: isStartUrl,
+                  defEmail: defStart,
+                  defUrl: defStartUrl,
+                  definedNotifications: scheduledExecution.notifications?.findAll { it.eventTrigger == ScheduledExecutionController.ONSTART_TRIGGER_NAME },
+                  adminauth: adminauth,
+                  serviceName: ServiceNameConstants.Notification
+          ]}"/>

--- a/rundeckapp/test/integration/rundeck/quartzjobs/ExecutionJobTest.groovy
+++ b/rundeckapp/test/integration/rundeck/quartzjobs/ExecutionJobTest.groovy
@@ -28,11 +28,13 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import rundeck.CommandExec
 import rundeck.Execution
+import rundeck.Notification
 import rundeck.ScheduledExecution
 import rundeck.Workflow
 import rundeck.services.ExecutionService
 import rundeck.services.ExecutionUtilService
 import rundeck.services.FrameworkService
+import rundeck.services.NotificationService
 
 /**
  * $INTERFACE is ...
@@ -774,6 +776,57 @@ class ExecutionJobTest extends GroovyTestCase{
         job.finalizeRetryMax=2
         def result=job.saveState(null,es,execution,true,false, false,true,null,-1,null,execMap)
         Assert.assertEquals(false,result)
+    }
+
+
+    /**
+     * executeAsyncBegin succeeds,finish succeeds, thread succeeds, calls avgDurationExceeded
+     */
+    @Test
+    void testExecuteCommandNotification(){
+        ScheduledExecution se = setupJob()
+        Notification notif = new Notification()
+        notif.eventTrigger = "onavgduration"
+        notif.type = "email"
+        notif.content= '{"recipients":"test@test","subject":"test"}'
+        notif.save()
+        se.notifications = []
+        se.notifications.add(notif)
+        se.totalTime = 100
+        se.execCount = 10
+        se.save()
+        Execution execution = setupExecution(se, new Date(), new Date())
+        Assert.assertNotNull(execution)
+        ExecutionJob job = new ExecutionJob()
+        def mockes = new GrailsMock(ExecutionService)
+        def mockeus = new GrailsMock(ExecutionUtilService)
+        FrameworkService.metaClass.static.getFrameworkForUserAndRoles = { String user, List rolelist, String rundeckbase ->
+            'fakeFramework'
+        }
+        WorkflowExecutionServiceThread stb=new TestWEServiceThread(null,null,null,null)
+        stb.successful=true
+        stb.result=wfeForSuccess(true)
+        def testExecmap = [thread: stb, testExecuteAsyncBegin: true, scheduledExecution: se]
+        mockes.demand.executeAsyncBegin(1..1) { Framework framework, AuthContext authContext, Execution execution1, ScheduledExecution scheduledExecution = null, Map extraParams = null, Map extraParamsExposed = null ->
+            Assert.assertEquals(execution,execution1)
+            stb.start()
+            testExecmap
+        }
+        mockes.demand.avgDurationExceeded(1..1){long schedId, Map content->
+            true
+        }
+        mockeus.demand.finishExecution(1..1){ Map datamap->
+            Assert.assertTrue(datamap.testExecuteAsyncBegin)
+        }
+
+        ExecutionService es = mockes.createMock()
+        ExecutionUtilService eus = mockeus.createMock()
+        job.finalizeRetryMax=1
+        job.finalizeRetryDelay=0
+
+        def result=job.executeCommand(es,eus,execution,null, null, null, 0, [:], [:])
+        Assert.assertEquals(true,result.success)
+        Assert.assertEquals(testExecmap,result.execmap)
     }
 
     private ScheduledExecution setupJob(Closure extra=null) {

--- a/rundeckapp/test/integration/rundeck/quartzjobs/ExecutionJobTest.groovy
+++ b/rundeckapp/test/integration/rundeck/quartzjobs/ExecutionJobTest.groovy
@@ -34,7 +34,6 @@ import rundeck.Workflow
 import rundeck.services.ExecutionService
 import rundeck.services.ExecutionUtilService
 import rundeck.services.FrameworkService
-import rundeck.services.NotificationService
 
 /**
  * $INTERFACE is ...

--- a/rundeckapp/test/unit/ExecutionServiceTests.groovy
+++ b/rundeckapp/test/unit/ExecutionServiceTests.groovy
@@ -1308,10 +1308,15 @@ class ExecutionServiceTests  {
         assertEquals(2,Execution.findAll().size())
         assertEquals(1,Execution.findAllByDateCompletedAndServerNodeUUID(null, null).size())
         testService.cleanupRunningJobs((String)null)
-        exec1.refresh()
+
+        Execution.withSession { session ->
+            session.flush()
+            exec1.refresh()
+            exec2.refresh()
+        }
+
         assertNotNull(exec1.dateCompleted)
         assertEquals("false", exec1.status)
-        exec2.refresh()
         assertNull(exec2.dateCompleted)
         assertEquals(null, exec2.status)
 
@@ -1346,10 +1351,14 @@ class ExecutionServiceTests  {
         assertNull(exec2.status)
 
         testService.cleanupRunningJobs(uuid)
-        exec1.refresh()
+        Execution.withSession { session ->
+            session.flush()
+            exec1.refresh()
+            exec2.refresh()
+        }
+
         assertNull(exec1.dateCompleted)
         assertNull(exec1.status)
-        exec2.refresh()
         assertNotNull(exec2.dateCompleted)
         assertEquals("false", exec2.status)
     }
@@ -1371,7 +1380,12 @@ class ExecutionServiceTests  {
         assertEquals(ExecutionService.EXECUTION_SCHEDULED, exec1.status)
 
         testService.cleanupRunningJobs(uuid)
-        exec1.refresh()
+
+        Execution.withSession { session ->
+            session.flush()
+            exec1.refresh()
+        }
+
         assertNull(exec1.dateCompleted)
         assertEquals(ExecutionService.EXECUTION_SCHEDULED, exec1.status)
     }

--- a/rundeckapp/test/unit/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -763,6 +763,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         ScheduledExecutionController.ONSUCCESS_TRIGGER_NAME | 'email' | 'c@example.com,d@example.com'
         ScheduledExecutionController.ONFAILURE_TRIGGER_NAME | 'email' | 'c@example.com,d@example.com'
         ScheduledExecutionController.ONSTART_TRIGGER_NAME   | 'email' | 'c@example.com,d@example.com'
+        ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'email' | 'c@example.com,d@example.com'
     }
     def "validate notifications email data any domain"() {
         given:
@@ -793,6 +794,8 @@ class ScheduledExecutionServiceSpec extends Specification {
         ScheduledExecutionController.ONFAILURE_TRIGGER_NAME | 'email' | 'example@any.domain'
         ScheduledExecutionController.ONFAILURE_TRIGGER_NAME | 'email' | '${job.user.email}'
         ScheduledExecutionController.ONSTART_TRIGGER_NAME   | 'email' | 'monkey@internal'
+        ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'email' | 'user@test'
+
     }
     def "invalid notifications data"() {
         given:
@@ -829,6 +832,10 @@ class ScheduledExecutionServiceSpec extends Specification {
         ScheduledExecutionController.NOTIFY_START_RECIPIENTS|ScheduledExecutionController.ONSTART_TRIGGER_NAME   | 'email' | 'c@example.com d@example.com'
         ScheduledExecutionController.NOTIFY_START_URL|ScheduledExecutionController.ONSTART_TRIGGER_NAME   | 'url' | ''
         ScheduledExecutionController.NOTIFY_START_URL|ScheduledExecutionController.ONSTART_TRIGGER_NAME   | 'url' | 'c@example.com d@example.com'
+        ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS|ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'email' | ''
+        ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS|ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'email' | 'c@example.com d@example.com'
+        ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL|ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'url' | ''
+        ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL|ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'url' | 'c@example.com d@example.com'
     }
     def "do update job invalid notifications"() {
         given:
@@ -861,6 +868,8 @@ class ScheduledExecutionServiceSpec extends Specification {
         ScheduledExecutionController.NOTIFY_FAILURE_URL|ScheduledExecutionController.ONFAILURE_TRIGGER_NAME | 'url' | 'monkey@ example.com'
         ScheduledExecutionController.NOTIFY_START_RECIPIENTS|ScheduledExecutionController.ONSTART_TRIGGER_NAME   | 'email' | 'c@example.com d@example.com'
         ScheduledExecutionController.NOTIFY_START_URL|ScheduledExecutionController.ONSTART_TRIGGER_NAME   | 'url' | 'c@example.com d@example.com'
+        ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS|ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'email' | 'c@example.com d@example.com'
+        ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL|ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'url' | 'c@example.com d@example.com'
     }
     def "validate notifications email form fields"() {
         given:
@@ -883,6 +892,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         'onsuccess'|ScheduledExecutionController.NOTIFY_ONSUCCESS_EMAIL | ScheduledExecutionController.NOTIFY_SUCCESS_RECIPIENTS | 'c@example.com,d@example.com'
         'onfailure'|ScheduledExecutionController.NOTIFY_ONFAILURE_EMAIL | ScheduledExecutionController.NOTIFY_FAILURE_RECIPIENTS | 'c@example.com,d@example.com'
         'onstart'|ScheduledExecutionController.NOTIFY_ONSTART_EMAIL | ScheduledExecutionController.NOTIFY_START_RECIPIENTS | 'c@example.com,d@example.com'
+        'onavgduration'|ScheduledExecutionController.NOTIFY_OVERAVGDURATION_EMAIL | ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS | 'c@example.com,d@example.com'
     }
     def "invalid notifications email form fields"() {
         given:
@@ -904,6 +914,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         'onsuccess'|ScheduledExecutionController.NOTIFY_ONSUCCESS_EMAIL | ScheduledExecutionController.NOTIFY_SUCCESS_RECIPIENTS | 'c@example.'
         'onfailure'|ScheduledExecutionController.NOTIFY_ONFAILURE_EMAIL | ScheduledExecutionController.NOTIFY_FAILURE_RECIPIENTS | '@example.com'
         'onstart'|ScheduledExecutionController.NOTIFY_ONSTART_EMAIL | ScheduledExecutionController.NOTIFY_START_RECIPIENTS | 'c@example.'
+        'onavgduration'|ScheduledExecutionController.NOTIFY_OVERAVGDURATION_EMAIL | ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS | 'c@example.'
     }
 
 
@@ -1514,6 +1525,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         'onsuccess'|ScheduledExecutionController.NOTIFY_ONSUCCESS_EMAIL | ScheduledExecutionController.NOTIFY_SUCCESS_RECIPIENTS | 'c@example.com,d@example.com'
         'onfailure'|ScheduledExecutionController.NOTIFY_ONFAILURE_EMAIL | ScheduledExecutionController.NOTIFY_FAILURE_RECIPIENTS | 'c@example.com,d@example.com'
         'onstart'|ScheduledExecutionController.NOTIFY_ONSTART_EMAIL | ScheduledExecutionController.NOTIFY_START_RECIPIENTS | 'c@example.com,d@example.com'
+        'onavgduration'|ScheduledExecutionController.NOTIFY_OVERAVGDURATION_EMAIL | ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS | 'c@example.com,d@example.com'
     }
     @Unroll
     def "do update options modify"(){


### PR DESCRIPTION
Add a new trigger for job's notifications `onavgduration`.
When an execution takes more time that his *Average Duration* this notification is triggered, as long as got at least 1 execution to take the average duration and his *Average Duration* is greater than 0.
Any Notification plugin can be used in this new trigger
<img width="1175" alt="screenshot at ago 03 15-52-20" src="https://user-images.githubusercontent.com/2894508/28943227-ff1e0984-786b-11e7-8f1e-3b5c1ad195a2.png">

Here is a minimal example of groovy notification plugin included on the documentation:

**MinimalNotificationPlugin.groovy**:

~~~~~ {.java}
import com.dtolabs.rundeck.plugins.notification.NotificationPlugin;
 
rundeckPlugin(NotificationPlugin){
    onstart { 
        println("job start: data ${execution}")
        true
    }
 
    onfailure {
        println("failure: data ${execution}")
        true
    }
 
    onsuccess {
        println("success: data ${execution}")
        true
    }
    onavgduration{
        println("exceeded average duration: data ${execution}")
        true
    }
}
~~~~~~~~~~