### PR TITLE
ACL for uuid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 **/*/build
 **/out
 **/*/out
+/artifacts
 /cobertura.ser
 /gradle-cache
 /rundeckapp/stacktrace.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,28 +6,85 @@ jdk:
 sudo: required
 services:
 - docker
+
+stages:
+- build
+- test
+
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -y xmlstarlet jq
 - sudo chsh --shell $(which bash)
+- pip install awscli --upgrade --user
 install: true
 before_script:
 - export -f travis_nanoseconds
 - export -f travis_fold
 - export -f travis_time_start
 - export -f travis_time_finish
-script:
-- set -o errexit
-- source travis-helpers.sh
-- script_block 'gradle-build' './gradlew clean && ./gradlew build'
-- script_block 'groovy-test' 'groovy testbuild.groovy -gradle'
-- script_block 'make' 'make TAG=SNAPSHOT BUILD_NUM=$TRAVIS_BUILD_NUMBER rpm deb'
-- script_block 'deb-test' 'bash test-docker-install-deb.sh'
-- script_block 'rpm-test' 'bash test-docker-install-rpm.sh'
-- script_block 'api-test' 'DOCKER_COMPOSE_SPEC=docker-compose-api-mysql.yaml bash run-docker-api-tests.sh'
-- script_block 'docker-test' 'bash run-docker-tests.sh'
-- script_block 'docker-ssl-test' 'bash run-docker-ssl-tests.sh'
-- script_block 'docker-ansible-test' 'bash run-docker-ansible-tests.sh'
+
+jobs:
+  include:
+
+  - stage: build
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - mkdir -p artifacts/packaging
+    - mkdir -p artifacts/rundeckapp/build
+
+    - script_block 'gradle-build' './gradlew clean && ./gradlew build'
+    - script_block 'groovy-test' 'groovy testbuild.groovy -gradle'
+    - script_block 'make' 'make TAG=SNAPSHOT BUILD_NUM=$TRAVIS_BUILD_NUMBER rpm deb'
+
+    - find ./packaging -regex '.*\.\(deb\|rpm\)' -exec cp --parents {} artifacts \;
+    - cp -r --parents rundeckapp/build/libs artifacts/
+
+    - script_block 'sync-artifacts' sync_to_s3
+
+  - stage: test
+    env: JOB='Test deb install'
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'deb-test' 'bash test-docker-install-deb.sh'
+  
+  - env: JOB='Test rpm install'
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'rpm-test' 'bash test-docker-install-rpm.sh'
+
+  - env: JOB='Docker API tests'
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'api-test' 'DOCKER_COMPOSE_SPEC=docker-compose-api-mysql.yaml bash run-docker-api-tests.sh'
+
+  - env: JOB='Docker tests'
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'docker-test' 'bash run-docker-tests.sh'
+  
+  - env: JOB='Docker SSL tests'
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'docker-ssl-test' 'bash run-docker-ssl-tests.sh'
+
+  - env: JOB='Docker Ansible tests'
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'docker-ansible-test' 'bash run-docker-ansible-tests.sh'
+
 addons:
   hostname: rdbuild
   apt:
@@ -43,6 +100,7 @@ branches:
     - master
     - release-2.11
     - prerelease-2.12.0
+    - build-stages
 
 notifications:
   irc:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,37 +1,105 @@
-Release 2.11.3
+Release 3.0.0-alpha1
 ===========
 
-Date: 2018-05-11
+Date: 2018-06-01
 
-Name: <span style="color: RoyalBlue"><span class="glyphicon glyphicon-plane"></span> "cappuccino royalblue plane"</span>
+Name: <span style="color: aquamarine"><span class="glyphicon glyphicon-apple"></span> "jalapeño popper aquamarine apple"</span>
 
-## Upgrading from Earlier versions
+## Prerelease Notes
 
-* See the [Upgrading Guide](http://rundeck.org/docs/upgrading/index.html)
+**This is a prerelease** of Rundeck 3.0. There have been a number of changes and we are asking for community feedback
+on this version. If you find a bug or regression, please file an issue at <https://github.com/rundeck/rundeck/issues>.
 
-## Notes
+We are publishing the snapshot documentation for Rundeck 3.0 at this URL: <http://rundeck.org/3.0.x-SNAPSHOT/>. Currently the Upgrading Guide is *not* updated with specific Rundeck 3.0 information, so please read the notes below.
 
-Bug fixes
+The largest change is that we've upgraded the underlying web-app framework to Grails 3. This affects some aspects of install and configuration:
+
+Install:
+
+* The "launcher jar" for Rundeck 2 is gone (long live the launcher jar). However the .war file now operates the same way. Just use the .war in the same way as the previous launcher jar, or deploy it as a webapp.
+
+Configuration:
+
+* The `web.xml` file is no longer available. If you were modifying this after install before, let us know how/for what reason. (Typically modifying session timeout or auth constraints). Also, please see Authentication Changes below.
+* If using Mysql/other DBs which require a JDBC driver, be sure to specify it explicitly in the rundeck-config file, e.g. `dataSource.driverClassName=com.mysql.jdbc.Driver`
+* If you update and get an error about Log4j configuration, add a line to your rundeck-config file: `rundeck.log4j.config.file=/.../server/config/log4j.properties` and specify the correct path to a log4j.properties file.
+
+Authentication Changes:
+
+* We no longer rely on "container-based" security/authentication (i.e. web.xml auth constraints, coupled with Jetty/Tomcat authentication setup.)
+	We now use "Spring Security" for Grails, which moves the authentication checks into Rundeck itself.
+	This enables SSO, Oauth, and other types of authentication which was difficult/impossible to implement before.
+* The default JAAS authentication method still works, so existing JAAS based configuration should operate as expected.
+* Pre-authentication modes should work as they did before.
+* SSO integration: *documentation TBD*
+
+Thanks:
+
+A lot of work went into the Grails 3 upgrade, many thanks especially to:
+
+* Alberto Hormazabal
+* Stephen Joyner
+
+👏👏👏
+
+## Upgrading
+
+For the most part, Rundeck 3.0 is drop-in compatible with existing Rundeck 2.11 installations.
+
+We recommend doing a fresh install of 3.0.0-alpha1 and copying your Jobs/projects into it for testing.
+
+If you are upgrading in-place, *Be sure to backup import data/configs before upgrading.*
+
+If you are using the rundeck Launcher jar, replace it with the `.war` artifact, which can be renamed with a `.jar` extension if needed.
+
+See the *Configuration* notes above.
+
+
+## Additional Enhancements since Rundeck 2.11:
+
+* Limit multiple executions of a job
+* Encrypt passwords stored in configuration files
 
 ## Contributors
 
+* Alberto Hormazabal (ahormazabal)
+* Davy Gabard
+* Davy Gabard (Kaldor37)
 * Greg Schueler (gschueler)
-* Martin (martinbydefault)
 * Jaime Tobar (jtobard)
-* Romain LEON (PeekLeon)
-* Luis Toledo (ltamaster)
+* Jocelyn Thode
+* OmriShiv
+* Stephen Joyner
+* Stephen Joyner (sjrd218)
+* carlos (carlosrfranco)
+* scollector65
 
 ## Bug Reporters
 
-* martinbydefault
+* Kaldor37
+* Nomekrax
+* ahormazabal
+* gschueler
+* jquick
 * jtobard
-* PeekLeon
-* ltamaster
+* kino71
+* sebastianbello
+* turlubullu
+* wcliff
 
 ## Issues
 
-[Milestone 2.11.3](https://github.com/rundeck/rundeck/milestone/77)
+[Milestone 3.0.0](https://github.com/rundeck/rundeck/milestone/76)
 
-* [Documentation: fixed list not being correctly rendered](https://github.com/rundeck/rundeck/pull/3386)
-* [i18n Fix: default messages and 'by.you'](https://github.com/rundeck/rundeck/pull/3385)
+* [Fixed various french translations](https://github.com/rundeck/rundeck/pull/3430)
+* [importOptions missplaced in yaml/xml export.](https://github.com/rundeck/rundeck/issues/3429)
+* [Create project via API with invalid project name does not return error](https://github.com/rundeck/rundeck/issues/3423)
+* [BUG: Job Options not appearing in Duplicated Jobs](https://github.com/rundeck/rundeck/issues/3421)
+* [Using variable in Storage path job options](https://github.com/rundeck/rundeck/pull/3420)
+* [duplicate jobs page doesn't show options ](https://github.com/rundeck/rundeck/issues/3384)
+* [rundeck access log contains "\[Ljava.lang.String;" instead of project](https://github.com/rundeck/rundeck/issues/3379)
+* [Grails 3 Update](https://github.com/rundeck/rundeck/pull/3290)
+* [Using variable in Storage path job options](https://github.com/rundeck/rundeck/issues/2092)
+* [Encrypt passwords stored in configuration files](https://github.com/rundeck/rundeck/issues/2062)
+* [Limit Multiple Executions](https://github.com/rundeck/rundeck/issues/1387)
 * [i18n Update: node filter help](https://github.com/rundeck/rundeck/pull/3383)

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ task wrapper(type: Wrapper) {
 gradle.taskGraph.whenReady { taskGraph ->
     if (taskGraph.allTasks.any { it instanceof Sign } && project.hasProperty("signing.keyId") && !project.hasProperty( "signing.password") && !project.isDevBuild) {
         // Use Java 6's console to read from the console (no good for a CI environment)
-        Console console = System.console()
+        def console = System.console()
         console.printf "\n\nWe have to sign some things in this build.\n\nPlease enter your signing details.\n\n"
 
         //def id = console.readLine("PGP Key Id: ")

--- a/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
@@ -976,7 +976,7 @@ public class AclTool extends BaseTool {
 
     static {
         projResAttrsByType = new HashMap<>();
-        projResAttrsByType.put(ACLConstants.TYPE_JOB, Arrays.asList("group", "name"));
+        projResAttrsByType.put(ACLConstants.TYPE_JOB, Arrays.asList("group", "name", "uuid"));
         projResAttrsByType.put(ACLConstants.TYPE_ADHOC, new ArrayList<String>());
         List<String> nodeAttributeNames = Arrays.asList(
                 "nodename",

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -270,3 +270,16 @@ war {
 //spring boot 1.5.x bootRepackage is not a good gradle citizen
 // will be fixed in 2.0 https://github.com/spring-projects/spring-boot/issues/1666
 [install, buildArchives, uploadArchives].each { it.dependsOn assemble }
+
+def signArchives = project.tasks.findByName('signArchives')
+if (signArchives) {
+    project.tasks.matching {it.name == "bootRepackage"}.each {
+        Set<Object> deps =  it.taskDependencies.mutableValues
+        def toBeRemoved = deps.find {
+            it.class.name.startsWith("org.gradle.api.internal.artifacts.DefaultPublishArtifactSet")
+        }
+        deps.removeAll(toBeRemoved)
+    }
+    bootRepackage.dependsOn(war)
+    signArchives.dependsOn(bootRepackage)
+}

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -353,7 +353,7 @@ class FrameworkService implements ApplicationContextAware {
      * @return
      */
     def Map authResourceForJob(ScheduledExecution se){
-        return authResourceForJob(se.jobName,se.groupPath)
+        return authResourceForJob(se.jobName,se.groupPath, se.extid)
     }
 
     /**
@@ -361,8 +361,8 @@ class FrameworkService implements ApplicationContextAware {
      * @param se
      * @return
      */
-    def Map authResourceForJob(String name, String groupPath){
-        return AuthorizationUtil.resource(AuthConstants.TYPE_JOB,[name:name,group:groupPath?:''])
+    def Map authResourceForJob(String name, String groupPath, String uuid){
+        return AuthorizationUtil.resource(AuthConstants.TYPE_JOB, [name: name, group: groupPath ?: '',uuid: uuid])
     }
     /**
      * Return the resource definition for a project for use by authorization checks

--- a/rundeckapp/grails-app/taglib/rundeck/AuthTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/AuthTagLib.groovy
@@ -56,7 +56,7 @@ class AuthTagLib {
         boolean has=(!attrs.has || attrs.has == "true")
 
         def authContext = frameworkService.getAuthContextForSubjectAndProject(request.subject,attrs.project)
-        def resource = frameworkService.authResourceForJob(attrs.job?.jobName, attrs.job?.groupPath)
+        def resource = frameworkService.authResourceForJob(attrs.job?.jobName, attrs.job?.groupPath, attrs.job?.extid)
 
         def env = Collections.singleton(new Attribute(URI.create(EnvironmentalContext.URI_BASE+"project"), attrs.project))
 
@@ -272,7 +272,7 @@ class AuthTagLib {
         
                 
 
-        def Set resources = [frameworkService.authResourceForJob(attrs.job?.jobName, attrs.job?.groupPath) ]
+        def Set resources = [frameworkService.authResourceForJob(attrs.job?.jobName, attrs.job?.groupPath, attrs.job?.extid) ]
 
         def env = Collections.singleton(new Attribute(URI.create(EnvironmentalContext.URI_BASE +"project"), attrs.job?.project))
 

--- a/rundeckapp/src/test/groovy/FrameworkServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/FrameworkServiceTests.groovy
@@ -267,45 +267,45 @@ class FrameworkServiceTests  {
 
     void testAuthorizeProjectJobAll(){
         FrameworkService test= new FrameworkService();
-        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee')
+        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee', uuid: 'aaaa')
         def decisions = [[authorized: true]] as Set
-        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee'], decisions, ['test'], "testProject"){
+        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee', uuid: 'aaaa'], decisions, ['test'], "testProject"){
             assertTrue(test.authorizeProjectJobAll(it, job, ['test'] , 'testProject'))
         }
     }
 
     void testAuthorizeProjectJobAllSingleAuthFalse() {
         FrameworkService test = new FrameworkService();
-        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee')
+        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee', uuid:'aaaa')
         def decisions = [[authorized: false]] as Set
-        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee'], decisions, ['test'], "testProject") {
+        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee', uuid:'aaaa'], decisions, ['test'], "testProject") {
             assertFalse(test.authorizeProjectJobAll(it, job, ['test'], 'testProject'))
         }
     }
 
     void testAuthorizeProjectJobAllMultipleAuthFalse() {
         FrameworkService test = new FrameworkService();
-        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee')
+        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee', uuid:'aaaa')
         def decisions = [[authorized: false], [authorized: true]] as Set
-        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee'], decisions, ['test'], "testProject") {
+        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee', uuid:'aaaa'], decisions, ['test'], "testProject") {
             assertFalse(test.authorizeProjectJobAll(it, job, ['test'], 'testProject'))
         }
     }
 
     void testAuthorizeProjectJobAllAllMultipleAuthFalse() {
         FrameworkService test = new FrameworkService();
-        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee')
+        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee', uuid:'aaaa')
         def decisions = [[authorized: false], [authorized: false]] as Set
-        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee'], decisions, ['test'], "testProject") {
+        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee', uuid:'aaaa'], decisions, ['test'], "testProject") {
             assertFalse(test.authorizeProjectJobAll(it, job, ['test'], 'testProject'))
         }
     }
 
     void testAuthorizeProjectJobAllAllMultipleAuthTrue() {
         FrameworkService test = new FrameworkService();
-        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee')
+        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee', uuid:'aaaa')
         def decisions = [[authorized: true], [authorized: true]] as Set
-        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee'], decisions, ['test'], "testProject") {
+        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee', uuid:'aaaa'], decisions, ['test'], "testProject") {
             assertTrue(test.authorizeProjectJobAll(it, job, ['test'], 'testProject'))
         }
     }
@@ -373,23 +373,23 @@ class FrameworkServiceTests  {
 
         FrameworkService test = new FrameworkService();
         test:{
-            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee')
-            def expected = [type: 'job', name: 'name1', group: 'blah/blee']
+            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee', uuid: 'aaaa')
+            def expected = [type: 'job', name: 'name1', group: 'blah/blee',uuid:'aaaa']
             assertEquals expected,test.authResourceForJob(job)
         }
         test:{
-            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah')
-            def expected = [type: 'job', name: 'name1', group: 'blah']
+            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah', uuid: 'aaaa')
+            def expected = [type: 'job', name: 'name1', group: 'blah',uuid:'aaaa']
             assertEquals expected,test.authResourceForJob(job)
         }
         test:{
-            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: '')
-            def expected = [type: 'job', name: 'name1', group: '']
+            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: '', uuid: 'aaaa')
+            def expected = [type: 'job', name: 'name1', group: '',uuid:'aaaa']
             assertEquals expected,test.authResourceForJob(job)
         }
         test:{
-            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: null)
-            def expected = [type: 'job', name: 'name1', group: '']
+            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: null, uuid: 'aaaa')
+            def expected = [type: 'job', name: 'name1', group: '',uuid:'aaaa']
             assertEquals expected,test.authResourceForJob(job)
         }
     }
@@ -397,20 +397,20 @@ class FrameworkServiceTests  {
 
         FrameworkService test = new FrameworkService();
         test:{
-            def expected = [type: 'job', name: 'name1', group: 'blah/blee']
-            assertEquals expected,test.authResourceForJob('name1','blah/blee')
+            def expected = [type: 'job', name: 'name1', group: 'blah/blee', uuid: 'aaaa']
+            assertEquals expected,test.authResourceForJob('name1','blah/blee','aaaa')
         }
         test:{
-            def expected = [type: 'job', name: 'name1', group: 'blah']
-            assertEquals expected,test.authResourceForJob('name1','blah')
+            def expected = [type: 'job', name: 'name1', group: 'blah', uuid: 'aaaa']
+            assertEquals expected,test.authResourceForJob('name1','blah','aaaa')
         }
         test:{
-            def expected = [type: 'job', name: 'name1', group: '']
-            assertEquals expected,test.authResourceForJob('name1','')
+            def expected = [type: 'job', name: 'name1', group: '', uuid: 'aaaa']
+            assertEquals expected,test.authResourceForJob('name1','','aaaa')
         }
         test:{
-            def expected = [type: 'job', name: 'name1', group: '']
-            assertEquals expected,test.authResourceForJob('name1',null)
+            def expected = [type: 'job', name: 'name1', group: '', uuid: 'aaaa']
+            assertEquals expected,test.authResourceForJob('name1',null,'aaaa')
         }
     }
     void testAuthorizeApplicationResourceSuccess(){

--- a/setversion.sh
+++ b/setversion.sh
@@ -48,5 +48,3 @@ perl  -i'.orig' -p -e "s#^currentVersion\s*=.*\$#currentVersion = $VERSION#" `pw
 
 echo MODIFIED: `pwd`/version.properties
 
-perl  -i'.orig' -p -e "s#^app.version\s*=.*\$#app.version = $VERSION${TAG}#" `pwd`/rundeckapp/application.properties
-perl  -i'.orig' -p -e "s#^build.ident\s*=.*\$#build.ident = $VERSION-${RELEASE}${TAG}#" `pwd`/rundeckapp/application.properties

--- a/travis-helpers.sh
+++ b/travis-helpers.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+S3_ARTIFACT_PATH="s3://rundeck-travis-artifacts/oss/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/artifacts"
+
+mkdir -p artifacts/packaging
+
+# Wraps bash command in code folding and timing "stamps"
 script_block() {
     NAME="${1}"
 
@@ -15,4 +20,26 @@ script_block() {
     return $RET
 }
 
+sync_from_s3() {
+    aws s3 sync --delete "${S3_ARTIFACT_PATH}" artifacts
+}
+
+sync_to_s3() {
+    aws s3 sync --delete ./artifacts $S3_ARTIFACT_PATH
+}
+
+# Helper function that syncs artifacts from s3
+# and copies the most common into place.
+fetch_common_artifacts() {
+    sync_from_s3
+    # Drop to subshell and change dir; courtesy roundup
+    (
+        cd artifacts
+        cp -r --parents * ../
+    )
+}
+
 export -f script_block
+export -f sync_to_s3
+export -f sync_from_s3
+export -f fetch_common_artifacts

--- a/version.properties
+++ b/version.properties
@@ -15,5 +15,5 @@
 #
 
 version.number=3.0.0
-version.release.number=1
+version.release.number=2
 version.tag=alpha1

--- a/version.properties
+++ b/version.properties
@@ -15,5 +15,5 @@
 #
 
 version.number=3.0.0
-version.release.number=0
-version.tag=SNAPSHOT
+version.release.number=1
+version.tag=alpha1

--- a/version.properties
+++ b/version.properties
@@ -15,5 +15,5 @@
 #
 
 version.number=3.0.0
-version.release.number=2
-version.tag=alpha1
+version.release.number=0
+version.tag=SNAPSHOT


### PR DESCRIPTION
Closes #1812
Adds the capability to use job's UUID instead of name, group:

```
context:
  project: '.*' # all projects
for:
  job:
    - equals:
        uuid: baad57ad-1e0b-4452-b1e3-0cbcd10a7bec
      allow: [view,run]
    - equals:
        uuid: b8ed7b5b-cac9-44eb-a543-e62423bdac3f
      allow: [view,run,runAs]
```
works in the same way as using
```
context:
  project: '.*' # all projects
for:
  job:
    - equals:
        nane: exampleJobA
      allow: [view,run]
    - equals:
        name: exampleJobB
      allow: [view,run,runAs]
```
