### PR TITLE
Updated git-plugin to support multiple job definitions per YAML file.

### DIFF
--- a/plugins/git-plugin/build.gradle
+++ b/plugins/git-plugin/build.gradle
@@ -43,6 +43,7 @@ dependencies {
         exclude module: 'commons-logging'
     }
     compile 'org.codehaus.groovy:groovy-all:2.3.7'
+    compile 'org.yaml:snakeyaml:1.17'
     compile 'log4j:log4j:1.2.17'
 
     testCompile 'junit:junit:4.8.1',


### PR DESCRIPTION
Is a bit of a work around for #3139, I think you would have to do a bit of redesigning the job import plugin api to do it further up. You could potentially expose an `importMultipleFromStream` method, and that wouldn't be a breaking change? I quite liked that I could fix this without compiling the the entire application however. Feel free to reject this PR if it's hacky.