### PR TITLE
Fix #3585 sidebar project links from home list work

### DIFF
--- a/rundeckapp/grails-app/views/common/_sidebar.gsp
+++ b/rundeckapp/grails-app/views/common/_sidebar.gsp
@@ -18,7 +18,7 @@
 <g:set var="selectParams" value="${[:]}"/>
 <g:set var="buildIdent" value="${servletContextAttribute(attribute: 'app.ident')}"/>
 <g:set var="appId" value="${g.appTitle()}"/>
-<g:if test="${pageScope._metaTabPage && pageScope._metaTabPage != 'configure'&& pageScope._metaTabPage != 'projectconfigure'}">
+<g:if test="${pageScope._metaTabPage && !(pageScope._metaTabPage in ['configure','projectconfigure','home'])}">
     <g:set var="selectParams" value="${[page: _metaTabPage,project:params.project?:request.project]}"/>
 </g:if>
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #3585 

**Describe the solution you've implemented**

Don't force the contextual page info into the sidebar project link from the home page (project list)