### PR TITLE
Simple syntax error messages on ACL

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/YamlParsePolicy.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/YamlParsePolicy.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -661,7 +662,7 @@ public class YamlParsePolicy implements Policy {
                                     if (null != validation) {
                                         validation.addError(
                                                 currentIdentity(),
-                                                "Error parsing the policy document: " + e.getCause().getMessage()
+                                                "Error parsing the policy document: " +extractSyntaxError(e.getCause().getMessage())
                                         );
                                     }
                                     return null;
@@ -697,6 +698,17 @@ public class YamlParsePolicy implements Policy {
                 };
             }
 
+            private String extractSyntaxError(String error){
+                if(error != null) {
+                    Pattern pattern = Pattern.compile("Unable to find property\\s(.+)\\son class");
+                    Matcher matcher = pattern.matcher(error);
+                    if (matcher.find() && null != matcher.group(1)) {
+                        return "Unknown property: " + matcher.group(1);
+                    }
+                }
+                return error;
+
+            }
 
             @Override
             public void close() throws IOException {


### PR DESCRIPTION
On syntax exception it encapsulate the code, from this:
```
Error parsing the policy document: Cannot create property=for for JavaBean=Policy{context=null, description='Admin project level access control. Applies to resources within a specific project.', for=null, by=null, id='null'}; Cannot create property=eqauals for JavaBean=Rule{}; Unable to find property 'eqauals' on class: com.dtolabs.rundeck.core.authorization.providers.yaml.model.ACLPolicyDoc$TypeRule
```
to this:
<img width="760" alt="image" src="https://user-images.githubusercontent.com/2894508/31557934-46f4e2d6-b021-11e7-89b9-faec807b095c.png">
