### PR TITLE
Use the PluginService methods to load ResourceModelSourceFactory plugins

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/LocalNodeExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/LocalNodeExecutor.java
@@ -38,6 +38,9 @@ import com.dtolabs.rundeck.core.execution.service.NodeExecutorResult;
 import com.dtolabs.rundeck.core.execution.service.NodeExecutorResultImpl;
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepFailureReason;
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepFailureReason;
+import com.dtolabs.rundeck.core.plugins.Plugin;
+import com.dtolabs.rundeck.plugins.ServiceNameConstants;
+import com.dtolabs.rundeck.plugins.descriptions.PluginDescription;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.ExecTask;
@@ -50,6 +53,8 @@ import java.util.Map;
  *
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
+@Plugin(name = LocalNodeExecutor.SERVICE_PROVIDER_TYPE, service = ServiceNameConstants.NodeExecutor)
+@PluginDescription(title = "Local", description = "Executes commands locally on the Rundeck server")
 public class LocalNodeExecutor implements NodeExecutor {
     public static final String SERVICE_PROVIDER_TYPE = "local";
     private Framework framework;

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/ResourceModelSourceService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/ResourceModelSourceService.java
@@ -113,6 +113,11 @@ public class ResourceModelSourceService
         return closeableProviderOfType(type).convert(factoryConverter(configuration));
     }
 
+    /**
+     * Given input configuration, produce a function to convert from a factory to model source
+     * @param configuration
+     * @return
+     */
     public static Function<ResourceModelSourceFactory, ResourceModelSource> factoryConverter(
         final Properties configuration
     )

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/ResourceModelSourceService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/ResourceModelSourceService.java
@@ -34,14 +34,19 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.function.Function;
 
 /**
  * ResourceModelSourceService provides NodeSource factories
  *
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
-public class ResourceModelSourceService extends PluggableProviderRegistryService<ResourceModelSourceFactory> implements
-    ConfigurableService<ResourceModelSource>, DescribableService {
+public class ResourceModelSourceService
+    extends PluggableProviderRegistryService<ResourceModelSourceFactory>
+    implements ConfigurableService<ResourceModelSource>,
+               DescribableService,
+               PluggableProviderService<ResourceModelSourceFactory>
+{
 
     public static final String SERVICE_NAME = ServiceNameConstants.ResourceModelSource;
 
@@ -101,29 +106,29 @@ public class ResourceModelSourceService extends PluggableProviderRegistryService
      * @throws ExecutionServiceException on error
      */
     public CloseableProvider<ResourceModelSource> getCloseableSourceForConfiguration(
-            final String type,
-            final Properties configuration
-    ) throws
-            ExecutionServiceException
+        final String type,
+        final Properties configuration
+    ) throws ExecutionServiceException
     {
+        return closeableProviderOfType(type).convert(factoryConverter(configuration));
+    }
 
-        //load factory instance with closeable reference
-        final CloseableProvider<ResourceModelSourceFactory> reference = closeableProviderOfType(type);
-        try {
-            ResourceModelSource resourceModelSource = reference.getProvider().createResourceModelSource(configuration);
-            //wrap the built source into another closeable provider
-            return Closeables.closeableProvider(
-                    resourceModelSource,
-                    //close both the model source if it is closeable, and the original plugin loader reference, when
-                    // released
-                    Closeables.single(
-                            Closeables.maybeCloseable(resourceModelSource),
-                            reference
-                    )
-            );
-        } catch (Throwable e) {
-            throw new ResourceModelSourceServiceException(e);
-        }
+    public static Function<ResourceModelSourceFactory, ResourceModelSource> factoryConverter(
+        final Properties configuration
+    )
+    {
+        //nb: not using lambda due to inability to mock this class within grails tests, some conflict with cglib and
+        // j8 lambdas
+        return new Function<ResourceModelSourceFactory, ResourceModelSource>() {
+            @Override
+            public ResourceModelSource apply(final ResourceModelSourceFactory resourceModelSourceFactory) {
+                try {
+                    return resourceModelSourceFactory.createResourceModelSource(configuration);
+                } catch (ConfigurationException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
     }
 
     public boolean isValidProviderClass(Class clazz) {

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/common/ProjectNodeSupportSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/common/ProjectNodeSupportSpec.groovy
@@ -80,4 +80,47 @@ class ProjectNodeSupportSpec extends Specification {
         result2.nodeNames.size() == 1
 
     }
+
+    def "supports factory function for source"() {
+
+        given:
+        Date modifiedTime = new Date()
+        def config = Mock(IRundeckProjectConfig) {
+            getName() >> PROJECT_NAME
+            getProperties() >> (
+                [
+                    'resources.source.1.type'                            : 'file',
+                    'resources.source.1.config.file'                     : '/tmp/file',
+                    'resources.source.1.config.requireFileExists'        : 'false',
+                    'resources.source.1.config.includeServerNode'        : 'true',
+                    'resources.source.1.config.generateFileAutomatically': 'false',
+                    'resources.source.1.config.format'                   : 'resourcexml',
+                ] as Properties
+            )
+            getConfigLastModifiedTime() >> modifiedTime
+        }
+        def generatorService = new ResourceFormatGeneratorService(framework)
+        def sourceService = new ResourceModelSourceService(framework)
+
+        def factory = { String type, Properties props ->
+            sourceService.getCloseableSourceForConfiguration(type, props)
+        }
+        def support = new ProjectNodeSupport(config, generatorService, sourceService, factory)
+
+        when:
+
+        def result = support.getNodeSet()
+        support.close()
+        def result2 = support.getNodeSet()
+
+        then:
+        result != null
+
+        result.nodeNames != null
+        result.nodeNames.size() == 1
+
+        result2 != null
+        result2.nodeNames != null
+        result2.nodeNames.size() == 1
+    }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -23,11 +23,14 @@ import com.dtolabs.rundeck.core.authorization.*
 import com.dtolabs.rundeck.core.authorization.providers.EnvironmentalContext
 import com.dtolabs.rundeck.core.common.*
 import com.dtolabs.rundeck.core.execution.service.ExecutionServiceException
+import com.dtolabs.rundeck.core.execution.service.FileCopier
 import com.dtolabs.rundeck.core.execution.service.FileCopierService
 import com.dtolabs.rundeck.core.execution.service.MissingProviderException
+import com.dtolabs.rundeck.core.execution.service.NodeExecutor
 import com.dtolabs.rundeck.core.execution.service.NodeExecutorService
 import com.dtolabs.rundeck.core.plugins.PluggableProviderRegistryService
 import com.dtolabs.rundeck.core.plugins.configuration.*
+import com.dtolabs.rundeck.core.resources.ResourceModelSourceFactory
 import com.dtolabs.rundeck.server.authorization.AuthConstants
 import com.dtolabs.rundeck.server.plugins.loader.ApplicationContextPluginFileSource
 import grails.core.GrailsApplication
@@ -59,6 +62,7 @@ class FrameworkService implements ApplicationContextAware {
     def metricService
     def Framework rundeckFramework
     def rundeckPluginRegistry
+    def PluginService pluginService
     def PluginControlService pluginControlService
 
     def getRundeckBase(){
@@ -1045,15 +1049,24 @@ class FrameworkService implements ApplicationContextAware {
     }
 
     /**
-     * Return all the descriptions for the Rundeck Framework
-     * @return tuple(resourceConfigs, nodeExec
+     * Return all the Node Exec plugin type descriptions for the Rundeck Framework, in the order:
+
+     * @return tuple(resourceConfigs, nodeExec, filecopier)
      */
     public def listDescriptions() {
         final fmk = getRundeckFramework()
-        final descriptions = fmk.getResourceModelSourceService().listDescriptions()
-        final nodeexecdescriptions = getNodeExecutorService().listDescriptions()
-        final filecopydescs = getFileCopierService().listDescriptions()
+        final descriptions = pluginService.listPluginDescriptions(ResourceModelSourceFactory, fmk.getResourceModelSourceService())
+        final nodeexecdescriptions = pluginService.listPluginDescriptions(NodeExecutor, fmk.getNodeExecutorService())
+        final filecopydescs = pluginService.listPluginDescriptions(FileCopier, fmk.getFileCopierService())
         return [descriptions, nodeexecdescriptions, filecopydescs]
+    }
+
+
+    List<Description> listResourceModelSourceDescriptions() {
+        pluginService.listPluginDescriptions(
+            ResourceModelSourceFactory,
+            getRundeckFramework().getResourceModelSourceService()
+        )
     }
 
     public getDefaultNodeExecutorService(String project) {

--- a/rundeckapp/grails-app/services/rundeck/services/PluginService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/PluginService.groovy
@@ -19,6 +19,7 @@ package rundeck.services
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.plugins.CloseableProvider
 import com.dtolabs.rundeck.core.plugins.SimplePluginProviderLoader
+import com.dtolabs.rundeck.core.plugins.configuration.Description
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolver
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolverFactory
 import com.dtolabs.rundeck.core.plugins.PluggableProviderService
@@ -309,6 +310,15 @@ class PluginService {
 
     def <T> Map<String, DescribedPlugin<T>> listPlugins(Class<T> clazz) {
         listPlugins(clazz, rundeckPluginRegistry?.createPluggableService(clazz))
+    }
+    /**
+     * List all plugins with a valid Description
+     * @param clazz
+     * @param service
+     * @return List of Description
+     */
+    def <T> List<Description> listPluginDescriptions(Class<T> clazz, PluggableProviderService<T> service) {
+        listPlugins(clazz, service).findAll { it.value.description }.collect { it.value.description }
     }
     /**
      * @param clazz

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
@@ -82,14 +82,15 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
         }
     }
     
-    private String createServiceName(final String simpleName) {
+    String createServiceName(final String simpleName) {
         if (simpleName.endsWith("Plugin")) {
             return simpleName.substring(0, simpleName.length() - "Plugin".length());
         }
-        return simpleName + "Service";
+        return simpleName;
     }
     public <T> PluggableProviderService<T> createPluggableService(Class<T> type) {
-        def name = createServiceName(type.getSimpleName())
+        String found = ServiceTypes.TYPES.find { it.value == type }?.key
+        def name = found ?: createServiceName(type.getSimpleName())
         rundeckServerServiceProviderLoader.createPluginService(type, name)
     }
     /**

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistrySpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistrySpec.groovy
@@ -1,0 +1,47 @@
+package com.dtolabs.rundeck.server.plugins
+
+import com.dtolabs.rundeck.core.execution.service.NodeExecutor
+import com.dtolabs.rundeck.core.plugins.ServiceProviderLoader
+import com.dtolabs.rundeck.plugins.step.NodeStepPlugin
+import spock.lang.Specification
+
+class RundeckPluginRegistrySpec extends Specification {
+    def "service names"() {
+        given:
+        def sut = new RundeckPluginRegistry()
+        when:
+        def result = sut.createServiceName(input)
+
+        then:
+        result == expected
+
+        where:
+        input       | expected
+        'Abc'       | 'Abc'
+        'AbcPlugin' | 'Abc'
+
+    }
+
+    static interface TestPlugin {
+
+    }
+
+    def "create pluggable service"() {
+        given:
+        def sut = new RundeckPluginRegistry()
+        sut.rundeckServerServiceProviderLoader = Mock(ServiceProviderLoader)
+        when:
+        def result = sut.createPluggableService(type)
+
+        then:
+
+        1 * sut.rundeckServerServiceProviderLoader.createPluginService(type, expectedName)
+
+        where:
+        type           | expectedName
+        NodeExecutor   | 'NodeExecutor'
+        NodeStepPlugin | 'WorkflowNodeStep'
+        TestPlugin     | 'Test'
+
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -39,6 +39,7 @@ import rundeck.services.ApiService
 import rundeck.services.AuthorizationService
 import rundeck.services.FrameworkService
 import rundeck.services.PasswordFieldsService
+import rundeck.services.PluginService
 import rundeck.services.ScheduledExecutionService
 import rundeck.services.StorageManager
 import rundeck.services.UserService
@@ -1074,15 +1075,13 @@ class FrameworkControllerSpec extends Specification {
         setup:
         controller.metricService = Mock(MetricService)
         def rdframework=Mock(Framework){
-            1 * getNodeExecutorService() >> Mock(NodeExecutorService)
-            1 * getResourceModelSourceService() >> Mock(ResourceModelSourceService)
-            1 * getFileCopierService() >> Mock(FileCopierService)
         }
         controller.frameworkService=Mock(FrameworkService){
-            1 * getRundeckFramework() >> rdframework
+            getRundeckFramework() >> rdframework
             1 * getAuthContextForSubject(_) >> null
             1 * authorizeApplicationResourceTypeAll(null,'project',[AuthConstants.ACTION_CREATE])>>true
             1 * validateProjectConfigurableInput(_,_,_)>>[props:[:]]
+            listDescriptions()>>[Mock(ResourceModelSourceService),Mock(NodeExecutorService),Mock(FileCopierService)]
         }
 
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerTest.groovy
@@ -17,6 +17,7 @@
 package rundeck.controllers
 
 import groovy.mock.interceptor.MockFor
+import rundeck.services.PluginService
 
 import static org.junit.Assert.*
 
@@ -506,8 +507,20 @@ class FrameworkControllerTest {
             }
         }
 
+        controller.pluginService = mockWith(PluginService) {
+            validatePluginConfig{type,svc,props->
+
+                assertEquals('abc', type)
+                assertEquals('data2', props.test1)
+
+                [props: new Properties(),desc:'desc1',report:'report',valid:true]
+            }
+        }
+
         def config = new PluginConfigParams()
         controller.params.type='abc'
+        controller.params['orig.config.test1']='data1'
+        controller.params['config.test1']='data2'
         controller.checkResourceModelConfig(config)
         assertEquals(true,response.json.valid)
         assertNull(response.json.error)
@@ -522,9 +535,20 @@ class FrameworkControllerTest {
             }
         }
 
+        controller.pluginService = mockWith(PluginService) {
+            validatePluginConfig{type,svc,props->
+
+                assertEquals('abc', type)
+                assertEquals('data1', props.test1)
+
+                [props: new Properties(),desc:'desc1',report:'report',valid:true]
+            }
+        }
+
         def config = new PluginConfigParams()
         controller.params.type='abc'
         controller.params.revert='true'
+        controller.params['orig.config.test1']='data1'
         controller.checkResourceModelConfig(config)
         assertEquals(true,response.json.valid)
         assertNull(response.json.error)
@@ -556,6 +580,16 @@ class FrameworkControllerTest {
             }
         }
 
+        controller.pluginService = mockWith(PluginService) {
+            getPluginDescriptor {type,svc-> [description:'desc1'] }
+            validatePluginConfig{type,svc,props->
+
+                assertEquals('abc', type)
+
+                [props: new Properties(),desc:'desc1',report:'report']
+            }
+        }
+
         def params = new PluginConfigParams()
         controller.params.type = 'abc'
         def model = controller.viewResourceModelConfig(params)
@@ -577,10 +611,21 @@ class FrameworkControllerTest {
                 [props: new Properties(),desc:'desc1',report:'report']
             }
         }
+        controller.pluginService = mockWith(PluginService) {
+            getPluginDescriptor {type,svc-> [description:'desc1'] }
+            validatePluginConfig{type,svc,props->
+
+                assertEquals('abc', type)
+                assertEquals('data1', props.test1)
+
+                [props: new Properties(),desc:'desc1',report:'report']
+            }
+        }
 
         def params = new PluginConfigParams()
         controller.params.type = 'abc'
         controller.params.revert = 'true'
+        controller.params['orig.config.test1'] = 'data1'
         def model = controller.viewResourceModelConfig(params)
         assertEquals('', model.prefix)
         assertNotNull(model.values)


### PR DESCRIPTION
Use the PluginService methods to load ResourceModelSourceFactory plugins:

* allows loading spring-based bean plugins
* requires replacing use of the framework.getResourceModelSourceService() to directly load plugins


We have to pass the original ResourceModelSourceService to the PluginService, so it can load packaged plugin files as before, since the ResourceModelSourceService loads the plugins slightly differently than most other plugin types.  Otherwise we could have let the PluginService create a generic plugin loader service for the ResourceModelSourceFactory plugin types.  The problem is that the default no-arg constructor expected by the generic loader won't work with ResourceModelSourceFactory type, as they allow a single-arg Framework argument constructor.
