### PR TITLE
Fix potential concurrent modification exception

### DIFF
--- a/rundeckapp/grails-app/views/common/_topbar.gsp
+++ b/rundeckapp/grails-app/views/common/_topbar.gsp
@@ -85,7 +85,7 @@
                 <li class="dropdown" id="projectSelect">
                     <g:render template="/framework/projectSelect"
                               model="${[
-                                      projects    : session.frameworkProjects,
+                                      projects    : new ArrayList(session.frameworkProjects),
                                       labels      : session.frameworkLabels,
                                       project     : params.project ?: request.project,
                                       selectParams: selectParams


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix "ConcurrentModificationException" thrown in logs sometimes.

**Describe the solution you've implemented**

Use a copy of the session object in the view because the view sorts the list.

**Additional context**

Difficult to reproduce, but I've seen the exception occur, possibly when creating a new project while having another browser window open.  The user session has a list of project names, so two browser tabs might both access the session variable, and the projectSelect template sorts the variable directly which could cause concurrent modification.
