### PR TITLE
Trigger downstream snapshot builds immediately after build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ jobs:
     # Build artifacts: jars, wars, and docker images
     - script_block 'build' 'make TAG=$RUNDECK_RELEASE_TAG BUILD_NUM=$RUNDECK_BUILD_NUMBER rpm deb'
     - script_block 'build.docker.rdtest' build_rdtest
-
     # Copy artifacts and upload to s3
     - mkdir -p artifacts/packaging
     - mkdir -p artifacts/rundeckapp/build
@@ -58,7 +57,9 @@ jobs:
     - cp -r --parents core/build/libs artifacts/
     - cp -r --parents rundeckapp/**/build/libs artifacts/
     - cp -r --parents rundeck-storage/**/build/libs artifacts/
+    # Sync artifacts and trigger downstream snapshot builds if appropriate
     - script_block 'sync-artifacts' sync_to_s3
+    - script_block 'trigger.downstream' trigger_downstream_snapshots
 
     # Trigger rundeck/testdeck build
     - script_block 'travis-trigger.testdeck' 'trigger_travis_build "${TRAVIS_OSS_TOKEN}" org rundeck testdeck ${RUNDECK_BRANCH} || true'

--- a/scripts/travis-helpers.sh
+++ b/scripts/travis-helpers.sh
@@ -206,6 +206,17 @@ pull_rdtest() {
     docker tag rundeckapp/testdeck:rdtest-${RUNDECK_BUILD_NUMBER} rdtest:latest
 }
 
+# If this is a snapshot build we will trigger pro
+trigger_downstream_snapshots() {
+    if [[ -z "${RUNDECK_TAG}" && "${RUNDECK_BRANCH}" == "master" && "${TRAVIS_EVENT_TYPE}" == "push" ]] ; then
+        echo "Triggering downstream snapshot build..."
+        seal_artifacts
+        trigger_travis_build "${TRAVIS_RDPRO_TOKEN}" com rundeckpro rundeckpro master
+    else
+        echo "Skippping downstream snapshot build for non-master/snapshot build..."
+    fi
+}
+
 export_tag_info
 export_repo_info
 
@@ -218,3 +229,4 @@ export -f fetch_common_artifacts
 export -f trigger_travis_build
 export -f build_rdtest
 export -f pull_rdtest
+export -f trigger_downstream_snapshots


### PR DESCRIPTION
Assume master build is good for snapshot purposes based on full testing in PR builds.

This should tighten the snapshot feedback loop significantly.