### PR TITLE
LDAP authentication fixing

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -397,7 +397,7 @@ beans={
 
     rundeckUserDetailsService(RundeckUserDetailsService)
     rundeckJaasAuthorityGranter(RundeckJaasAuthorityGranter){
-        rolePrefix=grailsApplication.config.rundeck.security.jaasRolePrefix?.toString()?:'ROLE_'
+        rolePrefix=grailsApplication.config.rundeck.security.jaasRolePrefix?.toString()?:''
     }
 
     if(grailsApplication.config.rundeck.security.enforceMaxSessions in [true,'true']) {

--- a/rundeckapp/src/main/groovy/org/rundeck/security/RundeckJaasAuthorityGranter.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/RundeckJaasAuthorityGranter.groovy
@@ -15,7 +15,6 @@
  */
 package org.rundeck.security
 
-import org.eclipse.jetty.jaas.JAASPrincipal
 import org.eclipse.jetty.jaas.JAASRole
 import org.springframework.security.authentication.jaas.AuthorityGranter
 import org.springframework.util.Assert

--- a/rundeckapp/src/main/groovy/org/rundeck/security/RundeckJaasAuthorityGranter.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/RundeckJaasAuthorityGranter.groovy
@@ -15,6 +15,8 @@
  */
 package org.rundeck.security
 
+import org.eclipse.jetty.jaas.JAASPrincipal
+import org.eclipse.jetty.jaas.JAASRole
 import org.springframework.security.authentication.jaas.AuthorityGranter
 import org.springframework.util.Assert
 
@@ -27,7 +29,12 @@ class RundeckJaasAuthorityGranter implements AuthorityGranter {
 
     @Override
     Set<String> grant(final Principal principal) {
-        return [rolePrefix+ principal.name] as Set
+        if( principal instanceof JAASRole){
+            return [rolePrefix+ principal.name] as Set
+        }else{
+            return null
+        }
+
     }
 
     public String getRolePrefix() { return rolePrefix }


### PR DESCRIPTION

This is a fix for a bug getting the roles from LDAP.
1)  By default, rundeck3 use the role prefix `ROLE_` which can break the use of LDAP on 2.x
2) Also, rundeck3 add the username as a role.

**Describe the solution you've implemented**
1) Replacing the default role prefix with an empty value.
That value can be modified using the parameter `rundeck.security.jaasRolePrefix=` on `rundeck-config.properties`

**Describe alternatives you've considered**
I tried using  `rundeck.security.jaasRolePrefix=` on  `rundeck-config.properties` to pass an empty value, but that is not posible using  `rundeck-config.properties` (maybe using the groovy format)

**Additional context**
The use of `ROLE_` as prefix can produce this kind of errors

<img width="943" alt="screenshot 2018-08-22 15 51 34" src="https://user-images.githubusercontent.com/6034968/44484131-4ff01380-a623-11e8-9403-bd3549f673a8.png">

This can fix this issue: https://github.com/rundeck/rundeck/issues/3855


