### PR TITLE
Implement Travis stages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 **/*/build
 **/out
 **/*/out
+/artifacts
 /cobertura.ser
 /gradle-cache
 /rundeckapp/stacktrace.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,28 +6,85 @@ jdk:
 sudo: required
 services:
 - docker
+
+stages:
+- build
+- test
+
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -y xmlstarlet jq
 - sudo chsh --shell $(which bash)
+- pip install awscli --upgrade --user
 install: true
 before_script:
 - export -f travis_nanoseconds
 - export -f travis_fold
 - export -f travis_time_start
 - export -f travis_time_finish
-script:
-- set -o errexit
-- source travis-helpers.sh
-- script_block 'gradle-build' './gradlew clean && ./gradlew build'
-- script_block 'groovy-test' 'groovy testbuild.groovy -gradle'
-- script_block 'make' 'make TAG=SNAPSHOT BUILD_NUM=$TRAVIS_BUILD_NUMBER rpm deb'
-- script_block 'deb-test' 'bash test-docker-install-deb.sh'
-- script_block 'rpm-test' 'bash test-docker-install-rpm.sh'
-- script_block 'api-test' 'DOCKER_COMPOSE_SPEC=docker-compose-api-mysql.yaml bash run-docker-api-tests.sh'
-- script_block 'docker-test' 'bash run-docker-tests.sh'
-- script_block 'docker-ssl-test' 'bash run-docker-ssl-tests.sh'
-- script_block 'docker-ansible-test' 'bash run-docker-ansible-tests.sh'
+
+jobs:
+  include:
+
+  - stage: build
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - mkdir -p artifacts/packaging
+    - mkdir -p artifacts/rundeckapp/build
+
+    - script_block 'gradle-build' './gradlew clean && ./gradlew build'
+    - script_block 'groovy-test' 'groovy testbuild.groovy -gradle'
+    - script_block 'make' 'make TAG=SNAPSHOT BUILD_NUM=$TRAVIS_BUILD_NUMBER rpm deb'
+
+    - cp -r packaging/debdist artifacts/ && cp -r packaging/rpmdist artifacts/
+    - cp -r rundeckapp/build/libs artifacts/rundeckapp/build
+
+    - script_block 'sync-artifacts' sync_to_s3
+
+  - stage: test
+    env: JOB='Test deb install'
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'deb-test' 'bash test-docker-install-deb.sh'
+  
+  - env: JOB='Test rpm install'
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'rpm-test' 'bash test-docker-install-rpm.sh'
+
+  - env: JOB='Docker API tests'
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'api-test' 'DOCKER_COMPOSE_SPEC=docker-compose-api-mysql.yaml bash run-docker-api-tests.sh'
+
+  - env: JOB='Docker tests'
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'docker-test' 'bash run-docker-tests.sh'
+  
+  - env: JOB='Docker SSL tests'
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'docker-ssl-test' 'bash run-docker-ssl-tests.sh'
+
+  - env: JOB='Docker Ansible tests'
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'docker-ansible-test' 'bash run-docker-ansible-tests.sh'
+
 addons:
   hostname: rdbuild
   apt:
@@ -43,6 +100,7 @@ branches:
     - master
     - release-2.11
     - prerelease-2.12.0
+    - build-stages
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ jobs:
     - script_block 'groovy-test' 'groovy testbuild.groovy -gradle'
     - script_block 'make' 'make TAG=SNAPSHOT BUILD_NUM=$TRAVIS_BUILD_NUMBER rpm deb'
 
-    - cp -r packaging/debdist artifacts/ && cp -r packaging/rpmdist artifacts/
-    - cp -r rundeckapp/build/libs artifacts/rundeckapp/build
+    - find ./packaging -regex '.*\.\(deb\|rpm\)' -exec cp --parents {} artifacts \;
+    - cp -r --parents rundeckapp/build/libs artifacts/
 
     - script_block 'sync-artifacts' sync_to_s3
 

--- a/travis-helpers.sh
+++ b/travis-helpers.sh
@@ -32,10 +32,11 @@ sync_to_s3() {
 # and copies the most common into place.
 fetch_common_artifacts() {
     sync_from_s3
-
-    cp -r artifacts/debdist packaging/ 
-    cp -r artifacts/rpmdist packaging/
-    cp -r artifacts/rundeckapp/build rundeckapp/
+    # Drop to subshell and change dir; courtesy roundup
+    (
+        cd artifacts
+        cp -r --parents * ../
+    )
 }
 
 export -f script_block

--- a/travis-helpers.sh
+++ b/travis-helpers.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+S3_ARTIFACT_PATH="s3://rundeck-travis-artifacts/oss/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/artifacts"
+
+mkdir -p artifacts/packaging
+
+# Wraps bash command in code folding and timing "stamps"
 script_block() {
     NAME="${1}"
 
@@ -15,4 +20,25 @@ script_block() {
     return $RET
 }
 
+sync_from_s3() {
+    aws s3 sync --delete "${S3_ARTIFACT_PATH}" artifacts
+}
+
+sync_to_s3() {
+    aws s3 sync --delete ./artifacts $S3_ARTIFACT_PATH
+}
+
+# Helper function that syncs artifacts from s3
+# and copies the most common into place.
+fetch_common_artifacts() {
+    sync_from_s3
+
+    cp -r artifacts/debdist packaging/ 
+    cp -r artifacts/rpmdist packaging/
+    cp -r artifacts/rundeckapp/build rundeckapp/
+}
+
 export -f script_block
+export -f sync_to_s3
+export -f sync_from_s3
+export -f fetch_common_artifacts


### PR DESCRIPTION
This PR introduces an initial Travis CI stages **"spike"**.  It introduces a few new concepts:

* Travis CI stages to bundle jobs that can be run in **parallel**
* Scripts re-bundled into a build stage, followed by a test stage with parallel jobs
* Artifact syncing to s3 for sharing outputs between stages

### Immediate benefits:
* Knocks a further **10+ minutes** off the existing build process
* Further increases build output readability by grouping outputs under jobs in the Travis UI
* Opens up s3 and other aws services to the build process

### Future enhancements:
* Building base docker containers and pushing them to dockerhub for reuse in downstream stages
* Speeding up the API test suite(possibly use a different runner from roundup that support parallel execution and a junit results formatter)
* Gradle caching(some info out there on how to do this with Travis)
* Exporting junit reports to a location for further visibility/analysis; could also pull all the junit files into a stage and spit some details out in travis)


### There are a few Travis CI oddities worth mentioning:
* Matrix expansion is not super friendly with stages(or at all TBH)
* The reported build time in notifications is based on the sum of all jobs, not the elapsed wall time of the entire build
* Travis CI does not support naming jobs; an environment variable is set to work around this and it is visible in the UI