### PR TITLE
Fix #3828 node names with / break GUI output loading

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -191,7 +191,7 @@ function WorkflowStepInfo(multiworkflow,stepctx,data){
     self.parentStepInfo=ko.computed(function(){
         var ctx=self.stepctxArray();
         if(ctx.length>1) {
-            var parent = ctx.slice(0, -1).join('/');
+            var parent = RDWorkflow.createContextId(ctx.slice(0, -1));
             return self.multiworkflow.getStepInfoForStepctx(parent);
         }
         return null;
@@ -574,7 +574,7 @@ function MultiWorkflow(workflowInfo,data){
         var ndx = RDWorkflow.workflowIndexForContextId(lastctx);
 
         //get the parent workflow, and then fill in the current step
-        self.getParentJobStepInfoForStepctx(ctx.join('/'),function(parentjobinfo){
+        self.getParentJobStepInfoForStepctx(RDWorkflow.createContextId(ctx),function(parentjobinfo){
             //TODO: currently node summary state context string does not indicate errorHandler, but
             //in case it does in the future, force use of correct job info
             var iseh=ctx.length>0?RDWorkflow.isErrorhandlerForContextId(ctx[ctx.length-1]):false;

--- a/rundeckapp/grails-app/assets/javascripts/util/testing.js
+++ b/rundeckapp/grails-app/assets/javascripts/util/testing.js
@@ -130,7 +130,7 @@ var TestHarness = function (name,data) {
 
     self.testAll = function () {
         self.prepare();
-        jQuery(document.body).append(jQuery('<div id="'+ident+'" class="collapse in"></div>'));
+        jQuery('body > div.wrapper > div.main-panel').append(jQuery('<div id="'+ident+'" class="collapse in"></div>'));
         var jQuery2 = jQuery('#'+ident);
         self.log("Start: "+self.name);
         for (var i in self) {
@@ -149,7 +149,7 @@ var TestHarness = function (name,data) {
             jQuery2.prepend(jQuery('<div></div>').append(jQuery('<span class="text-danger"></span>').text("FAIL: " + failed+"/"+total+" assertions failed")));
         }else{
             jQuery2.collapse('hide');
-            jQuery(document.body).append('<div></div>')
+            jQuery('body > div.wrapper > div.main-panel').append('<div></div>')
                 .append('<span class="btn btn-link text-success" data-toggle="collapse" data-target="#'+ident+'">OK: '+total+' Tests Passed</span>')
         }
         self.restore();

--- a/rundeckapp/grails-app/assets/javascripts/workflow.js
+++ b/rundeckapp/grails-app/assets/javascripts/workflow.js
@@ -147,6 +147,24 @@ RDWorkflow.unescape=function(input,echar,chars,breakchars){
     return {text:arr.join(""),bchar:bchar,rest:i<=input.length-1?input.substring(i+1):null};
 };
 /**
+ * escape listed chars in the string with the escape char
+ * @param str input string
+ * @param echar escape char
+ * @param chars chars to be escaped
+ * @returns {string}
+ */
+RDWorkflow.escapeStr = function (str, echar, chars) {
+    var arr = [];
+    for (var i = 0; i < str.length; i++) {
+        var c = str.charAt(i);
+        if(chars.indexOf(c)>=0){
+            arr.push(echar);
+        }
+        arr.push(c);
+    }
+    return arr.join("");
+};
+/**
  *
  * @param input
  * @param sep
@@ -165,6 +183,23 @@ RDWorkflow.splitEscaped=function(input,sep){
     return parts;
 };
 /**
+ * join array strings into single string using the separator, escaping
+ * internal chars with backslash
+ * @param arr array of strings
+ * @param sep separator char
+ * @returns {string}
+ */
+RDWorkflow.joinEscaped = function (arr, sep) {
+    var res = [];
+    for (var i = 0; i < arr.length; i++) {
+        if (i > 0) {
+            res.push(sep);
+        }
+        res.push(RDWorkflow.escapeStr(arr[i], '\\', ['\\', sep]));
+    }
+    return res.join("");
+};
+/**
  * Returns array of step context strings given the context identifier
  * @param context
  * @returns {*}
@@ -174,9 +209,29 @@ RDWorkflow.parseContextId= function (context) {
     if (context == null) {
         return null;
     }
+    //if context is already array, return it
+    if (jQuery.isArray(context)) {
+        return context;
+    }
     //split context into project,type,object
     var t = RDWorkflow.splitEscaped(context,RDWorkflow.contextStringSeparator);
     return t.slice();
+};
+/**
+ * Create context ID string by joining context array with appropriate escaping
+ * @param contextArr
+ * @returns {*}
+ */
+RDWorkflow.createContextId = function (contextArr) {
+    if (contextArr == null) {
+        return null;
+    }
+    //if context is already array, return it
+    if (!jQuery.isArray(contextArr)) {
+        contextArr = [contextArr];
+    }
+    //split context into project,type,object
+    return RDWorkflow.joinEscaped(contextArr, RDWorkflow.contextStringSeparator);
 };
 
 /**

--- a/rundeckapp/grails-app/assets/javascripts/workflow.test.js
+++ b/rundeckapp/grails-app/assets/javascripts/workflow.test.js
@@ -21,7 +21,7 @@
 jQuery(function () {
     "use strict";
     new TestHarness("workflow.test.js", {
-        workflowTest: function () {
+        unescapeTest: function () {
 
             this.assert("unescape", RDWorkflow.unescape('abc/123', '\\', ['\\', '/'], ['/']), {
                 text: 'abc',
@@ -39,9 +39,18 @@ jQuery(function () {
                 rest: '123/456'
             });
         },
+        escapeStrTest: function(){
+            this.assert("escapeStr", RDWorkflow.escapeStr('abc/123', '\\', ['\\', '/']), 'abc\\/123');
+            this.assert("escapeStr", RDWorkflow.escapeStr('abc\\123', '\\', ['\\', '/']), 'abc\\\\123');
+        },
         splitEscapedTest: function () {
             this.assert("splitEscaped", RDWorkflow.splitEscaped('a\\/bc/123/456', '/'), ['a/bc', '123', '456']);
             this.assert("splitEscaped", RDWorkflow.splitEscaped('a\\/b@c/1,2=3/4\\\\56', '/'), ['a/b@c', '1,2=3', '4\\56']);
+
+        },
+        joinEscapedTest: function () {
+            this.assert("joinEscaped", RDWorkflow.joinEscaped(['a/bc','123','456'], '/'), 'a\\/bc/123/456');
+            this.assert("joinEscaped", RDWorkflow.joinEscaped(['a/b@c','1,2=3','4\\56'], '/'), 'a\\/b@c/1,2=3/4\\\\56');
 
         },
         isErrorhandlerForContextIdTest: function () {
@@ -85,6 +94,18 @@ jQuery(function () {
             this.assert("parseContextId", RDWorkflow.parseContextId('1e@abc/2/3'), ['1e@abc', '2', '3']);
             this.assert("parseContextId", RDWorkflow.parseContextId('1/2e@asdf=xyz/3'), ['1', '2e@asdf=xyz', '3']);
             this.assert("parseContextId", RDWorkflow.parseContextId('2@node=crub\\/dub-1/1'), ['2@node=crub/dub-1', '1']);
+
+
+        },
+        createContextIdTest: function () {
+            //parse context id
+            this.assert("createContextId", RDWorkflow.createContextId(['1']),'1');
+            this.assert("createContextId", RDWorkflow.createContextId(['1', '1']), '1/1');
+            this.assert("createContextId", RDWorkflow.createContextId(['1', '1', '1']),'1/1/1' );
+            this.assert("createContextId", RDWorkflow.createContextId(['1', '2', '3']),'1/2/3' );
+            this.assert("createContextId", RDWorkflow.createContextId(['1e@abc', '2', '3']), '1e@abc/2/3');
+            this.assert("createContextId", RDWorkflow.createContextId(['1', '2e@asdf=xyz', '3']),'1/2e@asdf=xyz/3' );
+            this.assert("createContextId", RDWorkflow.createContextId(['2@node=crub/dub-1', '1']),'2@node=crub\\/dub-1/1' );
 
 
         },


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #3828 

**Describe the solution you've implemented**

Properly escape `/` char in node names when loading workflow step details in a workflow with node-step job references.


**Additional context**

Docker plugin was generating node names like `/word_word` breaking output loading in some cases when viewing execution output.