### PR TITLE
Child job - update statistics

### DIFF
--- a/docs/en/developer/01-plugin-development.md
+++ b/docs/en/developer/01-plugin-development.md
@@ -19,7 +19,7 @@ Java plugins are distributed as .jar files containing the necessary classes for
 one or more service provider, as well as any other java jar dependency files.
 
 Each classname listed must be a valid "[Provider Class](#provider-classes)" as defined below,
-and must have a `@Plugin` annotation to define it's service type and provider name.
+and must have a `@Plugin` annotation to define its service type and provider name.
 
 The `.jar` file you distribute must have this metadata within the main Manifest
 for the jar file to be correctly loaded by the system:

--- a/rundeckapp/grails-app/assets/javascripts/historyKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/historyKO.js
@@ -167,6 +167,12 @@ function Report(data) {
         }
         }
     });
+
+    self.textJobRef = function (schedId) {
+        if(self.jobId() != schedId){
+            return '(Referenced)'
+        }
+    };
     ko.mapping.fromJS(data, {}, self);
 }
 function History(ajaxHistoryLink,ajaxNowRunningLink,ajaxBulkDeleteLink) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
@@ -24,7 +24,9 @@ import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.converters.JSON
 import org.grails.plugins.metricsweb.MetricService
+import rundeck.ExecReport
 import rundeck.Execution
+import rundeck.ReferencedExecution
 import rundeck.ScheduledExecution
 import rundeck.services.ApiService
 import rundeck.services.ExecutionService
@@ -121,6 +123,20 @@ class ReportsController extends ControllerBase{
             //auto date filter based on session login
             query.dostartafterFilter=true
             query.startafterFilter=new Date(session.creationTime)
+        }
+        if(params.includeJobRef && params.jobIdFilter){
+            ScheduledExecution.withTransaction {
+                ScheduledExecution sched = ScheduledExecution.get(params.jobIdFilter)
+                def list = ReferencedExecution.findAllByScheduledExecution(sched)
+                def include = []
+                list.each {refex ->
+                    include << String.valueOf(refex.execution.id)
+                }
+                if(include){
+                    query.execIdFilter = include
+                }
+            }
+
         }
 
         if(null!=query){

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
@@ -130,7 +130,18 @@ class ReportsController extends ControllerBase{
                 def list = ReferencedExecution.findAllByScheduledExecution(sched)
                 def include = []
                 list.each {refex ->
-                    include << String.valueOf(refex.execution.id)
+                    boolean add = true
+                    if(refex.execution.project != params.project){
+                        if(unauthorizedResponse(frameworkService.authorizeProjectResourceAll(authContext, AuthorizationUtil
+                                .resourceType('event'), [AuthConstants.ACTION_READ],
+                                params.project), AuthConstants.ACTION_READ,'Events in project',refex.execution.project)){
+                            log.debug('Cant read executions on project '+refex.execution.project)
+                        }else{
+                            include << String.valueOf(refex.execution.id)
+                        }
+                    }else{
+                        include << String.valueOf(refex.execution.id)
+                    }
                 }
                 if(include){
                     query.execIdFilter = include

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -287,9 +287,6 @@ class ScheduledExecutionController  extends ControllerBase{
             total = Execution.withTransaction([isolationLevel: TransactionDefinition.ISOLATION_READ_UNCOMMITTED]) {
                 Execution.countByScheduledExecution(scheduledExecution)
             }
-            if(scheduledExecution.refExecCount) {
-                total += scheduledExecution.refExecCount
-            }
         }
 
         def remoteClusterNodeUUID = null
@@ -523,9 +520,6 @@ class ScheduledExecutionController  extends ControllerBase{
 
         def total = Execution.withTransaction([isolationLevel: TransactionDefinition.ISOLATION_READ_UNCOMMITTED]) {
             Execution.countByScheduledExecution(scheduledExecution)
-        }
-        if(scheduledExecution.refExecCount) {
-            total += scheduledExecution.refExecCount
         }
 
         def remoteClusterNodeUUID=null

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -287,6 +287,9 @@ class ScheduledExecutionController  extends ControllerBase{
             total = Execution.withTransaction([isolationLevel: TransactionDefinition.ISOLATION_READ_UNCOMMITTED]) {
                 Execution.countByScheduledExecution(scheduledExecution)
             }
+            if(scheduledExecution.refExecCount) {
+                total += scheduledExecution.refExecCount
+            }
         }
 
         def remoteClusterNodeUUID = null
@@ -402,6 +405,10 @@ class ScheduledExecutionController  extends ControllerBase{
         def total = Execution.withTransaction([isolationLevel: TransactionDefinition.ISOLATION_READ_UNCOMMITTED]) {
             Execution.countByScheduledExecution(scheduledExecution)
         }
+        def reftotal = 0
+        if(scheduledExecution.refExecCount) {
+            reftotal = scheduledExecution.refExecCount
+        }
 
         def remoteClusterNodeUUID=null
         if (scheduledExecution.scheduled && frameworkService.isClusterModeEnabled()) {
@@ -414,6 +421,7 @@ class ScheduledExecutionController  extends ControllerBase{
                 crontab: crontab,
                 params: params,
                 total: total,
+                reftotal: reftotal,
                 nextExecution: scheduledExecutionService.nextExecutionTime(scheduledExecution),
                 remoteClusterNodeUUID: remoteClusterNodeUUID,
                 serverNodeUUID: frameworkService.isClusterModeEnabled()?frameworkService.serverUUID:null,
@@ -515,6 +523,9 @@ class ScheduledExecutionController  extends ControllerBase{
 
         def total = Execution.withTransaction([isolationLevel: TransactionDefinition.ISOLATION_READ_UNCOMMITTED]) {
             Execution.countByScheduledExecution(scheduledExecution)
+        }
+        if(scheduledExecution.refExecCount) {
+            total += scheduledExecution.refExecCount
         }
 
         def remoteClusterNodeUUID=null

--- a/rundeckapp/grails-app/domain/rundeck/ExecReport.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ExecReport.groovy
@@ -40,6 +40,7 @@ class ExecReport extends BaseReport{
         DomainIndexHelper.generate(delegate) {
             index 'EXEC_REPORT_IDX_0', [/*'class', 'ctxProject', 'dateCompleted',*/ 'jcExecId', 'jcJobId']
             index 'EXEC_REPORT_IDX_1', [/*'ctxProject',*/ 'jcJobId']
+            index 'EXEC_REPORT_IDX_2', [/*'class',*/ 'jcExecId']
         }
     }
 

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -45,6 +45,7 @@ class Execution extends ExecutionContext {
     Orchestrator orchestrator;
     String userRoleList
 
+    static hasMany = [refExec:ReferencedExecution]
     static hasOne = [logFileStorageRequest: LogFileStorageRequest]
     static transients = ['executionState', 'customStatusString', 'userRoles']
     static constraints = {
@@ -103,6 +104,7 @@ class Execution extends ExecutionContext {
         userRoleList(nullable: true)
         retryDelay(nullable:true)
         successOnEmptyNodeFilter(nullable: true)
+        refExec(nullable: true)
     }
 
     static mapping = {

--- a/rundeckapp/grails-app/domain/rundeck/ReferencedExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ReferencedExecution.groovy
@@ -1,0 +1,16 @@
+package rundeck
+
+class ReferencedExecution {
+    ScheduledExecution scheduledExecution
+    String status
+    Execution execution
+
+    static belongsTo=[Execution]
+
+    static constraints = {
+        scheduledExecution(nullable:true)
+        status(nullable:true)
+        execution(nullable: false)
+
+    }
+}

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -74,6 +74,8 @@ class ScheduledExecution extends ExecutionContext {
     Boolean scheduleEnabled = true
     Boolean executionEnabled = true
 
+    Long refExecCount=0
+
     static transients = ['userRoles','adhocExecutionType','notifySuccessRecipients','notifyFailureRecipients',
                          'notifyStartRecipients', 'notifySuccessUrl', 'notifyFailureUrl', 'notifyStartUrl',
                          'crontabString','averageDuration','notifyAvgDurationRecipients','notifyAvgDurationUrl']
@@ -108,6 +110,7 @@ class ScheduledExecution extends ExecutionContext {
         loglevel(nullable:true)
         totalTime(nullable:true)
         execCount(nullable:true)
+        refExecCount(nullable:true)
         nodeThreadcount(nullable:true,validator:{val,obj->
             return null==val||val>=1
         })

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1587,3 +1587,4 @@ aclpolicy.file.upload.exists.warning.message=A Policy already exists with the sp
 title.location.prompt=Location: 
 execution.log.clusterExec.log.delayed.message=This execution is running on another cluster member, so log output and execution summary data may be delayed.
 project.name.invalid=Project Name is not valid
+Execution.plural.ref=Referenced executions

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1585,3 +1585,4 @@ aclpolicy.file.upload.exists.warning.message=A Policy already exists with the sp
 title.location.prompt=Location: 
 execution.log.clusterExec.log.delayed.message=This execution is running on another cluster member, so log output and execution summary data may be delayed.
 project.name.invalid=Project Name is not valid
+Execution.plural.ref=Ejecuciones referenciadas

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -1586,3 +1586,4 @@ aclpolicy.file.upload.exists.warning.message=A Policy already exists with the sp
 title.location.prompt=Location: 
 execution.log.clusterExec.log.delayed.message=This execution is running on another cluster member, so log output and execution summary data may be delayed.
 project.name.invalid=Project Name is not valid
+Execution.plural.ref=Referenced executions

--- a/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
@@ -218,6 +218,8 @@ class ReportService  {
         def eqfilters = [
                 stat: 'status',
                 reportId: 'reportId',
+        ]
+        def jobfilters = [
                 jobId: 'jcJobId',
                 proj: 'ctxProject',
         ]
@@ -275,6 +277,38 @@ class ReportService  {
                         eq(val, query["${key}Filter"])
                     }
                 }
+
+                if (query.execIdFilter) {
+                    'in'('jcExecId', query.execIdFilter)
+                }else {
+                    jobfilters.each { key, val ->
+                        if (query["${key}Filter"] == 'null') {
+                            or {
+                                isNull(val)
+                                eq(val, '')
+                            }
+                        } else if (query["${key}Filter"] == '!null') {
+                            and {
+                                isNotNull(val)
+                                ne(val, '')
+                            }
+                        } else if (key == 'stat' && query["${key}Filter"] == 'succeed') {
+                            or {
+                                eq(val, 'succeed')
+                                eq(val, 'succeeded')
+                                eq(val, 'true')
+                            }
+                        } else if (key == 'stat' && query["${key}Filter"] == 'fail') {
+                            or {
+                                eq(val, 'fail')
+                                eq(val, 'failed')
+                            }
+                        } else if (query["${key}Filter"]) {
+                            eq(val, query["${key}Filter"])
+                        }
+                    }
+                }
+
                 if (query.titleFilter) {
                     or {
                         eq('jcJobId', '')

--- a/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
@@ -279,8 +279,38 @@ class ReportService  {
                 }
 
                 if (query.execIdFilter) {
-                    'in'('jcExecId', query.execIdFilter)
-                }else {
+                    or {
+                        'in'('jcExecId', query.execIdFilter)
+                        and{
+                                    jobfilters.each { key, val ->
+                                        if (query["${key}Filter"] == 'null') {
+                                            or {
+                                                isNull(val)
+                                                eq(val, '')
+                                            }
+                                        } else if (query["${key}Filter"] == '!null') {
+                                            and {
+                                                isNotNull(val)
+                                                ne(val, '')
+                                            }
+                                        } else if (key == 'stat' && query["${key}Filter"] == 'succeed') {
+                                            or {
+                                                eq(val, 'succeed')
+                                                eq(val, 'succeeded')
+                                                eq(val, 'true')
+                                            }
+                                        } else if (key == 'stat' && query["${key}Filter"] == 'fail') {
+                                            or {
+                                                eq(val, 'fail')
+                                                eq(val, 'failed')
+                                            }
+                                        } else if (query["${key}Filter"]) {
+                                            eq(val, query["${key}Filter"])
+                                        }
+                                    }
+                        }
+                    }
+                }else{
                     jobfilters.each { key, val ->
                         if (query["${key}Filter"] == 'null') {
                             or {

--- a/rundeckapp/grails-app/views/reports/_activityLinks.gsp
+++ b/rundeckapp/grails-app/views/reports/_activityLinks.gsp
@@ -20,7 +20,7 @@
 <g:set var="linkParams" value="${filter?filter+projParams:projParams}"/>
 <g:set var="runningParams" value="${filter ? filter + projParams : projParams}"/>
 <g:if test="${scheduledExecution}">
-    <g:set var="linkParams" value="${[jobIdFilter: scheduledExecution.id]+projParams}"/>
+    <g:set var="linkParams" value="${[jobIdFilter: scheduledExecution.id, includeJobRef: includeJobRef]+projParams}"/>
     <g:set var="runningParams" value="${[jobIdFilter: scheduledExecution.extid]+projParams}"/>
 </g:if>
 <ul class="nav nav-tabs activity_links">
@@ -62,17 +62,6 @@
         </li>
     </g:if>
 
-    <g:if test="${includeJobRef}">
-        <li>
-            <g:link controller="reports" action="index" class="activity_link"
-                    title="Referenced Executions"
-                    params="${linkParams+[ includeJobRef: includeJobRef]}">
-                <i class="glyphicon glyphicon-circle-arrow-right"></i>
-                referenced
-            </g:link>
-        </li>
-    </g:if>
-
     <g:if test="${execution}">
         <li>
             <g:link controller="reports" action="index" class="activity_link"
@@ -106,6 +95,9 @@
             </td>
             <td class="eventtitle autoclickable" data-bind="css: { job: isJob(), adhoc: isAdhoc() }">
                 <a href="#" data-bind="text: '#'+executionId(), attr: { href: executionHref() }" class="_defaultAction"></a>
+                <g:if test="${includeJobRef}">
+                    <span data-bind="text: textJobRef('${scheduledExecution.extid}')"></span>
+                </g:if>
                 <g:if test="${showTitle}">
                     <span data-bind="if: !jobDeleted()">
                         <span data-bind="text: isJob()?jobName():executionString()"></span>

--- a/rundeckapp/grails-app/views/reports/_activityLinks.gsp
+++ b/rundeckapp/grails-app/views/reports/_activityLinks.gsp
@@ -62,6 +62,17 @@
         </li>
     </g:if>
 
+    <g:if test="${includeJobRef}">
+        <li>
+            <g:link controller="reports" action="index" class="activity_link"
+                    title="Referenced Executions"
+                    params="${linkParams+[ includeJobRef: includeJobRef]}">
+                <i class="glyphicon glyphicon-circle-arrow-right"></i>
+                referenced
+            </g:link>
+        </li>
+    </g:if>
+
     <g:if test="${execution}">
         <li>
             <g:link controller="reports" action="index" class="activity_link"

--- a/rundeckapp/grails-app/views/scheduledExecution/_renderJobStats.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_renderJobStats.gsp
@@ -14,13 +14,19 @@
   - limitations under the License.
   --}%
 
-<%@ page import="rundeck.Execution" %>
+<%@ page import="rundeck.ReferencedExecution; rundeck.Execution" %>
 <g:set var="lastrun"
        value="${scheduledExecution.id ? Execution.findByScheduledExecutionAndDateCompletedIsNotNull(scheduledExecution, [max: 1, sort: 'dateStarted', order: 'desc']) : null}"/>
+<g:set var="reflastrun"
+       value="${scheduledExecution.id ? ReferencedExecution.findByScheduledExecution(scheduledExecution, [max: 1]) : null}"/>
 <g:set var="successcount"
        value="${scheduledExecution.id ? Execution.countByScheduledExecutionAndStatusInList(scheduledExecution, ['true','succeeded','scheduled']) : 0}"/>
+<g:set var="refsuccesscount"
+       value="${scheduledExecution.id ? ReferencedExecution.countByScheduledExecutionAndStatusInList(scheduledExecution, ['true','succeeded','scheduled']) : 0}"/>
 <g:set var="execCount"
        value="${scheduledExecution.id ? Execution.countByScheduledExecution(scheduledExecution) : 0}"/>
-<g:set var="successrate" value="${execCount > 0 ? (successcount / execCount) : 0}"/>
+<g:set var="refexecCount"
+       value="${scheduledExecution.id ? ReferencedExecution.countByScheduledExecution(scheduledExecution) : 0}"/>
+<g:set var="successrate" value="${(execCount + refexecCount) > 0 ? ((successcount+refsuccesscount) / (execCount+refexecCount)) : 0}"/>
 <g:render template="/scheduledExecution/showStats"
-          model="[scheduledExecution: scheduledExecution, lastrun: lastrun ? lastrun : null, successrate: successrate]"/>
+          model="[scheduledExecution: scheduledExecution, lastrun: lastrun ? lastrun : null, successrate: successrate,reflastrun: reflastrun ? reflastrun : null]"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
@@ -99,7 +99,7 @@
     <div class="col-sm-12">
         <h4 class="text-muted"><g:message code="page.section.Activity.for.this.job" /></h4>
 
-        <g:render template="/reports/activityLinks" model="[scheduledExecution: scheduledExecution, knockoutBinding:true]"/>
+        <g:render template="/reports/activityLinks" model="[scheduledExecution: scheduledExecution, knockoutBinding:true, includeJobRef:(scheduledExecution.refExecCount?true:false)]"/>
     </div>
 </div>
 

--- a/rundeckapp/grails-app/views/scheduledExecution/_showStats.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_showStats.gsp
@@ -20,11 +20,6 @@
             <th style="width: 20%" class="text-muted text-center  text-header">
                 <g:message code="Execution.plural" />
             </th>
-            <g:if test="${reftotal && reftotal>0}">
-                <th style="width: 20%" class="text-muted text-center  text-header">
-                    <g:message code="Execution.plural.ref" default="Referenced Executions" />
-                </th>
-            </g:if>
         <g:if test="${lastrun || reflastrun}">
             <th style="width: 20%" class="text-muted text-center  text-header">
                 <g:message code="success.rate" />
@@ -42,13 +37,6 @@
                     <g:formatNumber number="${total}" />
                 </span>
             </td>
-<g:if test="${reftotal && reftotal>0}">
-    <td class="text-center">
-                <span class="h3 ">
-                    <g:formatNumber number="${reftotal}" />
-                </span>
-            </td>
-</g:if>
         <g:if test="${lastrun || reflastrun}">
             <g:set var="successrate" value="${params.float('success')?:successrate}"/>
             <g:set var="ratecolors" value="${['text-success','text-muted','text-warning','text-danger']}"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_showStats.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_showStats.gsp
@@ -20,7 +20,12 @@
             <th style="width: 20%" class="text-muted text-center  text-header">
                 <g:message code="Execution.plural" />
             </th>
-        <g:if test="${lastrun}">
+            <g:if test="${reftotal && reftotal>0}">
+                <th style="width: 20%" class="text-muted text-center  text-header">
+                    <g:message code="Execution.plural.ref" default="Referenced Executions" />
+                </th>
+            </g:if>
+        <g:if test="${lastrun || reflastrun}">
             <th style="width: 20%" class="text-muted text-center  text-header">
                 <g:message code="success.rate" />
             </th>
@@ -37,7 +42,14 @@
                     <g:formatNumber number="${total}" />
                 </span>
             </td>
-        <g:if test="${lastrun}">
+<g:if test="${reftotal && reftotal>0}">
+    <td class="text-center">
+                <span class="h3 ">
+                    <g:formatNumber number="${reftotal}" />
+                </span>
+            </td>
+</g:if>
+        <g:if test="${lastrun || reflastrun}">
             <g:set var="successrate" value="${params.float('success')?:successrate}"/>
             <g:set var="ratecolors" value="${['text-success','text-muted','text-warning','text-danger']}"/>
             <g:set var="ratelevels" value="${[0.9f,0.75f,0.5f]}"/>

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/app/support/ExecQuery.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/app/support/ExecQuery.groovy
@@ -31,6 +31,7 @@ class ExecQuery extends ReportQuery{
     String cmdFilter
     String groupPathFilter
     String groupPathExactFilter
+    List execIdFilter
 
     static constraints = {
         abortedByFilter(nullable: true)
@@ -59,6 +60,7 @@ class ExecQuery extends ReportQuery{
         excludeJobListFilter(nullable: true)
         statFilter(nullable:true,inList:["succeed","fail",'cancel'])
         execnodeFilter(nullable: true)
+        execIdFilter(nullable:true)
         sortBy(nullable:true,inList:[
             "jobFilter",
             "jobIdFilter",

--- a/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -1132,4 +1132,79 @@ class ScheduledExecutionControllerSpec extends Specification {
         model.failed
         model.error == 'project.execution.disabled'
     }
+
+
+    def "total and reftotal on show"(){
+        given:
+        def refTotal = 10
+        def se = new ScheduledExecution(
+                uuid: 'testUUID',
+                jobName: 'test1',
+                project: 'project1',
+                groupPath: 'testgroup',
+                doNodedispatch: true,
+                filter:'name: ${option.nodes}',
+                refExecCount: refTotal,
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [
+                                new CommandExec([
+                                        adhocRemoteString: 'test buddy',
+                                        argString: '-delay 12 -monkey cheese -particle'
+                                ])
+                        ]
+                )
+        ).save()
+        def exec = new Execution(
+                user: "testuser",
+                project: "project1",
+                loglevel: 'WARN',
+                status: 'FAILED',
+                doNodedispatch: true,
+                filter:'name: nodea',
+                succeededNodeList:'fwnode',
+                failedNodeList: 'nodec xyz,nodea',
+                workflow: new Workflow(commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]).save(),
+                scheduledExecution: se
+        ).save()
+
+
+
+        NodeSetImpl testNodeSet = new NodeSetImpl()
+        testNodeSet.putNode(new NodeEntryImpl("nodea"))
+        testNodeSet.putNode(new NodeEntryImpl("nodeb"))
+        testNodeSet.putNode(new NodeEntryImpl("nodec xyz"))
+        NodeSetImpl testNodeSetB = new NodeSetImpl()
+        testNodeSetB.putNode(new NodeEntryImpl("nodea"))
+        testNodeSetB.putNode(new NodeEntryImpl("nodec xyz"))
+
+        controller.frameworkService=Mock(FrameworkService){
+            authorizeProjectJobAll(_,_,_,_)>>true
+            filterAuthorizedNodes(_,_,_,_)>>{args-> args[2]}
+            filterNodeSet({ NodesSelector selector->
+                selector.acceptNode(new NodeEntryImpl("nodea")) &&
+                        selector.acceptNode(new NodeEntryImpl("nodec xyz")) &&
+                        !selector.acceptNode(new NodeEntryImpl("nodeb"))
+
+            },_)>>testNodeSetB
+            getRundeckFramework()>>Mock(Framework){
+                getFrameworkNodeName()>>'fwnode'
+            }
+        }
+        controller.scheduledExecutionService=Mock(ScheduledExecutionService){
+            getByIDorUUID(_)>>se
+        }
+        controller.notificationService=Mock(NotificationService)
+        controller.orchestratorPluginService=Mock(OrchestratorPluginService)
+        controller.pluginService = Mock(PluginService)
+        when:
+        request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
+
+        def model = controller.show()
+        then:
+        response.redirectedUrl==null
+        model != null
+        model.reftotal == refTotal
+
+    }
 }


### PR DESCRIPTION
The execution of referenced jobs now updates his statistics (Average Duration and Success Rate).
And (if the job has been called by another job at least once) on the recent, failed and by me tabs, the parent executions are displayed, with the added text `(Referenced)`, as links to the parent execution that runs the current job.

<img width="1558" alt="image" src="https://user-images.githubusercontent.com/2894508/34443151-0454c916-eca6-11e7-9d8f-1dcc35a9085e.png">
