### PR TITLE
Fix postgresql problems on JobReference

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -451,8 +451,8 @@ class ScheduledExecutionController  extends ControllerBase{
         }
 
 
-       def isReferenced= JobExec.hasAnyReference(scheduledExecution)
-        def parentList = JobExec.parentList(scheduledExecution,10)
+        def parentList = ReferencedExecution.parentList(scheduledExecution,10)
+        def isReferenced = parentList?.size()>0
 
         def dataMap= [
                 scheduledExecution: scheduledExecution,
@@ -1410,7 +1410,7 @@ class ScheduledExecutionController  extends ControllerBase{
             return
         }
         if(request.method=='POST') {
-            def isReferenced = JobExec.hasAnyReference(scheduledExecution)
+            def isReferenced = ReferencedExecution.parentList(scheduledExecution,1)?.size()>0
             withForm {
                 def result = scheduledExecutionService.deleteScheduledExecutionById(
                         jobid,

--- a/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
@@ -250,29 +250,4 @@ public class JobExec extends WorkflowStep implements IWorkflowJobItem{
         //nb: error handler is created inside Workflow.fromMap
         return exec
     }
-
-    static boolean hasAnyReference(ScheduledExecution se) {
-        if (!se) {
-            return false
-        }
-        def uuid = se.extid
-        def jobName = se.jobName
-        def jobGroup = se.groupPath
-
-        def res = findByUuid(uuid)
-        if (res) {
-            return true
-        }
-
-        res = findByJobNameAndJobGroup(jobName,jobGroup)
-        return res!=null
-    }
-
-    static List<ScheduledExecution> parentList(ScheduledExecution se, int max = 0){
-        def refExecs = ReferencedExecution.findAllByScheduledExecution(se)?.collect{ re ->
-            re.execution?.scheduledExecution
-        }?.unique()
-        refExecs.subList(0, (max!=0 && refExecs.size()>max)?max:refExecs.size())
-
-    }
 }

--- a/rundeckapp/grails-app/domain/rundeck/ReferencedExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ReferencedExecution.groovy
@@ -13,4 +13,12 @@ class ReferencedExecution {
         execution(nullable: false)
 
     }
+
+    static List<ScheduledExecution> parentList(ScheduledExecution se, int max = 0){
+        def refExecs = findAllByScheduledExecution(se)?.collect{ re ->
+            re.execution?.scheduledExecution
+        }?.unique()
+        refExecs.subList(0, (max!=0 && refExecs.size()>max)?max:refExecs.size())
+
+    }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1641,6 +1641,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             if (e.dateCompleted == null && e.dateStarted != null) {
                 return [error: 'running', message: "Failed to delete execution {{Execution ${e.id}}}: The execution is currently running", success: false]
             }
+            ReferencedExecution.findAllByExecution(e).each{ re ->
+                re.delete()
+            }
                 //delete all reports
             ExecReport.findAllByJcExecId(e.id.toString()).each { rpt ->
                 rpt.delete()

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -899,6 +899,12 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                         '" it is currently being executed: {{Execution ' + found.id + '}}'
                 return [success:false,error:errmsg]
             }
+            def refExec = ReferencedExecution.findAllByScheduledExecution(scheduledExecution)
+            if(refExec){
+                refExec.each { re ->
+                    re.delete()
+                }
+            }
             //unlink any Execution records
             def result = Execution.findAllByScheduledExecution(scheduledExecution)
             if(deleteExecutions){

--- a/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -41,7 +41,7 @@ import javax.security.auth.Subject
  * Created by greg on 7/14/15.
  */
 @TestFor(ScheduledExecutionController)
-@Mock([ScheduledExecution, Option, Workflow, CommandExec, Execution, JobExec])
+@Mock([ScheduledExecution, Option, Workflow, CommandExec, Execution, JobExec, ReferencedExecution])
 class ScheduledExecutionControllerSpec extends Specification {
     def setup() {
         mockCodec(URIComponentCodec)

--- a/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -1406,6 +1406,23 @@ class ScheduledExecutionControllerSpec extends Specification {
                         ]
                 )
         ).save()
+        def seb = new ScheduledExecution(
+                jobName: 'test2',
+                project: 'project1',
+                groupPath: 'testgroup',
+                doNodedispatch: true,
+                filter:'name: ${option.nodes}',
+                refExecCount: refTotal,
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [
+                                new CommandExec([
+                                        adhocRemoteString: 'test buddy',
+                                        argString: '-delay 12 -monkey cheese -particle'
+                                ])
+                        ]
+                )
+        ).save()
         def exec = new Execution(
                 user: "testuser",
                 project: "project1",
@@ -1416,10 +1433,12 @@ class ScheduledExecutionControllerSpec extends Specification {
                 succeededNodeList:'fwnode',
                 failedNodeList: 'nodec xyz,nodea',
                 workflow: new Workflow(commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]).save(),
-                scheduledExecution: se
+                scheduledExecution: seb
         ).save()
 
-        def jobref = new JobExec(uuid: refuuid).save()
+        if(expected){
+            def re = new ReferencedExecution(scheduledExecution: se,execution: exec).save()
+        }
 
 
 
@@ -1434,12 +1453,7 @@ class ScheduledExecutionControllerSpec extends Specification {
         controller.frameworkService=Mock(FrameworkService){
             authorizeProjectJobAny(_,_,_,_)>>true
             filterAuthorizedNodes(_,_,_,_)>>{args-> args[2]}
-            filterNodeSet({ NodesSelector selector->
-                selector.acceptNode(new NodeEntryImpl("nodea")) &&
-                        selector.acceptNode(new NodeEntryImpl("nodec xyz")) &&
-                        !selector.acceptNode(new NodeEntryImpl("nodeb"))
-
-            },_)>>testNodeSetB
+            filterNodeSet(_,_)>>testNodeSetB
             getRundeckFramework()>>Mock(Framework){
                 getFrameworkNodeName()>>'fwnode'
             }
@@ -1460,9 +1474,9 @@ class ScheduledExecutionControllerSpec extends Specification {
         model.isReferenced==expected
 
         where:
-        jobuuid | refuuid   | expected
-        'a'     | 'b'       | false
-        'a'     | 'a'       | true
+        jobuuid     | expected
+        '000000'    | false
+        '111111'    | true
 
     }
 
@@ -1487,6 +1501,23 @@ class ScheduledExecutionControllerSpec extends Specification {
                         ]
                 )
         ).save()
+        def seb = new ScheduledExecution(
+                jobName: 'test2',
+                project: 'project1',
+                groupPath: 'testgroup',
+                doNodedispatch: true,
+                filter:'name: ${option.nodes}',
+                refExecCount: refTotal,
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [
+                                new CommandExec([
+                                        adhocRemoteString: 'test buddy',
+                                        argString: '-delay 12 -monkey cheese -particle'
+                                ])
+                        ]
+                )
+        ).save()
         def exec = new Execution(
                 user: "testuser",
                 project: "project1",
@@ -1497,10 +1528,12 @@ class ScheduledExecutionControllerSpec extends Specification {
                 succeededNodeList:'fwnode',
                 failedNodeList: 'nodec xyz,nodea',
                 workflow: new Workflow(commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]).save(),
-                scheduledExecution: se
+                scheduledExecution: seb
         ).save()
 
-        def jobref = new JobExec(jobName: refname).save()
+        if(expected){
+            def re = new ReferencedExecution(scheduledExecution: se,execution: exec).save()
+        }
 
 
 
@@ -1515,12 +1548,7 @@ class ScheduledExecutionControllerSpec extends Specification {
         controller.frameworkService=Mock(FrameworkService){
             authorizeProjectJobAny(_,_,_,_)>>true
             filterAuthorizedNodes(_,_,_,_)>>{args-> args[2]}
-            filterNodeSet({ NodesSelector selector->
-                selector.acceptNode(new NodeEntryImpl("nodea")) &&
-                        selector.acceptNode(new NodeEntryImpl("nodec xyz")) &&
-                        !selector.acceptNode(new NodeEntryImpl("nodeb"))
-
-            },_)>>testNodeSetB
+            filterNodeSet(_,_)>>testNodeSetB
             getRundeckFramework()>>Mock(Framework){
                 getFrameworkNodeName()>>'fwnode'
             }
@@ -1541,9 +1569,9 @@ class ScheduledExecutionControllerSpec extends Specification {
         model.isReferenced==expected
 
         where:
-        jobname | refname   | expected
-        'a'     | 'b'       | false
-        'a'     | 'a'       | true
+        jobname | expected
+        'a'     | false
+        'b'     | true
 
     }
 }

--- a/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerTests.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerTests.groovy
@@ -35,6 +35,7 @@ import org.codehaus.groovy.grails.web.servlet.mvc.SynchronizerTokensHolder
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.mock.web.MockMultipartHttpServletRequest
 import rundeck.JobExec
+import rundeck.ReferencedExecution
 import rundeck.codecs.URIComponentCodec
 import rundeck.services.ApiService
 import rundeck.services.FileUploadService
@@ -65,7 +66,7 @@ import javax.servlet.http.HttpServletResponse
 * $Id$
 */
 @TestFor(ScheduledExecutionController)
-@Mock([ScheduledExecution,Option,Workflow,CommandExec,Execution,JobExec])
+@Mock([ScheduledExecution,Option,Workflow,CommandExec,Execution,JobExec, ReferencedExecution])
 class ScheduledExecutionControllerTests  {
     /**
      * utility method to mock a class


### PR DESCRIPTION
Fix #3340 
Caused by a query with many `or`, the query has moved to `ReferencedExecution` to avoid multiple or on `JobExec`.

Fix #3346 
Force delete ReferencedExecution on delete of a job and executions.

