### PR TITLE
Add html otuput to tab selector

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -808,7 +808,35 @@ class ExecutionController extends ControllerBase{
             log.error("Output file reader error: ${msg}")
             response.outputStream << msg
             return
-        }else if (reader.state != ExecutionLogState.AVAILABLE) {
+        }else if(reader.state == ExecutionLogState.WAITING){
+            if(params.reload=='true') {
+                response.outputStream << '''<html>
+                <head>
+                <title></title>
+                </head>
+                <body>
+                <div class="container">
+                <div class="row">
+                <div class="col-sm-12">
+                '''
+                response.outputStream << g.message(code: "execution.html.waiting")
+                response.outputStream << '''
+                </div>
+                <script>
+                setTimeout(function(){
+                   window.location.reload(1);
+                }, 5000);
+                </script>
+                </body>
+                </html>
+                '''
+            }else{
+                response.setStatus(HttpServletResponse.SC_NOT_FOUND)
+                log.error("Output file not available")
+            }
+            return
+
+        } else if (reader.state != ExecutionLogState.AVAILABLE) {
             //TODO: handle other states
             response.setStatus(HttpServletResponse.SC_NOT_FOUND)
             log.error("Output file not available")
@@ -871,14 +899,29 @@ class ExecutionController extends ControllerBase{
             response.outputStream<<lineSep
         }
         iterator.close()
-
-        response.outputStream << '''</div>
+        if(jobcomplete || params.reload!='true'){
+            response.outputStream << '''</div>
 </div>
 </div>
 </div>
 </body>
 </html>
 '''
+        }else{
+            response.outputStream << '''</div>
+</div>
+</div>
+</div>
+<script>
+setTimeout(function(){
+   window.location.reload(1);
+}, 5000);
+</script>
+</body>
+</html>
+'''
+        }
+
     }
 
     /**

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2913,7 +2913,12 @@ class ScheduledExecutionController  extends ControllerBase{
 
         def link
         if(params.followdetail){
-            link =createLink(controller: "execution",action: "follow",id: results.id, fragment: params.followdetail)
+            if(params.followdetail=='html'){
+                link =createLink(controller: "execution", action: "renderOutput", id: results.id,
+                        params:[convertContent:'on', loglevels:'on', ansicolor:'on', project:params.project, reload:'true'])
+            }else{
+                link =createLink(controller: "execution",action: "follow",id: results.id, fragment: params.followdetail)
+            }
         } else {
             link = createLink(controller: "execution", action: "follow", id: results.id)
         }
@@ -2956,7 +2961,11 @@ class ScheduledExecutionController  extends ControllerBase{
         }
         def link
         if(params.followdetail){
-            link =createLink(controller: "execution",action: "follow",id: results.id, fragment: params.followdetail)
+            if(params.followdetail=='html'){
+                link =createLink(controller: "execution", action: "renderOutput", id: results.id, params:[convertContent:'on', loglevels:'on', ansicolor:'on', project:params.project, reload:'true'])
+            }else{
+                link =createLink(controller: "execution",action: "follow",id: results.id, fragment: params.followdetail)
+            }
         }else {
             link = createLink(controller: "execution", action: "follow", id: results.id)
         }
@@ -3013,7 +3022,11 @@ class ScheduledExecutionController  extends ControllerBase{
             }
             return renderErrorView(results)
         } else if (params.follow == 'true') {
-            redirect(controller: "execution", action: "follow", id: results.id, params:[outdetails: params.followdetail])
+            if(params.followdetail=='html'){
+                redirect(controller: "execution", action: "renderOutput", id: results.id, params:[convertContent:'on', loglevels:'on', ansicolor:'on', project:params.project, reload:'true'])
+            }else{
+                redirect(controller: "execution", action: "follow", id: results.id, params:[outdetails: params.followdetail])
+            }
         } else {
             redirect(controller: "scheduledExecution", action: "show", id: params.id)
         }

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1653,3 +1653,5 @@ scheduledExecution.property.defaultTab.description=Default tab to display when y
 passwordUtility.page.label=Password Encrypter Utility
 passwordUtility.output.label=Output
 passwordUtility.encoder.label=Encoder:
+
+execution.html.waiting=Waiting for Execution log...

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1635,3 +1635,5 @@ scheduledExecution.action.menu.none-available=No actions available
 
 scheduledExecution.property.defaultTab.label=Pestaña por defecto
 scheduledExecution.property.defaultTab.description=Pestaña por defecto para ser mostrada cuando sigues una ejecución.
+
+execution.html.waiting=Esperando log de la ejecución...

--- a/rundeckapp/grails-app/i18n/messages_fr_FR.properties
+++ b/rundeckapp/grails-app/i18n/messages_fr_FR.properties
@@ -1637,3 +1637,6 @@ attribute=Attribut
 value=Valeur
 examples=Exemples
 more=Plus
+
+
+execution.html.waiting=Waiting for Execution log...

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -1637,3 +1637,5 @@ scheduledExecution.action.menu.none-available=No actions available
 
 scheduledExecution.property.defaultTab.label=Default Tab
 scheduledExecution.property.defaultTab.description=Default tab to display when you follow an execution.
+
+execution.html.waiting=Waiting for Execution log...

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -1201,10 +1201,10 @@ function getCurSEID(){
             </label>
 
             <label class="radio-inline">
-                <g:radio name="defaultTab" value="definition"
-                         checked="${scheduledExecution.defaultTab=='definition'}"
-                         id="tabDefinition"/>
-                <g:message code="definition"/>
+                <g:radio name="defaultTab" value="html"
+                         checked="${scheduledExecution.defaultTab=='html'}"
+                         id="tabHTML"/>
+                <g:message code="html"/>
             </label>
 
             <span class="help-block">

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -480,8 +480,8 @@
                       <option value="output" ${scheduledExecution.defaultTab=='output'?'selected="selected"':''}>
                           <g:message code="execution.show.mode.Log.title"/>
                       </option>
-                      <option value="definition" ${scheduledExecution.defaultTab=='definition'?'selected="selected"':''}>
-                          <g:message code="definition"/>
+                      <option value="html" ${scheduledExecution.defaultTab=='html'?'selected="selected"':''}>
+                          <g:message code="html"/>
                       </option>
                   </select>
                 </div>
@@ -561,8 +561,8 @@
                         <option value="output" ${scheduledExecution.defaultTab=='output'?'selected="selected"':''}>
                             <g:message code="execution.show.mode.Log.title"/>
                         </option>
-                        <option value="definition" ${scheduledExecution.defaultTab=='definition'?'selected="selected"':''}>
-                            <g:message code="definition"/>
+                        <option value="html" ${scheduledExecution.defaultTab=='html'?'selected="selected"':''}>
+                            <g:message code="html"/>
                         </option>
                     </select>
                 </label>

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -751,25 +751,35 @@ class ScheduledExecutionControllerSpec extends Specification {
         setupFormTokens(params)
         when:
         request.method = 'POST'
+        params.project='testproject'
         params.followdetail = follow
         controller.runJobInline(command, extra)
 
         then:
         response.status == 200
         response.contentType.contains 'application/json'
-        response.json == [
-                href   : "/execution/follow/${exec.id}#"+follow,
-                success: true,
-                id     : exec.id,
-                follow : false
-        ]
+        if(follow != 'html'){
+            response.json == [
+                    href   : "/execution/follow/${exec.id}#"+follow,
+                    success: true,
+                    id     : exec.id,
+                    follow : false
+            ]
+        }else{
+            response.json == [
+                    href : "/project/${params.project}/execution/renderOutput/${exec.id}?convertContent=on&loglevels=on&ansicolor=on&reload=true",
+                    success: true,
+                    id     : exec.id,
+                    follow : false
+            ]
+        }
 
         where:
         follow      |_
         'output'    |_
         'summary'   |_
         'monitor'   |_
-        'definition'|_
+        'html'      |_
 
     }
 
@@ -894,24 +904,35 @@ class ScheduledExecutionControllerSpec extends Specification {
         params.runAtTime = 'dummy'
         when:
         request.method = 'POST'
+        params.project='testproject'
         params.followdetail = follow
         controller.scheduleJobInline(command, extra)
 
         then:
         response.status == 200
         response.contentType.contains 'application/json'
-        response.json == [
-                href   : "/execution/follow/${exec.id}#"+follow,
-                success: true,
-                id     : exec.id,
-                follow : false
-        ]
+        if(follow != 'html') {
+            response.json == [
+                    href   : "/execution/follow/${exec.id}#" + follow,
+                    success: true,
+                    id     : exec.id,
+                    follow : false
+            ]
+        } else {
+            response.json == [
+                    href   : "/project/${params.project}/execution/renderOutput/${exec.id}?convertContent=on&loglevels=on&ansicolor=on&reload=true",
+                    success: true,
+                    id     : exec.id,
+                    follow : false
+            ]
+        }
+
         where:
         follow      |_
         'output'    |_
         'summary'   |_
         'monitor'   |_
-        'definition'|_
+        'html'      |_
     }
     def "run job later at time"() {
         given:


### PR DESCRIPTION
fixes #3612

Definition removed from Default tab selector.

HTML added creating a link to `/project/<project>/execution/renderOutput/<id>?ansicolor=on&loglevels=on&convertContent=on`

Since the log is in `waiting` state, a new param is added `reload`, that causes the HTML view to reload every 5 seconds until the execution is complete.

<img width="517" alt="1_edit" src="https://user-images.githubusercontent.com/2894508/42043188-d99638de-7ac3-11e8-9faa-84046b75cb5c.png">

<img width="1172" alt="2_run" src="https://user-images.githubusercontent.com/2894508/42043196-db71a9d6-7ac3-11e8-974a-47a8f03970ae.png">

