### PR TITLE
Fix #3556 wf/opt drag and drop not working

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/jobedit.js
+++ b/rundeckapp/grails-app/assets/javascripts/jobedit.js
@@ -720,53 +720,109 @@ function _updateWFUndoRedo() {
 
 
 ///Drag drop
-function moveDragItem(dragged, droparea) {
-    var num = jQuery(dragged).data('wfitemnum');
-    var to = jQuery(droparea).data('wfitemnum');
-
-    if (to > num) {
-        to = to - 1;
-    }
-
-    _doMoveItem(num, to);
-}
+var wfDragger;
 function _enableWFDragdrop() {
     "use strict";
-    _enableDragdrop("#workflowContent ol>li","workflowDropfinal",moveDragItem);
+    var select = "#workflowContent ol>li";
+
+    wfDragger = _enableDragdrop(
+        select,
+        null,
+        function (elem) {
+            return jQuery.extend({}, jQuery(elem).data('wfitemnum'));
+        },
+        function (datafrom, datato) {
+            if (datafrom < datato) {
+                return 'hoverActiveDown';
+            } else if (datafrom > datato) {
+                return 'hoverActiveUp';
+            }
+            return null;
+        },
+        ['hoverActiveUp', 'hoverActiveDown'],
+        _doMoveItem
+    );
 }
-function _enableDragdrop(select, finalid, callback) {
-    $$(select).each(function (item) {
-        new Draggable(
-            item,
-            {
-                revert: 'failure',
-                ghosting: false,
-                constraint: 'vertical',
-                handle: 'dragHandle',
-                scroll: window,
-                onStart: function (d) {
-                    $(finalid).show();
-                },
-                onEnd: function (d) {
-                    $(finalid).hide();
-                }
-            }
+
+function _enableDragdrop(select, finalid, getdata, hovercss, allcss, callback) {
+    var dragger = {
+        //data from drag source
+        dragged    : null,
+        //currently dragged source elem
+        draggedElem: null,
+        //array of drop elements
+        allowed    : []
+    };
+
+    var dragStart = function (evt) {
+        dragger.draggedElem = evt.originalEvent.target;
+        dragger.dragged = getdata(evt.originalEvent.target);
+        evt.originalEvent.dataTransfer.dropEffect = 'move';
+        evt.originalEvent.dataTransfer.effectAllowed = 'move';
+
+        if (finalid) {
+            jQuery("#" + finalid).show();
+        }
+    };
+    var allowDrop = function (evt) {
+        if (!dragger.draggedElem) {
+            //not currently dragging one of my expected draggables
+            return;
+        }
+        if (evt.originalEvent.currentTarget === dragger.draggedElem) {
+            return;
+        }
+        evt.preventDefault();
+        var css = hovercss(
+            dragger.dragged,
+            getdata(evt.originalEvent.currentTarget)
         );
-        Droppables.add(item, {
-                hoverclass: 'hoverActive',
-                onDrop: callback
-            }
-        );
-        $(item).addClassName("ready");
-    });
-    $$('#' + finalid).each(function (item) {
-        Droppables.add(item, {
-                hoverclass: 'hoverActive',
-                onDrop: callback
-            }
-        );
-        $(item).addClassName("ready");
-    });
+
+        if (css) {
+            jQuery(evt.originalEvent.currentTarget).addClass(css);
+        }
+    };
+    var dragend = function (evt) {
+        jQuery(dragger.allowed).removeClass(allcss.join(' '));
+        if (finalid) {
+            jQuery("#" + finalid).hide();
+        }
+        dragger.draggedElem = null;
+    };
+    var dragleave = function (evt) {
+        evt.preventDefault();
+        jQuery(evt.originalEvent.target).removeClass(allcss.join(' '));
+    };
+    var drop = function (evt) {
+        evt.preventDefault();
+        var fromdata = dragger.dragged;
+        var todata = getdata(evt.delegateTarget);
+        jQuery(dragger.allowed).off();
+        dragend();
+        callback(jQuery.extend({}, fromdata), jQuery.extend({}, todata));
+    };
+
+
+    dragger.allowed = jQuery(select).toArray();
+
+
+    jQuery(select).attr('draggable', 'true')
+                  .on('dragstart', dragStart)
+                  .on('dragover', allowDrop)
+                  .on('dragleave', dragleave)
+                  .on('dragend', dragend)
+                  .on('drop', drop);
+    if (finalid) {
+        var finalElem = jQuery("#" + finalid);
+        dragger.allowed.push(finalElem[0]);
+        finalElem
+            .on('dragover', allowDrop)
+            .on('drop', drop)
+            .on('dragleave', dragleave)
+            .on('dragend', dragend)
+            .addClass('ready');
+    }
+    return dragger;
 }
 /** end wf edit code */
 
@@ -812,9 +868,28 @@ function _showOptControls() {
     clearHtml('optsload');
 }
 
+var optsDragger;
 function _enableOptDragDrop(){
     "use strict";
-    _enableDragdrop('#optionContent ul>li','optionDropFinal',_dragReorderOption);
+    var select = "#optionContent ul>li";
+    optsDragger = _enableDragdrop(
+        select,
+        'optionDropFinal',
+        function (elem) {
+            return jQuery(elem).data();
+        },
+        function (datafrom, datato) {
+            if (datato.isFinal) {
+                return 'hoverActiveAll';
+            } else if (datafrom.optName !== datato.optName) {
+                return 'hoverActiveUp';
+            }
+            return null;
+        },
+
+        ['hoverActiveUp', 'hoverActiveAll'],
+        _dragReorderOption
+    );
 }
 function _showOptEmptyMessage() {
     var x = $('optionsContent').down('ul li');
@@ -1031,19 +1106,18 @@ function _doRemoveOption(name, elem,tokendataid) {
         }
     );
 }
-function _dragReorderOption(dragged,drop){
+
+function _dragReorderOption(fromData, toData) {
     "use strict";
-    var optName = jQuery(dragged).data('optName');
-    var toOptName = jQuery(drop).data('optName');
     var data={};
-    if(!toOptName && jQuery(drop).data('isFinal')){
+    if (!toData.optName && toData.isFinal) {
         data={end:true};
     }else{
-        data={before:toOptName};
+        data = {before: toData.optName};
     }
 
 
-    _doReorderOption(optName, data);
+    _doReorderOption(fromData.optName, data);
 
 }
 function _doReorderOption(name,data) {

--- a/rundeckapp/grails-app/views/execution/_execDetailsWorkflow.gsp
+++ b/rundeckapp/grails-app/views/execution/_execDetailsWorkflow.gsp
@@ -174,7 +174,7 @@ jQuery(function(){
     <ol id="wfilist_${rkey}" class="flowlist">
         <g:render template="/execution/wflistContent" model="${[workflow:workflow,edit:edit,noimgs:noimgs,project:project]}"/>
     </ol>
-    <div id="workflowDropfinal" class="dragdropfinal" data-wfitemnum="${workflow?.commands? workflow.commands.size():0}" style="display:none"></div>
+
     <div class="empty note ${error?'error':''}" id="wfempty" style="${wdgt.styleVisible(unless:workflow && workflow?.commands)}">
         No Workflow ${g.message(code:'Workflow.step.label')}s
     </div>

--- a/rundeckapp/grails-app/views/execution/_wflistContent.gsp
+++ b/rundeckapp/grails-app/views/execution/_wflistContent.gsp
@@ -22,7 +22,7 @@
  --%>
 <g:if test="${workflow && workflow?.commands}">
 <g:each in="${workflow.commands}" var="item" status="i">
-    <li class="${i%2==1?'alternate':''} draggableitem" data-wfitemnum="${i}">
+    <li class="${i%2==1?'alternate':''} draggableitem droppableitem" data-wfitemnum="${i}">
         <div id="wfli_${i}">
         <g:render template="/execution/wflistitemContent" model="${[i:i,stepNum: i,item:item,workflow:workflow,edit:edit,highlight:highlight,noimgs:noimgs, project: project]}"/>
         </div>

--- a/rundeckapp/grails-app/views/scheduledExecution/_detailsOptions.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_detailsOptions.gsp
@@ -51,7 +51,7 @@
     <ul class="options">
         <g:render template="/scheduledExecution/optlistContent" model="${[options:options,edit:edit]}"/>
     </ul>
-    <div id="optionDropFinal" class="dragdropfinal" data-abs-index="${options?.size()?:1}" data-is-final="true" style="display:none"></div>
+    <div id="optionDropFinal" class="dragdropfinal droppableitem" data-abs-index="${options?.size()?:1}" data-is-final="true" style="display:none"></div>
     <g:embedJSON id="optDataList" data="${options.collect{[name:it.name,type:it.optionType,multivalued:it.multivalued, delimiter: it.delimiter]}}"/>
     <g:javascript>
     jQuery(function(){

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -206,13 +206,21 @@ function getCurSEID(){
     .draggableitem{
         padding:0;
     }
-    .draggableitem.hoverActive{
-        border-top: 2px solid blue;
-    }
-    .dragdropfinal.hoverActive{
-        border-top: 2px solid blue;
-        padding:8px;
 
+    .droppableitem.hoverActiveAll {
+        border: 3px solid #0000ff88;
+    }
+
+    .droppableitem.hoverActiveUp {
+        border-top: 3px solid #0000ff88;
+    }
+
+    .droppableitem.hoverActiveDown {
+        border-bottom: 3px solid #0000ff88;
+    }
+    .dragdropfinal{
+        height: 25px;
+        background: #ddd;
     }
 
 

--- a/rundeckapp/grails-app/views/scheduledExecution/_optlistContent.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optlistContent.gsp
@@ -21,7 +21,7 @@
     $Id$
  --%>
 <g:each in="${options}" var="optionsel" status="i">
-    <li id="optli_${i}" class="optEntry draggableitem ${highlight==optionsel?.name?'dohighlight':''} ${i%2==1?'alternate':''}"
+    <li id="optli_${i}" class="optEntry draggableitem droppableitem ${highlight==optionsel?.name?'dohighlight':''} ${i%2==1?'alternate':''}"
         data-opt-index="${i}" data-opt-name="${optionsel?.name}">
         <g:render template="/scheduledExecution/optlistitemContent" model="${[option:optionsel,edit:edit,optIndex:i,optCount:options.size()]}"/>
     </li>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #3556 

**Describe the solution you've implemented**

replace prototype dragdrop with html5 drag and drop


**Additional context**

Prototype dragdrop could work, it broke due to scrollable content instead of page scroll (i think). If you drag and drop without scrolling the page down at all, the drop targets work correctly, however any scrolling means that the targets no longer work.

`Position.includeScrollOffsets` may just need to be set to true, but i'd rather ditch prototype instead of trying to fix it.
