### PR TITLE
Fix #3840 restore jetty forwarded headers support

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -471,5 +471,6 @@ beans={
         initParams = configParams?.toProperties()?.collectEntries {
             [it.key.toString(), it.value.toString()]
         }
+        useForwardHeaders = Boolean.getBoolean('rundeck.jetty.connector.forwarded')
     }
 }

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -15,6 +15,7 @@
  */
 package rundeckapp.init.servlet
 
+import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.webapp.AbstractConfiguration
 import org.eclipse.jetty.webapp.WebAppContext
 import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer
@@ -29,11 +30,15 @@ class JettyServletContainerCustomizer implements EmbeddedServletContainerCustomi
      * Set of init parameters to set in the web app context
      */
     Map<String, String> initParams = [:]
+    boolean useForwardHeaders
 
     @Override
     void customize(final ConfigurableEmbeddedServletContainer container) {
         if(container instanceof JettyEmbeddedServletContainerFactory) {
             container.addConfigurations(new JettyConfigPropsInitParameterConfiguration(initParams))
+            if(useForwardHeaders) {
+                container.useForwardHeaders = useForwardHeaders
+            }
         }
     }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #3840 

**Describe the solution you've implemented**

Enable `rundeck.jetty.connector.forwarded` system property to enable the jetty forwarded headers support.

**Additional context**

Spring boot jetty settings already supports this with the `server.useForwardHeaders=true` setting which can be set in rundeck-config.properties. This PR restores the functionality of enabling it via system property.