### PR TITLE
debian/rpm install tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 - sudo chsh --shell $(which bash)
 script:
 - "./gradlew clean && ./gradlew build && groovy testbuild.groovy -gradle && make TAG=SNAPSHOT BUILD_NUM=$TRAVIS_BUILD_NUMBER
-  rpm deb && DOCKER_COMPOSE_SPEC=docker-compose-api-mysql.yaml bash run-docker-api-tests.sh
+  rpm deb && bash test-docker-install-deb.sh && bash test-docker-install-rpm.sh &&  DOCKER_COMPOSE_SPEC=docker-compose-api-mysql.yaml bash run-docker-api-tests.sh
   && bash run-docker-tests.sh && bash run-docker-ssl-tests.sh && bash run-docker-ansible-tests.sh"
 addons:
   hostname: rdbuild

--- a/docker/debinstall/Dockerfile
+++ b/docker/debinstall/Dockerfile
@@ -1,22 +1,15 @@
-FROM ubuntu:16.04
+FROM rdubuntu16.04-util:latest
 
 ## General package configuration
 RUN apt-get -y update && \
     apt-get -y install \
         sudo \
-        unzip \
-        curl \
-        xmlstarlet \
-        git \
-        netcat-traditional \
         software-properties-common \
         debconf-utils \
         uuid-runtime \
-        ncurses-bin \
-        iputils-ping \
-        zip \
-        vim \
+        openssh-client \
         apt-transport-https
+        
 
 
 ## Install Oracle JVM

--- a/docker/debinstall/entry.sh
+++ b/docker/debinstall/entry.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
+. /rd-util.sh
 
-echo "args $*"
-
-test -f $HOME/rundeck/packaging/rundeck*.deb || {
-	echo "debian not found at $HOME/rundeck/packaging/rundeck*.deb"
+test -f "$HOME"/rundeck/packaging/debdist/rundeck*.deb || {
+	echo "debian not found at $HOME/rundeck/packaging/debdist/rundeck*.deb"
 	exit 2
 }
 
-dpkg -i $HOME/rundeck/packaging/rundeck*.deb 
+dpkg -i "$HOME"/rundeck/packaging/debdist/rundeck*.deb
 
 service rundeckd start
-
+wait_for_start /var/log/rundeck/service.log
 exec "$@"

--- a/docker/installcommon/centos6.Dockerfile
+++ b/docker/installcommon/centos6.Dockerfile
@@ -1,0 +1,3 @@
+FROM centos:6
+
+ADD scripts/rd-util.sh /rd-util.sh

--- a/docker/installcommon/scripts/rd-util.sh
+++ b/docker/installcommon/scripts/rd-util.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+
+wait_for_start(){
+	local LOGFILE="${1:-/var/log/rundeck/service.log}"
+
+	echo "started rundeck"
+	
+	# Wait for server to start
+	local SUCCESS_MSG="Grails application running"
+	local MAX_ATTEMPTS=30
+	local SLEEP=10
+	echo "Waiting for Rundeck to start. This will take about 2 minutes... "
+	declare -i count=0
+	while (( count <= MAX_ATTEMPTS ))
+	do
+	    if ! [ -f "$LOGFILE" ] 
+	    then  echo "Waiting. hang on..."; # output a progress character.
+	    elif ! grep "${SUCCESS_MSG}" "$LOGFILE" ; then
+	      echo "Still working. hang on..."; # output a progress character.
+	    else  break; # found successful startup message.
+	    fi
+	    (( count += 1 ))  ; # increment attempts counter.
+	    (( count == MAX_ATTEMPTS )) && {
+	        echo >&2 "FAIL: Reached max attempts to find success message in logfile. Exiting."
+	        exit 1
+	    }
+	    tail -n 5 "$LOGFILE"
+	    service rundeckd status || {
+	        echo >&2 "FAIL: rundeckd is not running. Exiting."
+	        exit 1
+	    }
+	    sleep "$SLEEP"; # wait before trying again.
+
+	done
+	echo "Rundeck started successfully!!"
+	
+}

--- a/docker/installcommon/ubuntu.Dockerfile
+++ b/docker/installcommon/ubuntu.Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:16.04
+
+ADD scripts/rd-util.sh /rd-util.sh

--- a/docker/rpminstall/Dockerfile
+++ b/docker/rpminstall/Dockerfile
@@ -1,13 +1,9 @@
 # original https://hub.docker.com/r/bwits/rundeck-build/
-FROM centos:6
+FROM rdcentos6-util:latest
 MAINTAINER Bill W
 RUN rpm -Uvh  http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 RUN yum -y update
-RUN yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel git rpm-build unzip fakeroot dpkg
-RUN yum -y install wget zip
-RUN wget https://bintray.com/artifact/download/groovy/maven/groovy-binary-2.4.3.zip
-RUN unzip groovy-binary-2.4.3.zip
-RUN rm groovy-binary-2.4.3.zip
+RUN yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel initscripts openssh
 RUN useradd rundeck
 #USER rundeck
 
@@ -19,10 +15,9 @@ ENV USERNAME=rundeck \
 
 
 ENV JAVA_HOME=/etc/alternatives/java_sdk
-ENV GROOVY_HOME=/groovy-2.4.3
-ENV PATH=$PATH:$GROOVY_HOME/bin
 ADD entry.sh /entry.sh
 RUN chmod +x /entry.sh
+
 VOLUME $HOME/rundeck
 WORKDIR $HOME/rundeck
 

--- a/docker/rpminstall/entry.sh
+++ b/docker/rpminstall/entry.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
+. /rd-util.sh
 
 echo "args $*"
 
-if ! find $HOME/rundeck/packaging/rpmdist/RPMS/noarch/ -name '*.rpm' ; then
+if ! find "$HOME/rundeck/packaging/rpmdist/RPMS/noarch/" -name '*.rpm' ; then
 	echo "rpm not found at $HOME/rundeck/packaging/rpmdist/RPMS/noarch/rundeck*.rpm"
 	exit 2
 fi
 
-rpm -ivh $HOME/rundeck/packaging/rpmdist/RPMS/noarch/rundeck*.rpm 
+rpm -ivh "$HOME/rundeck/packaging/rpmdist/RPMS/noarch/rundeck*.rpm"
 
 service rundeckd start
-
+wait_for_start /var/log/rundeck/service.log
 exec "$@"

--- a/packaging/debroot/etc/init.d/rundeckd
+++ b/packaging/debroot/etc/init.d/rundeckd
@@ -29,7 +29,7 @@ USER="rundeck"
 RETVAL=0
 PIDFILE=/var/run/$prog.pid
 DAEMON="${JAVA_HOME:-/usr}/bin/java"
-DAEMON_ARGS="$RDECK_JVM $RDECK_JVM_OPTS -cp $BOOTSTRAP_CP com.dtolabs.rundeck.RunServer $RDECK_BASE"
+DAEMON_EXEC="$rundeckd"
 LOG="/var/log/rundeck/service.log"
 
 
@@ -44,7 +44,7 @@ start() {
   start-stop-daemon --start --quiet --chuid $USER:$USER \
                     --make-pidfile --pidfile $PIDFILE \
                     --background --startas /bin/bash -- \
-                    -c "exec $DAEMON $DAEMON_ARGS >> $LOG 2>&1" 
+                    -c "exec $DAEMON_EXEC >> $LOG 2>&1" 
 
 	RETVAL=$?
 	if [ $RETVAL -eq 0 ]; then

--- a/packaging/debroot/etc/rundeck/profile
+++ b/packaging/debroot/etc/rundeck/profile
@@ -85,4 +85,4 @@ unset JRE_HOME
 
 umask 002
 
-rundeckd="$JAVA_CMD $RDECK_JVM $RDECK_JVM_OPTS -jar $EXECUTABLE_WAR"
+rundeckd="$JAVA_CMD $RDECK_JVM $RDECK_JVM_OPTS -jar $EXECUTABLE_WAR --skipinstall"

--- a/packaging/root/etc/rundeck/profile
+++ b/packaging/root/etc/rundeck/profile
@@ -85,4 +85,4 @@ unset JRE_HOME
 
 umask 002
 
-rundeckd="$JAVA_CMD $RDECK_JVM $RDECK_JVM_OPTS -jar $EXECUTABLE_WAR"
+rundeckd="$JAVA_CMD $RDECK_JVM $RDECK_JVM_OPTS -jar $EXECUTABLE_WAR --skipinstall"

--- a/test-docker-install-deb.sh
+++ b/test-docker-install-deb.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+readonly ARGS=("$@")
+
+NAME=ubuntu16.04
+DIR=docker/debinstall
+TAG="rd$NAME"
+
+build(){
+	docker build -t "$TAG-util" -f docker/installcommon/ubuntu.Dockerfile docker/installcommon
+	docker build "$DIR" -t "$TAG"
+}
+run(){
+	docker run -it -v "$PWD:/home/rundeck/rundeck" "$TAG":latest
+}
+
+build
+run

--- a/test-docker-install-rpm.sh
+++ b/test-docker-install-rpm.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+readonly ARGS=("$@")
+
+NAME=centos6
+DIR=docker/rpminstall
+TAG="rd$NAME"
+
+build(){
+	docker build -t "$TAG-util" -f docker/installcommon/centos6.Dockerfile docker/installcommon
+	docker build "$DIR" -t "$TAG"
+}
+run(){
+	docker run -it -v "$PWD:/home/rundeck/rundeck" "$TAG":latest 
+}
+
+build
+run


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

For #3444 adds docker based tests for installing rundeck using the deb and rpm artifacts.

**Describe the solution you've implemented**

* `test-docker-install-rpm.sh` installs the rpm packages in centos6 and verifies startup
* `test-docker-install-deb.sh` installs the deb package in ubuntu16.04 and verifies startup

NOTE: work-in-progress, the tests fail with current init scripts