### PR TITLE
Execution log storage partial checkpointing

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/logging/ExecutionFileStorage.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/logging/ExecutionFileStorage.java
@@ -44,6 +44,26 @@ public interface ExecutionFileStorage {
             ExecutionFileStorageException;
 
     /**
+     * Stores the incomplete snapshot file of the given file type, read from the given stream
+     *
+     * @param filetype     filetype or extension of the file to store
+     * @param stream       the input stream
+     * @param length       the file length
+     * @param lastModified the file modification time
+     *
+     * @return true if successful
+     *
+     * @throws java.io.IOException                                            if an IO error occurs
+     * @throws com.dtolabs.rundeck.core.logging.ExecutionFileStorageException if other errors occur
+     */
+    default boolean partialStore(String filetype, InputStream stream, long length, Date lastModified)
+            throws IOException,
+            ExecutionFileStorageException
+    {
+        throw new UnsupportedOperationException("partialStore is not implemented");
+    }
+
+    /**
      * Write a file of the given file type to the given stream
      *
      * @param filetype key to identify stored file
@@ -55,4 +75,21 @@ public interface ExecutionFileStorage {
      * @throws com.dtolabs.rundeck.core.logging.ExecutionFileStorageException if other errors occur
      */
     boolean retrieve(String filetype, OutputStream stream) throws IOException, ExecutionFileStorageException;
+
+    /**
+     * Write the incomplete snapshot of the file of the given file type to the given stream
+     *
+     * @param filetype key to identify stored file
+     * @param stream   the output stream
+     *
+     * @return true if successful
+     *
+     * @throws IOException                                                    if an IO error occurs
+     * @throws com.dtolabs.rundeck.core.logging.ExecutionFileStorageException if other errors occur
+     */
+    default boolean partialRetrieve(String filetype, OutputStream stream)
+            throws IOException, ExecutionFileStorageException
+    {
+        throw new UnsupportedOperationException("partialRetrieve is not implemented");
+    }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/logging/ExecutionFileStorageOptions.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/logging/ExecutionFileStorageOptions.java
@@ -26,7 +26,21 @@ public interface ExecutionFileStorageOptions {
     boolean getRetrieveSupported();
 
     /**
+     * @return true if a partial retrieve request is supported
+     */
+    default boolean getPartialRetrieveSupported() {
+        return false;
+    }
+
+    /**
      * @return true if store is supported, false otherwise
      */
     boolean getStoreSupported();
+
+    /**
+     * @return true if a partial storage request is supported
+     */
+    default boolean getPartialStoreSupported() {
+        return false;
+    }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/logging/LogFileState.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/logging/LogFileState.java
@@ -25,6 +25,10 @@ public enum LogFileState {
     /** Available  */
     AVAILABLE,
     /**
+     * Partially Available
+     */
+    AVAILABLE_PARTIAL,
+    /**
      * In process of being transferred to local storage
      */
     PENDING,

--- a/core/src/main/java/com/dtolabs/rundeck/core/logging/StorageFile.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/logging/StorageFile.java
@@ -42,4 +42,9 @@ public interface StorageFile {
      * @return last modified date
      */
     Date getLastModified();
+
+    /**
+     * @return true if the file is complete
+     */
+    boolean isComplete();
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/logging/ExecutionFileStoragePlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/logging/ExecutionFileStoragePlugin.java
@@ -44,4 +44,17 @@ public interface ExecutionFileStoragePlugin extends ExecutionFileStorage {
      */
     public boolean isAvailable(String filetype) throws ExecutionFileStorageException;
 
+    /**
+     * Return true if the file type has partial content available, false otherwise
+     *
+     * @param filetype file type or extension of the file to check
+     *
+     * @return true if a file with the given filetype is partially available
+     *
+     * @throws ExecutionFileStorageException if there is an error determining the availability
+     */
+    default boolean isAvailablePartial(String filetype) throws ExecutionFileStorageException {
+        return false;
+    }
+
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/logging/ExecutionFileStoragePlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/logging/ExecutionFileStoragePlugin.java
@@ -53,7 +53,7 @@ public interface ExecutionFileStoragePlugin extends ExecutionFileStorage {
      *
      * @throws ExecutionFileStorageException if there is an error determining the availability
      */
-    default boolean isAvailablePartial(String filetype) throws ExecutionFileStorageException {
+    default boolean isPartialAvailable(String filetype) throws ExecutionFileStorageException {
         return false;
     }
 

--- a/rundeckapp/grails-app/assets/javascripts/executionControl.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionControl.js
@@ -75,6 +75,7 @@ var FollowControl = Class.create({
     appLinks: null,
     workflow:null,
     multiworkflow:null,
+    clusterExec: null,
 
     initialize: function(eid,elem,params){
         this.executionId=eid;
@@ -667,6 +668,7 @@ var FollowControl = Class.create({
             $(this.viewoptionsCompleteId).hide();
             return;
         }
+        this.clusterExec = data.clusterExec && data.serverNodeUUID || null;
 
         this.runningcmd.id = data.id;
         this.runningcmd.offset = data.offset;
@@ -702,6 +704,12 @@ var FollowControl = Class.create({
 
         if (typeof(this.onAppend) == 'function') {
             this.onAppend();
+        }
+        if (this.clusterExec && !this.runningcmd.completed) {
+            //show cluster loading info
+            jQuery('#' + this.parentElement + '_clusterinfo').show();
+        } else {
+            jQuery('#' + this.parentElement + '_clusterinfo').hide();
         }
 
         if (this.runningcmd.completed && this.runningcmd.jobcompleted) {

--- a/rundeckapp/grails-app/assets/javascripts/executionControl.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionControl.js
@@ -722,6 +722,9 @@ var FollowControl = Class.create({
             if(this.runningcmd.pending != null){
                 time= (this.tailmode && this.taildelay > 0) ? this.taildelay * 5000 : 5000
             }
+            if (data.retryBackoff) {
+                time = Math.max(data.retryBackoff,time);
+            }
             setTimeout(function() {
                 obj.loadMoreOutput(obj.runningcmd.id, obj.runningcmd.offset);
             }, time);

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -901,6 +901,7 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
     self.followOutputUrl= outputUrl;
     self.nodeStateUpdateUrl= nodeStateUpdateUrl;
     self.completed=ko.observable();
+    self.partial=ko.observable();
     self.executionState=ko.observable();
     self.executionStatusString=ko.observable();
     self.retryExecutionId=ko.observable();
@@ -1362,8 +1363,8 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
         "use strict";
         flowState.addUpdater({
             updateError: function (error, data) {
-                self.stateLoaded(false);
                 if (error !== 'pending') {
+                    self.stateLoaded(false);
                     self.errorMessage(data.state.errorMessage ? data.state.errorMessage : error);
                 } else {
                     self.statusMessage(data.state.errorMessage ? data.state.errorMessage : error);
@@ -1377,6 +1378,7 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
                     retryExecutionAttempt: data.retryExecutionAttempt,
                     retry: data.retry,
                     completed: data.completed,
+                    partial: data.partial,
                     execDuration: data.execDuration,
                     jobAverageDuration: data.jobAverageDuration,
                     startTime: data.startTime ? data.startTime : data.state ? data.state.startTime : null,
@@ -1393,6 +1395,7 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
                     retryExecutionAttempt: data.retryExecutionAttempt,
                     retry: data.retry,
                     completed: data.completed,
+                    partial: data.partial,
                     execDuration: data.execDuration,
                     jobAverageDuration: data.jobAverageDuration,
                     startTime: data.startTime ? data.startTime : data.state ? data.state.startTime : null,

--- a/rundeckapp/grails-app/assets/javascripts/util/compactMapList.js
+++ b/rundeckapp/grails-app/assets/javascripts/util/compactMapList.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Decompact a list of maps in compacted form, and call func for each entry after decompaction
+ * @param entries array of entries. The first item must be an object, and all others must be an object or a string.
+ *     Each decompacted entry is an object. The decompacted form of the first entry is the same as the first entry. The
+ *     decompacted form of each subsequent entry is created by duplicating all missing object keys from the previous
+ *     decompacted entry into the new one.  If the new entry has 'null' values for a key, that key is removed.  If the
+ *     new entry is a simple string, the new entry is replaced with an object with only the "compactedAttr" key, whose
+ *     value is the entry string, before decompaction. If a key is '_' it is replaced with the compactedAttr key.
+ * @param compactedAttr an object key that will be used for simple string decompaction
+ * @param func called for each decompacted entry
+ * @private
+ */
+function _decompactMapList(entries, compactedAttr, func) {
+    var odata = {};
+    for (var i = 0; i < entries.length; i++) {
+        var e = entries[i];
+        //fill data from previous entry
+        //compactedAttr is attr name to replace '_' with
+        if (compactedAttr && typeof(e) === 'string') {
+            var s = e;
+            e = {};
+            e[compactedAttr] = s;
+        } else if (compactedAttr && typeof(e['_']) !== 'undefined') {
+            e[compactedAttr] = e['_'];
+            delete e['_'];
+        }
+        for (k in odata) {
+            if (odata.hasOwnProperty(k)) {
+                if (typeof(e[k]) === 'undefined') {
+                    e[k] = odata[k]
+                } else if (e[k] === null) {
+                    delete e[k];
+                }
+            }
+        }
+        odata = e;
+        func(e);
+    }
+}

--- a/rundeckapp/grails-app/assets/javascripts/util/compactMapList.test.js
+++ b/rundeckapp/grails-app/assets/javascripts/util/compactMapList.test.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+//= require util/testing
+
+
+jQuery(function () {
+    "use strict";
+    new TestHarness("compactMapList.test.js", {
+
+        decompactMapListTest: function () {
+            var self = this;
+            var arr = [
+                {log: 'blah1', user: 'auser', node: 'anode1', level: 'NORMAL', stepctx: '1'},
+                'blah2',
+                {},
+                'blah4',
+                {node: null, stepctx: null}
+            ];
+            var newarr = [];
+            _decompactMapList(arr, 'log', function (e) {
+                newarr.push(e);
+            });
+
+            self.assert('same size', arr.length, newarr.length);
+            self.assert('first value', arr[0], newarr[0]);
+            self.assert('string only', {
+                log: 'blah2',
+                user: 'auser',
+                node: 'anode1',
+                level: 'NORMAL',
+                stepctx: '1'
+            }, newarr[1]);
+            self.assert('dupe map', {
+                log: 'blah2',
+                user: 'auser',
+                node: 'anode1',
+                level: 'NORMAL',
+                stepctx: '1'
+            }, newarr[2]);
+            self.assert('string again', {
+                log: 'blah4',
+                user: 'auser',
+                node: 'anode1',
+                level: 'NORMAL',
+                stepctx: '1'
+            }, newarr[3]);
+            self.assert('remove attributes', {log: 'blah4', user: 'auser', level: 'NORMAL'}, newarr[4]);
+        }
+    });
+})();

--- a/rundeckapp/grails-app/assets/javascripts/util/compactMapList.test.js
+++ b/rundeckapp/grails-app/assets/javascripts/util/compactMapList.test.js
@@ -62,4 +62,4 @@ jQuery(function () {
             self.assert('remove attributes', {log: 'blah4', user: 'auser', level: 'NORMAL'}, newarr[4]);
         }
     });
-})();
+});

--- a/rundeckapp/grails-app/conf/ExecutionCompleteEvents.groovy
+++ b/rundeckapp/grails-app/conf/ExecutionCompleteEvents.groovy
@@ -21,4 +21,5 @@ import rundeck.services.events.ExecutionCompleteEvent
 events = {
     executionComplete filter: ExecutionCompleteEvent, fork: true
     executionBeforeStart filter: ExecutionPrepareEvent, fork: false
+    executionCheckpoint filter: ExecutionCompleteEvent, fork: false
 }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -798,6 +798,9 @@ class ExecutionController extends ControllerBase{
             params.nodename = null
             params.stepctx = null
         }
+        if (request.api_version < ApiRequestFilters.V21) {
+            params.remove('compacted')
+        }
         return tailExecutionOutput()
     }
     static final String invalidXmlPattern = "[^" + "\\u0009\\u000A\\u000D" + "\\u0020-\\uD7FF" +
@@ -908,6 +911,9 @@ class ExecutionController extends ControllerBase{
             return
         }
         params.stateOutput = true
+        if (request.api_version < ApiRequestFilters.V21) {
+            params.remove('compacted')
+        }
         return tailExecutionOutput()
     }
     /**

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -862,6 +862,7 @@ class ExecutionController extends ControllerBase{
                 if (it.loghtml) {
                     datamap.loghtml = it.loghtml
                 }
+                def removed = []
                 if (compacted) {
                     def origmap = new HashMap(datamap)
                     prev.each { k, v ->
@@ -869,6 +870,7 @@ class ExecutionController extends ControllerBase{
                             datamap.remove(k)
                         } else if (null == datamap[k] && null != prev[k]) {
                             datamap[k] = null
+                            removed << k
                         }
                     }
                     prev = origmap
@@ -885,7 +887,13 @@ class ExecutionController extends ControllerBase{
                     }
                 } else {
                     if (datamap instanceof Map) {
-                        datamap.log = datamap.log.replaceAll(invalidXmlPattern, '')
+                        if (compacted && removed) {
+                            datamap['removed'] = removed.join(',')
+                            removed.each{datamap.remove(it)}
+                        }
+                        if(datamap.log!=null) {
+                            datamap.log = datamap.log?.replaceAll(invalidXmlPattern, '')
+                        }
                         //xml
                         if (apiVersion <= ApiRequestFilters.V5) {
                             def text = datamap.remove('log')
@@ -1358,7 +1366,6 @@ class ExecutionController extends ControllerBase{
                 response.addHeader('X-Rundeck-ExecOutput-TotalSize', totsize.toString())
                 response.addHeader('X-Rundeck-ExecOutput-LastLinesSupported', lastlinesSupported.toString())
                 response.addHeader('X-Rundeck-ExecOutput-RetryBackoff', reader.retryBackoff.toString())
-                response.addHeader('X-Rundeck-ExecOutput-Compacted', compacted.toString())
                 def lineSep = System.getProperty("line.separator")
                 response.setHeader("Content-Type","text/plain")
                 response.outputStream.withWriter("UTF-8"){w->

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -37,7 +37,6 @@ import com.dtolabs.rundeck.server.authorization.AuthConstants
 import com.dtolabs.rundeck.server.plugins.DescribedPlugin
 import grails.converters.JSON
 import org.codehaus.groovy.grails.web.mapping.LinkGenerator
-import org.codehaus.groovy.grails.web.servlet.mvc.GrailsParameterMap
 import rundeck.CommandExec
 import rundeck.Execution
 import rundeck.ScheduledExecution
@@ -87,13 +86,15 @@ class ExecutionController extends ControllerBase{
             cancelExecution:'POST'
     ]
 
-    def index ={
+    def index() {
         redirect(controller:'menu',action:'index')
     }
-    def follow ={
+
+    def follow() {
         return render(view:'show',model:show())
     }
-    def followFragment ={
+
+    def followFragment() {
         return render(view:'showFragment',model:show())
     }
     /**
@@ -276,7 +277,8 @@ class ExecutionController extends ControllerBase{
                 clusterModeEnabled    : frameworkService.isClusterModeEnabled()
         ]
     }
-    def delete = {
+
+    def delete() {
         withForm{
         def Execution e = Execution.get(params.id)
         if (notFoundResponse(e, 'Execution ID', params.id)) {
@@ -475,7 +477,8 @@ class ExecutionController extends ControllerBase{
         }
         return renderCompressed(request, response, 'application/json', data.encodeAsJSON())
     }
-    def mail ={
+
+    def mail() {
         def Execution e = Execution.get(params.id)
         if (notFoundResponse(e, 'Execution ID', params.id)) {
             return
@@ -521,7 +524,7 @@ class ExecutionController extends ControllerBase{
     }
 
 
-    def xmlerror={
+    private def xmlerror() {
         render(contentType:"text/xml",encoding:"UTF-8"){
             result(error:"true"){
                 delegate.'error'{
@@ -558,7 +561,7 @@ class ExecutionController extends ControllerBase{
                     }
                 }
                 xml {
-                    xmlerror.call()
+                    xmlerror()
                 }
             }
         }
@@ -573,7 +576,7 @@ class ExecutionController extends ControllerBase{
                     }
                 }
                 xml {
-                    xmlerror.call()
+                    xmlerror()
                 }
             }
         }
@@ -618,7 +621,7 @@ class ExecutionController extends ControllerBase{
         }
     }
 
-    def downloadOutput = {
+    def downloadOutput() {
         Execution e = Execution.get(Long.parseLong(params.id))
         if(!e){
             log.error("Execution with id "+params.id+" not found")
@@ -677,7 +680,8 @@ class ExecutionController extends ControllerBase{
         }
         iterator.close()
     }
-    def renderOutput = {
+
+    def renderOutput() {
         Execution e = Execution.get(Long.parseLong(params.id))
         if(!e){
             log.error("Execution with id "+params.id+" not found")
@@ -784,7 +788,7 @@ class ExecutionController extends ControllerBase{
     /**
      * API: /api/execution/{id}/output, version 5
      */
-    def apiExecutionOutput = {
+    def apiExecutionOutput() {
         if (!apiService.requireVersion(request, response, ApiRequestFilters.V5)) {
             return
         }
@@ -802,7 +806,7 @@ class ExecutionController extends ControllerBase{
     /**
      * Use a builder delegate to render tailExecutionOutput result in XML or JSON
      */
-    private def renderOutputClosure= {String outf, Map data, List outputData, apiVersion,delegate, stateoutput=false ->
+    private def renderOutputFormat(String outf, Map data, List outputData, apiVersion, delegate, stateoutput = false) {
         def keys = [
                 'id', 'offset', 'completed', 'empty', 'unmodified', 'error', 'message', 'execCompleted',
                 'hasFailedNodes', 'execState', 'lastModified', 'execDuration', 'percentLoaded', 'totalSize',
@@ -899,7 +903,7 @@ class ExecutionController extends ControllerBase{
     /**
      * API: /api/execution/{id}/output/state, version ?
      */
-    def apiExecutionStateOutput = {
+    def apiExecutionStateOutput() {
         if (!apiService.requireVersion(request,response,ApiRequestFilters.V10)) {
             return
         }
@@ -930,7 +934,7 @@ class ExecutionController extends ControllerBase{
                         response.setStatus(status)
                     }
                     render(contentType: "application/json") {
-                        renderOutputClosure('json', [
+                        renderOutputFormat('json', [
                                 error: message,
                                 id: params.id.toString(),
                                 offset: "0",
@@ -1003,13 +1007,13 @@ class ExecutionController extends ControllerBase{
                 xml {
                     apiService.renderSuccessXml(request,response) {
                         output{
-                            renderOutputClosure('xml', dataMap, [], request.api_version, delegate)
+                            renderOutputFormat('xml', dataMap, [], request.api_version, delegate)
                         }
                     }
                 }
                 json {
                     render(contentType: "application/json") {
-                        renderOutputClosure('json', dataMap, [], request.api_version, delegate)
+                        renderOutputFormat('json', dataMap, [], request.api_version, delegate)
                     }
                 }
                 text {
@@ -1051,13 +1055,13 @@ class ExecutionController extends ControllerBase{
                 xml {
                     apiService.renderSuccessXml(request,response) {
                         output {
-                            renderOutputClosure('xml', dataMap, [], request.api_version, delegate)
+                            renderOutputFormat('xml', dataMap, [], request.api_version, delegate)
                         }
                     }
                 }
                 json {
                     render(contentType: "application/json") {
-                        renderOutputClosure('json', dataMap, [], request.api_version, delegate)
+                        renderOutputFormat('json', dataMap, [], request.api_version, delegate)
                     }
                 }
                 text {
@@ -1141,13 +1145,13 @@ class ExecutionController extends ControllerBase{
                     xml {
                         apiService.renderSuccessXml(request,response) {
                             output {
-                                renderOutputClosure('xml', dataMap, [], request.api_version, delegate)
+                                renderOutputFormat('xml', dataMap, [], request.api_version, delegate)
                             }
                         }
                     }
                     json {
                         render(contentType: "application/json") {
-                            renderOutputClosure('json', dataMap, [], request.api_version, delegate)
+                            renderOutputFormat('json', dataMap, [], request.api_version, delegate)
                         }
                     }
                     text {
@@ -1328,13 +1332,13 @@ class ExecutionController extends ControllerBase{
             xml {
                 apiService.renderSuccessXml(request,response) {
                     output {
-                        renderOutputClosure('xml', resultData, entry, request.api_version, delegate, stateoutput)
+                        renderOutputFormat('xml', resultData, entry, request.api_version, delegate, stateoutput)
                     }
                 }
             }
             json {
                 render(contentType: "application/json") {
-                    renderOutputClosure('json', resultData, entry, request.api_version, delegate, stateoutput)
+                    renderOutputFormat('json', resultData, entry, request.api_version, delegate, stateoutput)
                 }
             }
             text{
@@ -1477,7 +1481,7 @@ class ExecutionController extends ControllerBase{
     /**
      * Render execution list xml given a List of executions, and a builder delegate
      */
-    public def renderApiExecutions= { LinkGenerator grailsLinkGenerator, List execlist, paging=[:],delegate ->
+    private def renderApiExecutions(LinkGenerator grailsLinkGenerator, List execlist, paging, delegate) {
         apiService.renderExecutionsXml(execlist.collect{ Execution e->
             [
                 execution:e,

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -1038,8 +1038,8 @@ class ExecutionController extends ControllerBase{
                         response.addHeader('X-Rundeck-ExecOutput-Message', errmsg.toString())
                     }
                     response.addHeader('X-Rundeck-ExecOutput-Empty', dataMap.empty.toString())
-                    response.addHeader('X-Rundeck-ExecOutput-Completed', dataMap.execCompleted.toString())
-                    response.addHeader('X-Rundeck-Exec-Completed', dataMap.completed.toString())
+                    response.addHeader('X-Rundeck-ExecOutput-Completed', dataMap.completed.toString())
+                    response.addHeader('X-Rundeck-Exec-Completed', dataMap.execCompleted.toString())
                     response.addHeader('X-Rundeck-Exec-State', dataMap.execState.toString())
                     response.addHeader('X-Rundeck-Exec-Status-String', dataMap.statusString.toString())
                     response.addHeader('X-Rundeck-Exec-Duration', dataMap.execDuration.toString())

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -356,6 +356,7 @@ execution.state.storage.state.PENDING_LOCAL=Retrieving Execution Summary and Rep
 execution.state.storage.state.WAITING=Waiting for execution to start...
 execution.state.storage.state.NOT_FOUND=Execution Summary and Report detail is not available.
 execution.state.storage.state.ERROR=Execution Summary and Report detail availability could not be determined: {1} (via plugin "{0}")
+execution.state.storage.state.UNKNOWN=Execution Summary and Report detail availability could not be determined: {0}
 execution.state.storage.retrieval.ERROR=Execution Summary and Report detail could not be retrieved: {1} (via plugin "{0}")
 
 #form text

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1590,3 +1590,4 @@ aclpolicy.file.upload.failed.acl.policy.validation.message=Uploaded File failed 
 aclpolicy.file.upload.overwrite.label=Overwrite an existing ACL Policy with the same name
 aclpolicy.file.upload.exists.warning.message=A Policy already exists with the specified name
 title.location.prompt=Location: 
+execution.log.clusterExec.log.delayed.message=This execution is running on another cluster member, so log output and execution summary data may be delayed.

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -356,6 +356,7 @@ execution.state.storage.state.PENDING_LOCAL=Recuperando los detalles del Resumen
 execution.state.storage.state.WAITING=Esperando que inicie la ejecución...
 execution.state.storage.state.NOT_FOUND=Detalles de Resumen e Informe Ejecución no disponibles.
 execution.state.storage.state.ERROR=La disponibilidad de los detalles de Resumen e Informe Ejecución no puedo ser determinada: {1} (via plugin "{0}")
+execution.state.storage.state.UNKNOWN=Execution Summary and Report detail availability could not be determined: {0}
 execution.state.storage.retrieval.ERROR=No se pudieron recuerar los detalles de Resumen e Informe Ejecución: {1} (via plugin "{0}")
 
 #form text

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1588,3 +1588,4 @@ aclpolicy.file.upload.failed.acl.policy.validation.message=Uploaded File failed 
 aclpolicy.file.upload.overwrite.label=Overwrite an existing ACL Policy with the same name
 aclpolicy.file.upload.exists.warning.message=A Policy already exists with the specified name
 title.location.prompt=Location: 
+execution.log.clusterExec.log.delayed.message=This execution is running on another cluster member, so log output and execution summary data may be delayed.

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -1589,3 +1589,4 @@ aclpolicy.file.upload.failed.acl.policy.validation.message=Uploaded File failed 
 aclpolicy.file.upload.overwrite.label=Overwrite an existing ACL Policy with the same name
 aclpolicy.file.upload.exists.warning.message=A Policy already exists with the specified name
 title.location.prompt=Location: 
+execution.log.clusterExec.log.delayed.message=This execution is running on another cluster member, so log output and execution summary data may be delayed.

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -356,6 +356,7 @@ execution.state.storage.state.PENDING_LOCAL=Retrieving Execution Summary and Rep
 execution.state.storage.state.WAITING=\u7B49\u5F85\u6267\u884C...
 execution.state.storage.state.NOT_FOUND=\u6267\u884C\u6C47\u603B\u548C\u62A5\u544A\u4E0D\u53EF\u7528
 execution.state.storage.state.ERROR=Execution Summary and Report detail availability could not be determined: {1} (via plugin "{0}")
+execution.state.storage.state.UNKNOWN=Execution Summary and Report detail availability could not be determined: {0}
 execution.state.storage.retrieval.ERROR=Execution Summary and Report detail could not be retrieved: {1} (via plugin "{0}")
 
 #form text

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -392,9 +392,7 @@ class ExecutionJob implements InterruptableJob {
                     avgNotificationSent=true
                 }
             }
-            if(periodicCheck){
-                periodicCheck.accept(duration)
-            }
+            periodicCheck?.accept(duration)
             if (
             !wasInterrupted
                     && !wasTimeout

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionEventsService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionEventsService.groovy
@@ -33,4 +33,12 @@ class ExecutionEventsService {
 
         logFileStorageService.submitForStorage(e.execution)
     }
+    /**
+     * Checkpoint during job execution to allow partiallog storage
+     * @param event
+     */
+    @Listener
+    def executionCheckpoint(ExecutionCompleteEvent e) {
+        logFileStorageService.submitForPartialStorage(e.execution, e.context.fileSizeChange, e.context.timediff)
+    }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1011,7 +1011,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     jobcontext,
                     extraParamsExposed
             )
-            def checkpoint = workflowService.createPeriodicCheckpoint(execution)
+            def checkpoint = logFileStorageService.createPeriodicCheckpoint(execution)
 
             def wfEventListener = new WorkflowEventLoggerListener(executionListener)
             def logOutFlusher = new LogFlusher()

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1011,6 +1011,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     jobcontext,
                     extraParamsExposed
             )
+            def checkpoint = workflowService.createPeriodicCheckpoint(execution)
 
             def wfEventListener = new WorkflowEventLoggerListener(executionListener)
             def logOutFlusher = new LogFlusher()
@@ -1108,8 +1109,15 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             )
             thread.start()
             log.debug("started thread")
-            return [thread            : thread, loghandler: loghandler, noderecorder: recorder, execution: execution,
-                    scheduledExecution: scheduledExecution, threshold: threshold]
+            return [
+                    thread            : thread,
+                    loghandler        : loghandler,
+                    noderecorder      : recorder,
+                    execution         : execution,
+                    scheduledExecution: scheduledExecution,
+                    threshold         : threshold,
+                    periodicCheck     : checkpoint
+            ]
         }catch(Exception e) {
             log.error("Failed while starting execution: ${execution.id}", e)
             loghandler.logError('Failed to start execution: ' + e.getClass().getName() + ": " + e.message)

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1612,9 +1612,21 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             //aggregate all files to delete
             execs << e
             [LoggingService.LOG_FILE_FILETYPE, WorkflowService.STATE_FILE_FILETYPE].each { ftype ->
-                def file = logFileStorageService.getFileForExecutionFiletype(e, ftype, true)
+                def file = logFileStorageService.getFileForExecutionFiletype(e, ftype, true, false)
                 if (null != file && file.exists()) {
                     files << file
+                }
+                def fileb = logFileStorageService.getFileForExecutionFiletype(e, ftype, true, true)
+                if (null != fileb && fileb.exists()) {
+                    files << fileb
+                }
+                def file2 = logFileStorageService.getFileForExecutionFiletype(e, ftype, false, false)
+                if (null != file2 && file2.exists()) {
+                    files << file2
+                }
+                def file2b = logFileStorageService.getFileForExecutionFiletype(e, ftype, false, true)
+                if (null != file2b && file2b.exists()) {
+                    files << file2b
                 }
             }
             //delete all job file records

--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -1034,10 +1034,10 @@ class LogFileStorageService implements InitializingBean,ApplicationContextAware{
             return previous + [backoff: remain]
         } else if (previous != null && !isResultCacheItemAllowedRetry(previous)) {
             //no more retries
-            log.warn("getRetrievalCacheResult, reached max retry count of ${previous.count} for ${key}, not retrying")
+            log.debug("getRetrievalCacheResult, reached max retry count of ${previous.count} for ${key}, not retrying")
             return previous
         }else if(previous!=null){
-            log.warn("getRetrievalCacheResult, expired cache result: ${previous}")
+            log.debug("getRetrievalCacheResult, expired cache result: ${previous}")
 //            logFileRetrievalResults.remove(key)
         }
         return null

--- a/rundeckapp/grails-app/services/rundeck/services/LoggingService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LoggingService.groovy
@@ -70,13 +70,23 @@ class LoggingService implements ExecutionFileProducer {
 
     @Override
     boolean isExecutionFileGenerated() {
-        return false
+        false
     }
 
     @Override
     ExecutionFile produceStorageFileForExecution(final Execution e) {
-        File file = getLogFileForExecution(e)
+        File file = getLogFileForExecution e
         new ProducedExecutionFile(localFile: file, fileDeletePolicy: ExecutionFileDeletePolicy.WHEN_RETRIEVABLE)
+    }
+
+    @Override
+    boolean isCheckpointable() {
+        true
+    }
+
+    @Override
+    ExecutionFile produceStorageCheckpointForExecution(final Execution e) {
+        produceStorageFileForExecution e
     }
 
     /**
@@ -131,7 +141,7 @@ class LoggingService implements ExecutionFileProducer {
                     defaultMeta,
                     threshold?.watcherForType(LoggingThreshold.TOTAL_FILE_SIZE)
             )
-            outfilepath = logFileStorageService.getFileForExecutionFiletype(execution, LOG_FILE_FILETYPE, false)
+            outfilepath = logFileStorageService.getFileForExecutionFiletype(execution, LOG_FILE_FILETYPE, false, false)
         } else {
             log.debug("File log writer disabled for execution ${execution.id}")
         }
@@ -166,7 +176,7 @@ class LoggingService implements ExecutionFileProducer {
      * Return the log file for the execution
      */
     public File getLogFileForExecution(Execution execution) {
-        logFileStorageService.getFileForExecutionFiletype(execution, LOG_FILE_FILETYPE, true)
+        logFileStorageService.getFileForExecutionFiletype(execution, LOG_FILE_FILETYPE, false, false)
     }
 
     String getConfiguredStreamingReaderPluginName() {

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -132,6 +132,16 @@ class ProjectService implements InitializingBean, ExecutionFileProducer{
     }
 
     @Override
+    boolean isCheckpointable() {
+        return false
+    }
+
+    @Override
+    ExecutionFile produceStorageCheckpointForExecution(final Execution e) {
+        return null
+    }
+
+    @Override
     ExecutionFile produceStorageFileForExecution(final Execution e) {
         File localfile = getExecutionXmlFileForExecution(e)
 
@@ -1280,8 +1290,12 @@ class ProjectService implements InitializingBean, ExecutionFileProducer{
                 if (e.outputfilepath && execout[e.outputfilepath]) {
                     File oldfile = execout[e.outputfilepath]
                     //move to appropriate location and update outputfilepath
-                    String filename = logFileStorageService.getFileForExecutionFiletype(e,
-                            LoggingService.LOG_FILE_FILETYPE, false)
+                    String filename = logFileStorageService.getFileForExecutionFiletype(
+                            e,
+                            LoggingService.LOG_FILE_FILETYPE,
+                            false,
+                            false
+                    )
                     File newfile = new File(filename)
                     try{
                         FileUtils.moveFile(oldfile, newfile)
@@ -1298,8 +1312,12 @@ class ProjectService implements InitializingBean, ExecutionFileProducer{
                 //copy state.json file
                 if(execout["state-${oldids[e]}.state.json"]){
                     File statefile= execout["state-${oldids[e]}.state.json"]
-                    String filename = logFileStorageService.getFileForExecutionFiletype(e,
-                            WorkflowService.STATE_FILE_FILETYPE, false)
+                    String filename = logFileStorageService.getFileForExecutionFiletype(
+                            e,
+                            WorkflowService.STATE_FILE_FILETYPE,
+                            false,
+                            false
+                    )
                     File newfile = new File(filename)
                     try {
                         FileUtils.moveFile(statefile, newfile)

--- a/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
@@ -425,7 +425,13 @@ class WorkflowService implements ApplicationContextAware,ExecutionFileProducer{
             }
             statemap=stateMapping.summarize(new HashMap(statemap),nodes,selectedOnly,stepStates)
         }
-        return new WorkflowStateFileLoader(workflowState: statemap, state: loader.state, errorCode: loader.errorCode,
-                                           errorData: loader.errorData, file: loader.file)
+        return new WorkflowStateFileLoader(
+                workflowState: statemap,
+                state: loader.state,
+                errorCode: loader.errorCode,
+                errorData: loader.errorData,
+                file: loader.file,
+                retryBackoff: loader.retryBackoff
+        )
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
@@ -351,11 +351,21 @@ class WorkflowService implements ApplicationContextAware,ExecutionFileProducer{
     }
     /**
      * Summarize the data for only the selected nodes
-     * @param loader
-     * @param nodes
+     * @param e execution
+     * @param nodes list of selected nodes to get state for
+     * @param selectedOnly if ture, only get state for the nodes, otherwise all node states are returned
+     * @param performLoad if true, ask log storage to load the log if necessary
+     * @param stepStates if true, include individual step states
      * @return
      */
-    WorkflowStateFileLoader requestStateSummary(Execution e, List<String> nodes,boolean selectedOnly=false,boolean performLoad = true, boolean stepStates=false){
+    WorkflowStateFileLoader requestStateSummary(
+            Execution e,
+            List<String> nodes,
+            boolean selectedOnly = false,
+            boolean performLoad = true,
+            boolean stepStates = false
+    )
+    {
         //look for active state
         def state1 = activeStates[e.id]
         if (state1) {

--- a/rundeckapp/grails-app/services/rundeck/services/logging/ExecutionFileProducer.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/logging/ExecutionFileProducer.groovy
@@ -32,10 +32,12 @@ interface ExecutionFileProducer {
      * @return true if the file will be generated, false if it was previously generated
      */
     boolean isExecutionFileGenerated()
+    boolean isCheckpointable()
 
     /**
      * @param e execution
      * @return the file to store
      */
     ExecutionFile produceStorageFileForExecution(Execution e)
+    ExecutionFile produceStorageCheckpointForExecution(Execution e)
 }

--- a/rundeckapp/grails-app/services/rundeck/services/logging/ExecutionLogState.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/logging/ExecutionLogState.groovy
@@ -34,6 +34,10 @@ public enum ExecutionLogState {
      */
     AVAILABLE,
     /**
+     * Partial data present locally
+     */
+    AVAILABLE_PARTIAL,
+    /**
      * Waiting for output
      */
     WAITING,
@@ -41,6 +45,10 @@ public enum ExecutionLogState {
      * Present on remote storage
      */
     AVAILABLE_REMOTE,
+    /**
+     * Partial data on remote storage
+     */
+    AVAILABLE_REMOTE_PARTIAL,
     /**
      * Pending presence on remote storage
      */
@@ -69,10 +77,17 @@ public enum ExecutionLogState {
      * @param notFoundState a state to return if both states are NOT_FOUND
      * @return
      */
-    public static ExecutionLogState forFileStates(LogFileState local, LogFileState remote, ExecutionLogState notFoundState) {
+    public static ExecutionLogState forFileStates(
+            LogFileState local,
+            LogFileState remote,
+            ExecutionLogState notFoundState
+    )
+    {
         switch (local) {
             case LogFileState.AVAILABLE:
                 return AVAILABLE
+            case LogFileState.AVAILABLE_PARTIAL:
+                return AVAILABLE_PARTIAL
             case LogFileState.PENDING:
                 return PENDING_LOCAL
             case LogFileState.NOT_FOUND:
@@ -81,6 +96,8 @@ public enum ExecutionLogState {
                         return ERROR
                     case LogFileState.AVAILABLE:
                         return AVAILABLE_REMOTE
+                    case LogFileState.AVAILABLE_PARTIAL:
+                        return AVAILABLE_REMOTE_PARTIAL
                     case LogFileState.PENDING:
                         return PENDING_REMOTE
                     case LogFileState.NOT_FOUND:

--- a/rundeckapp/grails-app/services/rundeck/services/logging/ExecutionLogState.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/logging/ExecutionLogState.groovy
@@ -61,6 +61,10 @@ public enum ExecutionLogState {
      * Error determining state
      */
     ERROR
+
+    public boolean isAvailableOrPartial() {
+        return this in [AVAILABLE, AVAILABLE_PARTIAL]
+    }
     /**
      * Return an {@link ExecutionLogState} given a local and remote {@link LogFileState}
      * @param local

--- a/rundeckapp/grails-app/services/rundeck/services/logging/LogFileLoader.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/logging/LogFileLoader.groovy
@@ -27,4 +27,5 @@ class LogFileLoader {
     String errorCode
     List errorData
     File file
+    long retryBackoff
 }

--- a/rundeckapp/grails-app/services/rundeck/services/logging/MultiFileStorageRequestImpl.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/logging/MultiFileStorageRequestImpl.groovy
@@ -49,13 +49,14 @@ class MultiFileStorageRequestImpl implements MultiFileStorageRequestErrors {
         if (!files[filetype]) {
             return null
         }
-        new StorageFileImpl(filetype: filetype, file: files[filetype])
+        new StorageFileImpl(filetype: filetype, file: files[filetype], complete: true)
     }
 }
 
 class StorageFileImpl implements StorageFile {
     String filetype
     File file
+    boolean complete
 
     @Override
     InputStream getInputStream() {

--- a/rundeckapp/grails-app/services/rundeck/services/logging/MultiFileStorageRequestImpl.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/logging/MultiFileStorageRequestImpl.groovy
@@ -27,6 +27,7 @@ class MultiFileStorageRequestImpl implements MultiFileStorageRequestErrors {
     Map<String, File> files
     Map<String, Boolean> completion = [:]
     Map<String, String> errors = [:]
+    boolean completed=true
 
     @Override
     void storageResultForFiletype(final String filetype, boolean success) {
@@ -49,7 +50,7 @@ class MultiFileStorageRequestImpl implements MultiFileStorageRequestErrors {
         if (!files[filetype]) {
             return null
         }
-        new StorageFileImpl(filetype: filetype, file: files[filetype], complete: true)
+        new StorageFileImpl(filetype: filetype, file: files[filetype], complete: completed)
     }
 }
 

--- a/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
@@ -444,7 +444,7 @@ class UtilityTagLib{
      * renders a java date as the W3C format used by dc:date in RSS feed
      */
     def w3cDateValue = {attrs,body ->
-        SimpleDateFormat dateFormater = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'",Locale.US);
+        SimpleDateFormat dateFormater = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX",Locale.US);
         dateFormater.setTimeZone(TimeZone.getTimeZone("GMT"));
         return dateFormater.format(attrs.date);
     }

--- a/rundeckapp/grails-app/views/execution/_showFragment.gsp
+++ b/rundeckapp/grails-app/views/execution/_showFragment.gsp
@@ -276,4 +276,15 @@
     </div>
     </div>
 </div>
+<div id="commandPerform_clusterinfo" style="display: none">
+    <div class="row"><div class="col-sm-12">
+        <div class="well well-nobg inline">
+            <p class="text-muted">
+                <i class="glyphicon glyphicon-info-sign"></i>
+                <em><g:message code="execution.log.clusterExec.log.delayed.message" /></em>
+            </p>
+        </div>
+    </div>
+    </div>
+</div>
 </div>

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -193,6 +193,7 @@
 
       <g:if test="${grails.util.Environment.current==grails.util.Environment.DEVELOPMENT}">
           <asset:javascript src="workflow.test.js"/>
+          <asset:javascript src="util/compactMapList.test.js"/>
       </g:if>
       <style type="text/css">
 

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/workflow/PeriodicFileChecker.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/internal/workflow/PeriodicFileChecker.groovy
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.internal.workflow
+
+import groovy.transform.ToString
+
+import java.time.Clock
+import java.util.concurrent.TimeUnit
+
+/**
+ * Checks a file for size difference and/or elapsed time and can trigger
+ * an action if threshold and/or period has elapsed
+ * @author greg
+ * @since 9/22/17
+ */
+@ToString(includePackage = false, includeFields = true, includeNames = true)
+class PeriodicFileChecker {
+    /**
+     * The action to trigger with argument of (file size change, time change)
+     */
+    Closure action
+    /**
+     * file to check for size changes
+     */
+    File logfile
+    /**
+     * Time period unit
+     */
+    TimeUnit periodUnit = TimeUnit.SECONDS
+    /**
+     * Time period to cause a trigger
+     */
+    Long period = 30
+    /**
+     * minimum time before initial checkpoint
+     */
+    Long periodThreshold = 30
+    /**
+     * minimum log file size before initial checkpoint
+     */
+    Long sizeThreshold = 0
+    /**
+     * minimum size change between checkpoints
+     */
+    Long sizeIncrement = 0
+    /**
+     * Whether to require both thresholds to be met (AND), or only one (OR)
+     */
+    Behavior thresholdBehavior = Behavior.OR
+    /**
+     * Whether both time+size increment must be met
+     */
+    Behavior incrementBehavior = Behavior.OR
+    private Date lastUpdate = null
+    private long lastSize = 0
+    private long periodMS
+    private long thresholdMS
+    private boolean sizeThresholdMet = false
+    private boolean timeThresholdMet = false
+
+    static enum Behavior {
+        AND,
+        OR
+
+        boolean check(List<Boolean> vals) {
+            if (this == AND) {
+                return vals.every()
+            } else {
+                return vals.any()
+            }
+        }
+    }
+    Clock clock = Clock.systemUTC()
+    /**
+     * Trigger a check on the file
+     * @return true if the action was called, false otherwise
+     */
+    boolean triggerCheck() {
+        Date current = tick()
+        long filesize = logfile.exists() ? logfile.length() : -1
+
+        def thresholdChecks = []
+        if (thresholdMS) {
+            thresholdChecks << isTimeThreshold(current)
+        }
+        if (sizeThreshold) {
+            thresholdChecks << isSizeThreshold(filesize)
+        }
+        if (!thresholdBehavior.check(thresholdChecks)) {
+            return false
+        }
+
+        long timediff = current.time - lastUpdate.time
+        long diff = filesize > 0 ? filesize - lastSize : 0
+
+        def periodicChecks = []
+        if (periodMS) {
+            periodicChecks << isTimeIncrement(timediff)
+        }
+        if (sizeIncrement) {
+            periodicChecks << isSizeCheckpoint(diff)
+        }
+        if (incrementBehavior.check(periodicChecks)) {
+            lastUpdate = current
+            lastSize = filesize
+            action.call(diff, timediff)
+            return true
+        }
+        return false
+    }
+
+    private Date tick() {
+        Date current = Date.from clock.instant()
+        if (lastUpdate != null) {
+            return current
+        }
+        lastUpdate = current
+        periodMS = TimeUnit.MILLISECONDS.convert(period, periodUnit)
+        thresholdMS = TimeUnit.MILLISECONDS.convert(periodThreshold, periodUnit)
+        current
+    }
+
+    private boolean isSizeCheckpoint(long diff) {
+        sizeIncrement && diff >= sizeIncrement
+    }
+
+    private boolean isSizeThreshold(long filesize) {
+        if (!sizeThreshold) {
+            sizeThresholdMet = true
+        }
+        if (!sizeThresholdMet) {
+            if (sizeThreshold && filesize >= sizeThreshold) {
+                sizeThresholdMet = true
+            }
+        }
+        sizeThresholdMet
+    }
+
+    private boolean isTimeIncrement(long timediff) {
+        periodMS && timediff >= periodMS
+    }
+
+    private boolean isTimeThreshold(Date current) {
+        if (!thresholdMS) {
+            timeThresholdMet = true
+        }
+        if (!timeThresholdMet) {
+            if (thresholdMS && (current.time - lastUpdate.time) >= thresholdMS) {
+                timeThresholdMet = true
+            }
+        }
+        timeThresholdMet
+    }
+
+}

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/ExecutionFileStoragePluginBuilder.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/ExecutionFileStoragePluginBuilder.groovy
@@ -63,7 +63,23 @@ class ExecutionFileStoragePluginBuilder extends ScriptPluginBuilder implements P
             handlers[name] = list[0]
             return true
         }
+        if (name == 'partialStore' && list.size() == 1 && list[0] instanceof Closure) {
+            if (!ScriptExecutionFileStoragePlugin.validStoreClosure(list[0])) {
+                logger.error("Invalid trigger closure: ${name}, unexpected parameter set: ${list[0].parameterTypes}")
+                throw new MissingMethodException(name.toString(), getClass(), list.toArray(), false);
+            }
+            handlers[name] = list[0]
+            return true
+        }
         if (name == 'retrieve' && list.size() == 1 && list[0] instanceof Closure) {
+            if (!ScriptExecutionFileStoragePlugin.validRetrieveClosure(list[0])) {
+                logger.error("Invalid trigger closure: ${name}, unexpected parameter set: ${list[0].parameterTypes}")
+                throw new MissingMethodException(name.toString(), getClass(), list.toArray(), false);
+            }
+            handlers[name] = list[0]
+            return true
+        }
+        if (name == 'partialRetrieve' && list.size() == 1 && list[0] instanceof Closure) {
             if (!ScriptExecutionFileStoragePlugin.validRetrieveClosure(list[0])) {
                 logger.error("Invalid trigger closure: ${name}, unexpected parameter set: ${list[0].parameterTypes}")
                 throw new MissingMethodException(name.toString(), getClass(), list.toArray(), false);

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/ExecutionFileStoragePluginBuilder.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/ExecutionFileStoragePluginBuilder.groovy
@@ -37,7 +37,7 @@ class ExecutionFileStoragePluginBuilder extends ScriptPluginBuilder implements P
 
     @Override
     ExecutionFileStoragePlugin buildPlugin() {
-        if(handlers.storeMultiple){
+        if (handlers.storeMultiple || handlers.partialStoreMultiple) {
             return new ScriptExecutionMultiFileStoragePlugin(handlers, descriptionBuilder.build())
         }else{
             return new ScriptExecutionFileStoragePlugin(handlers, descriptionBuilder.build())
@@ -47,7 +47,7 @@ class ExecutionFileStoragePluginBuilder extends ScriptPluginBuilder implements P
     @Override
     Object invokeMethod(String name, Object args) {
         List list = InvokerHelper.asList(args);
-        if (name == 'available' && list.size() == 1 && list[0] instanceof Closure) {
+        if (name in ['available', 'partialAvailable'] && list.size() == 1 && list[0] instanceof Closure) {
             if (!ScriptExecutionFileStoragePlugin.validAvailableClosure(list[0])) {
                 logger.error("Invalid trigger closure: ${name}, unexpected parameter set: ${list[0].parameterTypes}")
                 throw new MissingMethodException(name.toString(), getClass(), list.toArray(), false);
@@ -55,7 +55,7 @@ class ExecutionFileStoragePluginBuilder extends ScriptPluginBuilder implements P
             handlers[name] = list[0]
             return true
         }
-        if (name == 'store' && list.size() == 1 && list[0] instanceof Closure) {
+        if (name in ['store', 'partialStore'] && list.size() == 1 && list[0] instanceof Closure) {
             if (!ScriptExecutionFileStoragePlugin.validStoreClosure(list[0])) {
                 logger.error("Invalid trigger closure: ${name}, unexpected parameter set: ${list[0].parameterTypes}")
                 throw new MissingMethodException(name.toString(), getClass(), list.toArray(), false);
@@ -63,15 +63,7 @@ class ExecutionFileStoragePluginBuilder extends ScriptPluginBuilder implements P
             handlers[name] = list[0]
             return true
         }
-        if (name == 'partialStore' && list.size() == 1 && list[0] instanceof Closure) {
-            if (!ScriptExecutionFileStoragePlugin.validStoreClosure(list[0])) {
-                logger.error("Invalid trigger closure: ${name}, unexpected parameter set: ${list[0].parameterTypes}")
-                throw new MissingMethodException(name.toString(), getClass(), list.toArray(), false);
-            }
-            handlers[name] = list[0]
-            return true
-        }
-        if (name == 'retrieve' && list.size() == 1 && list[0] instanceof Closure) {
+        if (name in ['retrieve', 'partialRetrieve'] && list.size() == 1 && list[0] instanceof Closure) {
             if (!ScriptExecutionFileStoragePlugin.validRetrieveClosure(list[0])) {
                 logger.error("Invalid trigger closure: ${name}, unexpected parameter set: ${list[0].parameterTypes}")
                 throw new MissingMethodException(name.toString(), getClass(), list.toArray(), false);
@@ -79,15 +71,7 @@ class ExecutionFileStoragePluginBuilder extends ScriptPluginBuilder implements P
             handlers[name] = list[0]
             return true
         }
-        if (name == 'partialRetrieve' && list.size() == 1 && list[0] instanceof Closure) {
-            if (!ScriptExecutionFileStoragePlugin.validRetrieveClosure(list[0])) {
-                logger.error("Invalid trigger closure: ${name}, unexpected parameter set: ${list[0].parameterTypes}")
-                throw new MissingMethodException(name.toString(), getClass(), list.toArray(), false);
-            }
-            handlers[name] = list[0]
-            return true
-        }
-        if (name == 'storeMultiple' && list.size() == 1 && list[0] instanceof Closure) {
+        if (name in ['storeMultiple', 'partialStoreMultiple'] && list.size() == 1 && list[0] instanceof Closure) {
             if (!ScriptExecutionMultiFileStoragePlugin.validStoreMultipleClosure(list[0])) {
                 logger.error("Invalid trigger closure: ${name}, unexpected parameter set: ${list[0].parameterTypes}")
                 throw new MissingMethodException(name.toString(), getClass(), list.toArray(), false);

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/ScriptExecutionFileStoragePlugin.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/ScriptExecutionFileStoragePlugin.groovy
@@ -36,7 +36,9 @@ class ScriptExecutionFileStoragePlugin
     Map configuration
     Map<String, ? extends Object> pluginContext
     boolean storeSupported
+    boolean partialStoreSupported
     boolean retrieveSupported
+    boolean partialRetrieveSupported
 
     ScriptExecutionFileStoragePlugin(Map<String, Closure> handlers, Description description) {
         this.handlers = handlers
@@ -55,6 +57,8 @@ class ScriptExecutionFileStoragePlugin
     void initialize(Map<String, ? extends Object> context) {
         this.pluginContext = context
         this.storeSupported = handlers['store'] ? true : false
+        this.partialStoreSupported = handlers['partialStore'] ? true : false
+        this.partialRetrieveSupported = handlers['partialRetrieve'] ? true : false
         this.retrieveSupported = (handlers['available'] != null && handlers['retrieve'] != null)
         if(retrieveSupported) {
             ['available', 'retrieve'].each {

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/ScriptExecutionFileStoragePlugin.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/ScriptExecutionFileStoragePlugin.groovy
@@ -58,17 +58,8 @@ class ScriptExecutionFileStoragePlugin
         this.pluginContext = context
         this.storeSupported = handlers['store'] ? true : false
         this.partialStoreSupported = handlers['partialStore'] ? true : false
-        this.partialRetrieveSupported = handlers['partialRetrieve'] ? true : false
+        this.partialRetrieveSupported = handlers['partialAvailable'] && handlers['partialRetrieve'] ? true : false
         this.retrieveSupported = (handlers['available'] != null && handlers['retrieve'] != null)
-        if(retrieveSupported) {
-            ['available', 'retrieve'].each {
-                if (!handlers[it]) {
-                    throw new RuntimeException(
-                            "ScriptExecutionFileStoragePlugin: '${it}' closure not defined for plugin ${description.name}"
-                    )
-                }
-            }
-        }
     }
 
     boolean isAvailable(String filetype) throws ExecutionFileStorageException {
@@ -109,6 +100,49 @@ class ScriptExecutionFileStoragePlugin
         return result ? true : false
     }
 
+    boolean isPartialAvailable(String filetype) throws ExecutionFileStorageException {
+
+        if (!partialRetrieveSupported) {
+            throw new IllegalStateException("partialRetrieve/partialAvailable is not supported")
+        }
+        logger.debug("isAvailable(${filetype}) ${pluginContext}")
+        return execAvailableClosure(filetype)
+    }
+
+    private boolean execAvailableClosure(String filetype, String action) {
+        def closure = handlers[action]
+        def binding = [
+                configuration: configuration,
+                context      : pluginContext + (filetype ? [filetype: filetype] : [:])
+        ]
+        def result = null
+        if (closure.getMaximumNumberOfParameters() == 3) {
+            def Closure newclos = closure.clone()
+            newclos.resolveStrategy = Closure.DELEGATE_ONLY
+            newclos.delegate = binding
+            try {
+                result = newclos.call(filetype, binding.context, binding.configuration)
+            } catch (Exception e) {
+                throw new ExecutionFileStorageException(e.getMessage(), e)
+            }
+        } else if (closure.getMaximumNumberOfParameters() == 2) {
+            def Closure newclos = closure.clone()
+            newclos.delegate = binding
+            newclos.resolveStrategy = Closure.DELEGATE_ONLY
+            try {
+                result = newclos.call(filetype, binding.context)
+            } catch (Exception e) {
+                throw new ExecutionFileStorageException(e.getMessage(), e)
+            }
+        } else {
+            throw new RuntimeException(
+                    "ScriptExecutionFileStoragePlugin: '${action}' closure signature invalid for plugin " +
+                            "${description.name}, cannot open"
+            )
+        }
+        return result ? true : false
+    }
+
     boolean store(String filetype, InputStream stream, long length, Date lastModified)
             throws IOException, ExecutionFileStorageException
     {
@@ -116,7 +150,6 @@ class ScriptExecutionFileStoragePlugin
             throw new IllegalStateException("store is not supported")
         }
         logger.debug("store($filetype) ${pluginContext}")
-        def closure = handlers.store
         def binding = [
                 configuration: configuration,
                 context      : pluginContext + (filetype ? [filetype: filetype] : [:]),
@@ -124,6 +157,34 @@ class ScriptExecutionFileStoragePlugin
                 length       : length,
                 lastModified : lastModified
         ]
+        return execStoreClosure(binding, filetype, 'store')
+    }
+
+    boolean partialStore(String filetype, InputStream stream, long length, Date lastModified)
+            throws IOException, ExecutionFileStorageException
+    {
+        if (!partialStoreSupported) {
+            throw new IllegalStateException("partialStore is not supported")
+        }
+        logger.debug("partialStore($filetype) ${pluginContext}")
+        def binding = [
+                configuration: configuration,
+                context      : pluginContext + (filetype ? [filetype: filetype] : [:]),
+                stream       : stream,
+                length       : length,
+                lastModified : lastModified
+        ]
+        return execStoreClosure(binding, filetype, 'partialStore')
+    }
+
+    private Object execStoreClosure(
+            LinkedHashMap<String, Object> binding,
+            String filetype,
+            String action
+    )
+    {
+        def closure = handlers[action]
+
         if (closure.getMaximumNumberOfParameters() == 4) {
             def Closure newclos = closure.clone()
             newclos.resolveStrategy = Closure.DELEGATE_ONLY
@@ -153,7 +214,8 @@ class ScriptExecutionFileStoragePlugin
             }
         } else {
             throw new RuntimeException(
-                    "ScriptExecutionFileStoragePlugin: 'store' closure signature invalid for plugin ${description.name}, cannot open"
+                    "ScriptExecutionFileStoragePlugin: '$action' closure signature invalid for plugin " +
+                            "${description.name}, cannot open"
             )
         }
     }
@@ -164,8 +226,21 @@ class ScriptExecutionFileStoragePlugin
         if(!retrieveSupported){
             throw new IllegalStateException("retrieve/available is not supported")
         }
-        logger.debug("retrieve($filetype) ${pluginContext}")
-        def closure = handlers.retrieve
+        return execRetrieveClosure(filetype, stream, 'retrieve')
+    }
+
+    @Override
+    boolean partialRetrieve(String filetype, OutputStream stream) throws IOException, ExecutionFileStorageException {
+
+        if (!partialRetrieveSupported) {
+            throw new IllegalStateException("partialRetrieve/partialAvailable is not supported")
+        }
+        return execRetrieveClosure(filetype, stream, 'partialRetrieve')
+    }
+
+    private Object execRetrieveClosure(String filetype, OutputStream stream, String action) {
+        logger.debug("$action($filetype) ${pluginContext}")
+        def closure = handlers[action]
         def binding = [
                 configuration: configuration,
                 context      : pluginContext + (filetype ? [filetype: filetype] : [:]),
@@ -200,7 +275,8 @@ class ScriptExecutionFileStoragePlugin
             }
         } else {
             throw new RuntimeException(
-                    "ScriptExecutionFileStoragePlugin: 'retrieve' closure signature invalid for plugin ${description.name}, cannot open"
+                    "ScriptExecutionFileStoragePlugin: '$action' closure signature invalid for plugin " +
+                            "${description.name}, cannot open"
             )
         }
     }

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/ScriptExecutionMultiFileStoragePlugin.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/builder/ScriptExecutionMultiFileStoragePlugin.groovy
@@ -34,7 +34,8 @@ class ScriptExecutionMultiFileStoragePlugin extends ScriptExecutionFileStoragePl
     @Override
     void initialize(final Map<String, ? extends Object> context) {
         super.initialize(context)
-        this.storeSupported = handlers['storeMultiple'] ? true : false
+        this.storeSupported = (handlers['storeMultiple'] || handlers['partialStoreMultiple'])
+        this.partialStoreSupported = handlers['partialStoreMultiple'] ? true : false
     }
 
     @Override
@@ -49,11 +50,11 @@ class ScriptExecutionMultiFileStoragePlugin extends ScriptExecutionFileStoragePl
 
     @Override
     void storeMultiple(final MultiFileStorageRequest files) throws IOException, ExecutionFileStorageException {
-        if (!storeSupported) {
+        if (!storeSupported && !partialStoreSupported) {
             throw new IllegalStateException("store is not supported")
         }
         logger.debug("storeMultiple($files) ${pluginContext}")
-        def closure = handlers.storeMultiple
+        def closure = handlers.partialStoreMultiple ?: handlers.storeMultiple
         def binding = [
                 configuration: configuration,
                 context      : pluginContext + (files ? [files: files] : [:]),

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/logstorage/TreeExecutionFileStoragePlugin.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/logstorage/TreeExecutionFileStoragePlugin.groovy
@@ -86,7 +86,6 @@ class TreeExecutionFileStoragePlugin
     boolean isAvailable(final String filetype) throws ExecutionFileStorageException {
         Path path = createFilePath(filetype)
         def hasResource = rundeckStorageTree.hasResource(path)
-//        System.err.println("$this: isAvailable: $filetype: $hasResource")
         return hasResource
     }
 
@@ -99,7 +98,7 @@ class TreeExecutionFileStoragePlugin
             'execution.xml': 'application/xml'
     ]
 
-    Map<String, String> createMetadata(String type, long length, Date lastModified) {
+    static Map<String, String> createMetadata(String type, long length, Date lastModified) {
         /*
         [loglevel:INFO, wasRetry:false, url:http://ecto1.local:4440/project/ctest/execution/follow/1701,
         id:cb1f39af-5d15-4d13-bcfe-b3e963c9b21e, project:ctest, username:admin, retryAttempt:0, user.name:admin,
@@ -147,6 +146,7 @@ class TreeExecutionFileStoragePlugin
         resource.contents.writeContent(stream)
         return true
     }
+
 
     @Override
     void storeMultiple(final MultiFileStorageRequest files) throws IOException, ExecutionFileStorageException {

--- a/rundeckapp/test/integration/rundeck/services/ProjectServiceTest.groovy
+++ b/rundeckapp/test/integration/rundeck/services/ProjectServiceTest.groovy
@@ -208,7 +208,7 @@ class ProjectServiceTest extends GroovyTestCase {
         assertTrue resultoutfile.delete()
         def errs=[]
         def result
-        projectService.logFileStorageService.metaClass.getFileForExecutionFiletype={Execution execution, String filetype, boolean useStoredPath->
+        projectService.logFileStorageService.metaClass.getFileForExecutionFiletype={Execution execution, String filetype, boolean useStoredPath, boolean partial->
             resultoutfile
         }
         Execution.withNewSession {
@@ -245,7 +245,7 @@ class ProjectServiceTest extends GroovyTestCase {
         ]
         def errs=[]
         def result
-        projectService.logFileStorageService.metaClass.getFileForExecutionFiletype={Execution execution, String filetype, boolean useStoredPath->
+        projectService.logFileStorageService.metaClass.getFileForExecutionFiletype={Execution execution, String filetype, boolean useStoredPath, boolean partial->
             files[filetype]
         }
         Execution.withNewSession {

--- a/rundeckapp/test/unit/ExecutionServiceSpec.groovy
+++ b/rundeckapp/test/unit/ExecutionServiceSpec.groovy
@@ -1092,8 +1092,14 @@ class ExecutionServiceSpec extends Specification {
 
         service.fileUploadService = Mock(FileUploadService)
         service.logFileStorageService = Mock(LogFileStorageService) {
-            1 * getFileForExecutionFiletype(execution, 'rdlog', true) >> file1
-            1 * getFileForExecutionFiletype(execution, 'state.json', true) >> file2
+            1 * getFileForExecutionFiletype(execution, 'rdlog', true, false) >> file1
+            1 * getFileForExecutionFiletype(execution, 'rdlog', true, true) >> file1
+            1 * getFileForExecutionFiletype(execution, 'rdlog', false, false) >> file1
+            1 * getFileForExecutionFiletype(execution, 'rdlog', false, true) >> file1
+            1 * getFileForExecutionFiletype(execution, 'state.json', true, false) >> file2
+            1 * getFileForExecutionFiletype(execution, 'state.json', true, true) >> file2
+            1 * getFileForExecutionFiletype(execution, 'state.json', false, false) >> file2
+            1 * getFileForExecutionFiletype(execution, 'state.json', false, true) >> file2
             0 * _(*_)
         }
 
@@ -1141,8 +1147,14 @@ class ExecutionServiceSpec extends Specification {
         }
         service.fileUploadService = Mock(FileUploadService)
         service.logFileStorageService = Mock(LogFileStorageService) {
-            1 * getFileForExecutionFiletype(execution, 'rdlog', true) >> file1
-            1 * getFileForExecutionFiletype(execution, 'state.json', true)
+            1 * getFileForExecutionFiletype(execution, 'rdlog', true, false) >> file1
+            1 * getFileForExecutionFiletype(execution, 'rdlog', true, true) >> file1
+            1 * getFileForExecutionFiletype(execution, 'rdlog', false, false) >> file1
+            1 * getFileForExecutionFiletype(execution, 'rdlog', false, true) >> file1
+            1 * getFileForExecutionFiletype(execution, 'state.json', true, false)
+            1 * getFileForExecutionFiletype(execution, 'state.json', true, true)
+            1 * getFileForExecutionFiletype(execution, 'state.json', false, false)
+            1 * getFileForExecutionFiletype(execution, 'state.json', false, true)
             0 * _(*_)
         }
 

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/logging/LegacyLogEntryLineIteratorTest.groovy
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/logging/LegacyLogEntryLineIteratorTest.groovy
@@ -50,7 +50,7 @@ class LegacyLogEntryLineIteratorTest  {
                 new Date(nowtime - (30000) /*30 sec ago*/),
                 new Date(nowtime),
         ]
-        w3cDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
+        w3cDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.US);
         w3cDateFormat.timeZone=TimeZone.getTimeZone("GMT")
         def lines=[
                 "^^^${w3cDateFormat.format(dates[0])}|ERROR|user1|||nodea|ctx1|This is a test^^^\n",

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/logging/RundeckLogFormatTest.groovy
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/logging/RundeckLogFormatTest.groovy
@@ -38,7 +38,7 @@ class RundeckLogFormatTest  {
 
     
     public void setUp() throws Exception {
-        dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
+        dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.US);
         dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
         event = new DefaultLogEvent()
         event.loglevel = LogLevel.DEBUG

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/workflow/PeriodicFileCheckerSpec.groovy
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/workflow/PeriodicFileCheckerSpec.groovy
@@ -40,7 +40,7 @@ class PeriodicFileCheckerSpec extends Specification {
         testfile.deleteOnExit()
     }
 
-    def teardown() {
+    def cleanup() {
         testfile?.delete()
     }
 

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/workflow/PeriodicFileCheckerSpec.groovy
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/app/internal/workflow/PeriodicFileCheckerSpec.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2017 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.internal.workflow
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.file.Files
+import java.time.Clock
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+import static com.dtolabs.rundeck.app.internal.workflow.PeriodicFileChecker.Behavior.AND
+import static com.dtolabs.rundeck.app.internal.workflow.PeriodicFileChecker.Behavior.OR
+
+/**
+ * @author greg
+ * @since 9/25/17
+ */
+class PeriodicFileCheckerSpec extends Specification {
+
+    File testfile
+
+    def setup() {
+        testfile = Files.createTempFile("PeriodicFileCheckerSpec-test", ".file").toFile()
+        testfile.deleteOnExit()
+    }
+
+    def teardown() {
+        testfile?.delete()
+    }
+
+    static interface CheckerAction {
+        void check(long diff, long timediff)
+    }
+
+    @Unroll
+    def "triggerCheck"() {
+        given:
+        def now = Instant.now()
+        def allTimes = [now] + times.collect { new Date(it + Date.from(now).time).toInstant() }
+        Clock clock1 = Mock(Clock) {
+            instant() >>> allTimes
+        }
+        def checkerAction = Mock(CheckerAction)
+        def checker = new PeriodicFileChecker(
+                clock: clock1,
+                logfile: testfile,
+                periodUnit: TimeUnit.SECONDS,
+                period: tPer,
+                periodThreshold: tThresh,
+                sizeThreshold: sThresh,
+                sizeIncrement: sInc,
+                action: checkerAction.&check,
+                thresholdBehavior: behavior
+        )
+        when:
+        def first = checker.triggerCheck()
+//        println("check: $checker")
+        def rest = (0..<times.size()).collect { inc ->
+            if (sizes[inc]) {
+                def bytes = new byte[sizes[inc]]
+//                (0..<sizes[inc]).each { bytes[it] = 0 }
+                testfile.bytes = bytes
+            }
+            def result = checker.triggerCheck()
+//            println("check[$inc]: $checker")
+            result
+        }
+
+        then:
+        [first] + rest == expects
+        rest.size() == Math.max(sizes.size(), times.size())
+
+        where:
+        sizes          | times        | tPer | tThresh | sThresh | sInc | behavior | expects
+        //baseline
+        [0]            | [0]          | 0    | 0       | 0       | 0    | AND      | [false, false]
+        //minimum time threshold
+        [0]            | [0]          | 1    | 1       | 0       | 0    | AND      | [false, false]
+        //before threshold
+        [0]            | [999]        | 1    | 1       | 0       | 0    | AND      | [false, false]
+        //meet threshold
+        [0]            | [1000]       | 1    | 1       | 0       | 0    | AND      | [false, true]
+        [0]            | [1000]       | 1    | 1       | 0       | 0    | OR       | [false, true]
+        //time period
+        [0]            | [0]          | 1    | 0       | 0       | 0    | AND      | [false, false]
+        [0]            | [999]        | 1    | 0       | 0       | 0    | AND      | [false, false]
+        [0]            | [1000]       | 1    | 0       | 0       | 0    | AND      | [false, true]
+        [0]            | [1000, 1999] | 1    | 0       | 0       | 0    | AND      | [false, true, false]
+        [0]            | [1000, 2000] | 1    | 0       | 0       | 0    | AND      | [false, true, true]
+        //period with time threshold
+        [0]            | [1999]       | 1    | 2       | 0       | 0    | AND      | [false, false]
+        [0]            | [2000]       | 1    | 2       | 0       | 0    | AND      | [false, true]
+        [0]            | [2000, 2999] | 1    | 2       | 0       | 0    | AND      | [false, true, false]
+        [0]            | [2000, 3000] | 1    | 2       | 0       | 0    | AND      | [false, true, true]
+        //size check
+        [0]            | [0]          | 0    | 0       | 100     | 1    | AND      | [false, false]
+        [99]           | [0]          | 0    | 0       | 100     | 1    | AND      | [false, false]
+        [100]          | [0]          | 0    | 0       | 100     | 1    | AND      | [false, true]
+        [100]          | [0]          | 0    | 0       | 100     | 1    | OR       | [false, true]
+        //size increment
+        [0]            | [0]          | 0    | 0       | 0       | 100  | AND      | [false, false]
+        [99]           | [0]          | 0    | 0       | 0       | 100  | AND      | [false, false]
+        [100]          | [0]          | 0    | 0       | 0       | 100  | AND      | [false, true]
+        [99, 199]      | [0, 1]       | 0    | 0       | 0       | 100  | AND      | [false, false, true]
+        [99, 299]      | [0, 1]       | 0    | 0       | 0       | 100  | AND      | [false, false, true]
+        [99, 299, 300] | [0, 1, 2]    | 0    | 0       | 0       | 100  | AND      | [false, false, true, false]
+        [99, 299, 398] | [0, 1, 2]    | 0    | 0       | 0       | 100  | AND      | [false, false, true, false]
+        [99, 299, 399] | [0, 1, 2]    | 0    | 0       | 0       | 100  | AND      | [false, false, true, true]
+        [100, 199]     | [0, 1]       | 0    | 0       | 0       | 100  | AND      | [false, true, false]
+        [100, 200]     | [0, 1]       | 0    | 0       | 0       | 100  | AND      | [false, true, true]
+        //both size and time threshold
+        [0]            | [0]          | 1    | 1       | 100     | 1    | AND      | [false, false]
+        [0]            | [999]        | 1    | 1       | 100     | 1    | AND      | [false, false]
+        [99]           | [0]          | 1    | 1       | 100     | 1    | AND      | [false, false]
+        [100]          | [0]          | 1    | 1       | 100     | 1    | AND      | [false, false]
+        [0]            | [1000]       | 1    | 1       | 100     | 1    | AND      | [false, false]
+        [99]           | [1000]       | 1    | 1       | 100     | 1    | AND      | [false, false]
+        [100]          | [999]        | 1    | 1       | 100     | 1    | AND      | [false, false]
+        [100]          | [1000]       | 1    | 1       | 100     | 1    | AND      | [false, true]
+        //both size and time threshold with OR
+        [0]            | [0]          | 1    | 1       | 100     | 1    | OR       | [false, false]
+        [0]            | [999]        | 1    | 1       | 100     | 1    | OR       | [false, false]
+        [99]           | [0]          | 1    | 1       | 100     | 1    | OR       | [false, false]
+        [100]          | [0]          | 1    | 1       | 100     | 1    | OR       | [false, true]
+        [0]            | [1000]       | 1    | 1       | 100     | 1    | OR       | [false, true]
+        [99]           | [1000]       | 1    | 1       | 100     | 1    | OR       | [false, true]
+        [100]          | [999]        | 1    | 1       | 100     | 1    | OR       | [false, true]
+        [100]          | [1000]       | 1    | 1       | 100     | 1    | OR       | [false, true]
+
+    }
+}

--- a/rundeckapp/test/unit/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -29,11 +29,13 @@ import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import grails.test.mixin.TestMixin
 import grails.test.mixin.web.GroovyPageUnitTestMixin
+import groovy.xml.MarkupBuilder
 import rundeck.Execution
 import rundeck.UtilityTagLib
 import rundeck.codecs.AnsiColorCodec
 import rundeck.codecs.HTMLElementCodec
 import rundeck.codecs.URIComponentCodec
+import rundeck.filters.ApiRequestFilters
 import rundeck.services.ApiService
 import rundeck.services.ApiServiceSpec
 import rundeck.services.ConfigurationService
@@ -296,7 +298,7 @@ class ExecutionControllerSpec extends Specification {
      * value.
      * @return
      */
-    def "api execution output compacted"() {
+    def "api execution output compacted json"() {
         given:
 
         def assetTaglib = mockTagLib(UtilityTagLib)
@@ -387,6 +389,153 @@ class ExecutionControllerSpec extends Specification {
         json.entries[3] == [log: 'message3', stepctx: '1', level: 'DEBUG']
         json.entries[4] == [log: 'message4', stepctx: null]
 
+    }
+    /**
+     * compacted=true, the log entries returned will include only the changed
+     * attributes, and if only the "log" is changed, will produce only a string instead of a map.
+     * an empty map means the same entries as previously, an null map entry means remove the previous
+     * value.
+     * @return
+     */
+    def "api execution output compacted xml"() {
+        given:
+
+        def assetTaglib = mockTagLib(UtilityTagLib)
+        Execution e1 = new Execution(
+                project: 'test1',
+                user: 'bob',
+                dateStarted: new Date(),
+                dateEnded: new Date(),
+                status: 'successful'
+
+        )
+        e1.save() != null
+        controller.loggingService = Mock(LoggingService)
+        controller.configurationService = Mock(ConfigurationService)
+        controller.frameworkService = Mock(FrameworkService) {
+            authorizeProjectExecutionAll(*_) >> true
+            1 * getAuthContextForSubjectAndProject(*_)
+            1 * isClusterModeEnabled()
+            _ * getServerUUID()
+            0 * _(*_)
+        }
+        controller.apiService = Mock(ApiService) {
+            requireVersion(*_) >> true
+            requireExists(*_) >> true
+            renderSuccessXml(_, _, _) >> { args ->
+                def writer = new StringWriter()
+                def xml = new MarkupBuilder(writer)
+                def response = args[1]
+                def recall = args[2]
+                xml.with {
+                    recall.delegate = delegate
+                    recall.resolveStrategy = Closure.DELEGATE_FIRST
+                    recall()
+                }
+                def xmlstr = writer.toString()
+                response.setContentType('application/xml')
+                response.setCharacterEncoding('UTF-8')
+                def out = response.outputStream
+                out << xmlstr
+                out.flush()
+            }
+            0 * _(*_)
+        }
+        def reader = new ExecutionLogReader(state: ExecutionLogState.AVAILABLE)
+        def date1 = new Date(90000000)
+        reader.reader = new TestReader(logs:
+                                               [
+                                                       new DefaultLogEvent(
+                                                               eventType: LogUtil.EVENT_TYPE_LOG,
+                                                               datetime: date1,
+                                                               message: 'message1',
+                                                               metadata: [:],
+                                                               loglevel: LogLevel.NORMAL
+                                                       ),
+                                                       new DefaultLogEvent(
+                                                               eventType: LogUtil.EVENT_TYPE_LOG,
+                                                               datetime: date1,
+                                                               message: 'message2',
+                                                               metadata: [:],
+                                                               loglevel: LogLevel.NORMAL
+                                                       ),
+                                                       new DefaultLogEvent(
+                                                               eventType: LogUtil.EVENT_TYPE_LOG,
+                                                               datetime: date1,
+                                                               message: 'message2',
+                                                               metadata: [:],
+                                                               loglevel: LogLevel.NORMAL
+                                                       ),
+                                                       new DefaultLogEvent(
+                                                               eventType: LogUtil.EVENT_TYPE_LOG,
+                                                               datetime: date1,
+                                                               message: 'message3',
+                                                               metadata: [stepctx: '1'],
+                                                               loglevel: LogLevel.DEBUG
+                                                       ),
+                                                       new DefaultLogEvent(
+                                                               eventType: LogUtil.EVENT_TYPE_LOG,
+                                                               datetime: date1,
+                                                               message: 'message4',
+                                                               metadata: [:],
+                                                               loglevel: LogLevel.DEBUG
+                                                       ),
+                                               ]
+        )
+        when:
+        params.id = e1.id.toString()
+        params.compacted = 'true'
+        request.api_version = 21
+        response.format = 'xml'
+        controller.apiExecutionOutput()
+        def xml = response.xml
+        then:
+        1 * controller.loggingService.getLogReader(e1) >> reader
+        xml != null
+        xml.compacted.text() == 'true'
+        xml.entries.entry.size() == 5
+
+        xml.entries.entry[0]."@absolute_time".text() == '1970-01-02T01:00:00Z'
+        xml.entries.entry[0]."@log".text() == 'message1'
+        xml.entries.entry[0]."@level".text() == 'NORMAL'
+        xml.entries.entry[0]."@time".text() == '17:00:00'
+        xml.entries.entry[0]."@time".size() == 1
+        xml.entries.entry[0]."@node".size() == 0
+        xml.entries.entry[0]."@stepctx".size() == 0
+        xml.entries.entry[0]."@removed".size() == 0
+
+        xml.entries.entry[1]."@absolute_time".size() == 0
+        xml.entries.entry[1]."@log".text() == 'message2'
+        xml.entries.entry[1]."@level".size() == 0
+        xml.entries.entry[1]."@time".size() == 0
+        xml.entries.entry[1]."@node".size() == 0
+        xml.entries.entry[1]."@stepctx".size() == 0
+        xml.entries.entry[0]."@removed".size() == 0
+
+        xml.entries.entry[2]."@absolute_time".size() == 0
+        xml.entries.entry[2]."@log".size() == 0
+        xml.entries.entry[2]."@level".size() == 0
+        xml.entries.entry[2]."@time".size() == 0
+        xml.entries.entry[2]."@node".size() == 0
+        xml.entries.entry[2]."@stepctx".size() == 0
+        xml.entries.entry[0]."@removed".size() == 0
+
+
+        xml.entries.entry[3]."@absolute_time"
+        xml.entries.entry[3]."@log".text() == 'message3'
+        xml.entries.entry[3]."@level".text() == 'DEBUG'
+        xml.entries.entry[3]."@time".size() == 0
+        xml.entries.entry[3]."@node".size() == 0
+        xml.entries.entry[3]."@stepctx".text() == '1'
+        xml.entries.entry[3]."@removed".size() == 0
+
+        xml.entries.entry[4]."@absolute_time".size() == 0
+        xml.entries.entry[4]."@log".text() == 'message4'
+        xml.entries.entry[4]."@level".size() == 0
+        xml.entries.entry[4]."@time".size() == 0
+        xml.entries.entry[4]."@node".size() == 0
+        xml.entries.entry[4]."@stepctx".size() == 0
+        xml.entries.entry[4]."@removed".text() == 'stepctx'
 
     }
 }

--- a/rundeckapp/test/unit/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -328,6 +328,12 @@ class ExecutionControllerSpec extends Specification {
         }
         def reader = new ExecutionLogReader(state: ExecutionLogState.AVAILABLE)
         def date1 = new Date(90000000)
+        def sdf=new SimpleDateFormat('yyyy-MM-dd\'T\'HH:mm:ssXXX')
+        sdf.timeZone=TimeZone.getTimeZone('GMT')
+        def abstime=sdf.format(date1)
+        def sdf2=new SimpleDateFormat('HH:mm:ss')
+//        sdf2.timeZone=TimeZone.getTimeZone('GMT')
+        def timestr=sdf2.format(date1)
         reader.reader = new TestReader(logs:
                                                [
                                                        new DefaultLogEvent(
@@ -380,10 +386,10 @@ class ExecutionControllerSpec extends Specification {
         json.compactedAttr == 'log'
         json.entries.size() == 5
         json.entries[0] == [
-                absolute_time: '1970-01-02T01:00:00Z',
+                absolute_time: abstime,
                 log          : 'message1',
                 level        : 'NORMAL',
-                time         : '17:00:00',
+                time         : timestr,
         ]
         json.entries[1] == 'message2'
         json.entries[2] == [:]
@@ -447,6 +453,9 @@ class ExecutionControllerSpec extends Specification {
         def sdf=new SimpleDateFormat('yyyy-MM-dd\'T\'HH:mm:ssXXX')
         sdf.timeZone=TimeZone.getTimeZone('GMT')
         def abstime=sdf.format(date1)
+        def sdf2=new SimpleDateFormat('HH:mm:ss')
+//        sdf2.timeZone=TimeZone.getTimeZone('GMT')
+        def timestr=sdf2.format(date1)
         reader.reader = new TestReader(logs:
                                                [
                                                        new DefaultLogEvent(
@@ -502,7 +511,7 @@ class ExecutionControllerSpec extends Specification {
         xml.entries.entry[0]."@absolute_time".text() == abstime
         xml.entries.entry[0]."@log".text() == 'message1'
         xml.entries.entry[0]."@level".text() == 'NORMAL'
-        xml.entries.entry[0]."@time".text() == '17:00:00'
+        xml.entries.entry[0]."@time".text() == timestr
         xml.entries.entry[0]."@time".size() == 1
         xml.entries.entry[0]."@node".size() == 0
         xml.entries.entry[0]."@stepctx".size() == 0

--- a/rundeckapp/test/unit/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -48,6 +48,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import javax.servlet.http.HttpServletResponse
+import java.text.SimpleDateFormat
 
 /**
  * Created by greg on 1/6/16.
@@ -443,6 +444,9 @@ class ExecutionControllerSpec extends Specification {
         }
         def reader = new ExecutionLogReader(state: ExecutionLogState.AVAILABLE)
         def date1 = new Date(90000000)
+        def sdf=new SimpleDateFormat('yyyy-MM-dd\'T\'HH:mm:ssXXX')
+        sdf.timeZone=TimeZone.getTimeZone('GMT')
+        def abstime=sdf.format(date1)
         reader.reader = new TestReader(logs:
                                                [
                                                        new DefaultLogEvent(
@@ -495,7 +499,7 @@ class ExecutionControllerSpec extends Specification {
         xml.compacted.text() == 'true'
         xml.entries.entry.size() == 5
 
-        xml.entries.entry[0]."@absolute_time".text() == '1970-01-02T01:00:00Z'
+        xml.entries.entry[0]."@absolute_time".text() == abstime
         xml.entries.entry[0]."@log".text() == 'message1'
         xml.entries.entry[0]."@level".text() == 'NORMAL'
         xml.entries.entry[0]."@time".text() == '17:00:00'

--- a/rundeckapp/test/unit/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -367,7 +367,7 @@ class ExecutionControllerSpec extends Specification {
         when:
         params.id = e1.id.toString()
         params.compacted = 'true'
-        request.api_version = 12
+        request.api_version = 21
         response.format = 'json'
         controller.apiExecutionOutput()
         def json = response.json

--- a/rundeckapp/test/unit/rundeck/services/LogFileStorageServiceSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/services/LogFileStorageServiceSpec.groovy
@@ -422,12 +422,14 @@ class LogFileStorageServiceSpec extends Specification {
         given:
         grailsApplication.config.clear()
         grailsApplication.config.rundeck.execution.logs.fileStorage.remotePendingDelay = pend
-        def outFile = new File(tempDir, "1.rdlog")
-        def outFilePart = new File(tempDir, "1.rdlog.part")
+        def outFile = new File(tempDir, "rundeck/test/run/logs/1.rdlog")
+        def outFilePart = new File(tempDir, "rundeck/test/run/logs/1.rdlog.part")
         if (loData) {
-            outFile.text = 'test-partial.complete'
+            outFile.parentFile.mkdirs()
+            outFile.text = 'test-complete'
         }
         if (loPart) {
+            outFile.parentFile.mkdirs()
             outFilePart.text = 'test-partial'
         }
         def now = new Date()
@@ -443,6 +445,13 @@ class LogFileStorageServiceSpec extends Specification {
             getPartialRetrieveSupported() >> supports
             isAvailable(filetype) >> reData
             isPartialAvailable(filetype) >> rePart
+        }
+
+        service.frameworkService = Mock(FrameworkService) {
+            getFrameworkProperties() >> (['framework.logs.dir': tempDir.getAbsolutePath()] as Properties)
+        }
+        service.configurationService = Mock(ConfigurationService) {
+            getTimeDuration('execution.logs.fileStorage.checkpoint.time.interval', '30s', _) >> 30
         }
         when:
         def result = service.getLogFileState(exec, filetype, plugin, getPart)

--- a/rundeckapp/test/unit/rundeck/services/LogFileStorageServiceSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/services/LogFileStorageServiceSpec.groovy
@@ -17,6 +17,7 @@
 package rundeck.services
 
 import asset.pipeline.grails.LinkGenerator
+import com.dtolabs.rundeck.core.logging.ExecutionFileStorageOptions
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
 import com.dtolabs.rundeck.plugins.logging.ExecutionFileStoragePlugin
 import com.dtolabs.rundeck.server.plugins.ConfiguredPlugin
@@ -24,9 +25,19 @@ import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import rundeck.Execution
 import rundeck.LogFileStorageRequest
+import rundeck.services.logging.ExecutionLogState
 import spock.lang.Specification
+import spock.lang.Unroll
 
+import java.nio.file.Files
 import java.util.concurrent.ScheduledExecutorService
+
+import static rundeck.services.logging.ExecutionLogState.AVAILABLE
+import static rundeck.services.logging.ExecutionLogState.AVAILABLE_PARTIAL
+import static rundeck.services.logging.ExecutionLogState.AVAILABLE_REMOTE
+import static rundeck.services.logging.ExecutionLogState.AVAILABLE_REMOTE_PARTIAL
+import static rundeck.services.logging.ExecutionLogState.NOT_FOUND
+import static rundeck.services.logging.ExecutionLogState.PENDING_REMOTE
 
 /**
  * Created by greg on 3/28/16.
@@ -34,6 +45,16 @@ import java.util.concurrent.ScheduledExecutorService
 @Mock([LogFileStorageRequest, Execution])
 @TestFor(LogFileStorageService)
 class LogFileStorageServiceSpec extends Specification {
+    File tempDir
+
+    def setup() {
+        tempDir = Files.createTempDirectory("LogFileStorageServiceSpec").toFile()
+    }
+
+    def cleanup() {
+
+
+    }
 
     def "resume incomplete delayed"() {
         given:
@@ -342,5 +363,120 @@ class LogFileStorageServiceSpec extends Specification {
         1 == service.retryIncompleteRequests.size()
         2 == LogFileStorageRequest.count()
 
+    }
+
+    @Unroll
+    def "generateLocalPathForExecutionFile"() {
+        given:
+        def exec = new Execution(dateStarted: new Date(),
+                                 dateCompleted: null,
+                                 user: 'user1',
+                                 project: 'test',
+                                 serverNodeUUID: null
+        ).save()
+
+
+        expect:
+        result == service.generateLocalPathForExecutionFile(exec, type, partial)
+
+        where:
+        type    | partial | result
+        'rdlog' | false   | 'test/run/logs/1.rdlog'
+        'rdlog' | true    | 'test/run/logs/1.rdlog.part'
+    }
+
+    @Unroll
+    def "getFileForExecutionFiletype partial"() {
+        given:
+        def exec = new Execution(dateStarted: new Date(),
+                                 dateCompleted: null,
+                                 user: 'user1',
+                                 project: 'test',
+                                 serverNodeUUID: null,
+                                 outputfilepath: '/tmp/test/logs/blah/1.rdlog'
+        ).save()
+
+        service.frameworkService = Mock(FrameworkService) {
+            getFrameworkProperties() >> (['framework.logs.dir': '/tmp/test/logs'] as Properties)
+        }
+
+        when:
+        def result = service.getFileForExecutionFiletype(exec, type, useStored, true)
+        then:
+        result == new File(expected)
+
+        where:
+        type         | useStored | expected
+        'rdlog'      | false     | '/tmp/test/logs/rundeck/test/run/logs/1.rdlog.part'
+        'state.json' | false     | '/tmp/test/logs/rundeck/test/run/logs/1.state.json.part'
+        'rdlog'      | true      | '/tmp/test/logs/blah/1.rdlog.part'
+        'state.json' | true      | '/tmp/test/logs/blah/1.state.json.part'
+    }
+
+    static interface TestFilePlugin extends ExecutionFileStoragePlugin, ExecutionFileStorageOptions {
+
+    }
+
+    @Unroll
+    def "getLogFileState"() {
+        given:
+        grailsApplication.config.clear()
+        grailsApplication.config.rundeck.execution.logs.fileStorage.remotePendingDelay = pend
+        def outFile = new File(tempDir, "1.rdlog")
+        def outFilePart = new File(tempDir, "1.rdlog.part")
+        if (loData) {
+            outFile.text = 'test-partial.complete'
+        }
+        if (loPart) {
+            outFilePart.text = 'test-partial'
+        }
+        def now = new Date()
+        def exec = new Execution(dateStarted: new Date(now.time - 20000),
+                                 dateCompleted: done ? new Date(now.time - 10000) : null,
+                                 user: 'user1',
+                                 project: 'test',
+                                 serverNodeUUID: null,
+                                 outputfilepath: outFile.absolutePath
+        ).save()
+        def plugin = Mock(TestFilePlugin) {
+            getRetrieveSupported() >> true
+            getPartialRetrieveSupported() >> supports
+            isAvailable(filetype) >> reData
+            isPartialAvailable(filetype) >> rePart
+        }
+        when:
+        def result = service.getLogFileState(exec, filetype, plugin, getPart)
+        then:
+        result.state == eState
+
+        where:
+        filetype | done  | getPart | supports | loData | loPart | reData | rePart | pend | eState
+        //not requesting partial check
+        'rdlog'  | false | false   | false    | false  | false  | false  | false  | 120  | PENDING_REMOTE
+        'rdlog'  | true  | false   | false    | false  | false  | false  | false  | 120  | PENDING_REMOTE
+        'rdlog'  | true  | false   | false    | false  | false  | false  | false  | 1    | NOT_FOUND
+        'rdlog'  | false | false   | false    | true   | false  | false  | false  | 120  | AVAILABLE
+        'rdlog'  | false | false   | false    | false  | true   | false  | false  | 120  | PENDING_REMOTE
+        'rdlog'  | false | false   | false    | false  | false  | true   | false  | 120  | AVAILABLE_REMOTE
+        'rdlog'  | false | false   | false    | false  | false  | false  | true   | 120  | PENDING_REMOTE
+        'rdlog'  | false | false   | false    | false  | false  | true   | true   | 120  | AVAILABLE_REMOTE
+        //requesting partial check, not supported
+        'rdlog'  | false | true    | false    | false  | false  | false  | false  | 120  | PENDING_REMOTE
+        'rdlog'  | true  | true    | false    | false  | false  | false  | false  | 120  | PENDING_REMOTE
+        'rdlog'  | true  | true    | false    | false  | false  | false  | false  | 1    | NOT_FOUND
+        'rdlog'  | false | true    | false    | true   | false  | false  | false  | 120  | AVAILABLE
+        'rdlog'  | false | true    | false    | false  | true   | false  | false  | 120  | PENDING_REMOTE
+        'rdlog'  | false | true    | false    | false  | false  | true   | false  | 120  | AVAILABLE_REMOTE
+        'rdlog'  | false | true    | false    | false  | false  | false  | true   | 120  | PENDING_REMOTE
+        'rdlog'  | false | true    | false    | false  | false  | true   | true   | 120  | AVAILABLE_REMOTE
+        //requesting partial check, is supported
+        'rdlog'  | false | true    | true     | false  | false  | false  | false  | 120  | PENDING_REMOTE
+        'rdlog'  | true  | true    | true     | false  | false  | false  | false  | 120  | PENDING_REMOTE
+        'rdlog'  | true  | true    | true     | false  | false  | false  | false  | 1    | NOT_FOUND
+        'rdlog'  | false | true    | true     | true   | false  | false  | false  | 120  | AVAILABLE
+        'rdlog'  | false | true    | true     | false  | true   | false  | false  | 120  | AVAILABLE_PARTIAL
+        'rdlog'  | false | true    | true     | false  | false  | true   | false  | 120  | AVAILABLE_REMOTE
+        'rdlog'  | false | true    | true     | false  | false  | false  | true   | 120  | AVAILABLE_REMOTE_PARTIAL
+        'rdlog'  | false | true    | true     | false  | false  | true   | true   | 120  | AVAILABLE_REMOTE
     }
 }

--- a/rundeckapp/test/unit/rundeck/services/LoggingServiceTests.groovy
+++ b/rundeckapp/test/unit/rundeck/services/LoggingServiceTests.groovy
@@ -131,7 +131,8 @@ class LoggingServiceTests  {
             assertEquals([test: "blah"], defaultMeta)
             writer
         }
-        lfmock.demand.getFileForExecutionFiletype(1..1) { Execution e2, String filetype, boolean stored ->
+        lfmock.demand.getFileForExecutionFiletype(1..1) {
+            Execution e2, String filetype, boolean stored, boolean partial ->
             assertEquals(1, e2.id)
             assertEquals("rdlog", filetype)
             assertEquals(false, stored)
@@ -204,7 +205,8 @@ class LoggingServiceTests  {
             assertEquals(null,x)
             writer
         }
-        lfmock.demand.getFileForExecutionFiletype(1..1) { Execution e2, String filetype, boolean stored ->
+        lfmock.demand.getFileForExecutionFiletype(1..1) {
+            Execution e2, String filetype, boolean stored, boolean partial ->
             assertEquals(1, e2.id)
             assertEquals("rdlog", filetype)
             assertEquals(false, stored)
@@ -243,7 +245,8 @@ class LoggingServiceTests  {
             assertNotNull("expected a value watcher for logging file size threshold",x)
             writer
         }
-        lfmock.demand.getFileForExecutionFiletype(1..1) { Execution e2, String filetype, boolean stored ->
+        lfmock.demand.getFileForExecutionFiletype(1..1) {
+            Execution e2, String filetype, boolean stored, boolean partial ->
             assertEquals(1, e2.id)
             assertEquals("rdlog", filetype)
             assertEquals(false, stored)
@@ -279,7 +282,8 @@ class LoggingServiceTests  {
             assertNull("expected no logging file size threshold",x)
             writer
         }
-        lfmock.demand.getFileForExecutionFiletype(1..1) { Execution e2, String filetype, boolean stored ->
+        lfmock.demand.getFileForExecutionFiletype(1..1) {
+            Execution e2, String filetype, boolean stored, boolean partial ->
             assertEquals(1, e2.id)
             assertEquals("rdlog", filetype)
             assertEquals(false, stored)
@@ -321,7 +325,8 @@ class LoggingServiceTests  {
             assertNull("expected no logging file size threshold",x)
             writer
         }
-        lfmock.demand.getFileForExecutionFiletype(1..1) { Execution e2, String filetype, boolean stored ->
+        lfmock.demand.getFileForExecutionFiletype(1..1) {
+            Execution e2, String filetype, boolean stored, boolean partial ->
             assertEquals(1, e2.id)
             assertEquals("rdlog", filetype)
             assertEquals(false, stored)

--- a/rundeckapp/web-app/js/executionState.js
+++ b/rundeckapp/web-app/js/executionState.js
@@ -103,8 +103,9 @@ var FlowState = Class.create({
         return parent?parent:$(elem).parentNode;
     },
     /**
-     * Create a clone of a template node, which has data-template=(template name), and attach it to the discovered parent node, which is
-     * either the immediate parentNode, or an ancestor node with data-template-parent=(template name).
+     * Create a clone of a template node, which has data-template=(template name), and attach it to the discovered
+     * parent node, which is either the immediate parentNode, or an ancestor node with data-template-parent=(template
+     * name).
      * @param e target node containing the template node
      * @param templ name of the template
      * @returns cloned node, or null if the template was not found
@@ -230,8 +231,13 @@ var FlowState = Class.create({
         }else{
             this.updateError(data.error,json);
         }
+
         if (data.error && this.retry>=0 || !json.completed && this.shouldUpdate) {
-            this.timer = setTimeout(this.callUpdate.bind(this), this.reloadInterval);
+            var reloadTime = this.reloadInterval;
+            if (json.retryBackoff) {
+                reloadTime = Math.max(this.reloadInterval, json.retryBackoff);
+            }
+            this.timer = setTimeout(this.callUpdate.bind(this), reloadTime);
         } else {
             this.stopFollowing(json.completed);
         }

--- a/test/api/test-execution-output-plain.sh
+++ b/test/api/test-execution-output-plain.sh
@@ -85,7 +85,7 @@ while [[ $ddone == "false" && $dc -lt $dmax ]]; do
     unmod=$(grep 'X-Rundeck-ExecOutput-Unmodified:' $DIR/headers.out | cut -d' ' -f 2 | tr -d "\r\n")
     doff=$(grep 'X-Rundeck-ExecOutput-Offset:' $DIR/headers.out | cut -d' ' -f 2 | tr -d "\r\n")
     dlast=$(grep 'X-Rundeck-ExecOutput-LastModifed:' $DIR/headers.out | cut -d' ' -f 2 | tr -d "\r\n")
-    ddone=$(grep 'X-Rundeck-ExecOutput-Completed:' $DIR/headers.out | cut -d' ' -f 2 | tr -d "\r\n")
+    ddone=$(grep 'X-Rundeck-Exec-Completed:' $DIR/headers.out | cut -d' ' -f 2 | tr -d "\r\n")
     #echo "unmod $unmod"
     #echo "doff $doff"
     #echo "dlast $dlast"

--- a/test/api/test-execution-output-utf8.sh
+++ b/test/api/test-execution-output-utf8.sh
@@ -85,7 +85,7 @@ while [[ $ddone == "false" && $dc -lt $dmax ]]; do
     unmod=$(grep 'X-Rundeck-ExecOutput-Unmodified:' $DIR/headers.out | cut -d' ' -f 2 | tr -d "\r\n")
     doff=$(grep 'X-Rundeck-ExecOutput-Offset:' $DIR/headers.out | cut -d' ' -f 2 | tr -d "\r\n")
     dlast=$(grep 'X-Rundeck-ExecOutput-LastModifed:' $DIR/headers.out | cut -d' ' -f 2 | tr -d "\r\n")
-    ddone=$(grep 'X-Rundeck-ExecOutput-Completed:' $DIR/headers.out | cut -d' ' -f 2 | tr -d "\r\n")
+    ddone=$(grep 'X-Rundeck-Exec-Completed:' $DIR/headers.out | cut -d' ' -f 2 | tr -d "\r\n")
     #echo "unmod $unmod"
     #echo "doff $doff"
     #echo "dlast $dlast"


### PR DESCRIPTION
Adds partial log/state file checkpointing when a ExecutionFileStoragePlugin supports it. Adds visibility of live executions in cluster mode with a compatible plugin.

* Update ExecutionFileStoragePlugin to support partial available/retrieve/store actions
* When executing, based on size increments and time intervals, the state and rdlog files will be stored as-is as "partial" log files
* When viewing an execution on another cluster member, state/log file loading will periodically retrieve available 'partial' files for display. once the 'complete' state/log files are available they will be retrieved normally, and any partial files removed

Related changes:

* GUI: logging result ajax requests will backoff when rundeck knows the result will be cached
* GUI: add "compacted" log file output format to reduce size of log file output sent to GUI

Configuration in rundeck-config.properties

~~~ {.properties}
# interval between checkpoints, as a time duration such as '5m' or '30s'
rundeck.execution.logs.fileStorage.checkpoint.time.interval=30s


# minimum time before first checkpoint, as a time duration such as '5m' or '30s'
rundeck.execution.logs.fileStorage.checkpoint.time.minimum=30s

# optional file size increment between checkpoints, as a file size such as '12K' or '1M'
rundeck.execution.logs.fileStorage.checkpoint.fileSize.increment=0

#  optional minimum file size before first checkpoint, as a file size such as '12K'
rundeck.execution.logs.fileStorage.checkpoint.fileSize.minimum=0
~~~