### PR TITLE
fix #3505 Bundle jdbc drivers.

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -132,7 +132,14 @@ dependencies {
 //    runtime "org.springframework:spring-test:5.0.3.RELEASE"
     runtime "org.glassfish.web:el-impl:2.1.2-b03"
     runtime "com.h2database:h2:1.4.197"
+
+    // Database drivers
     runtime 'mysql:mysql-connector-java:5.1.42'
+    runtime 'com.microsoft.sqlserver:mssql-jdbc:6.4.0.jre8'
+    runtime 'org.mariadb.jdbc:mariadb-java-client:1.7.4'
+    runtime 'org.postgresql:postgresql:42.2.2'
+
+
     runtime "org.apache.tomcat:tomcat-jdbc"
     runtime "com.bertramlabs.plugins:asset-pipeline-grails:2.14.7"
     runtime "org.slf4j:jcl-over-slf4j:1.7.25"


### PR DESCRIPTION
This PR adds the latest JDK8 compatible JDBC drivers for supported databases to the run-time dependencies in `rundeckapp/build.gradle`. This will cause Spring Boot to bundle them in the repackaged `war` file.

### Drivers Added
* Postgresql
* SQL Server
* MariaDB

### Oracle
The `ojdbc8` driver is hosted on Oracles own Maven repository which requires registration and authentication. Adding this to the deps like the others will require anyone building the application to jump through these hoops. I'm still looking for the best way to handle this:
* Add a class path via the spring boot config(incidentally we could probably do this with all drivers, but it's more friendly IMHO to bundle the drivers for supported databases)
* Go ahead and add the repository and dep info; require developers to export environment variables for auth or install the jar into a local repo via gradle