### PR TITLE
Follow execution enhancements

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -224,11 +224,11 @@ class ExecutionController extends ControllerBase{
             return
         }
         if(!params.project || params.project!=e.project) {
-            def extraParams = [:]
+            def fragment
             if(params?.outdetails == 'true'){
-                extraParams = [outdetails: true]
+                fragment = 'output'
             }
-            return redirect(controller: 'execution', action: 'show', params: [id: params.id, project: e.project]+extraParams)
+            return redirect(controller: 'execution', action: 'show', params: [id: params.id, project: e.project], fragment: fragment)
         }
         params.project=e.project
         request.project=e.project

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -224,7 +224,11 @@ class ExecutionController extends ControllerBase{
             return
         }
         if(!params.project || params.project!=e.project) {
-            return redirect(controller: 'execution', action: 'show', params: [id: params.id, project: e.project])
+            def extraParams = [:]
+            if(params?.outdetails == 'true'){
+                extraParams = [outdetails: true]
+            }
+            return redirect(controller: 'execution', action: 'show', params: [id: params.id, project: e.project]+extraParams)
         }
         params.project=e.project
         request.project=e.project

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -224,11 +224,8 @@ class ExecutionController extends ControllerBase{
             return
         }
         if(!params.project || params.project!=e.project) {
-            def fragment
-            if(params?.outdetails == 'true'){
-                fragment = 'output'
-            }
-            return redirect(controller: 'execution', action: 'show', params: [id: params.id, project: e.project], fragment: fragment)
+            return redirect(controller: 'execution', action: 'show', params: [id: params.id, project: e.project], fragment: params?.outdetails)
+
         }
         params.project=e.project
         request.project=e.project

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2873,7 +2873,11 @@ class ScheduledExecutionController  extends ControllerBase{
             }else{
                 delegate.success=true
                 delegate.id=results.id
-                delegate.href=createLink(controller: "execution",action: "follow",id: results.id, params:[outdetails: params.followdetail?'true':'false'])
+                if(params.followdetail){
+                    delegate.href=createLink(controller: "execution",action: "follow",id: results.id, fragment: 'output')
+                }else{
+                    delegate.href=createLink(controller: "execution",action: "follow",id: results.id)
+                }
                 delegate.follow=(params.follow == 'true')
             }
         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2873,7 +2873,7 @@ class ScheduledExecutionController  extends ControllerBase{
             }else{
                 delegate.success=true
                 delegate.id=results.id
-                delegate.href=createLink(controller: "execution",action: "follow",id: results.id)
+                delegate.href=createLink(controller: "execution",action: "follow",id: results.id, params:[outdetails: params.followdetail?'true':'false'])
                 delegate.follow=(params.follow == 'true')
             }
         }
@@ -2953,7 +2953,7 @@ class ScheduledExecutionController  extends ControllerBase{
             }
             return renderErrorView(results)
         } else if (params.follow == 'true') {
-            redirect(controller: "execution", action: "follow", id: results.id)
+            redirect(controller: "execution", action: "follow", id: results.id, params:[outdetails: params.followdetail?'true':'false'])
         } else {
             redirect(controller: "scheduledExecution", action: "show", id: params.id)
         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2874,7 +2874,7 @@ class ScheduledExecutionController  extends ControllerBase{
                 delegate.success=true
                 delegate.id=results.id
                 if(params.followdetail){
-                    delegate.href=createLink(controller: "execution",action: "follow",id: results.id, fragment: 'output')
+                    delegate.href=createLink(controller: "execution",action: "follow",id: results.id, fragment: params.followdetail)
                 }else{
                     delegate.href=createLink(controller: "execution",action: "follow",id: results.id)
                 }
@@ -2913,7 +2913,11 @@ class ScheduledExecutionController  extends ControllerBase{
             } else {
                 delegate.success = true
                 delegate.id = results.id
-                delegate.href = createLink(controller: "execution", action: "follow", id: results.id)
+                if(params.followdetail){
+                    delegate.href=createLink(controller: "execution",action: "follow",id: results.id, fragment: params.followdetail)
+                }else{
+                    delegate.href = createLink(controller: "execution", action: "follow", id: results.id)
+                }
                 delegate.follow = (params.follow == 'true')
             }
         }
@@ -2957,7 +2961,7 @@ class ScheduledExecutionController  extends ControllerBase{
             }
             return renderErrorView(results)
         } else if (params.follow == 'true') {
-            redirect(controller: "execution", action: "follow", id: results.id, params:[outdetails: params.followdetail?'true':'false'])
+            redirect(controller: "execution", action: "follow", id: results.id, params:[outdetails: params.followdetail])
         } else {
             redirect(controller: "scheduledExecution", action: "show", id: params.id)
         }

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -85,6 +85,8 @@ class ScheduledExecution extends ExecutionContext {
     String nodeThreadcountDynamic
     Long refExecCount=0
 
+    String defaultTab
+
     static transients = ['userRoles','adhocExecutionType','notifySuccessRecipients','notifyFailureRecipients',
                          'notifyStartRecipients', 'notifySuccessUrl', 'notifyFailureUrl', 'notifyStartUrl',
                          'crontabString','averageDuration','notifyAvgDurationRecipients','notifyAvgDurationUrl',
@@ -163,6 +165,7 @@ class ScheduledExecution extends ExecutionContext {
         successOnEmptyNodeFilter(nullable: true)
         nodeThreadcountDynamic(nullable: true)
         notifyAvgDurationThreshold(nullable: true)
+        defaultTab(maxSize: 256, blank: true, nullable: true)
     }
 
     static mapping = {
@@ -278,6 +281,9 @@ class ScheduledExecution extends ExecutionContext {
         if(timeZone){
             map.timeZone=timeZone
         }
+        if(defaultTab){
+            map.defaultTab = defaultTab
+        }
 
         if(options){
             map.options = []
@@ -384,6 +390,7 @@ class ScheduledExecution extends ExecutionContext {
             se.retryDelay = data.retryDelay?.toString()
         }
         se.timeZone = data.timeZone?data.timeZone.toString():null
+        se.defaultTab = data.defaultTab?data.defaultTab.toString():null
         if(data.options){
             TreeSet options=new TreeSet()
             if(data.options instanceof Map) {

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -596,7 +596,6 @@ run.job.later=Run Job Later
 schedule.job=Schedule Job
 page.section.Activity=Activity
 job.run.watch.output=Follow execution
-job.run.watch.output.detail=Follow Output Tab
 job.schedule.will.never.fire=Job schedule will never fire
 never=Never
 scheduled.to.run.on.server.0=Scheduled to run on server {0}

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -596,6 +596,7 @@ run.job.later=Run Job Later
 schedule.job=Schedule Job
 page.section.Activity=Activity
 job.run.watch.output=Follow execution
+job.run.watch.output.detail=Follow Output Tab
 job.schedule.will.never.fire=Job schedule will never fire
 never=Never
 scheduled.to.run.on.server.0=Scheduled to run on server {0}
@@ -1636,3 +1637,5 @@ user.login.username.label=Username
 user.login.password.label=Password
 user.login.login.button=Login
 
+scheduledExecution.property.defaultTab.label=Default Tab
+scheduledExecution.property.defaultTab.description=Default tab to display when you follow an execution.

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -593,7 +593,6 @@ run.job.later=Trabajo Ejecture Más Tarde
 schedule.job=Horario de Trabajo
 page.section.Activity=Actividad
 job.run.watch.output=Seguir ejecución
-job.run.watch.output.detail=Seguir a Pestaña Salida
 job.schedule.will.never.fire=Horario de trabajo nunca se disparará
 never=Nunca
 scheduled.to.run.on.server.0=Contar con otro servidor de clúster para ejecutar ({0}).

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -593,6 +593,7 @@ run.job.later=Trabajo Ejecture Más Tarde
 schedule.job=Horario de Trabajo
 page.section.Activity=Actividad
 job.run.watch.output=Seguir ejecución
+job.run.watch.output.detail=Seguir a Pestaña Salida
 job.schedule.will.never.fire=Horario de trabajo nunca se disparará
 never=Nunca
 scheduled.to.run.on.server.0=Contar con otro servidor de clúster para ejecutar ({0}).
@@ -1626,3 +1627,5 @@ user.login.username.label=Username
 user.login.password.label=Password
 user.login.login.button=Login
 
+scheduledExecution.property.defaultTab.label=Pestaña por defecto
+scheduledExecution.property.defaultTab.description=Pestaña por defecto para ser mostrada cuando sigues una ejecución.

--- a/rundeckapp/grails-app/i18n/messages_fr_FR.properties
+++ b/rundeckapp/grails-app/i18n/messages_fr_FR.properties
@@ -14,12 +14,12 @@
 # limitations under the License.						
 #						
 						
-default.doesnt.match.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] ne correspond pas au mod&egrave;le requis [{3}]				
+default.doesnt.match.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] ne correspond pas au mod&egrave;le requis [{3}]
 default.invalid.url.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] n&#39;est pas une URL valide				
 default.invalid.creditCard.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] n&#39;est pas un num&eacute;ro de carte de cr&eacute;dit valide				
 default.invalid.email.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] n&#39;est pas une adresse de messagerie valide.				
 default.invalid.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] n&#39;est pas valide [{2}].				
-default.invalid.range.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] ne correspond pas &agrave; la plage valide de [{3}] &agrave; [{4}]				
+default.invalid.range.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] ne correspond pas &agrave; la plage valide de [{3}] &agrave; [{4}]
 default.invalid.size.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] ne correspond pas &agrave; la plage de taille valide de [{3}] &agrave; [{4}]				
 default.invalid.length.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] ne correspond pas &agrave; la plage de longueur valide de [{3}] &agrave; [{4}]				
 default.invalid.min.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] est inf&eacute;rieure &agrave; la valeur minimale [{3}]				
@@ -577,8 +577,8 @@ retry.job.failed.nodes=Ex&eacute;cuter le travail sur les noeuds d&eacute;failla
 run.job.now=Ex&eacute;cuter un travail maintenant				
 run.job.later=Ex&eacute;cuter le travail plus tard				
 schedule.job=Planifier le travail				
-page.section.Activity=Activit&eacute;				
-job.run.watch.output=Suivez l&#39;ex&eacute;cution				
+page.section.Activity=Activit&eacute;
+job.run.watch.output=Suivez l'ex&eacute;cution
 job.schedule.will.never.fire=Le travail plannifi&eacute;e ne commencera jamais				
 never=Jamais				
 scheduled.to.run.on.server.0=Pr&eacute;vu pour s&#39;ex&eacute;cuter sur le serveur {0}				
@@ -1576,3 +1576,6 @@ deleted.referenced.job=Ce travail a &eacute;t&eacute; r&eacute;f&eacute;renc&eac
 user.login.username.label=Identifiant
 user.login.password.label=Mot de passe
 user.login.login.button=Connexion
+
+scheduledExecution.property.defaultTab.label=Onglet par d&eacute;faut
+scheduledExecution.property.defaultTab.description=L'onglet par d&eacute;faut &a afficher lorsque vous suivez une ex&eacute;cution..

--- a/rundeckapp/grails-app/i18n/messages_fr_FR.properties
+++ b/rundeckapp/grails-app/i18n/messages_fr_FR.properties
@@ -14,12 +14,12 @@
 # limitations under the License.						
 #						
 						
-default.doesnt.match.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] ne correspond pas au mod&egrave;le requis [{3}]
+default.doesnt.match.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] ne correspond pas au mod&egrave;le requis [{3}]				
 default.invalid.url.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] n&#39;est pas une URL valide				
 default.invalid.creditCard.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] n&#39;est pas un num&eacute;ro de carte de cr&eacute;dit valide				
 default.invalid.email.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] n&#39;est pas une adresse de messagerie valide.				
 default.invalid.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] n&#39;est pas valide [{2}].				
-default.invalid.range.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] ne correspond pas &agrave; la plage valide de [{3}] &agrave; [{4}]
+default.invalid.range.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] ne correspond pas &agrave; la plage valide de [{3}] &agrave; [{4}]				
 default.invalid.size.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] ne correspond pas &agrave; la plage de taille valide de [{3}] &agrave; [{4}]				
 default.invalid.length.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] ne correspond pas &agrave; la plage de longueur valide de [{3}] &agrave; [{4}]				
 default.invalid.min.message=La propri&eacute;t&eacute; [{0}] de la classe [{1}] avec la valeur [{2}] est inf&eacute;rieure &agrave; la valeur minimale [{3}]				
@@ -577,8 +577,8 @@ retry.job.failed.nodes=Ex&eacute;cuter le travail sur les noeuds d&eacute;failla
 run.job.now=Ex&eacute;cuter un travail maintenant				
 run.job.later=Ex&eacute;cuter le travail plus tard				
 schedule.job=Planifier le travail				
-page.section.Activity=Activit&eacute;
-job.run.watch.output=Suivez l'ex&eacute;cution
+page.section.Activity=Activit&eacute;				
+job.run.watch.output=Suivez l&#39;ex&eacute;cution				
 job.schedule.will.never.fire=Le travail plannifi&eacute;e ne commencera jamais				
 never=Jamais				
 scheduled.to.run.on.server.0=Pr&eacute;vu pour s&#39;ex&eacute;cuter sur le serveur {0}				

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -596,7 +596,6 @@ run.job.later=\u5EF6\u8FDF\u8FD0\u884C
 schedule.job=\u786E\u5B9A\u8BA1\u5212
 page.section.Activity=Activity
 job.run.watch.output=Follow execution
-job.run.watch.output.detail=Follow Output Tab
 job.schedule.will.never.fire=Job schedule will never fire
 never=Never
 scheduled.to.run.on.server.0=Scheduled to run on server {0}
@@ -1628,3 +1627,5 @@ user.login.username.label=Username
 user.login.password.label=Password
 user.login.login.button=Login
 
+scheduledExecution.property.defaultTab.label=Default Tab
+scheduledExecution.property.defaultTab.description=Default tab to display when you follow an execution.

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -596,6 +596,7 @@ run.job.later=\u5EF6\u8FDF\u8FD0\u884C
 schedule.job=\u786E\u5B9A\u8BA1\u5212
 page.section.Activity=Activity
 job.run.watch.output=Follow execution
+job.run.watch.output.detail=Follow Output Tab
 job.schedule.will.never.fire=Job schedule will never fire
 never=Never
 scheduled.to.run.on.server.0=Scheduled to run on server {0}

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -188,8 +188,8 @@
                 jQuery('#selectProject').modal();
             });
 
-            var outDetails = ${enc(js:params.boolean('outdetails') ?: false)};
-            if(outDetails){
+            var outDetails = window.location.hash;
+            if(outDetails == '#output'){
                 nodeflowvm.activeTab("output");
                 followOutput();
                 showTab('tab_link_output');

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -187,6 +187,13 @@
                 jQuery('#jobid').val(el.data('jobId'));
                 jQuery('#selectProject').modal();
             });
+
+            var outDetails = ${enc(js:params.boolean('outdetails') ?: false)};
+            if(outDetails){
+                nodeflowvm.activeTab("output");
+                followOutput();
+                showTab('tab_link_output');
+            }
         }
         jQuery(init);
       </g:javascript>

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -193,6 +193,11 @@
                 nodeflowvm.activeTab("output");
                 followOutput();
                 showTab('tab_link_output');
+            }else if(outDetails == '#monitor'){
+                nodeflowvm.activeTab("flow");
+                showTab('tab_link_flow');
+            }else if(outDetails== '#definition'){
+                showTab('tab_link_definition');
             }
         }
         jQuery(init);
@@ -628,7 +633,7 @@
                         <li id="tab_link_output">
                             <a href="#output" data-toggle="tab"><g:message code="execution.show.mode.Log.title" /></a>
                         </li>
-                        <li>
+                        <li id ="tab_link_definition">
                             <a href="#schedExDetails${scheduledExecution?.id}" data-toggle="tab"><g:message code="definition" /></a>
                         </li>
                     </ul>

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -1147,6 +1147,46 @@ function getCurSEID(){
         </div>
     </div>
 
+    %{--default exec tab--}%
+    <div class="form-group">
+        <div class="${labelColSize} control-label text-form-label">
+            <g:message code="scheduledExecution.property.defaultTab.label"/>
+        </div>
+
+        <div class="${fieldColSize}">
+            <label class="radio-inline">
+                <g:radio value="summary" name="defaultTab"
+                         checked="${!scheduledExecution.defaultTab || scheduledExecution.defaultTab=='summary'}"
+                         id="tabSummary"/>
+                <g:message code="execution.page.show.tab.Summary.title"/>
+            </label>
+
+            <label class="radio-inline">
+                <g:radio name="defaultTab" value="monitor"
+                         checked="${scheduledExecution.defaultTab=='monitor'}"
+                         id="tabMonitor"/>
+                <g:message code="report"/>
+            </label>
+
+            <label class="radio-inline">
+                <g:radio name="defaultTab" value="output"
+                         checked="${scheduledExecution.defaultTab=='output'}"
+                         id="tabOutput"/>
+                <g:message code="execution.show.mode.Log.title"/>
+            </label>
+
+            <label class="radio-inline">
+                <g:radio name="defaultTab" value="definition"
+                         checked="${scheduledExecution.defaultTab=='definition'}"
+                         id="tabDefinition"/>
+                <g:message code="definition"/>
+            </label>
+
+            <span class="help-block">
+                <g:message code="scheduledExecution.property.defaultTab.description"/>
+            </span>
+        </div>
+    </div>
 
     %{--uuid--}%
     <div class="form-group ${hasErrors(bean: scheduledExecution, field: 'uuid', 'has-error')}" id="schedJobUuidLabel">

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -619,12 +619,6 @@
                         </option>
                     </select>
                 </label>
-                <label style="margin-left: 30px;">
-                    <g:checkBox id="followoutputdetailcheck" name="followdetail"
-                                checked="${params.followdetail == 'true'}"
-                                value="true"/>
-                    <g:message code="job.run.watch.output.detail" default="Follow Output tab"/>
-                </label>
             </div>
         </div>
     </div>

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -527,12 +527,20 @@
                             checked="${defaultFollow || params.follow == 'true'}"
                             value="true"/>
                 <g:message code="job.run.watch.output"/>
-            </label>
-            <label class="control-label">
-                <g:checkBox id="followoutputdetailcheck" name="followdetail"
-                            checked="${params.followdetail == 'true'}"
-                            value="true"/>
-                <g:message code="job.run.watch.output.detail" default="Follow Output tab"/>
+                <select name="followdetail">
+                    <option value="summary" ${(!scheduledExecution.defaultTab || scheduledExecution.defaultTab=='summary')?'selected="selected"':''}>
+                        <g:message code="execution.page.show.tab.Summary.title"/>
+                    </option>
+                    <option value="monitor" ${scheduledExecution.defaultTab=='monitor'?'selected="selected"':''}>
+                        <g:message code="report"/>
+                    </option>
+                    <option value="output" ${scheduledExecution.defaultTab=='output'?'selected="selected"':''}>
+                        <g:message code="execution.show.mode.Log.title"/>
+                    </option>
+                    <option value="definition" ${scheduledExecution.defaultTab=='definition'?'selected="selected"':''}>
+                        <g:message code="definition"/>
+                    </option>
+                </select>
             </label>
         </div>
     </div>
@@ -596,6 +604,20 @@
                                 checked="${defaultFollow || params.follow == 'true'}"
                                 value="true"/>
                     <g:message code="job.run.watch.output"/>
+                    <select name="followdetail">
+                        <option value="summary" ${(!scheduledExecution.defaultTab || scheduledExecution.defaultTab=='summary')?'selected="selected"':''}>
+                            <g:message code="execution.page.show.tab.Summary.title"/>
+                        </option>
+                        <option value="monitor" ${scheduledExecution.defaultTab=='monitor'?'selected="selected"':''}>
+                            <g:message code="report"/>
+                        </option>
+                        <option value="output" ${scheduledExecution.defaultTab=='output'?'selected="selected"':''}>
+                            <g:message code="execution.show.mode.Log.title"/>
+                        </option>
+                        <option value="definition" ${scheduledExecution.defaultTab=='definition'?'selected="selected"':''}>
+                            <g:message code="definition"/>
+                        </option>
+                    </select>
                 </label>
                 <label style="margin-left: 30px;">
                     <g:checkBox id="followoutputdetailcheck" name="followdetail"

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -528,6 +528,12 @@
                             value="true"/>
                 <g:message code="job.run.watch.output"/>
             </label>
+            <label class="control-label">
+                <g:checkBox id="followoutputdetailcheck" name="followdetail"
+                            checked="${params.followdetail == 'true'}"
+                            value="true"/>
+                <g:message code="job.run.watch.output.detail" default="Follow Output tab"/>
+            </label>
         </div>
     </div>
 </div>
@@ -590,6 +596,12 @@
                                 checked="${defaultFollow || params.follow == 'true'}"
                                 value="true"/>
                     <g:message code="job.run.watch.output"/>
+                </label>
+                <label style="margin-left: 30px;">
+                    <g:checkBox id="followoutputdetailcheck" name="followdetail"
+                                checked="${params.followdetail == 'true'}"
+                                value="true"/>
+                    <g:message code="job.run.watch.output.detail" default="Follow Output tab"/>
                 </label>
             </div>
         </div>

--- a/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -676,6 +676,71 @@ class ScheduledExecutionControllerSpec extends Specification {
 
     }
 
+    def "run job now inline to output page"() {
+        given:
+        def se = new ScheduledExecution(
+                jobName: 'monkey1', project: 'testProject', description: 'blah',
+                workflow: new Workflow(
+                        commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]
+                ).save()
+        )
+        se.save()
+
+        def exec = new Execution(
+                user: "testuser", project: "testproj", loglevel: 'WARN',
+                workflow: new Workflow(
+                        commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]
+                ).save()
+        ).save()
+
+        def testcontext = Mock(UserAndRolesAuthContext) {
+            getUsername() >> 'test'
+            getRoles() >> (['test'] as Set)
+        }
+
+        controller.frameworkService = Mock(FrameworkService) {
+            getAuthContextForSubjectAndProject(*_) >> testcontext
+            authorizeProjectJobAll(*_) >> true
+        }
+
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService) {
+            1 * getByIDorUUID(_) >> se
+            isProjectExecutionEnabled(_) >> true
+        }
+
+
+        controller.executionService = Mock(ExecutionService) {
+            1 * getExecutionsAreActive() >> true
+            1 * executeJob(se, testcontext, _,  {opts->
+                opts['runAtTime']==null && opts['executionType']=='user'
+            }) >> [executionId: exec.id]
+        }
+        controller.fileUploadService = Mock(FileUploadService)
+
+        def command = new RunJobCommand()
+        command.id = se.id.toString()
+        def extra = new ExtraCommand()
+
+
+        request.subject = new Subject()
+        setupFormTokens(params)
+        when:
+        request.method = 'POST'
+        params.followdetail = 'true'
+        controller.runJobInline(command, extra)
+
+        then:
+        response.status == 200
+        response.contentType.contains 'application/json'
+        response.json == [
+                href   : "/execution/follow/${exec.id}#output",
+                success: true,
+                id     : exec.id,
+                follow : false
+        ]
+
+    }
+
     def "schedule job inline"() {
         given:
         def se = new ScheduledExecution(

--- a/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -676,7 +676,8 @@ class ScheduledExecutionControllerSpec extends Specification {
 
     }
 
-    def "run job now inline to output page"() {
+
+    def "run job now inline to selected tab"() {
         given:
         def se = new ScheduledExecution(
                 jobName: 'monkey1', project: 'testProject', description: 'blah',
@@ -726,18 +727,25 @@ class ScheduledExecutionControllerSpec extends Specification {
         setupFormTokens(params)
         when:
         request.method = 'POST'
-        params.followdetail = 'true'
+        params.followdetail = follow
         controller.runJobInline(command, extra)
 
         then:
         response.status == 200
         response.contentType.contains 'application/json'
         response.json == [
-                href   : "/execution/follow/${exec.id}#output",
+                href   : "/execution/follow/${exec.id}#"+follow,
                 success: true,
                 id     : exec.id,
                 follow : false
         ]
+
+        where:
+        follow      |_
+        'output'    |_
+        'summary'   |_
+        'monitor'   |_
+        'definition'|_
 
     }
 
@@ -806,6 +814,80 @@ class ScheduledExecutionControllerSpec extends Specification {
                 id     : exec.id,
                 follow : false
         ]
+    }
+
+    def "schedule job inline to selected tab"() {
+        given:
+        def se = new ScheduledExecution(
+                jobName: 'monkey1', project: 'testProject', description: 'blah',
+                workflow: new Workflow(
+                        commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]
+                ).save()
+        )
+        se.save()
+
+        def exec = new Execution(
+                user: "testuser", project: "testproj", loglevel: 'WARN',
+                workflow: new Workflow(
+                        commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]
+                ).save()
+        )
+        exec.save()
+        def testcontext = Mock(UserAndRolesAuthContext) {
+            getUsername() >> 'test'
+            getRoles() >> (['test'] as Set)
+        }
+
+        controller.frameworkService = Mock(FrameworkService) {
+            getAuthContextForSubjectAndProject(*_) >> testcontext
+            authorizeProjectJobAll(*_) >> true
+        }
+
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService) {
+            1 * getByIDorUUID(_) >> se
+            isProjectExecutionEnabled(_) >> true
+        }
+
+
+        controller.executionService = Mock(ExecutionService) {
+            1 * getExecutionsAreActive() >> true
+            0 * executeJob(*_)
+            1 * scheduleAdHocJob(se, testcontext, _, { opts ->
+                opts['runAtTime'] == 'dummy' /*&& opts['executionType'] == 'user-scheduled'*/
+            }
+            ) >> [executionId: exec.id, id: exec.id]
+        }
+        controller.fileUploadService = Mock(FileUploadService)
+
+        def command = new RunJobCommand()
+        command.id = se.id.toString()
+        def extra = new ExtraCommand()
+
+
+        request.subject = new Subject()
+        setupFormTokens(params)
+
+        params.runAtTime = 'dummy'
+        when:
+        request.method = 'POST'
+        params.followdetail = follow
+        controller.scheduleJobInline(command, extra)
+
+        then:
+        response.status == 200
+        response.contentType.contains 'application/json'
+        response.json == [
+                href   : "/execution/follow/${exec.id}#"+follow,
+                success: true,
+                id     : exec.id,
+                follow : false
+        ]
+        where:
+        follow      |_
+        'output'    |_
+        'summary'   |_
+        'monitor'   |_
+        'definition'|_
     }
     def "run job later at time"() {
         given:


### PR DESCRIPTION
Features #1144 and #1107 implemented.

For 1107:
If you enter the URL using the fragment `#output` you start on the `Log Output` tab.
<img width="782" alt="output fragment" src="https://user-images.githubusercontent.com/2894508/39262252-47831b7a-4895-11e8-8d9d-3339ee3f805f.png">

For 1144:
On the job edit page you get a new option to select the default tab:
<img width="902" alt="Edit job" src="https://user-images.githubusercontent.com/2894508/39262403-a62ebd50-4895-11e8-8b42-02792e32e34e.png">


Also you can edit on the `Prepare and Run` page the default tab to be used for this execution.
<img width="394" alt="prepare and run" src="https://user-images.githubusercontent.com/2894508/39262299-66b99b7c-4895-11e8-9a88-78666a9277e2.png">
<img width="650" alt="prepare and run inline" src="https://user-images.githubusercontent.com/2894508/39262438-c53d3dde-4895-11e8-865d-7e42626a551c.png">


