### PR TITLE
Issue/project import dir traversal

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProject.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProject.java
@@ -361,7 +361,12 @@ public class FrameworkProject extends FrameworkResource implements IRundeckProje
 
     @Override
     public long storeFileResource(final String path, final InputStream input) throws IOException {
+        String canonicalPath = getBaseDir().getCanonicalPath();
         File result = new File(getBaseDir(), path);
+        String resultPath = result.getCanonicalPath();
+        if (!resultPath.startsWith(canonicalPath)) {
+            throw new IOException(String.format("Path is outside of destination directory: %s", result));
+        }
         if(!result.getParentFile().exists()){
             result.getParentFile().mkdirs();
         }

--- a/core/src/test/java/com/dtolabs/rundeck/core/common/TestFrameworkProject.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/common/TestFrameworkProject.java
@@ -286,6 +286,28 @@ public class TestFrameworkProject extends AbstractBaseTest {
         assertEquals(testFile.length(), sourceFile.length());
         testFile.delete();
     }
+
+    /**
+     * Test store file resource
+     *
+     * @throws Exception
+     */
+    public void testStoreFileResource_invalid() throws Exception {
+        FrameworkProject project = createProject();
+
+        File sourceFile = new File(
+            "src/test/resources/com/dtolabs/rundeck/core/common/test-nodes1.xml"
+        );
+        long copied = 0;
+        try {
+            copied = project.storeFileResource("blah/../../test.file", new FileInputStream(sourceFile));
+            fail("Expected exception");
+        } catch (IOException e) {
+            assertTrue(e.getMessage(), e.getMessage().contains("Path is outside of destination directory"));
+        }
+
+
+    }
     /**
      * Test delete file resource
      * @throws Exception

--- a/rundeck-storage/rundeck-storage-filesys/src/test/groovy/org/rundeck/storage/data/file/FileTreeSpecification.groovy
+++ b/rundeck-storage/rundeck-storage-filesys/src/test/groovy/org/rundeck/storage/data/file/FileTreeSpecification.groovy
@@ -20,6 +20,7 @@ import org.rundeck.storage.api.PathUtil
 import org.rundeck.storage.api.StorageException
 import org.rundeck.storage.data.DataUtil
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  * $INTERFACE is ...
@@ -45,6 +46,30 @@ class FileTreeSpecification extends Specification {
         then:
         thrown(StorageException)
     }
+
+    @Unroll
+    def "operation #operation invalid path"() {
+        def dir = new File(testDir, "root1")
+        def ft = FileTreeUtil.forRoot(dir, DataUtil.contentFactory())
+        when:
+        ft."$operation"(PathUtil.asPath('some/../path'))
+        then:
+        StorageException e = thrown()
+        e.message.contains('Invalid path')
+
+        where:
+        operation                | _
+        'getPath'                | _
+        'getResource'            | _
+        'hasDirectory'           | _
+        'hasPath'                | _
+        'hasResource'            | _
+        'listDirectory'          | _
+        'listDirectoryResources' | _
+        'listDirectorySubdirs'   | _
+    }
+
+
     def "basic constructor creates dirs"() {
         def dir = new File(testDir,"root1")
         def ft = FileTreeUtil.forRoot(dir,DataUtil.contentFactory())
@@ -83,6 +108,28 @@ class FileTreeSpecification extends Specification {
         expectedMetaFile.text.contains('"monkey":"blister"')
         expectedDataFile.delete()
         expectedMetaFile.delete()
+    }
+
+    @Unroll
+    def "store via #operation invalid path"() {
+        def dir = new File(testDir, "root1")
+        def ft = FileTreeUtil.forRoot(dir, DataUtil.contentFactory())
+        when:
+        ft."$operation"(
+            PathUtil.asPath('some/../path'),
+            DataUtil.withText(
+                "sample text",
+                [monkey: 'blister', 'Content-Type': 'text/plain'],
+                DataUtil.contentFactory()
+            )
+        )
+        then:
+        StorageException e = thrown()
+        e.message.contains('Invalid path')
+        where:
+        operation        | _
+        'createResource' | _
+        'updateResource' | _
     }
     def "store mixed metadata"(){
         def dir = new File(testDir, "root1")

--- a/rundeckapp/grails-app/services/rundeck/services/DbStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/DbStorageService.groovy
@@ -266,6 +266,9 @@ class DbStorageService implements NamespacedStorage{
 
     @Override
     Resource<ResourceMeta> createResource(String ns,Path path, ResourceMeta content) {
+        if (path.path.contains('../')) {
+            throw StorageException.createException(path, "Invalid path: ${path.path}")
+        }
         if(findResource(ns,path)){
             throw StorageException.createException(path,"Exists")
         }
@@ -334,11 +337,14 @@ class DbStorageService implements NamespacedStorage{
 
     @Override
     Resource<ResourceMeta> updateResource(String ns,Path path, ResourceMeta content) {
-        def storage = findResource(ns,path)
-        if (!storage) {
-            throw StorageException.createException(path, "Not found")
+        if (path.path.contains('../')) {
+            throw StorageException.updateException(path, "Invalid path: ${path.path}")
         }
-        storage=saveStorage(storage,content,ns,path,'update')
+        def storage = findResource(ns, path)
+        if (!storage) {
+            throw StorageException.updateException(path, "Not found")
+        }
+        storage = saveStorage(storage, content, ns, path, 'update')
 
         return loadResource(storage)
     }

--- a/rundeckapp/src/test/groovy/rundeck/services/DbStorageServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/DbStorageServiceTests.groovy
@@ -264,6 +264,14 @@ class DbStorageServiceTests {
         } catch (StorageException e) {
         }
     }
+    void testCreateResource_invalid() {
+        try {
+            def res1 = service.createResource(null,'xyz/../abc', StorageUtil.withStream(bytes('abc'),[abc:'xyz3']))
+            fail("expected error")
+        } catch (StorageException e) {
+            assert  e.message.contains('Invalid path')
+        }
+    }
 
     void testCreateResource_ns_ok() {
         def s1 = new Storage(data: 'abc1'.bytes, name: 'abc', dir: '', storageMeta: [abc: 'xyz1']).save(flush:
@@ -349,6 +357,15 @@ class DbStorageServiceTests {
             def res1 = service.updateResource(null,'abc2', StorageUtil.withStream(bytes('abc'), [abc: 'xyz3']))
             fail("expected error")
         } catch (StorageException e) {
+        }
+    }
+
+    void testUpdateResource_invalid() {
+        try {
+            def res1 = service.updateResource(null,'xyz/../abc2', StorageUtil.withStream(bytes('abc'), [abc: 'xyz3']))
+            fail("expected error")
+        } catch (StorageException e) {
+            assert  e.message.contains('Invalid path')
         }
     }
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fixes #3471

**Describe the solution you've implemented**

Prevents malicious zip files used in project import from causing file overwrites outside of the destination directory.  Improves validation of input paths for db and filesystem storage trees.

