### PR TITLE
Separate notifications for retryable failures

### DIFF
--- a/docs/en/developer/05-notification-plugins.md
+++ b/docs/en/developer/05-notification-plugins.md
@@ -12,6 +12,7 @@ Currently there are three conditions that can trigger notifications:
 * `onsuccess` - the Job completed without error
 * `onfailure` - the Job failed or was aborted
 * `onavgduration` - The Execution exceed the average duration of the Job
+* `onretryablefailure` - the Job failed but will be retried
 
 Rundeck has two built-in notification types that can be configured for Jobs:
 
@@ -289,7 +290,7 @@ The user is presented with any `Instance` scoped properties in the Rundeck GUI w
 
 ### Notification handlers
 
-For a `NotificationPlugin`, you can define custom handlers for each of the notification triggers (`onsuccess`, `onfailure`, `onstart` and `onavgduration`).
+For a `NotificationPlugin`, you can define custom handlers for each of the notification triggers (`onsuccess`, `onfailure`, `onstart`, `onavgduration`, and `onretryablefailure`).
 
 Simply define a closure with the given trigger name, and return a true value if your action was successful:
 
@@ -311,7 +312,12 @@ onfailure{ Map execution, Map configuration ->
 }
 onavgduration{ Map execution, Map configuration ->
     //perform an action using the execution and configuration
-    println "Job ${execution.job.name} exceeded Average Duration!."
+    println "Job ${execution.job.name} exceeded Average Duration!"
+    return true
+}
+onretryablefailure{ Map execution, Map configuration ->
+    //perform an action using the execution and configuration
+    println "Job ${execution.job.name} failed but will be retried."
     return true
 }
 ~~~~~~~~
@@ -344,6 +350,10 @@ rundeckPlugin(NotificationPlugin){
     }
     onavgduration{
         println("exceeded average duration: data ${execution}")
+        true
+    }
+    onretryablefailure{
+        println("retryable failure: data ${execution}")
         true
     }
 }
@@ -414,6 +424,11 @@ rundeckPlugin(NotificationPlugin) {
 
     onavgduration { Map executionData,Map config ->
         println("script, exceeded average duration: data ${executionData}, config: ${config}")
+        true
+    }
+
+    onretryablefailure { Map executionData,Map config ->
+        println("script, retryable failure: data ${executionData}, config: ${config}")
         true
     }
 }

--- a/docs/en/manpages/man5/job-v20.md
+++ b/docs/en/manpages/man5/job-v20.md
@@ -1187,6 +1187,10 @@ Defines email, webhook or plugin notifications for Job success and failure, with
 
 :    define notifications when exceed average duration
 
+[onretryablefailure][]
+
+:    define notifications when job fails but will be retried
+
 *Example*
 
 ~~~~~~~~ {.xml}
@@ -1209,6 +1213,9 @@ Defines email, webhook or plugin notifications for Job success and failure, with
         <email recipients='test@example.com' subject='Job Exceeded average duration' />
         <plugin type='MinimalNotificationPlugin' />
       </onavgduration>
+    <onfailure>
+        <email recipients="test@example.com,foo@example.com" subject='Job will be retried' />
+    </onfailure>
 </notification>      
 ~~~~~~~~ 
 
@@ -1257,9 +1264,20 @@ Embed an [webhook](#webhook) element to perform a HTTP POST to some URLs, within
 Embed an [plugin](#plugin) element to perform a custom action, within
 [notification](#notification).
 
+### onretryablefailure
+
+Embed an [email](#email) element to send email on failure with retries scheduled, within
+[notification](#notification).
+
+Embed an [webhook](#webhook) element to perform a HTTP POST to some URLs, within
+[notification](#notification).
+
+Embed an [plugin](#plugin) element to perform a custom action, within
+[notification](#notification).
+
 ### email 
 
-Define email recipients for Job execution result, within [onsuccess][], [onfailure][], [onstart][] or [onavgduration][].
+Define email recipients for Job execution result, within [onsuccess][], [onfailure][], [onstart][], [onavgduration][], or [onretryablefailure][].
 
 *Attributes*
 
@@ -1273,7 +1291,7 @@ recipients
 
 ### webhook
 
-Define URLs to submit a HTTP POST to containing the job execution result, within [onsuccess][], [onfailure][], [onstart][] or [onavgduration][].
+Define URLs to submit a HTTP POST to containing the job execution result, within [onsuccess][], [onfailure][], [onstart][], [onavgduration][], or [onretryablefailure][].
 
 
 *Attributes*
@@ -1293,7 +1311,7 @@ urls
 
 ### plugin
 
-Defines a configuration for a plugin to perform a Notification, within [onsuccess][], [onfailure][], [onstart][] or [onavgduration][].
+Defines a configuration for a plugin to perform a Notification, within [onsuccess][], [onfailure][], [onstart][], [onavgduration][], or [onretryablefailure][].
 
 *Attributes*
 
@@ -1358,3 +1376,4 @@ The Rundeck source code and all documentation may be downloaded from
 [onfailure]: #onfailure
 [onstart]: #onstart
 [onavgduration]: #onavgduration
+[onretryablefailure]: #onretryablefailure

--- a/docs/en/manpages/man5/job-yaml-v12.md
+++ b/docs/en/manpages/man5/job-yaml-v12.md
@@ -828,10 +828,10 @@ Deprecated Example:
 
 ### Notification
 
-Defines a notification for the job.  You can include any of `onsuccess`, `onfailure`, `onstart` or `onavgduration` notifications. Each type of notification can define any of the built in notifications, or define plugin notifications.
+Defines a notification for the job.  You can include any of `onsuccess`, `onfailure`, `onstart`, `onavgduration`, or `onretryablefailure` notifications. Each type of notification can define any of the built in notifications, or define plugin notifications.
 
 
-`onsuccess`/`onfailure`/`onstart`/`onavgduration`
+`onsuccess`/`onfailure`/`onstart`/`onavgduration`/`onretryablefailure`
 
 :    A Map containing either or both of:
 
@@ -872,6 +872,10 @@ Example:
       email:
         recipients: test@example.com
         subject: Job Exceeded average duration
+      plugin:
+        configuration: {}
+        type: MinimalNotificationPlugin
+    onretryablefailure:
       plugin:
         configuration: {}
         type: MinimalNotificationPlugin

--- a/docs/en/plugins-user-guide/configuring.md
+++ b/docs/en/plugins-user-guide/configuring.md
@@ -200,6 +200,7 @@ currently available triggers:
 * `onsuccess` - the Job succeeded
 * `onfailure` - the Job failed
 * `onavgduration` - the Execution exceed the average duration of the Job
+* `onretryablefailure` - the Job failed but will be retried
 
 When you define the Job in the GUI or via [XML](../man5/job-v20.html#notification) or
 [Yaml](../man5/job-yaml-v12.html#notification), you can add any of the available Notification plugin types to happen for

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -88,11 +88,19 @@ class ScheduledExecutionController  extends ControllerBase{
     public static final String ONFAILURE_TRIGGER_NAME = 'onfailure'
     public static final String ONSTART_TRIGGER_NAME = 'onstart'
     public static final String OVERAVGDURATION_TRIGGER_NAME = 'onavgduration'
+    public static final String ONRETRYABLEFAILURE_TRIGGER_NAME = 'onretryablefailure'
     public static final String NOTIFY_OVERAVGDURATION_EMAIL = 'notifyAvgDurationEmail'
     public static final String NOTIFY_OVERAVGDURATION_URL = 'notifyAvgDurationUrl'
     public static final String NOTIFY_ONOVERAVGDURATION_URL = 'notifyOnAvgDurationUrl'
     public static final String NOTIFY_OVERAVGDURATION_RECIPIENTS = 'notifyAvgDurationRecipients'
     public static final String NOTIFY_OVERAVGDURATION_SUBJECT = 'notifyAvgDurationSubject'
+    public static final String NOTIFY_ONRETRYABLEFAILURE_URL = 'notifyOnRetryableFailureUrl'
+    public static final String NOTIFY_ONRETRYABLEFAILURE_EMAIL = 'notifyOnRetryableFailureEmail'
+    public static final String NOTIFY_RETRYABLEFAILURE_EMAIL = 'notifyRetryableFailureEmail'
+    public static final String NOTIFY_RETRYABLEFAILURE_URL = 'notifyRetryableFailureUrl'
+    public static final String NOTIFY_RETRYABLEFAILURE_RECIPIENTS = 'notifyRetryableFailureRecipients'
+    public static final String NOTIFY_RETRYABLEFAILURE_SUBJECT = 'notifyRetryableFailureSubject'
+    public static final String NOTIFY_RETRYABLEFAILURE_ATTACH= 'notifyFailureAttach'
 
     public static final String EMAIL_NOTIFICATION_TYPE = 'email'
     public static final String WEBHOOK_NOTIFICATION_TYPE = 'url'
@@ -104,7 +112,9 @@ class ScheduledExecutionController  extends ControllerBase{
             NOTIFY_ONSTART_EMAIL,
             NOTIFY_ONSTART_URL,
             NOTIFY_OVERAVGDURATION_EMAIL,
-            NOTIFY_ONOVERAVGDURATION_URL
+            NOTIFY_ONOVERAVGDURATION_URL,
+            NOTIFY_ONRETRYABLEFAILURE_EMAIL,
+            NOTIFY_ONRETRYABLEFAILURE_URL
     ]
 
     def Scheduler quartzScheduler

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -66,6 +66,8 @@ class ScheduledExecution extends ExecutionContext {
     String notifyStartUrl
     String notifyAvgDurationRecipients
     String notifyAvgDurationUrl
+    String notifyRetryableFailureRecipients
+    String notifyRetryableFailureUrl
     Boolean multipleExecutions = false
     Orchestrator orchestrator
 
@@ -76,7 +78,8 @@ class ScheduledExecution extends ExecutionContext {
 
     static transients = ['userRoles','adhocExecutionType','notifySuccessRecipients','notifyFailureRecipients',
                          'notifyStartRecipients', 'notifySuccessUrl', 'notifyFailureUrl', 'notifyStartUrl',
-                         'crontabString','averageDuration','notifyAvgDurationRecipients','notifyAvgDurationUrl']
+                         'crontabString','averageDuration','notifyAvgDurationRecipients','notifyAvgDurationUrl',
+                         'notifyRetryableFailureRecipients','notifyRetryableFailureUrl']
 
     static constraints = {
         project(nullable:false, blank: false, matches: FrameworkResource.VALID_RESOURCE_NAME_REGEX)

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -274,6 +274,7 @@ status.label.succeed=Succeeded
 status.label.succeeded=Succeeded
 status.label.fail=Failed
 status.label.failed=Failed
+status.label.failed-with-retry=Failed, will retry
 status.label.cancel=Killed
 status.label.aborted=Killed
 status.label.short.OK=OK
@@ -325,6 +326,7 @@ notification.event.onfailure=On Failure
 notification.event.onsuccess=On Success
 notification.event.onstart=On Start
 notification.event.onavgduration=Average Duration Exceeded
+notification.event.onretryablefailure=On Retryable Failure
 
 #metadata for resources
 resource.metadata.entity.deployment-install-root=Install Root

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -274,6 +274,7 @@ status.label.succeed=Completado
 status.label.succeeded=Completado
 status.label.fail=Fallido
 status.label.failed=Fallido
+status.label.failed-with-retry=Fallido, se volverá a intentar
 status.label.cancel=Eliminado
 status.label.aborted=Eliminado
 status.label.short.OK=OK
@@ -325,6 +326,7 @@ notification.event.onfailure=Por Fracaso
 notification.event.onsuccess=Por Éxito
 notification.event.onstart=Al Inicio
 notification.event.onavgduration=Cuando excede la duración promedio
+notification.event.onretryablefailure=Por Fracaso Reintentable
 
 #metadata for resources
 resource.metadata.entity.deployment-install-root=Instalar Raíz

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -274,6 +274,7 @@ status.label.succeed=\u6210\u529F
 status.label.succeeded=\u6210\u529F
 status.label.fail=\u5931\u8D25
 status.label.failed=\u5931\u8D25
+status.label.failed-with-retry=\u5931\u8D25\uFF0C\u4F1A\u91CD\u65B0\u8BD5
 status.label.cancel=\u505C\u6B62
 status.label.aborted=\u505C\u6B62
 status.label.short.OK=OK
@@ -325,6 +326,7 @@ notification.event.onfailure=On Failure
 notification.event.onsuccess=On Success
 notification.event.onstart=On Start
 notification.event.onavgduration=Average Duration Exceeded
+notification.event.onretryablefailure=On Retryable Failure
 
 #metadata for resources
 resource.metadata.entity.deployment-install-root=Install Root

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2604,7 +2604,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
                 def context = execmap?.thread?.context
                 notificationService.triggerJobNotification(
-                        execution.statusSucceeded() ? 'success' : 'failure',
+                        execution.statusSucceeded() ? 'success' : execution.willRetry ? 'retryablefailure' : 'failure',
                         schedId,
                         [
                                 execution: execution,

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1762,13 +1762,34 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                      content: params[ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL]]
         }
 
+        if ('true' == params[ScheduledExecutionController.NOTIFY_ONRETRYABLEFAILURE_EMAIL]) {
+            def config = [
+                    recipients: params[ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_RECIPIENTS],
+            ]
+            if (params[ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_SUBJECT]) {
+                config.subject = params[ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_SUBJECT]
+            }
+            if (params[ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_ATTACH]!=null) {
+                config.attachLog = params[ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_ATTACH] in ['true', true]
+            }
+            nots << [eventTrigger: ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME,
+                     type: ScheduledExecutionController.EMAIL_NOTIFICATION_TYPE,
+                     configuration: config
+            ]
+        }
+        if ('true' == params[ScheduledExecutionController.NOTIFY_ONRETRYABLEFAILURE_URL]) {
+            nots << [eventTrigger: ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME,
+                     type: ScheduledExecutionController.WEBHOOK_NOTIFICATION_TYPE,
+                     content: params[ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_URL]]
+        }
 
 
         //notifyOnsuccessPlugin
         if (params.notifyPlugin) {
             [ScheduledExecutionController.ONSUCCESS_TRIGGER_NAME, ScheduledExecutionController
                     .ONFAILURE_TRIGGER_NAME, ScheduledExecutionController.ONSTART_TRIGGER_NAME,
-             ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME].each { trig ->
+             ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME,
+             ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME].each { trig ->
 //                params.notifyPlugin.each { trig, plug ->
                 def plugs = params.notifyPlugin[trig]
                 if (plugs) {
@@ -2422,6 +2443,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                         ScheduledExecutionController.NOTIFY_START_RECIPIENTS,
                 (ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME):
                         ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS,
+                (ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME):
+                        ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_RECIPIENTS,
         ]
         def conf = notif.configuration
         def arr = (conf?.recipients?: notif.content)?.split(",")
@@ -2471,6 +2494,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 (ScheduledExecutionController.ONFAILURE_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_FAILURE_URL,
                 (ScheduledExecutionController.ONSTART_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_START_URL,
                 (ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL,
+                (ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_URL,
         ]
         def arr = notif.content.split(",")
         def validCount=0
@@ -2526,12 +2550,15 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                         ScheduledExecutionController.NOTIFY_START_RECIPIENTS,
                 (ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME):
                         ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS,
+                (ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME):
+                        ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_RECIPIENTS,
         ]
         def fieldNamesUrl = [
                 (ScheduledExecutionController.ONSUCCESS_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_SUCCESS_URL,
                 (ScheduledExecutionController.ONFAILURE_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_FAILURE_URL,
                 (ScheduledExecutionController.ONSTART_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_START_URL,
                 (ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL,
+                (ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME): ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_URL,
         ]
         
         def addedNotifications=[]

--- a/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsForm.gsp
@@ -39,6 +39,10 @@
 <g:set var="isAvgUrl"
        value="${'true' == params[ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL] || null == params[ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL] && defAvgUrl}"/>
 
+<g:set var="defRetryableFailure" value="${scheduledExecution.findNotification(ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME, ScheduledExecutionController.EMAIL_NOTIFICATION_TYPE)}"/>
+<g:set var="isRetryableFailure" value="${'true' == params[ScheduledExecutionController.NOTIFY_ONRETRYABLEFAILURE_EMAIL] || null == params[ScheduledExecutionController.NOTIFY_ONRETRYABLEFAILURE_EMAIL] &&defFailure}"/>
+<g:set var="defRetryableFailureUrl" value="${scheduledExecution.findNotification(ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME, ScheduledExecutionController.WEBHOOK_NOTIFICATION_TYPE)}"/>
+<g:set var="isRetryableFailureUrl" value="${'true' == params[ScheduledExecutionController.NOTIFY_ONRETRYABLEFAILURE_URL] || null == params[ScheduledExecutionController.NOTIFY_ONRETRYABLEFAILURE_URL] &&defFailureUrl}"/>
 
 
 <div class="form-group">
@@ -139,6 +143,25 @@
                   defEmail: defAvg,
                   defUrl: defAvgUrl,
                   definedNotifications: scheduledExecution.notifications?.findAll { it.eventTrigger == ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME },
+                  adminauth: adminauth,
+                  serviceName: ServiceNameConstants.Notification
+          ]}"/>
+
+<g:render template="/scheduledExecution/editNotificationsTriggerForm"
+          model="${[
+                  isVisible: (notifications|| params.notified == 'true'),
+                  trigger: ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME,
+                  triggerEmailCheckboxName: ScheduledExecutionController.NOTIFY_ONRETRYABLEFAILURE_EMAIL,
+                  triggerEmailRecipientsName: ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_RECIPIENTS,
+                  triggerEmailSubjectName: ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_SUBJECT,
+                  triggerEmailAttachName: ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_ATTACH,
+                  triggerUrlCheckboxName: ScheduledExecutionController.NOTIFY_ONRETRYABLEFAILURE_URL,
+                  triggerUrlFieldName: ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_URL,
+                  isEmail: isRetryableFailure,
+                  isUrl: isRetryableFailureUrl,
+                  defEmail: defRetryableFailure,
+                  defUrl: defRetryableFailureUrl,
+                  definedNotifications: scheduledExecution.notifications?.findAll { it.eventTrigger == ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME },
                   adminauth: adminauth,
                   serviceName: ServiceNameConstants.Notification
           ]}"/>

--- a/rundeckapp/test/unit/ScheduledExecutionServiceTests.groovy
+++ b/rundeckapp/test/unit/ScheduledExecutionServiceTests.groovy
@@ -109,6 +109,37 @@ public class ScheduledExecutionServiceTests {
                         (ScheduledExecutionController.NOTIFY_FAILURE_URL): 'http://blah.com']
         )
     }
+
+    public void testParseParamNotificationsRetryableFailure() {
+        assertParseParamNotifications(
+                [[eventTrigger: ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME,
+                        type: ScheduledExecutionController.EMAIL_NOTIFICATION_TYPE,
+                        configuration: [recipients:'c@example.com,d@example.com']]],
+                [(ScheduledExecutionController.NOTIFY_ONRETRYABLEFAILURE_EMAIL): 'true',
+                        (ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_RECIPIENTS): 'c@example.com,d@example.com']
+        )
+    }
+    public void testParseParamNotificationsRetryableFailure_subject() {
+        assertParseParamNotifications(
+                [[eventTrigger: ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME,
+                        type: ScheduledExecutionController.EMAIL_NOTIFICATION_TYPE,
+                        configuration: [recipients: 'c@example.com,d@example.com', subject:
+                                'elf']]],
+                [(ScheduledExecutionController.NOTIFY_ONRETRYABLEFAILURE_EMAIL): 'true',
+                        (ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_RECIPIENTS): 'c@example.com,d@example.com',
+                        (ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_SUBJECT): 'elf']
+        )
+    }
+
+    public void testParseParamNotificationsRetryableFailureUrl() {
+        assertParseParamNotifications(
+                [[eventTrigger: ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME,
+                        type: ScheduledExecutionController.WEBHOOK_NOTIFICATION_TYPE,
+                        content: 'http://blah.com']],
+                [(ScheduledExecutionController.NOTIFY_ONRETRYABLEFAILURE_URL): 'true',
+                        (ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_URL): 'http://blah.com']
+        )
+    }
     public void testParseParamNotificationsStart() {
         assertParseParamNotifications(
                 [[eventTrigger: ScheduledExecutionController.ONFAILURE_TRIGGER_NAME,
@@ -164,6 +195,24 @@ public class ScheduledExecutionServiceTests {
                 [
                         notifyPlugin: [
                                 (ScheduledExecutionController.ONFAILURE_TRIGGER_NAME): [
+                                        type: 'plugin1',
+                                        enabled: [
+                                                'plugin1': 'true'
+                                        ],
+                                        'plugin1': [
+                                                config: [:]
+                                        ]
+                                ]
+                        ],
+                ]
+        )
+    }
+    public void testParseParamNotificationsRetryableFailurePluginEnabled() {
+        assertParseParamNotifications(
+                [[eventTrigger: ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME, type: 'plugin1', configuration: [:]]],
+                [
+                        notifyPlugin: [
+                                (ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME): [
                                         type: 'plugin1',
                                         enabled: [
                                                 'plugin1': 'true'

--- a/rundeckapp/test/unit/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -764,6 +764,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         ScheduledExecutionController.ONFAILURE_TRIGGER_NAME | 'email' | 'c@example.com,d@example.com'
         ScheduledExecutionController.ONSTART_TRIGGER_NAME   | 'email' | 'c@example.com,d@example.com'
         ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'email' | 'c@example.com,d@example.com'
+        ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME | 'email' | 'c@example.com,d@example.com'
     }
     def "validate notifications email data any domain"() {
         given:
@@ -795,7 +796,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         ScheduledExecutionController.ONFAILURE_TRIGGER_NAME | 'email' | '${job.user.email}'
         ScheduledExecutionController.ONSTART_TRIGGER_NAME   | 'email' | 'monkey@internal'
         ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'email' | 'user@test'
-
+        ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME | 'email' | 'example@any.domain'
     }
     def "invalid notifications data"() {
         given:
@@ -836,6 +837,10 @@ class ScheduledExecutionServiceSpec extends Specification {
         ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS|ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'email' | 'c@example.com d@example.com'
         ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL|ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'url' | ''
         ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL|ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'url' | 'c@example.com d@example.com'
+        ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_RECIPIENTS|ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME | 'email' | ''
+        ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_RECIPIENTS|ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME | 'email' | 'monkey@ example.com'
+        ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_URL|ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME | 'url' | ''
+        ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_URL|ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME | 'url' | 'monkey@ example.com'
     }
     def "do update job invalid notifications"() {
         given:
@@ -870,6 +875,8 @@ class ScheduledExecutionServiceSpec extends Specification {
         ScheduledExecutionController.NOTIFY_START_URL|ScheduledExecutionController.ONSTART_TRIGGER_NAME   | 'url' | 'c@example.com d@example.com'
         ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS|ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'email' | 'c@example.com d@example.com'
         ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL|ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME   | 'url' | 'c@example.com d@example.com'
+        ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_RECIPIENTS|ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME | 'email' | 'monkey@ example.com'
+        ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_URL|ScheduledExecutionController.ONRETRYABLEFAILURE_TRIGGER_NAME | 'url' | 'monkey@ example.com'
     }
     def "validate notifications email form fields"() {
         given:
@@ -893,6 +900,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         'onfailure'|ScheduledExecutionController.NOTIFY_ONFAILURE_EMAIL | ScheduledExecutionController.NOTIFY_FAILURE_RECIPIENTS | 'c@example.com,d@example.com'
         'onstart'|ScheduledExecutionController.NOTIFY_ONSTART_EMAIL | ScheduledExecutionController.NOTIFY_START_RECIPIENTS | 'c@example.com,d@example.com'
         'onavgduration'|ScheduledExecutionController.NOTIFY_OVERAVGDURATION_EMAIL | ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS | 'c@example.com,d@example.com'
+        'onretryablefailure'|ScheduledExecutionController.NOTIFY_ONRETRYABLEFAILURE_EMAIL | ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_RECIPIENTS | 'c@example.com,d@example.com'
     }
     def "invalid notifications email form fields"() {
         given:
@@ -915,6 +923,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         'onfailure'|ScheduledExecutionController.NOTIFY_ONFAILURE_EMAIL | ScheduledExecutionController.NOTIFY_FAILURE_RECIPIENTS | '@example.com'
         'onstart'|ScheduledExecutionController.NOTIFY_ONSTART_EMAIL | ScheduledExecutionController.NOTIFY_START_RECIPIENTS | 'c@example.'
         'onavgduration'|ScheduledExecutionController.NOTIFY_OVERAVGDURATION_EMAIL | ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS | 'c@example.'
+        'onretryablefailure'|ScheduledExecutionController.NOTIFY_ONRETRYABLEFAILURE_EMAIL | ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_RECIPIENTS | '@example.com'
     }
 
 
@@ -1526,6 +1535,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         'onfailure'|ScheduledExecutionController.NOTIFY_ONFAILURE_EMAIL | ScheduledExecutionController.NOTIFY_FAILURE_RECIPIENTS | 'c@example.com,d@example.com'
         'onstart'|ScheduledExecutionController.NOTIFY_ONSTART_EMAIL | ScheduledExecutionController.NOTIFY_START_RECIPIENTS | 'c@example.com,d@example.com'
         'onavgduration'|ScheduledExecutionController.NOTIFY_OVERAVGDURATION_EMAIL | ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS | 'c@example.com,d@example.com'
+        'onretryablefailure'|ScheduledExecutionController.NOTIFY_ONRETRYABLEFAILURE_EMAIL | ScheduledExecutionController.NOTIFY_RETRYABLEFAILURE_RECIPIENTS | 'c@example.com,d@example.com'
     }
     @Unroll
     def "do update options modify"(){


### PR DESCRIPTION
This addresses issue #1067 by adding a new notification trigger
alongside the existing succeeded, failed, started, and average
duration exceeded notifications.

The new notification is triggered when a job that's configured to
retry on failure fails with retries still remaining. Jobs without
retries enabled never get the new notification.

The "failed" notification is now only sent on the last attempt.