### PR TITLE
Fix default node source for new projects with db storage

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProjectConfig.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProjectConfig.java
@@ -174,13 +174,7 @@ public class FrameworkProjectConfig implements IRundeckProjectConfig, IRundeckPr
         if (addDefaultProps) {
             if (null == properties || !properties.containsKey("resources.source.1.type")) {
                 //add default file source
-                newProps.setProperty("resources.source.1.type", "file");
-                newProps.setProperty(
-                        "resources.source.1.config.file",
-                        new File(destfile.getParentFile(), "resources.xml").getAbsolutePath()
-                );
-                newProps.setProperty("resources.source.1.config.includeServerNode", "true");
-                newProps.setProperty("resources.source.1.config.generateFileAutomatically", "true");
+                newProps.setProperty("resources.source.1.type", "local");
             }
             if (null == properties || !properties.containsKey("service.NodeExecutor.default.provider")) {
                 newProps.setProperty("service.NodeExecutor.default.provider", "jsch-ssh");

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/ProjectNodeSupport.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/ProjectNodeSupport.java
@@ -562,24 +562,6 @@ public class ProjectNodeSupport implements IProjectNodes, Closeable {
         return list;
     }
 
-    /**
-     * @return specific nodes resources file path for the project, based on the framework.nodes.file.name property
-     */
-    public static String getNodesResourceFilePath(IRundeckProject project, Framework framework) {
-        if(project.hasProperty(ProjectNodeSupport.PROJECT_RESOURCES_FILE_PROPERTY)) {
-            return new File(project.getProperty(ProjectNodeSupport.PROJECT_RESOURCES_FILE_PROPERTY)).getAbsolutePath();
-        }
-        if(null!=framework) {
-            File etcDir = new File(framework.getFrameworkProjectsBaseDir(), project.getName() + "/etc/");
-            if (framework.hasProperty(Framework.NODES_RESOURCES_FILE_PROP)) {
-                return new File(etcDir, framework.getProperty(Framework.NODES_RESOURCES_FILE_PROP)).getAbsolutePath();
-            } else {
-                return new File(etcDir, ProjectNodeSupport.NODES_XML).getAbsolutePath();
-            }
-        }else{
-            return null;
-        }
-    }
 
     public IRundeckProjectConfig getProjectConfig() {
         return projectConfig;

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/LocalResourceModelSource.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/LocalResourceModelSource.java
@@ -1,0 +1,151 @@
+package com.dtolabs.rundeck.core.resources;
+
+import com.dtolabs.rundeck.core.common.Framework;
+import com.dtolabs.rundeck.core.common.INodeSet;
+import com.dtolabs.rundeck.core.common.NodeEntryImpl;
+import com.dtolabs.rundeck.core.common.NodeSetImpl;
+import com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException;
+import com.dtolabs.rundeck.core.plugins.configuration.Description;
+import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+
+import static com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants.CODE_SYNTAX_MODE;
+import static com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants.DISPLAY_TYPE_KEY;
+import static com.dtolabs.rundeck.plugins.util.DescriptionBuilder.buildDescriptionWith;
+
+public class LocalResourceModelSource implements ResourceModelSource {
+    final Framework framework;
+    String     description;
+    String     hostname;
+    String     osArch;
+    String     osName;
+    String     osVersion;
+    String     osFamily;
+    Properties attributes;
+
+    public LocalResourceModelSource(final Framework framework) {
+        this.framework = framework;
+    }
+
+    @Override
+    public INodeSet getNodes() throws ResourceModelSourceException {
+        NodeSetImpl newNodes = new NodeSetImpl();
+        final NodeEntryImpl node = createFrameworkNodeNew();
+        newNodes.putNode(node);
+        return newNodes;
+    }
+
+    private NodeEntryImpl createFrameworkNodeNew() {
+        NodeEntryImpl node = new NodeEntryImpl(
+            null != hostname ? hostname : framework.getFrameworkNodeHostname(),
+            framework.getFrameworkNodeName()
+        );
+
+        node.setDescription(description != null ? description : "Rundeck server node");
+        node.setOsArch(osArch != null ? osArch : System.getProperty("os.arch"));
+        node.setOsName(osName != null ? osName : System.getProperty("os.name"));
+        node.setOsVersion(osVersion != null ? osVersion : System.getProperty("os.version"));
+        //family has to be guessed at
+        if (osFamily != null) {
+            node.setOsFamily(osFamily);
+        } else {
+            final String s = System.getProperty("file.separator");
+            node.setOsFamily("/".equals(s) ? "unix" : "\\".equals(s) ? "windows" : "");
+        }
+        if (null != attributes) {
+            for (Object o : attributes.keySet()) {
+                if (o.toString().equals("tags")) {
+                    String[] split = attributes.getProperty(o.toString()).split("\\s*,\\s*");
+                    node.setTags(new HashSet<String>(Arrays.asList(split)));
+
+                } else {
+                    node.setAttribute(o.toString(), attributes.getProperty(o.toString()));
+                }
+            }
+        }
+        return node;
+    }
+
+    private NodeEntryImpl createFrameworkNodeOrig() {
+        return framework.createFrameworkNode();
+    }
+
+    static Description createDescription() {
+        return buildDescriptionWith(d -> d
+            .name(LocalResourceModelSourceFactory.SERVICE_PROVIDER_TYPE)
+            .title("Local")
+            .description("Provides the local node as the single resource")
+            .property(
+                p -> p
+                    .string("description")
+                    .title("Description")
+                    .description("Description of the local server node")
+                    .defaultValue("Rundeck server node")
+            )
+            .property(
+                p -> p
+                    .string("hostname")
+                    .title("Hostname")
+                    .description("Server hostname (default: via host OS)")
+            )
+            .property(
+                p -> p
+                    .string("osFamily")
+                    .title("OS Family")
+                    .description("OS Family: unix, windows, ... (default: via host OS)")
+            )
+            .property(
+                p -> p
+                    .string("osName")
+                    .title("OS Name")
+                    .description("(default: via host OS)")
+            )
+            .property(
+                p -> p
+                    .string("osArch")
+                    .title("OS Architecture")
+                    .description("(default: via host OS)")
+            )
+            .property(
+                p -> p
+                    .string("osVersion")
+                    .title("OS Version")
+                    .description("(default: via host OS)")
+            )
+            .property(
+                p -> p
+                    .string("attributes")
+                    .renderingOption(DISPLAY_TYPE_KEY, "CODE")
+                    .renderingOption(CODE_SYNTAX_MODE, "properties")
+                    .title("Attributes")
+                    .description("Custom attributes, in Java properties format")
+            )
+        );
+    }
+
+    public void configure(final Properties configuration) throws ConfigurationException {
+        description = configuration.getProperty("description");
+        hostname = configuration.getProperty("hostname");
+        osFamily = configuration.getProperty("osFamily");
+        osVersion = configuration.getProperty("osVersion");
+        osName = configuration.getProperty("osName");
+        osArch = configuration.getProperty("osArch");
+        String attributes = configuration.getProperty("attributes");
+        if (null != attributes && !("".equals(attributes.trim()))) {
+            Properties props = new Properties();
+            try {
+                props.load(new StringReader(attributes));
+            } catch (IOException e) {
+                throw new ConfigurationException("Cannot parse attributes text as Java Properties format: "
+                                                 + e.getMessage(), e);
+            }
+            this.attributes = props;
+        }
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/LocalResourceModelSourceFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/LocalResourceModelSourceFactory.java
@@ -1,0 +1,28 @@
+package com.dtolabs.rundeck.core.resources;
+
+import com.dtolabs.rundeck.core.common.Framework;
+import com.dtolabs.rundeck.core.plugins.Plugin;
+import com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException;
+import com.dtolabs.rundeck.core.plugins.configuration.Describable;
+
+import java.util.Properties;
+
+@Plugin(name = LocalResourceModelSourceFactory.SERVICE_PROVIDER_TYPE, service = "ResourceModelSource")
+public class LocalResourceModelSourceFactory implements ResourceModelSourceFactory, Describable {
+    public static final String    SERVICE_PROVIDER_TYPE = "local";
+    private             Framework framework;
+
+    public LocalResourceModelSourceFactory(final Framework framework) {
+        this.framework = framework;
+    }
+
+    public ResourceModelSource createResourceModelSource(final Properties configuration) throws ConfigurationException {
+        final LocalResourceModelSource fileResourceModelSource = new LocalResourceModelSource(framework);
+        fileResourceModelSource.configure(configuration);
+        return fileResourceModelSource;
+    }
+
+    public com.dtolabs.rundeck.core.plugins.configuration.Description getDescription() {
+        return LocalResourceModelSource.createDescription();
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/ResourceModelSourceService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/ResourceModelSourceService.java
@@ -51,6 +51,7 @@ public class ResourceModelSourceService extends PluggableProviderRegistryService
     public ResourceModelSourceService(final Framework framework) {
         super(framework);
 
+        registry.put(LocalResourceModelSourceFactory.SERVICE_PROVIDER_TYPE, LocalResourceModelSourceFactory.class);
         registry.put(FileResourceModelSourceFactory.SERVICE_PROVIDER_TYPE, FileResourceModelSourceFactory.class);
         registry.put(DirectoryResourceModelSourceFactory.SERVICE_PROVIDER_TYPE,
             DirectoryResourceModelSourceFactory.class);

--- a/core/src/test/java/com/dtolabs/rundeck/core/common/TestFrameworkProject.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/common/TestFrameworkProject.java
@@ -351,13 +351,10 @@ public class TestFrameworkProject extends AbstractBaseTest {
     
     public void testGetNodes() throws Exception {
         final FrameworkProject project = createProject();
-        FileUtils.copyFileStreams(new File("src/test/resources/com/dtolabs/rundeck/core/common/test-nodes1.xml"), nodesfile);
-        assertTrue(nodesfile.exists());
         INodeSet nodes = project.getNodeSet();
         assertNotNull(nodes);
-        assertEquals("nodes was incorrect size", 2, nodes.getNodes().size());
+        assertEquals("nodes was incorrect size", 1, nodes.getNodes().size());
         assertNotNull("nodes did not have correct test node1", nodes.getNode("test1"));
-        assertNotNull("nodes did not have correct test node2", nodes.getNode("testnode2"));
     }
 
 
@@ -375,12 +372,12 @@ public class TestFrameworkProject extends AbstractBaseTest {
 
          Properties p = new Properties();
         loadProps(p,propFile);
-        assertEquals("file", p.get("resources.source.1.type"));
+        assertEquals("local", p.get("resources.source.1.type"));
         assertEquals(null, p.get("a.b"));
 
         assertTrue(project.hasProperty("resources.source.1.type"));
         assertFalse(project.hasProperty("a.b"));
-        assertEquals("file", project.getProperty("resources.source.1.type"));
+        assertEquals("local", project.getProperty("resources.source.1.type"));
 
         boolean overwrite = true;
         Properties newprops = new Properties();
@@ -389,13 +386,13 @@ public class TestFrameworkProject extends AbstractBaseTest {
 
         p = new Properties();
         loadProps(p,propFile);
-        assertEquals("file", p.get("resources.source.1.type"));
+        assertEquals("local", p.get("resources.source.1.type"));
         assertEquals("value", p.get("a.b"));
 
         assertTrue(project.hasProperty("resources.source.1.type"));
         assertTrue(project.hasProperty("a.b"));
         assertEquals("value",project.getProperty("a.b"));
-        assertEquals("file", project.getProperty("resources.source.1.type"));
+        assertEquals("local", project.getProperty("resources.source.1.type"));
 
 
     }
@@ -542,9 +539,10 @@ public class TestFrameworkProject extends AbstractBaseTest {
         factory1.returnProvider=provider1;
 
 
-        service.registerInstance("file", factory1);
-        service.registerInstance("url", factory1);
-        service.registerInstance("directory", factory1);
+//        service.registerInstance("file", factory1);
+//        service.registerInstance("url", factory1);
+//        service.registerInstance("directory", factory1);
+        service.registerInstance("local", factory1);
 
 
         FrameworkProject project = createProject();

--- a/rundeckapp/grails-app/assets/javascripts/resourceModelConfig.js
+++ b/rundeckapp/grails-app/assets/javascripts/resourceModelConfig.js
@@ -174,6 +174,11 @@ editConfig: function (elem, type, prefix, index) {
             if (ajax.request.success()) {
                 self.didChange();
                 self.addConfigChrome(elem, type, prefix, index);
+                if (typeof(_setupAceTextareaEditor) === 'function') {
+                    jQuery(elem).find('.apply_ace').each(function () {
+                        _setupAceTextareaEditor(this, this.didChange);
+                    });
+                }
             } else {
                 self.error(ajax);
             }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -1909,13 +1909,21 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         // Store Password Fields values in Session
         // Replace the Password Fields in configs with hashes
         resourcesPasswordFieldsService.track(resourceConfig,true, *resourceDescs)
-        execPasswordFieldsService.track([[type:defaultNodeExec,props:nodeConfig]], true, *execDesc)
-        fcopyPasswordFieldsService.track([[type:defaultFileCopy,props:filecopyConfig]],true, *filecopyDesc)
+        if(defaultNodeExec) {
+            execPasswordFieldsService.track([[type: defaultNodeExec, props: nodeConfig]], true, *execDesc)
+        }
+        if(defaultFileCopy) {
+            fcopyPasswordFieldsService.track([[type: defaultFileCopy, props: filecopyConfig]], true, *filecopyDesc)
+        }
         // resourceConfig CRUD rely on this session mapping
         // saveProject will replace the password fields on change
         //replace password values with hashed values
-        frameworkService.addProjectFileCopierPropertiesForType(defaultFileCopy, projectProps, filecopyConfig)
-        frameworkService.addProjectNodeExecutorPropertiesForType(defaultNodeExec, projectProps, nodeConfig)
+        if(defaultFileCopy) {
+            frameworkService.addProjectFileCopierPropertiesForType(defaultFileCopy, projectProps, filecopyConfig)
+        }
+        if(defaultNodeExec) {
+            frameworkService.addProjectNodeExecutorPropertiesForType(defaultNodeExec, projectProps, nodeConfig)
+        }
         def count = 1
         final service = framework.getResourceModelSourceService()
         resourceConfig.each {resconfig ->

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -881,18 +881,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         final nodeexecdescriptions = framework.getNodeExecutorService().listDescriptions()
         final descriptions = framework.getResourceModelSourceService().listDescriptions()
         final filecopydescs = framework.getFileCopierService().listDescriptions()
-        def defaultResourceFile= new File(framework.getFrameworkProjectsBaseDir(),'${project.name}/etc/resources.xml').getAbsolutePath()
-        def configs=[
-            [
-                type: FileResourceModelSourceFactory.SERVICE_PROVIDER_TYPE,
-                props:[
-                        (FileResourceModelSource.Configuration.FILE): defaultResourceFile,
-                        (FileResourceModelSource.Configuration.FORMAT): 'resourcexml',
-                        (FileResourceModelSource.Configuration.GENERATE_FILE_AUTOMATICALLY): 'true',
-                        (FileResourceModelSource.Configuration.INCLUDE_SERVER_NODE): 'true',
-                ]
-            ]
-        ]
+
         //get grails services that declare project configurations
         Map<String, Map> extraConfig = frameworkService.loadProjectConfigurableInput('extraConfig.', [:])
 

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -758,13 +758,6 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
             );
 
     /**
-     * @return specific nodes resources file path for the project, based on the framework.nodes.file.name property
-     */
-    public String getNodesResourceFilePath(IRundeckProject project) {
-        ProjectNodeSupport.getNodesResourceFilePath(project, frameworkService.getRundeckFramework())
-    }
-
-    /**
      * Import any projects that do not exist from the source
      * @param source
      */

--- a/rundeckapp/grails-app/views/framework/editProjectNodeSources.gsp
+++ b/rundeckapp/grails-app/views/framework/editProjectNodeSources.gsp
@@ -43,12 +43,15 @@
     function init(){
         configControl=new ResourceModelConfigControl('${enc(js:prefixKey)}',confirm.setNeedsConfirm);
         configControl.pageInit();
-        $$('input').each(function(elem){
+        jQuery('input').each(function(elem){
             if(elem.type=='text'){
                 elem.observe('keypress',noenter);
             }
         });
-    }
+        jQuery('.apply_ace').each(function () {
+            _setupAceTextareaEditor(this, confirm.setNeetsConfirm);
+        });
+        }
     var _storageBrowseSelected=confirm.setNeedsConfirm;
     jQuery(init);
     </g:javascript>
@@ -178,5 +181,6 @@
         </g:form>
     </div>
   </div>
+<!--[if (gt IE 8)|!(IE)]><!--> <asset:javascript src="ace-bundle.js"/><!--<![endif]-->
 </body>
 </html>

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
@@ -292,7 +292,7 @@ class ProjectManagerServiceSpec extends Specification {
         0*service.nodeService.getNodes('test1')
 
         result.name=='test1'
-        2==result.getProjectProperties().size()
+        (2+ProjectManagerService.DEFAULT_PROJ_PROPS.size())==result.getProjectProperties().size()
         'test1'==result.getProjectProperties().get('project.name')
         'def'==result.getProjectProperties().get('abc')
 
@@ -357,7 +357,7 @@ class ProjectManagerServiceSpec extends Specification {
 
         0*service.nodeService._(*_)
         result.name=='test1'
-        2==result.getProjectProperties().size()
+        (2+ProjectManagerService.DEFAULT_PROJ_PROPS.size())==result.getProjectProperties().size()
         'test1'==result.getProjectProperties().get('project.name')
         'def'==result.getProjectProperties().get('abc')
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

* fix #3185 - use new `local` provider as default node source provider for new projects 
    * applies to db-storage and file-storage
    * Upgrade issue: new projects using file-based config storage will not have a `file` nodes provider set by default
* fix some tangential issues: 
    * ACE text area not loading on Project configuration editor page for code/multi-line properties of resource model sources
    * 500 page error on Edit Project Configuration page if some expected config properties were not set

**Describe the solution you've implemented**

Add a default resource model provider implementation that generates the local node, but does not require a file to be used.
