### PR TITLE
Update default profile

### DIFF
--- a/packaging/common/etc/rundeck/profile
+++ b/packaging/common/etc/rundeck/profile
@@ -46,7 +46,7 @@ RDECK_JVM_SETTINGS="${RDECK_JVM_SETTINGS:- -Xmx1024m -Xms256m -XX:MaxMetaspaceSi
 RDECK_TRUSTSTORE_FILE="${RDECK_TRUSTSTORE_FILE:-$RDECK_CONFIG/ssl/truststore}"
 RDECK_TRUSTSTORE_TYPE="${RDECK_TRUSTSTORE_TYPE:-jks}"
 JAAS_LOGIN="${JAAS_LOGIN:-true}"
-JAAS_CONF="${JAAS_CONF:-$RDECK_CONFIG/jaas-loginmodule.conf}"
+JAAS_CONF_FILE="${JAAS_CONF_FILE:-jaas-loginmodule.conf}"
 LOGIN_MODULE="${LOGIN_MODULE:-RDpropertyfilelogin}"
 RDECK_HTTP_PORT=${RDECK_HTTP_PORT:-4440}
 RDECK_HTTPS_PORT=${RDECK_HTTPS_PORT:-4443}
@@ -70,7 +70,7 @@ for war in $(find $RDECK_INSTALL/bootstrap -name '*.war') ; do
 done
 
 RDECK_JVM="-Drundeck.jaaslogin=$JAAS_LOGIN \
-           -Djava.security.auth.login.config=$JAAS_CONF \
+           -Dloginmodule.conf.name=$JAAS_CONF_FILE \
            -Dloginmodule.name=$LOGIN_MODULE \
            -Drdeck.config=$RDECK_CONFIG \
            -Drundeck.server.configDir=$RDECK_SERVER_CONFIG \


### PR DESCRIPTION
Based on the following issue, I think the default profile should change
to match 3.0.0

https://github.com/rundeck/rundeck/issues/3755
https://github.com/rundeck/rundeck/issues/3757

IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".

**Is this a bugfix, or an enhancement? Please describe.**
A clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing.
Updates the default profile to fix #3755 #3757 

**Describe the solution you've implemented**
A clear and concise description of what you want to happen.
Change the properties as required and add a new one.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.
Since #3755 is closed I'm not certain I've done the right thing.  People mention a workaround and I have been able to just mount the working one.  But it seemed like a working profile should be in the package.

**Additional context**
Add any other context or screenshots about the change here.
