### PR TITLE
Add git info to core and rundeck app metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ buildscript {
             }
         }
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.adaptc.gradle:nexus-workflow:0.6'
@@ -46,6 +47,7 @@ buildscript {
 
 plugins {
     id 'com.gradle.build-scan' version '1.13'
+    id "org.dvaske.gradle.git-build-info" version "0.8"
 }
 
 apply plugin: 'nexus-workflow'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
+plugins {
+    id "org.dvaske.gradle.git-build-info"
+    id 'de.fuerstenau.buildconfig' version '1.1.8'
+}
 import java.text.SimpleDateFormat
 
 /**
  * The Rundeck Core API build file
  **/
 evaluationDependsOn(':rundeck-storage')
+apply plugin: 'idea'
 description = 'The Rundeck Core API project'
 
 archivesBaseName = 'rundeck-core'
@@ -79,6 +84,38 @@ dependencies {
     testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
     testCompile "com.squareup.retrofit2:retrofit-mock:2.2.0"
 }
+buildConfig {
+    clsName = 'BuildConfig'
+    packageName = project.group + '.meta'
+    charset = 'UTF-8'
+    appName = project.name
+    version = project.version
+    buildConfigField 'String', 'GIT_COMMIT', {
+        project.gitCommit
+    }
+    buildConfigField 'String', 'GIT_BRANCH', {
+        project.gitBranch
+    }
+    buildConfigField 'String', 'GIT_DESCRIPTION', {
+        project.gitDescribeInfo
+    }
+    buildConfigField 'String', 'BUILD_DATE', {
+        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").format(new Date())
+    }
+    buildConfigField 'String', 'BUILD_NUM', buildNum
+    buildConfigField 'String', 'BUILD_IDENT', (version + '-' + buildNum)
+
+}
+
+task gitInfo {
+    doLast {
+        println "HEAD:     $project.gitHead"
+        println "Describe: $project.gitDescribeInfo"
+        println "Commit:   $project.gitCommit"
+        println "Branch:   $project.gitBranch"
+        println "Remote:   $project.gitRemote"
+    }
+}
 
 jar.doFirst {
     manifest {
@@ -90,7 +127,7 @@ jar.doFirst {
 
 def expandTemplate = {
     ant.delete(file:"$projectDir/src/main/resources/META-INF/com/dtolabs/rundeck/core/application.properties")
-    def datestring=new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(new Date())
+    def datestring = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").format(new Date())
     println("Building: $version-$buildNum ($datestring)")
     copy{
         expand('version':version,'version_build':buildNum,'version_ident':version+'-'+buildNum,date:datestring)

--- a/core/src/main/java/com/dtolabs/rundeck/core/VersionConstants.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/VersionConstants.java
@@ -72,7 +72,7 @@ public final class VersionConstants {
             e.printStackTrace();
         }
         DATE_STRING = versionProperties.getProperty("version.date", "2016-06-25T07:29:23Z");
-        SimpleDateFormat iso8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        SimpleDateFormat iso8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX");
         Date parse = null;
         try {
             parse = iso8601.parse(DATE_STRING);

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -14,9 +14,9 @@ buildscript {
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:2.14.10"
     }
 }
-
-//version "0.1"
-//group "rundeckapp"
+plugins {
+    id "org.dvaske.gradle.git-build-info"
+}
 
 apply plugin:"eclipse"
 apply plugin:"idea"
@@ -195,6 +195,17 @@ buildProperties.doLast {
     }
 
     properties.setProperty("build.ident",properties.getProperty("info.app.version"))
+    properties.setProperty("core.version",properties.getProperty("info.app.version"))
+
+    if (project.gitDescribeInfo) {
+        properties.setProperty("build.core.git.description", project.gitDescribeInfo)
+    }
+    if (project.gitCommit) {
+        properties.setProperty("build.core.git.commit", project.gitCommit)
+    }
+    if (project.gitBranch) {
+        properties.setProperty("build.core.git.branch", project.gitBranch)
+    }
 
     grailsBuildInfoFile.withOutputStream {
         properties.store(it,null)

--- a/rundeckapp/grails-app/views/menu/welcome.gsp
+++ b/rundeckapp/grails-app/views/menu/welcome.gsp
@@ -28,24 +28,34 @@
 
     <meta name="layout" content="base"/>
     <meta name="tabpage" content="home"/>
-    <title><g:appTitle/><g:message code="page.welcome.title.suffix" /></title>
+    <title><g:appTitle/><g:message code="page.welcome.title.suffix"/></title>
 </head>
 
 <body>
 
-<div class="row">
-    <div class="col-sm-12">
-        <div class="jumbotron">
-            <h2>
-                <g:message code="app.firstRun.title"
-                           args="${[g.appTitle(), grailsApplication.metadata['build.ident']]}"/>
-            </h2>
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-xs-12">
+            <div class="jumbotron">
+                <h2>
+                    <g:message code="app.firstRun.title"
+                               args="${[g.appTitle(), grailsApplication.metadata['build.ident']]}"/>
+                </h2>
 
-            <g:markdown><g:autoLink>${message(code: "app.firstRun.md")}</g:autoLink></g:markdown>
+                <g:markdown><g:autoLink>${message(code: "app.firstRun.md")}</g:autoLink></g:markdown>
 
-            <g:link controller="menu" action="index" class="btn btn-lg btn-success">
-                <g:message code="welcome.button.use.rundeck" />
-            </g:link>
+                <g:link controller="menu" action="index" class="btn btn-lg btn-success">
+                    <g:message code="welcome.button.use.rundeck"/>
+                </g:link>
+            </div>
+        </div>
+
+        <div class="col-xs-12">
+            <div>
+                <g:set var="buildDataKeys" value="${grailsApplication.metadata.keySet().
+                    findAll { it.startsWith('build.') && (grailsApplication.metadata[it] instanceof String) }}"/>
+                <g:basicData data="${grailsApplication.metadata.subMap(buildDataKeys)}" fields="${buildDataKeys.sort()}"/>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
display build info on welcome page

**Is this a bugfix, or an enhancement? Please describe.**

Adds git info to metadata for core and app, displays it on the secondary welcome page.

**Describe the solution you've implemented**

Uses git-build-info and buildconfig gradle plugins to include git info in both a java BuildConfig class in core, and in the grails metadata file.
