### PR TITLE
Set a max file size of 25mb configurable

### DIFF
--- a/rundeckapp/grails-app/conf/application.groovy
+++ b/rundeckapp/grails-app/conf/application.groovy
@@ -13,6 +13,9 @@ dataSource {
     password = ''
 }
 
+grails.controllers.upload.maxFileSize=26214400
+grails.controllers.upload.maxRequestSize=26214400
+
 environments {
     production {
 //        grails.serverURL = "http://www.changeme.com"


### PR DESCRIPTION
Fix #3476
Default max size for file upload. The grails 3 max by default is 128kb, but exported projects can be greater than that.
The new default max size is 25MB but can be overrided on the `rundeck-config.properties` file with the file size in bytes:
```
grails.controllers.upload.maxFileSize=26214400
grails.controllers.upload.maxRequestSize=26214400
```
