### PR TITLE
Problem saving api token on postgres

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
@@ -106,7 +106,7 @@ class ApiService {
                 creator: ownerUsername
         )
 
-        if (token.save()) {
+        if (token.save(flush:true)) {
             log.info(
                     "GENERATE TOKEN: ID:${uuid} creator:${ownerUsername} username:${u.login} roles:"
                             + "${token.authRoles} expiration:${expiration}"


### PR DESCRIPTION
see #3767 
The token is used on the next method after the creation, on Postgres without flushing the save, the token is not yet on the database, causing a `null` message.

