### PR TITLE
Fix for #3366. 

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -529,7 +529,6 @@ class ScheduledExecutionController  extends ControllerBase{
                 render(text:writer.toString(),contentType:"text/xml",encoding:"UTF-8")
             }
         }
-        dataMap
     }
     private static String getFname(name){
         final Pattern s = Pattern.compile("[\\r\\n \"\\\\]")


### PR DESCRIPTION
Job definition download should only contain desired format contents.