### PR TITLE
fix issue for menuController.jobsAjax  on rundeck3 

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -387,7 +387,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     if(results.nextExecutions?.get(se.id)){
                         data.nextScheduledExecution=results.nextExecutions?.get(se.id)
                         if (futureDate) {
-                            data.futureScheduledExecutions = se.nextExecutions(futureDate)
+                            data.futureScheduledExecutions = scheduledExecutionService.nextExecutions(se,futureDate)
                             if (maxFutures
                                 && data.futureScheduledExecutions
                                 && data.futureScheduledExecutions.size() > maxFutures) {

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -51,8 +51,6 @@ class ScheduledExecution extends ExecutionContext {
 
     Workflow workflow
 
-    def scheduledExecutionService
-
     Date nextExecution
     boolean scheduled = false
     Boolean nodesSelectedByDefault = true
@@ -628,10 +626,6 @@ class ScheduledExecution extends ExecutionContext {
         return (null == scheduleEnabled || scheduleEnabled)
     }
 
-    def shouldScheduleExecutionProject(){
-        return scheduledExecutionService.shouldScheduleInThisProject(project)
-    }
-
     def boolean shouldScheduleExecution() {
         return scheduled && hasExecutionEnabled() && hasScheduleEnabled()
     }
@@ -1053,20 +1047,6 @@ class ScheduledExecution extends ExecutionContext {
             return Math.floor(totalTime / execCount)
         }
         return 0;
-    }
-
-    /**
-     * Retrun a list of dates in a time lapse between now and the to Date.
-     * @param to Date in the future
-     * @return list of dates
-     */
-    List<Date> nextExecutions(Date to){
-        def trigger = scheduledExecutionService.createTrigger(this)
-        Calendar cal = new BaseCalendar()
-        if(timeZone){
-            cal.setTimeZone(TimeZone.getTimeZone(timeZone))
-        }
-        return TriggerUtils.computeFireTimesBetween(trigger, cal, new Date(), to)
     }
 
     //new threadcount value that can be defined using an option value

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -45,6 +45,7 @@ import org.apache.log4j.MDC
 import org.hibernate.StaleObjectStateException
 import org.hibernate.criterion.CriteriaSpecification
 import org.quartz.*
+import org.quartz.impl.calendar.BaseCalendar
 import org.rundeck.util.Sizes
 import org.springframework.beans.factory.InitializingBean
 import org.springframework.context.ApplicationContext
@@ -3735,5 +3736,19 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
 
         deleteScheduledExecutionById(jobid, authContext, false, user, callingAction)
+    }
+
+    /**
+     * Retrun a list of dates in a time lapse between now and the to Date.
+     * @param to Date in the future
+     * @return list of dates
+     */
+    List<Date> nextExecutions(ScheduledExecution se, Date to){
+        def trigger = createTrigger(se)
+        Calendar cal = new BaseCalendar()
+        if(se.timeZone){
+            cal.setTimeZone(TimeZone.getTimeZone(se.timeZone))
+        }
+        return TriggerUtils.computeFireTimesBetween(trigger, cal, new Date(), to)
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -316,15 +316,14 @@ class MenuControllerSpec extends Specification {
         def testUUID2 = UUID.randomUUID().toString()
         controller.apiService = Mock(ApiService)
         controller.frameworkService = Mock(FrameworkService)
-        controller.scheduledExecutionService = Mock(ScheduledExecutionService)
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService) {
+            nextExecutions(_,_) >> [new Date()]
+        }
         ScheduledExecution job1 = new ScheduledExecution(createJobParams(jobName: 'job1', uuid:testUUID))
         job1.serverNodeUUID = testUUID2
         job1.totalTime=200*1000
         job1.execCount=100
         job1.save()
-        job1.scheduledExecutionService = Mock(ScheduledExecutionService){
-            createTrigger(_) >> org.quartz.TriggerBuilder.newTrigger().build();
-        }
         request.addHeader('x-rundeck-ajax', 'true')
 
         when:
@@ -362,15 +361,14 @@ class MenuControllerSpec extends Specification {
         def testUUID2 = UUID.randomUUID().toString()
         controller.apiService = Mock(ApiService)
         controller.frameworkService = Mock(FrameworkService)
-        controller.scheduledExecutionService = Mock(ScheduledExecutionService)
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService) {
+            nextExecutions(_,_) >> [new Date()]
+        }
         ScheduledExecution job1 = new ScheduledExecution(createJobParams(jobName: 'job1', uuid: testUUID))
         job1.serverNodeUUID = testUUID2
         job1.totalTime = 200 * 1000
         job1.execCount = 100
         job1.save()
-        job1.scheduledExecutionService = Mock(ScheduledExecutionService) {
-            createTrigger(_) >> org.quartz.TriggerBuilder.newTrigger().build();
-        }
         request.addHeader('x-rundeck-ajax', 'true')
 
         when:


### PR DESCRIPTION

**Bugfix description**
The function MenuController.jobsAjax return the following error:
> java.lang.NullPointerException: Cannot invoke method createTrigger() on null object

**Solution**
Grails 3 removed the ability to inject services in domain classes, so I moved `nextExecutions` function (which called the ScheduledExectionService service)  from the domain class ScheduledExection to the ScheduledExectionService class. Then, I modify MenuController.jobsAjax to call the new `nextExecutions`  on ScheduledExectionService.

**Additional context**
This function is using on PRO to get the future executions of a scheduled job