### PR TITLE
Add "footer" message on login page.

### DIFF
--- a/docs/en/administration/12-gui-customization.md
+++ b/docs/en/administration/12-gui-customization.md
@@ -61,6 +61,9 @@ these properties in the [rundeck-config.properties](configuration-file-reference
 `rundeck.gui.login.welcomeHtml`             HTML displayed in the login form
                                             pages. The HTML will be sanitized
                                             before display. (Default: blank)
+`rundeck.gui.login.footerMessageHtml`       HTML displayed in the login form
+                                            pages (below the login form). The HTML will be sanitized
+                                            before display. (Default: blank)                                           
 
 `rundeck.gui.errorpage.hidestacktrace`      Hide Java stacktraces from the end   true/false
                                             user when an error occurs.

--- a/rundeckapp/grails-app/views/user/login.gsp
+++ b/rundeckapp/grails-app/views/user/login.gsp
@@ -92,6 +92,17 @@
             <div class="form-group">
                 <button type="submit" class="btn btn-primary">Login</button>
             </div>
+
+            <g:set var="footermessagehtml" value="${grailsApplication.config.rundeck?.gui?.login?.footerMessageHtml ?: ''}"/>
+            <g:if test="${footermessagehtml}">
+                <div class="row">
+                    <span class="col-sm-12">
+                        ${enc(sanitize:footermessagehtml)}
+                    </span>
+                </div>
+            </g:if>
+
+
         </form>
         </div>
         <g:if test="${flash.loginerror}">


### PR DESCRIPTION
Add a "footer" message below the login form.
It will be controlled by the attribute `rundeck.gui.login.footerMessageHtml` on rundeck.config.properties

