### PR TITLE
FIX #3189: Referenced job error handlers

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
@@ -143,7 +143,7 @@ class ExecutionUtilService {
                 workflow.commands.collect {
                     itemForWFCmdItem(
                             it,
-                            it.errorHandler ? itemForWFCmdItem(it.errorHandler) : null,
+                            it.errorHandler ? itemForWFCmdItem(it.errorHandler,null,parentProject) : null,
                             parentProject
                     )
                 },

--- a/rundeckapp/test/unit/rundeck/services/ExecutionUtilServiceTests.groovy
+++ b/rundeckapp/test/unit/rundeck/services/ExecutionUtilServiceTests.groovy
@@ -20,12 +20,14 @@ import com.dtolabs.rundeck.core.execution.ServiceThreadBase
 import com.dtolabs.rundeck.core.execution.StepExecutionItem
 import com.dtolabs.rundeck.core.execution.workflow.ControlBehavior
 import com.dtolabs.rundeck.core.execution.workflow.WFSharedContext
+import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionItem
 import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionResult
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutionResult
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.impl.ExecCommandExecutionItem
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.impl.ScriptFileCommandExecutionItem
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.impl.ScriptURLCommandExecutionItem
 import com.dtolabs.rundeck.core.utils.ThreadBoundOutputStream
+import com.dtolabs.rundeck.execution.ExecutionItemFactory
 import com.dtolabs.rundeck.execution.JobExecutionItem
 import com.dtolabs.rundeck.execution.JobRefCommand
 import grails.test.mixin.*
@@ -33,13 +35,14 @@ import org.grails.plugins.metricsweb.MetricService
 import org.junit.*
 import rundeck.CommandExec
 import rundeck.JobExec
+import rundeck.Workflow
 import rundeck.services.logging.ExecutionLogWriter
 
 /**
  * See the API for {@link grails.test.mixin.services.ServiceUnitTestMixin} for usage instructions
  */
 @TestFor(ExecutionUtilService)
-@Mock([CommandExec, JobExec])
+@Mock([CommandExec, JobExec, Workflow])
 class ExecutionUtilServiceTests {
 
     void testfinishExecutionMetricsSuccess() {
@@ -535,5 +538,30 @@ class ExecutionUtilServiceTests {
         assertEquals([], item.args as List)
         JobRefCommand jrc = (JobRefCommand) res
         jrc.project=='jobProject'
+    }
+
+    void testcreateExecutionItemForWorkflow() {
+        def testService = service
+        def project = 'test'
+        def eh1= new JobExec([jobName: 'refhandler', jobGroup: 'grp', project: null,
+                              argString: 'blah err4', keepgoingOnSuccess: false])
+        Workflow w = new Workflow(
+            keepgoing: true,
+            commands: [
+                new JobExec([jobName: 'refjob', jobGroup: 'grp', jobProject: project,
+                             keepgoingOnSuccess: false ,errorHandler: eh1])
+                ]
+            )
+        w.save()
+        WorkflowExecutionItem res = testService.createExecutionItemForWorkflow(w, project)
+        assertNotNull(res)
+        assertNotNull(res.workflow)
+        def item = res.workflow.commands[0]
+        println(item)
+        assertNotNull(item.failureHandler)
+        println(item.failureHandler)
+        assertNotNull(item.failureHandler.project)
+        assertEquals(project,item.failureHandler.project)
+
     }
 }


### PR DESCRIPTION
Fix #3189

When a job that references another as an error handler is referenced and run on another project, the referenced job project is used to search the handler job.