### PR TITLE
Refactor to make coordinating tagged releases with pro easier.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
 - pip install awscli --upgrade --user
 install: true
 before_script:
+- source scripts/travis-helpers.sh
 - export -f travis_nanoseconds
 - export -f travis_fold
 - export -f travis_time_start
@@ -45,10 +46,6 @@ jobs:
   # Stage: build
   - stage: build
     script:
-    - set -o errexit
-    - shopt -s globstar
-    - source scripts/travis-helpers.sh
-
     # Build artifacts: jars, wars, and docker images
     - script_block 'build' 'make TAG=$RUNDECK_RELEASE_TAG BUILD_NUM=$RUNDECK_BUILD_NUMBER rpm deb'
     - script_block 'build.docker.rdtest' build_rdtest
@@ -70,15 +67,11 @@ jobs:
   - stage: test
     env: JOB='Test Grails'
     script:
-    - set -o errexit
-    - source scripts/travis-helpers.sh
     - script_block 'sync-artifacts' fetch_common_artifacts
     - script_block 'grails-test' './gradlew -g gradle-cache --build-cache test'
 
   - env: JOB='Docker API tests'
     script:
-    - set -o errexit
-    - source scripts/travis-helpers.sh
     - script_block 'sync-artifacts' fetch_common_artifacts
     - script_block 'docker.pull' pull_rdtest
     - script_block 'api-test' 'DOCKER_COMPOSE_SPEC=docker-compose-api-mysql.yaml bash test/run-docker-api-tests.sh'
@@ -86,38 +79,28 @@ jobs:
   - stage: test
     env: JOB='Test deb install'
     script:
-    - set -o errexit
-    - source scripts/travis-helpers.sh
     - script_block 'sync-artifacts' fetch_common_artifacts
     - script_block 'deb-test' 'bash test/test-docker-install-deb.sh'
   
   - env: JOB='Test rpm install'
     script:
-    - set -o errexit
-    - source scripts/travis-helpers.sh
     - script_block 'sync-artifacts' fetch_common_artifacts
     - script_block 'rpm-test' 'bash test/test-docker-install-rpm.sh'
 
   - env: JOB='Docker tests'
     script:
-    - set -o errexit
-    - source scripts/travis-helpers.sh
     - script_block 'sync-artifacts' fetch_common_artifacts
     - script_block 'docker.pull' pull_rdtest
     - script_block 'docker-test' 'bash test/run-docker-tests.sh'
   
   - env: JOB='Docker SSL tests'
     script:
-    - set -o errexit
-    - source scripts/travis-helpers.sh
     - script_block 'sync-artifacts' fetch_common_artifacts
     - script_block 'docker.pull' pull_rdtest
     - script_block 'docker-ssl-test' 'bash test/run-docker-ssl-tests.sh'
 
   - env: JOB='Docker Ansible tests'
     script:
-    - set -o errexit
-    - source scripts/travis-helpers.sh
     - script_block 'sync-artifacts' fetch_common_artifacts
     - script_block 'docker.pull' pull_rdtest
     - script_block 'docker-ansible-test' 'bash test/run-docker-ansible-tests.sh'
@@ -125,8 +108,6 @@ jobs:
   # # Stage: snapshot release publishes snapshot artifacts to external repositories
   - stage: snapshot release
     script:
-    - set -o errexit
-    - source scripts/travis-helpers.sh
     # Sync artifacts under commit so we can use them for tag releases
     - script_block 'sync.artifacts' fetch_common_artifacts
     - script_block 'sync.ci-resources' fetch_common_resources
@@ -147,8 +128,6 @@ jobs:
   # Stage: tag release publishes artifacts to the appropriate external repsositories
   - stage: tag release
     script:
-    - set -o errexit
-    - source scripts/travis-helpers.sh
     - script_block 'sync-artifacts' fetch_common_artifacts
     - export VCS_URL=https://github.com/rundeck/rundeck.git
 
@@ -161,8 +140,6 @@ jobs:
   # Forks do not have access to encrypted envars so we can't pass artifacts between jobs/stages.
   - stage: fork
     script:
-    - set -o errexit
-    - source scripts/travis-helpers.sh
     - script_block 'gradle-build' './gradlew clean && ./gradlew build'
     - script_block 'groovy-test' 'groovy testbuild.groovy -gradle'
     - script_block 'make' 'make TAG=SNAPSHOT BUILD_NUM=$RUNDECK_BUILD_NUMBER rpm deb'

--- a/scripts/travis-helpers.sh
+++ b/scripts/travis-helpers.sh
@@ -4,6 +4,7 @@
 # Exported variables
 # ==================
 # RUNDECK_BUILD_NUMBER = build number from TRAVIS_BUILD_NUMBER
+# RUNDECK_TAG = Git tag used for this build and extracted from TRAVIS_TAG
 # RUNDECK_RELEASE_TAG = (SNAPSHOT|GA|other) extracted from TRAVIS_TAG
 # RUNDECK_RELEASE_VERSION = version number extracted from TRAVIS_TAG
 # RUNDECK_PREV_RELEASE_VERSION = same as above extracted from second oldest tag in git history
@@ -13,21 +14,37 @@
 # BINTRAY_RPM_REPO = selected rpm bintray repo based on release tag
 # BINTRAY_MAVEN_REPO = selected maven(jar,war) bintray repo based on release tag
 
-set -e
+set -eo pipefail
+shopt -s globstar
 
 source scripts/helpers.sh
 
 ## Overrides: Should be commented out in master
-# RUNDECK_BUILD_NUMBER = "3347"
+# RUNDECK_BUILD_NUMBER="3347"
+# RUNDECK_TAG="v3.0.0-alpha4"
 
 export RUNDECK_BUILD_NUMBER="${RUNDECK_BUILD_NUMBER:-$TRAVIS_BUILD_NUMBER}"
 export RUNDECK_COMMIT="${RUNDECK_COMMIT:-$TRAVIS_COMMIT}"
 export RUNDECK_BRANCH="${RUNDECK_BRANCH:-$TRAVIS_BRANCH}"
+export RUNDECK_TAG="${RUNDECK_TAG:-$TRAVIS_TAG}"
 
-S3_BUILD_ARTIFACT_PATH="s3://rundeck-travis-artifacts/oss/${TRAVIS_BRANCH}/travis-builds/${RUNDECK_BUILD_NUMBER}/artifacts"
-S3_COMMIT_ARTIFACT_PATH="s3://rundeck-travis-artifacts/oss/${TRAVIS_BRANCH}/commits/${RUNDECK_COMMIT}/artifacts"
-
+# Location of CI resources such as private keys
 S3_CI_RESOURCES="s3://rundeck-ci/shared/resources"
+
+# Locations we could push build artifacts to depending on release type (snapshot, alpha, ga, etc).
+# The directory layout is designed to make browsing via the AWS console, and fetching from other projects easier.
+S3_ARTIFACT_BASE="s3://rundeck-travis-artifacts/oss/rundeck"
+
+S3_BUILD_ARTIFACT_PATH="${S3_ARTIFACT_BASE}/branch/${RUNDECK_BRANCH}/build/${RUNDECK_BUILD_NUMBER}/artifacts"
+S3_COMMIT_ARTIFACT_PATH="${S3_ARTIFACT_BASE}/branch/${RUNDECK_BRANCH}/commit/${RUNDECK_COMMIT}/artifacts"
+S3_TAG_ARTIFACT_PATH="${S3_ARTIFACT_BASE}/tag/${RUNDECK_TAG}/artifacts"
+
+# Store artifacts in a predictable location in the case of version tags.
+# This will allow us to locate them across repos without passing information explicitly.
+S3_ARTIFACT_PATH="${S3_BUILD_ARTIFACT_PATH}"
+if [[ "${RUNDECK_TAG}" =~ ^v ]] ; then
+    S3_ARTIFACT_PATH="${S3_TAG_ARTIFACT_PATH}"
+fi
 
 mkdir -p artifacts/packaging
 
@@ -40,7 +57,7 @@ export_tag_info() {
         TAG_PARTS=( $TAG_PARTS )
     fi
 
-    PREV_TAG_PARTS=( $(tag_parts `git describe --abbrev=0 --tags $(git describe --abbrev=0)^ `) )
+    local PREV_TAG_PARTS=( $(tag_parts `git describe --abbrev=0 --tags $(git describe --abbrev=0)^ `) )
 
     export RUNDECK_RELEASE_VERSION="${TAG_PARTS[0]}"
     export RUNDECK_RELEASE_TAG="${TAG_PARTS[1]:-SNAPSHOT}"
@@ -61,27 +78,28 @@ export_repo_info() {
 
 # Wraps bash command in code folding and timing "stamps"
 script_block() {
-    NAME="${1}"
+    local NAME="${1}"; shift;
+    local COMMAND="${@}"
 
-    # Remove block name from arg array
-    shift
+    # Return from 
+    local ret
 
     travis_fold start "${NAME}"
         travis_time_start
-            eval "${@}"
+            eval "${COMMAND}"
             ret=$?
-            echo "Command [${@}] returned ${ret}"
+            echo "Command [${COMMAND}] returned ${ret}"
         travis_time_finish
     travis_fold end "${NAME}"
-    return $RET
+    return $ret
 }
 
 sync_from_s3() {
-    aws s3 sync --delete "${S3_BUILD_ARTIFACT_PATH}" artifacts
+    aws s3 sync --delete "${S3_ARTIFACT_PATH}" artifacts
 }
 
 sync_to_s3() {
-    aws s3 sync --delete ./artifacts "$S3_BUILD_ARTIFACT_PATH"
+    aws s3 sync --delete ./artifacts "${S3_ARTIFACT_PATH}"
 }
 
 sync_commit_from_s3() {
@@ -89,7 +107,7 @@ sync_commit_from_s3() {
 }
 
 sync_commit_to_s3() {
-    aws s3 sync --delete ./artifacts "$S3_COMMIT_ARTIFACT_PATH"
+    aws s3 sync --delete ./artifacts "${S3_COMMIT_ARTIFACT_PATH}"
 }
 
 extract_artifacts() {
@@ -133,7 +151,8 @@ trigger_travis_build() {
                 "env": {
                     "UPSTREAM_PROJECT": "rundeck",
                     "UPSTREAM_BUILD_NUMBER": "${RUNDECK_BUILD_NUMBER}",
-                    "UPSTREAM_BRANCH": "${RUNDECK_BRANCH}"
+                    "UPSTREAM_BRANCH": "${RUNDECK_BRANCH}",
+                    "UPSTREAM_TAG": "${RUNDECK_TAG}"
                 }
             }
         }


### PR DESCRIPTION
### Change Summary
* Stores artifacts in a new, more predictable S3 path scheme
* Stores tagged build artifacts in a singular location(discovery for other projects)
* Passes tag information to downstream Travis builds
* Cleanup and comments