### PR TITLE
Force to kill execution on database problem

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/executionControl.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionControl.js
@@ -1460,5 +1460,22 @@ var FollowControl = Class.create({
                 obj.updatecancel({error: "Failed to kill Job: " + (jqxhr.responseJSON && jqxhr.responseJSON.error? jqxhr.responseJSON.error: err)});
             }
         }).success(_ajaxReceiveTokens.curry('exec_cancel_token'));
-    }
+    },
+
+    doincomplete: function() {
+        var obj=this;
+        return jQuery.ajax({
+            type: 'POST',
+            url: this.appLinks.executionCancelExecution,
+            dataType:'json',
+            data: {id: this.executionId},
+            beforeSend: _ajaxSendTokens.curry('exec_cancel_token'),
+            success: function (data,status,jqxhr) {
+                obj.updatecancel(data);
+            },
+            error: function (jqxhr,status,err) {
+                obj.updatecancel({error: "Failed to kill Job: " + (jqxhr.responseJSON && jqxhr.responseJSON.error? jqxhr.responseJSON.error: err)});
+            }
+        }).success(_ajaxReceiveTokens.curry('exec_cancel_token'));
+    },
 });

--- a/rundeckapp/grails-app/assets/javascripts/executionControl.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionControl.js
@@ -1466,7 +1466,7 @@ var FollowControl = Class.create({
         var obj=this;
         return jQuery.ajax({
             type: 'POST',
-            url: this.appLinks.executionCancelExecution,
+            url: this.appLinks.executionMarkExecutionIncomplete,
             dataType:'json',
             data: {id: this.executionId},
             beforeSend: _ajaxSendTokens.curry('exec_cancel_token'),
@@ -1474,7 +1474,7 @@ var FollowControl = Class.create({
                 obj.updatecancel(data);
             },
             error: function (jqxhr,status,err) {
-                obj.updatecancel({error: "Failed to kill Job: " + (jqxhr.responseJSON && jqxhr.responseJSON.error? jqxhr.responseJSON.error: err)});
+                obj.updatecancel({error: "Failed to mark Job as incomplete: " + (jqxhr.responseJSON && jqxhr.responseJSON.error? jqxhr.responseJSON.error: err)});
             }
         }).success(_ajaxReceiveTokens.curry('exec_cancel_token'));
     },

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -948,6 +948,14 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
             });
         }
     };
+    self.markExecAction = function () {
+        if (self.execFollowingControl) {
+            self.execFollowingControl.doincomplete().then(function (data) {
+                self.killRequested(true);
+                self.killResponseData(data);
+            });
+        }
+    };
     self.killStatusFailed = ko.computed(function () {
         "use strict";
         var req = self.killRequested();
@@ -979,6 +987,15 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
         } else {
             return (data ? data['error'] || data.reason : '') || 'Failed to Kill Job.';
         }
+    });
+    self.killedbutNotSaved = ko.computed(function () {
+        "use strict";
+        var req = self.killRequested();
+        var data = self.killResponseData();
+        if (!req) {
+            return "";
+        }
+        return data && data.cancelled && data.status === 'db-error';
     });
     self.totalNodeCount=ko.observable(0);
     self.nodeIndex={};

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -1710,8 +1710,9 @@ class ExecutionController extends ControllerBase{
             return
         }
         ExecutionService.AbortResult abortresult
+        def Execution e
         try {
-            def Execution e = Execution.get(params.id)
+            e = Execution.get(params.id)
             if (!apiService.requireExists(response, e, ['Execution ID', params.id])) {
                 return
             }
@@ -1755,6 +1756,7 @@ class ExecutionController extends ControllerBase{
             }
 
             abortresult.abortstate = didCancel?ExecutionService.ABORT_ABORTED:ExecutionService.ABORT_PENDING
+            throw ex
         }
 
         def reportstate=[status: abortresult.abortstate]

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -349,6 +349,13 @@ class ExecutionController extends ControllerBase{
             return render(contentType: 'application/json', text: [error: "Execution not found for id: " + params.id] as JSON)
         }
 
+        JobExecutionContext jexec = scheduledExecutionService.findExecutingQuartzJob(Long.valueOf(params.id))
+        if(!jexec && !e.dateCompleted){
+            log.debug("Mark killed execution ${params.id} as incomplete")
+            executionService.cleanupExecution(e,'incomplete')
+        }
+
+
         AuthContext authContext = frameworkService.getAuthContextForSubjectAndProject(session.subject,e.project)
 
         if (e && !frameworkService.authorizeProjectExecutionAll(authContext, e, [AuthConstants.ACTION_READ])) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -349,13 +349,6 @@ class ExecutionController extends ControllerBase{
             return render(contentType: 'application/json', text: [error: "Execution not found for id: " + params.id] as JSON)
         }
 
-        JobExecutionContext jexec = scheduledExecutionService.findExecutingQuartzJob(Long.valueOf(params.id))
-        if(!jexec && !e.dateCompleted){
-            log.debug("Mark killed execution ${params.id} as incomplete")
-            executionService.cleanupExecution(e,'incomplete')
-        }
-
-
         AuthContext authContext = frameworkService.getAuthContextForSubjectAndProject(session.subject,e.project)
 
         if (e && !frameworkService.authorizeProjectExecutionAll(authContext, e, [AuthConstants.ACTION_READ])) {
@@ -630,7 +623,8 @@ class ExecutionController extends ControllerBase{
                 )
             }
 
-            abortresult.abortstate = didCancel?ExecutionService.ABORT_ABORTED:ExecutionService.ABORT_PENDING
+            abortresult.abortstate = ExecutionService.ABORT_ABORTED
+            abortresult.status = "db-error"
         }
 
 

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -850,6 +850,7 @@ really.delete.this.execution=Really delete this Execution?
 delete.execution.title=Delete Execution
 button.action.delete.this.execution=Delete this Execution
 button.action.kill.job=Kill Job
+button.action.incomplete.job=Mark as Incomplete
 execution.page.show.tab.Summary.title=Summary
 elapsed.time.prompt=Elapsed Time\:
 button.action.view.log.output=View Log Output &raquo;

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -847,6 +847,7 @@ really.delete.this.execution=¿Realmente borrar esta Ejecución?
 delete.execution.title=Borrar Ejecución
 button.action.delete.this.execution=Borrar esta Ejecución
 button.action.kill.job=Eliminar Trabajo
+button.action.incomplete.job=Marcar como Incompleto
 execution.page.show.tab.Summary.title=Resumen
 elapsed.time.prompt=Tiempo transcurrido\:
 button.action.view.log.output=Ver Salida de Registro &raquo;

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -850,6 +850,7 @@ really.delete.this.execution=\u786E\u5B9A\u8981\u5220\u9664\u4E48\uFF1F
 delete.execution.title=\u5220\u9664\u8FD0\u884C\u8BB0\u5F55
 button.action.delete.this.execution=\u5220\u9664\u8FD0\u884C\u8BB0\u5F55
 button.action.kill.job=\u505C\u6B62
+button.action.incomplete.job=Mark as Incomplete
 execution.page.show.tab.Summary.title=\u6C47\u603B
 elapsed.time.prompt=\u8FD0\u884C\u65F6\u95F4\:
 button.action.view.log.output=\u663E\u793A\u65E5\u5FD7&raquo;

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1149,6 +1149,23 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     }
 
     /**
+     *
+     * @param id execution id
+     * @return quartz scheduler JobExecutionContext
+     */
+    def JobExecutionContext findExecutingQuartzJob(Long id) {
+        JobExecutionContext found = null
+        quartzScheduler.getCurrentlyExecutingJobs().each {def JobExecutionContext jexec ->
+            def job = jexec.getJobInstance()
+            if (job instanceof ExecutionJob && id == job.executionId) {
+                found = jexec
+            }
+        }
+
+        return found
+    }
+
+    /**
      * Interrupt a running quartz job if present or optinoally delete from scheduler if not
      * @param quartzIntanceId quartz fire instance Id
      * @param jobName

--- a/rundeckapp/grails-app/views/common/_js.gsp
+++ b/rundeckapp/grails-app/views/common/_js.gsp
@@ -27,6 +27,7 @@
         iconTinyRemoveX: '${resource(dir:"images",file:"icon-tiny-removex.png")}',
         iconSpinner: '${resource(dir:"images",file:"icon-tiny-disclosure-waiting.gif")}',
         executionCancelExecution: '${createLink(controller:"execution",action:"cancelExecution",params:[format:'json'])}',
+        executionMarkExecutionIncomplete: '${createLink(controller:"execution",action:"incompleteExecution",params:[format:'json'])}',
         tailExecutionOutput: '${createLink(controller: "execution", action: "tailExecutionOutput",params:[format:'json'])}',
         reportsEventsFragment:"${createLink(controller:'reports',action:'eventsFragment',params:projParams)}",
         executionAjaxExecState: "${createLink(action: 'ajaxExecState', controller: 'execution')}",

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -341,6 +341,13 @@
                                             <!-- /ko -->
                                             <span class="loading" data-bind="text: killStatusText"></span>
                                             <!-- /ko -->
+                                            <!-- ko if: killedbutNotSaved() -->
+                                            <span class="btn btn-danger btn-sm"
+                                                  data-bind="click: markExecAction">
+                                                <g:message code="button.action.incomplete.job" default="Mark as Incomplete"/>
+                                                <i class="glyphicon glyphicon-remove"></i>
+                                            </span>
+                                            <!-- /ko -->
                                         </span>
                                         </div>
                                 </g:if>

--- a/rundeckapp/test/unit/rundeck/controllers/ExecutionControllerTests.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ExecutionControllerTests.groovy
@@ -23,6 +23,7 @@ import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.test.ControllerUnitTestCase
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
+import org.quartz.JobExecutionContext
 import rundeck.CommandExec
 import rundeck.Execution
 import rundeck.ScheduledExecution
@@ -31,7 +32,10 @@ import rundeck.services.ApiService
 import rundeck.services.ExecutionService
 import rundeck.services.FrameworkService
 import rundeck.services.LoggingService
+import rundeck.services.ScheduledExecutionService
+import rundeck.services.WorkflowService
 import rundeck.services.logging.ExecutionLogState
+import rundeck.services.logging.WorkflowStateFileLoader
 
 @TestFor(ExecutionController)
 @Mock([Workflow,ScheduledExecution,Execution,CommandExec])
@@ -136,6 +140,10 @@ class ExecutionControllerTests  {
         Execution e1 = new Execution( project: 'test1', user: 'bob', dateStarted: new Date())
         assert e1.validate(), e1.errors.allErrors.collect { it.toString() }.join(",")
         assert e1.save()
+        def jobexec = mockWith(JobExecutionContext){}
+        controller.scheduledExecutionService = mockWith(ScheduledExecutionService){
+            findExecutingQuartzJob{id -> jobexec}
+        }
         controller.params.id=e1.id
         controller.frameworkService=mockWith(FrameworkService){
             getAuthContextForSubjectAndProject{ subj,proj-> null }
@@ -613,5 +621,60 @@ class ExecutionControllerTests  {
 
         assert 403 == controller.response.status
         assert null == controller.flash.errorCode
+    }
+
+    void testAjaxExecState_ok(){
+        Execution e1 = new Execution( project: 'test1', user: 'bob', dateStarted: new Date())
+        assert e1.validate(), e1.errors.allErrors.collect { it.toString() }.join(",")
+        assert e1.save()
+        def jobexec = mockWith(JobExecutionContext){}
+        controller.scheduledExecutionService = mockWith(ScheduledExecutionService){
+            findExecutingQuartzJob{id -> jobexec}
+        }
+        controller.params.id=e1.id
+        controller.frameworkService=mockWith(FrameworkService){
+            getAuthContextForSubjectAndProject{ subj,proj-> null }
+            authorizeProjectExecutionAll{ ctx, exec, actions-> true }
+            isClusterModeEnabled{->false}
+        }
+
+        controller.executionService = mockWith(ExecutionService){
+            getExecutionState{e -> ExecutionService.EXECUTION_ABORTED}
+        }
+        def loader = new WorkflowStateFileLoader()
+        loader.state = ExecutionLogState.AVAILABLE
+        controller.workflowService = mockWith(WorkflowService){
+            requestStateSummary{e,nodes,selectedOnly, perform,steps-> loader}
+        }
+        controller.ajaxExecState()
+        assertEquals(200,response.status)
+    }
+
+    void testAjaxExecState_killed_with_db_down(){
+        Execution e1 = new Execution( project: 'test1', user: 'bob', dateStarted: new Date())
+        assert e1.validate(), e1.errors.allErrors.collect { it.toString() }.join(",")
+        assert e1.save()
+        //def jobexec = mockWith(JobExecutionContext){}
+        controller.scheduledExecutionService = mockWith(ScheduledExecutionService){
+            findExecutingQuartzJob{id -> null}
+        }
+        controller.params.id=e1.id
+        controller.frameworkService=mockWith(FrameworkService){
+            getAuthContextForSubjectAndProject{ subj,proj-> null }
+            authorizeProjectExecutionAll{ ctx, exec, actions-> true }
+            isClusterModeEnabled{->false}
+        }
+
+        controller.executionService = mockWith(ExecutionService){
+            cleanupExecution{}
+            getExecutionState{e -> ExecutionService.EXECUTION_ABORTED}
+        }
+        def loader = new WorkflowStateFileLoader()
+        loader.state = ExecutionLogState.AVAILABLE
+        controller.workflowService = mockWith(WorkflowService){
+            requestStateSummary{e,nodes,selectedOnly, perform,steps-> loader}
+        }
+        controller.ajaxExecState()
+        assertEquals(200,response.status)
     }
 }

--- a/rundeckapp/test/unit/rundeck/controllers/ExecutionControllerTests.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ExecutionControllerTests.groovy
@@ -649,32 +649,4 @@ class ExecutionControllerTests  {
         controller.ajaxExecState()
         assertEquals(200,response.status)
     }
-
-    void testAjaxExecState_killed_with_db_down(){
-        Execution e1 = new Execution( project: 'test1', user: 'bob', dateStarted: new Date())
-        assert e1.validate(), e1.errors.allErrors.collect { it.toString() }.join(",")
-        assert e1.save()
-        //def jobexec = mockWith(JobExecutionContext){}
-        controller.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            findExecutingQuartzJob{id -> null}
-        }
-        controller.params.id=e1.id
-        controller.frameworkService=mockWith(FrameworkService){
-            getAuthContextForSubjectAndProject{ subj,proj-> null }
-            authorizeProjectExecutionAll{ ctx, exec, actions-> true }
-            isClusterModeEnabled{->false}
-        }
-
-        controller.executionService = mockWith(ExecutionService){
-            cleanupExecution{}
-            getExecutionState{e -> ExecutionService.EXECUTION_ABORTED}
-        }
-        def loader = new WorkflowStateFileLoader()
-        loader.state = ExecutionLogState.AVAILABLE
-        controller.workflowService = mockWith(WorkflowService){
-            requestStateSummary{e,nodes,selectedOnly, perform,steps-> loader}
-        }
-        controller.ajaxExecState()
-        assertEquals(200,response.status)
-    }
 }

--- a/rundeckapp/web-app/js/executionState.js
+++ b/rundeckapp/web-app/js/executionState.js
@@ -216,6 +216,8 @@ var FlowState = Class.create({
                 }
             }
         }
+        //retry if was a temp db error
+        this.timer = setTimeout(this.callUpdate.bind(this), this.reloadInterval);
     },
     update: function (json) {
         var data=json.state;


### PR DESCRIPTION
Fix #3155 
Kill execution wrapped on try catch block, in case a database error is thrown, the job is forced to be killed, and later.
If was killed on the job execution page, ~~the next `ajaxExecState` will try to mark the execution as incomplete.~~ the kill button is replaced with a **Mark as Incomplete** button if you're still on the same execution page.