### PR TITLE
Fix: jobs list content should be inside correct id

### DIFF
--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -903,12 +903,28 @@
     <div class="col-xs-12">
       <div class="card">
         <div class="card-header">
-          <g:render template="workflowsFull" model="${[jobExpandLevel:jobExpandLevel,jobgroups:jobgroups,wasfiltered:wasfiltered?true:false, clusterMap: clusterMap,nextExecutions:nextExecutions,jobauthorizations:jobauthorizations,authMap:authMap,nowrunningtotal:nowrunningtotal,max:max,offset:offset,paginateParams:paginateParams,sortEnabled:true,rkey:rkey, clusterModeEnabled:clusterModeEnabled]}"/>
         </div>
         <div class="card-content">
-          <div class="runbox primary jobs" id="indexMain">
-              <div id="error" class="alert alert-danger" style="display:none;"></div>
-          </div>
+            <div class="runbox primary jobs" id="indexMain">
+                <div id="error" class="alert alert-danger" style="display:none;"></div>
+                <g:render template="workflowsFull"
+                          model="${[
+                              jobExpandLevel    : jobExpandLevel,
+                              jobgroups         : jobgroups,
+                              wasfiltered       : wasfiltered ? true : false,
+                              clusterMap        : clusterMap,
+                              nextExecutions    : nextExecutions,
+                              jobauthorizations : jobauthorizations,
+                              authMap           : authMap,
+                              nowrunningtotal   : nowrunningtotal,
+                              max               : max,
+                              offset            : offset,
+                              paginateParams    : paginateParams,
+                              sortEnabled       : true,
+                              rkey              : rkey,
+                              clusterModeEnabled: clusterModeEnabled
+                          ]}"/>
+            </div>
         </div>
       </div>
     </div>

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -933,7 +933,7 @@
     <div class="col-xs-12">
       <div class="card"  id="activity_section">
         <div class="card-header">
-          <h3 class="card-title"><g:message code="page.section.Activity.for.jobs" /></h4>
+            <h3 class="card-title"><g:message code="page.section.Activity.for.jobs"/></h3>
         </div>
         <div class="card-content">
           <g:render template="/reports/activityLinks" model="[filter: [projFilter: params.project ?: request.project, jobIdFilter: '!null',], knockoutBinding: true, showTitle:true]"/>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix Pro UI integration https://github.com/rundeckpro/rundeckpro/issues/276

**Describe the solution you've implemented**

Put the jobs list content inside the `#indexMain` div
