### PR TITLE
API: Run job based on execution (retryExecId)

### DIFF
--- a/docs/en/api/rundeck-api.md
+++ b/docs/en/api/rundeck-api.md
@@ -2302,6 +2302,49 @@ and this format is expected in the content:
 
 See [Listing Running Executions](#listing-running-executions).
 
+### Retry a Job on Failed Nodes
+
+Retry a failed execution only on failed nodes.
+This is the same functionality as the `Retry Failed Nodes ...` button on the execution page.
+
+**Request:**
+
+    POST /api/23/job/[ID]/retry/[EXECID]
+
+Optional parameters. 
+All of this parameters are going to be populated with the execution values unless they are included in the call:
+
+* `argString`: argument string to pass to the job, of the form: `-opt value -opt2 value ...`.
+* `loglevel`: argument specifying the loglevel to use, one of: 'DEBUG','VERBOSE','INFO','WARN','ERROR'
+* `asUser` : specifies a username identifying the user who ran the job. Requires `runAs` permission.
+* `option.OPTNAME`: Option value for option named `OPTNAME`. If any `option.OPTNAME` parameters are specified,
+    the `argString` value is ignored.
+
+
+
+
+If the request has `Content-Type: application/json`, then the parameters will be ignored,
+and this format is expected in the content:
+
+~~~~~ {.json}
+{
+    "argString":"...",
+    "loglevel":"...",
+    "asUser":"...",
+    "options": {
+        "myopt1":"value",
+        ...
+    }
+}
+~~~~~
+
+The `options` entry can contain a map of option name -> value, in which case the `argString` is ignored.
+
+
+**Response**:
+
+See [Listing Running Executions](#listing-running-executions).
+
 ### Exporting Jobs
 
 Export the job definitions for in XML or YAML formats.

--- a/docs/en/api/rundeck-api.md
+++ b/docs/en/api/rundeck-api.md
@@ -2302,9 +2302,9 @@ and this format is expected in the content:
 
 See [Listing Running Executions](#listing-running-executions).
 
-### Retry a Job on Failed Nodes
+### Retry a Job based on execution
 
-Retry a failed execution only on failed nodes.
+Retry a failed execution on failed nodes only or on the same as the execution.
 This is the same functionality as the `Retry Failed Nodes ...` button on the execution page.
 
 **Request:**
@@ -2319,6 +2319,7 @@ All of this parameters are going to be populated with the execution values unles
 * `asUser` : specifies a username identifying the user who ran the job. Requires `runAs` permission.
 * `option.OPTNAME`: Option value for option named `OPTNAME`. If any `option.OPTNAME` parameters are specified,
     the `argString` value is ignored.
+* `failedNodes` : `false` to run on the same nodes as the original execution, `true`or empty to run only on failed nodes.
 
 
 

--- a/docs/en/api/rundeck-api.md
+++ b/docs/en/api/rundeck-api.md
@@ -55,6 +55,11 @@ View the [Index](#index) listing API paths.
 
 Changes introduced by API Version number:
 
+**Version 24**:
+
+* New Endpoints.
+    - [`POST /api/24/job/[ID]/retry/[EXECID]`][POST /api/24/job/[ID]/retry/[EXECID]] - Retry a Job based on execution
+
 **Version 23**:
 
 * New Endpoints. (replacing removed `POST /api/2/project/[PROJECT]/resources` endpoint)
@@ -2309,7 +2314,7 @@ This is the same functionality as the `Retry Failed Nodes ...` button on the exe
 
 **Request:**
 
-    POST /api/23/job/[ID]/retry/[EXECID]
+    POST /api/24/job/[ID]/retry/[EXECID]
 
 Optional parameters. 
 All of this parameters are going to be populated with the execution values unless they are included in the call:

--- a/rundeckapp/grails-app/conf/UrlMappings.groovy
+++ b/rundeckapp/grails-app/conf/UrlMappings.groovy
@@ -68,6 +68,7 @@ class UrlMappings {
         }
 
         "/api/$api_version/job/$id/run"(controller: 'scheduledExecution', action: 'apiJobRun')
+        "/api/$api_version/job/$id/retry/$executionId"(controller: 'scheduledExecution', action: 'apiJobRetry')
         "/api/$api_version/job/$id/input/file/$optionName?"(
                 controller: 'scheduledExecution',
                 action: 'apiJobFileUpload'

--- a/rundeckapp/grails-app/conf/rundeck/filters/ApiRequestFilters.groovy
+++ b/rundeckapp/grails-app/conf/rundeck/filters/ApiRequestFilters.groovy
@@ -67,15 +67,16 @@ public class ApiRequestFilters {
     public static final int V21 = 21
     public static final int V22 = 22
     public static final int V23 = 23
+    public static final int V24 = 24
     public static final Map VersionMap = [:]
-    public static final List Versions = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21,V22,V23]
+    public static final List Versions = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21,V22,V23, V24]
     static {
         Versions.each { VersionMap[it.toString()] = it }
     }
     public static final Set VersionStrings = new HashSet(VersionMap.values())
 
     public final static int API_EARLIEST_VERSION = V1
-    public final static int API_CURRENT_VERSION = V23
+    public final static int API_CURRENT_VERSION = V24
     public final static int API_MIN_VERSION = API_EARLIEST_VERSION
     public final static int API_MAX_VERSION = API_CURRENT_VERSION
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -3631,11 +3631,12 @@ class ScheduledExecutionController  extends ControllerBase{
     }
 
     def apiJobRetry() {
-        if (!apiService.requireVersion(request, response, ApiRequestFilters.V23)) {
+        if (!apiService.requireVersion(request, response, ApiRequestFilters.V24)) {
             return
         }
         String jobId = params.id
         String execId = params.executionId
+        String failedOnly = params.failedNodes?:'true'
 
         Execution e = Execution.get(execId)
         if(e?.scheduledExecution?.extid != jobId){
@@ -3675,7 +3676,9 @@ class ScheduledExecutionController  extends ControllerBase{
                 params.argString = params.argString?:e.argString
             }
         }
-        params.name=e.failedNodeList
+        if(failedOnly == 'true'){
+            params.name=e.failedNodeList
+        }
 
         apiJobRun()
     }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -174,7 +174,8 @@ class ScheduledExecutionController  extends ControllerBase{
             apiRunCommandv14             : ['POST', 'GET'],
             apiJobDeleteBulk             : ['DELETE', 'POST'],
             apiJobClusterTakeoverSchedule: 'PUT',
-            apiJobUpdateSingle           : 'PUT'
+            apiJobUpdateSingle           : 'PUT',
+            apiJobRetry                  : 'POST'
     ]
 
     def cancel (){
@@ -3627,6 +3628,56 @@ class ScheduledExecutionController  extends ControllerBase{
                 return executionService.respondExecutionsJson(request,response,[e],[single:true])
             }
         }
+    }
+
+    def apiJobRetry() {
+        if (!apiService.requireVersion(request, response, ApiRequestFilters.V23)) {
+            return
+        }
+        String jobId = params.id
+        String execId = params.executionId
+
+        Execution e = Execution.get(execId)
+        if(e?.scheduledExecution?.extid != jobId){
+            e = null
+        }
+        if (!apiService.requireExists(response, e, ['Execution ID', execId])) {
+            return
+        }
+        if (!apiService.requireExists(response, e.failedNodeList, ['Failed node List for execution ID', execId])) {
+            return
+        }
+
+        if (request.format == 'json') {
+            request.JSON.asUser = request.JSON.asUser?:e.user
+            request.JSON.loglevel = request.JSON.loglevel?:e.loglevel
+            if(request.JSON.options){
+                def map = FrameworkService.parseOptsFromString(e.argString)
+                map.each{k,v ->
+                    if(!request.JSON.options.containsKey(k)){
+                        request.JSON.options.put(k,v)
+                    }
+                }
+            }else if(!request.JSON.argString){
+                request.JSON.argString = request.JSON.argString?:e.argString
+            }
+        }else{
+            params.asUser=params.asUser?:e.user
+            params.loglevel=params.loglevel?:e.loglevel
+            if(params.option){
+                def map = FrameworkService.parseOptsFromString(e.argString)
+                map.each{k,v ->
+                    if(!params.option.containsKey(k)){
+                        params.option.put(k,v)
+                    }
+                }
+            }else if(!params.argString){
+                params.argString = params.argString?:e.argString
+            }
+        }
+        params.name=e.failedNodeList
+
+        apiJobRun()
     }
 
     /**

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -3636,7 +3636,7 @@ class ScheduledExecutionController  extends ControllerBase{
         }
         String jobId = params.id
         String execId = params.executionId
-        String failedOnly = params.failedNodes?:'true'
+        String failedOnly = 'true'
 
         Execution e = Execution.get(execId)
         if(e?.scheduledExecution?.extid != jobId){
@@ -3650,6 +3650,7 @@ class ScheduledExecutionController  extends ControllerBase{
         }
 
         if (request.format == 'json') {
+            failedOnly = request.JSON.failedNodes?:'true'
             request.JSON.asUser = request.JSON.asUser?:e.user
             request.JSON.loglevel = request.JSON.loglevel?:e.loglevel
             if(request.JSON.options){
@@ -3663,6 +3664,7 @@ class ScheduledExecutionController  extends ControllerBase{
                 request.JSON.argString = request.JSON.argString?:e.argString
             }
         }else{
+            failedOnly = params.failedNodes?:'true'
             params.asUser=params.asUser?:e.user
             params.loglevel=params.loglevel?:e.loglevel
             if(params.option){

--- a/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -1574,4 +1574,137 @@ class ScheduledExecutionControllerSpec extends Specification {
         'b'     | true
 
     }
+
+    def "api retry job option params"() {
+        given:
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService)
+        controller.apiService = Mock(ApiService)
+        controller.executionService = Mock(ExecutionService)
+        controller.frameworkService = Mock(FrameworkService)
+
+        def se = new ScheduledExecution(
+                uuid: 'testUUID',
+                jobName: 'test1',
+                project: 'project1',
+                groupPath: 'testgroup',
+                doNodedispatch: true,
+                filter:'name: ${option.nodes}',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [
+                                new CommandExec([
+                                        adhocRemoteString: 'test buddy',
+                                        argString: '-delay 12 -monkey cheese -particle'
+                                ])
+                        ]
+                )
+        ).save()
+        def exec = new Execution(
+                user: "testuser",
+                project: "project1",
+                loglevel: 'WARN',
+                status: 'FAILED',
+                doNodedispatch: true,
+                filter:'name: nodea',
+                succeededNodeList:'fwnode',
+                failedNodeList: 'nodec xyz,nodea',
+                workflow: new Workflow(commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]).save(),
+                scheduledExecution: se
+        ).save()
+
+
+        when:
+        request.api_version=23
+        request.method='POST'
+        params.executionId = exec.id.toString()
+        params.id = se.extid.toString()
+        params.putAll(paramoptions)
+        def result=controller.apiJobRetry()
+
+        then:
+
+        1 * controller.apiService.requireVersion(_,_,23)>>true
+        1 * controller.apiService.requireApi(_,_)>>true
+        1 * controller.scheduledExecutionService.getByIDorUUID(se.extid.toString())>>[:]
+        1 * controller.frameworkService.getAuthContextForSubjectAndProject(_,_)
+        1 * controller.frameworkService.authorizeProjectJobAll(_,_,['run'],_)>>true
+        3 * controller.apiService.requireExists(_,_,_)>>true
+        1 * controller.executionService.executeJob(
+                _,
+                _,
+                _,
+                { it['option.abc'] == 'tyz' && it['option.def'] == 'xyz' }
+        ) >> [success: true]
+        1 * controller.executionService.respondExecutionsXml(_,_,_)
+        0 * controller.executionService._(*_)
+
+        where:
+
+        paramoptions                               | _
+        [option: [abc: 'tyz', def: 'xyz']]         | _
+        ['option.abc': 'tyz', 'option.def': 'xyz'] | _
+    }
+    def "api retry job option params json"() {
+        given:
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService)
+        controller.apiService = Mock(ApiService)
+        controller.executionService = Mock(ExecutionService)
+        controller.frameworkService = Mock(FrameworkService)
+        def se = new ScheduledExecution(
+                uuid: 'testUUID',
+                jobName: 'test1',
+                project: 'project1',
+                groupPath: 'testgroup',
+                doNodedispatch: true,
+                filter:'name: ${option.nodes}',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [
+                                new CommandExec([
+                                        adhocRemoteString: 'test buddy',
+                                        argString: '-delay 12 -monkey cheese -particle'
+                                ])
+                        ]
+                )
+        ).save()
+        def exec = new Execution(
+                user: "testuser",
+                project: "project1",
+                loglevel: 'WARN',
+                status: 'FAILED',
+                doNodedispatch: true,
+                filter:'name: nodea',
+                succeededNodeList:'fwnode',
+                failedNodeList: 'nodec xyz,nodea',
+                workflow: new Workflow(commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]).save(),
+                scheduledExecution: se
+        ).save()
+
+        when:
+        request.api_version = 23
+        request.method = 'POST'
+        params.executionId = exec.id.toString()
+        params.id = se.extid.toString()
+        request.json = [
+                options: [abc: 'tyz', def: 'xyz']
+        ]
+        def result = controller.apiJobRetry()
+
+        then:
+
+        1 * controller.apiService.requireVersion(_,_,23)>>true
+        1 * controller.apiService.requireApi(_, _) >> true
+        1 * controller.scheduledExecutionService.getByIDorUUID(se.extid.toString()) >> [:]
+        1 * controller.frameworkService.getAuthContextForSubjectAndProject(_, _)
+        1 * controller.frameworkService.authorizeProjectJobAll(_, _, ['run'], _) >> true
+        3 * controller.apiService.requireExists(_, _, _) >> true
+        1 * controller.executionService.executeJob(
+                _,
+                _,
+                _,
+                { it['option.abc'] == 'tyz' && it['option.def'] == 'xyz' }
+        ) >> [success: true]
+        1 * controller.executionService.respondExecutionsXml(_, _, _)
+        0 * controller.executionService._(*_)
+    }
 }

--- a/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -1614,7 +1614,7 @@ class ScheduledExecutionControllerSpec extends Specification {
 
 
         when:
-        request.api_version=23
+        request.api_version=24
         request.method='POST'
         params.executionId = exec.id.toString()
         params.id = se.extid.toString()
@@ -1623,7 +1623,7 @@ class ScheduledExecutionControllerSpec extends Specification {
 
         then:
 
-        1 * controller.apiService.requireVersion(_,_,23)>>true
+        1 * controller.apiService.requireVersion(_,_,24)>>true
         1 * controller.apiService.requireApi(_,_)>>true
         1 * controller.scheduledExecutionService.getByIDorUUID(se.extid.toString())>>[:]
         1 * controller.frameworkService.getAuthContextForSubjectAndProject(_,_)
@@ -1681,7 +1681,7 @@ class ScheduledExecutionControllerSpec extends Specification {
         ).save()
 
         when:
-        request.api_version = 23
+        request.api_version = 24
         request.method = 'POST'
         params.executionId = exec.id.toString()
         params.id = se.extid.toString()
@@ -1692,7 +1692,7 @@ class ScheduledExecutionControllerSpec extends Specification {
 
         then:
 
-        1 * controller.apiService.requireVersion(_,_,23)>>true
+        1 * controller.apiService.requireVersion(_,_,24)>>true
         1 * controller.apiService.requireApi(_, _) >> true
         1 * controller.scheduledExecutionService.getByIDorUUID(se.extid.toString()) >> [:]
         1 * controller.frameworkService.getAuthContextForSubjectAndProject(_, _)

--- a/test/api/include.sh
+++ b/test/api/include.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # common header for test scripts
-API_CURRENT_VERSION=23
+API_CURRENT_VERSION=24
 
 SRC_DIR=$(cd `dirname $0` && pwd)
 DIR=${TMP_DIR:-$SRC_DIR}

--- a/test/api/test-v23-project-sources-json.sh
+++ b/test/api/test-v23-project-sources-json.sh
@@ -3,6 +3,7 @@
 #test listing project sources
 
 DIR=$(cd `dirname $0` && pwd)
+export API_CURRENT_VERSION=${API_VERSION}
 export API_VERSION=23 #/api/23/project/NAME/sources
 source $DIR/include.sh
 
@@ -21,7 +22,7 @@ assert_json_value '1' 'length'  ${file}
 assert_json_value 'file'  '.[0].type' ${file}
 assert_json_value '1'  '.[0].index' ${file}
 assert_json_value 'false'  '.[0].resources.writeable' ${file}
-assert_json_value "${APIURL}/project/${proj}/source/1/resources" '.[0].resources.href' ${file}
+assert_json_value "${RDURL}/api/${API_CURRENT_VERSION}/project/${proj}/source/1/resources" '.[0].resources.href' ${file}
 
 test_succeed
 

--- a/test/api/test-v23-project-sources-xml.sh
+++ b/test/api/test-v23-project-sources-xml.sh
@@ -3,6 +3,7 @@
 #test listing project sources
 
 DIR=$(cd `dirname $0` && pwd)
+export API_CURRENT_VERSION=${API_VERSION}
 export API_VERSION=23 #/api/23/project/NAME/sources
 source $DIR/include.sh
 
@@ -25,7 +26,7 @@ assert_xml_value '1' 'count(/sources/source)'  ${file}
 assert_xml_value 'file'  '/sources/source/@type' ${file}
 assert_xml_value '1'  '/sources/source/@index' ${file}
 assert_xml_value 'false'  '/sources/source/resources/@writeable' ${file}
-assert_xml_value "${APIURL}/project/${proj}/source/1/resources" '/sources/source/resources/@href' ${file}
+assert_xml_value "${RDURL}/api/${API_CURRENT_VERSION}/project/${proj}/source/1/resources" '/sources/source/resources/@href' ${file}
 
 test_succeed
 


### PR DESCRIPTION
An endpoint for the API to retry a job's execution on failed nodes.

The new endpoint is: 
`POST /api/23/job/[ID]/retry/[EXECID]`

Optional parameters. 
All of this parameters are going to be populated with the execution values unless they are included in the call:

* `argString`: argument string to pass to the job, of the form: `-opt value -opt2 value ...`.
* `loglevel`: argument specifying the log level to use, one of: 'DEBUG','VERBOSE','INFO','WARN','ERROR'
* `asUser`: specifies a username identifying the user who ran the job. Requires `runAs` permission.
* `option.OPTNAME`: Option value for an option named `OPTNAME`. If any `option.OPTNAME` parameters are specified, the `argString` value is ignored.
* `failedNodes` : `false` to run on the same nodes as the original execution, `true`or empty to run only on failed nodes.


If the request has `Content-Type: application/json`, then the parameters will be ignored,
and this format is expected in the content:

~~~~~ {.json}
{
    "argString":"...",
    "loglevel":"...",
    "asUser":"...",
    "options": {
        "myopt1":"value",
        ...
    }
}
~~~~~

The `options` entry can contain a map of option name -> value, in which case the `argString` is ignored.