### PR TITLE
${job.executionType} to context variables documentation

### DIFF
--- a/docs/en/manual/04-jobs.md
+++ b/docs/en/manual/04-jobs.md
@@ -1647,6 +1647,7 @@ Job context variables:
 * `job.group`: Group of the Job
 * `job.id`: ID of the Job
 * `job.execid`: ID of the current Execution
+* `job.executionType` : Execution type, can be `user`, `scheduled` or `user-scheduled` for `Run Job Later` executions
 * `job.username`: Username of the user executing the Job
 * `job.project`: Project name
 * `job.loglevel`: Logging level, one of: 'ERROR','WARN','INFO','VERBOSE','DEBUG'

--- a/rundeckapp/grails-app/assets/javascripts/jobedit.js
+++ b/rundeckapp/grails-app/assets/javascripts/jobedit.js
@@ -85,6 +85,7 @@ function _jobVarData() {
         var jobdata = {
             'id': {title: 'Job ID'},
             'execid': {title: 'Execution ID'},
+            'executionType': {title: 'Execution Type'},
             'name': {title: 'Job Name'},
             'group': {title: 'Job Group'},
             'username': {title: 'Name of user executing the job'},
@@ -96,7 +97,7 @@ function _jobVarData() {
             'threadcount': {title: 'Job Threadcount'},
             'filter': {title: 'Job Node Filter Query'}
         };
-        ['id', 'execid', 'name', 'group', 'username', 'project', 'loglevel', 'user.email', 'retryAttempt', 'wasRetry', 'threadcount', 'filter'].each(function (e) {
+        ['id', 'execid', 'executionType', 'name', 'group', 'username', 'project', 'loglevel', 'user.email', 'retryAttempt', 'wasRetry', 'threadcount', 'filter'].each(function (e) {
             _VAR_DATA['job'].push({key: 'job.' + e, category: 'Job', title: jobdata[e].title, desc: jobdata[e].desc});
         });
     }


### PR DESCRIPTION
Fix #1811 
Added ${job.executionType} to context variables documentation and to autocomplete.

![imagen](https://user-images.githubusercontent.com/2894508/36906060-b2ce077a-1e13-11e8-9888-bd065197f480.png)

![imagen](https://user-images.githubusercontent.com/2894508/36906011-925e5120-1e13-11e8-91d1-8e2bc580841d.png)