### PR TITLE
Add order by groupPath so that UI grouping makes sense in pagination mode

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -338,6 +338,9 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             if(query && query.sortBy && xfilters[query.sortBy]){
                 order(xfilters[query.sortBy],query.sortOrder=='ascending'?'asc':'desc')
             }else{
+                if(paginationEnabled) {
+                    order("groupPath","asc")
+                }
                 order("jobName","asc")
             }
         };


### PR DESCRIPTION
For large projects with many jobs in many groups, if pagination is turned on the query needs to order by groupPath so the output results make more sense to a user.
