### PR TITLE
Fix #3012 admin access required to modify project config/nodes in gui

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -925,12 +925,12 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
-                frameworkService.authorizeApplicationResourceAll(
+                frameworkService.authorizeApplicationResourceAny(
                         authContext,
                         frameworkService.authResourceForProject(project),
-                        [AuthConstants.ACTION_ADMIN]
+                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
                 ),
-                AuthConstants.ACTION_ADMIN, 'Project',project
+                AuthConstants.ACTION_CONFIGURE, 'Project',project
         )) {
             return
         }
@@ -1115,9 +1115,9 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
-                frameworkService.authorizeApplicationResourceAll(authContext,
-                        frameworkService.authResourceForProject(project), [AuthConstants.ACTION_ADMIN]),
-                AuthConstants.ACTION_ADMIN, 'Project',project)) {
+                frameworkService.authorizeApplicationResourceAny(authContext,
+                        frameworkService.authResourceForProject(project), [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]),
+                AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
 
@@ -1381,12 +1381,12 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
-                frameworkService.authorizeApplicationResourceAll(
+                frameworkService.authorizeApplicationResourceAny(
                         authContext,
                         frameworkService.authResourceForProject(project),
-                        [AuthConstants.ACTION_ADMIN]
+                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
                 ),
-                AuthConstants.ACTION_ADMIN, 'Project', project
+                AuthConstants.ACTION_CONFIGURE, 'Project', project
         )) {
             return
         }
@@ -1507,7 +1507,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         def project = params.project
         if (unauthorizedResponse(
-                frameworkService.authorizeApplicationResourceAll(
+                frameworkService.authorizeApplicationResourceAny(
                         frameworkService.getAuthContextForSubject(session.subject),
                         frameworkService.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -1568,7 +1568,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
 
         if (unauthorizedResponse(
-                frameworkService.authorizeApplicationResourceAll(
+                frameworkService.authorizeApplicationResourceAny(
                         frameworkService.getAuthContextForSubject(session.subject),
                         frameworkService.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -1634,12 +1634,12 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def index = params.index.toInteger()
 
         if (unauthorizedResponse(
-                frameworkService.authorizeApplicationResourceAll(
+                frameworkService.authorizeApplicationResourceAny(
                         frameworkService.getAuthContextForSubject(session.subject),
                         frameworkService.authResourceForProject(project),
-                        [AuthConstants.ACTION_ADMIN]
+                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
                 ),
-                AuthConstants.ACTION_ADMIN, 'Project', project
+                AuthConstants.ACTION_CONFIGURE, 'Project', project
         )) {
             return
         }
@@ -1710,7 +1710,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def project = params.project
 
         if (unauthorizedResponse(
-                frameworkService.authorizeApplicationResourceAll(
+                frameworkService.authorizeApplicationResourceAny(
                         frameworkService.getAuthContextForSubject(session.subject),
                         frameworkService.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -1772,7 +1772,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def project = params.project
 
         if (unauthorizedResponse(
-                frameworkService.authorizeApplicationResourceAll(
+                frameworkService.authorizeApplicationResourceAny(
                         frameworkService.getAuthContextForSubject(session.subject),
                         frameworkService.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -1827,11 +1827,11 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def project = params.project
 
         if (unauthorizedResponse(
-                frameworkService.authorizeApplicationResourceAll(
+                frameworkService.authorizeApplicationResourceAny(
                         frameworkService.getAuthContextForSubject(session.subject),
                         frameworkService.authResourceForProject(project),
-                        [AuthConstants.ACTION_ADMIN]),
-                AuthConstants.ACTION_ADMIN, 'Project', project)) {
+                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]),
+                AuthConstants.ACTION_CONFIGURE, 'Project', project)) {
             return
         }
 
@@ -1865,11 +1865,11 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def project = params.project
 
         if (unauthorizedResponse(
-            frameworkService.authorizeApplicationResourceAll(
+                frameworkService.authorizeApplicationResourceAny(
                 frameworkService.getAuthContextForSubject(session.subject),
                 frameworkService.authResourceForProject(project),
-                [AuthConstants.ACTION_ADMIN]),
-            AuthConstants.ACTION_ADMIN, 'Project', project)) {
+                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]),
+                AuthConstants.ACTION_CONFIGURE, 'Project', project)) {
             return
         }
 

--- a/rundeckapp/test/unit/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -640,7 +640,7 @@ class FrameworkControllerSpec extends Specification {
         request.errors == null
         1 * fwkService.authResourceForProject(_)
         1 * fwkService.getAuthContextForSubject(_)
-        1 * fwkService.authorizeApplicationResourceAll(null,null,['admin']) >> true
+        1 * fwkService.authorizeApplicationResourceAny(null,null,['configure','admin']) >> true
         1 * fwkService.listDescriptions() >> [null,null,null]
         1 * fwkService.updateFrameworkProjectConfig(_,{
             it['project.description'] == 'abc'
@@ -672,7 +672,7 @@ class FrameworkControllerSpec extends Specification {
         request.errors == null
         1 * fwkService.authResourceForProject(_)
         1 * fwkService.getAuthContextForSubject(_)
-        1 * fwkService.authorizeApplicationResourceAll(null,null,['admin']) >> true
+        1 * fwkService.authorizeApplicationResourceAny(null,null,['configure','admin']) >> true
         1 * fwkService.listDescriptions() >> [null,null,null]
         1 * fwkService.updateFrameworkProjectConfig(_,{
             it['project.description'] == ''
@@ -885,7 +885,7 @@ class FrameworkControllerSpec extends Specification {
         request.errors == null
         1 * fwkService.authResourceForProject(_)
         1 * fwkService.getAuthContextForSubject(_)
-        1 * fwkService.authorizeApplicationResourceAll(null,null,['admin']) >> true
+        1 * fwkService.authorizeApplicationResourceAny(null,null,['configure','admin']) >> true
         1 * fwkService.listDescriptions() >> [null,null,null]
         1 * fwkService.updateFrameworkProjectConfig(_,{
             it['project.description'] == 'abc'

--- a/rundeckapp/test/unit/rundeck/controllers/FrameworkControllerTest.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/FrameworkControllerTest.groovy
@@ -261,7 +261,7 @@ class FrameworkControllerTest {
         fwk.demand.getAuthContextForSubject { subject -> return null}
         fwk.demand.getAuthContextForSubjectAndProject { subject,proj -> return null}
         fwk.demand.authResourceForProject {project -> return null}
-        fwk.demand.authorizeApplicationResourceAll {ctx, e, actions -> true }
+        fwk.demand.authorizeApplicationResourceAny {ctx, e, actions -> true }
 
         fwk.demand.listResourceModelConfigurations { project ->
             [
@@ -382,7 +382,7 @@ class FrameworkControllerTest {
 
         fwk.demand.getAuthContextForSubject {subject -> return null}
         fwk.demand.authResourceForProject {project -> return null}
-        fwk.demand.authorizeApplicationResourceAll {ctx, e, actions -> true }
+        fwk.demand.authorizeApplicationResourceAny {ctx, e, actions -> true }
         fwk.demand.listDescriptions { -> [null, null, null] }
         fwk.demand.getRundeckFramework { -> null }
 


### PR DESCRIPTION
This changes the ACL requirement to edit project/resource configurations from `admin` to `configure` 