### PR TITLE
file options on referenced jobs

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2461,7 +2461,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     def boolean validateOptionValues(
             ScheduledExecution scheduledExecution,
             Map optparams,
-            AuthContext authContext = null
+            AuthContext authContext = null,
+            isJobRef = false
     ) throws ExecutionServiceValidationException
     {
 
@@ -2488,7 +2489,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     def validate = fileUploadService.validateFileRefForJobOption(
                             optparams[opt.name],
                             scheduledExecution.extid,
-                            opt.name
+                            opt.name,
+                            isJobRef
                     )
                     if (!validate.valid) {
                         invalidOpt opt, lookupMessage('domain.Option.validation.file.' + validate.error, validate.args)
@@ -3193,7 +3195,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
         //validate the option values
         if(dovalidate){
-            validateOptionValues(se, evalPlainOpts + evalSecOpts + evalSecAuthOpts,executionContext.authContext)
+            validateOptionValues(se, evalPlainOpts + evalSecOpts + evalSecAuthOpts,executionContext.authContext,true)
         }
 
         //arg list for new context
@@ -3234,6 +3236,15 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     nodeRankAttribute,
                     nodeRankOrderAscending,
                     nodeIntersect
+            )
+        }
+        if(dovalidate){
+            fileUploadService.executionBeforeStart(
+                    new ExecutionPrepareEvent(
+                            execution: exec,
+                            job: se,
+                            context: newContext
+                    ),true
             )
         }
         return newContext

--- a/rundeckapp/grails-app/services/rundeck/services/FileUploadService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FileUploadService.groovy
@@ -285,22 +285,22 @@ class FileUploadService {
      * @param option
      * @return [valid: true/false, error: 'code', args: [...]]
      */
-    def validateFileRefForJobOption(String fileuuid, String jobid, String option) {
+    def validateFileRefForJobOption(String fileuuid, String jobid, String option, boolean isJobRef = false) {
         JobFileRecord jfr = findUuid(fileuuid)
         if (!jfr) {
             return [valid: false, error: 'notfound', args: [fileuuid, jobid, option]]
         }
-        return validateJobFileRecordForJobOption(jfr, jobid, option)
+        return validateJobFileRecordForJobOption(jfr, jobid, option, isJobRef)
     }
 
-    def validateJobFileRecordForJobOption(JobFileRecord jfr, String jobid, String option) {
+    def validateJobFileRecordForJobOption(JobFileRecord jfr, String jobid, String option, boolean isJobRef = false) {
         if (!jfr) {
             return [valid: false, error: 'notfound', args: [null, jobid, option]]
         }
-        if (jfr.jobId != jobid || jfr.recordName != option) {
+        if ((!isJobRef && jfr.jobId != jobid) || jfr.recordName != option) {
             return [valid: false, error: 'invalid', args: [jfr.uuid, jobid, option]]
         }
-        if (jfr.execution != null) {
+        if (!isJobRef && jfr.execution != null) {
             return [valid: false, error: 'inuse', args: [jfr.uuid, jfr.execution.id]]
         }
         if (!jfr.canBecomeRetained()) {
@@ -317,9 +317,9 @@ class FileUploadService {
      * @param fileuuid
      * @return
      */
-    JobFileRecord attachFileForExecution(String fileuuid, Execution execution, String option) {
+    JobFileRecord attachFileForExecution(String fileuuid, Execution execution, String option, boolean skip = false) {
         JobFileRecord jfr = findUuid(fileuuid)
-        def validate = validateJobFileRecordForJobOption(jfr, execution.scheduledExecution.extid, option)
+        def validate = validateJobFileRecordForJobOption(jfr, execution.scheduledExecution.extid, option, skip)
 
         if (!validate.valid) {
             if (validate.error in ['notfound', 'invalid']) {
@@ -472,7 +472,8 @@ class FileUploadService {
     Map<String, String> loadFileOptionInputs(
             Execution execution,
             ScheduledExecution scheduledExecution,
-            StepExecutionContext context
+            StepExecutionContext context,
+            boolean skip = false
     )
     {
         def loadedFiles = [:]
@@ -480,7 +481,7 @@ class FileUploadService {
         fileopts?.each {
             def key = context.dataContext['option'][it.name]
             if (key) {
-                JobFileRecord jfr = attachFileForExecution(key, execution, it.name)
+                JobFileRecord jfr = attachFileForExecution(key, execution, it.name, skip)
                 File file = retrieveFileForExecution(jfr)
                 loadedFiles[it.name] = file.absolutePath
                 loadedFiles[it.name + '.fileName'] = jfr.fileName
@@ -521,13 +522,14 @@ class FileUploadService {
      * @return
      */
     @Subscriber
-    def executionBeforeStart(ExecutionPrepareEvent evt) {
+    def executionBeforeStart(ExecutionPrepareEvent evt, boolean skip = false) {
         if (evt.job) {
             //handle uploaded files
             Map loadedFilePaths = loadFileOptionInputs(
                     evt.execution,
                     evt.job,
-                    evt.context
+                    evt.context,
+                    skip
             )
             if (loadedFilePaths) {
                 evt.context.dataContext['file'] = loadedFilePaths

--- a/rundeckapp/src/test/groovy/ExecutionServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceTests.groovy
@@ -1721,6 +1721,12 @@ class ExecutionServiceTests  {
                 null
             }
         }
+        service.fileUploadService = mockWith(FileUploadService){
+            executionBeforeStart { evt, skip->
+                null
+            }
+        }
+
         def newCtxt=service.createJobReferenceContext(job,null,context,['-test1','value'] as String[],null,null,null,null,null,null, false,false,true);
 
         //verify nodeset
@@ -1795,6 +1801,12 @@ class ExecutionServiceTests  {
                 null
             }
         }
+        service.fileUploadService = mockWith(FileUploadService){
+            executionBeforeStart { evt, skip->
+                null
+            }
+        }
+
         assertEquals(null, context.nodeRankAttribute)
         assertEquals(true, context.nodeRankOrderAscending)
         def newCtxt=service.createJobReferenceContext(job,null,context,['-test1','value'] as String[],'z p',true,3, 'rank', false,null, false,false,true);
@@ -1870,6 +1882,11 @@ class ExecutionServiceTests  {
         }
         service.storageService=mockWith(StorageService){
             storageTreeWithContext(1..1){AuthContext->
+                null
+            }
+        }
+        service.fileUploadService = mockWith(FileUploadService){
+            executionBeforeStart { evt, skip->
                 null
             }
         }
@@ -1961,6 +1978,13 @@ class ExecutionServiceTests  {
             }
 
         }
+
+        service.fileUploadService = mockWith(FileUploadService){
+            executionBeforeStart { evt, skip->
+                null
+            }
+        }
+
         service.storageService=mockWith(StorageService){
             storageTreeWithContext(1..1){AuthContext->
                 null

--- a/rundeckapp/src/test/groovy/rundeck/services/NodeServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NodeServiceSpec.groovy
@@ -33,8 +33,6 @@ import org.springframework.core.task.AsyncListenableTaskExecutor
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import java.util.concurrent.Future
-
 /**
  * Created by greg on 2/3/16.
  */
@@ -193,13 +191,16 @@ class NodeServiceSpec extends Specification {
         'false'   | 3
         null      | 1
     }
-    def "get nodes when project cache with preload ignores config asynch"( ) {
+
+    @Unroll
+    def "get nodes when project cache with preload #defFirstLoadAsynch ignores config asynch"() {
         given:
         service.nodeTaskExecutor = Mock(AsyncListenableTaskExecutor)
         service.frameworkService = Mock(FrameworkService)
         service.configurationService = Mock(ConfigurationService) {
             getCacheEnabledFor('nodeService', 'nodeCache', true) >> true
-            getBoolean('nodeService.nodeCache.firstLoadAsynch',true)>>defFirstLoadAsynch
+            getBoolean('nodeService.nodeCache.firstLoadAsynch', false) >> defFirstLoadAsynch
+            0 * _(*_)
         }
         INodeSet preloadedNodes = new NodeSetImpl()
         preloadedNodes.putNode(new NodeEntryImpl('bnode'))
@@ -265,13 +266,102 @@ class NodeServiceSpec extends Specification {
 
     }
 
+    @Unroll
+    def "get nodes with first load asynch #defAsynch project value #projAsynch"() {
+        given:
+        service.nodeTaskExecutor = Mock(AsyncListenableTaskExecutor)
+        service.frameworkService = Mock(FrameworkService)
+        service.configurationService = Mock(ConfigurationService) {
+            getCacheEnabledFor('nodeService', 'nodeCache', true) >> true
+            getBoolean('nodeService.nodeCache.firstLoadAsynch', false) >> defAsynch
+            0 * _(*_)
+        }
+        INodeSet preloadedNodes = new NodeSetImpl()
+        INodeSet sourceNodes = new NodeSetImpl()
+        sourceNodes.putNode(new NodeEntryImpl("bnode"))
+
+        def properties = [
+            'resources.source.1.type'                            : 'file',
+            'resources.source.1.config.file'                     : '/tmp/test.xml',
+            'resources.source.1.config.generateFileAutomatically': 'false',
+            'resources.source.1.config.includeServerNode'        : 'true',
+
+        ]
+        properties['project.nodeCache.enabled'] = 'true'
+        if (null != projSynch) {
+            properties['project.nodeCache.firstLoadSynch'] = projSynch.toString()
+        }
+        def projConfig = new PropsConfig(
+            projectProperties: properties,
+            properties: properties,
+            name: 'test1',
+            configLastModifiedTime: new Date()
+        )
+        def modelSource = Mock(ResourceModelSource)
+        def cacheModelsource = Mock(ResourceModelSource)
+
+        service.frameworkService.getRundeckFramework() >> Mock(Framework) {
+            getProjectManager() >> Mock(ProjectManager) {
+                existsFrameworkProject('test1') >> true
+                1 * loadProjectConfig('test1') >> projConfig
+            }
+            getResourceModelSourceService() >> Mock(ResourceModelSourceService) {
+                _ * getSourceForConfiguration(
+                    'file', { args ->
+                    args['file'] == '/tmp/test.xml'
+                }
+                ) >> modelSource
+                _ * getSourceForConfiguration(
+                    'file', { args ->
+                    args['file'] != '/tmp/test.xml'
+                }
+                ) >> cacheModelsource
+            }
+            getResourceFormatGeneratorService() >> Mock(ResourceFormatGeneratorService) {
+                _ * getGeneratorForFormat('xml') >> Mock(ResourceFormatGenerator) {
+
+                }
+            }
+        }
+        when:
+        def result1 = service.getNodes('test1')
+
+        then:
+        //cached first-run
+        if (expectAsynch) {
+            result1.nodes == null
+        } else {
+            result1.nodes != null
+            null != result1.nodes.getNode('bnode')
+            result1.nodes.nodeNames as List == ['bnode']
+        }
+
+        result1.doCache == true
+        (expectAsynch ? 1 : 0) * service.nodeTaskExecutor.execute(_) >> { args ->
+            //no op. do not call closure, simulates delay in loading nodes
+        }
+        0 * modelSource.getNodes() >> sourceNodes
+        1 * cacheModelsource.getNodes() >> preloadedNodes
+
+        where:
+        defAsynch | projSynch | expectAsynch
+        false     | null      | false
+        true      | null      | true
+        false     | true     | false
+        false     | false      | true
+        true      | true     | false
+        true      | false      | true
+
+    }
+
     def "get nodes with project cache without preload with forced synchronous behavior"( ) {
         given:
         service.nodeTaskExecutor = Mock(AsyncListenableTaskExecutor)
         service.frameworkService = Mock(FrameworkService)
         service.configurationService = Mock(ConfigurationService) {
             getCacheEnabledFor('nodeService', 'nodeCache', true) >> true
-            getBoolean('nodeService.nodeCache.firstLoadAsynch',true)>>false
+            getBoolean('nodeService.nodeCache.firstLoadAsynch', false) >> false
+            0 * _(*_)
         }
         INodeSet modelNodes = new NodeSetImpl()
         modelNodes.putNode(new NodeEntryImpl('anode'))
@@ -343,7 +433,8 @@ class NodeServiceSpec extends Specification {
         service.frameworkService = Mock(FrameworkService)
         service.configurationService = Mock(ConfigurationService) {
             getCacheEnabledFor('nodeService', 'nodeCache', true) >> true
-            getBoolean('nodeService.nodeCache.firstLoadAsynch',true)>>true
+            getBoolean('nodeService.nodeCache.firstLoadAsynch', false) >> true
+            0 * _(*_)
         }
         INodeSet modelNodes = new NodeSetImpl()
         modelNodes.putNode(new NodeEntryImpl('anode'))


### PR DESCRIPTION
Fix #2598 
Pass the options of type `file` to the context of the referenced job and skip the validations on the new context.
