### PR TITLE
display icon for project schedule/exec disabled state in header

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/menu/home.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/home.js
@@ -19,6 +19,7 @@
 //= require knockout-onenter
 //= require ko/binding-url-path-param
 //= require ko/binding-message-template
+//= require ko/binding-popover
 //= require jquery.waypoints.min
 //= require menu/project-model
 

--- a/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
@@ -38,6 +38,7 @@ class UtilityTagLib{
             'nodeStatusColorCss',
             'logStorageEnabled',
             'executionMode',
+            'scheduleMode',
             'appTitle',
             'rkey',
             'w3cDateValue',
@@ -1142,6 +1143,11 @@ class UtilityTagLib{
 
     def ifExecutionMode={attrs,body->
         if(executionMode(attrs,body)){
+            out<<body()
+        }
+    }
+    def ifScheduleMode={attrs,body->
+        if(scheduleMode(attrs,body)){
             out<<body()
         }
     }

--- a/rundeckapp/grails-app/views/common/_mainbar.gsp
+++ b/rundeckapp/grails-app/views/common/_mainbar.gsp
@@ -102,7 +102,20 @@
           </ul>
         </g:if>
       </div>
+
       <div class="collapse navbar-collapse">
+          <g:if test="${(project?: params.project ?: request.project)}">
+          <g:ifExecutionMode is="passive" project="${project?:params.project?:request.project}">
+              <p class="navbar-text text-warning  has_tooltip" data-placement="right" title="${message(code:'project.execution.disabled')}">
+                  <i class="glyphicon glyphicon-pause"></i>
+              </p>
+          </g:ifExecutionMode>
+          <g:ifScheduleMode is="passive" project="${project?:params.project?:request.project}">
+              <p class="navbar-text text-warning has_tooltip"  data-placement="right" title="${message(code:'project.schedule.disabled')}">
+                  <i class="glyphicon glyphicon-ban-circle"></i>
+              </p>
+          </g:ifScheduleMode>
+      </g:if>
         <ul class="nav navbar-nav navbar-right">
 
           <g:set var="userDefinedInstanceName" value="${grailsApplication.config.rundeck?.gui?.instanceName}"/>

--- a/rundeckapp/grails-app/views/menu/home.gsp
+++ b/rundeckapp/grails-app/views/menu/home.gsp
@@ -234,6 +234,16 @@
                       <span data-bind="text: project"></span>
                     </span>
                   </a>
+                    <span data-bind="if: !$root.projectForName(project).executionEnabled()">
+                        <span class=" text-warning  has_tooltip" data-placement="right" data-bind="bootstrapTooltip: true" title="${message(code:'project.execution.disabled')}">
+                            <i class="glyphicon glyphicon-pause"></i>
+                        </span>
+                    </span>
+                    <span data-bind="if: !$root.projectForName(project).scheduleEnabled()">
+                        <span class=" text-warning has_tooltip"  data-placement="right"  data-bind="bootstrapTooltip: true" title="${message(code:'project.schedule.disabled')}">
+                            <i class="glyphicon glyphicon-ban-circle"></i>
+                        </span>
+                    </span>
                   <!-- <span data-bind="if: $root.projectForName(project)">
                     <span class="text-primary" data-bind="text: $root.projectForName(project).description"></span>
                   </span> -->


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Feature for #3898 

**Describe the solution you've implemented**

- [x] Displays icon in the header bar if the current project schedule or executions are disabled.
- [x] Displays icon next to project name in project list page
