### PR TITLE
getUserRoles ldap search attributes filter

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
@@ -414,7 +414,9 @@ public class JettyCachingLdapLoginModule extends AbstractLoginModule {
             return roleList;
         }
 
+        String[] attrIDs = { _roleNameAttribute };
         SearchControls ctls = new SearchControls();
+        ctls.setReturningAttributes(attrIDs);
         ctls.setDerefLinkFlag(true);
         ctls.setSearchScope(SearchControls.SUBTREE_SCOPE);
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Performance bugfix/enhancement

**Describe the solution you've implemented**
getUserRoles ldap search currently fetches ALL attributes which is a waste of bandwidth resources and woefully slow on large ldap groups when it only needs to parse roleNameAttribute.

This 2 line fix makes ldap role search 1000x faster.

**Additional context**
Returning Selected Attributes from https://docs.oracle.com/javase/jndi/tutorial/basics/directory/filter.html
