### PR TITLE
Grails3: Cleanup gradle/grails props with version numbers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,8 @@
 group = org.rundeck
 currentVersion = 3.0.0
 grailsVersion = 3.3.5
+gormVersion=6.1.9.RELEASE
+gradleWrapperVersion=3.5
 groovyVersion = 2.4.13
 mavenCentralUrl = http://repo1.maven.org/maven2/
 grailsCentralUrl = http://grails.org/plugins

--- a/rundeckapp/gradle.properties
+++ b/rundeckapp/gradle.properties
@@ -1,4 +1,0 @@
-grailsVersion=3.3.5
-gormVersion=6.1.8.RELEASE
-gradleWrapperVersion=3.5
-

--- a/rundeckapp/metricsweb/gradle.properties
+++ b/rundeckapp/metricsweb/gradle.properties
@@ -1,3 +1,0 @@
-grailsVersion=3.3.2
-gormVersion=6.1.8.RELEASE
-gradleWrapperVersion=3.5


### PR DESCRIPTION
Fix #3464

- [x] Use default gorm version for grails 3.3.5
- [x] synchronize grails version used by metricsweb plugin
