### PR TITLE
Fix wrong redirect on node edit with errors

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -1707,7 +1707,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def desc = frameworkService.rundeckFramework.getResourceModelSourceService().
                 listDescriptions()?.find { it.name == providerType }
         return render(
-                view: 'editProjectResourceFile',
+                view: 'editProjectNodeSourceFile',
                 model: [
                         project     : project,
                         index       : index,


### PR DESCRIPTION
Edit node resources on error redirect to missing page `editProjectResourceFile`, corrected to `editProjectNodeSourceFile`.

Fix #3317