### PR TITLE
ACL for uuid

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
@@ -75,6 +75,8 @@ public class AclTool extends BaseTool {
     public static final String PROJECT_ACL_LONG_OPT = "projectacl";
     public static final String JOB_OPT = "j";
     public static final String JOB_LONG_OPT = "job";
+    public static final String JOB_UUID_OPT = "I";
+    public static final String JOB_UUID_LONG_OPT = "jobUuid";
     public static final String CONTEXT_OPT = "c";
     public static final String CONTEXT_LONG_OPT = "context";
     public static final String ADHOC_OPT = "A";
@@ -236,6 +238,7 @@ public class AclTool extends BaseTool {
     private String argProject;
     private String argProjectAcl;
     private String argProjectJob;
+    private String argProjectJobUUID;
     private String argProjectNode;
     private String argTags;
     private List<String> tagsSet;
@@ -335,6 +338,15 @@ public class AclTool extends BaseTool {
                                          "Job group/name. (project context)"
                                  )
                                  .create(JOB_OPT)
+            );
+            options.addOption(
+                    OptionBuilder.withArgName("uuid")
+                            .withLongOpt(JOB_UUID_LONG_OPT)
+                            .hasArg()
+                            .withDescription(
+                                    "Job uuid. (project context)"
+                            )
+                            .create(JOB_UUID_OPT)
             );
             options.addOption(
                     OptionBuilder.withArgName("application | project")
@@ -458,6 +470,9 @@ public class AclTool extends BaseTool {
             }
             if (cli.hasOption(JOB_OPT)) {
                 argProjectJob = cli.getOptionValue(JOB_OPT);
+            }
+            if (cli.hasOption(JOB_UUID_OPT)) {
+                argProjectJobUUID = cli.getOptionValue(JOB_UUID_OPT);
             }
             if (cli.hasOption(CONTEXT_OPT)) {
                 argContext = Context.valueOf(cli.getOptionValue(CONTEXT_OPT).toLowerCase());
@@ -686,8 +701,18 @@ public class AclTool extends BaseTool {
                     new HashSet<>(projectJobActions),
                     projectEnv
             );
+        }else if(null!=argProjectJobUUID) {
+            Map<String,Object> resourceMap = createProjectJobUUIDResource();
+            logDecisions(
+                    "Job UUID\""+argProjectJobUUID+"\"",
+                    authorization,
+                    subject,
+                    resources(resourceMap),
+                    new HashSet<>(projectJobActions),
+                    projectEnv
+            );
         }else{
-            log("\n(No job (-j) specified, skipping Project context actions for a specific job.)\n");
+            log("\n(No job name(-j) or uuid (-I) specified, skipping Project context actions for a specific job.)\n");
         }
         //node
 
@@ -976,7 +1001,7 @@ public class AclTool extends BaseTool {
 
     static {
         projResAttrsByType = new HashMap<>();
-        projResAttrsByType.put(ACLConstants.TYPE_JOB, Arrays.asList("group", "name"));
+        projResAttrsByType.put(ACLConstants.TYPE_JOB, Arrays.asList("group", "name", "uuid"));
         projResAttrsByType.put(ACLConstants.TYPE_ADHOC, new ArrayList<String>());
         List<String> nodeAttributeNames = Arrays.asList(
                 "nodename",
@@ -1078,6 +1103,8 @@ public class AclTool extends BaseTool {
             resourceMap = createStorageResource();
         } else if (argContext == Context.project && argProjectJob != null) {
             resourceMap = createProjectJobResource();
+        } else if (argContext == Context.project && argProjectJobUUID != null) {
+            resourceMap = createProjectJobUUIDResource();
         } else if (argContext == Context.project && (argProjectNode != null || argTags != null)) {
             resourceMap = createProjectNodeResource();
         } else if (argContext == Context.project && argProjectAdhoc) {
@@ -1229,7 +1256,7 @@ public class AclTool extends BaseTool {
         } else if (argContext == Context.project && argGenericType != null) {
             //actions for job
             possibleActions.addAll(projKindActionsByType.get(argGenericType.toLowerCase()));
-        } else if (argContext == Context.project && argProjectJob != null) {
+        } else if (argContext == Context.project && (argProjectJob != null || argProjectJobUUID != null)) {
             //actions for job
             possibleActions.addAll(projectJobActions);
         } else if (argContext == Context.project && argProjectAdhoc) {
@@ -1327,6 +1354,13 @@ public class AclTool extends BaseTool {
         return resourceMap;
     }
 
+    private Map<String, Object> createProjectJobUUIDResource() {
+        final Map<String, Object> resourceMap;HashMap<String, Object> res = new HashMap<>();
+        res.put("uuid", argProjectJobUUID);
+        resourceMap = AuthorizationUtil.resourceRule(ACLConstants.TYPE_JOB, res);
+        return resourceMap;
+    }
+    
     private Map<String, Object> createProjectAdhocResource() {
         return AuthorizationUtil.resourceRule(ACLConstants.TYPE_ADHOC, new HashMap<String, Object>());
     }

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -353,7 +353,7 @@ class FrameworkService implements ApplicationContextAware {
      * @return
      */
     def Map authResourceForJob(ScheduledExecution se){
-        return authResourceForJob(se.jobName,se.groupPath)
+        return authResourceForJob(se.jobName,se.groupPath,se.extid)
     }
 
     /**
@@ -361,8 +361,8 @@ class FrameworkService implements ApplicationContextAware {
      * @param se
      * @return
      */
-    def Map authResourceForJob(String name, String groupPath){
-        return AuthorizationUtil.resource(AuthConstants.TYPE_JOB,[name:name,group:groupPath?:''])
+    def Map authResourceForJob(String name, String groupPath, String uuid){
+        return AuthorizationUtil.resource(AuthConstants.TYPE_JOB,[name:name,group:groupPath?:'',uuid: uuid])
     }
     /**
      * Return the resource definition for a project for use by authorization checks

--- a/rundeckapp/grails-app/taglib/rundeck/AuthTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/AuthTagLib.groovy
@@ -56,7 +56,7 @@ class AuthTagLib {
         boolean has=(!attrs.has || attrs.has == "true")
 
         def authContext = frameworkService.getAuthContextForSubjectAndProject(request.subject,attrs.project)
-        def resource = frameworkService.authResourceForJob(attrs.job?.jobName, attrs.job?.groupPath)
+        def resource = frameworkService.authResourceForJob(attrs.job?.jobName, attrs.job?.groupPath, attrs.job?.extid)
 
         def env = Collections.singleton(new Attribute(URI.create(EnvironmentalContext.URI_BASE+"project"), attrs.project))
 
@@ -272,7 +272,7 @@ class AuthTagLib {
         
                 
 
-        def Set resources = [frameworkService.authResourceForJob(attrs.job?.jobName, attrs.job?.groupPath) ]
+        def Set resources = [frameworkService.authResourceForJob(attrs.job?.jobName, attrs.job?.groupPath, attrs.job?.extid) ]
 
         def env = Collections.singleton(new Attribute(URI.create(EnvironmentalContext.URI_BASE +"project"), attrs.job?.project))
 

--- a/rundeckapp/src/test/groovy/FrameworkServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/FrameworkServiceTests.groovy
@@ -267,45 +267,45 @@ class FrameworkServiceTests  {
 
     void testAuthorizeProjectJobAll(){
         FrameworkService test= new FrameworkService();
-        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee')
+        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b')
         def decisions = [[authorized: true]] as Set
-        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee'], decisions, ['test'], "testProject"){
+        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b'], decisions, ['test'], "testProject"){
             assertTrue(test.authorizeProjectJobAll(it, job, ['test'] , 'testProject'))
         }
     }
 
     void testAuthorizeProjectJobAllSingleAuthFalse() {
         FrameworkService test = new FrameworkService();
-        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee')
+        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b')
         def decisions = [[authorized: false]] as Set
-        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee'], decisions, ['test'], "testProject") {
+        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b'], decisions, ['test'], "testProject") {
             assertFalse(test.authorizeProjectJobAll(it, job, ['test'], 'testProject'))
         }
     }
 
     void testAuthorizeProjectJobAllMultipleAuthFalse() {
         FrameworkService test = new FrameworkService();
-        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee')
+        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b')
         def decisions = [[authorized: false], [authorized: true]] as Set
-        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee'], decisions, ['test'], "testProject") {
+        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b'], decisions, ['test'], "testProject") {
             assertFalse(test.authorizeProjectJobAll(it, job, ['test'], 'testProject'))
         }
     }
 
     void testAuthorizeProjectJobAllAllMultipleAuthFalse() {
         FrameworkService test = new FrameworkService();
-        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee')
+        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b')
         def decisions = [[authorized: false], [authorized: false]] as Set
-        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee'], decisions, ['test'], "testProject") {
+        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b'], decisions, ['test'], "testProject") {
             assertFalse(test.authorizeProjectJobAll(it, job, ['test'], 'testProject'))
         }
     }
 
     void testAuthorizeProjectJobAllAllMultipleAuthTrue() {
         FrameworkService test = new FrameworkService();
-        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee')
+        ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b')
         def decisions = [[authorized: true], [authorized: true]] as Set
-        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee'], decisions, ['test'], "testProject") {
+        assertTestAuthorizeSet(test, [type: 'job', name: 'name1', group: 'blah/blee', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b'], decisions, ['test'], "testProject") {
             assertTrue(test.authorizeProjectJobAll(it, job, ['test'], 'testProject'))
         }
     }
@@ -373,23 +373,23 @@ class FrameworkServiceTests  {
 
         FrameworkService test = new FrameworkService();
         test:{
-            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee')
-            def expected = [type: 'job', name: 'name1', group: 'blah/blee']
+            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah/blee', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b')
+            def expected = [type: 'job', name: 'name1', group: 'blah/blee', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b']
             assertEquals expected,test.authResourceForJob(job)
         }
         test:{
-            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah')
-            def expected = [type: 'job', name: 'name1', group: 'blah']
+            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: 'blah', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b')
+            def expected = [type: 'job', name: 'name1', group: 'blah', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b']
             assertEquals expected,test.authResourceForJob(job)
         }
         test:{
-            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: '')
-            def expected = [type: 'job', name: 'name1', group: '']
+            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: '', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b')
+            def expected = [type: 'job', name: 'name1', group: '', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b']
             assertEquals expected,test.authResourceForJob(job)
         }
         test:{
-            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: null)
-            def expected = [type: 'job', name: 'name1', group: '']
+            ScheduledExecution job = new ScheduledExecution(jobName: 'name1', groupPath: null, uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b')
+            def expected = [type: 'job', name: 'name1', group: '', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b']
             assertEquals expected,test.authResourceForJob(job)
         }
     }
@@ -397,20 +397,20 @@ class FrameworkServiceTests  {
 
         FrameworkService test = new FrameworkService();
         test:{
-            def expected = [type: 'job', name: 'name1', group: 'blah/blee']
-            assertEquals expected,test.authResourceForJob('name1','blah/blee')
+            def expected = [type: 'job', name: 'name1', group: 'blah/blee', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b']
+            assertEquals expected,test.authResourceForJob('name1','blah/blee','8b411ae8-8931-4db9-b12e-8d29a6fec43b')
         }
         test:{
-            def expected = [type: 'job', name: 'name1', group: 'blah']
-            assertEquals expected,test.authResourceForJob('name1','blah')
+            def expected = [type: 'job', name: 'name1', group: 'blah', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b']
+            assertEquals expected,test.authResourceForJob('name1','blah','8b411ae8-8931-4db9-b12e-8d29a6fec43b')
         }
         test:{
-            def expected = [type: 'job', name: 'name1', group: '']
-            assertEquals expected,test.authResourceForJob('name1','')
+            def expected = [type: 'job', name: 'name1', group: '', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b']
+            assertEquals expected,test.authResourceForJob('name1','','8b411ae8-8931-4db9-b12e-8d29a6fec43b')
         }
         test:{
-            def expected = [type: 'job', name: 'name1', group: '']
-            assertEquals expected,test.authResourceForJob('name1',null)
+            def expected = [type: 'job', name: 'name1', group: '', uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b']
+            assertEquals expected,test.authResourceForJob('name1',null,'8b411ae8-8931-4db9-b12e-8d29a6fec43b')
         }
     }
     void testAuthorizeApplicationResourceSuccess(){


### PR DESCRIPTION
Closes #1812
* Adds the capability to use job's UUID instead of name, group:

```
context:
  project: '.*' # all projects
for:
  job:
    - equals:
        uuid: baad57ad-1e0b-4452-b1e3-0cbcd10a7bec
      allow: [view,run]
    - equals:
        uuid: b8ed7b5b-cac9-44eb-a543-e62423bdac3f
      allow: [view,run,runAs]
```
works in the same way as using
```
context:
  project: '.*' # all projects
for:
  job:
    - equals:
        nane: exampleJobA
      allow: [view,run]
    - equals:
        name: exampleJobB
      allow: [view,run,runAs]
```
* Adds the option `-I --jobUuid <uuid>` to use instead of job's name on rd-cli tool.
* Adds the Uuid field to the project Resources Attributes By Type to be used on rundeckpro gui acl editor