### PR TITLE
Update to mysql 5.7, quell ssl startup warning

### DIFF
--- a/test/docker/docker-compose-api-mysql.yaml
+++ b/test/docker/docker-compose-api-mysql.yaml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   mysql:
-    image: mysql:5.6
+    image: mysql:5.7
     expose:
       - 3306
     environment:
@@ -32,7 +32,7 @@ services:
       - WAIT_NODES=rundeck1
       - CONFIG_SCRIPT_PRESTART=scripts/config-db.sh
       - DATABASE_DRIVER=com.mysql.jdbc.Driver
-      - DATABASE_URL=jdbc:mysql://mysql:3306/rundeck?autoReconnect=true&useUnicode=yes
+      - DATABASE_URL=jdbc:mysql://mysql:3306/rundeck?autoReconnect=true&useUnicode=yes&useSSL=false
       - DATABASE_USER=rundeck
       - DATABASE_PASS=rundeck
     volumes:


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Update mysql-api test to remove warnings about index key sizes.

* upgrade to mysql 5.7, fixes errors like:

> 2018-07-08 00:25:11,810 [main] ERROR hbm2ddl.SchemaUpdate - HHH000388: Unsuccessful: create index EXEC_REPORT_IDX_0 on base_report (ctx_project, date_completed, jc_exec_id, jc_job_id)
2018-07-08 00:25:11,812 [main] ERROR hbm2ddl.SchemaUpdate - Specified key was too long; max key length is 767 bytes

* add `useSSL=false` to jdbc string to quell errors about not using SSL.

TODO:

- [ ] remaining warning during index creation about `Specified key was too long; max key length is 3072 bytes`, related to index on Storage.dir field https://github.com/rundeck/rundeck/blob/master/rundeckapp/grails-app/domain/rundeck/Storage.groovy#L70