### PR TITLE
Project description on project list api call

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
@@ -26,15 +26,16 @@ class ApiVersions {
     public static final int V23 = 23
     public static final int V24 = 24
     public static final int V25 = 25
+    public static final int V26 = 26
     public static final Map VersionMap = [:]
-    public static final List Versions = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25]
+    public static final List Versions = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18, V19, V20, V21, V22, V23, V24, V25, V26]
     static {
         Versions.each { VersionMap[it.toString()] = it }
     }
     public static final Set VersionStrings = new HashSet(VersionMap.values())
 
     public final static int API_EARLIEST_VERSION = V1
-    public final static int API_CURRENT_VERSION = V25
+    public final static int API_CURRENT_VERSION = V26
     public final static int API_MIN_VERSION = API_EARLIEST_VERSION
     public final static int API_MAX_VERSION = API_CURRENT_VERSION
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
@@ -239,15 +239,15 @@ class ApiControllerSpec extends Specification {
         ''    | [:]                                                           | false              | false     | [:]
         ''    | [:]                                                           | false  | false     | [:]
         ''    | [metrics: true]                                               | false | false     | [:]
-        ''    | [metrics: true]                                               | true                                                                          | false                                                                                                | [metrics: [href: '/api/25/metrics/metrics']]
-        ''    | [healthcheck: true]                                           | true                                                                      | false                                                                                                | [healthcheck: [href: '/api/25/metrics/healthcheck']]
-        ''    | [ping: true]                                                  | true                                                                             | false                                                                                                | [ping: [href: '/api/25/metrics/ping']]
-        ''    | [threads: true]                                               | true                                                                          | false                                                                                                | [threads: [href: '/api/25/metrics/threads']]
+        ''    | [metrics: true]                                               | true                                                                          | false                                                                                                | [metrics: [href: '/api/26/metrics/metrics']]
+        ''    | [healthcheck: true]                                           | true                                                                      | false                                                                                                | [healthcheck: [href: '/api/26/metrics/healthcheck']]
+        ''    | [ping: true]                                                  | true                                                                             | false                                                                                                | [ping: [href: '/api/26/metrics/ping']]
+        ''    | [threads: true]                                               | true                                                                          | false                                                                                                | [threads: [href: '/api/26/metrics/threads']]
         ''    | [threads: true, ping: true, metrics: true, healthcheck: true] | true                            | false                                                                                                | [
-            metrics    : [href: '/api/25/metrics/metrics'],
-            threads    : [href: '/api/25/metrics/threads'],
-            healthcheck: [href: '/api/25/metrics/healthcheck'],
-            ping       : [href: '/api/25/metrics/ping'],
+            metrics    : [href: '/api/26/metrics/metrics'],
+            threads    : [href: '/api/26/metrics/threads'],
+            healthcheck: [href: '/api/26/metrics/healthcheck'],
+            ping       : [href: '/api/26/metrics/ping'],
         ]
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
@@ -17,6 +17,7 @@
 package rundeck.controllers
 
 import com.dtolabs.rundeck.app.api.ApiMarshallerRegistrar
+import com.dtolabs.rundeck.app.api.ApiVersions
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import grails.converters.JSON
 import grails.converters.XML
@@ -239,15 +240,15 @@ class ApiControllerSpec extends Specification {
         ''    | [:]                                                           | false              | false     | [:]
         ''    | [:]                                                           | false  | false     | [:]
         ''    | [metrics: true]                                               | false | false     | [:]
-        ''    | [metrics: true]                                               | true                                                                          | false                                                                                                | [metrics: [href: '/api/26/metrics/metrics']]
-        ''    | [healthcheck: true]                                           | true                                                                      | false                                                                                                | [healthcheck: [href: '/api/26/metrics/healthcheck']]
-        ''    | [ping: true]                                                  | true                                                                             | false                                                                                                | [ping: [href: '/api/26/metrics/ping']]
-        ''    | [threads: true]                                               | true                                                                          | false                                                                                                | [threads: [href: '/api/26/metrics/threads']]
+        ''    | [metrics: true]                                               | true                                                                          | false                                                                                                | [metrics: [href: '/api/'+ApiVersions.API_CURRENT_VERSION+'/metrics/metrics']]
+        ''    | [healthcheck: true]                                           | true                                                                      | false                                                                                                | [healthcheck: [href: '/api/'+ApiVersions.API_CURRENT_VERSION+'/metrics/healthcheck']]
+        ''    | [ping: true]                                                  | true                                                                             | false                                                                                                | [ping: [href: '/api/'+ApiVersions.API_CURRENT_VERSION+'/metrics/ping']]
+        ''    | [threads: true]                                               | true                                                                          | false                                                                                                | [threads: [href: '/api/'+ApiVersions.API_CURRENT_VERSION+'/metrics/threads']]
         ''    | [threads: true, ping: true, metrics: true, healthcheck: true] | true                            | false                                                                                                | [
-            metrics    : [href: '/api/26/metrics/metrics'],
-            threads    : [href: '/api/26/metrics/threads'],
-            healthcheck: [href: '/api/26/metrics/healthcheck'],
-            ping       : [href: '/api/26/metrics/ping'],
+            metrics    : [href: '/api/'+ApiVersions.API_CURRENT_VERSION+'/metrics/metrics'],
+            threads    : [href: '/api/'+ApiVersions.API_CURRENT_VERSION+'/metrics/threads'],
+            healthcheck: [href: '/api/'+ApiVersions.API_CURRENT_VERSION+'/metrics/healthcheck'],
+            ping       : [href: '/api/'+ApiVersions.API_CURRENT_VERSION+'/metrics/ping'],
         ]
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerTest.groovy
@@ -18,6 +18,9 @@
 package rundeck.controllers
 
 import com.dtolabs.rundeck.app.api.ApiVersions
+import com.dtolabs.rundeck.core.common.IRundeckProject
+import com.dtolabs.rundeck.server.projects.RundeckProject
+import groovy.mock.interceptor.StubFor
 
 import static org.junit.Assert.*
 
@@ -99,21 +102,27 @@ class ProjectControllerTest {
     }
     @Test
     void apiProjectList_json(){
+        def prja = new MockFor(IRundeckProject)
+        prja.demand.getName(1..3) { -> 'testproject'}
+        prja.demand.getProjectProperties(1..2){ -> [:]}
+        def prjb = new MockFor(IRundeckProject)
+        prjb.demand.getName(1..3) { -> 'testproject2'}
+        prjb.demand.getProjectProperties(1..2){ -> [:]}
         controller.frameworkService = mockWith(FrameworkService) {
             getAuthContextForSubject(1..1) { subj ->
                 null
             }
             projects(1..1) { auth ->
                 [
-                        [name: 'testproject'],
-                        [name: 'testproject2'],
+                        prja.proxyInstance(),
+                        prjb.proxyInstance(),
                 ]
             }
         }
         controller.apiService=mockWith(ApiService){
             requireApi(1..1){req,resp->true}
         }
-
+        request.setAttribute('api_version', 24)
         response.format='json'
         controller.apiProjectList()
         def base='http://localhost:8080/api/'+ApiVersions.API_CURRENT_VERSION
@@ -126,6 +135,44 @@ class ProjectControllerTest {
         assert response.json[1].description==''
         assert response.json[1].url==base+'/project/testproject2'
     }
+    @Test
+    void apiProjectList_v26_json(){
+        def prja = new MockFor(IRundeckProject)
+        prja.demand.getName(1..3) { -> 'testproject'}
+        prja.demand.getProjectProperties(1..2){ -> [:]}
+        def prjb = new MockFor(IRundeckProject)
+        prjb.demand.getName(1..3) { -> 'testproject2'}
+        prjb.demand.getProjectProperties(1..2){ -> [:]}
+        controller.frameworkService = mockWith(FrameworkService) {
+            getAuthContextForSubject(1..1) { subj ->
+                null
+            }
+            projects(1..1) { auth ->
+                [
+                        prja.proxyInstance(),
+                        prjb.proxyInstance(),
+                ]
+            }
+        }
+        controller.apiService=mockWith(ApiService){
+            requireApi(1..1){req,resp->true}
+        }
+        request.setAttribute('api_version', 26)
+        response.format='json'
+        controller.apiProjectList()
+        def base='http://localhost:8080/api/'+ApiVersions.API_CURRENT_VERSION
+        assert response.status == HttpServletResponse.SC_OK
+        assert response.json.size()==2
+        assert response.json[0].name=='testproject'
+        assert response.json[0].description==''
+        assert response.json[0].label==''
+        assert response.json[0].url==base+'/project/testproject'
+        assert response.json[1].name=='testproject2'
+        assert response.json[1].description==''
+        assert response.json[1].label==''
+        assert response.json[1].url==base+'/project/testproject2'
+    }
+
     @Test
     void apiProjectList_unacceptableReceivesXml(){
         controller.frameworkService = mockWith(FrameworkService) {
@@ -241,6 +288,11 @@ class ProjectControllerTest {
 
     private Object createFrameworkService(boolean configAuth, String projectName, LinkedHashMap<String,
     String> projectProperties=[:]) {
+        def prja = new StubFor(IRundeckProject)
+        prja.demand.getName(0..10) { -> 'test1'}
+        prja.demand.getProjectProperties(0..1){ -> [:]}
+        prja.demand.hasProperty(0..1){ String prop -> false}
+        def pInstance = prja.proxyInstance()
         mockWith(FrameworkService) {
             getAuthContextForSubject(1..1) { subj ->
                 null
@@ -282,11 +334,11 @@ class ProjectControllerTest {
             }
             getFrameworkProject(1..1) { String name ->
                 assertEquals(projectName, name)
-                [name: projectName]
+                pInstance
             }
             if(configAuth){
                 loadProjectProperties(1..1){pject->
-                    assertEquals([name:projectName],pject)
+                    assertEquals(pInstance,pject)
                     projectProperties
                 }
             }
@@ -811,6 +863,10 @@ class ProjectControllerTest {
     private Object mockFrameworkServiceForProjectCreate(boolean authorized, boolean exists, ArrayList createErrors,
                                                        LinkedHashMap<String, String> inputProps,
                                                        LinkedHashMap<String, String> configProps) {
+        def prja = new StubFor(IRundeckProject)
+        prja.demand.getName(0..10) { -> 'test1'}
+        prja.demand.getProjectProperties(0..1){ -> [:]}
+
         mockWith(FrameworkService) {
             getAuthContextForSubject(1..1) { subject -> null }
             authorizeApplicationResourceTypeAll { auth, type, actions ->
@@ -831,7 +887,7 @@ class ProjectControllerTest {
             createFrameworkProject { name, props ->
                 assertEquals 'test1', name
                 assertEquals(inputProps, props)
-                [createErrors.size() > 0 ? null: [name: 'test1'], createErrors]
+                [createErrors.size() > 0 ? null: prja.proxyInstance(), createErrors]
             }
             if(createErrors.size()>0){
                 return

--- a/test/api/include.sh
+++ b/test/api/include.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # common header for test scripts
-API_CURRENT_VERSION=25
+API_CURRENT_VERSION=26
 
 SRC_DIR=$(cd `dirname $0` && pwd)
 DIR=${TMP_DIR:-$SRC_DIR}


### PR DESCRIPTION
fix #3827 

Project description from project configuration file and adds the label on new API version v26

Using API version >=26 adds the project `label` to the API call  `/api/26/projects` 

```
[
    {
        "name":"...",
        "description":"...",
        "url":"...",
       "label":"..."
    }
]
```
Doc documentation PR: rundeck/docs#72