### PR TITLE
Use debian standard naming convention for .deb files

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -91,7 +91,7 @@ deb:
 	@unzip -oq ../rundeckapp/target/rundeck-$(JVERS).war -d debdist/var/lib/rundeck/exp/webapp/
 	@ln -s /etc/rundeck/log4j.properties; mv log4j.properties debdist/var/lib/rundeck/exp/webapp/WEB-INF/classes
 	fakeroot dpkg-deb --build -Zgzip debdist
-	@mv debdist.deb rundeck-$(VERSION)-$(RELEASE)$(DEB_TAG).deb
+	@mv debdist.deb rundeck_$(VERSION)-$(RELEASE)$(DEB_TAG)_all.deb
 
 clean: rpmclean debclean
 


### PR DESCRIPTION
Change the .deb naming convention to a standard one to avoid potential problems. More details in issue

Fixes https://github.com/rundeck/rundeck/issues/2777