### PR TITLE
Average notification duration enhancement

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -336,6 +336,8 @@ class ScheduledExecution extends ExecutionContext {
                             map.notification[it.eventTrigger].plugin.sort { a, b -> a.type <=> b.type }
                 }
             }
+
+            map.notifyAvgDurationThreshold = notifyAvgDurationThreshold
         }
         return map
     }
@@ -513,6 +515,11 @@ class ScheduledExecution extends ExecutionContext {
                 }
             }
             se.notifications=nots
+
+            if(null!=data.notifyAvgDurationThreshold){
+                se.notifyAvgDurationThreshold = data.notifyAvgDurationThreshold
+            }
+
         }
         return se
     }

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -69,6 +69,8 @@ class ScheduledExecution extends ExecutionContext {
     Boolean multipleExecutions = false
     Orchestrator orchestrator
 
+    String notifyAvgDurationThreshold
+
     String timeZone
 
     Boolean scheduleEnabled = true
@@ -150,6 +152,7 @@ class ScheduledExecution extends ExecutionContext {
         timeZone(maxSize: 256, blank: true, nullable: true)
         retryDelay(nullable:true)
         successOnEmptyNodeFilter(nullable: true)
+        notifyAvgDurationThreshold(nullable: true)
     }
 
     static mapping = {
@@ -179,6 +182,7 @@ class ScheduledExecution extends ExecutionContext {
         timeout(type: 'text')
         retry(type: 'text')
         retryDelay(type: 'text')
+        notifyAvgDurationThreshold(type: 'text')
     }
 
     static namedQueries = {

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -711,6 +711,13 @@ scheduledExecution.property.timeout.description=The maximum time for an executio
   or specify time units: "120m", "2h", "3d".  Use blank or 0 to indicate no timeout. Can include option value \
   references like "${option.timeout}".
 scheduledExecution.property.timeout.label=Timeout
+scheduledExecution.property.notifyAvgDurationThreshold.description=Add or set a threshold value to the avg duration in order to trigger this notification. Options: \
+  - percentage => eg: 20% \
+  - time delta => eg: +20s, +20  \
+  - absolute time => 30s, 5m \
+  Time in seconds if you don't specify time units \
+  Can include option value references like ${option.avgDurationThreshold}.
+scheduledExecution.property.notifyAvgDurationThreshold.label=Threshold
 scheduledExecution.property.retry.label=Retry
 scheduledExecution.property.retry.description=Maximum number of times to retry execution when this job is directly invoked.  Retry will occur if the job fails or times out, but not if it is manually killed. Can use an option value reference like "${option.retry}".
 execution.retry.attempt.x.of.max.ko=(attempt <span data-bind\="{0}"></span> of maximum <span data-bind\="{1}"></span>)

--- a/rundeckapp/grails-app/views/execution/_execDetails.gsp
+++ b/rundeckapp/grails-app/views/execution/_execDetails.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.app.support.ExecutionContext; com.dtolabs.rundeck.server.authorization.AuthConstants; com.dtolabs.rundeck.core.plugins.configuration.Description; rundeck.ScheduledExecution" %>
+<%@ page import="com.dtolabs.rundeck.app.support.ExecutionContext; com.dtolabs.rundeck.server.authorization.AuthConstants; com.dtolabs.rundeck.core.plugins.configuration.Description; rundeck.ScheduledExecution; rundeck.controllers.ScheduledExecutionController" %>
 <g:set var="rkey" value="${g.rkey()}"/>
 <div class="row" >
 <div class="col-sm-12">
@@ -271,6 +271,13 @@
                 <div class="row">
                     <div class="col-sm-12" >
                         <span class=""><g:message code="notification.event.${trigger}"/>:</span>
+
+                        <g:if test="${trigger == ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME}">
+                            <div class="">
+                                <g:message code="scheduledExecution.property.notifyAvgDurationThreshold.label" default="Threshold"/>:
+                                <code class="argstring optvalue"><g:enc>${scheduledExecution.notifyAvgDurationThreshold}</g:enc></code>
+                            </div>
+                        </g:if>
                 <g:if test="${bytrigger[trigger].size()>1}">
                 <ul class="overflowx">
                 <g:each var="notify" in="${bytrigger[trigger].sort{a,b->a.type.toLowerCase()<=>b.type.toLowerCase()}}" status="i">

--- a/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsTriggerForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsTriggerForm.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.plugins.configuration.PropertyScope; com.dtolabs.rundeck.core.plugins.configuration.Description" %>
+<%@ page import="com.dtolabs.rundeck.core.plugins.configuration.PropertyScope; com.dtolabs.rundeck.core.plugins.configuration.Description; rundeck.controllers.ScheduledExecutionController" %>
 <g:set var="tkey" value="${g.rkey()}"/>
 <div class="notifyFields form-group"
      style="${wdgt.styleVisible(if: isVisible)}">
@@ -24,7 +24,33 @@
         <g:message code="notification.event.${trigger}"/>
     </div>
     <div class="col-sm-10 ">
+
+        <g:if test="${trigger == ScheduledExecutionController.OVERAVGDURATION_TRIGGER_NAME}">
+            <div class="row row-space form-inline">
+                <div  class="form-group col-sm-10">
+
+                    %{--Job notifyAvgDurationThreshold--}%
+                    <div class="input-group  input-group-sm">
+
+                        <label class="input-group-addon"><g:message code="scheduledExecution.property.notifyAvgDurationThreshold.label" default="Threshold"/></label>
+
+                        <input type='text' name="notifyAvgDurationThreshold" value="${enc(attr:scheduledExecution?.notifyAvgDurationThreshold)}"
+                               id="schedJobNotifyAvgDurationThreshold" class="form-control" size="40"/>
+
+                        <g:helpTooltip code="scheduledExecution.property.notifyAvgDurationThreshold.description"
+                                       css="input-group-addon text-info"/>
+
+                    </div>
+                </div>
+            </div>
+            <div class="row row-space form-inline">
+
+            </div>
+
+        </g:if>
+
         <div class="row row-space form-inline">
+
             <div class="form-group  col-sm-12 ${hasErrors(bean: scheduledExecution, field: triggerEmailRecipientsName,
                     'has-error')} ">
                 <g:checkBox name="${triggerEmailCheckboxName}" value="true" checked="${isEmail}"/>

--- a/rundeckapp/test/unit/JobsXMLCodecTests.groovy
+++ b/rundeckapp/test/unit/JobsXMLCodecTests.groovy
@@ -6456,4 +6456,39 @@ void testDecodeBasic__no_group(){
         assertEquals "incorrect notifications onsuccess email size", 1, doc.job[0].notification[0].onfailure[0].email.size()
         assertEquals "incorrect notifications onsuccess email size", "test2@example.com", doc.job[0].notification[0].onfailure[0].email[0]['@recipients'].text()
     }
+
+    void testNotificationThreshold(){
+        def XmlSlurper parser = new XmlSlurper()
+        def jobs1 = [
+                new ScheduledExecution(
+                        jobName:'test job 1',
+                        description:'test descrip',
+                        loglevel: 'INFO',
+                        project:'test1',
+                        timeout:'2h',
+                        workflow: new Workflow(keepgoing: true, commands: [new CommandExec([adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle'])]),
+                        nodeThreadcountDynamic: "10",
+                        nodeKeepgoing:true,
+                        doNodedispatch:true,
+                        notifications: [
+                                new Notification(eventTrigger: 'avgduration', type: 'email', content: 'test2@example.com')
+                        ],
+                        notifyAvgDurationThreshold: '30s'
+                )
+        ]
+        def  xmlstr = JobsXMLCodec.encode(jobs1)
+        assertNotNull xmlstr
+        assertTrue xmlstr instanceof String
+
+        def doc = parser.parse(new StringReader(xmlstr))
+
+        println(jobs1)
+        println(xmlstr)
+        println(doc)
+
+        assertNotNull doc
+        assertEquals "wrong root node name",'joblist',doc.name()
+        assertEquals "wrong number of jobs",1,doc.job.size()
+        assertEquals "incorrect notification Threshold","30s",doc.job[0].notifyAvgDurationThreshold.text()
+    }
 }

--- a/rundeckapp/test/unit/JobsYAMLCodecTests.groovy
+++ b/rundeckapp/test/unit/JobsYAMLCodecTests.groovy
@@ -2060,4 +2060,37 @@ public class JobsYAMLCodecTests  {
 
     }
 
+    void testNotificationThreshold() {
+        def Yaml yaml = new Yaml()
+        ScheduledExecution se = new ScheduledExecution(
+                jobName:'test job 1',
+                description:'test descrip',
+                loglevel: 'INFO',
+                project:'test1',
+                timeout:'2h',
+                workflow: new Workflow(keepgoing: true, commands: [new CommandExec([adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle'])]),
+                options:[new Option([name:'threadCount',defaultValue:'30'])] as TreeSet,
+                nodeThreadcountDynamic: "15",
+                nodeKeepgoing:true,
+                doNodedispatch:true,
+                notifications: [
+                        new Notification(eventTrigger: 'avgduration', type: 'email', content: 'test2@example.com')
+                ],
+                notifyAvgDurationThreshold: '30s'
+        )
+
+        def jobs1 = [se]
+        def  ymlstr = JobsYAMLCodec.encode(jobs1)
+        assertNotNull ymlstr
+        assertTrue ymlstr instanceof String
+
+
+        def doc = yaml.load(ymlstr)
+        assertNotNull doc
+        assertEquals "wrong number of jobs", 1, doc.size()
+        assertEquals "wrong name", "test job 1", doc[0].name
+        assertEquals "incorrect notification Threshold","30s",doc[0].notifyAvgDurationThreshold
+
+    }
+
 }

--- a/rundeckapp/test/unit/rundeck/quartzjobs/ExecutionJobSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/quartzjobs/ExecutionJobSpec.groovy
@@ -23,6 +23,7 @@ import org.quartz.JobExecutionContext
 import org.quartz.JobKey
 import org.quartz.Scheduler
 import rundeck.CommandExec
+import rundeck.Option
 import rundeck.ScheduledExecution
 import rundeck.Workflow
 import rundeck.Execution
@@ -244,6 +245,142 @@ class ExecutionJobSpec extends Specification {
         true        | false         | true
         true        | true          | false
 
+
+    }
+
+    def "average notification threshold from options"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution(
+                jobName: 'blue',
+                project: 'AProject',
+                groupPath: 'some/where',
+                description: 'a job',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec(
+                                [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
+                        )]
+                ),
+                options:[
+                        new Option(name: 'threshold',  required: true)
+                ],
+                notifyAvgDurationThreshold:'${option.threshold}',
+                totalTime: 60000,
+                execCount: 2
+        )
+        se.save(flush:true)
+        def dataContext = [option: [threshold: '+30s']]
+        ExecutionJob executionJob = new ExecutionJob()
+
+
+        when:
+
+        def result=executionJob.getNotifyAvgDurationThreshold(se.notifyAvgDurationThreshold,
+                                                              se.averageDuration,dataContext)
+
+        then:
+
+        result == 60000
+
+
+    }
+
+    def "average notification threshold add time to avg"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution(
+                jobName: 'blue',
+                project: 'AProject',
+                groupPath: 'some/where',
+                description: 'a job',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec(
+                                [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
+                        )]
+                ),
+                notifyAvgDurationThreshold:'+30s',
+                totalTime: 60000,
+                execCount: 2
+        )
+        se.save(flush:true)
+        def dataContext = [:]
+        ExecutionJob executionJob = new ExecutionJob()
+
+
+        when:
+
+        def result=executionJob.getNotifyAvgDurationThreshold(se.notifyAvgDurationThreshold,
+                se.averageDuration,dataContext)
+
+        then:
+
+        result == 60000
+
+    }
+
+    def "average notification threshold fixed time"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution(
+                jobName: 'blue',
+                project: 'AProject',
+                groupPath: 'some/where',
+                description: 'a job',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec(
+                                [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
+                        )]
+                ),
+                notifyAvgDurationThreshold:'20s',
+                totalTime: 60000,
+                execCount: 2
+        )
+        se.save(flush:true)
+        def dataContext = [:]
+        ExecutionJob executionJob = new ExecutionJob()
+
+
+        when:
+
+        def result=executionJob.getNotifyAvgDurationThreshold(se.notifyAvgDurationThreshold,
+                se.averageDuration,dataContext)
+
+        then:
+
+        result == 20000
+
+    }
+
+    def "average notification threshold perc time"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution(
+                jobName: 'blue',
+                project: 'AProject',
+                groupPath: 'some/where',
+                description: 'a job',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec(
+                                [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
+                        )]
+                ),
+                notifyAvgDurationThreshold:'10%',
+                totalTime: 60000,
+                execCount: 2
+        )
+        se.save(flush:true)
+        def dataContext = [:]
+        ExecutionJob executionJob = new ExecutionJob()
+
+
+        when:
+
+        def result=executionJob.getNotifyAvgDurationThreshold(se.notifyAvgDurationThreshold,
+                se.averageDuration,dataContext)
+
+        then:
+
+        result == 33000
 
     }
 }

--- a/rundeckapp/test/unit/rundeck/quartzjobs/ExecutionJobSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/quartzjobs/ExecutionJobSpec.groovy
@@ -383,4 +383,37 @@ class ExecutionJobSpec extends Specification {
         result == 33000
 
     }
+
+    def "average notification threshold bad value"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution(
+                jobName: 'blue',
+                project: 'AProject',
+                groupPath: 'some/where',
+                description: 'a job',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec(
+                                [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
+                        )]
+                ),
+                notifyAvgDurationThreshold:'somethingbad',
+                totalTime: 60000,
+                execCount: 2
+        )
+        se.save(flush:true)
+        def dataContext = [:]
+        ExecutionJob executionJob = new ExecutionJob()
+
+
+        when:
+
+        def result=executionJob.getNotifyAvgDurationThreshold(se.notifyAvgDurationThreshold,
+                se.averageDuration,dataContext)
+
+        then:
+
+        result == 30000
+
+    }
 }


### PR DESCRIPTION
Adding a threshold on a per job basis to trigger on the avg duration plus some overrun allowance.

For example:
* avgduration 20% 
* avgduration +5m
* avgduration  5m

New inputs for notification form:
* percentage
* time delta
* absolute time

https://github.com/rundeck/rundeck/issues/3064