### PR TITLE
Build test images from dockerhub base.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ cache:
 
 before_install:
 - sudo apt-get update -qq
-- sudo apt-get install -y xmlstarlet jq
+- sudo apt-get install -y jq xmlstarlet
 - sudo chsh --shell $(which bash)
 - pip install awscli --upgrade --user
 install: true
@@ -49,10 +49,11 @@ jobs:
     - shopt -s globstar
     - source scripts/travis-helpers.sh
 
+    - script_block 'build' 'make TAG=$RUNDECK_RELEASE_TAG BUILD_NUM=$RUNDECK_BUILD_NUMBER rpm deb'
+    - script_block 'build.docker.rdtest' build_rdtest
+
     - mkdir -p artifacts/packaging
     - mkdir -p artifacts/rundeckapp/build
-
-    - script_block 'build' 'make TAG=$RUNDECK_RELEASE_TAG BUILD_NUM=$RUNDECK_BUILD_NUMBER rpm deb'
 
     - find ./packaging -regex '.*\.\(deb\|rpm\)' -exec cp --parents {} artifacts \;
     - cp -r --parents core/build/libs artifacts/
@@ -75,6 +76,7 @@ jobs:
     - set -o errexit
     - source scripts/travis-helpers.sh
     - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'docker.pull' pull_rdtest
     - script_block 'api-test' 'DOCKER_COMPOSE_SPEC=docker-compose-api-mysql.yaml bash test/run-docker-api-tests.sh'
 
   - stage: test
@@ -97,6 +99,7 @@ jobs:
     - set -o errexit
     - source scripts/travis-helpers.sh
     - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'docker.pull' pull_rdtest
     - script_block 'docker-test' 'bash test/run-docker-tests.sh'
   
   - env: JOB='Docker SSL tests'
@@ -104,6 +107,7 @@ jobs:
     - set -o errexit
     - source scripts/travis-helpers.sh
     - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'docker.pull' pull_rdtest
     - script_block 'docker-ssl-test' 'bash test/run-docker-ssl-tests.sh'
 
   - env: JOB='Docker Ansible tests'
@@ -111,6 +115,7 @@ jobs:
     - set -o errexit
     - source scripts/travis-helpers.sh
     - script_block 'sync-artifacts' fetch_common_artifacts
+    - script_block 'docker.pull' pull_rdtest
     - script_block 'docker-ansible-test' 'bash test/run-docker-ansible-tests.sh'
 
   # # Stage: snapshot release publishes snapshot artifacts to external repositories
@@ -180,7 +185,6 @@ branches:
     - release-2.11
     - prerelease-2.12.0
     - /^v.*/
-    - travis-trigger
 
 notifications:
   irc:

--- a/scripts/travis-helpers.sh
+++ b/scripts/travis-helpers.sh
@@ -134,7 +134,26 @@ trigger_travis_build() {
         https://api.travis-ci.com/repo/${owner}%2F${repo}/requests
 }
 
+build_rdtest() {
+    local buildJar=( $PWD/rundeckapp/build/libs/*.war )
+    cp ${buildJar[0]} test/docker/rundeck-launcher.war
 
+    (
+        set -e
+        cd test/docker/
+        source common.sh
+        build_rdtest_docker
+    )
+
+    # Tag and push to be used as cache source in later test builds
+    docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+    docker tag rdtest:latest rundeckapp/testdeck:rdtest-latest
+    docker push rundeckapp/testdeck:rdtest-latest
+}
+
+pull_rdtest() {
+    docker pull rundeckapp/testdeck:rdtest-latest
+}
 
 export_tag_info
 export_repo_info
@@ -146,3 +165,5 @@ export -f sync_from_s3
 export -f sync_commit_from_s3
 export -f fetch_common_artifacts
 export -f trigger_travis_build
+export -f build_rdtest
+export -f pull_rdtest

--- a/test/docker/common.sh
+++ b/test/docker/common.sh
@@ -7,6 +7,7 @@ export LAUNCHER_URL=${LAUNCHER_URL:-http://dl.bintray.com/rundeck/rundeck-maven/
 export CLI_DEB_URL=${CLI_DEB_URL:-https://dl.bintray.com/rundeck/rundeck-deb}
 export CLI_VERS=${CLI_VERS:-1.0.15-1}
 
+# Builds the rdtest:latest image which is required as a base image by many test images
 build_rdtest_docker(){
 	if [ -f rundeck-launcher.war ] ; then
 		mv rundeck-launcher.war dockers/rundeck/data/
@@ -19,16 +20,16 @@ build_rdtest_docker(){
 	# setup test dirs
 	cp -r ../src dockers/rundeck/api_test/
 	cp -r ../api dockers/rundeck/api_test/
-	
+
 	# tickle installer for it to rebuild
 	#date > dockers/rundeck/data/build_control
 
 	# create base image for rundeck
 	docker build \
 		-t rdtest:latest \
+		--cache-from rundeckapp/testdeck:rdtest-latest \
 		--build-arg LAUNCHER_URL=$LAUNCHER_URL \
 		--build-arg CLI_DEB_URL=$CLI_DEB_URL \
 		--build-arg CLI_VERS=$CLI_VERS \
 		dockers/rundeck
-
 }

--- a/test/docker/dockers/rundeck/Dockerfile
+++ b/test/docker/dockers/rundeck/Dockerfile
@@ -1,38 +1,4 @@
-FROM ubuntu:16.04
-
-## General package configuration
-RUN apt-get -y update && \
-    apt-get -y install \
-        sudo \
-        unzip \
-        curl \
-        xmlstarlet \
-        git \
-        netcat-traditional \
-        software-properties-common \
-        debconf-utils \
-        uuid-runtime \
-        ncurses-bin \
-        iputils-ping \
-        jq \
-        zip \
-        apt-transport-https \
-        openjdk-8-jdk
-
-# add cli tool debian repo
-ARG CLI_DEB_URL
-ARG CLI_VERS
-RUN echo "deb $CLI_DEB_URL /" | sudo tee -a /etc/apt/sources.list
-
-# add GPG key
-#RUN curl "https://bintray.com/user/downloadSubjectPublicKey?username=rundeck" > /tmp/rundeck.gpg.key
-#RUN apt-key add - < /tmp/rundeck.gpg.key
-RUN curl "https://bintray.com/user/downloadSubjectPublicKey?username=bintray" > /tmp/bintray.gpg.key
-RUN apt-key add - < /tmp/bintray.gpg.key
-
-# RUNDECK
-
-## RUNDECK setup env
+FROM rundeckapp/testdeck:base-latest
 
 ENV USERNAME=rundeck \
     USER=rundeck \
@@ -40,54 +6,40 @@ ENV USERNAME=rundeck \
     LOGNAME=$USERNAME \
     TERM=xterm-256color
 
-# RUNDECK - create user
-RUN adduser --shell /bin/bash --home $HOME --gecos "" --disabled-password $USERNAME && \
-    passwd -d $USERNAME && \
-    addgroup $USERNAME sudo
+ARG CLI_DEB_URL
+ARG CLI_VERS
+
+    # Add gpg key
+RUN curl "https://bintray.com/user/downloadSubjectPublicKey?username=bintray" > /tmp/bintray.gpg.key \
+    && apt-key add - < /tmp/bintray.gpg.key \
+    # Add cli tool debian repo
+    && echo "deb $CLI_DEB_URL /" | sudo tee -a /etc/apt/sources.list \
+    # RUNDECK - create user
+    && adduser --shell /bin/bash --home $HOME --gecos "" --disabled-password $USERNAME && \
+        passwd -d $USERNAME && \
+        addgroup $USERNAME sudo
 
 WORKDIR $HOME
 
-#RUN sed -i.bak -e "s|securerandom.source=file:/dev/random|securerandom.source=file:/dev/urandom|" /usr/lib/jvm/java-8-oracle/jre/lib/security/java.security
+COPY --chown=rundeck:rundeck data $HOME
+COPY --chown=rundeck:rundeck api_test $HOME/api_test
 
-RUN mkdir -p $HOME/data
-COPY data $HOME/data
-VOLUME $HOME/data
-
-#Install Rundeck CLI tool
-RUN test -f $HOME/data/rd.deb && dpkg -i $HOME/data/rd.deb || true
-RUN test -f $HOME/data/rd.deb || apt-get -y update
-RUN test -f $HOME/data/rd.deb || apt-get -y install rundeck-cli=$CLI_VERS
-
-
-#download installer
 ARG LAUNCHER_URL
 ARG RUNDECK_NODE=rundeck1
-RUN echo "download rundeck launcher: ${LAUNCHER_URL}"
-RUN test -f $HOME/data/rundeck-launcher.war && \
-     cp $HOME/data/rundeck-launcher.war $HOME/rundeck-launcher.war || \
-     true
-RUN test -f $HOME/rundeck-launcher.war || curl -sS -f -L -o $HOME/rundeck-launcher.war ${LAUNCHER_URL}
+RUN echo "download rundeck launcher: ${LAUNCHER_URL}" \
+    && { test -f $HOME/rundeck-launcher.war || curl -sS -f -L ${LAUNCHER_URL} > $HOME/rundeck-launcher.war; } \
+    && { test -f $HOME/data/rd.deb && dpkg -i $HOME/data/rd.deb || true; } \
+    && { test -f $HOME/data/rd.deb || apt-get -y update && apt-get -y install rundeck-cli=$CLI_VERS; } \
+    && java \
+        -Dserver.http.port=4440 \
+        -Dserver.hostname=$RUNDECK_NODE \
+        -jar $HOME/rundeck-launcher.war --installonly \
+    && rm -rf /var/lib/apt/lists/*
 
-# copy api test sources
-RUN mkdir $HOME/api_test
-COPY api_test $HOME/api_test
-
-# RUNDECK - install
-RUN chown -R $USERNAME:$USERNAME $HOME
-WORKDIR $HOME
 USER rundeck
 
-RUN java \
-      -Dserver.http.port=4440 \
-      -Dserver.hostname=$RUNDECK_NODE \
-      -jar $HOME/rundeck-launcher.war --installonly
-
-#      --java-opts "-Djava.security.egd=file:/dev/./urandom" 
-
-EXPOSE 22 4440 4443 4444
 
 # Copy files.
-#COPY config $HOME/config
 RUN mkdir -p $HOME/scripts
 COPY scripts $HOME/scripts
 RUN sudo chmod -R a+x $HOME/scripts/*
@@ -100,6 +52,7 @@ VOLUME /var/lib/docker
 VOLUME /test
 VOLUME $HOME/resources
 
+EXPOSE 22 4440 4443 4444
+
 # Start the instance.
 CMD $HOME/scripts/run.sh
-

--- a/test/docker/test-api.sh
+++ b/test/docker/test-api.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 . common.sh
 
+# Sets the compose file to use for test run
+# Different compose files used for different environments
 export DOCKER_COMPOSE_SPEC=${DOCKER_COMPOSE_SPEC:-docker-compose-api-test.yml}
 export SETUP_TEST_PROJECT=test
 
@@ -15,6 +17,7 @@ if [ -f rd.deb ] ; then
 	mv rd.deb dockers/rundeck/data/
 fi
 
+# Most test images require rdtest:lastest as a base image
 build_rdtest_docker
 
 # clean up docker env


### PR DESCRIPTION
### Change Summary
* Utilizes base Ubuntu image from testdeck(pre-installs most dependencies like jdk)
* Refactors rdtest Dockerfile to reduce layers and image size
* Pushes/pulls rdtest to/from DockerHub and uses it as a cache candidate