### PR TITLE
Create new branch on git-export

### DIFF
--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/BaseGitPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/BaseGitPlugin.groovy
@@ -23,6 +23,7 @@ import com.dtolabs.rundeck.core.storage.ResourceMeta
 import com.dtolabs.rundeck.plugins.scm.*
 import org.apache.log4j.Logger
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.ListBranchCommand
 import org.eclipse.jgit.api.PullResult
 import org.eclipse.jgit.api.RebaseCommand
 import org.eclipse.jgit.api.RebaseResult
@@ -33,6 +34,7 @@ import org.eclipse.jgit.lib.BranchConfig
 import org.eclipse.jgit.lib.ConfigConstants
 import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.lib.ObjectId
+import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.merge.MergeStrategy
 import org.eclipse.jgit.revwalk.RevCommit
@@ -570,10 +572,10 @@ class BaseGitPlugin {
         return msgs.join("; ")
     }
 
-    private void performClone(File base, String url, ScmOperationContext context) {
+    private void performClone(File base, String url, ScmOperationContext context, String branch=this.branch) {
         logger.debug("cloning...");
         def cloneCommand = Git.cloneRepository().
-                setBranch(this.branch).
+                setBranch(branch).
                 setRemote(REMOTE_NAME).
                 setDirectory(base).
                 setURI(url)
@@ -586,6 +588,7 @@ class BaseGitPlugin {
         }
         repo = git.getRepository()
     }
+
 
     /**
      * Configure authentication for the git command depending on the configured ssh private Key storage path, or password

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
@@ -139,44 +139,6 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
         inited = true
     }
 
-    private void createBranch(ScmOperationContext context, String newBranch, String baseBranch){
-        def createCommand = git.branchCreate()
-                .setName(newBranch)
-                .setStartPoint("${REMOTE_NAME}/${baseBranch}")
-                .setForce(true)
-
-        try {
-            createCommand.call()
-        } catch (Exception e) {
-            logger.debug("Failed creating branch ${newBranch}: ${e.message}", e)
-            throw new ScmPluginException("Failed creating branch ${newBranch}: ${e.message}", e)
-        }
-        def pushb = git.push()
-        pushb.setRemote(REMOTE_NAME)
-        pushb.add(branch)
-        setupTransportAuthentication(sshConfig, context, pushb)
-
-        def push
-        try {
-            push = pushb.call()
-        } catch (Exception e) {
-            plugin.logger.debug("Failed push to remote: ${e.message}", e)
-            throw new ScmPluginException("Failed push to remote: ${e.message}", e)
-        }
-
-    }
-
-    private boolean existBranch(String remoteName){
-        List<Ref> call = git.branchList().setListMode(ListBranchCommand.ListMode.ALL).call()
-        for (Ref ref : call) {
-            if (remoteName == ref.getName()) {
-                return true
-            }
-        }
-        return false
-    }
-
-
     @Override
     void cleanup() {
         git?.close()

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
@@ -123,7 +123,7 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
         //check clone was ok
         if (git?.repository.getFullBranch() != "refs/heads/$branch") {
             logger.debug("branch differs")
-            if(config.shouldCreateBranch()){
+            if(config.createBranch){
                 if(config.baseBranch && existBranch("refs/remotes/${this.REMOTE_NAME}/${config.baseBranch}")){
                     createBranch(context, config.branch, config.baseBranch)
                     cloneOrCreate(context, base, config.url)
@@ -132,7 +132,8 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
                     throw new ScmPluginException("Non existent remote branch: ${config.baseBranch}")
                 }
             }else{
-                throw new ScmPluginException("Non existent remote branch: ${this.branch}")
+                throw new ScmPluginException("Could not clone the remote branch: ${this.branch}, " +
+                        "because it does not exist. To create it, you need to set the Create Branch option to true.")
             }
         }
         workingDir = base

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/config/Export.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/config/Export.groovy
@@ -82,16 +82,13 @@ Template".
 
     @PluginProperty(
             title = "Create Branch if it doesn't exist",
-            description = "If the entered branch doesnt exist on remote repo, create a new one. If false, it will fail if the branch doesn't exist",
-            defaultValue = 'false',
-            required = false
+            description = "If the entered branch doesnt exist on remote repo, create a new one. If false, it will fail if the branch doesn't exist"
     )
-    @SelectValues(values = ['true', 'false'])
     @RenderingOption(
             key = StringRenderingConstants.GROUP_NAME,
             value = "Git Repository"
     )
-    String createBranch
+    boolean createBranch
 
     @PluginProperty(
             title = "Base branch on",
@@ -121,9 +118,5 @@ Template".
 
     boolean shouldPullAutomatically(){
         return pullAutomatically in ['true']
-    }
-
-    boolean shouldCreateBranch(){
-        return createBranch in ['true']
     }
 }

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/config/Export.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/config/Export.groovy
@@ -80,6 +80,35 @@ Template".
     )
     String pullAutomatically
 
+    @PluginProperty(
+            title = "Create Branch if it doesn't exist",
+            description = "If the entered branch doesnt exist on remote repo, create a new one. If false, it will fail if the branch doesn't exist",
+            defaultValue = 'false',
+            required = false
+    )
+    @SelectValues(values = ['true', 'false'])
+    @RenderingOption(
+            key = StringRenderingConstants.GROUP_NAME,
+            value = "Git Repository"
+    )
+    String createBranch
+
+    @PluginProperty(
+            title = "Base branch on:",
+            description = "Create the new branch based on the existen branch",
+            defaultValue = 'master',
+            required = false
+
+    )
+    @RenderingOption(
+            key = StringRenderingConstants.GROUP_NAME,
+            value = "Git Repository"
+    )
+    String baseBranch
+
+
+
+
     boolean isExportPreserve() {
         exportUuidBehavior == 'preserve' || !exportUuidBehavior
     }
@@ -92,5 +121,9 @@ Template".
 
     boolean shouldPullAutomatically(){
         return pullAutomatically in ['true']
+    }
+
+    boolean shouldCreateBranch(){
+        return createBranch in ['true']
     }
 }

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/config/Export.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/config/Export.groovy
@@ -94,7 +94,7 @@ Template".
     String createBranch
 
     @PluginProperty(
-            title = "Base branch on:",
+            title = "Base branch on",
             description = "Create the new branch based on the existen branch",
             defaultValue = 'master',
             required = false

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginFactorySpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginFactorySpec.groovy
@@ -46,7 +46,7 @@ class GitExportPluginFactorySpec extends Specification {
         expect:
         desc.title == 'Git Export'
         desc.name == 'git-export'
-        desc.properties.size() == 13
+        desc.properties.size() == 15
     }
 
     def "base description properties"() {
@@ -68,7 +68,9 @@ class GitExportPluginFactorySpec extends Specification {
                 'committerName',
                 'committerEmail',
                 'exportUuidBehavior',
-                'pullAutomatically'
+                'pullAutomatically',
+                'createBranch',
+                'baseBranch'
         ] as Set
     }
 
@@ -91,7 +93,9 @@ class GitExportPluginFactorySpec extends Specification {
                 'committerName',
                 'committerEmail',
                 'exportUuidBehavior',
-                'pullAutomatically'
+                'pullAutomatically',
+                'createBranch',
+                'baseBranch'
         ] as Set
         def dirprop = properties.find { it.name == 'dir' }
         dirprop.defaultValue == null
@@ -120,7 +124,9 @@ class GitExportPluginFactorySpec extends Specification {
                 'committerName',
                 'committerEmail',
                 'exportUuidBehavior',
-                'pullAutomatically'
+                'pullAutomatically',
+                'createBranch',
+                'baseBranch'
         ] as Set
         properties.find { it.name == 'dir' }.defaultValue == new File(tempdir.absolutePath, 'scm').absolutePath
     }

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
@@ -1659,7 +1659,8 @@ class GitExportPluginSpec extends Specification {
 
         then:
         ScmPluginException e = thrown()
-        e.message=="Non existent remote branch: dev2"
+        e.message=="Could not clone the remote branch: dev2, because it does not exist. " +
+                "To create it, you need to set the Create Branch option to true."
     }
 
     def "initialize plugin with unknown branch with create config"() {

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
@@ -1620,4 +1620,134 @@ class GitExportPluginSpec extends Specification {
         status.state==SynchState.CLEAN
         status.message=='Automatic pull from the repository failed: Could not get advertised Ref for branch master'
     }
+
+    def "initialize plugin with unknown branch without create config"() {
+        given:
+
+        def gitdir = new File(tempdir, 'scm')
+        def origindir = new File(tempdir, 'origin')
+        Export config = createTestConfig(gitdir, origindir)
+        //create a git dir
+        def git = createGit(origindir)
+        def commit = addCommitFile(origindir, git, 'testcommit.txt', 'blah')
+        git.close()
+
+        def context = Mock(ScmOperationContext)
+
+        //first init with origin1
+        new GitExportPlugin(config).initialize(Mock(ScmOperationContext))
+
+        //add loose file in working dir
+        def testfile=new File(gitdir,'test-file')
+        testfile<<'test'
+
+
+        //create dev branch
+        def git2 = openGit(origindir)
+        git2.branchCreate().setName('dev').call()
+        git2.checkout().setName('dev').call()
+        def commit2 = addCommitFile(origindir, git2, 'testcommit.txt', 'blee')
+        git2.close()
+
+        Export config2 = createTestConfig(gitdir, origindir,[
+                branch:'dev2'
+        ])
+        def plugin = new GitExportPlugin(config2)
+
+        when:
+        plugin.initialize(context)
+
+        then:
+        ScmPluginException e = thrown()
+        e.message=="Non existent remote branch: dev2"
+    }
+
+    def "initialize plugin with unknown branch with create config"() {
+        given:
+
+        def gitdir = new File(tempdir, 'scm')
+        def origindir = new File(tempdir, 'origin')
+        Export config = createTestConfig(gitdir, origindir)
+        //create a git dir
+        def git = createGit(origindir)
+        def commit = addCommitFile(origindir, git, 'testcommit.txt', 'blah')
+        git.close()
+
+        def context = Mock(ScmOperationContext)
+
+        //first init with origin1
+        new GitExportPlugin(config).initialize(Mock(ScmOperationContext))
+
+        //add loose file in working dir
+        def testfile=new File(gitdir,'test-file')
+        testfile<<'test'
+
+
+        //create dev branch
+        def git2 = openGit(origindir)
+        git2.branchCreate().setName('dev').call()
+        git2.checkout().setName('dev').call()
+        def commit2 = addCommitFile(origindir, git2, 'testcommit.txt', 'blee')
+        git2.close()
+
+        Export config2 = createTestConfig(gitdir, origindir,[
+                branch:'dev2',
+                createBranch:'true',
+                baseBranch: 'dev'
+
+        ])
+        def plugin = new GitExportPlugin(config2)
+
+        when:
+        plugin.initialize(context)
+
+        then:
+        gitdir.isDirectory()
+        new File(gitdir, '.git').isDirectory()
+        openGit(gitdir).repository.getFullBranch()=='refs/heads/dev2'
+
+    }
+
+    def "initialize plugin with unknown branch with create config and bad remote"() {
+        given:
+
+        def gitdir = new File(tempdir, 'scm')
+        def origindir = new File(tempdir, 'origin')
+        Export config = createTestConfig(gitdir, origindir)
+        //create a git dir
+        def git = createGit(origindir)
+        def commit = addCommitFile(origindir, git, 'testcommit.txt', 'blah')
+        git.close()
+
+        def context = Mock(ScmOperationContext)
+
+        //first init with origin1
+        new GitExportPlugin(config).initialize(Mock(ScmOperationContext))
+
+        //add loose file in working dir
+        def testfile=new File(gitdir,'test-file')
+        testfile<<'test'
+
+
+        //create dev branch
+        def git2 = openGit(origindir)
+        git2.branchCreate().setName('dev').call()
+        git2.checkout().setName('dev').call()
+        def commit2 = addCommitFile(origindir, git2, 'testcommit.txt', 'blee')
+        git2.close()
+
+        Export config2 = createTestConfig(gitdir, origindir,[
+                branch:'dev2',
+                createBranch:'true',
+                baseBranch: 'wrong'
+        ])
+        def plugin = new GitExportPlugin(config2)
+
+        when:
+        plugin.initialize(context)
+
+        then:
+        ScmPluginException e = thrown()
+        e.message=="Non existent remote branch: wrong"
+    }
 }

--- a/test/api/test-scm-git-plugin-inputs.sh
+++ b/test/api/test-scm-git-plugin-inputs.sh
@@ -38,9 +38,11 @@ exprops="committerName
 committerEmail
 exportUuidBehavior
 pullAutomatically
+createBranch
+baseBranch
 $commonprops
 "
-expcount=13
+expcount=15
 
 test_git_plugin_input_xml(){
 	local integration=$1


### PR DESCRIPTION
Add new configuration options to create a new branch on the `git-export` SCM plugin.

<img width="1395" alt="config" src="https://user-images.githubusercontent.com/2894508/43008800-f7d94f14-8c09-11e8-8ab6-3601edc75c5f.png">

If the branch doesn't exist on the remote repo, it will create a new one with the `branch` name. It will be based on the `base branch`.

If the `base branch` doesn't exist on remote, it will throw an error:

<img width="500" alt="imagen" src="https://user-images.githubusercontent.com/2894508/43009162-e720f162-8c0a-11e8-9cec-7f5a1f05ea38.png">




