### PR TITLE
Addresses issue #2062 

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/properties/CoreConfigurationPropertiesLoader.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/properties/CoreConfigurationPropertiesLoader.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dtolabs.rundeck.core.properties;
+
+import java.util.Properties;
+
+/**
+* CoreConfigurationPropertiesLoader
+* This interface defines a service that can be used to customize the loading of the rundeck-config.properties file
+* when Rundeck bootstraps.
+* Implementing classes can be installed using the facilities provided by the java {@link java.util.ServiceLoader} class.
+*
+* @author Stephen Joyner
+* @version $Revision$
+*/
+public interface CoreConfigurationPropertiesLoader {
+    Properties loadProperties();
+}

--- a/rundeckapp/grails-app/init/rundeckapp/Application.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/Application.groovy
@@ -1,5 +1,6 @@
 package rundeckapp
 
+import com.dtolabs.rundeck.core.properties.CoreConfigurationPropertiesLoader
 import grails.boot.GrailsApp
 import grails.boot.config.GrailsAutoConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -9,6 +10,7 @@ import org.springframework.core.env.Environment
 import org.springframework.core.env.MapPropertySource
 import org.springframework.core.env.PropertiesPropertySource
 import rundeckapp.cli.CommandLineSetup
+import rundeckapp.init.DefaultRundeckConfigPropertyLoader
 import rundeckapp.init.RundeckInitConfig
 import rundeckapp.init.RundeckInitializer
 
@@ -36,20 +38,35 @@ class Application extends GrailsAutoConfiguration implements EnvironmentAware {
 
         RundeckInitializer initilizer = new RundeckInitializer(rundeckConfig)
         initilizer.initialize()
-        Properties rundeckConfigs = new Properties()
-        rundeckConfigs.load(new File(System.getProperty(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION)).newInputStream())
+        CoreConfigurationPropertiesLoader rundeckConfigPropertyFileLoader = new DefaultRundeckConfigPropertyLoader()
+        ServiceLoader<CoreConfigurationPropertiesLoader> rundeckPropertyLoaders = ServiceLoader.load(
+                CoreConfigurationPropertiesLoader
+        )
+        rundeckPropertyLoaders.each { loader ->
+            rundeckConfigPropertyFileLoader = loader
+        }
+        Properties rundeckConfigs = rundeckConfigPropertyFileLoader.loadProperties()
         rundeckConfigs.setProperty("rundeck.useJaas", rundeckConfig.useJaas.toString())
-        rundeckConfigs.setProperty("rundeck.security.fileUserDataSource",rundeckConfig.runtimeConfiguration.getProperty(RundeckInitializer.PROP_REALM_LOCATION))
-        rundeckConfigs.setProperty("rundeck.security.jaasLoginModuleName",rundeckConfig.runtimeConfiguration.getProperty(RundeckInitializer.PROP_LOGINMODULE_NAME))
-        environment.propertySources.addFirst(new PropertiesPropertySource(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION, rundeckConfigs))
+        rundeckConfigs.setProperty(
+                "rundeck.security.fileUserDataSource",
+                rundeckConfig.runtimeConfiguration.getProperty(RundeckInitializer.PROP_REALM_LOCATION)
+        )
+        rundeckConfigs.setProperty(
+                "rundeck.security.jaasLoginModuleName",
+                rundeckConfig.runtimeConfiguration.getProperty(RundeckInitializer.PROP_LOGINMODULE_NAME)
+        )
+        environment.propertySources.addFirst(
+                new PropertiesPropertySource(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION, rundeckConfigs)
+        )
         loadGroovyRundeckConfigIfExists(environment)
     }
 
     void loadGroovyRundeckConfigIfExists(final Environment environment) {
-        String rundeckGroovyConfigFile = System.getProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_CONFIG_DIR)+"/rundeck-config.groovy"
-        if(Files.exists(Paths.get(rundeckGroovyConfigFile))) {
+        String rundeckGroovyConfigFile = System.getProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_CONFIG_DIR) +
+                                         "/rundeck-config.groovy"
+        if (Files.exists(Paths.get(rundeckGroovyConfigFile))) {
             def config = new ConfigSlurper().parse(new File(rundeckGroovyConfigFile).toURL())
-            environment.propertySources.addFirst( new MapPropertySource("rundeck-config-groovy", config ) )
+            environment.propertySources.addFirst(new MapPropertySource("rundeck-config-groovy", config))
         }
 
     }

--- a/rundeckapp/grails-app/init/rundeckapp/init/DefaultRundeckConfigPropertyLoader.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/DefaultRundeckConfigPropertyLoader.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rundeckapp.init
+
+import com.dtolabs.rundeck.core.properties.CoreConfigurationPropertiesLoader
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+
+class DefaultRundeckConfigPropertyLoader implements CoreConfigurationPropertiesLoader {
+    private static final transient Logger LOG = LoggerFactory.getLogger(DefaultRundeckConfigPropertyLoader.class)
+
+    @Override
+    Properties loadProperties() {
+        Properties rundeckConfigs = new Properties()
+        try {
+            rundeckConfigs.load(
+                    new File(System.getProperty(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION)).newInputStream()
+            )
+        } catch (Exception ex) {
+            LOG.error("Unable to load rundeck-config.properties.", ex)
+        }
+
+        return rundeckConfigs
+    }
+
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
@@ -38,6 +38,8 @@ import javax.security.auth.Subject;
 import javax.security.auth.callback.*;
 import javax.security.auth.login.LoginException;
 
+import grails.boot.config.GrailsAutoConfiguration;
+import grails.util.Holders;
 import org.eclipse.jetty.jaas.callback.ObjectCallback;
 import org.eclipse.jetty.jaas.spi.AbstractLoginModule;
 import org.eclipse.jetty.jaas.spi.UserInfo;
@@ -845,7 +847,12 @@ public class JettyCachingLdapLoginModule extends AbstractLoginModule {
         _providerUrl = (String) options.get("providerUrl");
         _contextFactory = (String) options.get("contextFactory");
         _bindDn = (String) options.get("bindDn");
-        _bindPassword = (String) options.get("bindPassword");
+        String bindPassword = Holders.getConfig().get("rundeck.security.ldap.bindPassword").toString();
+        if(bindPassword != null && !"null".equals(bindPassword)) {
+            _bindPassword = bindPassword;
+        } else {
+            _bindPassword = (String) options.get("bindPassword");
+        }
         _authenticationMethod = (String) options.get("authenticationMethod");
 
         _userBaseDn = (String) options.get("userBaseDn");


### PR DESCRIPTION
Allows a user to write a custom property loader for rundeck-config.properties.

Adds the rundeck.security.ldap.bindPassword property that can be specified in the rundeck-config.properties file so that it can be loaded in the same way as the other properties in rundeck-config.properties.