### PR TITLE
Project free form label

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/menu/project-model.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/project-model.js
@@ -43,6 +43,7 @@ function Project(data) {
     self.failedCount = ko.observable(data.failedCount || 0);
     self.userCount = ko.observable(data.userCount || 0);
     self.description = ko.observable(data.description);
+    self.label = ko.observable(data.label);
     self.auth = ko.observable(new ProjectAuth());
     self.readme = ko.observable(new ProjectReadme());
     self.loaded = ko.observable(false);

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -1141,7 +1141,11 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             }else{
                 projProps['project.description']=''
             }
-
+            if(params.label){
+                projProps['project.label']=params.label
+            }else{
+                projProps['project.label']=''
+            }
 
 
             def Set<String> removePrefixes=[]
@@ -1756,6 +1760,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         [
             project: project,
             projectDescription:projectDescription,
+            projectLabel:fwkProject.getProjectProperties().get("project.label"),
             nodeexecconfig:nodeConfig,
             fcopyconfig:filecopyConfig,
             defaultNodeExec: defaultNodeExec,
@@ -2171,6 +2176,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         }else{
             projects = frameworkService.projectNames(authContext)
             session.frameworkProjects=projects
+        }
+        if(!session.frameworkLabels){
+            def flabels = frameworkService.projectLabels(authContext)
+            session.frameworkLabels = flabels
         }
         [projects:projects,project:params.project] + (params.page?[selectParams:[page:params.page]]:[:])
     }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2106,7 +2106,9 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
         long start = System.currentTimeMillis()
         def fprojects = frameworkService.projectNames(authContext)
+        def flabels = frameworkService.projectLabels(authContext)
         session.frameworkProjects = fprojects
+        session.frameworkLabels = flabels
         log.debug("frameworkService.projectNames(context)... ${System.currentTimeMillis() - start}")
         def stats=cachedSummaryProjectStats(fprojects)
 
@@ -2290,7 +2292,9 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
         long start = System.currentTimeMillis()
         def fprojects = frameworkService.projectNames(authContext)
+        def flabels = frameworkService.projectLabels(authContext)
         session.frameworkProjects = fprojects
+        session.frameworkLabels = flabels
         log.debug("frameworkService.projectNames(context)... ${System.currentTimeMillis() - start}")
 
         render(contentType:'application/json',text:
@@ -2358,7 +2362,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     }
                 }
             }
-
+            summary[project.name].label= project.hasProperty("project.label")?project.getProperty("project.label"):''
             summary[project.name].description= description
             if(!params.refresh) {
                 summary[project.name].readmeDisplay = menuService.getReadmeDisplay(project)

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -181,6 +181,16 @@ class FrameworkService implements ApplicationContextAware {
         def authed = authorizeApplicationResourceSet(authContext, resources, [AuthConstants.ACTION_READ,AuthConstants.ACTION_ADMIN] as Set)
         return new ArrayList(new HashSet(authed.collect{it.name})).sort()
     }
+    def projectLabels (AuthContext authContext) {
+        def projectNames = projectNames(authContext)
+        def projectMap = [:]
+        projectNames.each { project ->
+            def fwkProject = getFrameworkProject(project)
+            def label = fwkProject.getProjectProperties().get("project.label")
+            projectMap.put(project,label?:project)
+        }
+        projectMap
+    }
 
     def existsFrameworkProject(String project) {
         return rundeckFramework.getFrameworkProjectMgr().existsFrameworkProject(project)

--- a/rundeckapp/grails-app/views/common/_topbar.gsp
+++ b/rundeckapp/grails-app/views/common/_topbar.gsp
@@ -86,6 +86,7 @@
                     <g:render template="/framework/projectSelect"
                               model="${[
                                       projects    : session.frameworkProjects,
+                                      labels      : session.frameworkLabels,
                                       project     : params.project ?: request.project,
                                       selectParams: selectParams
                               ]}"/>
@@ -107,7 +108,14 @@
                             params: [project: project ?: params.project ?: request.project]
                     )}">
                         <i class="glyphicon glyphicon-tasks"></i>
-                        <g:enc>${project ?: params.project ?: request.project ?: 'Choose ...'}</g:enc>
+                        <g:if test="${session.frameworkLabels}">
+                            <g:enc>${project ?session.frameworkLabels[project]: params.project ?
+                                     session.frameworkLabels[params.project]: request.project ?
+                                     session.frameworkLabels[request.project]: 'Choose ...'}</g:enc>
+                        </g:if>
+                        <g:if test="${!session.frameworkLabels}">
+                            <g:enc>${project ?: params.project ?: request.project ?: 'Choose ...'}</g:enc>
+                        </g:if>
                     </a>
                 </li>
             </g:if>

--- a/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
@@ -43,6 +43,12 @@
 </div>
     <div class="list-group-item">
         <div class="form-group ">
+            <label for="label">
+                <g:message code="domain.Project.label.label" default="Label"/>
+            </label>
+            <g:textField name="label" size="50"  value="${projectLabel}" class="form-control"/>
+        </div>
+        <div class="form-group ">
             <label for="description">
                 <g:message code="domain.Project.description.label" default="Description"/>
             </label>

--- a/rundeckapp/grails-app/views/framework/_projectSelect.gsp
+++ b/rundeckapp/grails-app/views/framework/_projectSelect.gsp
@@ -34,7 +34,7 @@
         <g:each var="project" in="${projectSet}">
             <bs:menuitem controller="menu" action="index" params="${selectParams + [project: project]}"
                          icon="tasks">
-                ${project}
+                ${labels?labels[project]:project}
             </bs:menuitem>
         </g:each>
 </bs:dropdown>

--- a/rundeckapp/grails-app/views/framework/adhoc.gsp
+++ b/rundeckapp/grails-app/views/framework/adhoc.gsp
@@ -21,7 +21,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="layout" content="base"/>
     <meta name="tabpage" content="adhoc"/>
-    <title><g:message code="gui.menu.Adhoc"/> - <g:enc>${params.project ?: request.project}</g:enc></title>
+    <g:set var="projectName" value="${params.project ?: request.project}"></g:set>
+    <g:set var="projectLabel" value="${session.frameworkLabels?session.frameworkLabels[projectName]:projectName}"/>
+    <title><g:message code="gui.menu.Adhoc"/> - <g:enc>${projectLabel}</g:enc></title>
     <g:javascript src="executionState.js"/>
     <asset:javascript src="executionControl.js"/>
     <asset:javascript src="util/yellowfade.js"/>

--- a/rundeckapp/grails-app/views/framework/nodes.gsp
+++ b/rundeckapp/grails-app/views/framework/nodes.gsp
@@ -21,7 +21,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="layout" content="base"/>
     <meta name="tabpage" content="nodes"/>
-    <title><g:message code="gui.menu.Nodes"/> - <g:enc>${params.project ?: request.project}</g:enc></title>
+    <g:set var="projectName" value="${params.project ?: request.project}"></g:set>
+    <g:set var="projectLabel" value="${session.frameworkLabels?session.frameworkLabels[projectName]:projectName}"/>
+    <title><g:message code="gui.menu.Nodes"/> - <g:enc>${projectLabel}</g:enc></title>
     <asset:javascript src="framework/nodes.js"/>
     <g:if test="${grails.util.Environment.current==grails.util.Environment.DEVELOPMENT}">
         <asset:javascript src="nodeFiltersKOTest.js"/>

--- a/rundeckapp/grails-app/views/menu/_projectHomeKO.gsp
+++ b/rundeckapp/grails-app/views/menu/_projectHomeKO.gsp
@@ -27,7 +27,13 @@
                data-bind="urlPathParam: projectName"
                class="h1">
                 <i class="glyphicon glyphicon-tasks"></i>
-                <span data-bind="text: projectName"></span>
+                <span data-bind="if: project && project.label">
+                    <span data-bind="text: project.label"></span>
+                </span>
+                <span data-bind="ifnot: project && project.label">
+                    <span data-bind="text: projectName"></span>
+                </span>
+
             </a>
 
             <span data-bind="if: project">

--- a/rundeckapp/grails-app/views/menu/home.gsp
+++ b/rundeckapp/grails-app/views/menu/home.gsp
@@ -229,7 +229,12 @@
                                 data-bind="urlPathParam: project"
                                class="h3">
                                 <i class="glyphicon glyphicon-tasks"></i>
-                                <span data-bind="text: project"></span>
+                                <span data-bind="if: $root.projectForName(project) && $root.projectForName(project).label">
+                                    <span data-bind="text: $root.projectForName(project).label"></span>
+                                </span>
+                                <span data-bind="ifnot: $root.projectForName(project) && $root.projectForName(project).label">
+                                    <span data-bind="text: project"></span>
+                                </span>
                             </a>
 
                             <span data-bind="if: $root.projectForName(project)">

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -21,7 +21,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="layout" content="base"/>
     <meta name="tabpage" content="jobs"/>
-    <title><g:message code="gui.menu.Workflows"/> - <g:enc>${params.project ?: request.project}</g:enc></title>
+    <g:set var="projectName" value="${params.project ?: request.project}"></g:set>
+    <g:set var="projectLabel" value="${session.frameworkLabels?session.frameworkLabels[projectName]:projectName}"/>
+    <title><g:message code="gui.menu.Workflows"/> - <g:enc>${projectLabel}</g:enc></title>
 
     <asset:javascript src="util/yellowfade.js"/>
     <g:javascript library="pagehistory"/>

--- a/rundeckapp/grails-app/views/menu/projectAcls.gsp
+++ b/rundeckapp/grails-app/views/menu/projectAcls.gsp
@@ -62,7 +62,8 @@
     <meta name="layout" content="base"/>
     <meta name="tabpage" content="projectconfigure"/>
     <meta name="projtabtitle" content="${message(code: 'gui.menu.AccessControl')}"/>
-    <title><g:message code="page.title.project.access.control.0" args="${[params.project]}"/></title>
+    <g:set var="projectLabel" value="${session.frameworkLabels?session.frameworkLabels[params.project]:params.project}"/>
+    <title><g:message code="page.title.project.access.control.0" args="${[projectLabel]}"/></title>
 
     <asset:javascript src="menu/aclListing.js"/>
     <script type="application/javascript">

--- a/rundeckapp/grails-app/views/menu/projectHome.gsp
+++ b/rundeckapp/grails-app/views/menu/projectHome.gsp
@@ -29,7 +29,7 @@
 
     <meta name="layout" content="base"/>
     <meta name="tabpage" content="projectHome"/>
-    <title><g:appTitle/> - ${project}</title>
+    <title><g:appTitle/> - ${session.frameworkLabels?session.frameworkLabels[project]:project}</title>
     <g:embedJSON data="${[project: project]}" id="projectData"/>
     <asset:javascript src="menu/projectHome.js"/>
 

--- a/rundeckapp/grails-app/views/reports/index.gsp
+++ b/rundeckapp/grails-app/views/reports/index.gsp
@@ -22,7 +22,9 @@
 <g:ifServletContextAttribute attribute="RSS_ENABLED" value="true">
     <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="${createLink(controller:"feed",action:"index",params:paginateParams?paginateParams:[:])}"/>
     </g:ifServletContextAttribute>
-    <title><g:message code="gui.menu.Events"/> - <g:enc>${params.project ?: request.project}</g:enc></title>
+    <g:set var="projectName" value="${params.project ?: request.project}"></g:set>
+
+    <title><g:message code="gui.menu.Events"/> - <g:enc>${session.frameworkLabels?session.frameworkLabels[projectName]:projectName}</g:enc></title>
 
     <asset:javascript src="util/yellowfade.js"/>
     <g:javascript library="pagehistory"/>

--- a/rundeckapp/grails-app/views/scm/diff.gsp
+++ b/rundeckapp/grails-app/views/scm/diff.gsp
@@ -27,7 +27,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="tabpage" content="configure"/>
     <meta name="layout" content="base"/>
-    <title><g:appTitle/> - <g:message code="scmController.page.${integration}.diff.title" args="[params.project]"/></title>
+    <g:set var="projectLabel" value="${session.frameworkLabels?session.frameworkLabels[params.project]:params.project}"/>
+    <title><g:appTitle/> - <g:message code="scmController.page.${integration}.diff.title" args="[projectLabel]"/></title>
 
 </head>
 

--- a/rundeckapp/grails-app/views/scm/index.gsp
+++ b/rundeckapp/grails-app/views/scm/index.gsp
@@ -28,7 +28,8 @@
     <meta name="tabpage" content="projectconfigure"/>
     <meta name="projtabtitle" content="${message(code: 'gui.menu.Scm')}"/>
     <meta name="layout" content="base"/>
-    <title><g:appTitle/> - <g:message code="scmController.page.index.title" args="[params.project]"/></></title>
+    <g:set var="projectLabel" value="${session.frameworkLabels?session.frameworkLabels[params.project]:params.project}"/>
+    <title><g:appTitle/> - <g:message code="scmController.page.index.title" args="[projectLabel]"/></></title>
 
 </head>
 

--- a/rundeckapp/grails-app/views/scm/performAction.gsp
+++ b/rundeckapp/grails-app/views/scm/performAction.gsp
@@ -27,7 +27,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="tabpage" content="configure"/>
     <meta name="layout" content="base"/>
-    <title><g:appTitle/> - <g:message code="scmController.page.commit.title" args="[params.project]"/></title>
+    <g:set var="projectLabel" value="${session.frameworkLabels?session.frameworkLabels[params.project]:params.project}"/>
+    <title><g:appTitle/> - <g:message code="scmController.page.commit.title" args="[projectLabel]"/></title>
 
 </head>
 

--- a/rundeckapp/grails-app/views/scm/setup.gsp
+++ b/rundeckapp/grails-app/views/scm/setup.gsp
@@ -27,7 +27,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="tabpage" content="configure"/>
     <meta name="layout" content="base"/>
-    <title><g:appTitle/> - <g:message code="scmController.page.setup.title" args="[params.project]"/></title>
+    <g:set var="projectLabel" value="${session.frameworkLabels?session.frameworkLabels[params.project]:params.project}"/>
+    <title><g:appTitle/> - <g:message code="scmController.page.setup.title" args="[projectLabel]"/></title>
     <asset:javascript src="storageBrowseKO.js"/>
     <g:javascript>
 

--- a/rundeckapp/test/unit/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/MenuControllerSpec.groovy
@@ -989,4 +989,30 @@ class MenuControllerSpec extends Specification {
 
         response.status == 302
     }
+
+    def "homeAjax get project label"() {
+        given:
+
+        controller.frameworkService = Mock(FrameworkService)
+        new Project(name: 'proj',description: 'desc').save(flush: true)
+        def iproj = Mock(IRundeckProject) {
+            getName() >> 'proj'
+        }
+        def projects = [iproj]
+        controller.configurationService = Mock(ConfigurationService)
+        controller.menuService = Mock(MenuService)
+
+        request.addHeader('x-rundeck-ajax', 'true')
+
+        when:
+        controller.homeAjax()
+
+        then:
+        1 * controller.frameworkService.getAuthContextForSubject(_)
+        1 * controller.frameworkService.projectNames(_) >> []
+        1 * controller.frameworkService.projects(_) >> projects
+        1 * iproj.hasProperty('project.label') >> true
+        1 * iproj.getProperty('project.label') >> 'label'
+        'label' == response.json.projects[0].label
+    }
 }


### PR DESCRIPTION
Free-form labels for projects.
New property `project.label` in the project configuration:
![File configuration](https://user-images.githubusercontent.com/2894508/38384422-7c2cfd24-38e5-11e8-8944-1cf0e2d0224e.png)

![Project configuration](https://user-images.githubusercontent.com/2894508/38384447-926c5b98-38e5-11e8-8474-7a8d63d3a2c1.png)

This label is going to be rendered on the GUI instead of the project name in the project list page:
Old:
![screenshot at apr 05 15-09-02](https://user-images.githubusercontent.com/2894508/38384540-d36aa208-38e5-11e8-9525-47f71e4ad41c.png)

New:
![screenshot at apr 05 15-09-17](https://user-images.githubusercontent.com/2894508/38384545-d579eab8-38e5-11e8-91da-559af0ef33c8.png)

In the project home page:
![Project Home Page](https://user-images.githubusercontent.com/2894508/38384456-993d26be-38e5-11e8-9fa4-86c35202c19f.png)
In the project selector on the menu:
![Project selector](https://user-images.githubusercontent.com/2894508/38384497-af2bac16-38e5-11e8-94b9-262ac41f1d77.png)

On the API can be read using the `project.label` value:
`/api/21/project/<project>/config/project.label`