### PR TITLE
API: Run execution with just failed nodes (retryExecId)

### DIFF
--- a/docs/en/api/rundeck-api.md
+++ b/docs/en/api/rundeck-api.md
@@ -2302,6 +2302,49 @@ and this format is expected in the content:
 
 See [Listing Running Executions](#listing-running-executions).
 
+### Retry a Job on Failed Nodes
+
+Retry a failed execution only on failed nodes.
+This is the same functionality as the `Retry Failed Nodes ...` button on the execution page.
+
+**Request:**
+
+    POST /api/23/job/[ID]/retry/[EXECID]
+
+Optional parameters. 
+All of this parameters are going to be populated with the execution values unless they are included in the call:
+
+* `argString`: argument string to pass to the job, of the form: `-opt value -opt2 value ...`.
+* `loglevel`: argument specifying the loglevel to use, one of: 'DEBUG','VERBOSE','INFO','WARN','ERROR'
+* `asUser` : specifies a username identifying the user who ran the job. Requires `runAs` permission.
+* `option.OPTNAME`: Option value for option named `OPTNAME`. If any `option.OPTNAME` parameters are specified,
+    the `argString` value is ignored.
+
+
+
+
+If the request has `Content-Type: application/json`, then the parameters will be ignored,
+and this format is expected in the content:
+
+~~~~~ {.json}
+{
+    "argString":"...",
+    "loglevel":"...",
+    "asUser":"...",
+    "options": {
+        "myopt1":"value",
+        ...
+    }
+}
+~~~~~
+
+The `options` entry can contain a map of option name -> value, in which case the `argString` is ignored.
+
+
+**Response**:
+
+See [Listing Running Executions](#listing-running-executions).
+
 ### Exporting Jobs
 
 Export the job definitions for in XML or YAML formats.

--- a/rundeckapp/grails-app/conf/UrlMappings.groovy
+++ b/rundeckapp/grails-app/conf/UrlMappings.groovy
@@ -68,6 +68,7 @@ class UrlMappings {
         }
 
         "/api/$api_version/job/$id/run"(controller: 'scheduledExecution', action: 'apiJobRun')
+        "/api/$api_version/job/$id/retry/$executionId"(controller: 'scheduledExecution', action: 'apiJobRetry')
         "/api/$api_version/job/$id/input/file/$optionName?"(
                 controller: 'scheduledExecution',
                 action: 'apiJobFileUpload'

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -3649,8 +3649,6 @@ class ScheduledExecutionController  extends ControllerBase{
         }
 
         if (request.format == 'json') {
-            request.JSON.name = e.failedNodeList
-
             request.JSON.asUser = request.JSON.asUser?:e.user
             request.JSON.loglevel = request.JSON.loglevel?:e.loglevel
             if(request.JSON.options){
@@ -3664,8 +3662,6 @@ class ScheduledExecutionController  extends ControllerBase{
                 request.JSON.argString = request.JSON.argString?:e.argString
             }
         }else{
-            params.name=e.failedNodeList
-
             params.asUser=params.asUser?:e.user
             params.loglevel=params.loglevel?:e.loglevel
             if(params.option){
@@ -3679,6 +3675,7 @@ class ScheduledExecutionController  extends ControllerBase{
                 params.argString = params.argString?:e.argString
             }
         }
+        params.name=e.failedNodeList
 
         apiJobRun()
     }


### PR DESCRIPTION
An endpoint for the API to retry a job's execution on failed nodes.

The new endpoint is: 
`POST /api/23/job/[ID]/retry/[EXECID]`

Optional parameters. 
All of this parameters are going to be populated with the execution values unless they are included in the call:

* `argString`: argument string to pass to the job, of the form: `-opt value -opt2 value ...`.
* `loglevel`: argument specifying the log level to use, one of: 'DEBUG','VERBOSE','INFO','WARN','ERROR'
* `asUser`: specifies a username identifying the user who ran the job. Requires `runAs` permission.
* `option.OPTNAME`: Option value for an option named `OPTNAME`. If any `option.OPTNAME` parameters are specified, the `argString` value is ignored.


If the request has `Content-Type: application/json`, then the parameters will be ignored,
and this format is expected in the content:

~~~~~ {.json}
{
    "argString":"...",
    "loglevel":"...",
    "asUser":"...",
    "options": {
        "myopt1":"value",
        ...
    }
}
~~~~~

The `options` entry can contain a map of option name -> value, in which case the `argString` is ignored.