### PR TITLE
ImportOptions to jobref in job definition

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
@@ -134,7 +134,7 @@ public class JobExec extends WorkflowStep implements IWorkflowJobItem{
             map.failOnDisable = failOnDisable
         }
         if(importOptions){
-            map.importOptions = importOptions
+            map.jobref.importOptions = importOptions
         }
         if(nodeFilter){
             map.jobref.nodefilters=[filter:nodeFilter]

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2416,7 +2416,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     def Map<String,String> addImportedOptions(ScheduledExecution scheduledExecution, Map optparams, StepExecutionContext executionContext) throws ExecutionServiceException {
         def newMap = new HashMap()
         executionContext.dataContext.option.each {it ->
-            println(it.key)
             if(scheduledExecution.findOption(it.key)){
                 newMap<<it
             }

--- a/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
@@ -219,7 +219,7 @@ class JobExecSpec extends Specification {
         null            | _
     }
 
-    def "from map with node intersect"() {
+    def "from map with importOptions"() {
         given:
         def map = [
                 jobref     : [

--- a/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
@@ -167,4 +167,80 @@ class JobExecSpec extends Specification {
         result.jobProject == 'projectB'
 
     }
+
+    def "to map with importOptions"() {
+        when:
+        Map map = new JobExec(
+                jobGroup: 'group',
+                jobName: 'name',
+                description: 'a monkey',
+                nodeFilter: 'abc def',
+                importOptions: importOption,
+                nodeThreadcount: 2,
+        ).toMap()
+
+        then:
+
+        if(importOption) {
+            map == [
+                    jobref     : [
+                            group        : 'group',
+                            name         : 'name',
+                            importOptions: 'true',
+                            nodefilters  : [
+                                    filter  : 'abc def',
+                                    dispatch: [
+                                            threadcount: 2
+                                    ]
+                            ]
+                    ],
+                    description: 'a monkey'
+            ]
+        }else{
+            map == [
+                    jobref     : [
+                            group        : 'group',
+                            name         : 'name',
+                            nodefilters  : [
+                                    filter  : 'abc def',
+                                    dispatch: [
+                                            threadcount: 2
+                                    ]
+                            ]
+                    ],
+                    description: 'a monkey'
+            ]
+        }
+
+        where:
+        importOption    | _
+        true            | _
+        false           | _
+        null            | _
+    }
+
+    def "from map with node intersect"() {
+        given:
+        def map = [
+                jobref     : [
+                        group      : 'group',
+                        name       : 'name'
+                ],
+                description: 'a monkey'
+        ]
+        if(importOption != null) {
+            map.jobref.importOptions = importOption
+        }
+        when:
+        def result = JobExec.jobExecFromMap(map)
+
+        then:
+        result.importOptions == (importOption?.equals('true')?:null)
+        where:
+        importOption    | _
+        'true'          | _
+        'false'         | _
+        null            | _
+
+    }
 }


### PR DESCRIPTION
Fix #3429

Job definition now it's exported correctly:

```
  sequence:
    commands:
    - jobref:
        group: ''
        importOptions: true
        name: test2
```
