### PR TITLE
Travis snapshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,20 @@ stages:
   if: fork = false
 - name: test
   if: fork = false
+- name: release
+  if: (fork = false AND (TRAVIS_EVENT_TYPE = cron OR env(RELEASE) = true))
+
 - name: fork
   if: fork = true
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 
 before_install:
 - sudo apt-get update -qq
@@ -29,7 +41,7 @@ before_script:
 
 jobs:
   include:
-
+  # Stage: build
   - stage: build
     script:
     - set -o errexit
@@ -37,15 +49,16 @@ jobs:
     - mkdir -p artifacts/packaging
     - mkdir -p artifacts/rundeckapp/build
 
-    - script_block 'gradle-build' './gradlew clean && ./gradlew build'
-    - script_block 'groovy-test' 'groovy testbuild.groovy -gradle'
-    - script_block 'make' 'make TAG=SNAPSHOT BUILD_NUM=$TRAVIS_BUILD_NUMBER rpm deb'
+    - script_block 'build' 'bash jenkins-build.sh no SNAPSHOT'
+    - script_block 'make' 'make TAG=SNAPSHOT BUILD_NUM=$RUNDECK_BUILD_NUMBER rpm deb'
 
     - find ./packaging -regex '.*\.\(deb\|rpm\)' -exec cp --parents {} artifacts \;
+    - cp -r --parents core/build/libs artifacts/
     - cp -r --parents rundeckapp/build/libs artifacts/
 
     - script_block 'sync-artifacts' sync_to_s3
-
+  
+  # Stage: test
   - stage: test
     env: JOB='Test deb install'
     script:
@@ -89,7 +102,23 @@ jobs:
     - script_block 'sync-artifacts' fetch_common_artifacts
     - script_block 'docker-ansible-test' 'bash run-docker-ansible-tests.sh'
 
-  # Fork stage consolidates all tets into one job.
+  # Stage: release publishes artifacts to external repositories
+  - stage: release
+    script:
+    - set -o errexit
+    - source travis-helpers.sh
+    - script_block 'sync-artifacts' fetch_common_artifacts
+    - export VCS_URL=https://github.com/rundeck/rundeck.git
+    # Delete existing packages
+    - bash scripts/delete-bintray-package.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck ci-snapshot-deb rundeck
+    - bash scripts/delete-bintray-package.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck ci-staging-rpm rundeck
+    - bash scripts/delete-bintray-package.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck ci-staging-rpm rundeck-config
+    # Deploy new snapshot packages
+    - bash scripts/deploy-deb-snapshots.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck ci-snapshot-deb "${RUNDECK_BUILD_NUMBER}"
+    - bash scripts/deploy-rpm-snapshots.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck ci-staging-rpm
+    - bash scripts/deploy-maven-snapshots.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck ci-snapshot-maven "${RUNDECK_BUILD_NUMBER}"
+
+  # Stage: fork consolidates all tests into one job.
   # Forks do not have access to encrypted envars so we can't pass artifacts between jobs/stages.
   - stage: fork
     script:
@@ -97,7 +126,7 @@ jobs:
     - source travis-helpers.sh
     - script_block 'gradle-build' './gradlew clean && ./gradlew build'
     - script_block 'groovy-test' 'groovy testbuild.groovy -gradle'
-    - script_block 'make' 'make TAG=SNAPSHOT BUILD_NUM=$TRAVIS_BUILD_NUMBER rpm deb'
+    - script_block 'make' 'make TAG=SNAPSHOT BUILD_NUM=$RUNDECK_BUILD_NUMBER rpm deb'
     - script_block 'deb-test' 'bash test-docker-install-deb.sh'
     - script_block 'rpm-test' 'bash test-docker-install-rpm.sh'
     - script_block 'api-test' 'DOCKER_COMPOSE_SPEC=docker-compose-api-mysql.yaml bash run-docker-api-tests.sh'
@@ -120,7 +149,6 @@ branches:
     - master
     - release-2.11
     - prerelease-2.12.0
-    - build-stages
 
 notifications:
   irc:

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -10,26 +10,6 @@ apply plugin: 'idea';
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-// add static analysis support when running on build servers (-Penvironment=build)
-if (project.hasProperty('environment') && environment == 'build') {
-    if(project in rootProject.exportedProjects.collect{project(it)}){
-        apply from: rootDir.path + '/gradle/cobertura.gradle'
-        apply plugin: 'findbugs'
-
-        findbugs {
-            toolVersion = '3.0.1'
-            ignoreFailures = true
-        }
-        if (project.hasProperty('findbugsHtml')) {
-            tasks.withType(org.gradle.api.plugins.quality.FindBugs) {
-                reports {
-                    xml.enabled false
-                    html.enabled true
-                }
-            }
-        }
-    }
-}
 
 repositories {
     mavenLocal()

--- a/scripts/delete-bintray-package.sh
+++ b/scripts/delete-bintray-package.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# del_rpm_from_bintray.sh - henri.gomez@gmail.com
+# 
+# This script delete a package from Bintray repo
+#
+
+set -e
+set -u
+
+function usage() {
+  echo "$0 username api_key org repo_name rpm_name*"
+  exit 0
+}
+
+if [ $# -lt 5 ]; then
+ usage
+fi
+
+BINTRAY_USER=$1
+BINTRAY_APIKEY=$2
+BINTRAY_ACCOUNT=$3
+BINTRAY_REPO=$4
+
+shift;
+shift;
+shift;
+shift;
+
+CURL_CMD="curl --write-out %{http_code} --silent --output /dev/null -u$BINTRAY_USER:$BINTRAY_APIKEY"
+
+
+for RPM_NAME in $@; do
+    echo "Deleting package $RPM_NAME from Bintray repository $BINTRAY_REPO ..."
+    HTTP_CODE=`$CURL_CMD -H "Content-Type: application/json" -X DELETE https://api.bintray.com/packages/$BINTRAY_ACCOUNT/$BINTRAY_REPO/$RPM_NAME`
+
+    if [[ "$HTTP_CODE" != "200" && "$HTTP_CODE" != "404" ]]; then
+        echo "can't delete package -> $HTTP_CODE"
+    else
+        echo "Package deleted"
+    fi
+
+done

--- a/scripts/deploy-deb-snapshots.sh
+++ b/scripts/deploy-deb-snapshots.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+set -u
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+bintray_user=$1
+bintray_api_key=$2
+bintray_org=$3
+bintray_repo=$4
+build_number=$5
+
+for deb in packaging/debdist/*.deb; do
+    bash $DIR/publish-deb-to-bintray.sh $bintray_user $bintray_api_key $bintray_org $bintray_repo $deb "SNAPSHOT-${build_number}"
+done

--- a/scripts/deploy-maven-snapshots.sh
+++ b/scripts/deploy-maven-snapshots.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+# set -u
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+bintray_user=$1
+bintray_api_key=$2
+bintray_org=$3
+bintray_repo=$4
+build_number=$5
+
+WORKSPACE=release
+
+if [ ! -d $WORKSPACE ]; then
+    mkdir $WORKSPACE
+fi
+
+cp core/build/libs/* $WORKSPACE
+cp rundeckapp/build/libs/*.{jar,war} $WORKSPACE
+
+# remove other artifacts we don't want and can't exclude in the copy artifacts step
+rm $WORKSPACE/*-sources.jar $WORKSPACE/*-tests.jar $WORKSPACE/*-javadoc.jar
+
+for pkg in rundeck-core rundeck rundeckapp ; do
+    bash $DIR/delete-bintray-package.sh $bintray_user $bintray_api_key $bintray_org $bintray_repo $pkg;
+done
+
+
+for jar in $WORKSPACE/*.jar $WORKSPACE/*.war ; do
+    #rename any SNAPSHOT to something else
+    bash $DIR/replace-filename-token.sh $jar SNAPSHOT $build_number
+done
+
+for war in $WORKSPACE/*.war ; do 
+    bash $DIR/replace-filename-token.sh $war rundeck- rundeckapp-
+done
+
+for jar in $WORKSPACE/*.jar $WORKSPACE/*.war ; do
+    bash $DIR/publish-jar-to-bintray.sh $bintray_user $bintray_api_key $bintray_org $bintray_repo $jar "org/rundeck/" ;
+done

--- a/scripts/deploy-rpm-snapshots.sh
+++ b/scripts/deploy-rpm-snapshots.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+set -u
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+bintray_user=$1
+bintray_api_key=$2
+bintray_org=$3
+bintray_repo=$4
+
+VCS_URL=https://github.com/rundeck/rundeck.git
+
+
+for rpm in packaging/rpmdist/RPMS/**/*.rpm ; do
+  PCK_NAME=$(rpm -qp ${rpm} --queryformat "%{NAME}") ;
+  echo "{ \"name\": \"${PCK_NAME}\",
+    \"desc\": \"\",
+    \"vcs_url\": \"${VCS_URL}\",
+    \"licenses\": [\"Apache-2.0\"]}" > bintray-package.json
+
+   bash $DIR/publish-rpm-to-bintray.sh $bintray_user $bintray_api_key $bintray_org $bintray_repo $rpm
+   rm bintray-package.json
+done
+

--- a/scripts/publish-deb-to-bintray.sh
+++ b/scripts/publish-deb-to-bintray.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+#The MIT License
+#
+#Copyright (c) 2012, Daniel Petisme
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+# This script aims to ease the publication of the freshly built devops debs to the
+# content manager https://bintray.com/ It's a lazy script so you won't found any
+# CLI controls...
+
+set -u
+
+#Constants
+API=https://api.bintray.com
+NOT_FOUND=404
+SUCCESS=200
+CREATED=201
+PACKAGE_DESCRIPTOR=bintray-package.json
+DEB_DIST=${DEB_DIST:-stable}
+DEB_COMPONENT=${DEB_COMPONENT:-main}
+DEB_ARCH=${DEB_ARCH:-all}
+
+# Arguments
+# $1 SUBJECT aka. your BinTray username
+# $2 API_KEY act as a password for REST authentication
+# $3 ORG the bintray org
+# $4 REPO the targeted repo
+# $5 the deb to deploy on BinTray 
+# $6 the build number
+
+function main() {
+  SUBJECT=$1
+  API_KEY=$2
+  ORG=$3
+  REPO=$4
+  DEB=$5
+  PCK_RELEASE=$6
+
+  DEB_FILE=`basename ${DEB}`
+
+  PCK_NAME=${PCK_NAME:-$(dpkg-deb -f ${DEB} Package)}
+  PCK_VERSION=${PCK_VERSION:-$(dpkg-deb -f ${DEB} Version)}
+
+  if [ -z "$PCK_NAME" ] || [ -z "$PCK_VERSION" ] || [ -z "$PCK_RELEASE" ]; then
+   echo "no DEB metadata information in $DEB_FILE, aborting..."
+   exit -1
+  fi
+  
+  echo "[DEBUG] SUBJECT    : ${SUBJECT}"
+  echo "[DEBUG] ORG        : ${ORG}"
+  echo "[DEBUG] REPO       : ${REPO}"
+  echo "[DEBUG] DEB_PATH   : ${DEB}"
+  echo "[DEBUG] DEB        : ${DEB_FILE}"
+  echo "[DEBUG] PCK_NAME   : ${PCK_NAME}"
+  echo "[DEBUG] PCK_VERSION: ${PCK_VERSION}"
+  echo "[DEBUG] PCK_RELEASE: ${PCK_RELEASE}"
+  
+  init_curl
+  check_package_exists
+  local pkg_exists=$?
+  if [ 0 != $pkg_exists ] ; then
+    echo "[DEBUG] The package ${PCK_NAME} does not exit. It will be created"
+    create_package        
+  fi
+  
+  deploy_deb
+}
+
+function init_curl() {
+  CURL="curl -u${SUBJECT}:${API_KEY} -H Content-Type:application/json -H Accept:application/json"
+}
+
+function check_package_exists() {
+  echo "[DEBUG] Checking if package ${PCK_NAME} exists..."
+  [  $(${CURL} --write-out %{http_code} --silent --output /dev/null -X GET  ${API}/packages/${ORG}/${REPO}/${PCK_NAME})  -eq ${SUCCESS} ]
+  package_exists=$?
+  echo "[DEBUG] Package ${PCK_NAME} exists? y:1/N:0 ${package_exists}"   
+  return ${package_exists} 
+}
+
+function create_package() {
+  echo "[DEBUG] Creating package ${PCK_NAME}..."
+  #search for a descriptor in the current folder or generate one on the fly
+  if [ -f "${PACKAGE_DESCRIPTOR}" ]; then
+    data="@${PACKAGE_DESCRIPTOR}"
+  else
+    data="{
+    \"name\": \"${PCK_NAME}\",
+    \"desc\": \"\",
+    \"vcs_url\": \"${VCS_URL}\",
+    \"licenses\": [\"Apache-2.0\"]
+    }"
+  fi
+  
+  ${CURL} -X POST  -d  "${data}" ${API}/packages/${ORG}/${REPO}/
+}
+
+function upload_content() {
+  echo "[DEBUG] Uploading ${DEB_FILE}..."
+  local CURLRESULT=$(${CURL} \
+    --write-out %{http_code} \
+    --silent \
+    --output curl.out \
+    -T ${DEB} \
+    -H X-Bintray-Debian-Distribution:$DEB_DIST \
+    -H X-Bintray-Debian-Component:$DEB_COMPONENT \
+    -H X-Bintray-Debian-Architecture:$DEB_ARCH \
+    -H X-Bintray-Package:${PCK_NAME} \
+    -H X-Bintray-Version:${PCK_VERSION}-${PCK_RELEASE} \
+    ${API}/content/${ORG}/${REPO}/${DEB_FILE})
+  [ $CURLRESULT -eq ${CREATED} ]
+  uploaded=$?
+  echo "[DEBUG] DEB ${DEB_FILE} uploaded? y:0/N:1 ${uploaded} result $CURLRESULT"
+  return ${uploaded}
+}
+function deploy_deb() {
+  
+  if ( upload_content); then
+    echo "[DEBUG] Publishing ${DEB_FILE}..."
+    ${CURL} -X POST ${API}/content/${ORG}/${REPO}/${PCK_NAME}/${PCK_VERSION}-${PCK_RELEASE}/publish -d "{ \"discard\": \"false\" }"
+  else
+    echo "[SEVERE] First you should upload your deb ${DEB_FILE}"
+    exit 2
+  fi    
+}
+
+main "$@"

--- a/scripts/publish-jar-to-bintray.sh
+++ b/scripts/publish-jar-to-bintray.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+#The MIT License
+#
+#Copyright (c) 2012, Daniel Petisme
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+# This script aims to ease the publication of the freshly built devops rpms to the
+# content manager https://bintray.com/ It's a lazy script so you won't found any
+# CLI controls...
+
+set -e
+set -u
+
+#Constants
+API=https://api.bintray.com
+NOT_FOUND=404
+SUCCESS=200
+CREATED=201
+PACKAGE_DESCRIPTOR=bintray-package.json
+
+# Arguments
+# $1 SUBJECT aka. your BinTray username
+# $2 API_KEY act as a password for REST authentication
+# $3 ORG bintray org may be different than username
+# $4 REPO the targeted repo
+# $5 the rpm to deploy on BinTray 
+
+function main() {
+  SUBJECT=$1
+  API_KEY=$2
+  BINTRAY_ORG=$3
+  REPO=$4
+  JAR=$5
+  JAR_FILE=`basename ${JAR}`
+
+  PCK_BASE=${JAR_FILE%\.[wj]ar}
+  PCK_NAME=${PCK_BASE%-[0-9].*}
+  PCK_VERSION=${PCK_BASE#${PCK_NAME}-}
+
+  if [ -z "$PCK_NAME" ] || [ -z "$PCK_VERSION" ]; then
+   echo "no JAR metadata information in $JAR_FILE, aborting..."
+   exit -1
+  fi
+  
+  echo "[DEBUG] SUBJECT    : ${SUBJECT}"
+  echo "[DEBUG] ORG        : ${BINTRAY_ORG}"
+  echo "[DEBUG] REPO       : ${REPO}"
+  echo "[DEBUG] JAR_PATH   : ${JAR}"
+  echo "[DEBUG] JAR        : ${JAR_FILE}"
+  echo "[DEBUG] PCK_NAME   : ${PCK_NAME}"
+  echo "[DEBUG] PCK_VERSION: ${PCK_VERSION}"
+  
+  init_curl
+  if ( check_package_exists ); then
+    echo "[DEBUG] The package ${PCK_NAME} does not exit. It will be created"
+    create_package        
+  fi
+  
+  deploy_rpm
+}
+
+function init_curl() {
+  CURL="curl -u${SUBJECT}:${API_KEY} -H Accept:application/json"
+  CURLJSON="$CURL -H Content-Type:application/json"
+}
+
+function check_package_exists() {
+  echo "[DEBUG] Checking if package ${PCK_NAME} exists..."
+  package_exists=`[  $(${CURL} --write-out %{http_code} --silent --output /dev/null -X GET  ${API}/packages/${BINTRAY_ORG}/${REPO}/${PCK_NAME})  -eq ${SUCCESS} ]`
+  echo "[DEBUG] Package ${PCK_NAME} exists? y:1/N:0 ${package_exists}"   
+  return ${package_exists} 
+}
+
+function create_package() {
+  echo "[DEBUG] Creating package ${PCK_NAME}..."
+  #search for a descriptor in the current folder or generate one on the fly
+  if [ -f "${PACKAGE_DESCRIPTOR}" ]; then
+    data="@${PACKAGE_DESCRIPTOR}"
+  else
+    data="{
+    \"name\": \"${PCK_NAME}\",
+    \"desc\": \"\",
+    \"vcs_url\": \"${VCS_URL}\",
+    \"licenses\": [\"Apache-2.0\"]
+    }"
+  fi
+  
+  ${CURLJSON} -X POST  -d  "${data}" ${API}/packages/${BINTRAY_ORG}/${REPO}/
+}
+
+function upload_content() {
+  echo "[DEBUG] Uploading ${JAR_FILE}..."
+  [ $(${CURL} --write-out %{http_code} --silent --output /dev/null -T ${JAR} -H X-Bintray-Package:${PCK_NAME} -H X-Bintray-Version:${PCK_VERSION} ${API}/content/${BINTRAY_ORG}/${REPO}/${JAR_FILE}) -eq ${CREATED} ]
+  uploaded=$?
+  echo "[DEBUG] JAR ${JAR_FILE} uploaded? y:1/N:0 ${uploaded}"
+  return ${uploaded}
+}
+function deploy_rpm() {
+  
+  if ( upload_content); then
+    echo "[DEBUG] Publishing ${JAR_FILE}..."
+    ${CURLJSON} -X POST ${API}/content/${BINTRAY_ORG}/${REPO}/${PCK_NAME}/${PCK_VERSION}/publish -d "{ \"discard\": \"false\" }"
+  else
+    echo "[SEVERE] First you should upload your rpm ${JAR_FILE}"
+    exit 2
+  fi    
+}
+
+main "$@"

--- a/scripts/publish-rpm-to-bintray.sh
+++ b/scripts/publish-rpm-to-bintray.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+#The MIT License
+#
+#Copyright (c) 2012, Daniel Petisme
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+# This script aims to ease the publication of the freshly built devops rpms to the
+# content manager https://bintray.com/ It's a lazy script so you won't found any
+# CLI controls...
+
+set -e
+set -u
+
+#Constants
+API=https://api.bintray.com
+NOT_FOUND=404
+SUCCESS=200
+CREATED=201
+PACKAGE_DESCRIPTOR=bintray-package.json
+
+# Arguments
+# $1 SUBJECT aka. your BinTray username
+# $2 API_KEY act as a password for REST authentication
+# $3 ORG bintray org may be different than username
+# $4 REPO the targeted repo
+# $5 the rpm to deploy on BinTray 
+
+function main() {
+  SUBJECT=$1
+  API_KEY=$2
+  BINTRAY_ORG=$3
+  REPO=$4
+  RPM=$5
+  RPM_FILE=`basename ${RPM}`
+
+  PCK_NAME=$(rpm -qp ${RPM} --queryformat "%{NAME}")
+  PCK_VERSION=$(rpm -qp ${RPM} --qf "%{VERSION}")
+  PCK_RELEASE=$(rpm -qp ${RPM} --qf "%{RELEASE}")
+
+  if [ -z "$PCK_NAME" ] || [ -z "$PCK_VERSION" ] || [ -z "$PCK_RELEASE" ]; then
+   echo "no RPM metadata information in $RPM_FILE, aborting..."
+   exit -1
+  fi
+  
+  echo "[DEBUG] SUBJECT    : ${SUBJECT}"
+  echo "[DEBUG] ORG        : ${BINTRAY_ORG}"
+  echo "[DEBUG] REPO       : ${REPO}"
+  echo "[DEBUG] RPM_PATH   : ${RPM}"
+  echo "[DEBUG] RPM        : ${RPM_FILE}"
+  echo "[DEBUG] PCK_NAME   : ${PCK_NAME}"
+  echo "[DEBUG] PCK_VERSION: ${PCK_VERSION}"
+  echo "[DEBUG] PCK_RELEASE: ${PCK_RELEASE}"
+  
+  init_curl
+  if ( check_package_exists ); then
+    echo "[DEBUG] The package ${PCK_NAME} does not exit. It will be created"
+    create_package        
+  fi
+  
+  deploy_rpm
+}
+
+function init_curl() {
+  CURL="curl -u${SUBJECT}:${API_KEY} -H Content-Type:application/json -H Accept:application/json"
+}
+
+function check_package_exists() {
+  echo "[DEBUG] Checking if package ${PCK_NAME} exists..."
+  package_exists=`[  $(${CURL} --write-out %{http_code} --silent --output /dev/null -X GET  ${API}/packages/${BINTRAY_ORG}/${REPO}/${PCK_NAME})  -eq ${SUCCESS} ]`
+  echo "[DEBUG] Package ${PCK_NAME} exists? y:1/N:0 ${package_exists}"   
+  return ${package_exists} 
+}
+
+function create_package() {
+  echo "[DEBUG] Creating package ${PCK_NAME}..."
+  #search for a descriptor in the current folder or generate one on the fly
+  if [ -f "${PACKAGE_DESCRIPTOR}" ]; then
+    data="@${PACKAGE_DESCRIPTOR}"
+  else
+    data="{
+    \"name\": \"${PCK_NAME}\",
+    \"desc\": \"\",
+    \"vcs_url\": \"${VCS_URL}\",
+    \"licenses\": [\"Apache-2.0\"]
+    }"
+  fi
+  
+  ${CURL} -X POST  -d  "${data}" ${API}/packages/${BINTRAY_ORG}/${REPO}/
+}
+
+function upload_content() {
+  echo "[DEBUG] Uploading ${RPM_FILE}..."
+  [ $(${CURL} --write-out %{http_code} --silent --output /dev/null -T ${RPM} -H X-Bintray-Package:${PCK_NAME} -H X-Bintray-Version:${PCK_VERSION}-${PCK_RELEASE} ${API}/content/${BINTRAY_ORG}/${REPO}/${RPM_FILE}) -eq ${CREATED} ]
+  uploaded=$?
+  echo "[DEBUG] RPM ${RPM_FILE} uploaded? y:1/N:0 ${uploaded}"
+  return ${uploaded}
+}
+function deploy_rpm() {
+  
+  if ( upload_content); then
+    echo "[DEBUG] Publishing ${RPM_FILE}..."
+    ${CURL} -X POST ${API}/content/${BINTRAY_ORG}/${REPO}/${PCK_NAME}/${PCK_VERSION}-${PCK_RELEASE}/publish -d "{ \"discard\": \"false\" }"
+  else
+    echo "[SEVERE] First you should upload your rpm ${RPM_FILE}"
+    exit 2
+  fi    
+}
+
+main "$@"

--- a/scripts/replace-filename-token.sh
+++ b/scripts/replace-filename-token.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+set -u
+
+if [ $# -lt 3 ] ; then
+    echo "Usage: $0 filename replace value"
+    exit 1
+fi
+FILE=$1
+REPL=$2
+NEW=$3
+
+NAME=$(basename $FILE)
+
+function replace(){
+    echo $1 | sed "s/$2/$3/"
+}
+NNAME=$(replace $NAME $REPL $NEW)
+
+echo "Renaming $NAME to $NNAME"
+
+mv $(dirname $FILE)/$NAME $(dirname $FILE)/$NNAME

--- a/travis-helpers.sh
+++ b/travis-helpers.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-S3_ARTIFACT_PATH="s3://rundeck-travis-artifacts/oss/${TRAVIS_BRANCH}/${TRAVIS_BUILD_NUMBER}/artifacts"
+export RUNDECK_BUILD_NUMBER="${TRAVIS_BUILD_NUMBER}"
+
+S3_ARTIFACT_PATH="s3://rundeck-travis-artifacts/oss/${TRAVIS_BRANCH}/${RUNDECK_BUILD_NUMBER}/artifacts"
 
 mkdir -p artifacts/packaging
 


### PR DESCRIPTION
This PR introduces a `snapshot` stage to the Travis build. The stage will run on a daily Travis cron to build and publish snapshot artifacts from master. It can also be triggered manually through the Travis UI by setting `RELEASE=true`.

**Change synopsis:**
* Vendors external script dependencies used for publishing to Bintray
* Consolidates Jenkins steps into top level scripts for portability
* Removes findbugs, a deprecated Gradle plugin which was silently failing builds on the Jenkins server
* Consistency improvements in script naming and calling convention

This work will serve as a first step to cutting beta and GA releases from Travis CI as well.