### PR TITLE
fix #3289 on import project without db storage

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -1145,12 +1145,6 @@ class ProjectService implements InitializingBean, ExecutionFileProducer{
         def newprops = new Properties()
         newprops.putAll(map)
         project.setProjectProperties(newprops)
-        def description = map['project.description']
-        Project.withNewSession{
-            def dbproj = Project.findByName(project.name)
-            dbproj.description = description?description:null
-            dbproj.save(flush: true)
-        }
     }
 
     /**


### PR DESCRIPTION
Now the project table it's only updated if the project exists on the project list page, not on the import project code to avoid an NPE when the storage=db it's disabled.