### PR TITLE
Fix incorrect workflow state when non-node-step jobrefs complete

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/state/WorkflowExecutionStateListenerAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/state/WorkflowExecutionStateListenerAdapter.java
@@ -183,9 +183,9 @@ public class WorkflowExecutionStateListenerAdapter implements WorkflowExecutionL
     }
 
     public void finishWorkflowItem(int step, StepExecutionItem item, StepExecutionResult result) {
-        if (NodeDispatchStepExecutor.STEP_EXECUTION_TYPE.equals(item.getType()) || item instanceof NodeStepExecutionItem) {
-            //dont notify
-        } else {
+        boolean isNodeStep = NodeDispatchStepExecutor.STEP_EXECUTION_TYPE.equals(item.getType())
+                             || NodeStepExecutionItem.isNodeStep(item);
+        if (!isNodeStep) {
             notifyAllStepState(createIdentifier(), createStepStateChange(result), new Date());
         }
         stepContext.finishStepContext();

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepExecutionItem.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepExecutionItem.java
@@ -36,4 +36,16 @@ public interface NodeStepExecutionItem extends StepExecutionItem {
      * @return the type name of the StepExecution provider to use.
      */
     public String getNodeStepType();
+
+    /**
+     * @return true if the step item is a node step
+     */
+    default boolean isNodeStep() {
+        return true;
+    }
+
+    static boolean isNodeStep(StepExecutionItem item) {
+        boolean nodeExecItem = item instanceof NodeStepExecutionItem;
+        return nodeExecItem && ((NodeStepExecutionItem) item).isNodeStep();
+    }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/state/WorkflowExecutionStateListenerAdapterSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/state/WorkflowExecutionStateListenerAdapterSpec.groovy
@@ -1,0 +1,87 @@
+package com.dtolabs.rundeck.core.execution.workflow.state
+
+import com.dtolabs.rundeck.core.common.INodeEntry
+import com.dtolabs.rundeck.core.common.NodeEntryImpl
+import com.dtolabs.rundeck.core.common.NodeSetImpl
+import com.dtolabs.rundeck.core.execution.ExecutionContextImpl
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutionResultImpl
+import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepExecutionItem
+import spock.lang.Specification
+
+class WorkflowExecutionStateListenerAdapterSpec extends Specification {
+
+    static class TestListener1 implements WorkflowStateListener {
+        List<Map> events = []
+
+        @Override
+        public void stepStateChanged(StepIdentifier identifier, StepStateChange stepStateChange, Date timestamp) {
+            events.add([type: "step", id: identifier, change: stepStateChange, timestamp: timestamp]);
+        }
+
+        @Override
+        public void workflowExecutionStateChanged(ExecutionState executionState, Date timestamp, List<String> nodeSet) {
+            events.add([type: "workflow", state: executionState, timestamp: timestamp, nodeSet: nodeSet]);
+        }
+
+        @Override
+        public void subWorkflowExecutionStateChanged(
+            StepIdentifier identifier, ExecutionState executionState, Date
+                timestamp, List<String> nodeSet
+        ) {
+            events.add(
+                [type: "subworkflow", id: identifier, state: executionState, timestamp: timestamp, nodeSet: nodeSet]
+            );
+        }
+    }
+
+    static class TestJobRefItem implements NodeStepExecutionItem {
+
+        String nodeStepType = "non-node-dispatch"
+
+        String type = "non-node-dispatch"
+
+        String label = null
+
+        boolean nodeStep
+
+    }
+
+    def "finish job ref workflow item"() {
+        given:
+        HashMap<String, INodeEntry> nodes = new HashMap<String, INodeEntry>();
+        nodes.put("test1", new NodeEntryImpl("test1"));
+        def testListener1 = new TestListener1()
+
+
+        List<WorkflowStateListener> testListener1s = Arrays.asList((WorkflowStateListener) testListener1);
+        def test = new WorkflowExecutionStateListenerAdapter(testListener1s);
+
+        test.beginWorkflowExecution(ExecutionContextImpl.builder().nodes(new NodeSetImpl(nodes)).build(), null);
+        TestJobRefItem testJobRefItem = new TestJobRefItem(nodeStep: isNodeStep);
+        test.beginWorkflowItem(1, testJobRefItem);
+
+        when:
+        test.finishWorkflowItem(1, testJobRefItem, new StepExecutionResultImpl());
+        then:
+        (size) == testListener1.events.size()
+        def evt1 = testListener1.events.get(0)
+        'workflow' == evt1.type
+        ExecutionState.RUNNING == evt1.state
+
+        def evt2 = testListener1.events.get(1)
+        evt2.type == 'step'
+        evt2.change.stepState.executionState == ExecutionState.RUNNING
+
+        if (size > 2) {
+            def evt3 = testListener1.events.get(2)
+            evt3.type == 'step'
+            evt3.change.stepState.executionState == ExecutionState.SUCCEEDED
+        }
+
+        where:
+        isNodeStep | size
+        false      | 3
+        true       | 2
+
+    }
+}


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**

Fix #3791 


**Describe the solution you've implemented**

* fix incorrect test for node step items.  Job references were incorrectly treated as node steps in all cases, and final state was not correctly updated when they were non-node-steps.
