### PR TITLE
Update jackson-databind to 2.8.11.2

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -65,7 +65,7 @@ dependencies {
         'com.jcraft:jsch.agentproxy.usocket-nc:0.0.9',
         'com.jcraft:jsch.agentproxy.connector-factory:0.0.9',
         'com.jcraft:jsch.agentproxy.core:0.0.9',
-        'com.fasterxml.jackson.core:jackson-databind:2.8.11.1',
+        'com.fasterxml.jackson.core:jackson-databind:2.8.11.2',
         'com.fasterxml.jackson.core:jackson-core:2.8.11',
         'com.fasterxml.jackson.core:jackson-annotations:2.8.0',
         'org.yaml:snakeyaml:1.14',

--- a/packaging/rundeck.spec
+++ b/packaging/rundeck.spec
@@ -116,7 +116,7 @@ fi
 /var/lib/rundeck/cli/snakeyaml-1.14.jar
 /var/lib/rundeck/cli/jackson-annotations-2.8.0.jar
 /var/lib/rundeck/cli/jackson-core-2.8.11.jar
-/var/lib/rundeck/cli/jackson-databind-2.8.11.1.jar
+/var/lib/rundeck/cli/jackson-databind-2.8.11.2.jar
 /var/lib/rundeck/cli/converter-jackson-2.2.0.jar
 /var/lib/rundeck/cli/okhttp-3.6.0.jar
 /var/lib/rundeck/cli/okio-1.11.0.jar

--- a/rundeck-storage/build.gradle
+++ b/rundeck-storage/build.gradle
@@ -46,7 +46,7 @@ project(':rundeck-storage:rundeck-storage-filesys') {
     dependencies {
         compile project(':rundeck-storage:rundeck-storage-data')
         compile "com.fasterxml.jackson.core:jackson-core:2.8.11"
-        compile "com.fasterxml.jackson.core:jackson-databind:2.8.11.1"
+        compile "com.fasterxml.jackson.core:jackson-databind:2.8.11.2"
     }
 }
 

--- a/rundeckapp/grails-app/conf/BuildConfig.groovy
+++ b/rundeckapp/grails-app/conf/BuildConfig.groovy
@@ -115,7 +115,7 @@ grails.project.dependency.resolution = {
                 'commons-collections:commons-collections:3.2.2',
                 'commons-codec:commons-codec:1.5',
                 'com.fasterxml.jackson.core:jackson-core:2.8.11',
-                'com.fasterxml.jackson.core:jackson-databind:2.8.11.1',
+                'com.fasterxml.jackson.core:jackson-databind:2.8.11.2',
                 'com.fasterxml.jackson.core:jackson-annotations:2.8.11',
                 'com.codahale.metrics:metrics-core:3.0.1',
                 'com.google.guava:guava:24.1.1-jre',


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix: testbuild.groovy failing due to jackson-databind version
