### PR TITLE
Add metrics to API, update to APIv25

### DIFF
--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -159,6 +159,16 @@ rundeck:
                 delimiter: ','
         useHMacRequestTokens: true
     storage:
+    execution:
+        finalize:
+            retryMax: 10
+            retryDelay: 5000
+        status:
+            retryMax: 5
+            retryDelay: 5000
+        logs:
+            fileStorage:
+                cancelOnStorageFailure: true
     mail:
         template:
             subject: '${notification.eventStatus} [${execution.project}] ${job.group}/${job.name} ${execution.argstring}'
@@ -167,22 +177,6 @@ rundeck:
         jmxEnabled: true
         requestFilterEnabled: true
         servletUrlPattern: '/metrics/*'
-        execution:
-            finalize:
-                retryMax: 10
-                retryDelay: 5000
-            status:
-                retryMax: 5
-                retryDelay: 5000
-            logs:
-                fileStorage:
-                    cancelOnStorageFailure: true
-        gui:
-            execution:
-                tail:
-                    lines:
-                        default: 20
-                        max: 500
         api:
             enabled: true
             metrics:
@@ -194,6 +188,11 @@ rundeck:
             healthcheck:
                 enabled: true
     gui:
+        execution:
+            tail:
+                lines:
+                    default: 20
+                    max: 500
         job:
             description:
                 disableHTML: false

--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -194,6 +194,16 @@ rundeck:
                     enabled: true
                 healthcheck:
                     enabled: true
+    api:
+        metrics:
+            metrics:
+                enabled: true
+            ping:
+                enabled: true
+            threads:
+                enabled: true
+            healthcheck:
+                enabled: true
     gui:
         job:
             description:

--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -159,6 +159,9 @@ rundeck:
                 delimiter: ','
         useHMacRequestTokens: true
     storage:
+    mail:
+        template:
+            subject: '${notification.eventStatus} [${execution.project}] ${job.group}/${job.name} ${execution.argstring}'
     metrics:
         enabled: true
         jmxEnabled: true
@@ -180,22 +183,8 @@ rundeck:
                     lines:
                         default: 20
                         max: 500
-    mail:
-        template:
-            subject: '${notification.eventStatus} [${execution.project}] ${job.group}/${job.name} ${execution.argstring}'
-    web:
-        metrics:
-            servlets:
-                metrics:
-                    enabled: true
-                ping:
-                    enabled: true
-                threads:
-                    enabled: true
-                healthcheck:
-                    enabled: true
-    api:
-        metrics:
+        api:
+            enabled: true
             metrics:
                 enabled: true
             ping:

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -21,6 +21,7 @@ import com.dtolabs.rundeck.app.api.tokens.RemoveExpiredTokens
 import com.dtolabs.rundeck.app.api.tokens.Token
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.extension.ApplicationExtension
+import grails.web.mapping.LinkGenerator
 import org.rundeck.util.Sizes
 import rundeck.AuthToken
 
@@ -40,6 +41,7 @@ class ApiController extends ControllerBase{
     def apiService
     def userService
     def configurationService
+    LinkGenerator grailsLinkGenerator
 
     static allowedMethods = [
             apiTokenList         : ['GET'],
@@ -93,10 +95,7 @@ class ApiController extends ControllerBase{
                             [
                                 it.key,
                                 [
-                                    href: createLink(
-                                        uri: "/api/${ApiVersions.API_CURRENT_VERSION}/metrics/$it.key",
-                                        absolute: true
-                                    )
+                                    href: grailsLinkGenerator.link(uri: "/api/${ApiVersions.API_CURRENT_VERSION}/metrics/$it.key", absolute: true)
                                 ]
                             ]
                         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -96,11 +96,12 @@ class ApiController extends ControllerBase{
             )
         }
         def names = ['metrics', 'ping', 'threads', 'healthcheck']
+        def globalEnabled=configurationService.getBoolean("metrics.enabled", true) &&
+                          configurationService.getBoolean("metrics.api.enabled", true)
         def enabled =
             names.collectEntries { mname ->
                 [mname,
-                 configurationService.getBoolean("web.metrics.servlets.${mname}.enabled", true) &&
-                 configurationService.getBoolean("api.metrics.${mname}.enabled", true),
+                 globalEnabled && configurationService.getBoolean("metrics.api.${mname}.enabled", true)
                 ]
             }
         if (!name) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -409,7 +409,7 @@ class ApiController extends ControllerBase{
     /**
      * /api/1/system/info: display stats and info about the server
      */
-    def apiSystemInfo={
+    def apiSystemInfo(){
         if (!apiService.requireApi(request, response)) {
             return
         }
@@ -436,9 +436,12 @@ class ApiController extends ControllerBase{
         Date startupDate = new Date(nowDate.getTime()-durationTime)
         int threadActiveCount=Thread.activeCount()
         boolean executionModeActive=configurationService.executionModeActive
-        def metricsJsonUrl = createLink(uri: '/metrics/metrics?pretty=true',absolute: true)
-        def metricsThreadDumpUrl = createLink(uri: '/metrics/threads',absolute: true)
-        def metricsHealthcheckUrl = createLink(uri: '/metrics/healthcheck',absolute: true)
+
+        def metricsJsonUrl = grailsLinkGenerator.link(uri: "/api/${ApiVersions.API_CURRENT_VERSION}/metrics/metrics?pretty=true", absolute: true)
+        def metricsThreadDumpUrl = grailsLinkGenerator.link(uri: "/api/${ApiVersions.API_CURRENT_VERSION}/metrics/threads", absolute: true)
+        def metricsHealthcheckUrl = grailsLinkGenerator.link(uri: "/api/${ApiVersions.API_CURRENT_VERSION}/metrics/healthcheck", absolute: true)
+        def metricsPingUrl = grailsLinkGenerator.link(uri: "/api/${ApiVersions.API_CURRENT_VERSION}/metrics/ping", absolute: true)
+
         if (request.api_version < ApiVersions.V14 && !(response.format in ['all','xml'])) {
             return apiService.renderErrorXml(response,[
                     status:HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE,
@@ -511,6 +514,7 @@ class ApiController extends ControllerBase{
                         metrics(href:metricsJsonUrl,contentType:'application/json')
                         threadDump(href:metricsThreadDumpUrl,contentType:'text/plain')
                         healthcheck(href:metricsHealthcheckUrl,contentType:'application/json')
+                        ping(href:metricsPingUrl,contentType:'text/plain')
 
                         if (extMeta) {
                             extended {
@@ -590,6 +594,7 @@ class ApiController extends ControllerBase{
                         metrics=[href:metricsJsonUrl,contentType:'application/json']
                         threadDump=[href:metricsThreadDumpUrl,contentType:'text/plain']
                         healthcheck=[href:metricsHealthcheckUrl,contentType:'application/json']
+                        ping=[href:metricsPingUrl,contentType:'text/plain']
 
                         if (extMeta) {
                             extended = {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -78,6 +78,23 @@ class ApiController extends ControllerBase{
         if (!apiService.requireVersion(request, response, ApiVersions.V25)) {
             return
         }
+
+        AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
+        if (!frameworkService.authorizeApplicationResource(
+            authContext,
+            AuthConstants.RESOURCE_TYPE_SYSTEM,
+            AuthConstants.ACTION_READ
+        )) {
+            return apiService.renderErrorFormat(
+                response,
+                [
+                    status: HttpServletResponse.SC_FORBIDDEN,
+                    code  : 'api.error.item.unauthorized',
+                    args  : ['Read System Metrics', 'Rundeck', ""],
+                    format: 'json'
+                ]
+            )
+        }
         def names = ['metrics', 'ping', 'threads', 'healthcheck']
         def enabled =
             names.collectEntries { mname ->

--- a/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
+++ b/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
@@ -234,6 +234,8 @@ class UrlMappings {
             moved_to="/api/${ApiVersions.API_CURRENT_VERSION}/scheduler/takeover"
         }
 
+        "/api/$api_version/metrics/$name**?"(controller: 'api', action: 'apiMetrics')
+
         //catchall
         "/api/$api_version/$other/$extra**?"(controller: 'api', action: 'invalid')
 

--- a/rundeckapp/metricsweb/src/main/groovy/metricsweb/MetricswebGrailsPlugin.groovy
+++ b/rundeckapp/metricsweb/src/main/groovy/metricsweb/MetricswebGrailsPlugin.groovy
@@ -127,7 +127,7 @@ each HTTP reqest, and provides some utility methods to Controllers and Services 
     }
 
     def doWithSpring = {
-        disablingAdminServlet(ServletRegistrationBean, new DisablingAdminServlet(), '/metrics/*') {
+        disablingAdminServlet(ServletRegistrationBean, new DisablingAdminServlet(), grailsApplication.config.rundeck.metrics.servletUrlPattern.toString()) {
             loadOnStartup = 2
         }
         metricRegistry(MetricRegistry)

--- a/rundeckapp/metricsweb/src/main/groovy/org/grails/plugins/metricsweb/DisablingAdminServlet.groovy
+++ b/rundeckapp/metricsweb/src/main/groovy/org/grails/plugins/metricsweb/DisablingAdminServlet.groovy
@@ -67,10 +67,12 @@ class DisablingAdminServlet extends AdminServlet {
         def threadsUri = notNullParam(config.getInitParameter("threads-uri"), DEFAULT_THREADS_URI);
         def healthcheckUri = notNullParam(config.getInitParameter("healthcheck-uri"), DEFAULT_HEALTHCHECK_URI);
 
-        map[metricsUri] = gapp.config.rundeck?.web?.metrics?.servlets?.metrics?.enabled in [true, 'true']
-        map[pingUri] = gapp.config.rundeck?.web?.metrics?.servlets?.ping?.enabled in [true, 'true']
-        map[threadsUri] = gapp.config.rundeck?.web?.metrics?.servlets?.threads?.enabled in [true, 'true']
-        map[healthcheckUri] = gapp.config.rundeck?.web?.metrics?.servlets?.healthcheck?.enabled in [true, 'true']
+        def apiEnabled = (gapp.config.rundeck?.metrics?.enabled in [true, 'true']) &&
+                         (gapp.config.rundeck?.metrics?.api?.enabled in [true, 'true'])
+        map[metricsUri] = apiEnabled && gapp.config.rundeck?.metrics?.api?.metrics?.enabled in [true, 'true']
+        map[pingUri] = apiEnabled && gapp.config.rundeck?.metrics?.api?.ping?.enabled in [true, 'true']
+        map[threadsUri] = apiEnabled && gapp.config.rundeck?.metrics?.api?.threads?.enabled in [true, 'true']
+        map[healthcheckUri] = apiEnabled && gapp.config.rundeck?.metrics?.api?.healthcheck?.enabled in [true, 'true']
         this.enabledMap = Collections.unmodifiableMap(map)
     }
 

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
@@ -25,15 +25,16 @@ class ApiVersions {
     public static final int V22 = 22
     public static final int V23 = 23
     public static final int V24 = 24
+    public static final int V25 = 25
     public static final Map VersionMap = [:]
-    public static final List Versions = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24]
+    public static final List Versions = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25]
     static {
         Versions.each { VersionMap[it.toString()] = it }
     }
     public static final Set VersionStrings = new HashSet(VersionMap.values())
 
     public final static int API_EARLIEST_VERSION = V1
-    public final static int API_CURRENT_VERSION = V24
+    public final static int API_CURRENT_VERSION = V25
     public final static int API_MIN_VERSION = API_EARLIEST_VERSION
     public final static int API_MAX_VERSION = API_CURRENT_VERSION
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
@@ -204,6 +204,10 @@ class ApiControllerSpec extends Specification {
             }
             0 * _(*_)
         }
+        controller.frameworkService = Mock(FrameworkService) {
+            1 * getAuthContextForSubject(_)
+            1 * authorizeApplicationResource(_, [type: 'resource', kind: 'system'], 'read') >> true
+        }
         when:
         def result = controller.apiMetrics(input)
 
@@ -273,6 +277,10 @@ class ApiControllerSpec extends Specification {
             }
             0 * _(*_)
         }
+        controller.frameworkService = Mock(FrameworkService) {
+            1 * getAuthContextForSubject(_)
+            1 * authorizeApplicationResource(_, [type: 'resource', kind: 'system'], 'read') >> true
+        }
         when:
         def result = controller.apiMetrics(input)
 
@@ -299,6 +307,42 @@ class ApiControllerSpec extends Specification {
     }
 
     @Unroll
+    def "api metrics unauthorized"() {
+        given:
+        def endpoints = ['metrics', 'healthcheck', 'ping', 'threads']
+        controller.apiService = Mock(ApiService)
+        controller.configurationService = Mock(ConfigurationService)
+        controller.grailsLinkGenerator = Mock(LinkGenerator) {
+            _ * link(*_) >> {
+                it[0].uri
+            }
+            0 * _(*_)
+        }
+        controller.frameworkService = Mock(FrameworkService) {
+            1 * getAuthContextForSubject(_)
+            1 * authorizeApplicationResource(_, [type: 'resource', kind: 'system'], 'read') >> false
+        }
+        when:
+        def result = controller.apiMetrics(input)
+
+        then:
+
+        response.status == 403
+
+
+        1 * controller.apiService.requireVersion(_, _, 25) >> true
+
+        1 * controller.apiService.renderErrorFormat(
+            _, {
+            it.code == 'api.error.item.unauthorized' && it.status == 403
+        }
+        ) >> { it[0].status = it[1].status }
+
+        where:
+        input << ['metrics', 'ping', 'threads', 'healthcheck']
+    }
+
+    @Unroll
     def "api metrics bad endpoint"() {
         given:
         def endpoints = ['metrics', 'healthcheck', 'ping', 'threads']
@@ -309,6 +353,10 @@ class ApiControllerSpec extends Specification {
                 it[0].uri
             }
             0 * _(*_)
+        }
+        controller.frameworkService = Mock(FrameworkService) {
+            1 * getAuthContextForSubject(_)
+            1 * authorizeApplicationResource(_, [type: 'resource', kind: 'system'], 'read') >> true
         }
         when:
         def result = controller.apiMetrics(input)
@@ -349,6 +397,10 @@ class ApiControllerSpec extends Specification {
                 it[0].uri
             }
             0 * _(*_)
+        }
+        controller.frameworkService = Mock(FrameworkService) {
+            1 * getAuthContextForSubject(_)
+            1 * authorizeApplicationResource(_, [type: 'resource', kind: 'system'], 'read') >> true
         }
         when:
         def result = controller.apiMetrics(input)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
@@ -22,11 +22,14 @@ import grails.converters.JSON
 import grails.converters.XML
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
+import grails.web.mapping.LinkGenerator
 import rundeck.AuthToken
 import rundeck.User
 import rundeck.services.ApiService
+import rundeck.services.ConfigurationService
 import rundeck.services.FrameworkService
 import spock.lang.Specification
+import spock.lang.Unroll
 
 @TestFor(ApiController)
 @Mock([User, AuthToken])
@@ -187,5 +190,196 @@ class ApiControllerSpec extends Specification {
         apivers | _
         19      | _
 
+    }
+
+    @Unroll
+    def "api metrics links response"() {
+        given:
+        def endpoints = ['metrics', 'healthcheck', 'ping', 'threads']
+        controller.apiService = Mock(ApiService)
+        controller.configurationService = Mock(ConfigurationService)
+        controller.grailsLinkGenerator = Mock(LinkGenerator) {
+            _ * link(*_) >> {
+                it[0].uri
+            }
+            0 * _(*_)
+        }
+        when:
+        def result = controller.apiMetrics(input)
+
+        then:
+
+        response.forwardedUrl == (forwarded ? "/metrics/$input?" : null)
+        response.json == (
+            forwarded ? null : [
+                '_links': links
+            ]
+        )
+
+        1 * controller.apiService.requireVersion(_, _, 25) >> true
+        for (def i = 0; i < endpoints.size(); i++) {
+            def endp = endpoints[i]
+            1 * controller.configurationService.getBoolean("web.metrics.servlets.${endp}.enabled", true) >>
+            (enabledServlet[endp] ? true : false)
+            (enabledServlet[endp] ? 1 : 0) * controller.configurationService.getBoolean(
+                "api.metrics.${endp}.enabled",
+                true
+            ) >> (enabledApi[endp] ? true : false)
+        }
+        (forwarded ? 1 : 0) * controller.configurationService.getString('metrics.servletUrlPattern', '/metrics/*') >>
+        '/metrics/*'
+
+        where:
+        input | enabledApi                                                    | enabledServlet   | forwarded | links
+        ''    | [:]                                                           | [:]              | false     | [:]
+        ''    | [:]                                                           | [metrics: true]  | false     | [:]
+        ''    | [metrics: true]                                               | [metrics: false] | false     | [:]
+        ''    | [metrics: true]                                               |
+        [metrics: true]                                                                          |
+        false                                                                                                |
+        [metrics: [href: '/api/25/metrics/metrics']]
+        ''    | [healthcheck: true]                                           |
+        [healthcheck: true]                                                                      |
+        false                                                                                                |
+        [healthcheck: [href: '/api/25/metrics/healthcheck']]
+        ''    | [ping: true]                                                  |
+        [ping: true]                                                                             |
+        false                                                                                                |
+        [ping: [href: '/api/25/metrics/ping']]
+        ''    | [threads: true]                                               |
+        [threads: true]                                                                          |
+        false                                                                                                |
+        [threads: [href: '/api/25/metrics/threads']]
+        ''    | [threads: true, ping: true, metrics: true, healthcheck: true] |
+        [threads: true, ping: true, metrics: true, healthcheck: true]                            |
+        false                                                                                                |
+        [
+            metrics    : [href: '/api/25/metrics/metrics'],
+            threads    : [href: '/api/25/metrics/threads'],
+            healthcheck: [href: '/api/25/metrics/healthcheck'],
+            ping       : [href: '/api/25/metrics/ping'],
+        ]
+    }
+
+    @Unroll
+    def "api metrics forwarding"() {
+        given:
+        def endpoints = ['metrics', 'healthcheck', 'ping', 'threads']
+        controller.apiService = Mock(ApiService)
+        controller.configurationService = Mock(ConfigurationService)
+        controller.grailsLinkGenerator = Mock(LinkGenerator) {
+            _ * link(*_) >> {
+                it[0].uri
+            }
+            0 * _(*_)
+        }
+        when:
+        def result = controller.apiMetrics(input)
+
+        then:
+
+        response.forwardedUrl == "/metrics/$input?"
+
+
+        1 * controller.apiService.requireVersion(_, _, 25) >> true
+        for (def i = 0; i < endpoints.size(); i++) {
+            def endp = endpoints[i]
+            1 * controller.configurationService.getBoolean("web.metrics.servlets.${endp}.enabled", true) >>
+            true
+            1 * controller.configurationService.getBoolean(
+                "api.metrics.${endp}.enabled",
+                true
+            ) >> true
+        }
+        1 * controller.configurationService.getString('metrics.servletUrlPattern', '/metrics/*') >>
+        '/metrics/*'
+
+        where:
+        input << ['metrics', 'ping', 'threads', 'healthcheck']
+    }
+
+    @Unroll
+    def "api metrics bad endpoint"() {
+        given:
+        def endpoints = ['metrics', 'healthcheck', 'ping', 'threads']
+        controller.apiService = Mock(ApiService)
+        controller.configurationService = Mock(ConfigurationService)
+        controller.grailsLinkGenerator = Mock(LinkGenerator) {
+            _ * link(*_) >> {
+                it[0].uri
+            }
+            0 * _(*_)
+        }
+        when:
+        def result = controller.apiMetrics(input)
+
+        then:
+
+        response.forwardedUrl == null
+        response.status == 404
+
+
+        1 * controller.apiService.requireVersion(_, _, 25) >> true
+        for (def i = 0; i < endpoints.size(); i++) {
+            def endp = endpoints[i]
+            1 * controller.configurationService.getBoolean("web.metrics.servlets.${endp}.enabled", true) >>
+            true
+            1 * controller.configurationService.getBoolean(
+                "api.metrics.${endp}.enabled",
+                true
+            ) >> true
+        }
+        1 * controller.apiService.renderErrorFormat(
+            _, {
+            it.code == 'api.error.invalid.request' && it.status == 404
+        }
+        ) >> { it[0].status = it[1].status }
+        where:
+        input << ['blah', 'asdfasdf']
+    }
+
+    @Unroll
+    def "api metrics disabled"() {
+        given:
+        def endpoints = ['metrics', 'healthcheck', 'ping', 'threads']
+        controller.apiService = Mock(ApiService)
+        controller.configurationService = Mock(ConfigurationService)
+        controller.grailsLinkGenerator = Mock(LinkGenerator) {
+            _ * link(*_) >> {
+                it[0].uri
+            }
+            0 * _(*_)
+        }
+        when:
+        def result = controller.apiMetrics(input)
+
+        then:
+
+        response.forwardedUrl == null
+        response.status == 404
+
+        1 * controller.apiService.requireVersion(_, _, 25) >> true
+        for (def i = 0; i < endpoints.size(); i++) {
+            def endp = endpoints[i]
+            1 * controller.configurationService.getBoolean("web.metrics.servlets.${endp}.enabled", true) >>
+            (enabledServlet[endp] ? true : false)
+            (enabledServlet[endp] ? 1 : 0) * controller.configurationService.getBoolean(
+                "api.metrics.${endp}.enabled",
+                true
+            ) >> (enabledApi[endp] ? true : false)
+        }
+        1 * controller.apiService.renderErrorFormat(
+            _, {
+            it.code == 'api.error.invalid.request' && it.status == 404
+        }
+        ) >> { it[0].status = it[1].status }
+
+        where:
+        input         | enabledApi       | enabledServlet
+        'metrics'     | [metrics: false] | [metrics: true]
+        'metrics'     | [metrics: true]  | [metrics: false]
+        'healthcheck' | [metrics: true]  | [metrics: true]
+        'ping'        | [metrics: true]  | [metrics: true]
+        'threads'     | [metrics: true]  | [metrics: true]
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
@@ -221,12 +221,13 @@ class ApiControllerSpec extends Specification {
         )
 
         1 * controller.apiService.requireVersion(_, _, 25) >> true
+
+        1 * controller.configurationService.getBoolean("metrics.enabled", true) >> enabledAll
+        (enabledAll?1:0) * controller.configurationService.getBoolean("metrics.api.enabled", true) >> enabledAll
         for (def i = 0; i < endpoints.size(); i++) {
             def endp = endpoints[i]
-            1 * controller.configurationService.getBoolean("web.metrics.servlets.${endp}.enabled", true) >>
-            (enabledServlet[endp] ? true : false)
-            (enabledServlet[endp] ? 1 : 0) * controller.configurationService.getBoolean(
-                "api.metrics.${endp}.enabled",
+            (enabledAll ? 1 : 0) * controller.configurationService.getBoolean(
+                "metrics.api.${endp}.enabled",
                 true
             ) >> (enabledApi[endp] ? true : false)
         }
@@ -234,30 +235,15 @@ class ApiControllerSpec extends Specification {
         '/metrics/*'
 
         where:
-        input | enabledApi                                                    | enabledServlet   | forwarded | links
-        ''    | [:]                                                           | [:]              | false     | [:]
-        ''    | [:]                                                           | [metrics: true]  | false     | [:]
-        ''    | [metrics: true]                                               | [metrics: false] | false     | [:]
-        ''    | [metrics: true]                                               |
-        [metrics: true]                                                                          |
-        false                                                                                                |
-        [metrics: [href: '/api/25/metrics/metrics']]
-        ''    | [healthcheck: true]                                           |
-        [healthcheck: true]                                                                      |
-        false                                                                                                |
-        [healthcheck: [href: '/api/25/metrics/healthcheck']]
-        ''    | [ping: true]                                                  |
-        [ping: true]                                                                             |
-        false                                                                                                |
-        [ping: [href: '/api/25/metrics/ping']]
-        ''    | [threads: true]                                               |
-        [threads: true]                                                                          |
-        false                                                                                                |
-        [threads: [href: '/api/25/metrics/threads']]
-        ''    | [threads: true, ping: true, metrics: true, healthcheck: true] |
-        [threads: true, ping: true, metrics: true, healthcheck: true]                            |
-        false                                                                                                |
-        [
+        input | enabledApi                                                    | enabledAll   | forwarded | links
+        ''    | [:]                                                           | false              | false     | [:]
+        ''    | [:]                                                           | false  | false     | [:]
+        ''    | [metrics: true]                                               | false | false     | [:]
+        ''    | [metrics: true]                                               | true                                                                          | false                                                                                                | [metrics: [href: '/api/25/metrics/metrics']]
+        ''    | [healthcheck: true]                                           | true                                                                      | false                                                                                                | [healthcheck: [href: '/api/25/metrics/healthcheck']]
+        ''    | [ping: true]                                                  | true                                                                             | false                                                                                                | [ping: [href: '/api/25/metrics/ping']]
+        ''    | [threads: true]                                               | true                                                                          | false                                                                                                | [threads: [href: '/api/25/metrics/threads']]
+        ''    | [threads: true, ping: true, metrics: true, healthcheck: true] | true                            | false                                                                                                | [
             metrics    : [href: '/api/25/metrics/metrics'],
             threads    : [href: '/api/25/metrics/threads'],
             healthcheck: [href: '/api/25/metrics/healthcheck'],
@@ -290,12 +276,14 @@ class ApiControllerSpec extends Specification {
 
 
         1 * controller.apiService.requireVersion(_, _, 25) >> true
+
+
+        1 * controller.configurationService.getBoolean("metrics.enabled", true) >> true
+        1 * controller.configurationService.getBoolean("metrics.api.enabled", true) >> true
         for (def i = 0; i < endpoints.size(); i++) {
             def endp = endpoints[i]
-            1 * controller.configurationService.getBoolean("web.metrics.servlets.${endp}.enabled", true) >>
-            true
             1 * controller.configurationService.getBoolean(
-                "api.metrics.${endp}.enabled",
+                "metrics.api.${endp}.enabled",
                 true
             ) >> true
         }
@@ -368,12 +356,13 @@ class ApiControllerSpec extends Specification {
 
 
         1 * controller.apiService.requireVersion(_, _, 25) >> true
+
+        1 * controller.configurationService.getBoolean("metrics.enabled", true) >> true
+        1 * controller.configurationService.getBoolean("metrics.api.enabled", true) >> true
         for (def i = 0; i < endpoints.size(); i++) {
             def endp = endpoints[i]
-            1 * controller.configurationService.getBoolean("web.metrics.servlets.${endp}.enabled", true) >>
-            true
             1 * controller.configurationService.getBoolean(
-                "api.metrics.${endp}.enabled",
+                "metrics.api.${endp}.enabled",
                 true
             ) >> true
         }
@@ -411,12 +400,13 @@ class ApiControllerSpec extends Specification {
         response.status == 404
 
         1 * controller.apiService.requireVersion(_, _, 25) >> true
+
+        1 * controller.configurationService.getBoolean("metrics.enabled", true) >> enabledAll
+        (enabledAll?1:0) * controller.configurationService.getBoolean("metrics.api.enabled", true) >> enabledAll
         for (def i = 0; i < endpoints.size(); i++) {
             def endp = endpoints[i]
-            1 * controller.configurationService.getBoolean("web.metrics.servlets.${endp}.enabled", true) >>
-            (enabledServlet[endp] ? true : false)
-            (enabledServlet[endp] ? 1 : 0) * controller.configurationService.getBoolean(
-                "api.metrics.${endp}.enabled",
+            (enabledAll ? 1 : 0) * controller.configurationService.getBoolean(
+                "metrics.api.${endp}.enabled",
                 true
             ) >> (enabledApi[endp] ? true : false)
         }
@@ -427,11 +417,11 @@ class ApiControllerSpec extends Specification {
         ) >> { it[0].status = it[1].status }
 
         where:
-        input         | enabledApi       | enabledServlet
-        'metrics'     | [metrics: false] | [metrics: true]
-        'metrics'     | [metrics: true]  | [metrics: false]
-        'healthcheck' | [metrics: true]  | [metrics: true]
-        'ping'        | [metrics: true]  | [metrics: true]
-        'threads'     | [metrics: true]  | [metrics: true]
+        input         | enabledApi       | enabledAll
+        'metrics'     | [metrics: false] | true
+        'metrics'     | [metrics: true]  | false
+        'healthcheck' | [metrics: true]  | true
+        'ping'        | [metrics: true]  | true
+        'threads'     | [metrics: true]  | true
     }
 }

--- a/test/api/include.sh
+++ b/test/api/include.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # common header for test scripts
-API_CURRENT_VERSION=24
+API_CURRENT_VERSION=25
 
 SRC_DIR=$(cd `dirname $0` && pwd)
 DIR=${TMP_DIR:-$SRC_DIR}

--- a/test/api/test-metrics.sh
+++ b/test/api/test-metrics.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+#test metrics API endpoints
+
+DIR=$(cd `dirname $0` && pwd)
+export API_CURRENT_VERSION=${API_VERSION}
+source $DIR/include.sh
+
+file=$DIR/curl.out
+
+test_metrics_list(){
+
+	ENDPOINT="${APIURL}/metrics"
+	ACCEPT="application/json"
+
+	test_begin "List Metrics Links (json)"
+
+	api_request "$ENDPOINT" "${file}"
+
+	assert_json_value '4' '._links | length'  "${file}"
+	assert_json_value "${APIURL}/metrics/metrics"  '._links.metrics.href' "${file}"
+	assert_json_value "${APIURL}/metrics/ping"  '._links.ping.href' "${file}"
+	assert_json_value "${APIURL}/metrics/healthcheck"  '._links.healthcheck.href' "${file}"
+	assert_json_value "${APIURL}/metrics/threads"  '._links.threads.href' "${file}"
+	
+	test_succeed
+
+	rm "${file}"
+}
+test_metrics_metrics(){
+
+	ENDPOINT="${APIURL}/metrics/metrics"
+	ACCEPT="application/json"
+
+	test_begin "Get Metrics Data (json)"
+
+	api_request "$ENDPOINT" "${file}"
+
+	assert_json_value '27' '.gauges | length'  "${file}"
+	assert_json_value '1' '.counters | length'  "${file}"
+	assert_json_value '8' '.meters | length'  "${file}"
+	assert_json_value '26' '.timers | length'  "${file}"
+	
+	test_succeed
+
+	rm "${file}"
+}
+test_metrics_healthcheck(){
+
+	ENDPOINT="${APIURL}/metrics/healthcheck"
+	ACCEPT="application/json"
+
+	test_begin "Get Metrics healthcheck (json)"
+
+	api_request "$ENDPOINT" "${file}"
+
+	assert_json_value '2' 'length'  "${file}"
+	assert_json_value 'true' '.["dataSource.connection.time"].healthy'  "${file}"
+	assert_json_value 'true' '.["quartz.scheduler.threadPool"].healthy'  "${file}"
+	
+	test_succeed
+
+	rm "${file}"
+}
+test_metrics_ping(){
+
+	ENDPOINT="${APIURL}/metrics/ping"
+	ACCEPT="text/plain"
+
+	test_begin "Get Metrics ping (text)"
+
+	api_request "$ENDPOINT" "${file}"
+
+	local VAL=$(head -n 1 "${file}")
+	assert "pong" "$VAL"
+	local LEN=$(wc -l "$file"| awk \{'print $1'\} )
+	assert "1" "$LEN"
+	
+	test_succeed
+
+	rm "${file}"
+}
+test_metrics_threads(){
+
+	ENDPOINT="${APIURL}/metrics/threads"
+	ACCEPT="text/plain"
+
+	test_begin "Get Metrics threads (text)"
+
+	api_request "$ENDPOINT" "${file}"
+
+	local VAL=$(wc -l "$file"| awk \{'print $1'\} )
+	
+	if [ "$VAL" -lt 10 ] ; then
+        fail "Expected threads output to have > 10 lines"
+    fi
+	
+	test_succeed
+
+	rm "${file}"
+}
+main(){
+	test_metrics_list
+	test_metrics_metrics
+	test_metrics_healthcheck
+	test_metrics_ping
+	test_metrics_threads
+}
+main


### PR DESCRIPTION
paths: /api/25/metrics  - list of metric hrefs

/api/25/metrics/{metrics,ping,threads,healthcheck} - endpoints

configuration, the servlets must be enabled for each endpoint, plus
api must be enabled for each endpoint

rundeck.web.metrics.servlets.$endpoint.enabled=true
rundeck.api.metrics.$endpoint.enabled=true

TODO:

- [x] access control?
- [x] unit tests
- [x] api functional tests
- [x] documentation