### PR TITLE
Fix nested Job Reference

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3065,7 +3065,16 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         def project = null
         if(jitem instanceof JobRefCommand){
             JobRefCommand jitemRef = (JobRefCommand) jitem
-            project = jitemRef.project
+            if(jitemRef.project){
+                project = jitemRef.project
+            }else{
+                //use parent job project before using context framework
+                def globalContext = executionContext.getSharedDataContext().consolidate().getData(ContextView.global())
+                if(globalContext && globalContext.job && globalContext.job.project){
+                    project = executionContext.getSharedDataContext().consolidate().getData(ContextView.global()).job.project
+                }
+            }
+
         }
 
         def group = null

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3064,17 +3064,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         def result
         def project = null
         if(jitem instanceof JobRefCommand){
-            JobRefCommand jitemRef = (JobRefCommand) jitem
-            if(jitemRef.project){
-                project = jitemRef.project
-            }else{
-                //use parent job project before using context framework
-                def globalContext = executionContext.getSharedDataContext().consolidate().getData(ContextView.global())
-                if(globalContext && globalContext.job && globalContext.job.project){
-                    project = executionContext.getSharedDataContext().consolidate().getData(ContextView.global()).job.project
-                }
-            }
-
+            project = jitem.project
         }
 
         def group = null
@@ -3119,7 +3109,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 result = createFailure(JobReferenceFailureReason.Unauthorized, msg)
                 return
             }
-            newExecItem = executionUtilService.createExecutionItemForWorkflow(se.workflow)
+            newExecItem = executionUtilService.createExecutionItemForWorkflow(se.workflow, se.project)
 
             try {
                 newContext = createJobReferenceContext(

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
@@ -134,7 +134,7 @@ class ExecutionUtilService {
      * Create an WorkflowExecutionItem instance for the given Workflow,
      * suitable for the ExecutionService layer
      */
-    public WorkflowExecutionItem createExecutionItemForWorkflow(Workflow workflow) {
+    public WorkflowExecutionItem createExecutionItemForWorkflow(Workflow workflow, parentProject=null) {
         if (!workflow.commands || workflow.commands.size() < 1) {
             throw new Exception("Workflow is empty")
         }
@@ -143,7 +143,8 @@ class ExecutionUtilService {
                 workflow.commands.collect {
                     itemForWFCmdItem(
                             it,
-                            it.errorHandler ? itemForWFCmdItem(it.errorHandler) : null
+                            it.errorHandler ? itemForWFCmdItem(it.errorHandler) : null,
+                            parentProject
                     )
                 },
                 workflow.threadcount,
@@ -156,7 +157,7 @@ class ExecutionUtilService {
     }
 
 
-    public StepExecutionItem itemForWFCmdItem(final WorkflowStep step, final StepExecutionItem handler=null) throws FileNotFoundException {
+    public StepExecutionItem itemForWFCmdItem(final WorkflowStep step, final StepExecutionItem handler=null,final parentProject=null) throws FileNotFoundException {
         if(step instanceof CommandExec || step.instanceOf(CommandExec)){
             CommandExec cmd=step.asType(CommandExec)
             if (null != cmd.getAdhocRemoteString()) {
@@ -241,6 +242,9 @@ class ExecutionUtilService {
                 args = new String[0];
             }
 
+            if(!jobcmditem.jobProject && parentProject){
+                jobcmditem.jobProject = parentProject
+            }
             return ExecutionItemFactory.createJobRef(
                     jobcmditem.getJobIdentifier(),
                     args,

--- a/rundeckapp/test/unit/rundeck/services/ExecutionUtilServiceTests.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ExecutionUtilServiceTests.groovy
@@ -519,6 +519,21 @@ class ExecutionUtilServiceTests {
         assertEquals([], item.args as List)
         JobRefCommand jrc = (JobRefCommand) res
         jrc.project==null
+    }
 
+    void testItemForWFCmdItem_jobref_setproject() {
+        def testService = service
+        JobExec ce = new JobExec(jobName: 'abc', jobGroup: 'xyz', jobProject: null)
+        def res = testService.itemForWFCmdItem(ce, null, 'jobProject')
+        assertNotNull(res)
+        assertTrue(res instanceof StepExecutionItem)
+        assertFalse(res instanceof ScriptURLCommandExecutionItem)
+        assertTrue(res instanceof JobExecutionItem)
+        JobExecutionItem item = (JobExecutionItem) res
+        assertEquals('xyz/abc', item.getJobIdentifier())
+        assertNotNull(item.args)
+        assertEquals([], item.args as List)
+        JobRefCommand jrc = (JobRefCommand) res
+        jrc.project=='jobProject'
     }
 }

--- a/rundeckapp/test/unit/rundeck/services/ExecutionUtilServiceTests.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ExecutionUtilServiceTests.groovy
@@ -471,4 +471,54 @@ class ExecutionUtilServiceTests {
         assertNotNull(item.args)
         assertEquals([], item.args as List)
     }
+
+    void testItemForWFCmdItem_jobref_sameproject() {
+        def testService = service
+        //file url script path
+        JobExec ce = new JobExec(jobName: 'abc', jobGroup: 'xyz', jobProject: 'jobProject')
+        def res = testService.itemForWFCmdItem(ce, null,'jobProject')
+        assertNotNull(res)
+        assertTrue(res instanceof StepExecutionItem)
+        assertFalse(res instanceof ScriptURLCommandExecutionItem)
+        assertTrue(res instanceof JobExecutionItem)
+        JobExecutionItem item = (JobExecutionItem) res
+        assertEquals('xyz/abc', item.getJobIdentifier())
+        assertNotNull(item.args)
+        assertEquals([], item.args as List)
+        JobRefCommand jrc = (JobRefCommand) res
+        jrc.project=='jobProject'
+    }
+
+    void testItemForWFCmdItem_jobref_otherproject() {
+        def testService = service
+        JobExec ce = new JobExec(jobName: 'abc', jobGroup: 'xyz',jobProject: 'refProject')
+        def res = testService.itemForWFCmdItem(ce,null,'jobProject')
+        assertNotNull(res)
+        assertTrue(res instanceof StepExecutionItem)
+        assertFalse(res instanceof ScriptURLCommandExecutionItem)
+        assertTrue(res instanceof JobExecutionItem)
+        JobExecutionItem item = (JobExecutionItem) res
+        assertEquals('xyz/abc', item.getJobIdentifier())
+        assertNotNull(item.args)
+        assertEquals([], item.args as List)
+        JobRefCommand jrc = (JobRefCommand) res
+        jrc.project=='refProject'
+    }
+
+    void testItemForWFCmdItem_jobref_nullproject() {
+        def testService = service
+        JobExec ce = new JobExec(jobName: 'abc', jobGroup: 'xyz', jobProject: null)
+        def res = testService.itemForWFCmdItem(ce)
+        assertNotNull(res)
+        assertTrue(res instanceof StepExecutionItem)
+        assertFalse(res instanceof ScriptURLCommandExecutionItem)
+        assertTrue(res instanceof JobExecutionItem)
+        JobExecutionItem item = (JobExecutionItem) res
+        assertEquals('xyz/abc', item.getJobIdentifier())
+        assertNotNull(item.args)
+        assertEquals([], item.args as List)
+        JobRefCommand jrc = (JobRefCommand) res
+        jrc.project==null
+
+    }
 }


### PR DESCRIPTION
Fix #2718 
When the jobRef item has null project, the parent project is used instead.

Test case:
ProjectA - job1  -> *runs command*
ProjectA - job2 -> *ref job1*
ProjectB - job3 -> *ref ProjectA/job2*