### PR TITLE
Usage of option values for timeout

### DIFF
--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -251,6 +251,12 @@ class ExecutionJob implements InterruptableJob {
             initMap.secureOpts=jobDataMap.get("secureOpts")
             initMap.secureOptsExposed=jobDataMap.get("secureOptsExposed")
             initMap.execution = Execution.get(initMap.executionId)
+            def jobArguments=initMap.frameworkService.parseOptsFromString(initMap.execution.argString)
+            if (initMap.scheduledExecution?.timeout && initMap.scheduledExecution?.timeout.contains('${')) {
+                def timeout = DataContextUtils.replaceDataReferencesInString(initMap.scheduledExecution?.timeout,
+                        DataContextUtils.addContext("option", jobArguments, null))
+                initMap.timeout = timeout ? Sizes.parseTimeDuration(timeout) : -1
+            }
             //NOTE: Oracle/hibernate bug workaround: if session has not flushed we may have to wait until Execution.get
             //can return the right entity
             int retry=30

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -251,12 +251,6 @@ class ExecutionJob implements InterruptableJob {
             initMap.secureOpts=jobDataMap.get("secureOpts")
             initMap.secureOptsExposed=jobDataMap.get("secureOptsExposed")
             initMap.execution = Execution.get(initMap.executionId)
-            def jobArguments=initMap.frameworkService.parseOptsFromString(initMap.execution.argString)
-            if (initMap.scheduledExecution?.timeout && initMap.scheduledExecution?.timeout.contains('${')) {
-                def timeout = DataContextUtils.replaceDataReferencesInString(initMap.scheduledExecution?.timeout,
-                        DataContextUtils.addContext("option", jobArguments, null))
-                initMap.timeout = timeout ? Sizes.parseTimeDuration(timeout) : -1
-            }
             //NOTE: Oracle/hibernate bug workaround: if session has not flushed we may have to wait until Execution.get
             //can return the right entity
             int retry=30
@@ -278,6 +272,12 @@ class ExecutionJob implements InterruptableJob {
                 throw new RuntimeException("JobDataMap contained invalid Execution type: " + initMap.execution.getClass().getName())
             }
             initMap.execution.refresh()
+            def jobArguments=initMap.frameworkService.parseOptsFromString(initMap.execution?.argString)
+            if (initMap.scheduledExecution?.timeout && initMap.scheduledExecution?.timeout.contains('${')) {
+                def timeout = DataContextUtils.replaceDataReferencesInString(initMap.scheduledExecution?.timeout,
+                        DataContextUtils.addContext("option", jobArguments, null))
+                initMap.timeout = timeout ? Sizes.parseTimeDuration(timeout) : -1
+            }
             FrameworkService frameworkService = initMap.frameworkService
             initMap.framework = frameworkService.rundeckFramework
             initMap.authContext = jobDataMap.get('authContext')


### PR DESCRIPTION
Fix #3484
Get the options values from the executions if the timeout of the `scheduleExecution` starts with `${`.