### PR TITLE
Fix: key storage data type not set automatically with Vault plugin

### DIFF
--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/storage/KeyStorageLayer.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/storage/KeyStorageLayer.groovy
@@ -35,6 +35,7 @@ class KeyStorageLayer implements StorageConverterPlugin {
 
     @Override
     HasInputStream readResource(Path path, ResourceMetaBuilder resourceMetaBuilder, HasInputStream hasInputStream) {
+        validate(resourceMetaBuilder, path)
         return null
     }
 

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/storage/KeyStorageLayer.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/storage/KeyStorageLayer.groovy
@@ -32,6 +32,11 @@ class KeyStorageLayer implements StorageConverterPlugin {
     public static final String PASSWORD_MIME_TYPE = "application/x-rundeck-data-password"
     public static final String RUNDECK_KEY_TYPE = "Rundeck-key-type"
     public static final String RUNDECK_DATA_TYPE = "Rundeck-data-type"
+    public static final String RUNDECK_CONTENT_MASK = 'Rundeck-content-mask'
+    public static final String CONTENT_MASK_TYPE_CONTENT = 'content'
+    public static final String KEY_TYPE_PRIVATE = 'private'
+    public static final String KEY_TYPE_PUBLIC = 'public'
+    public static final String KEY_TYPE_PASSWORD = 'password'
 
     @Override
     HasInputStream readResource(Path path, ResourceMetaBuilder resourceMetaBuilder, HasInputStream hasInputStream) {
@@ -49,13 +54,13 @@ class KeyStorageLayer implements StorageConverterPlugin {
         def type = resourceMetaBuilder.contentType
 
         if (type.equals(PRIVATE_KEY_MIME_TYPE)) {
-            resourceMetaBuilder.setMeta('Rundeck-content-mask', 'content')
-            resourceMetaBuilder.setMeta(RUNDECK_KEY_TYPE, 'private')
+            resourceMetaBuilder.setMeta(RUNDECK_CONTENT_MASK, CONTENT_MASK_TYPE_CONTENT)
+            resourceMetaBuilder.setMeta(RUNDECK_KEY_TYPE, KEY_TYPE_PRIVATE)
         }else if (type.equals(PUBLIC_KEY_MIME_TYPE)){
-            resourceMetaBuilder.setMeta(RUNDECK_KEY_TYPE, 'public')
+            resourceMetaBuilder.setMeta(RUNDECK_KEY_TYPE, KEY_TYPE_PUBLIC)
         }else if (type.equals(PASSWORD_MIME_TYPE)){
-            resourceMetaBuilder.setMeta('Rundeck-content-mask', 'content')
-            resourceMetaBuilder.setMeta(RUNDECK_DATA_TYPE, 'password')
+            resourceMetaBuilder.setMeta(RUNDECK_CONTENT_MASK, CONTENT_MASK_TYPE_CONTENT)
+            resourceMetaBuilder.setMeta(RUNDECK_DATA_TYPE, KEY_TYPE_PASSWORD)
         }
     }
 

--- a/rundeckapp/test/unit/com/dtolabs/rundeck/server/plugins/storage/KeyStorageLayerSpec.groovy
+++ b/rundeckapp/test/unit/com/dtolabs/rundeck/server/plugins/storage/KeyStorageLayerSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.server.plugins.storage
+
+import com.dtolabs.rundeck.core.storage.ResourceMetaBuilder
+import com.dtolabs.rundeck.core.storage.StorageUtil
+import org.rundeck.storage.api.HasInputStream
+import org.rundeck.storage.api.PathUtil
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class KeyStorageLayerSpec extends Specification {
+
+    public static
+    final LinkedHashMap<String, String> EXPECT_PRIVATE_META = [(KeyStorageLayer.RUNDECK_CONTENT_MASK): KeyStorageLayer.CONTENT_MASK_TYPE_CONTENT, (KeyStorageLayer.RUNDECK_KEY_TYPE): KeyStorageLayer.KEY_TYPE_PRIVATE]
+    public static
+    final LinkedHashMap<String, String> EXPECT_PUBLIC_META = [(KeyStorageLayer.RUNDECK_KEY_TYPE): KeyStorageLayer.KEY_TYPE_PUBLIC]
+    public static
+    final LinkedHashMap<String, String> EXPECT_PASSWORD_META = [(KeyStorageLayer.RUNDECK_CONTENT_MASK): KeyStorageLayer.CONTENT_MASK_TYPE_CONTENT, (KeyStorageLayer.RUNDECK_DATA_TYPE): KeyStorageLayer.KEY_TYPE_PASSWORD]
+
+    @Unroll
+    def "#method with #ctype"() {
+        given:
+        def layer = new KeyStorageLayer()
+        def path = PathUtil.asPath('keys/test')
+        def meta = new ResourceMetaBuilder([:])
+        meta.contentType = ctype
+        def istream = Mock(HasInputStream)
+        when:
+        def result = layer."$method"(path, meta, istream)
+
+        then:
+        meta.meta == (expect + [(StorageUtil.RES_META_RUNDECK_CONTENT_TYPE): ctype])
+
+        where:
+        method           | ctype                                 | expect
+        'createResource' | 'text/plain'                          | [:]
+        'updateResource' | 'text/plain'                          | [:]
+        'readResource'   | 'text/plain'                          | [:]
+        'createResource' | KeyStorageLayer.PUBLIC_KEY_MIME_TYPE  | EXPECT_PUBLIC_META
+        'createResource' | KeyStorageLayer.PASSWORD_MIME_TYPE    | EXPECT_PASSWORD_META
+        'createResource' | KeyStorageLayer.PRIVATE_KEY_MIME_TYPE | EXPECT_PRIVATE_META
+        'updateResource' | KeyStorageLayer.PUBLIC_KEY_MIME_TYPE  | EXPECT_PUBLIC_META
+        'updateResource' | KeyStorageLayer.PASSWORD_MIME_TYPE    | EXPECT_PASSWORD_META
+        'updateResource' | KeyStorageLayer.PRIVATE_KEY_MIME_TYPE | EXPECT_PRIVATE_META
+        'readResource'   | KeyStorageLayer.PUBLIC_KEY_MIME_TYPE  | EXPECT_PUBLIC_META
+        'readResource'   | KeyStorageLayer.PASSWORD_MIME_TYPE    | EXPECT_PASSWORD_META
+        'readResource'   | KeyStorageLayer.PRIVATE_KEY_MIME_TYPE | EXPECT_PRIVATE_META
+
+    }
+}


### PR DESCRIPTION
If a provider plugin is used that does not return all the metadata set in the create/update, then public/private/password entries will not show up correctly in the key storage API/GUI