### PR TITLE
Fix #3888 activity links should be relative to app base url

### DIFF
--- a/rundeckapp/grails-spa/src/pages/project-dashboard/App.vue
+++ b/rundeckapp/grails-spa/src/pages/project-dashboard/App.vue
@@ -2,7 +2,7 @@
   <div id="app" v-if="project">
     <!-- <motd v-if="project && project.readme && project.readme.motd" :project="project"></motd> -->
     <project-description v-if="project && project.description" :project="project"></project-description>
-    <project-activity v-if="project" :project="project"></project-activity>
+    <project-activity v-if="project" :project="project" :rdBase="rdBase"></project-activity>
     <project-readme v-if="project" :project="project"></project-readme>
     <!-- <pre>{{project}}</pre> -->
   </div>
@@ -25,15 +25,17 @@ export default {
   },
   data () {
     return {
-      project: null
+      project: null,
+      rdBase: null
     }
   },
   mounted () {
     if (window._rundeck && window._rundeck.rdBase && window._rundeck.projectName) {
+      this.rdBase = window._rundeck.rdBase
       axios({
         method: 'get',
         headers: {'x-rundeck-ajax': true},
-        url: `${window._rundeck.rdBase}menu/homeAjax`,
+        url: `${this.rdBase}menu/homeAjax`,
         params: {
           projects: `${window._rundeck.projectName}`
         },

--- a/rundeckapp/grails-spa/src/pages/project-dashboard/components/activity.vue
+++ b/rundeckapp/grails-spa/src/pages/project-dashboard/components/activity.vue
@@ -3,14 +3,14 @@
     <div class="col-xs-12">
       <div class="card">
         <div class="card-content">
-          <a class="h4" :href="`/project/${project.name}/activity`">
+          <a class="h4" :href="`${rdBase}project/${project.name}/activity`">
             <span class="summary-count" :class="{ 'text-primary': project.execCount < 1, 'text-info': project.execCount > 0 }">
               {{project.execCount}}
             </span>
             <span>{{project.execCount | pluralize('Execution')}} In the last day</span>
           </a>
           <span :if="project.failedCount > 0">
-            <a class="text-warning" :href="`/project/${project.name}/activity?statFilter=fail`">
+            <a class="text-warning" :href="`${rdBase}project/${project.name}/activity?statFilter=fail`">
               ({{project.failedCount}} Failed)
             </a>
           </span>
@@ -32,7 +32,8 @@
 export default {
   name: 'Activity',
   props: [
-    'project'
+    'project',
+    'rdBase'
   ],
   data () {
     return {}


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #3888 

**Describe the solution you've implemented**

Links from project home page to Activity use `rdBase` as base URL.
