### PR TITLE
Restore embedded jetty security settings

### DIFF
--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -229,3 +229,7 @@ beans:
 
 server:
     port: 4440
+    session:
+      cookie:
+        http-only: true
+      tracking-modes: 'cookie'

--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -233,3 +233,10 @@ server:
       cookie:
         http-only: true
       tracking-modes: 'cookie'
+rundeck:
+    web:
+      jetty:
+        servlet:
+          initParams:
+            'org.eclipse.jetty.servlet.SessionIdPathParameterName': "none"
+            'org.eclipse.jetty.servlet.SessionCookie': "JSESSIONID"

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -48,7 +48,8 @@ import grails.plugin.springsecurity.SecurityFilterPosition
 import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.util.Environment
 import groovy.io.FileType
-
+import org.eclipse.jetty.server.session.SessionHandler
+import org.rundeck.jetty.init.MyServletContextInitializer
 import org.rundeck.security.RundeckJaasAuthorityGranter
 import org.rundeck.security.RundeckPreauthenticationRequestHeaderFilter
 import org.rundeck.security.RundeckUserDetailsService
@@ -78,6 +79,7 @@ import rundeck.services.QuartzJobScheduleManager
 import rundeck.services.scm.ScmJobImporter
 import rundeckapp.init.ExternalStaticResourceConfigurer
 import rundeckapp.init.RundeckInitConfig
+import rundeckapp.init.servlet.JettyServletContainerCustomizer
 
 import javax.security.auth.login.Configuration
 
@@ -463,6 +465,14 @@ beans={
         realmPropertyFileDataSource(InMemoryUserDetailsManager, realmProperties)
         realmAuthProvider(DaoAuthenticationProvider) {
             userDetailsService = ref('realmPropertyFileDataSource')
+        }
+    }
+
+    jettyServletCustomizer(JettyServletContainerCustomizer) {
+        def configParams = grailsApplication.config.rundeck?.web?.jetty?.servlet?.initParams
+
+        initParams = configParams?.toProperties()?.collectEntries {
+            [it.key.toString(), it.value.toString()]
         }
     }
 }

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -48,8 +48,6 @@ import grails.plugin.springsecurity.SecurityFilterPosition
 import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.util.Environment
 import groovy.io.FileType
-import org.eclipse.jetty.server.session.SessionHandler
-import org.rundeck.jetty.init.MyServletContextInitializer
 import org.rundeck.security.RundeckJaasAuthorityGranter
 import org.rundeck.security.RundeckPreauthenticationRequestHeaderFilter
 import org.rundeck.security.RundeckUserDetailsService

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -15,19 +15,43 @@
  */
 package rundeckapp.init.servlet
 
+import org.eclipse.jetty.webapp.AbstractConfiguration
+import org.eclipse.jetty.webapp.WebAppContext
 import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer
 import org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainerFactory
 
-
+/**
+ * Customize embedded jetty
+ */
 class JettyServletContainerCustomizer implements EmbeddedServletContainerCustomizer {
-
-    //This class must be registered in resources.groovy in order for it to be picked up
+    /**
+     * Set of init parameters to set in the web app context
+     */
+    Map<String, String> initParams = [:]
 
     @Override
     void customize(final ConfigurableEmbeddedServletContainer container) {
         if(container instanceof JettyEmbeddedServletContainerFactory) {
-            //customize jetty here if we need to
+            container.addConfigurations(new JettyConfigPropsInitParameterConfiguration(initParams))
+        }
+    }
+}
+
+/**
+ * Set init params for the WebAppContext
+ */
+class JettyConfigPropsInitParameterConfiguration extends AbstractConfiguration {
+    Map<String, String> initParams
+
+    JettyConfigPropsInitParameterConfiguration(final Map<String, String> initParams) {
+        this.initParams = initParams
+    }
+
+    @Override
+    void preConfigure(final WebAppContext context) throws Exception {
+        for (String key : initParams.keySet()) {
+            context.setInitParameter(key, initParams[key])
         }
     }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Restore security config settings from rundeck 2.x for embedded jetty:

* set httpOnly cookies
* disable session ID in url params

ref:  previous coded jetty embed configuration in RunServer: https://github.com/rundeck/rundeck/blob/v2.11.5/rundeck-launcher/rundeck-jetty-server/src/main/java/com/dtolabs/rundeck/RunServer.java#L118-L123