### PR TITLE
serverNodeUUID field to varchar 

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/JobFileRecord.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/JobFileRecord.groovy
@@ -72,7 +72,6 @@ class JobFileRecord {
     static mapping = {
         storageMeta(type: 'text')
         storageReference(type: 'text')
-        serverNodeUUID(type: 'text')
         user column: "rduser"
         size column: "`SIZE`"
     }


### PR DESCRIPTION
serverNodeUUID field works as a normal String field, no need to be a text field, causing the #3125 problem on Oracle.

This fixes the problem for future implementations over Oracle, current versions of the table need to migrate the CLOB field to Varchar2