### PR TITLE
Fix #3434. Method should be static.

### DIFF
--- a/rundeckapp/grails-app/init/rundeckapp/init/FileUtils.java
+++ b/rundeckapp/grails-app/init/rundeckapp/init/FileUtils.java
@@ -10,7 +10,7 @@ import java.nio.file.StandardOpenOption;
  * @author exaTech Ingenieria SpA. (info@exatech.cl)
  */
 public class FileUtils {
-  public void appendFile(final File test, final File origName) throws IOException {
+  public static void appendFile(final File test, final File origName) throws IOException {
 
     try (
         FileChannel inc = FileChannel.open(test.toPath(), StandardOpenOption.READ);


### PR DESCRIPTION
Method was ripped from 2.11 branch and moved to a separate class, but should've been marked static.