### PR TITLE
Fix issues with test ordering

### DIFF
--- a/core/src/test/java/com/dtolabs/rundeck/core/tools/AbstractBaseTest.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/tools/AbstractBaseTest.java
@@ -44,7 +44,7 @@ public abstract class AbstractBaseTest extends TestCase {
     //
     // derived modules and projects base
     //
-    private String PROJECTS_BASE = RDECK_BASE + "/" + "projects";
+    private static String PROJECTS_BASE = RDECK_BASE + "/" + "projects";
 
 
     /** hostname used for local node in test environment */
@@ -61,7 +61,7 @@ public abstract class AbstractBaseTest extends TestCase {
         return baseDir;
     }
 
-    private String projectsBase;
+    private String projectsBase = PROJECTS_BASE;
 
     public String getFrameworkProjectsBase() {
         return projectsBase;
@@ -137,18 +137,20 @@ public abstract class AbstractBaseTest extends TestCase {
     }
 
     public static Framework createTestFramework() {
+        if(!new File(RDECK_BASE).exists()) {
+            configureFramework();
+        }
         return FrameworkFactory.createForFilesystem(RDECK_BASE);
     }
 
-    protected void configureFramework()
+    protected static void configureFramework()
             throws BuildException {
 
         baseDir = RDECK_BASE;
-        projectsBase = PROJECTS_BASE;
         if(new File(baseDir).exists()){
             FileUtils.deleteDir(new File(baseDir));
         }
-        File projectsDir = new File(projectsBase);
+        File projectsDir = new File(PROJECTS_BASE);
         FileUtils.deleteDir(projectsDir);
         projectsDir.mkdirs();
         new File(baseDir,"etc").mkdirs();


### PR DESCRIPTION
Fix some test issues where test fail with `rdeck_base directory does not exist`

Due to spock groovy tests running before Junit java tests in some cases