### PR TITLE
Remove index for storage dir field to prevent mysql warning

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Storage.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Storage.groovy
@@ -20,6 +20,8 @@ import com.dtolabs.rundeck.app.support.DomainIndexHelper
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.rundeck.storage.api.PathUtil
 
+import static grails.gorm.hibernate.mapping.MappingBuilder.orm
+
 
 class Storage {
     String namespace
@@ -58,16 +60,18 @@ class Storage {
     def beforeValidate() {
         setupSha()
     }
-    static mapping= {
-        cache: true
-        data(type: 'binary')
-        dir(type: 'string')
-        jsonData(type: 'text')
-        name(type: 'string')
+    static final mapping = orm {
+        cache {
+            enabled true
+            usage 'nonstrict-read-write'
+        }
+        property 'data', [type: 'binary']
+        property 'dir', [type: 'string']
+        property 'jsonData', [type: 'text']
+        property 'name', [type: 'string']
 
         DomainIndexHelper.generate(delegate) {
             index 'STORAGE_IDX_NAMESPACE', ['namespace']
-            index 'STORAGE_IDX_DIR', ['dir']
         }
     }
     //ignore fake property 'storageMeta' and 'path' and do not store it

--- a/test/docker/docker-compose-api-mysql.yaml
+++ b/test/docker/docker-compose-api-mysql.yaml
@@ -31,6 +31,7 @@ services:
       - TEST_NC_HOST=rundeck1
       - WAIT_NODES=rundeck1
       - CONFIG_SCRIPT_PRESTART=scripts/config-db.sh
+      - "STARTUP_FAILURE_MSG=MySQLSyntaxErrorException"
       - DATABASE_DRIVER=com.mysql.jdbc.Driver
       - DATABASE_URL=jdbc:mysql://mysql:3306/rundeck?autoReconnect=true&useUnicode=yes&useSSL=false
       - DATABASE_USER=rundeck

--- a/test/docker/dockers/rundeck/scripts/start_rundeck.sh
+++ b/test/docker/dockers/rundeck/scripts/start_rundeck.sh
@@ -306,6 +306,13 @@ do
       echo "Still working. hang on..."; # output a progress character.
     else  break; # found successful startup message.
     fi
+    if [ -n "$STARTUP_FAILURE_MSG" ] ; then
+      if grep "${STARTUP_FAILURE_MSG}" "$LOGFILE" ; then
+        >&2 grep "${STARTUP_FAILURE_MSG}" "$LOGFILE"
+        echo >&2 "FAIL: found startup failure message: ${STARTUP_FAILURE_MSG}"
+        exit 1
+      fi
+    fi
     (( count += 1 ))  ; # increment attempts counter.
     (( count == MAX_ATTEMPTS )) && {
         echo >&2 "FAIL: Reached max attempts to find success message in logfile. Exiting."


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #3785 

**Describe the solution you've implemented**

Remove the index on the dir field


**Additional context**

Add check in mysql API tests to fail if startup log contains mysql exceptions