### PR TITLE
Next scheduled execution for cluster

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1363,12 +1363,14 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         if(!se.scheduled){
             return new Date(TWO_HUNDRED_YEARS)
         }
+        if(!require && (!se.scheduleEnabled || !se.executionEnabled)){
+            return null
+        }
         def trigger = quartzScheduler.getTrigger(TriggerKey.triggerKey(se.generateJobScheduledName(), se.generateJobGroupName()))
         if(trigger){
             return trigger.getNextFireTime()
         }else if (frameworkService.isClusterModeEnabled() &&
-                se.serverNodeUUID != frameworkService.getServerUUID() &&
-                (se.scheduleEnabled && se.executionEnabled) || require) {
+                se.serverNodeUUID != frameworkService.getServerUUID() || require) {
             //guess next trigger time for the job on the assigned cluster node
             def value= tempNextExecutionTime(se)
             return value

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1366,7 +1366,9 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         def trigger = quartzScheduler.getTrigger(TriggerKey.triggerKey(se.generateJobScheduledName(), se.generateJobGroupName()))
         if(trigger){
             return trigger.getNextFireTime()
-        }else if (frameworkService.isClusterModeEnabled() && se.serverNodeUUID != frameworkService.getServerUUID() || require) {
+        }else if (frameworkService.isClusterModeEnabled() &&
+                se.serverNodeUUID != frameworkService.getServerUUID() &&
+                (se.scheduleEnabled && se.executionEnabled) || require) {
             //guess next trigger time for the job on the assigned cluster node
             def value= tempNextExecutionTime(se)
             return value

--- a/rundeckapp/test/unit/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -2649,4 +2649,41 @@ class ScheduledExecutionServiceSpec extends Specification {
 
     }
 
+    @Unroll
+    def "nextExecutionTime on remote Cluster"() {
+        given:
+        setupDoValidate(true)
+        service.quartzScheduler = Mock(Scheduler)
+
+
+        def job = new ScheduledExecution(
+                createJobParams(
+                        scheduled: hasSchedule,
+                        scheduleEnabled: scheduleEnabled,
+                        executionEnabled: executionEnabled,
+                        userRoleList: 'a,b',
+                        serverNodeUUID: TEST_UUID2
+                )
+        ).save()
+
+        when:
+        def result = service.nextExecutionTime(job)
+
+        then:
+        1 * service.quartzScheduler.getTrigger(_) >> null
+        if(expectScheduled){
+            result != null
+        }else{
+            result == null
+        }
+
+
+        where:
+        scheduleEnabled | executionEnabled | hasSchedule | expectScheduled
+        true            | true             | true        | true
+        false           | true             | true        | false
+        true            | false            | true        | false
+        false           | false            | true        | false
+    }
+
 }

--- a/rundeckapp/test/unit/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -2654,7 +2654,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         given:
         setupDoValidate(true)
         service.quartzScheduler = Mock(Scheduler)
-
+        service.quartzScheduler.getTrigger(_) >> null
 
         def job = new ScheduledExecution(
                 createJobParams(
@@ -2670,7 +2670,6 @@ class ScheduledExecutionServiceSpec extends Specification {
         def result = service.nextExecutionTime(job)
 
         then:
-        1 * service.quartzScheduler.getTrigger(_) >> null
         if(expectScheduled){
             result != null
         }else{


### PR DESCRIPTION
Fix #2677 
Add validation for `scheduleEnabled` and `executionEnabled` on a job when a scheduledExecution is scheduled on a different serverNode.
And a unit test to check the right behavior.