### PR TITLE
Expose delete executions for plugins

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionReference.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionReference.java
@@ -11,10 +11,12 @@ public interface ExecutionReference {
     String getOptions();
     JobReference getJob();
     Date getDateStarted();
+    Date getDateCompleted();
     String getStatus();
     String getSucceededNodeList();
     String getFailedNodeList();
     String getTargetNodes();
+    String getAdhocCommand();
 
 
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobService.java
@@ -122,4 +122,11 @@ public interface JobService {
      * @return [success:true/false, failures:[ [success:false, message: String, id: id],... ], successTotal:Integer]
      */
     Map deleteBulkExecutionIds(Collection ids, String asUser);
+
+    /**
+     *
+     * @param filter for query executions
+     * @return map with results and total
+     */
+    Map queryExecutions(Map filter);
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobService.java
@@ -19,8 +19,10 @@ package com.dtolabs.rundeck.core.jobs;
 import com.dtolabs.rundeck.core.execution.ExecutionNotFound;
 import com.dtolabs.rundeck.core.execution.ExecutionReference;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Service for interacting with Jobs
@@ -76,7 +78,22 @@ public interface JobService {
      * @return a list of references to executions using the input parameters
      *
      */
-    List<ExecutionReference> searchExecutions(String state, String project, String jobUuid, String excludeJobUuid, String since);
+    List<ExecutionReference> searchExecutions(String state, String project, String jobUuid, String excludeJobUuid,
+                                              String since);
+
+    /**
+     * @param state    to search
+     * @param project the project
+     * @param jobUuid    to search or null
+     * @param excludeJobUuid    to search or null
+     * @param since    to search or null
+     * @param reverseSince    if true search executions older than since parameter
+     *
+     * @return a list of references to executions using the input parameters
+     *
+     */
+    List<ExecutionReference> searchExecutions(String state, String project, String jobUuid, String excludeJobUuid,
+                                              String since, boolean reverseSince);
 
     /**
      * @param id   execution id
@@ -97,4 +114,12 @@ public interface JobService {
      * @return Id of the result execution
      */
     String startJob(JobReference jobReference, String jobArgString, String jobFilter, String asUser)throws JobNotFound;
+
+    /**
+     *
+     * @param ids collection of id to iterate
+     * @param asUser user to execute delete (null for the same user)
+     * @return [success:true/false, failures:[ [success:false, message: String, id: id],... ], successTotal:Integer]
+     */
+    Map deleteBulkExecutionIds(Collection ids, String asUser);
 }

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -16,6 +16,7 @@
 
 package rundeck.services
 
+import com.dtolabs.rundeck.app.support.ExecutionQuery
 import com.dtolabs.rundeck.core.authentication.Group
 import com.dtolabs.rundeck.core.authentication.Username
 import com.dtolabs.rundeck.core.authorization.Attribute
@@ -1064,5 +1065,14 @@ class FrameworkService implements ApplicationContextAware {
      */
     Map deleteBulkExecutionIds(Collection ids, AuthContext authContext, String username) {
         executionService.deleteBulkExecutionIds(ids,authContext,username)
+    }
+
+    /**
+     * non transactional interface to query executions
+     * {@link ExecutionService#queryExecutions queryExecutions}
+     * @return [result:result,total:total]
+     */
+    Map queryExecutions(ExecutionQuery query, int offset=0, int max=-1) {
+        executionService.queryExecutions(query,offset,max)
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -1056,4 +1056,13 @@ class FrameworkService implements ApplicationContextAware {
     Map kickJob(ScheduledExecution scheduledExecution, UserAndRolesAuthContext authContext, String user, Map input){
         executionService.executeJob(scheduledExecution, authContext, user, input)
     }
+
+    /**
+     * non transactional interface to bulk delete executions
+     * {@link ExecutionService#deleteBulkExecutionIds deleteBulkExecutionIds}
+     * @return [success:true/false, failures:[ [success:false, message: String, id: id],... ], successTotal:Integer]
+     */
+    Map deleteBulkExecutionIds(Collection ids, AuthContext authContext, String username) {
+        executionService.deleteBulkExecutionIds(ids,authContext,username)
+    }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
@@ -17,6 +17,7 @@
 package rundeck.services
 
 import com.dtolabs.rundeck.app.support.BaseNodeFilters
+import com.dtolabs.rundeck.app.support.ExecutionQuery
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.Framework
@@ -228,8 +229,11 @@ class JobStateService implements AuthorizingJobService {
             throw new ExecutionNotFound("Execution not found", id, project)
         }
 
-        JobReferenceImpl jobRef = new JobReferenceImpl(id: se.extid, jobName: se.jobName, groupPath: se.groupPath,
-                project: se.project)
+        JobReferenceImpl jobRef
+        if(se) {
+            jobRef = new JobReferenceImpl(id: se.extid, jobName: se.jobName, groupPath: se.groupPath,
+                    project: se.project)
+        }
         new ExecutionReferenceImpl(id:exec.id, options: exec.argString, filter: exec.filter, job: jobRef,
                 dateStarted: exec.dateStarted, status: exec.status, succeededNodeList: exec.succeededNodeList, 
                 failedNodeList: exec.failedNodeList)
@@ -274,5 +278,92 @@ class JobStateService implements AuthorizingJobService {
     @Override
     Map deleteBulkExecutionIds(AuthContext auth, Collection ids, String asUser){
         frameworkService.deleteBulkExecutionIds(ids,auth, asUser)
+    }
+
+    @Override
+    Map queryExecutions(AuthContext auth,Map filter){
+        ExecutionQuery query = new ExecutionQuery()
+        query.projFilter = filter.project
+        int offset = filter.offset?:0
+        query.offset = offset
+        int max = filter.max?:0
+        query.max = max
+        if(filter.recentFilter){
+            query.recentFilter = filter.recentFilter
+            query.configureFilter()
+        }
+        if (filter.olderFilter) {
+            Date endDate=ExecutionQuery.parseRelativeDate(filter.olderFilter)
+            if(null!=endDate){
+                query.endbeforeFilter = endDate
+                query.doendbeforeFilter = true
+            }
+        }
+        if(filter.statusFilter){
+            query.statusFilter = filter.statusFilter
+        }
+        if(filter.userFilter){
+            query.userFilter = filter.userFilter
+        }
+        if(filter.adhoc){
+            query.adhoc = true
+        }else if(filter.jobonly){
+            query.adhoc = false
+        }
+        if(filter.groupPath){
+            query.groupPath = filter.groupPath
+        }
+        if(filter.groupPathExact){
+            query.groupPathExact = filter.groupPathExact
+        }
+        if(filter.excludeGroupPath){
+            query.excludeGroupPath = filter.excludeGroupPath
+        }
+        if(filter.excludeGroupPathExact){
+            query.excludeGroupPathExact = filter.excludeGroupPathExact
+        }
+        if(filter.jobFilter){
+            query.jobFilter = filter.jobFilter
+        }
+        if(filter.excludeJobFilter){
+            query.excludeJobFilter = filter.excludeJobFilter
+        }
+        if(filter.excludeJobExactFilter){
+            query.excludeJobExactFilter = filter.excludeJobExactFilter
+        }
+        if(filter.jobExactFilter){
+            query.jobExactFilter = filter.jobExactFilter
+        }
+        if(filter.excludeJobIdListFilter){
+            query.excludeJobIdListFilter = filter.excludeJobIdListFilter.tokenize(',')
+        }
+        if(filter.excludeJobListFilter){
+            query.excludeJobListFilter = filter.excludeJobListFilter.tokenize(',')
+        }
+        if(filter.jobListFilter){
+            query.jobListFilter = filter.jobListFilter.tokenize(',')
+        }
+        if(filter.jobIdListFilter){
+            query.jobIdListFilter = filter.jobIdListFilter.tokenize(',')
+        }
+        def results = frameworkService.queryExecutions(query, offset, max)
+        def result=results.result
+        def total=results.total
+        //filter query results to READ authorized executions
+        def filtered = frameworkService.filterAuthorizedProjectExecutionsAll(auth,result,[AuthConstants.ACTION_READ])
+        def idList = []
+        filtered.each { Execution exec->
+            ScheduledExecution se = exec.scheduledExecution
+            JobReferenceImpl jobRef
+            if(se){
+                jobRef = new JobReferenceImpl(id: se.extid, jobName: se.jobName, groupPath: se.groupPath,
+                        project: se.project)
+            }
+            ExecutionReferenceImpl execRef = new ExecutionReferenceImpl(id:exec.id, options: exec.argString, filter: exec.filter, job: jobRef,
+                    dateStarted: exec.dateStarted, status: exec.status, succeededNodeList: exec.succeededNodeList,
+                    failedNodeList: exec.failedNodeList)
+            idList.push(execRef)
+        }
+        return [result:idList, total:idList.size()]
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
@@ -235,8 +235,8 @@ class JobStateService implements AuthorizingJobService {
                     project: se.project)
         }
         new ExecutionReferenceImpl(id:exec.id, options: exec.argString, filter: exec.filter, job: jobRef,
-                dateStarted: exec.dateStarted, status: exec.status, succeededNodeList: exec.succeededNodeList, 
-                failedNodeList: exec.failedNodeList)
+                dateStarted: exec.dateStarted, status: exec.status, succeededNodeList: exec.succeededNodeList,
+                dateCompleted:exec.dateCompleted, failedNodeList: exec.failedNodeList)
 
     }
 
@@ -359,9 +359,13 @@ class JobStateService implements AuthorizingJobService {
                 jobRef = new JobReferenceImpl(id: se.extid, jobName: se.jobName, groupPath: se.groupPath,
                         project: se.project)
             }
-            ExecutionReferenceImpl execRef = new ExecutionReferenceImpl(id:exec.id, options: exec.argString, filter: exec.filter, job: jobRef,
-                    dateStarted: exec.dateStarted, status: exec.status, succeededNodeList: exec.succeededNodeList,
+            ExecutionReferenceImpl execRef = new ExecutionReferenceImpl(id:exec.id, options: exec.argString,
+                    filter: exec.filter, job: jobRef, dateStarted: exec.dateStarted, dateCompleted:exec.dateCompleted,
+                    status: exec.status, succeededNodeList: exec.succeededNodeList,
                     failedNodeList: exec.failedNodeList)
+            if(!se && exec.workflow && exec.workflow.commands && exec.workflow.commands[0]){
+                execRef.adhocCommand = exec.workflow.commands[0].summarize()
+            }
             idList.push(execRef)
         }
         return [result:idList, total:idList.size()]

--- a/rundeckapp/grails-app/services/rundeck/services/execution/ExecutionReferenceImpl.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/execution/ExecutionReferenceImpl.groovy
@@ -10,10 +10,12 @@ class ExecutionReferenceImpl implements ExecutionReference {
     String id
     JobReferenceImpl job
     Date dateStarted
+    Date dateCompleted
     String status
     String succeededNodeList
     String failedNodeList
     String targetNodes
+    String adhocCommand
 
     @Override
     String toString() {

--- a/rundeckapp/grails-app/services/rundeck/services/jobs/AuthorizingJobService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/jobs/AuthorizingJobService.groovy
@@ -36,10 +36,16 @@ interface AuthorizingJobService {
 
     JobState getJobState(AuthContext auth, JobReference jobReference) throws JobNotFound;
 
-    List<ExecutionReference> searchExecutions(AuthContext auth, String state, String project, String jobUuid, String excludeJobUuid, String since)
+    List<ExecutionReference> searchExecutions(AuthContext auth, String state, String project, String jobUuid,
+                                              String excludeJobUuid, String since)
+
+    List<ExecutionReference> searchExecutions(AuthContext auth, String state, String project, String jobUuid,
+                                              String excludeJobUuid, String since, boolean reverseSince)
 
     ExecutionReference executionForId(AuthContext auth, String id, String project) throws ExecutionNotFound
 
     String startJob(AuthContext auth, JobReference jobReference, String jobArgString, String jobFilter, String asUser) throws JobNotFound
+
+    Map deleteBulkExecutionIds(AuthContext auth, Collection ids, String asUser)
 
 }

--- a/rundeckapp/grails-app/services/rundeck/services/jobs/AuthorizingJobService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/jobs/AuthorizingJobService.groovy
@@ -48,4 +48,6 @@ interface AuthorizingJobService {
 
     Map deleteBulkExecutionIds(AuthContext auth, Collection ids, String asUser)
 
+    Map queryExecutions(AuthContext auth,Map filter)
+
 }

--- a/rundeckapp/grails-app/services/rundeck/services/jobs/ResolvedAuthJobService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/jobs/ResolvedAuthJobService.groovy
@@ -73,4 +73,8 @@ class ResolvedAuthJobService implements JobService {
         authJobService.deleteBulkExecutionIds(authContext, ids, asUser)
     }
 
+    Map queryExecutions(Map filter){
+        authJobService.queryExecutions(authContext, filter)
+    }
+
 }

--- a/rundeckapp/grails-app/services/rundeck/services/jobs/ResolvedAuthJobService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/jobs/ResolvedAuthJobService.groovy
@@ -51,6 +51,11 @@ class ResolvedAuthJobService implements JobService {
         authJobService.getJobState(authContext, jobReference)
     }
 
+    List<ExecutionReference> searchExecutions(String state, String project, String job, String excludeJob,
+                                              String since, boolean reverseSince){
+        authJobService.searchExecutions(authContext, state, project, job, excludeJob, since, reverseSince)
+    }
+
     List<ExecutionReference> searchExecutions(String state, String project, String job, String excludeJob, String since){
         authJobService.searchExecutions(authContext, state, project, job, excludeJob, since)
     }
@@ -62,6 +67,10 @@ class ResolvedAuthJobService implements JobService {
 
     String startJob(JobReference jobReference, String jobArgString, String jobFilter, String asUser) throws JobNotFound{
         authJobService.startJob(authContext, jobReference, jobArgString, jobFilter, asUser)
+    }
+
+    Map deleteBulkExecutionIds(Collection ids, String asUser){
+        authJobService.deleteBulkExecutionIds(authContext, ids, asUser)
     }
 
 }


### PR DESCRIPTION
Expose in the JobService methods for bulk delete executions and query to retrieve executions using same parameters as `rd executions bulkdelete`

`deleteBulkExecutionIds` accepts a list of ids and return a map with the result.
`queryExecutions` accepts a map with the search parameters and return a map with the executions as ExecutionReference.