### PR TITLE
Fix: local node executor provider can't be chosen in project config defaults

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/orchestrator/OrchestratorService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/orchestrator/OrchestratorService.java
@@ -38,12 +38,6 @@ public class OrchestratorService extends FrameworkPluggableProviderService<Orche
         super(SERVICE_NAME, framework, OrchestratorPlugin.class);
     }
 
-    @Override
-    public boolean isScriptPluggable() {
-        
-        return false;
-    }
-
     public Description getDescription(String name){
         for(Description description: listDescriptions()){
             if(description.getName().equals(name)){

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/service/FileCopierService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/service/FileCopierService.java
@@ -27,11 +27,7 @@ import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.execution.impl.jsch.JschScpFileCopier;
 import com.dtolabs.rundeck.core.execution.impl.local.LocalFileCopier;
-import com.dtolabs.rundeck.core.plugins.PluggableProviderService;
-import com.dtolabs.rundeck.core.plugins.PluginException;
-import com.dtolabs.rundeck.core.plugins.ProviderIdent;
-import com.dtolabs.rundeck.core.plugins.ScriptPluginProvider;
-import com.dtolabs.rundeck.core.plugins.configuration.Describable;
+import com.dtolabs.rundeck.core.plugins.*;
 import com.dtolabs.rundeck.core.plugins.configuration.DescribableService;
 import com.dtolabs.rundeck.core.plugins.configuration.DescribableServiceUtil;
 import com.dtolabs.rundeck.core.plugins.configuration.Description;
@@ -48,7 +44,10 @@ import java.util.List;
  */
 public class FileCopierService
     extends NodeSpecifiedService<FileCopier>
-    implements DescribableService, PluggableProviderService<FileCopier>
+    implements DescribableService,
+               PluggableProviderService<FileCopier>,
+               JavaClassProviderLoadable<FileCopier>,
+               ScriptPluginProviderLoadable<FileCopier>
 {
     private static final String SERVICE_NAME = ServiceNameConstants.FileCopier;
     public static final String SERVICE_DEFAULT_PROVIDER_PROPERTY = "service." + SERVICE_NAME + ".default.provider";
@@ -111,10 +110,6 @@ public class FileCopierService
     @Override
     public <X extends FileCopier> FileCopier createProviderInstance(Class<X> clazz, String name) throws PluginException, ProviderCreationException {
         return createProviderInstanceFromType(clazz, name);
-    }
-
-    public boolean isScriptPluggable() {
-        return true;
     }
 
     public FileCopier createScriptProviderInstance(final ScriptPluginProvider provider) throws PluginException {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeExecutorService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeExecutorService.java
@@ -28,19 +28,13 @@ import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.execution.impl.jsch.JschNodeExecutor;
 import com.dtolabs.rundeck.core.execution.impl.local.LocalNodeExecutor;
 import com.dtolabs.rundeck.core.execution.impl.local.NewLocalNodeExecutor;
-import com.dtolabs.rundeck.core.plugins.PluggableProviderService;
-import com.dtolabs.rundeck.core.plugins.PluginException;
-import com.dtolabs.rundeck.core.plugins.ProviderIdent;
-import com.dtolabs.rundeck.core.plugins.ScriptPluginProvider;
+import com.dtolabs.rundeck.core.plugins.*;
 import com.dtolabs.rundeck.core.plugins.configuration.*;
-import com.dtolabs.rundeck.core.resources.ResourceModelSource;
-import com.dtolabs.rundeck.core.resources.ResourceModelSourceFactory;
 import com.dtolabs.rundeck.plugins.ServiceNameConstants;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 
 /**
  * CommandExecutorFactory is ...
@@ -49,7 +43,10 @@ import java.util.Properties;
  */
 public class NodeExecutorService
     extends NodeSpecifiedService<NodeExecutor>
-    implements DescribableService, PluggableProviderService<NodeExecutor>
+    implements DescribableService,
+               PluggableProviderService<NodeExecutor>,
+               JavaClassProviderLoadable<NodeExecutor>,
+               ScriptPluginProviderLoadable<NodeExecutor>
 {
     private static final String SERVICE_NAME = ServiceNameConstants.NodeExecutor;
     public static final String SERVICE_DEFAULT_PROVIDER_PROPERTY = "service." + SERVICE_NAME + ".default.provider";
@@ -109,10 +106,6 @@ public class NodeExecutorService
     @Override
     public <X extends NodeExecutor> NodeExecutor createProviderInstance(Class<X> clazz, String name) throws PluginException, ProviderCreationException {
         return createProviderInstanceFromType(clazz, name);
-    }
-
-    public boolean isScriptPluggable() {
-        return true;
     }
 
     public NodeExecutor createScriptProviderInstance(final ScriptPluginProvider provider) throws PluginException {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/WorkflowStrategyService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/WorkflowStrategyService.java
@@ -5,6 +5,7 @@ import com.dtolabs.rundeck.core.common.IRundeckProjectConfig;
 import com.dtolabs.rundeck.core.common.ProviderService;
 import com.dtolabs.rundeck.core.execution.service.ExecutionServiceException;
 import com.dtolabs.rundeck.core.execution.service.ProviderCreationException;
+import com.dtolabs.rundeck.core.execution.service.ProviderLoaderException;
 import com.dtolabs.rundeck.core.plugins.*;
 import com.dtolabs.rundeck.core.plugins.configuration.*;
 import com.dtolabs.rundeck.plugins.ServiceNameConstants;
@@ -60,6 +61,26 @@ public class WorkflowStrategyService extends ChainedProviderService<WorkflowStra
 
         serviceList.add(builtinService);
         serviceList.add(pluginService);
+    }
+
+    @Override
+    public boolean canLoadWithLoader(final ProviderLoader loader) {
+        return pluginService.canLoadWithLoader(loader);
+    }
+
+    @Override
+    public WorkflowStrategy loadWithLoader(final String providerName, final ProviderLoader loader)
+        throws ProviderLoaderException
+    {
+        return pluginService.loadWithLoader(providerName,loader);
+    }
+
+    @Override
+    public CloseableProvider<WorkflowStrategy> loadCloseableWithLoader(
+        final String providerName, final ProviderLoader loader
+    ) throws ProviderLoaderException
+    {
+        return pluginService.loadCloseableWithLoader(providerName,loader);
     }
 
     @Override
@@ -173,28 +194,6 @@ public class WorkflowStrategyService extends ChainedProviderService<WorkflowStra
 
     public List<ProviderIdent> listDescribableProviders() {
         return DescribableServiceUtil.listDescribableProviders(this);
-    }
-
-    @Override
-    public boolean isValidProviderClass(final Class clazz) {
-        return pluginService.isValidProviderClass(clazz);
-    }
-
-    @Override
-    public <X extends WorkflowStrategy> WorkflowStrategy createProviderInstance(final Class<X> clazz, final String name)
-            throws PluginException, ProviderCreationException
-    {
-        return pluginService.createProviderInstance(clazz, name);
-    }
-
-    @Override
-    public boolean isScriptPluggable() {
-        return pluginService.isScriptPluggable();
-    }
-
-    @Override
-    public WorkflowStrategy createScriptProviderInstance(final ScriptPluginProvider provider) throws PluginException {
-        return pluginService.createScriptProviderInstance(provider);
     }
 
     public void registerClass(String name, Class<? extends WorkflowStrategy> clazz) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/PluginStepExecutionService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/PluginStepExecutionService.java
@@ -36,15 +36,11 @@ import com.dtolabs.rundeck.plugins.step.StepPlugin;
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
 class PluginStepExecutionService extends FrameworkPluggableProviderService<StepPlugin>
-    implements FrameworkSupportService, DescribableService {
+    implements FrameworkSupportService, DescribableService, ScriptPluginProviderLoadable<StepPlugin>
+{
 
     PluginStepExecutionService(final String name, final Framework framework) {
         super(name, framework, StepPlugin.class);
-    }
-
-    @Override
-    public boolean isScriptPluggable() {
-        return true;
     }
 
     @Override

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
@@ -79,6 +79,11 @@ class NodeStepPluginAdapter implements NodeStepExecutor, Describable, DynamicPro
         this.plugin = plugin;
     }
 
+    public static boolean canAdaptType(Class<?> testType){
+        return NodeStepPlugin.class.isAssignableFrom(testType);
+    }
+
+
     static class Convert implements Converter<NodeStepPlugin, NodeStepExecutor> {
         public NodeStepExecutor convert(final NodeStepPlugin plugin) {
             return new NodeStepPluginAdapter(plugin);

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginService.java
@@ -34,17 +34,15 @@ import com.dtolabs.rundeck.plugins.step.NodeStepPlugin;
  *
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
-class NodeStepPluginService extends FrameworkPluggableProviderService<NodeStepPlugin> implements DescribableService {
+class NodeStepPluginService extends FrameworkPluggableProviderService<NodeStepPlugin> implements DescribableService,
+                                                                                                 ScriptPluginProviderLoadable<NodeStepPlugin>
+{
 
     /**
      * Create the service with a given name
      */
     public NodeStepPluginService(final String name, final Framework framework) {
         super(name, framework, NodeStepPlugin.class);
-    }
-
-    public boolean isScriptPluggable() {
-        return true;
     }
 
     public NodeStepPlugin createScriptProviderInstance(ScriptPluginProvider provider) throws PluginException {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/RemoteScriptNodeStepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/RemoteScriptNodeStepPluginAdapter.java
@@ -85,6 +85,10 @@ class RemoteScriptNodeStepPluginAdapter implements NodeStepExecutor, Describable
         this.scriptUtils = scriptUtils;
     }
 
+    public static boolean canAdaptType(Class<?> testType){
+        return RemoteScriptNodeStepPlugin.class.isAssignableFrom(testType);
+    }
+
     static class Convert implements Converter<RemoteScriptNodeStepPlugin, NodeStepExecutor> {
         @Override
         public NodeStepExecutor convert(final RemoteScriptNodeStepPlugin plugin) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/RemoteScriptNodeStepPluginService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/RemoteScriptNodeStepPluginService.java
@@ -26,6 +26,7 @@ package com.dtolabs.rundeck.core.execution.workflow.steps.node;
 import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.plugins.FrameworkPluggableProviderService;
 import com.dtolabs.rundeck.core.plugins.PluginException;
+import com.dtolabs.rundeck.core.plugins.ScriptPluginProviderLoadable;
 import com.dtolabs.rundeck.core.plugins.ScriptPluginProvider;
 import com.dtolabs.rundeck.core.plugins.configuration.DescribableService;
 import com.dtolabs.rundeck.plugins.ServiceNameConstants;
@@ -39,15 +40,11 @@ import com.dtolabs.rundeck.plugins.step.RemoteScriptNodeStepPlugin;
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
 class RemoteScriptNodeStepPluginService extends FrameworkPluggableProviderService<RemoteScriptNodeStepPlugin>
-    implements DescribableService {
+    implements DescribableService, ScriptPluginProviderLoadable<RemoteScriptNodeStepPlugin>
+{
 
     RemoteScriptNodeStepPluginService(final String name, final Framework framework) {
         super(name, framework, RemoteScriptNodeStepPlugin.class);
-    }
-
-    @Override
-    public boolean isScriptPluggable() {
-        return true;
     }
 
     @Override

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/AdapterService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/AdapterService.java
@@ -25,6 +25,7 @@ package com.dtolabs.rundeck.core.plugins;
 
 import com.dtolabs.rundeck.core.common.ProviderService;
 import com.dtolabs.rundeck.core.execution.service.ExecutionServiceException;
+import com.dtolabs.rundeck.core.plugins.configuration.Description;
 import com.dtolabs.rundeck.core.utils.Converter;
 
 import java.util.*;
@@ -35,11 +36,11 @@ import java.util.*;
  *
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
-public class AdapterService<S,T> implements ProviderService<T> {
-    private ProviderService<S> sourceService;
+public class AdapterService<S,T> implements PluggableProviderService<T> {
+    private PluggableProviderService<S> sourceService;
     private Converter<S,T> converter;
 
-    public AdapterService(final ProviderService<S> sourceService, final Converter<S, T> converter) {
+    public AdapterService(final PluggableProviderService<S> sourceService, final Converter<S, T> converter) {
         this.sourceService = sourceService;
         this.converter = converter;
     }
@@ -65,6 +66,16 @@ public class AdapterService<S,T> implements ProviderService<T> {
     }
 
     @Override
+    public List<ProviderIdent> listDescribableProviders() {
+        return sourceService.listDescribableProviders();
+    }
+
+    @Override
+    public List<Description> listDescriptions() {
+        return sourceService.listDescriptions();
+    }
+
+    @Override
     public String getName() {
         return sourceService.getName();
     }
@@ -84,7 +95,7 @@ public class AdapterService<S,T> implements ProviderService<T> {
      * @param <X> provider type
      * @param <Y> destination type
      */
-    public static <X,Y> AdapterService<X,Y> adaptFor(final ProviderService<X> sourceService,
+    public static <X,Y> AdapterService<X,Y> adaptFor(final PluggableProviderService<X> sourceService,
                                                      final Converter<X, Y> converter) {
         return new AdapterService<X, Y>(sourceService, converter);
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/BasePluggableProviderService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/BasePluggableProviderService.java
@@ -16,7 +16,6 @@
 
 package com.dtolabs.rundeck.core.plugins;
 
-import com.dtolabs.rundeck.core.common.ProviderService;
 import com.dtolabs.rundeck.core.execution.service.ExecutionServiceException;
 import com.dtolabs.rundeck.core.execution.service.MissingProviderException;
 import com.dtolabs.rundeck.core.execution.service.ProviderCreationException;
@@ -34,7 +33,9 @@ import java.util.List;
  * Date: 4/12/13
  * Time: 4:52 PM
  */
-public abstract class BasePluggableProviderService<T> implements PluggableProviderService<T> {
+public abstract class BasePluggableProviderService<T>
+    implements PluggableProviderService<T>, JavaClassProviderLoadable<T>
+{
     protected Class<? extends T> implementationClass;
     protected String name;
 
@@ -97,18 +98,6 @@ public abstract class BasePluggableProviderService<T> implements PluggableProvid
         return providerIdents;
     }
 
-    /**
-     * default implementation returns false, subclasses should override to
-     */
-    public boolean isScriptPluggable() {
-        return false;
-    }
-
-    public T createScriptProviderInstance(ScriptPluginProvider provider)
-            throws PluginException {
-        throw new UnsupportedOperationException("This service does not support script plugins");
-    }
-
     protected T createProviderInstanceFromType(final Class<? extends T> execClass, final String providerName) throws
             ProviderCreationException {
 
@@ -158,7 +147,7 @@ public abstract class BasePluggableProviderService<T> implements PluggableProvid
      * @param <X> provider type
      * @param converter converter
      */
-    public <X> ProviderService<X> adapter(final Converter<T, X> converter) {
+    public <X> PluggableProviderService<X> adapter(final Converter<T, X> converter) {
         return AdapterService.adaptFor(this, converter);
     }
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/BasePluginProviderService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/BasePluginProviderService.java
@@ -57,16 +57,6 @@ public class BasePluginProviderService<T> extends BasePluggableProviderService<T
         return createProviderInstanceFromType(clazz, name);
     }
 
-    public boolean isScriptPluggable() {
-        return false;
-    }
-
-    @Override
-    public T createScriptProviderInstance(final ScriptPluginProvider provider)
-            throws PluginException
-    {
-        return null;
-    }
 
 
     public List<Description> listDescriptions() {

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/FrameworkPluggableProviderService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/FrameworkPluggableProviderService.java
@@ -35,7 +35,7 @@ import java.lang.reflect.Constructor;
  *
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
-public abstract class FrameworkPluggableProviderService<T> extends BasePluggableProviderService<T> {
+public class FrameworkPluggableProviderService<T> extends BasePluggableProviderService<T> {
     private Framework framework;
 
     protected FrameworkPluggableProviderService(final String name,

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/JavaClassProviderLoadable.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/JavaClassProviderLoadable.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.core.plugins;
+
+import com.dtolabs.rundeck.core.execution.service.ProviderCreationException;
+
+/**
+ * Can load a provider from a java class
+ *
+ * @param <T>
+ */
+public interface JavaClassProviderLoadable<T> {
+    /**
+     * @param clazz the class
+     * @return true if the class is a valid provider class for the service
+     */
+    public boolean isValidProviderClass(Class clazz);
+
+    /**
+     * @param clazz the class
+     * @param name  the provider name
+     * @param <X>   subtype of T
+     * @return Create provider instance from a class
+     * @throws PluginException           if the plugin has an error
+     * @throws ProviderCreationException if creating the instance has an error
+     */
+    public <X extends T> T createProviderInstance(Class<X> clazz, final String name) throws PluginException,
+                                                                                            ProviderCreationException;
+
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluggableProviderRegistryService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluggableProviderRegistryService.java
@@ -36,7 +36,7 @@ import java.util.List;
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
 public abstract class PluggableProviderRegistryService<T> extends BaseProviderRegistryService<T> implements
-    PluggableService<T> {
+    PluggableProviderService<T> {
     protected PluggableProviderRegistryService(final Framework framework) {
         super(framework);
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluggableService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluggableService.java
@@ -25,44 +25,51 @@ package com.dtolabs.rundeck.core.plugins;
 
 import com.dtolabs.rundeck.core.common.FrameworkSupportService;
 import com.dtolabs.rundeck.core.execution.service.ProviderCreationException;
+import com.dtolabs.rundeck.core.execution.service.ProviderLoaderException;
 
 /**
- * PluggableService is a service that supports plugin provider classes and optionally supports plugin provider scripts.
+ * PluggableService is a service that supports loading plugins via provider loaders.
  *
- * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
+ * @author Greg Schueler <a href="mailto:greg@rundeck.com">greg@rundeck.com</a>
  */
-public interface PluggableService<T> extends FrameworkSupportService {
+public interface PluggableService<T>
+    extends FrameworkSupportService
+{
     /**
-     * @return true if the class is a valid provider class for the service
-     *
-     * @param clazz the class
+     * @param loader loader
+     * @return true if the loader can be used for this service, by default delegates to the loader's
+     * {@link ProviderLoader#canLoadForService(FrameworkSupportService)}
      */
-    public boolean isValidProviderClass(Class clazz);
+    default boolean canLoadWithLoader(ProviderLoader loader) {
+        return loader.canLoadForService(this);
+    }
 
     /**
-     * @return Create provider instance from a class
+     * Load provider with the given loader
      *
-     * @param clazz the class
-     * @param name  the provider name
-     * @param <X> subtype of T
-     *              @throws PluginException if the plugin has an error
-     *              @throws ProviderCreationException if creating the instance has an error
+     * @param providerName provider name
+     * @param loader       loader
+     * @return loaded provider instance, by default delegates to the loader's
+     * {@link ProviderLoader#load(PluggableService,
+     *         String)}
+     * @throws ProviderLoaderException if an error occurs
      */
-    public <X extends T> T createProviderInstance(Class<X> clazz, final String name) throws PluginException,
-        ProviderCreationException;
+    default T loadWithLoader(String providerName, ProviderLoader loader) throws ProviderLoaderException {
+        return loader.load(this, providerName);
+    }
 
     /**
-     * @return true if the service supports script plugins
-     */
-    public boolean isScriptPluggable();
-
-    /**
-     * @return the instance for a ScriptPluginProvider definition
+     * Load a closeable provider with the given loader
      *
-     * @param provider the script plugin provider
-     *
-     *              @throws PluginException if the plugin has an error
+     * @param providerName provider name
+     * @param loader       loader
+     * @return closeable provider for instance, by default delegates to the loader's {@link
+     *         ProviderLoader#loadCloseable(PluggableService, String)}
+     * @throws ProviderLoaderException if an error occurs
      */
-    public T createScriptProviderInstance(final ScriptPluginProvider provider) throws PluginException;
-
+    default CloseableProvider<T> loadCloseableWithLoader(String providerName, ProviderLoader loader)
+        throws ProviderLoaderException
+    {
+        return loader.loadCloseable(this, providerName);
+    }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginManagerService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginManagerService.java
@@ -113,16 +113,18 @@ public class PluginManagerService implements FrameworkSupportService, ServicePro
         if (null == loaderForIdent) {
             throw new MissingProviderException("No matching plugin found", service.getName(), providerName);
         }
-        final CloseableProvider<T> load = loaderForIdent.loadCloseable(service, providerName);
-        if (null != load) {
-            return load;
-        } else {
-            throw new ProviderLoaderException(
-                    "Unable to load provider: " + providerName + ", for service: " + service.getName(),
-                    service.getName(),
-                    providerName
-            );
+        if (service.canLoadWithLoader(loaderForIdent)) {
+            final CloseableProvider<T> load = service.loadCloseableWithLoader(providerName, loaderForIdent);
+            if (null != load) {
+                return load;
+            }
         }
+        throw new ProviderLoaderException(
+                "Unable to load provider: " + providerName + ", for service: " + service.getName(),
+                service.getName(),
+                providerName
+        );
+
     }
 
     public synchronized <T> T loadProvider(final PluggableService<T> service, final String providerName) throws ProviderLoaderException {
@@ -131,14 +133,17 @@ public class PluginManagerService implements FrameworkSupportService, ServicePro
         if (null == loaderForIdent) {
             throw new MissingProviderException("No matching plugin found", service.getName(), providerName);
         }
-        final T load = loaderForIdent.load(service, providerName);
-        if (null != load) {
-            return load;
-        } else {
-            throw new ProviderLoaderException(
-                "Unable to load provider: " + providerName + ", for service: " + service.getName(), service.getName(),
-                providerName);
+        if (service.canLoadWithLoader(loaderForIdent)) {
+            final T load = service.loadWithLoader(providerName, loaderForIdent);
+            if (null != load) {
+                return load;
+            }
         }
+        throw new ProviderLoaderException(
+            "Unable to load provider: " + providerName + ", for service: " + service.getName(), service.getName(),
+            providerName
+        );
+
     }
 
     @Override

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/ProviderLoader.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/ProviderLoader.java
@@ -23,6 +23,7 @@
 */
 package com.dtolabs.rundeck.core.plugins;
 
+import com.dtolabs.rundeck.core.common.FrameworkSupportService;
 import com.dtolabs.rundeck.core.execution.service.ProviderLoaderException;
 import com.dtolabs.rundeck.core.utils.cache.FileCache;
 
@@ -33,7 +34,9 @@ import java.util.List;
  *
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
-interface ProviderLoader extends FileCache.Cacheable {
+public interface ProviderLoader
+    extends FileCache.Cacheable
+{
     /**
      * Return an provider instance for a service and provider name
      */
@@ -43,6 +46,13 @@ interface ProviderLoader extends FileCache.Cacheable {
      * Return true if this loader can load the given ident
      */
     public boolean isLoaderFor(ProviderIdent ident);
+
+    /**
+     * @param service service
+     * @return true if the service can be used to load with this loader, e.g. if it implements any necessary interface
+     */
+    boolean canLoadForService(FrameworkSupportService service);
+
     /**
      * List providers available
      */

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/ScriptPluginProviderLoadable.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/ScriptPluginProviderLoadable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,17 @@
 
 package com.dtolabs.rundeck.core.plugins;
 
-import com.dtolabs.rundeck.core.common.ProviderService;
-import com.dtolabs.rundeck.core.execution.service.ProviderLoaderException;
-import com.dtolabs.rundeck.core.plugins.configuration.DescribableService;
-
 /**
- * A pluggable provider service
+ * Indicates that the provider can be created via a {@link ScriptPluginProvider} instance
+ * @param <T>
  */
-public interface PluggableProviderService<T> extends ProviderService<T>, PluggableService<T>, DescribableService {
+public interface ScriptPluginProviderLoadable<T> {
+    /**
+     * @return the instance for a ScriptPluginProvider definition
+     *
+     * @param provider the script plugin provider
+     *
+     *              @throws PluginException if the plugin has an error
+     */
+    public T createScriptProviderInstance(final ScriptPluginProvider provider) throws PluginException;
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/ServiceFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/ServiceFactory.java
@@ -1,7 +1,6 @@
 package com.dtolabs.rundeck.core.plugins;
 
 import com.dtolabs.rundeck.core.common.Framework;
-import com.dtolabs.rundeck.core.common.ProviderService;
 
 import java.util.Map;
 
@@ -30,18 +29,11 @@ public class ServiceFactory {
             final Class<T> providerClass
     )
     {
-        FrameworkPluggableProviderService<T> frameworkPluggableProviderService = new
+        return new
                 FrameworkPluggableProviderService<T>(
                 serviceName,
                 framework,
                 providerClass
-        )
-        {
-            @Override
-            public boolean isScriptPluggable() {
-                return false;
-            }
-        };
-        return frameworkPluggableProviderService;
+        );
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/ResourceModelSourceService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/ResourceModelSourceService.java
@@ -45,7 +45,9 @@ public class ResourceModelSourceService
     extends PluggableProviderRegistryService<ResourceModelSourceFactory>
     implements ConfigurableService<ResourceModelSource>,
                DescribableService,
-               PluggableProviderService<ResourceModelSourceFactory>
+               PluggableProviderService<ResourceModelSourceFactory>,
+               JavaClassProviderLoadable<ResourceModelSourceFactory>,
+               ScriptPluginProviderLoadable<ResourceModelSourceFactory>
 {
 
     public static final String SERVICE_NAME = ServiceNameConstants.ResourceModelSource;
@@ -147,10 +149,7 @@ public class ResourceModelSourceService
         return createProviderInstanceFromType(clazz, name);
     }
 
-    public boolean isScriptPluggable() {
-        return true;
-    }
-
+    @Override
     public ResourceModelSourceFactory createScriptProviderInstance(final ScriptPluginProvider provider) throws
         PluginException {
         ScriptPluginResourceModelSourceFactory.validateScriptPlugin(provider);

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/format/ResourceFormatGeneratorService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/format/ResourceFormatGeneratorService.java
@@ -26,10 +26,7 @@ package com.dtolabs.rundeck.core.resources.format;
 import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.execution.service.ExecutionServiceException;
 import com.dtolabs.rundeck.core.execution.service.ProviderCreationException;
-import com.dtolabs.rundeck.core.plugins.PluggableProviderRegistryService;
-import com.dtolabs.rundeck.core.plugins.PluginException;
-import com.dtolabs.rundeck.core.plugins.ProviderIdent;
-import com.dtolabs.rundeck.core.plugins.ScriptPluginProvider;
+import com.dtolabs.rundeck.core.plugins.*;
 import com.dtolabs.rundeck.core.plugins.configuration.Describable;
 import com.dtolabs.rundeck.core.plugins.configuration.DescribableService;
 import com.dtolabs.rundeck.core.plugins.configuration.Description;
@@ -47,7 +44,7 @@ import java.util.List;
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
 public class ResourceFormatGeneratorService extends PluggableProviderRegistryService<ResourceFormatGenerator> implements
-    DescribableService {
+    DescribableService, JavaClassProviderLoadable<ResourceFormatGenerator> {
 
     public static final String SERVICE_NAME = ServiceNameConstants.ResourceFormatGenerator;
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/format/ResourceFormatParserService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/format/ResourceFormatParserService.java
@@ -26,10 +26,7 @@ package com.dtolabs.rundeck.core.resources.format;
 import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.execution.service.ExecutionServiceException;
 import com.dtolabs.rundeck.core.execution.service.ProviderCreationException;
-import com.dtolabs.rundeck.core.plugins.PluggableProviderRegistryService;
-import com.dtolabs.rundeck.core.plugins.PluginException;
-import com.dtolabs.rundeck.core.plugins.ProviderIdent;
-import com.dtolabs.rundeck.core.plugins.ScriptPluginProvider;
+import com.dtolabs.rundeck.core.plugins.*;
 import com.dtolabs.rundeck.core.plugins.configuration.Describable;
 import com.dtolabs.rundeck.core.plugins.configuration.DescribableService;
 import com.dtolabs.rundeck.core.plugins.configuration.Description;
@@ -44,8 +41,10 @@ import java.util.*;
  *
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
-public class ResourceFormatParserService extends PluggableProviderRegistryService<ResourceFormatParser> implements
-    DescribableService {
+public class ResourceFormatParserService
+    extends PluggableProviderRegistryService<ResourceFormatParser>
+    implements DescribableService, JavaClassProviderLoadable<ResourceFormatParser>
+{
 
     public static final String SERVICE_NAME = ServiceNameConstants.ResourceFormatParser;
 
@@ -214,14 +213,6 @@ public class ResourceFormatParserService extends PluggableProviderRegistryServic
         return createProviderInstanceFromType(clazz, name);
     }
 
-    public boolean isScriptPluggable() {
-        return false;
-    }
-
-    public ResourceFormatParser createScriptProviderInstance(ScriptPluginProvider provider) throws
-        PluginException {
-        return null;
-    }
 
     public List<ProviderIdent> listDescribableProviders() {
         return listProviders();

--- a/core/src/test/java/com/dtolabs/rundeck/core/plugins/TestDirPluginScanner.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/plugins/TestDirPluginScanner.java
@@ -23,6 +23,7 @@
 */
 package com.dtolabs.rundeck.core.plugins;
 
+import com.dtolabs.rundeck.core.common.FrameworkSupportService;
 import com.dtolabs.rundeck.core.execution.service.ProviderLoaderException;
 import com.dtolabs.rundeck.core.utils.FileUtils;
 import com.dtolabs.rundeck.core.utils.cache.FileCache;
@@ -109,6 +110,11 @@ public class TestDirPluginScanner extends TestCase {
                     idents.add(new ProviderIdent(ab[0], ab[1]));
                 }
             }
+        }
+
+        @Override
+        public boolean canLoadForService(final FrameworkSupportService service) {
+            return true;
         }
 
         public <T> T load(PluggableService<T> service, String providerName) throws ProviderLoaderException {

--- a/core/src/test/java/com/dtolabs/rundeck/core/plugins/TestJarPluginProviderLoader.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/plugins/TestJarPluginProviderLoader.java
@@ -844,7 +844,7 @@ public class TestJarPluginProviderLoader extends AbstractBaseTest {
         jarstream.closeEntry();
     }
 
-    public static class testService1 implements PluggableService<JarTestType1> {
+    public static class testService1 implements PluggableService<JarTestType1>,JavaClassProviderLoadable<JarTestType1> {
         private boolean isvalid;
         JarTestType1 createScriptInstance;
         private String name;

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/ExecutionFileStoragePluginProviderService.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/ExecutionFileStoragePluginProviderService.java
@@ -45,9 +45,4 @@ public class ExecutionFileStoragePluginProviderService extends BasePluggableProv
         this.rundeckServerServiceProviderLoader = rundeckServerServiceProviderLoader;
     }
 
-    @Override
-    public boolean isScriptPluggable() {
-        //for now
-        return false;
-    }
 }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/NotificationPluginProviderService.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/NotificationPluginProviderService.java
@@ -47,9 +47,4 @@ public class NotificationPluginProviderService extends BasePluggableProviderServ
         this.rundeckServerServiceProviderLoader = rundeckServerServiceProviderLoader;
     }
 
-    @Override
-    public boolean isScriptPluggable() {
-        //for now
-        return false;
-    }
 }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/PluggableStoragePluginProviderService.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/PluggableStoragePluginProviderService.java
@@ -37,12 +37,6 @@ public class PluggableStoragePluginProviderService extends BasePluggableProvider
         return getRundeckServerServiceProviderLoader();
     }
 
-    @Override
-    public boolean isScriptPluggable() {
-        //for now
-        return false;
-    }
-
     public ServiceProviderLoader getRundeckServerServiceProviderLoader() {
         return rundeckServerServiceProviderLoader;
     }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/StorageConverterPluginProviderService.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/StorageConverterPluginProviderService.java
@@ -44,9 +44,4 @@ public class StorageConverterPluginProviderService extends BasePluggableProvider
         this.rundeckServerServiceProviderLoader = rundeckServerServiceProviderLoader;
     }
 
-    @Override
-    public boolean isScriptPluggable() {
-        //for now
-        return false;
-    }
 }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/StoragePluginProviderService.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/StoragePluginProviderService.java
@@ -19,6 +19,7 @@ package com.dtolabs.rundeck.server.plugins.services;
 import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.common.ProviderService;
 import com.dtolabs.rundeck.core.execution.service.ProviderCreationException;
+import com.dtolabs.rundeck.core.execution.service.ProviderLoaderException;
 import com.dtolabs.rundeck.core.plugins.*;
 import com.dtolabs.rundeck.core.plugins.configuration.DescribableService;
 import com.dtolabs.rundeck.core.plugins.configuration.DescribableServiceUtil;
@@ -50,6 +51,26 @@ public class StoragePluginProviderService extends ChainedProviderService<Storage
         builtinResourceStoragePluginProviderService =
                 new BuiltinResourceStoragePluginProviderService(framework, SERVICE_NAME);
         serviceList.add(builtinResourceStoragePluginProviderService);
+    }
+
+    @Override
+    public boolean canLoadWithLoader(final ProviderLoader loader) {
+        return pluggableStoragePluginProviderService.canLoadWithLoader(loader);
+    }
+
+    @Override
+    public StoragePlugin loadWithLoader(final String providerName, final ProviderLoader loader)
+        throws ProviderLoaderException
+    {
+        return pluggableStoragePluginProviderService.loadWithLoader(providerName, loader);
+    }
+
+    @Override
+    public CloseableProvider<StoragePlugin> loadCloseableWithLoader(
+        final String providerName, final ProviderLoader loader
+    ) throws ProviderLoaderException
+    {
+        return pluggableStoragePluginProviderService.loadCloseableWithLoader(providerName, loader);
     }
 
     public List<String> getBundledProviderNames() {
@@ -84,24 +105,4 @@ public class StoragePluginProviderService extends ChainedProviderService<Storage
         serviceList.add(this.pluggableStoragePluginProviderService);
     }
 
-    @Override
-    public boolean isValidProviderClass(Class aClass) {
-        return getPluggableStoragePluginProviderService().isValidProviderClass(aClass);
-    }
-
-    @Override
-    public <X extends StoragePlugin> StoragePlugin createProviderInstance(Class<X> clazz, String name) throws PluginException, ProviderCreationException {
-        return getPluggableStoragePluginProviderService().createProviderInstance(clazz, name);
-    }
-
-    @Override
-    public boolean isScriptPluggable() {
-        return getPluggableStoragePluginProviderService().isScriptPluggable();
-    }
-
-    @Override
-    public StoragePlugin createScriptProviderInstance(ScriptPluginProvider scriptPluginProvider) throws
-            PluginException {
-        return null;
-    }
 }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/StreamingLogReaderPluginProviderService.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/StreamingLogReaderPluginProviderService.java
@@ -43,9 +43,4 @@ public class StreamingLogReaderPluginProviderService extends BasePluggableProvid
         this.rundeckServerServiceProviderLoader = rundeckServerServiceProviderLoader;
     }
 
-    @Override
-    public boolean isScriptPluggable() {
-        //for now
-        return false;
-    }
 }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/StreamingLogWriterPluginProviderService.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/StreamingLogWriterPluginProviderService.java
@@ -43,9 +43,4 @@ public class StreamingLogWriterPluginProviderService extends BasePluggableProvid
         this.rundeckServerServiceProviderLoader = rundeckServerServiceProviderLoader;
     }
 
-    @Override
-    public boolean isScriptPluggable() {
-        //for now
-        return false;
-    }
 }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/UIPluginProviderService.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/services/UIPluginProviderService.java
@@ -18,14 +18,14 @@ package com.dtolabs.rundeck.server.plugins.services;
 
 import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.plugins.*;
-import com.dtolabs.rundeck.plugins.ServiceNameConstants;
 import com.dtolabs.rundeck.plugins.rundeck.UIPlugin;
-import com.dtolabs.rundeck.plugins.storage.StoragePlugin;
 
 /**
  * Created by greg on 8/26/16.
  */
-public class UIPluginProviderService extends FrameworkPluggableProviderService<UIPlugin> {
+public class UIPluginProviderService extends FrameworkPluggableProviderService<UIPlugin>
+    implements ScriptPluginProviderLoadable<UIPlugin>
+{
     public static final String SERVICE_NAME = "UI";
     private ServiceProviderLoader rundeckServerServiceProviderLoader;
 
@@ -44,11 +44,6 @@ public class UIPluginProviderService extends FrameworkPluggableProviderService<U
 
     public void setRundeckServerServiceProviderLoader(ServiceProviderLoader rundeckServerServiceProviderLoader) {
         this.rundeckServerServiceProviderLoader = rundeckServerServiceProviderLoader;
-    }
-
-    @Override
-    public boolean isScriptPluggable() {
-        return true;
     }
 
     @Override

--- a/rundeckapp/src/test/groovy/rundeck/services/PluginServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/PluginServiceTests.groovy
@@ -66,29 +66,10 @@ class PluginServiceTests extends Specification {
             return null
         }
 
-        @Override
-        boolean isValidProviderClass(Class clazz) {
-            return false
-        }
-
-        @Override
-        boolean isScriptPluggable() {
-            return false
-        }
 
         @Override
         List<ProviderIdent> listProviders() {
             return null
-        }
-
-        String createProviderInstance(Class clazz, String name) {
-
-            return null;
-        }
-
-        String createScriptProviderInstance(ScriptPluginProvider name) {
-
-            return null;
         }
 
         String providerOfType(String name){


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #3852 

**Describe the solution you've implemented**

Refactor plugin provider classes so that builtin `local` provider can be correctly selected.
