### PR TITLE
Scm cluster config

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/plugins/scm/ScmExportPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/scm/ScmExportPlugin.java
@@ -129,4 +129,7 @@ public interface ScmExportPlugin {
      * @param originalPath original path
      */
     ScmDiffResult getFileDiff(JobExportReference job, String originalPath);
+
+
+    Map clusterFixJobs(List<JobReference> jobs);
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/scm/ScmExportPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/scm/ScmExportPlugin.java
@@ -138,5 +138,5 @@ public interface ScmExportPlugin {
      * @param jobs rundeck jobs
      * @return map with information on the process
      */
-    Map clusterFixJobs(List<JobReference> jobs);
+    Map clusterFixJobs(List<JobExportReference> jobs);
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/scm/ScmExportPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/scm/ScmExportPlugin.java
@@ -131,5 +131,12 @@ public interface ScmExportPlugin {
     ScmDiffResult getFileDiff(JobExportReference job, String originalPath);
 
 
+    /**
+     * Function to fix status of the jobs on cluster environment.
+     * To automatically match the job status on every node.
+     *
+     * @param jobs rundeck jobs
+     * @return map with information on the process
+     */
     Map clusterFixJobs(List<JobReference> jobs);
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/scm/ScmImportPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/scm/ScmImportPlugin.java
@@ -146,5 +146,12 @@ public interface ScmImportPlugin {
     ScmImportDiffResult getFileDiff(JobScmReference job, String originalPath);
 
 
+    /**
+     * Function to fix status of the jobs on cluster environment.
+     * To automatically match the job status on every node.
+     *
+     * @param jobs rundeck jobs
+     * @return map with information on the process
+     */
     Map clusterFixJobs(List<JobReference> jobs);
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/scm/ScmImportPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/scm/ScmImportPlugin.java
@@ -153,5 +153,5 @@ public interface ScmImportPlugin {
      * @param jobs rundeck jobs
      * @return map with information on the process
      */
-    Map clusterFixJobs(List<JobReference> jobs);
+    Map clusterFixJobs(List<JobScmReference> jobs);
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/scm/ScmImportPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/scm/ScmImportPlugin.java
@@ -144,4 +144,7 @@ public interface ScmImportPlugin {
      * @param originalPath original path
      */
     ScmImportDiffResult getFileDiff(JobScmReference job, String originalPath);
+
+
+    Map clusterFixJobs(List<JobReference> jobs);
 }

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
@@ -515,25 +515,21 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
         println(jobs.size())
         def toPull = false
         jobs.each { job ->
-            def storedCommitId = ((JobScmReference)job).scmImportMetadata.commitId
+            def storedCommitId = ((JobScmReference)job).scmImportMetadata?.commitId
             def commitId = lastCommitForPath(getRelativePathForJob(job))
             def path = getRelativePathForJob(job)
-            println(storedCommitId)
-            println(commitId)
-            println(job.jobName)
             if(storedCommitId != null && commitId == null){
                 //file to delete-pull
                 git.rm().addFilepattern(path).call()
                 toPull = true
-            }
-            if(storedCommitId != null && commitId?.name != storedCommitId){
+            }else if(storedCommitId != null && commitId?.name != storedCommitId){
                 git.checkout().addPath(path).call()
                 toPull = true
             }
         }
         Status status = git.status().call()
         if (status.isClean()) {
-            //behinf branch on deleted job
+            //behind branch on deleted job
             def bstat = BranchTrackingStatus.of(repo, branch)
             if (bstat && bstat.behindCount > 0) {
                 toPull = true

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
@@ -473,7 +473,6 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
         jobs.each { job ->
             def storedCommitId = ((JobScmReference)job).scmImportMetadata?.commitId
             def commitId = lastCommitForPath(getRelativePathForJob(job))
-            println(commitId)
             def path = getRelativePathForJob(job)
             if(storedCommitId != null && commitId == null){
                 //file to delete-pull

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
@@ -419,16 +419,6 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
         if (!inited) {
             return null
         }
-        /*if(commitId){
-            def path = getRelativePathForJob(job)
-            def commit = lastCommitForPath(path)
-            println(commit?.name)
-            if(commitId!=commit?.name){
-                //other node pushed the info, refresh the file
-                println('need to be refreshed!')
-                replaceFile(path)
-            }
-        }*/
 
 
         def status = hasJobStatusCached(job, originalPath)
@@ -440,7 +430,7 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
             def commit = lastCommitForPath(path)
             status['lastCommit']=commit?.name
         }
-        //println(status)
+
         return createJobStatus(status, jobActionsForStatus(status))
     }
 
@@ -452,31 +442,6 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
         }
     }
 
-    def replaceFile(String path){
-        git.fetch().call()
-        //git.pull().setRebase(true).call()
-        git.checkout().addPath(path).call()
-
-        /*ObjectId head = repo.resolve("HEAD^{tree}")
-        if(!head){
-            return
-        }
-
-        def tree = new TreeWalk(repo)
-        tree.addTree(head)
-        tree.setRecursive(true)
-
-        tree.setFilter(PathFilterGroup.createFromStrings(path))
-
-        while (tree.next()) {
-            println(tree.getPathString())
-            def objectId = tree.getObjectId(0)
-            def bytes = repo.open(objectId, Constants.OBJ_BLOB).getBytes(Integer.MAX_VALUE)
-            println(new String(bytes))
-
-        }
-        tree.release()*/
-    }
 
     @Override
     String getRelativePathForJob(final JobReference job) {
@@ -512,7 +477,6 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
 
 
     Map clusterFixJobs(final List<JobReference> jobs){
-        println(jobs.size())
         def toPull = false
         jobs.each { job ->
             def storedCommitId = ((JobScmReference)job).scmImportMetadata?.commitId

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
@@ -21,6 +21,8 @@ import com.dtolabs.rundeck.core.plugins.views.Action
 import com.dtolabs.rundeck.core.plugins.views.BasicInputView
 import com.dtolabs.rundeck.plugins.scm.*
 import org.apache.log4j.Logger
+import org.eclipse.jgit.api.PullResult
+import org.eclipse.jgit.api.Status
 import org.eclipse.jgit.diff.DiffEntry
 import org.eclipse.jgit.lib.BranchTrackingStatus
 import org.eclipse.jgit.lib.ObjectId
@@ -573,5 +575,15 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
 
     boolean isTrackedPath(final String path) {
         return trackedItems?.contains(path) || isUseTrackingRegex() && trackingRegex && path.matches(trackingRegex)
+    }
+
+
+    Map clusterFixJobs(List<JobReference> jobs){
+        Status st = git.status().call()
+        def bstat = BranchTrackingStatus.of(repo, branch)
+        if(st.clean && bstat && bstat.behindCount>0){
+            PullResult result = git.pull().call()
+        }
+
     }
 }

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
@@ -142,7 +142,7 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
     }
 
 
-    GitImportSynchState getStatusInternal(ScmOperationContext context, boolean performFetch) {
+    GitImportSynchState   getStatusInternal(ScmOperationContext context, boolean performFetch) {
         //look for any unimported paths
         if (!trackedItemsSelected) {
             return null
@@ -578,12 +578,16 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
     }
 
 
-    Map clusterFixJobs(List<JobReference> jobs){
+    Map clusterFixJobs(List<JobScmReference> jobs){
         Status st = git.status().call()
         def bstat = BranchTrackingStatus.of(repo, branch)
         if(st.clean && bstat && bstat.behindCount>0){
             PullResult result = git.pull().call()
+            jobs.each{job ->
+                refreshJobStatus(job,null)
+            }
+            return [updated:true]
         }
-
+        [:]
     }
 }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -429,17 +429,27 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                                                  ),
                                                                  [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT]
             )) {
+                if(frameworkService.isClusterModeEnabled()){
+                    if (!scmService.projectHasConfiguredExportPlugin(params.project)) {
+                        //initialize if in another node
+                        scmService.initProject(params.project, 'export')
+                    }
+                    if(minScm){
+                        scmService.fixExportStatus(params.project, results.nextScheduled)
+                    }
+                }
                 def pluginData = [:]
                 try {
                     if (scmService.projectHasConfiguredExportPlugin(params.project)) {
                         pluginData.scmExportEnabled = scmService.loadScmConfig(params.project, 'export').enabled
                         if(pluginData.scmExportEnabled){
-                            pluginData.scmExportActions = scmService.exportPluginActions(authContext, params.project)
+
                             if(!minScm){
                                 pluginData.scmStatus = scmService.exportStatusForJobs(results.nextScheduled)
                                 pluginData.scmExportStatus = scmService.exportPluginStatus(authContext, params.project)
                                 pluginData.scmExportRenamed = scmService.getRenamedJobPathsForProject(params.project)
                             }
+                            pluginData.scmExportActions = scmService.exportPluginActions(authContext, params.project)
                         }
                         results.putAll(pluginData)
                     }
@@ -453,16 +463,27 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                                                  ),
                                                                  [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT]
             )) {
+                if(frameworkService.isClusterModeEnabled()){
+                    if (!scmService.projectHasConfiguredImportPlugin(params.project)) {
+                        //initialize if in another node
+                        scmService.initProject(params.project, 'import')
+                    }
+                    if(minScm){
+                        scmService.fixImportStatus(params.project, results.nextScheduled)
+                        scmService.importPluginStatus(authContext, params.project)
+                    }
+                }
                 def pluginData = [:]
                 try {
                     if (scmService.projectHasConfiguredImportPlugin(params.project)) {
                         pluginData.scmImportEnabled = scmService.loadScmConfig(params.project, 'import').enabled
                         if(pluginData.scmImportEnabled){
-                            pluginData.scmImportActions = scmService.importPluginActions(authContext, params.project)
+
                             if(!minScm){
                                 pluginData.scmImportJobStatus = scmService.importStatusForJobs(results.nextScheduled)
                                 pluginData.scmImportStatus = scmService.importPluginStatus(authContext, params.project)
                             }
+                            pluginData.scmImportActions = scmService.importPluginActions(authContext, params.project)
                         }
                         results.putAll(pluginData)
                     }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2995,7 +2995,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             }
             try {
                 if (scmService.projectHasConfiguredExportPlugin(params.project)) {
-                    pluginData.scmExportEnabled = scmService.loadScmConfig(params.project, 'export').enabled
+                    pluginData.scmExportEnabled = scmService.loadScmConfig(params.project, 'export')?.enabled
                     if(pluginData.scmExportEnabled){
                         pluginData.scmStatus = scmService.exportStatusForJobs(result.nextScheduled)
                         pluginData.scmExportStatus = scmService.exportPluginStatus(authContext, params.project)
@@ -3021,7 +3021,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             def pluginData = [:]
             try {
                 if (scmService.projectHasConfiguredImportPlugin(params.project)) {
-                    pluginData.scmImportEnabled = scmService.loadScmConfig(params.project, 'import').enabled
+                    pluginData.scmImportEnabled = scmService.loadScmConfig(params.project, 'import')?.enabled
                     if(pluginData.scmImportEnabled){
                         pluginData.scmImportJobStatus = scmService.importStatusForJobs(result.nextScheduled)
                         pluginData.scmImportStatus = scmService.importPluginStatus(authContext, params.project)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -432,12 +432,14 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 def pluginData = [:]
                 try {
                     if (scmService.projectHasConfiguredExportPlugin(params.project)) {
-                        pluginData.scmExportEnabled = true
-                        pluginData.scmExportActions = scmService.exportPluginActions(authContext, params.project)
-                        if(!minScm){
-                            pluginData.scmStatus = scmService.exportStatusForJobs(results.nextScheduled)
-                            pluginData.scmExportStatus = scmService.exportPluginStatus(authContext, params.project)
-                            pluginData.scmExportRenamed = scmService.getRenamedJobPathsForProject(params.project)
+                        pluginData.scmExportEnabled = scmService.loadScmConfig(params.project, 'export').enabled
+                        if(pluginData.scmExportEnabled){
+                            pluginData.scmExportActions = scmService.exportPluginActions(authContext, params.project)
+                            if(!minScm){
+                                pluginData.scmStatus = scmService.exportStatusForJobs(results.nextScheduled)
+                                pluginData.scmExportStatus = scmService.exportPluginStatus(authContext, params.project)
+                                pluginData.scmExportRenamed = scmService.getRenamedJobPathsForProject(params.project)
+                            }
                         }
                         results.putAll(pluginData)
                     }
@@ -451,15 +453,16 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                                                  ),
                                                                  [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT]
             )) {
-
                 def pluginData = [:]
                 try {
                     if (scmService.projectHasConfiguredImportPlugin(params.project)) {
-                        pluginData.scmImportEnabled = true
-                        pluginData.scmImportActions = scmService.importPluginActions(authContext, params.project)
-                        if(!minScm){
-                            pluginData.scmImportJobStatus = scmService.importStatusForJobs(results.nextScheduled)
-                            pluginData.scmImportStatus = scmService.importPluginStatus(authContext, params.project)
+                        pluginData.scmImportEnabled = scmService.loadScmConfig(params.project, 'import').enabled
+                        if(pluginData.scmImportEnabled){
+                            pluginData.scmImportActions = scmService.importPluginActions(authContext, params.project)
+                            if(!minScm){
+                                pluginData.scmImportJobStatus = scmService.importStatusForJobs(results.nextScheduled)
+                                pluginData.scmImportStatus = scmService.importPluginStatus(authContext, params.project)
+                            }
                         }
                         results.putAll(pluginData)
                     }
@@ -2986,13 +2989,19 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT]
         )) {
             def pluginData = [:]
+            if(frameworkService.isClusterModeEnabled()){
+                //initialize if in another node
+                scmService.initProject(params.project,'export')
+            }
             try {
                 if (scmService.projectHasConfiguredExportPlugin(params.project)) {
-                    pluginData.scmExportEnabled = true
-                    pluginData.scmStatus = scmService.exportStatusForJobs(result.nextScheduled)
-                    pluginData.scmExportStatus = scmService.exportPluginStatus(authContext, params.project)
-                    pluginData.scmExportActions = scmService.exportPluginActions(authContext, params.project)
-                    pluginData.scmExportRenamed = scmService.getRenamedJobPathsForProject(params.project)
+                    pluginData.scmExportEnabled = scmService.loadScmConfig(params.project, 'export').enabled
+                    if(pluginData.scmExportEnabled){
+                        pluginData.scmStatus = scmService.exportStatusForJobs(result.nextScheduled)
+                        pluginData.scmExportStatus = scmService.exportPluginStatus(authContext, params.project)
+                        pluginData.scmExportActions = scmService.exportPluginActions(authContext, params.project)
+                        pluginData.scmExportRenamed = scmService.getRenamedJobPathsForProject(params.project)
+                    }
                     results.putAll(pluginData)
                 }
             } catch (ScmPluginException e) {
@@ -3005,14 +3014,19 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 ),
                 [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT]
         )) {
-
+            if(frameworkService.isClusterModeEnabled()){
+                //initialize if in another node
+                scmService.initProject(params.project,'import')
+            }
             def pluginData = [:]
             try {
                 if (scmService.projectHasConfiguredImportPlugin(params.project)) {
-                    pluginData.scmImportEnabled = true
-                    pluginData.scmImportJobStatus = scmService.importStatusForJobs(result.nextScheduled)
-                    pluginData.scmImportStatus = scmService.importPluginStatus(authContext, params.project)
-                    pluginData.scmImportActions = scmService.importPluginActions(authContext, params.project)
+                    pluginData.scmImportEnabled = scmService.loadScmConfig(params.project, 'import').enabled
+                    if(pluginData.scmImportEnabled){
+                        pluginData.scmImportJobStatus = scmService.importStatusForJobs(result.nextScheduled)
+                        pluginData.scmImportStatus = scmService.importPluginStatus(authContext, params.project)
+                        pluginData.scmImportActions = scmService.importPluginActions(authContext, params.project)
+                    }
                     results.putAll(pluginData)
                 }
 

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1035,9 +1035,8 @@ class ScmService {
         def clusterMode = frameworkService.isClusterModeEnabled()
         def joblist = exportjobRefsForJobs(jobs)
         if(jobs && jobs.size()>0 && clusterMode){
-            //check if are jobs outdated
-            def plugin = getLoadedExportPluginFor jobs.get(0).project
-            plugin.clusterFixJobs(joblist)
+            def project = jobs.get(0).project
+            fixExportStatus(project, jobs)
         }
 
         joblist.each { jobReference ->
@@ -1249,6 +1248,13 @@ class ScmService {
         return pluginConfig.getSettingList('trackedItems')
     }
 
+    private fixExportStatus(String project, List<ScheduledExecution> jobs){
+        if(jobs && jobs.size()>0){
+            def joblist = exportjobRefsForJobs(jobs)
+            def plugin = getLoadedExportPluginFor project
+            plugin.clusterFixJobs(joblist)
+        }
+    }
 
 }
 

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1056,7 +1056,13 @@ class ScmService {
      */
     Map<String, JobImportState> importStatusForJobs(List<ScheduledExecution> jobs) {
         def status = [:]
-        scmJobRefsForJobs(jobs).each { JobScmReference jobReference ->
+        def clusterMode = frameworkService.isClusterModeEnabled()
+        def joblist = scmJobRefsForJobs(jobs)
+        if(jobs && jobs.size()>0 && clusterMode){
+            def project = jobs.get(0).project
+            fixImportStatus(project,joblist)
+        }
+        joblist.each { JobScmReference jobReference ->
             def plugin = getLoadedImportPluginFor jobReference.project
             if (plugin) {
                 //TODO: deleted job paths?
@@ -1254,6 +1260,14 @@ class ScmService {
             def plugin = getLoadedExportPluginFor project
             plugin.clusterFixJobs(joblist)
         }
+    }
+
+    private fixImportStatus(String project, List<JobScmReference> jobs){
+        if(jobs && jobs.size()>0){
+            def plugin = getLoadedImportPluginFor project
+            plugin.clusterFixJobs(jobs)
+        }
+
     }
 
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -275,6 +275,9 @@ class ScmService {
     }
 
     private String pathForConfigFile(String integration) {
+        if(frameworkService.isClusterModeEnabled()){ //universal config for cluster
+            return "etc/scm-${integration}.properties"
+        }
         if (frameworkService.serverUUID) {
             return "${frameworkService.serverUUID}/etc/scm-${integration}.properties"
         }

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1033,13 +1033,12 @@ class ScmService {
     Map<String, JobState> exportStatusForJobs(List<ScheduledExecution> jobs) {
         def status = [:]
         def clusterMode = frameworkService.isClusterModeEnabled()
-        def joblist = exportjobRefsForJobs(jobs)
         if(jobs && jobs.size()>0 && clusterMode){
             def project = jobs.get(0).project
             fixExportStatus(project, jobs)
         }
 
-        joblist.each { jobReference ->
+        exportjobRefsForJobs(jobs).each { jobReference ->
             def plugin = getLoadedExportPluginFor jobReference.project
             if (plugin) {
                 def originalPath = getRenamedPathForJobId(jobReference.project, jobReference.id)
@@ -1057,12 +1056,11 @@ class ScmService {
     Map<String, JobImportState> importStatusForJobs(List<ScheduledExecution> jobs) {
         def status = [:]
         def clusterMode = frameworkService.isClusterModeEnabled()
-        def joblist = scmJobRefsForJobs(jobs)
         if(jobs && jobs.size()>0 && clusterMode){
             def project = jobs.get(0).project
-            fixImportStatus(project,joblist)
+            fixImportStatus(project,jobs)
         }
-        joblist.each { JobScmReference jobReference ->
+        scmJobRefsForJobs(jobs).each { JobScmReference jobReference ->
             def plugin = getLoadedImportPluginFor jobReference.project
             if (plugin) {
                 //TODO: deleted job paths?
@@ -1254,18 +1252,19 @@ class ScmService {
         return pluginConfig.getSettingList('trackedItems')
     }
 
-    private fixExportStatus(String project, List<ScheduledExecution> jobs){
+    public fixExportStatus(String project, List<ScheduledExecution> jobs){
         if(jobs && jobs.size()>0){
             def joblist = exportjobRefsForJobs(jobs)
             def plugin = getLoadedExportPluginFor project
-            plugin.clusterFixJobs(joblist)
+            plugin?.clusterFixJobs(joblist)
         }
     }
 
-    private fixImportStatus(String project, List<JobScmReference> jobs){
+    public fixImportStatus(String project, List<ScheduledExecution> jobs){
         if(jobs && jobs.size()>0){
+            def joblist = scmJobRefsForJobs(jobs)
             def plugin = getLoadedImportPluginFor project
-            plugin.clusterFixJobs(jobs)
+            plugin?.clusterFixJobs(joblist)
         }
 
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1032,7 +1032,15 @@ class ScmService {
      */
     Map<String, JobState> exportStatusForJobs(List<ScheduledExecution> jobs) {
         def status = [:]
-        exportjobRefsForJobs(jobs).each { jobReference ->
+        def clusterMode = frameworkService.isClusterModeEnabled()
+        def joblist = exportjobRefsForJobs(jobs)
+        if(jobs && jobs.size()>0 && clusterMode){
+            //check if are jobs outdated
+            def plugin = getLoadedExportPluginFor jobs.get(0).project
+            plugin.clusterFixJobs(joblist)
+        }
+
+        joblist.each { jobReference ->
             def plugin = getLoadedExportPluginFor jobReference.project
             if (plugin) {
                 def originalPath = getRenamedPathForJobId(jobReference.project, jobReference.id)

--- a/rundeckapp/test/unit/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/MenuControllerSpec.groovy
@@ -45,6 +45,7 @@ import rundeck.services.ScheduledExecutionService
 import rundeck.services.ScmService
 import rundeck.services.authorization.PoliciesValidation
 import rundeck.services.scm.ScmPluginConfig
+import rundeck.services.scm.ScmPluginConfigData
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -722,6 +723,9 @@ class MenuControllerSpec extends Specification {
         controller.scheduledExecutionService = Mock(ScheduledExecutionService)
         controller.scmService = Mock(ScmService)
         def project = 'test'
+        def scmConfig = Mock(ScmPluginConfigData){
+            getEnabled() >> true
+        }
 
         when:
         request.method = 'POST'
@@ -738,6 +742,7 @@ class MenuControllerSpec extends Specification {
         1 * controller.frameworkService.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT]) >> true
         1 * controller.scmService.projectHasConfiguredExportPlugin(project) >> true
         1 * controller.scmService.projectHasConfiguredImportPlugin(project) >> false
+        1 * controller.scmService.loadScmConfig(project,'export') >> scmConfig
 
         response.json
         response.json.scmExportEnabled

--- a/rundeckapp/test/unit/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ScmServiceSpec.groovy
@@ -584,4 +584,29 @@ class ScmServiceSpec extends Specification {
         info.lastName == 'b'
         info.email == 'test@test.com'
     }
+
+
+    def "lookup config on cluster mode"() {
+        given:
+        service.frameworkService = Mock(FrameworkService){
+            getServerUUID() >> uuid
+        }
+
+        when:
+        def result = service.pathForConfigFile(integration)
+
+        then:
+        1 * service.frameworkService.isClusterModeEnabled() >> clusterMode
+        path == result
+
+        where:
+        integration         | uuid      | clusterMode   | path
+        ScmService.EXPORT   | 'abcd'    |false          | 'abcd/etc/scm-export.properties'
+        ScmService.IMPORT   | 'efgh'    |false          | 'efgh/etc/scm-import.properties'
+        ScmService.EXPORT   | 'ijkl'    |null           | 'ijkl/etc/scm-export.properties'
+        ScmService.IMPORT   | 'mnop'    |null           | 'mnop/etc/scm-import.properties'
+        ScmService.EXPORT   | 'qrst'    |true           | 'etc/scm-export.properties'
+        ScmService.IMPORT   | 'uvwx'    |true           | 'etc/scm-import.properties'
+
+    }
 }


### PR DESCRIPTION
See #1622 

Removed member unique config. Now, on cluster mode, the configuration its saved on the `scm` folder, not in the `scm/nodeUuid` folder. This require configure again the scm plugins on cluster environments.
If a job is imported or from one node, other nodes got the same information.