### PR TITLE
Set logging to output jaas config issues.

### DIFF
--- a/rundeckapp/grails-app/conf/logback.groovy
+++ b/rundeckapp/grails-app/conf/logback.groovy
@@ -40,6 +40,13 @@ appender('STDOUT', TrueConsoleAppender) {
     logger it, ERROR, ['STDOUT'], false
 }
 
+// Provides critical visibility into jaas config issues
+['com.dtolabs.rundeck.jetty.jaas',
+ 'grails.plugin.springsecurity.web.authentication.GrailsUsernamePasswordAuthenticationFilter',
+ 'org.rundeck.jaas'].each {
+    logger it, DEBUG, ['STDOUT'], false
+}
+
 logger "rundeckapp.BootStrap", INFO, ["STDOUT"], false
 if (Environment.isDevelopmentMode()) {
 
@@ -85,4 +92,4 @@ if (Environment.isDevelopmentMode()) {
         }
     }
 }
-root(ERROR, ['STDOUT'])
+root(WARN, ['STDOUT'])


### PR DESCRIPTION
This increases the log level to `DEBUG` on select auth related loggers. Without this, and currently, JAAS configuration and module errors are not visible in the logs by default.

Some of the logging that is sent to `DEBUG` is probably more suitable for the error `ERROR` or `WARN` level, however this does not address that.

**Auth/JAAS Logging**
Sets related jaas packages to `DEBUG` so that config and run-time errors are visible in the log output.

**Logback `WARN` level**
Increases default logback log level to `WARN`, which is for potential problems, or "harmful situations" according to log4j.
