### PR TITLE
Job not found message on definition tab

### DIFF
--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1655,3 +1655,4 @@ passwordUtility.output.label=Output
 passwordUtility.encoder.label=Encoder:
 
 execution.html.waiting=Waiting for Execution log...
+jobreference.wrong=(Job not found)

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1637,3 +1637,4 @@ scheduledExecution.property.defaultTab.label=Pestaña por defecto
 scheduledExecution.property.defaultTab.description=Pestaña por defecto para ser mostrada cuando sigues una ejecución.
 
 execution.html.waiting=Esperando log de la ejecución...
+jobreference.wrong=(Trabajo no encontrado)

--- a/rundeckapp/grails-app/i18n/messages_fr_FR.properties
+++ b/rundeckapp/grails-app/i18n/messages_fr_FR.properties
@@ -1640,3 +1640,4 @@ more=Plus
 
 
 execution.html.waiting=Waiting for Execution log...
+jobreference.wrong=(Job not found)

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -1639,3 +1639,4 @@ scheduledExecution.property.defaultTab.label=Default Tab
 scheduledExecution.property.defaultTab.description=Default tab to display when you follow an execution.
 
 execution.html.waiting=Waiting for Execution log...
+jobreference.wrong=(Job not found)

--- a/rundeckapp/grails-app/views/execution/_wfItemView.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfItemView.gsp
@@ -44,10 +44,10 @@
                             <i class="glyphicon glyphicon-book"></i>
                         </g:else>
                     </g:if>
-                    <g:if test="${!edit }">
-                        <b><g:message code="jobreference.wrong" /></b>
-                    </g:if>
                     <g:enc>${(item.jobGroup?item.jobGroup+'/':'')+(item.jobName?:item.uuid) + (item.jobProject?' (' + item.jobProject+') ':'') }</g:enc>
+                    <g:if test="${!edit }">
+                        <label class="text-danger"><g:message code="jobreference.wrong" /></label>
+                    </g:if>
                 </g:else>
 
                 %{--display step description--}%

--- a/rundeckapp/grails-app/views/execution/_wfItemView.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfItemView.gsp
@@ -37,7 +37,15 @@
                 </g:if>
                 <g:else>
                     <g:if test="${!noimgs }">
-                        <i class="glyphicon glyphicon-book"></i>
+                        <g:if test="${!edit }">
+                            <i class="glyphicon glyphicon-remove-circle"></i>
+                        </g:if>
+                        <g:else>
+                            <i class="glyphicon glyphicon-book"></i>
+                        </g:else>
+                    </g:if>
+                    <g:if test="${!edit }">
+                        <b><g:message code="jobreference.wrong" /></b>
                     </g:if>
                     <g:enc>${(item.jobGroup?item.jobGroup+'/':'')+(item.jobName?:item.uuid) + (item.jobProject?' (' + item.jobProject+') ':'') }</g:enc>
                 </g:else>


### PR DESCRIPTION
Fix #3694
Adds message `(Job not found)` on definition tab for wrong referenced jobs.


<img width="641" alt="ss" src="https://user-images.githubusercontent.com/2894508/42767689-a027ea44-88eb-11e8-9c18-eba5dd2bffce.png">