### PR TITLE
Fix #3914 NodeFilter class was shadowed by glob import

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -27,7 +27,15 @@ import com.dtolabs.rundeck.app.support.PluginConfigParams
 import com.dtolabs.rundeck.app.support.StoreFilterCommand
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.Validation
-import com.dtolabs.rundeck.core.common.*
+import com.dtolabs.rundeck.core.common.Framework
+import com.dtolabs.rundeck.core.common.FrameworkResource
+import com.dtolabs.rundeck.core.common.IFramework
+import com.dtolabs.rundeck.core.common.INodeEntry
+import com.dtolabs.rundeck.core.common.INodeSet
+import com.dtolabs.rundeck.core.common.IProjectNodes
+import com.dtolabs.rundeck.core.common.IRundeckProject
+import com.dtolabs.rundeck.core.common.NodeSetImpl
+import com.dtolabs.rundeck.core.common.ProviderService
 import com.dtolabs.rundeck.core.execution.service.ExecutionServiceException
 import com.dtolabs.rundeck.core.execution.service.FileCopierService
 import com.dtolabs.rundeck.core.execution.service.NodeExecutorService


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #3914 

**Describe the solution you've implemented**

import statement glob was masking correct class. (revert code cleanup import optimization)
add a test for affected action
