### PR TITLE
Add: Job filter as a context variable

### DIFF
--- a/docs/en/manual/04-jobs.md
+++ b/docs/en/manual/04-jobs.md
@@ -1654,6 +1654,7 @@ Job context variables:
 * `job.retryAttempt`: A number indicating the attempt, if this execution is a [retry](#retry).
 * `job.wasRetry`: `true` if this execution is a retry, otherwise `false`. See: [retry](#retry).
 * `job.threadcount`: Threadcount (number of nodes run at once) of the Job
+* `job.filter`: The filter used to select the nodes for this job (if applicable)
 
 Node context variables:
 

--- a/rundeckapp/grails-app/assets/javascripts/jobedit.js
+++ b/rundeckapp/grails-app/assets/javascripts/jobedit.js
@@ -93,9 +93,10 @@ function _jobVarData() {
             'user.email': {title: 'Email of user executing the job'},
             'retryAttempt': {title: 'Retry attempt number'},
             'wasRetry': {title: 'True if execution is a retry'},
-            'threadcount': {title: 'Job Threadcount'}
+            'threadcount': {title: 'Job Threadcount'},
+            'filter': {title: 'Job Node Filter Query'}
         };
-        ['id', 'execid', 'name', 'group', 'username', 'project', 'loglevel', 'user.email', 'retryAttempt', 'wasRetry', 'threadcount'].each(function (e) {
+        ['id', 'execid', 'name', 'group', 'username', 'project', 'loglevel', 'user.email', 'retryAttempt', 'wasRetry', 'threadcount', 'filter'].each(function (e) {
             _VAR_DATA['job'].push({key: 'job.' + e, category: 'Job', title: jobdata[e].title, desc: jobdata[e].desc});
         });
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -898,6 +898,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             jobcontext.id = execution.scheduledExecution.extid
             jobcontext.successOnEmptyNodeFilter=execution.scheduledExecution.successOnEmptyNodeFilter?"true":"false"
         }
+        if (execution.filter) {
+            jobcontext.filter = execution.filter
+        }
         jobcontext.execid = execution.id.toString()
         jobcontext.executionType = execution.executionType
         jobcontext.serverUrl = generateServerURL(grailsLinkGenerator)

--- a/rundeckapp/test/unit/ExecutionServiceTests.groovy
+++ b/rundeckapp/test/unit/ExecutionServiceTests.groovy
@@ -2092,4 +2092,28 @@ class ExecutionServiceTests  {
         assertNotNull(execs)
         assertTrue(execs.contains(e2))
     }
+
+    void testExportContextForExectuion(){
+        def filterFixture = "foo bar"
+
+        def ex = new Execution(
+                project: "test",
+                user: "test",
+                workflow: new Workflow(
+                        commands: [
+                                new CommandExec(adhocRemoteString: "exec")
+                        ]
+                ),
+                filter: filterFixture
+        )
+
+        def lg = mockFor(org.codehaus.groovy.grails.web.mapping.LinkGenerator)
+        lg.demand.link(2..2) { return '' }
+
+        def jobcontext = ExecutionService.exportContextForExecution(ex, lg.createMock())
+
+        assertEquals(filterFixture, jobcontext.filter)
+
+        lg.verify()
+    }
 }


### PR DESCRIPTION
We have a situation where we need to do the following:

1) have a common deployment job that takes a number of parameters and can deploy any application
2) have individual jobs that reference the common job with the parameters filled in for that specific application
3) have a series of steps performed on each server before the deployment
4) have the deployment happen sequentially
5) only have a single job reference in each of the "individual" jobs (for ease of maintenance and to ensure governance/compliance)
6) have node filters work normally

It looks something like this in reality:

```
Node 1
--- Run puppet
Node 2
--- Run puppet

Node 1
--- Drain load balancer
--- Deploy application
--- Undrain load balancer

Node 2
--- Drain load balancer
--- Deploy application
--- Undrain load balancer

Workflow step
--- Notify deployment metrics
--- Update changelog
```

```
Application Job (with node filter)
└── Deployment Job (option.NODE as node filter) [workflow step] step first ordering
          └── Puppet Job (option.NODE as node filter)
          └── Drain/Deploy/Undrain Job (option.NODE as node filter) node first ordering
                     └── Drain
                     └── Deploy
                     └── UnDrain
          └── Post Deployment Tasks
```

There is currently no way to achieve this in rundeck, the closest we have is to pass in the nodes as an option to the top level job, but then we lose the node filter functionality.

By adding the job.filter variable as a job context variable, and then passing this to the NODE option of each job it is possible. We need job.filter to be available to ensure that the normal filter functionality continues to behave as expected.
