### PR TITLE
Fix missing job options on duplicated job 

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -504,7 +504,8 @@ function getCurSEID(){
 
                 <div  id="editoptssect" class="rounded">
                     <%
-                        def options = ScheduledExecution.get(scheduledExecution.id)?.options
+                        def tmpse = ScheduledExecution.get(scheduledExecution.id)
+                        def options = tmpse?tmpse.options:scheduledExecution.options
                     %>
                     <g:render template="/scheduledExecution/detailsOptions" model="${[options:options,edit:true]}"/>
                     <g:if test="${scheduledExecution && scheduledExecution.argString}">


### PR DESCRIPTION
Using temp `scheduledExecution` object when the job is copied and still not in the database.
Fix #3421 
Fix #3384