### PR TITLE
Enhancement: Using variable in Storage path job options

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1049,6 +1049,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     ]
             )
 
+            def secureOptionNodeDeferred = [:]
             if(scheduledExecution) {
                 if(!extraParamsExposed){
                     extraParamsExposed=[:]
@@ -1057,7 +1058,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     extraParams=[:]
                 }
                 Map<String, String> args = FrameworkService.parseOptsFromString(execution.argString)
-                loadSecureOptionStorageDefaults(scheduledExecution, extraParamsExposed, extraParams, authContext, true, args)
+                loadSecureOptionStorageDefaults(scheduledExecution, extraParamsExposed, extraParams, authContext, true,
+                        args, jobcontext, secureOptionNodeDeferred)
             }
             String inputCharset=frameworkService.getDefaultInputCharsetForProject(execution.project)
 
@@ -1074,7 +1076,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     extraParams,
                     extraParamsExposed,
                     inputCharset,
-                    workflowLogManager
+                    workflowLogManager,
+                    secureOptionNodeDeferred
             )
 
             fileUploadService.executionBeforeStart(
@@ -1186,7 +1189,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             Map secureOpts,
             AuthContext authContext,
             boolean failIfMissingRequired=false,
-            Map<String, String> args = null
+            Map<String, String> args = null,
+            Map<String, String> job = null,
+            Map secureOptionNodeDeferred = null
     )
     {
         def found = scheduledExecution.options?.findAll {
@@ -1206,11 +1211,27 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     if (args && defStoragePath?.contains('${option.')) {
                         defStoragePath = DataContextUtils.replaceDataReferencesInString(defStoragePath, DataContextUtils.addContext("option", args, null)).trim()
                     }
-                    def password = keystore.readPassword(defStoragePath)
+                    if (job && defStoragePath?.contains('${job.')) {
+                        defStoragePath = DataContextUtils.replaceDataReferencesInString(defStoragePath, DataContextUtils.addContext("job", job, null)).trim()
+                    }
+                    def password
+                    def nodeDeferred = false
+                    if (defStoragePath?.contains('${node.')) {
+                        nodeDeferred = secureOptionNodeDeferred != null ? true : false
+                        password = defStoragePath //to be resolved later
+                    }else {
+                        password = keystore.readPassword(defStoragePath)
+                    }
                     if (it.secureExposed) {
                         secureOptsExposed[it.name] = new String(password)
+                        if(nodeDeferred) {
+                            secureOptionNodeDeferred[it.name] = password
+                        }
                     } else {
                         secureOpts[it.name] = new String(password)
+                        if(nodeDeferred) {
+                            secureOptionNodeDeferred[it.name] = password
+                        }
                     }
                 } catch (StorageException e) {
                     if (it.required && failIfMissingRequired) {
@@ -1276,7 +1297,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                                               Map<String, String> jobcontext, String[] inputargs = null,
                                               Map extraParams = null, Map extraParamsExposed = null,
                                               String charsetEncoding = null,
-                                              LoggingManager manager = null
+                                              LoggingManager manager = null,
+                                              Map secureOptionNodeDeferred = null
     )
     {
         createContext(execMap,
@@ -1291,7 +1313,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                       extraParams,
                       extraParamsExposed,
                       charsetEncoding,
-                      manager
+                      manager,
+                      secureOptionNodeDeferred
         )
     }
     /**
@@ -1310,7 +1333,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             Map extraParams = null,
             Map extraParamsExposed = null,
             String charsetEncoding = null,
-            LoggingManager manager = null
+            LoggingManager manager = null,
+            Map secureOptionNodeDeferred = null
     )
     {
         if (!userName) {
@@ -1340,6 +1364,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         datacontext.put("option",optsmap)
         if(extraParamsExposed){
             datacontext.put("secureOption",extraParamsExposed.clone())
+        }
+        if(secureOptionNodeDeferred) {
+            datacontext.put("nodeDeferred", secureOptionNodeDeferred.clone())
         }
         datacontext.put("job",jobcontext?jobcontext:new HashMap<String,String>())
 
@@ -3139,7 +3166,18 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             )
         }
 
-        loadSecureOptionStorageDefaults(se, evalSecOpts, evalSecAuthOpts, executionContext.authContext)
+        //construct job data context
+        def jobcontext = new HashMap<String, String>(executionContext.dataContext.job?:[:])
+        jobcontext.id = se.extid
+        jobcontext.loglevel = mappedLogLevels[executionContext.loglevel]
+        jobcontext.name = se.jobName
+        jobcontext.group = se.groupPath
+        jobcontext.project = se.project
+        jobcontext.username = executionContext.getUser()
+        jobcontext['user.name'] = jobcontext.username
+
+        def secureOptionNodeDeferred = [:]
+        loadSecureOptionStorageDefaults(se, evalSecOpts, evalSecAuthOpts, executionContext.authContext,false,null,jobcontext, secureOptionNodeDeferred)
 
         //validate the option values
         if(dovalidate){
@@ -3150,15 +3188,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         def stringList = evalPlainOpts.collect { ["-" + it.key, it.value] }.flatten()
         newargs = stringList.toArray(new String[stringList.size()]);
 
-        //construct job data context
-        def jobcontext = new HashMap<String, String>(executionContext.dataContext.job?:[:])
-        jobcontext.id = se.extid
-        jobcontext.loglevel = mappedLogLevels[executionContext.loglevel]
-        jobcontext.name = se.jobName
-        jobcontext.group = se.groupPath
-        jobcontext.project = se.project
-        jobcontext.username = executionContext.getUser()
-        jobcontext['user.name'] = jobcontext.username
+
 
         def loggingFilters = se  ?
                 ExecutionUtilService.createLogFilterConfigs(
@@ -3177,7 +3207,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 evalSecAuthOpts,
                 evalSecOpts,
                 null,
-                workflowLogManager
+                workflowLogManager,
+                secureOptionNodeDeferred
         )
 
         if (nodeFilter || nodeIntersect) {

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -3121,4 +3121,138 @@ class ExecutionServiceSpec {
         true          | 2
         false         | 1
     }
+
+
+    def "loadSecureOptionStorageDefaults replace job vars"() {
+        given:
+        ScheduledExecution job = new ScheduledExecution(
+                jobName: 'blue',
+                project: 'AProject',
+                groupPath: 'some/where',
+                description: 'a job',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [
+                                new CommandExec(
+                                        adhocRemoteString: 'test buddy',
+                                        argString: '-delay 12 -monkey cheese -particle'
+                                )
+                        ]
+                ),
+                options: [
+                        new Option(
+                                name: 'pass',
+                                secureInput: true,
+                                secureExposed: false,
+                                defaultStoragePath: 'keys/${job.username}/pass'
+                        )
+                ]
+        )
+        job.save()
+
+        Map secureOptsExposed = [:]
+        Map secureOpts = [:]
+        def authContext = Mock(AuthContext)
+        Map<String, String> args = FrameworkService.parseOptsFromString(job.argString)
+        service.storageService = Mock(StorageService)
+
+        def jobcontext = [:]
+        jobcontext.id = job.extid
+        jobcontext.name = job.jobName
+        jobcontext.group = job.groupPath
+        jobcontext.project = job.project
+        jobcontext.username = username
+        jobcontext['user.name'] = jobcontext.username
+
+
+        when:
+        service.loadSecureOptionStorageDefaults(job, secureOptsExposed, secureOpts, authContext,false,
+                args,jobcontext)
+
+        then:
+        service.storageService.storageTreeWithContext(authContext) >> Mock(KeyStorageTree) {
+            readPassword('keys/admin/pass') >> {
+                return 'pass1'.bytes
+            }
+            readPassword('keys/dev/pass') >> {
+                return 'pass2'.bytes
+            }
+            readPassword('keys/op/pass') >> {
+                return 'pass3'.bytes
+            }
+            readPassword(_) >> {
+                return ''.bytes
+            }
+        }
+        expectedpass == secureOpts['pass']
+        where:
+        expectedpass    | username
+        'pass1'         | 'admin'
+        'pass2'         | 'dev'
+        'pass3'         | 'op'
+        ''              | 'user'
+
+    }
+
+
+    def "loadSecureOptionStorageDefaults node deferred variables"() {
+        given:
+        ScheduledExecution job = new ScheduledExecution(
+                jobName: 'blue',
+                project: 'AProject',
+                groupPath: 'some/where',
+                description: 'a job',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [
+                                new CommandExec(
+                                        adhocRemoteString: 'test buddy',
+                                        argString: '-delay 12 -monkey cheese -particle'
+                                )
+                        ]
+                ),
+                options: [
+                        new Option(
+                                name: 'pass',
+                                secureInput: true,
+                                secureExposed: false,
+                                defaultStoragePath: securepath
+                        )
+                ]
+        )
+        job.save()
+
+        Map secureOptsExposed = [:]
+        Map secureOpts = [:]
+        def authContext = Mock(AuthContext)
+        Map<String, String> args = FrameworkService.parseOptsFromString(job.argString)
+        service.storageService = Mock(StorageService)
+
+        def jobcontext = [:]
+        jobcontext.id = job.extid
+        jobcontext.name = job.jobName
+        jobcontext.group = job.groupPath
+        jobcontext.project = job.project
+        jobcontext.username = 'admin'
+        jobcontext['user.name'] = jobcontext.username
+
+        def secureOptionNodeDeferred = [:]
+
+
+        when:
+        service.loadSecureOptionStorageDefaults(job, secureOptsExposed, secureOpts, authContext,false,
+                args,jobcontext,secureOptionNodeDeferred)
+
+        then:
+        secureOptionNodeDeferred
+        secureOptionNodeDeferred.size()==1
+        secureOptionNodeDeferred['pass']
+        secureOptionNodeDeferred['pass']==securepath
+
+        where:
+        securepath                         | _
+        'keys/${node.hostname}/pass'       | _
+        'keys/${node.username}/pass'       | _
+
+    }
 }


### PR DESCRIPTION
Resolves #2092 

Add capability to use ${job.x} and ${node.x} on Storage Path options.


<img width="942" alt="example" src="https://user-images.githubusercontent.com/2894508/40376581-aa59e63e-5dbc-11e8-982b-7eb6c1dfa131.png">
