### PR TITLE
Adding support for init parameters

### DIFF
--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -32,6 +32,7 @@ import org.grails.plugins.metricsweb.CallableGauge
 import org.quartz.Scheduler
 
 import javax.servlet.ServletContext
+import java.net.URL
 import java.nio.charset.Charset
 import java.text.SimpleDateFormat
 
@@ -93,15 +94,28 @@ class BootStrap {
              FilterConfig filter2 = handler2.filterConfig
              filter1.name <=> filter2.name
          }*/
+         
+         def configLocation = servletContext.getInitParameter('rdeck.config.location')
+         if(configLocation){
+             def newconf = new ConfigObject(new URL("file://${configLocation}"))
+             grailsApplication.config.merge(newconf)
+             log.info("imported ${configLocation}")
+         }
 
          def String rdeckBase
          if(!grailsApplication.config.rdeck.base){
              //look for system property
              rdeckBase=System.getProperty('rdeck.base')
+             if(!rdeckBase){
+                 rdeckBase=servletContext.getInitParameter('rdeck.base')
+             }
              log.info("using rdeck.base system property: ${rdeckBase}");
-             def newconf= new ConfigObject()
-             newconf.rdeck.base = rdeckBase
-             grailsApplication.config.merge(newconf)
+             // if no rdeck.config.location was given, load it from default path
+             if(!configLocation) {
+                 def newconf= new ConfigObject()
+                 newconf.rdeck.base = rdeckBase
+                 grailsApplication.config.merge(newconf)
+             }
          }else{
              rdeckBase=grailsApplication.config.rdeck.base
              log.info("using rdeck.base config property: ${rdeckBase}");


### PR DESCRIPTION
Rundeck only support configuration from system properties. That's not a best practice for application server. A web context give access to servletContext.getInitParameter. Both glasshfish and tomcat allows to configure them for a web context. See [Glassfish's To Set a Web Context Parameter](https://docs.oracle.com/cd/E19798-01/821-1750/giyce/index.html) and [Tomcat's Context Parameters](https://tomcat.apache.org/tomcat-7.0-doc/config/context.html#Context_Parameters).

This pull request add support for 2 of them:
1. `rdeck.config.location`, that is checked first
2. `rdeck.base` that is used if it's missing for the configuration file.

`rdeck.config.location` if defined override the default configuration resolution found in BootStrap.groovy.

When I look at the system properties in profile, I see a mix of rundeck.something and rdeck.something.
So I'm not sur about the name of the parameter rdeck.config.location.