### PR TITLE
Allow ui plugin loading on executionMode page

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/ControllerBaseInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/ControllerBaseInterceptor.groovy
@@ -23,6 +23,7 @@ class ControllerBaseInterceptor {
             "menu/securityConfig",
             "menu/acls",
             "menu/editSystemAclFile",
+            "menu/executionMode",
             "menu/createSystemAclFile",
             "menu/saveSystemAclFile",
             "menu/systemInfo",


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #3544

**Describe the solution you've implemented**

Add executionMode page to allowed UI plugin pages.
