### PR TITLE
Fix missing ansi colorization css

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -177,7 +177,7 @@ tasks.withType(Test) {
 assets {
     minifyJs = false
     minifyCss = false
-    excludes = ["**/*.less",'gulpfile.js','**/*~','*.json']
+    excludes = ['gulpfile.js','**/*~','*.json']
 }
 
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #3554 

**Describe the solution you've implemented**

Re-enable less files to be built by the asset-pipeline.
