### PR TITLE
Optional sys prop displays build info on startup

### DIFF
--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -87,6 +87,10 @@ class BootStrap {
 
          servletContext.setAttribute("app.ident",grailsApplication.metadata['build.ident'])
          log.info("Starting ${appname} ${servletContext.getAttribute('app.ident')} ($shortBuildDate) ...")
+         if(Boolean.getBoolean('rundeck.bootstrap.build.info')){
+             def buildInfo=grailsApplication.metadata.findAll{it.key.startsWith('build.core.git.')}
+             log.info("${appname} Build: ${buildInfo}")
+         }
          /*filterInterceptor.handlers.sort { FilterToHandlerAdapter handler1,
                                            FilterToHandlerAdapter handler2 ->
              FilterConfig filter1 = handler1.filterConfig

--- a/test/docker/dockers/rundeck/scripts/start_rundeck.sh
+++ b/test/docker/dockers/rundeck/scripts/start_rundeck.sh
@@ -102,7 +102,7 @@ done
 export CLI_CP
 
 # force UTF-8 default encoding
-export RDECK_JVM="-Dfile.encoding=UTF-8 $RDECK_JVM_OPTS"
+export RDECK_JVM="-Dfile.encoding=UTF-8 -Drundeck.bootstrap.build.info=true $RDECK_JVM_OPTS"
 END
 
 # prevent CLI tool warning


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

System property `rundeck.bootstrap.build.info=true` will report build information at startup.
