### PR TITLE
Improve ISO 8601 date handling with timezone when scheduling ad-hoc job

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -115,6 +115,20 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     def fileUploadService
     def pluginService
 
+    static final ThreadLocal<DateFormat> ISO_8601_DATE_FORMAT_WITH_MS_XXX =
+        new ThreadLocal<DateFormat>() {
+            @Override
+            protected DateFormat initialValue() {
+				return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+			}
+		}
+    static final ThreadLocal<DateFormat> ISO_8601_DATE_FORMAT_XXX =
+        new ThreadLocal<DateFormat>() {
+            @Override
+            protected DateFormat initialValue() {
+				return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
+			}
+		}
     static final ThreadLocal<DateFormat> ISO_8601_DATE_FORMAT_WITH_MS =
         new ThreadLocal<DateFormat>() {
             @Override
@@ -1976,6 +1990,16 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      */
     def Date parseRunAtTime(String runAtTime) {
         try {
+            return ISO_8601_DATE_FORMAT_XXX.get().parse(runAtTime)
+        } catch (ParseException e1) {
+
+        }
+        try {
+            return ISO_8601_DATE_FORMAT_WITH_MS_XXX.get().parse(runAtTime)
+        } catch (ParseException e1) {
+
+        }
+        try {
             return ISO_8601_DATE_FORMAT.get().parse(runAtTime)
         } catch (ParseException e1) {
 
@@ -3491,6 +3515,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      */
     @PreDestroy
     public void onShutdownCleanUp() {
+        ISO_8601_DATE_FORMAT_WITH_MS_XXX.remove()
+        ISO_8601_DATE_FORMAT_XXX.remove()
         ISO_8601_DATE_FORMAT_WITH_MS.remove()
         ISO_8601_DATE_FORMAT.remove()
     }

--- a/rundeckapp/test/unit/ExecutionServiceSpec.groovy
+++ b/rundeckapp/test/unit/ExecutionServiceSpec.groovy
@@ -2051,8 +2051,8 @@ class ExecutionServiceSpec extends Specification {
         1 * service.scheduledExecutionService.scheduleAdHocJob(*_) >> { args ->
             final Date startDate    = args[6]
             // The start time may differ slightly (milliseconds)
-            assert startDate.getTime() - scheduleDate.getTime() <= 500 ||
-                startDate.getTime() - scheduleDate.getTime() >= -500
+            assert startDate.getTime() - scheduleDate.getTime() <= 1000 &&
+                startDate.getTime() - scheduleDate.getTime() >= -1000
             return scheduleDate
         }
         result.nextRun.getTime() == scheduleDate.getTime()
@@ -2063,6 +2063,7 @@ class ExecutionServiceSpec extends Specification {
         "2200-01-01T12:43:10.000Z"      | true                | true            | true             | true        | true
         "2200-01-01T12:43:10+00:00"     | true                | true            | true             | true        | true
         "2200-01-01T12:43:10Z"          | true                | true            | true             | true        | true
+        "2200-01-01T18:13:10+05:30"     | true                | true            | true             | true        | true
     }
 
     @Unroll

--- a/rundeckapp/test/unit/ExecutionServiceSpec.groovy
+++ b/rundeckapp/test/unit/ExecutionServiceSpec.groovy
@@ -2064,6 +2064,9 @@ class ExecutionServiceSpec extends Specification {
         "2200-01-01T12:43:10+00:00"     | true                | true            | true             | true        | true
         "2200-01-01T12:43:10Z"          | true                | true            | true             | true        | true
         "2200-01-01T18:13:10+05:30"     | true                | true            | true             | true        | true
+        "2200-01-01T18:13:10.000+05:30" | true                | true            | true             | true        | true
+        "2200-01-01T09:13:10-03:30"     | true                | true            | true             | true        | true
+        "2200-01-01T09:13:10.000-03:30" | true                | true            | true             | true        | true
     }
 
     @Unroll
@@ -2104,6 +2107,8 @@ class ExecutionServiceSpec extends Specification {
         "01/01/2001 10:11:12.000000 +0000" | true                | true            | true             | true        | true
         "0000-00-00 00:00:00.000+0000"     | true                | true            | true             | true        | true
         "2080-01-01T01:00:01.000"          | true                | true            | true             | true        | true
+        "2200-01-01 18:13:10.000 +05:30"   | true                | true            | true             | true        | true
+        "2080-01-01 01:00:01.000 -03:30"   | true                | true            | true             | true        | true
     }
 
     @Unroll


### PR DESCRIPTION
When user has a local timezone set to IST (+05:30) job is scheduled at wrong time. This is because ISO 8601 date format was not specified with long timezone format. Browsers (Chrome, Firefox and Safari) are sending runAtTime parameter with long TZ format:

```
------WebKitFormBoundaryxAWvOTSB4R0rNhMN
Content-Disposition: form-data; name="runAtTime"

2017-08-30T20:47:00+05:30

```

Fixed also test case 'should scheduleAdHocJob with alternative ISO 8601 date' where assertion was always true. 

Additional observation: when building and testing - local timezone should be set to GMT.
