### PR TITLE
fix #3478 reduce startup logging noise

### DIFF
--- a/rundeckapp/grails-app/conf/logback.groovy
+++ b/rundeckapp/grails-app/conf/logback.groovy
@@ -36,6 +36,9 @@ appender('STDOUT', TrueConsoleAppender) {
  'net.sf.ehcache.hibernate'].each {
     logger it, WARN, ['STDOUT'], false
 }
+['org.hibernate.cache.ehcache','org.springframework.beans.GenericTypeAwarePropertyDescriptor'].each {
+    logger it, ERROR, ['STDOUT'], false
+}
 
 logger "rundeckapp.BootStrap", INFO, ["STDOUT"], false
 if (Environment.isDevelopmentMode()) {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix startup WARN level logs that are just noise.

**Describe the solution you've implemented**

Set loglevel to ERROR for specific loggers.
