### PR TITLE
Add threadcount as a job context variable

### DIFF
--- a/docs/en/manual/04-jobs.md
+++ b/docs/en/manual/04-jobs.md
@@ -1653,6 +1653,7 @@ Job context variables:
 * `job.user.email`: Executing user's email address set in [User profile](user.html).
 * `job.retryAttempt`: A number indicating the attempt, if this execution is a [retry](#retry).
 * `job.wasRetry`: `true` if this execution is a retry, otherwise `false`. See: [retry](#retry).
+* `job.threadcount`: Threadcount (number of nodes run at once) of the Job
 
 Node context variables:
 

--- a/rundeckapp/grails-app/assets/javascripts/jobedit.js
+++ b/rundeckapp/grails-app/assets/javascripts/jobedit.js
@@ -92,9 +92,10 @@ function _jobVarData() {
             'loglevel': {title: 'Execution log level', desc: 'Logging level, one of: INFO, DEBUG'},
             'user.email': {title: 'Email of user executing the job'},
             'retryAttempt': {title: 'Retry attempt number'},
-            'wasRetry': {title: 'True if execution is a retry'}
+            'wasRetry': {title: 'True if execution is a retry'},
+            'threadcount': {title: 'Job Threadcount'}
         };
-        ['id', 'execid', 'name', 'group', 'username', 'project', 'loglevel', 'user.email', 'retryAttempt', 'wasRetry'].each(function (e) {
+        ['id', 'execid', 'name', 'group', 'username', 'project', 'loglevel', 'user.email', 'retryAttempt', 'wasRetry', 'threadcount'].each(function (e) {
             _VAR_DATA['job'].push({key: 'job.' + e, category: 'Job', title: jobdata[e].title, desc: jobdata[e].desc});
         });
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -908,6 +908,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         jobcontext.loglevel = textLogLevels[execution.loglevel] ?: execution.loglevel
         jobcontext.retryAttempt=Integer.toString(execution.retryAttempt?:0)
         jobcontext.wasRetry=Boolean.toString(execution.retryAttempt?true:false)
+        jobcontext.threadcount=Integer.toString(execution.nodeThreadcount?:1)
         jobcontext
     }
 


### PR DESCRIPTION
This commit adds threadcount as a job context variable, so scripts and
commands called by rundeck can use the threadcount of a job.

For example, if you are running a job that involves taking some nodes in a
cluster offline, the threadcount vs. the total number of nodes in the
cluster could be used by called scripts to check that enough capacity
will be left.