### PR TITLE
fix jobs failing over lock exception on mysql

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/DbStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/DbStorageService.groovy
@@ -30,7 +30,6 @@ import org.rundeck.storage.api.PathUtil
 import org.rundeck.storage.api.Resource
 import org.rundeck.storage.api.StorageException
 import org.rundeck.storage.impl.ResourceBase
-import org.springframework.dao.OptimisticLockingFailureException
 import rundeck.Storage
 
 import java.util.regex.Pattern
@@ -305,7 +304,7 @@ class DbStorageService implements NamespacedStorage{
 
                 retry = false
                 return true;
-            } catch (OptimisticLockingFailureException e) {
+            } catch (org.springframework.dao.ConcurrencyFailureException e) {
                 if (!retry) {
                     throw new StorageException("Failed to save content at path ${path}: content was modified", e,
                             StorageException.Event.valueOf(event.toUpperCase()),

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1578,7 +1578,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                             success = true
                         }
                     }
-                } catch (org.springframework.dao.OptimisticLockingFailureException ex) {
+                } catch (org.springframework.dao.ConcurrencyFailureException ex) {
                     log.error("Could not abort ${eid}, the execution was modified")
                 } catch (StaleObjectStateException ex) {
                     log.error("Could not abort ${eid}, the execution was modified")
@@ -2801,8 +2801,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 }
                 success = true
             }
-        } catch (org.springframework.dao.OptimisticLockingFailureException e) {
-            log.error("Caught OptimisticLockingFailure, will retry updateScheduledExecStatistics for ${eId}")
+        } catch (org.springframework.dao.ConcurrencyFailureException e) {
+            log.error("Caught ConcurrencyFailureException, will retry updateScheduledExecStatistics for ${eId}")
         } catch (StaleObjectStateException e) {
             log.error("Caught StaleObjectState, will retry updateScheduledExecStatistics for ${eId}")
         }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -482,7 +482,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                     }
                     retry = false
 //                }
-            } catch (org.springframework.dao.OptimisticLockingFailureException e) {
+            } catch (org.springframework.dao.ConcurrencyFailureException e) {
                 log.error("claimScheduledJob: failed for ${schedId} on node ${serverUUID}: locking failure")
                 retry = true
             } catch (StaleObjectStateException e) {
@@ -947,7 +947,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 scheduledExecution.delete(flush: true)
                 deleteJob(jobname, groupname)
                 success = true
-            } catch (org.springframework.dao.OptimisticLockingFailureException e) {
+            } catch (org.springframework.dao.ConcurrencyFailureException e) {
                 scheduledExecution.discard()
                 errmsg = 'Cannot delete Job "' + scheduledExecution.jobName + '" [' + scheduledExecution.extid + ']: it may have been modified or executed by another user'
             } catch (StaleObjectStateException e) {


### PR DESCRIPTION
Mysql use `ConcurrencyFailureException`  instead of `OptimisticLockingFailureException` in the same expected lock exception.

`org.springframework.dao.ConcurrencyFailureException` is the parent class of `org.springframework.dao.OptimisticLockingFailureException` so its no risk for other databases that use the current Exception without problems (tested so far on Postgres, h2, mssql and Oracle). 
