### PR TITLE
Improvement on load jobs page

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Option.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Option.groovy
@@ -123,7 +123,7 @@ public class Option implements Comparable{
     static mapping = {
         table "rdoption"
         valuesUrlLong length:3000
-        values type: 'text', lazy: false
+        values type: 'text'//, lazy: false
         description type: 'text'
         defaultValue type: 'text'
         regex type: 'text'

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -175,7 +175,7 @@ class ScheduledExecution extends ExecutionContext {
         description type: 'text'
         groupPath type: 'string'
 //        orchestrator type: 'text'
-        options lazy: false
+        //options lazy: false
         timeout(type: 'text')
         retry(type: 'text')
         retryDelay(type: 'text')
@@ -206,6 +206,22 @@ class ScheduledExecution extends ExecutionContext {
     public static final monthsofyearlist = ['JAN','FEB','MAR','APR','MAY','JUN','JUL','AUG','SEP','OCT','NOV','DEC'];
 
     String toString() { generateFullName()+" - $description" }
+
+    Map refreshOptions(){
+
+        HashMap map = new HashMap()
+        if(options){
+            map.options = []
+            options.sort().each{Option option->
+
+                def map1 = option.toMap()
+                map1.remove('sortIndex')
+                map.options.add(map1 + [name: option.name])
+            }
+        }
+        return map
+    }
+
     Map toMap(){
         HashMap map = new HashMap()
         map.name=jobName

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -585,6 +585,9 @@ class ExecutionJob implements InterruptableJob {
         def ScheduledExecution se=null
         ScheduledExecution.withNewSession {
             se = ScheduledExecution.get(seid)
+            if(se){
+                se.refreshOptions() //force fetch options and option values before return object
+            }
         }
 
         if (!se) {


### PR DESCRIPTION
Lazy fetch for `ScheduledExecution.options` and `Option.values` and fix for the quartz load scheduleExecution including the options on the return object.
Resulting in approx 25% less on the job list page loading time.