### PR TITLE
Changing RPM Spec file to add rundeck user and group within system UI…

### DIFF
--- a/packaging/rundeck.spec
+++ b/packaging/rundeck.spec
@@ -33,8 +33,8 @@ Rundeck provides a single console for dispatching commands across many resources
 	- Run the service as the rundeck user.
 
 %pre
-getent group rundeck >/dev/null || groupadd rundeck
-getent passwd rundeck >/dev/null || useradd -d /var/lib/rundeck -m -g rundeck rundeck
+getent group rundeck >/dev/null || groupadd -r rundeck
+getent passwd rundeck >/dev/null || useradd -r -d /var/lib/rundeck -m -g rundeck rundeck
 
 %post
 if [ ! -e ~rundeck/.ssh/id_rsa ]; then


### PR DESCRIPTION
…D ranges instead of normal UID ranges.

Currently, it is adding a user within normal UID ranges. As a result, if you install Rundeck on a node with LDAP authentication, Rundeck will create a user for itself using the next available UID and GID, that can cause a UID/GID conflict the next time that an LDAP user is created / populated on the server via nslcd.