### PR TITLE
Create empty resources file

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/FileResourceModelSource.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/FileResourceModelSource.java
@@ -139,7 +139,8 @@ public class FileResourceModelSource extends BaseFileResourceModelSource impleme
             return new FileInputStream(configuration.nodesFile);
         } else if (configuration.requireFileExists) {
             throw new ResourceModelSourceException("File does not exist: " + configuration.nodesFile);
-        } else {
+        }
+        else {
             return null;
         }
     }
@@ -259,33 +260,36 @@ public class FileResourceModelSource extends BaseFileResourceModelSource impleme
             } catch (UnsupportedFormatException e) {
                 throw new ResourceModelSourceException(e);
             }
-        } else {
+        }
+        else {
             try {
                 generator = framework.getResourceFormatGeneratorService().getGeneratorForFileExtension(resfile);
             } catch (UnsupportedFormatException e) {
                 throw new ResourceModelSourceException(e);
             }
         }
+
+        NodeSetImpl nodes = new NodeSetImpl();
         if (configuration.includeServerNode) {
-            NodeSetImpl nodes = new NodeSetImpl();
             nodes.putNode(node);
+        }
 
-            if (!resfile.getParentFile().exists()) {
-                if (!resfile.getParentFile().mkdirs()) {
-                    throw new ResourceModelSourceException(
-                            "Parent dir for resource file does not exists, and could not be created: " + resfile
-                    );
-                }
-            }
-
-            try {
-                try (FileOutputStream stream = new FileOutputStream(resfile)) {
-                    generator.generateDocument(nodes, stream);
-                }
-            } catch (IOException | ResourceFormatGeneratorException e) {
-                throw new ResourceModelSourceException(e);
+        if (!resfile.getParentFile().exists()) {
+            if (!resfile.getParentFile().mkdirs()) {
+                throw new ResourceModelSourceException(
+                    "Parent dir for resource file does not exists, and could not be created: " + resfile
+                );
             }
         }
+
+        try {
+            try (FileOutputStream stream = new FileOutputStream(resfile)) {
+                generator.generateDocument(nodes, stream);
+            }
+        } catch (IOException | ResourceFormatGeneratorException e) {
+            throw new ResourceModelSourceException(e);
+        }
+
     }
 
 

--- a/core/src/test/java/com/dtolabs/rundeck/core/resources/TestFileResourceModelSource.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/resources/TestFileResourceModelSource.java
@@ -65,7 +65,7 @@ public class TestFileResourceModelSource extends AbstractBaseTest {
         File projectdir = new File(getFrameworkProjectsBase(), PROJ_NAME);
         FileUtils.deleteDir(projectdir);
     }
-
+/*
     public void testConfigureProperties() throws Exception {
         final FileResourceModelSource fileNodesProvider = new FileResourceModelSource(getFrameworkInstance());
         try {
@@ -531,6 +531,23 @@ public class TestFileResourceModelSource extends AbstractBaseTest {
         } catch (ResourceModelSourceException e) {
             assertTrue(e.getMessage().contains("File does not exist: " + dneFile.getAbsolutePath()));
         }
+    }*/
+
+    public void testGetNodesWritableEmpty() throws Exception {
+        System.out.println("testGetNodesWritableEmpty");
+        Properties props = new Properties();
+        props.setProperty("project", PROJ_NAME);
+        props.setProperty("file", "src/test/resources/com/dtolabs/rundeck/core/common/test-nodesX.xml");
+        props.setProperty("generateFileAutomatically", "true");
+        props.setProperty("includeServerNode", "false");
+        final FileResourceModelSource fileNodesProvider = new FileResourceModelSource(getFrameworkInstance());
+        fileNodesProvider.configure(props);
+
+        final InputStream is = fileNodesProvider.openFileDataInputStream();
+        //assertNotNull(is);
+        final INodeSet nodes = fileNodesProvider.getNodes();
+        assertNotNull(nodes);
+        assertEquals(0, nodes.getNodes().size());
     }
 
 }


### PR DESCRIPTION
Fix #3246 
Now creates the resources file even without `Include Server Node` selected.