### PR TITLE
Bintray debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+*.orig
 !.github
 !.gitignore
 *~
@@ -15,6 +16,7 @@
 **/*/out
 makeenv
 /artifacts
+/ci-resources
 /cobertura.ser
 /gradle-cache
 /rundeckapp/stacktrace.log

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ ext.exportedProjects = [
 ]
 
 project.ext.environment = project.hasProperty('environment') ? environment : 'development'
+project.ext.artifactDir = "$projectDir/artifacts"
 
 def versionProps = new Properties()
 file("version.properties").withInputStream { versionProps.load(it) }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -317,8 +317,8 @@ bintray {
 
     if (findProperty('bintrayUseExisting')) {
         filesSpec {
-            from 'build/libs'
-            from 'build/poms'
+            from "$artifactDir/core/build/libs"
+            from "$artifactDir/core/build/poms"
             into "${project.group}.rundeck-${project.name}".replace('.', '/') + "/$version"
             rename { file ->
                 if (file =~ /^pom/)

--- a/rundeck-storage/build.gradle
+++ b/rundeck-storage/build.gradle
@@ -52,8 +52,8 @@ project(':rundeck-storage:rundeck-storage-api') {
 
         if (findProperty('bintrayUseExisting')) {
             filesSpec {
-                from 'build/libs'
-                from 'build/poms'
+                from "$artifactDir/rundeck-storage/$project.name/build/libs"
+                from "$artifactDir/rundeck-storage/$project.name/build/poms"
                 into "${project.group}.${project.name}".replace('.', '/') + "/$version"
                 rename { file ->
                     if (file =~ /^pom/)
@@ -100,8 +100,8 @@ project(':rundeck-storage:rundeck-storage-data') {
 
         if (findProperty('bintrayUseExisting')) {
             filesSpec {
-                from 'build/libs'
-                from 'build/poms'
+                from "$artifactDir/rundeck-storage/$project.name/build/libs"
+                from "$artifactDir/rundeck-storage/$project.name/build/poms"
                 into "${project.group}.${project.name}".replace('.', '/') + "/$version"
                 rename { file ->
                     if (file =~ /^pom/)
@@ -147,8 +147,8 @@ project(':rundeck-storage:rundeck-storage-conf') {
 
         if (findProperty('bintrayUseExisting')) {
             filesSpec {
-                from 'build/libs'
-                from 'build/poms'
+                from "$artifactDir/rundeck-storage/$project.name/build/libs"
+                from "$artifactDir/rundeck-storage/$project.name/build/poms"
                 into "${project.group}.${project.name}".replace('.', '/') + "/$version"
                 rename { file ->
                     if (file =~ /^pom/)
@@ -196,8 +196,8 @@ project(':rundeck-storage:rundeck-storage-filesys') {
 
         if (findProperty('bintrayUseExisting')) {
             filesSpec {
-                from 'build/libs'
-                from 'build/poms'
+                from "$artifactDir/rundeck-storage/$project.name/build/libs"
+                from "$artifactDir/rundeck-storage/$project.name/build/poms"
                 into "${project.group}.${project.name}".replace('.', '/') + "/$version"
                 rename { file ->
                     if (file =~ /^pom/)

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -307,9 +307,10 @@ bintray {
 
     if (findProperty('bintrayUseExisting')) {
         filesSpec {
-            from 'build/libs'
-            from 'build/poms'
+            from "$artifactDir/rundeckapp/build/libs"
+            from "$artifactDir/rundeckapp/build/poms"
             into "${project.group}.${project.name}".replace('.', '/') + "/$version"
+            exclude '*.original'
             rename { file ->
                 if (file =~ /^pom/)
                     return "rundeck-${version}.pom"


### PR DESCRIPTION
Uploads existing artifacts directly from their location in the artifacts directory.

Gradle seems to remove the project build directories when `bintrayUpload` is run if the project has never been built.