### PR TITLE
Fix #3787 deployment on jboss wildfly 13.

### DIFF
--- a/grails-persistlocale/build.gradle
+++ b/grails-persistlocale/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     compile "org.springframework.boot:spring-boot-autoconfigure"
     compile "org.grails:grails-core"
     compile "org.springframework.boot:spring-boot-starter-actuator"
-    compile "org.springframework.boot:spring-boot-starter-tomcat"
+    provided "org.springframework.boot:spring-boot-starter-jetty"
     compile "org.grails:grails-web-boot"
     compile "org.grails:grails-logging"
     compile "org.grails:grails-plugin-rest"


### PR DESCRIPTION
JBoss Wildfly uses a customized classloader, so the normal methods for extracting jars will fail.