### PR TITLE
Incomplete report at start on jobref

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/workflow/StateMapping.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/workflow/StateMapping.groovy
@@ -34,7 +34,6 @@ class StateMapping {
         def nodeSummaries=[:]
         def nodeSteps=[:]
         (selectedOnly?nodes:map.allNodes).each{node->
-
             def states = stepStatesForNode(map, node)
             nodeSummaries[node]=summarizeForNode(map,node, states)
             if(nodes.contains(node)){
@@ -182,6 +181,8 @@ class StateMapping {
                     def newfound=new HashMap(found)
                     newfound.stepctx = step.stepctx
                     newsteps.push(newfound)
+                }else{
+                    newsteps.push(step)
                 }
             }
         }

--- a/rundeckapp/test/unit/rundeck/services/WorkflowServiceSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/services/WorkflowServiceSpec.groovy
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rundeck.services
+
+import com.dtolabs.rundeck.app.internal.workflow.MutableWorkflowNodeStateImpl
+import com.dtolabs.rundeck.app.internal.workflow.MutableWorkflowStateImpl
+import com.dtolabs.rundeck.app.internal.workflow.MutableWorkflowStepStateImpl
+import com.dtolabs.rundeck.core.execution.workflow.state.ExecutionState
+import com.dtolabs.rundeck.core.execution.workflow.state.StateUtils
+import com.dtolabs.rundeck.core.execution.workflow.state.WorkflowState
+import grails.test.mixin.Mock
+import grails.test.mixin.TestFor
+import rundeck.Execution
+import rundeck.services.workflow.StateMapping
+import spock.lang.Specification
+
+import static com.dtolabs.rundeck.core.execution.workflow.state.StateUtils.stepIdentifier
+
+@TestFor(WorkflowService)
+@Mock([Execution])
+class WorkflowServiceSpec extends Specification{
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    def "state mapping"(){
+        given:
+        StateMapping mapping = new StateMapping()
+
+        def map = execMap()
+        def nodes = ['nodea']
+        when:
+        def resp = mapping.summarize(map,nodes,true)
+
+        then:
+        resp
+        resp.nodeSummaries
+        resp.nodeSteps
+        resp.nodeSteps.get('nodea')
+        resp.nodeSteps.get('nodea').size()==5
+    }
+
+
+    private Map execMap(){
+        def map = [executionId:2008,
+                   nodes:[nodea:[[stepctx:'1', executionState:'SUCCEEDED'],
+                                      [stepctx:'2/1', executionState:'WAITING'],
+                                      [stepctx:'2/2', executionState:'WAITING'],
+                                      [stepctx:'2/3', executionState:'WAITING'],
+                                      [stepctx:'3', executionState:'WAITING']],
+                          nodeb:[[stepctx:'2/1', executionState:'SUCCEEDED'],
+                               [stepctx:'2/2', executionState:'RUNNING'],
+                               [stepctx:'2/3', executionState:'WAITING'],
+                               [stepctx:'2@node=nodea/1', executionState:'SUCCEEDED'],
+                               [stepctx:'2@node=nodea/2', executionState:'RUNNING']]
+                   ],
+                   serverNode:'nodea',
+                   executionState:'RUNNING',
+                   completed:false,
+                   targetNodes:['nodea'],
+                   allNodes:['nodea', 'nodeb'],
+                   stepCount:3,
+                   updateTime:'2018-02-09T11:43:51Z',
+                   startTime:'2018-02-09T11:43:45Z',
+                   endTime:null,
+                   steps:[
+                           [nodeStates:
+                                    [nodea:[
+                                            executionState:'SUCCEEDED',
+                                            startTime:'2018-02-09T11:43:46Z',
+                                            updateTime:'2018-02-09T11:43:49Z',
+                                            duration:3108,
+                                            endTime:'2018-02-09T11:43:49Z']
+                                    ],
+                            parameterStates:[:],
+                            id:1,
+                            stepctx:1,
+                            nodeStep:true,
+                            executionState:'SUCCEEDED',
+                            startTime:'2018-02-09T11:43:46Z',
+                            updateTime:'2018-02-09T11:43:46Z',
+                            duration:3356,
+                            endTime:'2018-02-09T11:43:49Z'],
+                           [hasSubworkflow:true,
+                            workflow:[
+                                    executionState:'RUNNING',
+                                    completed:false,
+                                    targetNodes:['nodeb', 'nodea'],
+                                    allNodes:['nodeb', 'nodea'],
+                                    stepCount:3,
+                                    updateTime:'2018-02-09T11:43:51Z',
+                                    startTime:'2018-02-09T11:43:50Z',
+                                    endTime:null,
+                                    steps:[
+                                            [nodeStates:
+                                                     [nodea:[executionState:'WAITING',
+                                                                  startTime:null,
+                                                                  updateTime:null,
+                                                                  duration:-1,
+                                                                  endTime:null],
+                                                      nodeb:[executionState:'SUCCEEDED',
+                                                           startTime:'2018-02-09T11:43:50Z',
+                                                           updateTime:'2018-02-09T11:43:51Z',
+                                                           duration:1620,
+                                                           endTime:'2018-02-09T11:43:51Z']],
+                                             parameterStates:[:],
+                                             id:1,
+                                             stepctx:'2/1',
+                                             nodeStep:true,
+                                             executionState:'RUNNING',
+                                             startTime:'2018-02-09T11:43:50Z',
+                                             updateTime:'2018-02-09T11:43:50Z',
+                                             duration:0, endTime:null],
+                                            [nodeStates:[
+                                                    nodea:[executionState:'WAITING',
+                                                                startTime:null,
+                                                                updateTime:null,
+                                                                duration:-1,
+                                                                endTime:null],
+                                                    nodeb:[executionState:'RUNNING',
+                                                         startTime:'2018-02-09T11:43:51Z',
+                                                         updateTime:'2018-02-09T11:43:51Z',
+                                                         duration:0,
+                                                         endTime:null]],
+                                             parameterStates:[:],
+                                             id:2,
+                                             stepctx:'2/2',
+                                             nodeStep:true,
+                                             executionState:'RUNNING',
+                                             startTime:'2018-02-09T11:43:51Z',
+                                             updateTime:'2018-02-09T11:43:51Z',
+                                             duration:0,
+                                             endTime:null],
+                                            [nodeStates:[
+                                                    nodea:[executionState:'WAITING',
+                                                                startTime:null,
+                                                                updateTime:null,
+                                                                duration:-1,
+                                                                endTime:null],
+                                                    nodeb:[executionState:'WAITING',
+                                                         startTime:null,
+                                                         updateTime:null,
+                                                         duration:-1,
+                                                         endTime:null]],
+                                             parameterStates:[:],
+                                             id:3,
+                                             stepctx:'2/3',
+                                             nodeStep:true,
+                                             executionState:'WAITING',
+                                             startTime:null,
+                                             updateTime:null,
+                                             duration:-1,
+                                             endTime:null]]
+                            ],
+                            parameterStates:
+                                    ['node=nodea':[
+                                            hasSubworkflow:true,
+                                            workflow:[
+                                                    executionState:'RUNNING',
+                                                    completed:false,
+                                                    targetNodes:['nodeb', 'nodea'],
+                                                    allNodes:['nodeb', 'nodea'],
+                                                    stepCount:3,
+                                                    updateTime:'2018-02-09T11:43:51Z',
+                                                    startTime:'2018-02-09T11:43:50Z',
+                                                    endTime:null,
+                                                    steps:[
+                                                            [nodeStates:
+                                                                     [nodeb:
+                                                                              [executionState:'SUCCEEDED',
+                                                                               startTime:'2018-02-09T11:43:50Z',
+                                                                               updateTime:'2018-02-09T11:43:51Z',
+                                                                               duration:1620,
+                                                                               endTime:'2018-02-09T11:43:51Z']
+                                                                     ],
+                                                             parameterStates:[:],
+                                                             id:1,
+                                                             stepctx:'2@node=nodea/1',
+                                                             nodeStep:true,
+                                                             executionState:'RUNNING',
+                                                             startTime:'2018-02-09T11:43:50Z',
+                                                             updateTime:'2018-02-09T11:43:50Z',
+                                                             duration:0, endTime:null],
+                                                            [nodeStates:[
+                                                                    nodeb:[executionState:'RUNNING',
+                                                                         startTime:'2018-02-09T11:43:51Z',
+                                                                         updateTime:'2018-02-09T11:43:51Z',
+                                                                         duration:0, endTime:null]],
+                                                             parameterStates:[:],
+                                                             id:2,
+                                                             stepctx:'2@node=nodea/2',
+                                                             nodeStep:true,
+                                                             executionState:'RUNNING',
+                                                             startTime:'2018-02-09T11:43:51Z',
+                                                             updateTime:'2018-02-09T11:43:51Z',
+                                                             duration:0,
+                                                             endTime:null],
+                                                            [parameterStates:[:],
+                                                             id:3,
+                                                             stepctx:'2@node=nodea/3',
+                                                             nodeStep:false,
+                                                             executionState:'WAITING',
+                                                             startTime:null,
+                                                             updateTime:null,
+                                                             duration:-1,
+                                                             endTime:null]]
+                                            ],
+                                            parameterStates:[:],
+                                            parameters:[node:'nodea'],
+                                            id:'2@node=nodea',
+                                            stepctx:'2@node=nodea',
+                                            nodeStep:false,
+                                            executionState:'RUNNING',
+                                            startTime:null,
+                                            updateTime:null,
+                                            duration:-1,
+                                            endTime:null]
+                                    ],
+                            id:2,
+                            stepctx:'2',
+                            nodeStep:true,
+                            executionState:'RUNNING',
+                            startTime:'2018-02-09T11:43:49Z',
+                            updateTime:'2018-02-09T11:43:49Z',
+                            duration:0, endTime:null],
+                           [nodeStates:
+                                    [nodea:
+                                             [executionState:'WAITING',
+                                              startTime:null,
+                                              updateTime:null,
+                                              duration:-1,
+                                              endTime:null]
+                                    ],
+                            parameterStates:[:],
+                            id:3,
+                            stepctx:3,
+                            nodeStep:true,
+                            executionState:'WAITING',
+                            startTime:null,
+                            updateTime:null,
+                            duration:-1,
+                            endTime:null]
+                   ]
+        ]
+        return map
+    }
+}


### PR DESCRIPTION
Fix #1481

In some cases, the referenced jobs don't appear on the report at the start, only when the job is complete.

This specifically happens when the referenced job run on the same node as one of the parent jobs and in another node.

Prior to this PR.
At start:
![screenshot at feb 09 14-31-57](https://user-images.githubusercontent.com/2894508/36041492-7a113b36-0da7-11e8-86f5-4cbc8ead434a.png)
Running:
![screenshot at feb 09 14-32-13](https://user-images.githubusercontent.com/2894508/36041508-85072dac-0da7-11e8-83c5-0b3f07e7a487.png)

At the end:
![screenshot at feb 09 14-32-41](https://user-images.githubusercontent.com/2894508/36041519-8ee78f88-0da7-11e8-87b0-ae5ac5f2529c.png)


Now:

At start:
![screenshot at feb 09 14-36-36](https://user-images.githubusercontent.com/2894508/36041556-a56318cc-0da7-11e8-88ac-53856560ed7f.png)

Running:
![screenshot at feb 09 14-36-58](https://user-images.githubusercontent.com/2894508/36041567-ab4d4c58-0da7-11e8-865e-8fcfd4d7b184.png)

At the end:
![imagen](https://user-images.githubusercontent.com/2894508/36041575-b3b732a0-0da7-11e8-9b4b-0b9e3a982eb3.png)


