### PR TITLE
Consistent logging prefix.

### DIFF
--- a/core/src/main/resources/com/dtolabs/launcher/setup/templates/server-log4j.properties.template
+++ b/core/src/main/resources/com/dtolabs/launcher/setup/templates/server-log4j.properties.template
@@ -1,6 +1,6 @@
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.stdout.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} - %m%n
 # Enable logging for everything. Rarely useful
 log4j.rootLogger=warn, stdout, file
 
@@ -72,7 +72,7 @@ log4j.appender.file.file=${rundeck.log.dir}${file.separator}rundeck.log
 log4j.appender.file.datePattern='.'yyyy-MM-dd
 log4j.appender.file.append=true
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c - %m%n
+log4j.appender.file.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} [%t] - %m%n
 
 
 #log4j.logger.org.codehaus.groovy.grails.plugins.quartz=debug,stdout
@@ -85,7 +85,7 @@ log4j.appender.audit=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.audit.file=${rundeck.log.dir}${file.separator}rundeck.audit.log
 log4j.appender.audit.append=true
 log4j.appender.audit.layout=org.apache.log4j.PatternLayout
-log4j.appender.audit.layout.ConversionPattern=%d{ISO8601} - %m%n
+log4j.appender.audit.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} - %m%n
 
 
 #
@@ -163,4 +163,4 @@ log4j.appender.project=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.project.file=${rundeck.log.dir}${file.separator}rundeck.project.log
 log4j.appender.project.append=true
 log4j.appender.project.layout=org.apache.log4j.PatternLayout
-log4j.appender.project.layout.ConversionPattern=%d{ISO8601} - %m%n
+log4j.appender.project.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} - %m%n

--- a/docker/official/remco/templates/log4j.properties
+++ b/docker/official/remco/templates/log4j.properties
@@ -7,7 +7,7 @@
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d{ISO8601}] %c{2} %-5p %c{1} - %m%n
+log4j.appender.stdout.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} %c{1} - %m%n
 # Enable logging for everything. Rarely useful
 log4j.rootLogger=warn, stdout {% if strategy == "FILE" %}, file{% endif %}
 
@@ -86,7 +86,7 @@ log4j.appender.file.file=/home/rundeck/server/logs${file.separator}rundeck.log
 log4j.appender.file.datePattern='.'yyyy-MM-dd
 log4j.appender.file.append=true
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=[%d{ISO8601}] $c{2} [%t] %-5p %c - %m%n
+log4j.appender.file.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} [%t] - %m%n
 {% endif %}
 
 
@@ -102,7 +102,7 @@ log4j.appender.audit.file=/home/rundeck/server/logs${file.separator}rundeck.audi
 log4j.appender.audit.append=true
 {% endif %}
 log4j.appender.audit.layout=org.apache.log4j.PatternLayout
-log4j.appender.audit.layout.ConversionPattern=[%d{ISO8601}] %c{2} - %m%n
+log4j.appender.audit.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} - %m%n
 
 #
 # options log
@@ -115,7 +115,7 @@ log4j.appender.options.file=/home/rundeck/server/logs${file.separator}rundeck.op
 log4j.appender.options.append=true
 {% endif %}
 log4j.appender.options.layout=org.apache.log4j.PatternLayout
-log4j.appender.options.layout.ConversionPattern=[%d{ISO8601}] %c{2} %X{httpStatusCode} %X{contentLength}B %X{durationTime}ms %X{lastModifiedDateTime} [%X{jobName}] %X{url} %X{contentSHA1}%n
+log4j.appender.options.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} %X{httpStatusCode} %X{contentLength}B %X{durationTime}ms %X{lastModifiedDateTime} [%X{jobName}] %X{url} %X{contentSHA1}%n
 
 #
 # storage log
@@ -128,7 +128,7 @@ log4j.appender.storage.file=/home/rundeck/server/logs${file.separator}rundeck.st
 log4j.appender.storage.append=true
 {% endif %}
 log4j.appender.storage.layout=org.apache.log4j.PatternLayout
-log4j.appender.storage.layout.ConversionPattern=[%d{ISO8601}] %c{2} %X{action} %X{type} %X{path} %X{status} %X{metadata}%n
+log4j.appender.storage.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} %X{action} %X{type} %X{path} %X{status} %X{metadata}%n
 
 #
 # job changes log
@@ -141,7 +141,7 @@ log4j.appender.jobchanges.file=/home/rundeck/server/logs${file.separator}rundeck
 log4j.appender.jobchanges.append=true
 {% endif %}
 log4j.appender.jobchanges.layout=org.apache.log4j.PatternLayout
-log4j.appender.jobchanges.layout.ConversionPattern=[%d{ISO8601}] %c{2} %X{user} %X{change} [%X{id}] %X{project} "%X{groupPath}/%X{jobName}" (%X{method})%X{extraInfo}%n
+log4j.appender.jobchanges.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} %X{user} %X{change} [%X{id}] %X{project} "%X{groupPath}/%X{jobName}" (%X{method})%X{extraInfo}%n
 
 #
 # executions log
@@ -154,7 +154,7 @@ log4j.appender.execevents.file=/home/rundeck/server/logs${file.separator}rundeck
 log4j.appender.execevents.append=true
 {% endif %}
 log4j.appender.execevents.layout=org.apache.log4j.PatternLayout
-log4j.appender.execevents.layout.ConversionPattern=[%d{ISO8601}] %c{2} %X{eventUser} %X{event} [%X{id}:%X{state}] %X{project} %X{user}/%X{abortedby} "%X{groupPath}/%X{jobName} %X{argString}"[%X{uuid}] %n
+log4j.appender.execevents.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} %X{eventUser} %X{event} [%X{id}:%X{state}] %X{project} %X{user}/%X{abortedby} "%X{groupPath}/%X{jobName} %X{argString}"[%X{uuid}] %n
 
 #
 # api request log
@@ -167,7 +167,7 @@ log4j.appender.apirequests.file=/home/rundeck/server/logs${file.separator}rundec
 log4j.appender.apirequests.append=true
 {% endif %}
 log4j.appender.apirequests.layout=org.apache.log4j.PatternLayout
-log4j.appender.apirequests.layout.ConversionPattern=[%d{ISO8601}] %c{2} %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} "%X{method} %X{uri}" (%X{userAgent})%n
+log4j.appender.apirequests.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} (%X{userAgent})%n
 
 #
 # Web access log
@@ -180,7 +180,7 @@ log4j.appender.access.file=/home/rundeck/server/logs${file.separator}rundeck.acc
 log4j.appender.access.append=true
 {% endif %}
 log4j.appender.access.layout=org.apache.log4j.PatternLayout
-log4j.appender.access.layout.ConversionPattern=[%d{ISO8601}] %c{2} "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} [%X{contentType}] (%X{userAgent})%n
+log4j.appender.access.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} [%X{contentType}] (%X{userAgent})%n
 
 #
 # project log
@@ -193,7 +193,7 @@ log4j.appender.project.file=/home/rundeck/server/logs${file.separator}rundeck.pr
 log4j.appender.project.append=true
 {% endif %}
 log4j.appender.project.layout=org.apache.log4j.PatternLayout
-log4j.appender.project.layout.ConversionPattern=[%d{ISO8601}] %c{2} - %m%n
+log4j.appender.project.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} - %m%n
 # Enable cluster-messages logging
 log4j.logger.org.rundeck.messaging.events=INFO,messaging
 log4j.additivity.org.rundeck.messaging.events=false
@@ -208,4 +208,4 @@ log4j.appender.messaging.file=/home/rundeck/server/logs${file.separator}rundeck.
 log4j.appender.messaging.append=true
 {% endif %}
 log4j.appender.messaging.layout=org.apache.log4j.PatternLayout
-log4j.appender.messaging.layout.ConversionPattern=[%d{ISO8601}] %c{2} - id[%X{id}] namespace[%X{namespace}] topic[%X{topic}] type[%X{type}] sender[%X{sender}] state[%X{state}] destination[%X{destination}] %m%n
+log4j.appender.messaging.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} - id[%X{id}] namespace[%X{namespace}] topic[%X{topic}] type[%X{type}] sender[%X{sender}] state[%X{state}] destination[%X{destination}] %m%n

--- a/docker/official/remco/templates/log4j.properties
+++ b/docker/official/remco/templates/log4j.properties
@@ -7,7 +7,7 @@
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} - %m%n
+log4j.appender.stdout.layout.ConversionPattern=[%d{ISO8601}] %c{2} %-5p %c{1} - %m%n
 # Enable logging for everything. Rarely useful
 log4j.rootLogger=warn, stdout {% if strategy == "FILE" %}, file{% endif %}
 

--- a/grails-persistlocale/grails-app/conf/logback.groovy
+++ b/grails-persistlocale/grails-app/conf/logback.groovy
@@ -14,10 +14,10 @@ appender('STDOUT', ConsoleAppender) {
         charset = Charset.forName('UTF-8')
 
         pattern =
-                '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} ' + // Date
+                '[%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint}] ' + // Date
                         '%clr(%5p) ' + // Log level
+                        '%clr(%logger{0}){cyan} ' + // Logger
                         '%clr(---){faint} %clr([%15.15t]){faint} ' + // Thread
-                        '%clr(%-40.40logger{39}){cyan} %clr(:){faint} ' + // Logger
                         '%m%n%wex' // Message
     }
 }

--- a/grails-securityheaders/grails-app/conf/logback.groovy
+++ b/grails-securityheaders/grails-app/conf/logback.groovy
@@ -14,10 +14,10 @@ appender('STDOUT', ConsoleAppender) {
         charset = Charset.forName('UTF-8')
 
         pattern =
-                '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} ' + // Date
+                '[%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint}] ' + // Date
+                        '%clr(logger{0}){cyan} ' + // Logger
                         '%clr(%5p) ' + // Log level
                         '%clr(---){faint} %clr([%15.15t]){faint} ' + // Thread
-                        '%clr(%-40.40logger{39}){cyan} %clr(:){faint} ' + // Logger
                         '%m%n%wex' // Message
     }
 }

--- a/packaging/common/etc/rundeck/log4j.properties
+++ b/packaging/common/etc/rundeck/log4j.properties
@@ -163,9 +163,8 @@ log4j.appender.execevents=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.execevents.file=/var/log/rundeck/rundeck.executions.log
 log4j.appender.execevents.append=true
 log4j.appender.execevents.layout=org.apache.log4j.PatternLayout
+log4j.appender.execevents.layout.ConversionPattern=[%d{ISO8601}] %c{2} %X{eventUser} %X{event} [%X{id}:%X{state}] %X{project} %X{user}/%X{abortedby} "%X{groupPath}/%X{jobName} %X{argString}"[%X{uuid}]%n
 
-log4j.appender.execevents.layout.ConversionPattern=[%d{ISO8601}] %X{eventUser} %X{event} [%X{id}:%X{state}] %X{project} %X{user}/%X{abortedby} "%X{groupPath}/%X{jobName} %X{argString}"[%X{uuid}]%n
-log4j.appender.execevents.layout.ConversionPattern=[%d{ISO8601}] %c{2} %X{eventUser} %X{event} [%X{id}:%X{state}] %X{project} %X{user}/%X{abortedby} "%X{groupPath}/%X{jobName}"[%X{uuid}]%n
 
 #
 # api request log
@@ -187,7 +186,4 @@ log4j.appender.access=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.access.file=/var/log/rundeck/rundeck.access.log
 log4j.appender.access.append=true
 log4j.appender.access.layout=org.apache.log4j.PatternLayout
-
-log4j.appender.access.layout.ConversionPattern=[%d{ISO8601}] "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} [%X{contentType}] (%X{userAgent})%n
-
 log4j.appender.access.layout.ConversionPattern=[%d{ISO8601}] %c{2} "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} [%X{contentType}] (%X{userAgent})%n

--- a/packaging/common/etc/rundeck/log4j.properties
+++ b/packaging/common/etc/rundeck/log4j.properties
@@ -84,7 +84,7 @@ log4j.additivity.grails=false
 #
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%-5p %c{1}: %m%n
+log4j.appender.stdout.layout.ConversionPattern=[%d{ISO8601}] %c{2} %-5p %c{1}: %m%n
 
 #
 # cmd-logger - DailyRollingFileAppender
@@ -96,7 +96,7 @@ log4j.appender.cmd-logger.file=/var/log/rundeck/command.log
 log4j.appender.cmd-logger.datePattern='.'yyyy-MM-dd
 log4j.appender.cmd-logger.append=true
 log4j.appender.cmd-logger.layout=org.apache.log4j.PatternLayout
-log4j.appender.cmd-logger.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c - %m%n
+log4j.appender.cmd-logger.layout.ConversionPattern=[%d{ISO8601}] %c{2} [%t] %-5p %c - %m%n
 
 #
 # server-logger - DailyRollingFileAppender
@@ -108,7 +108,7 @@ log4j.appender.server-logger.file=/var/log/rundeck/rundeck.log
 log4j.appender.server-logger.datePattern='.'yyyy-MM-dd
 log4j.appender.server-logger.append=true
 log4j.appender.server-logger.layout=org.apache.log4j.PatternLayout
-log4j.appender.server-logger.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c - %m%n
+log4j.appender.server-logger.layout.ConversionPattern=[%d{ISO8601}] %c{2} [%t] %-5p %c - %m%n
 
 #
 # audit 
@@ -119,7 +119,7 @@ log4j.appender.audit=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.audit.file=/var/log/rundeck/rundeck.audit.log
 log4j.appender.audit.append=true
 log4j.appender.audit.layout=org.apache.log4j.PatternLayout
-log4j.appender.audit.layout.ConversionPattern=%d{ISO8601} - %m%n
+log4j.appender.audit.layout.ConversionPattern=[%d{ISO8601}] %c{2} - %m%n
 
 #
 # options log
@@ -130,7 +130,7 @@ log4j.appender.options=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.options.file=/var/log/rundeck/rundeck.options.log
 log4j.appender.options.append=true
 log4j.appender.options.layout=org.apache.log4j.PatternLayout
-log4j.appender.options.layout.ConversionPattern=[%d{ISO8601}] %X{httpStatusCode} %X{contentLength}B %X{durationTime}ms %X{lastModifiedDateTime} [%X{jobName}] %X{url} %X{contentSHA1}%n
+log4j.appender.options.layout.ConversionPattern=[%d{ISO8601}] %c{2} %X{httpStatusCode} %X{contentLength}B %X{durationTime}ms %X{lastModifiedDateTime} [%X{jobName}] %X{url} %X{contentSHA1}%n
 
 #
 # storage log
@@ -141,7 +141,7 @@ log4j.appender.storage=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.storage.file=/var/log/rundeck/rundeck.storage.log
 log4j.appender.storage.append=true
 log4j.appender.storage.layout=org.apache.log4j.PatternLayout
-log4j.appender.storage.layout.ConversionPattern=[%d{ISO8601}] %X{action} %X{type} %X{path} %X{status} %X{metadata}%n
+log4j.appender.storage.layout.ConversionPattern=[%d{ISO8601}] %c{2} %X{action} %X{type} %X{path} %X{status} %X{metadata}%n
 
 #
 # job changes log
@@ -152,7 +152,7 @@ log4j.appender.jobchanges=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.jobchanges.file=/var/log/rundeck/rundeck.jobs.log
 log4j.appender.jobchanges.append=true
 log4j.appender.jobchanges.layout=org.apache.log4j.PatternLayout
-log4j.appender.jobchanges.layout.ConversionPattern=[%d{ISO8601}] %X{user} %X{change} [%X{id}] %X{project} "%X{groupPath}/%X{jobName}" (%X{method})%n
+log4j.appender.jobchanges.layout.ConversionPattern=[%d{ISO8601}] %c{2} %X{user} %X{change} [%X{id}] %X{project} "%X{groupPath}/%X{jobName}" (%X{method})%n
 
 #
 # executions log
@@ -163,7 +163,9 @@ log4j.appender.execevents=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.execevents.file=/var/log/rundeck/rundeck.executions.log
 log4j.appender.execevents.append=true
 log4j.appender.execevents.layout=org.apache.log4j.PatternLayout
+
 log4j.appender.execevents.layout.ConversionPattern=[%d{ISO8601}] %X{eventUser} %X{event} [%X{id}:%X{state}] %X{project} %X{user}/%X{abortedby} "%X{groupPath}/%X{jobName} %X{argString}"[%X{uuid}]%n
+log4j.appender.execevents.layout.ConversionPattern=[%d{ISO8601}] %c{2} %X{eventUser} %X{event} [%X{id}:%X{state}] %X{project} %X{user}/%X{abortedby} "%X{groupPath}/%X{jobName}"[%X{uuid}]%n
 
 #
 # api request log
@@ -174,7 +176,7 @@ log4j.appender.apirequests=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.apirequests.file=/var/log/rundeck/rundeck.api.log
 log4j.appender.apirequests.append=true
 log4j.appender.apirequests.layout=org.apache.log4j.PatternLayout
-log4j.appender.apirequests.layout.ConversionPattern=[%d{ISO8601}] %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} "%X{method} %X{uri}" (%X{userAgent})%n
+log4j.appender.apirequests.layout.ConversionPattern=[%d{ISO8601}] %c{2} %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} "%X{method} %X{uri}" (%X{userAgent})%n
 
 #
 # Web access log
@@ -185,5 +187,7 @@ log4j.appender.access=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.access.file=/var/log/rundeck/rundeck.access.log
 log4j.appender.access.append=true
 log4j.appender.access.layout=org.apache.log4j.PatternLayout
+
 log4j.appender.access.layout.ConversionPattern=[%d{ISO8601}] "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} [%X{contentType}] (%X{userAgent})%n
 
+log4j.appender.access.layout.ConversionPattern=[%d{ISO8601}] %c{2} "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} [%X{contentType}] (%X{userAgent})%n

--- a/rundeckapp/grails-app/conf/logback.groovy
+++ b/rundeckapp/grails-app/conf/logback.groovy
@@ -15,10 +15,10 @@ appender('STDOUT', TrueConsoleAppender) {
         charset = Charset.forName('UTF-8')
 
         pattern =
-                '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} ' + // Date
+                '[%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint}] ' + // Date
+                        '%clr(%-40.40logger{39}){cyan} %clr(:){faint} ' + // Logger
                         '%clr(%5p) ' + // Log level
                         '%clr(---){faint} %clr([%15.15t]){faint} ' + // Thread
-                        '%clr(%-40.40logger{39}){cyan} %clr(:){faint} ' + // Logger
                         '%m%n%wex' // Message
     }
 }

--- a/rundeckapp/grails-app/conf/logback.groovy
+++ b/rundeckapp/grails-app/conf/logback.groovy
@@ -16,8 +16,8 @@ appender('STDOUT', TrueConsoleAppender) {
 
         pattern =
                 '[%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint}] ' + // Date
-                        '%clr(%-40.40logger{39}){cyan}' + // Logger
                         '%clr(%5p) ' + // Log level
+                        '%clr(%logger{0}){cyan} ' + // Logger
                         '%clr(---){faint} %clr([%15.15t]){faint} ' + // Thread
                         '%m%n%wex' // Message
     }

--- a/rundeckapp/grails-app/conf/logback.groovy
+++ b/rundeckapp/grails-app/conf/logback.groovy
@@ -16,7 +16,7 @@ appender('STDOUT', TrueConsoleAppender) {
 
         pattern =
                 '[%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint}] ' + // Date
-                        '%clr(%-40.40logger{39}){cyan} %clr(:){faint} ' + // Logger
+                        '%clr(%-40.40logger{39}){cyan}' + // Logger
                         '%clr(%5p) ' + // Log level
                         '%clr(---){faint} %clr([%15.15t]){faint} ' + // Thread
                         '%m%n%wex' // Message

--- a/rundeckapp/metricsweb/grails-app/conf/logback.groovy
+++ b/rundeckapp/metricsweb/grails-app/conf/logback.groovy
@@ -14,10 +14,10 @@ appender('STDOUT', ConsoleAppender) {
         charset = Charset.forName('UTF-8')
 
         pattern =
-                '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} ' + // Date
+                '[%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint}] ' + // Date
                         '%clr(%5p) ' + // Log level
+                        '%clr(%logger{0}){cyan} ' + // Logger
                         '%clr(---){faint} %clr([%15.15t]){faint} ' + // Thread
-                        '%clr(%-40.40logger{39}){cyan} %clr(:){faint} ' + // Logger
                         '%m%n%wex' // Message
     }
 }

--- a/rundeckapp/repository/grails-app/conf/logback.groovy
+++ b/rundeckapp/repository/grails-app/conf/logback.groovy
@@ -14,10 +14,10 @@ appender('STDOUT', ConsoleAppender) {
         charset = Charset.forName('UTF-8')
 
         pattern =
-                '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} ' + // Date
+                '[%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint}] ' + // Date
                         '%clr(%5p) ' + // Log level
+                        '%clr(%logger{0}){cyan} ' + // Logger
                         '%clr(---){faint} %clr([%15.15t]){faint} ' + // Thread
-                        '%clr(%-40.40logger{39}){cyan} %clr(:){faint} ' + // Logger
                         '%m%n%wex' // Message
     }
 }

--- a/rundeckapp/src/main/resources/config-defaults.properties
+++ b/rundeckapp/src/main/resources/config-defaults.properties
@@ -30,6 +30,7 @@ default.admin.password=admin
 default.user.name=user
 default.user.password=user
 default.encryption.algorithm=PBEWITHSHA256AND128BITAES-CBC-BC
+
 logger.options.format=[%d{ISO8601}] %X{httpStatusCode} %X{contentLength}B %X{durationTime}ms %X{lastModifiedDateTime} [%X{jobName}] %X{url} %X{contentSHA1}%n
 logger.jobchanges.format=[%d{ISO8601}] %X{user} %X{change} [%X{id}] %X{project} "%X{groupPath}/%X{jobName}" (%X{method})%X{extraInfo}%n
 logger.apirequests.format=[%d{ISO8601}] %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} "%X{method} %X{uri}" (%X{userAgent})%n
@@ -37,3 +38,11 @@ logger.access.format=[%d{ISO8601}] "%X{method} %X{uri}" %X{remoteHost} %X{secure
 logger.storage.format=[%d{ISO8601}] %X{action} %X{type} %X{path} %X{status} %X{metadata}%n
 logger.execevents.format=[%d{ISO8601}] %X{eventUser} %X{event} [%X{id}:%X{state}] %X{project} %X{user}/%X{abortedby} \
   "%X{groupPath}/%X{jobName} %X{argString}"[%X{uuid}] %n
+
+logger.options.format=[%d{ISO8601}] %c{2} %X{httpStatusCode} %X{contentLength}B %X{durationTime}ms %X{lastModifiedDateTime} [%X{jobName}] %X{url} %X{contentSHA1}%n
+logger.jobchanges.format=[%d{ISO8601}] %c{2} %X{user} %X{change} [%X{id}] %X{project} "%X{groupPath}/%X{jobName}" (%X{method})%X{extraInfo}%n
+logger.apirequests.format=[%d{ISO8601}] %c{2} %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} "%X{method} %X{uri}" (%X{userAgent})%n
+logger.access.format=[%d{ISO8601}] %c{2} "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} [%X{contentType}] (%X{userAgent})%n
+logger.storage.format=[%d{ISO8601}] %c{2} %X{action} %X{type} %X{path} %X{status} %X{metadata}%n
+logger.execevents.format=[%d{ISO8601}] %c{2} %X{eventUser} %X{event} [%X{id}:%X{state}] %X{project} %X{user}/%X{abortedby} \
+  "%X{groupPath}/%X{jobName}"[%X{uuid}] %n

--- a/rundeckapp/src/main/resources/config-defaults.properties
+++ b/rundeckapp/src/main/resources/config-defaults.properties
@@ -31,18 +31,10 @@ default.user.name=user
 default.user.password=user
 default.encryption.algorithm=PBEWITHSHA256AND128BITAES-CBC-BC
 
-logger.options.format=[%d{ISO8601}] %X{httpStatusCode} %X{contentLength}B %X{durationTime}ms %X{lastModifiedDateTime} [%X{jobName}] %X{url} %X{contentSHA1}%n
-logger.jobchanges.format=[%d{ISO8601}] %X{user} %X{change} [%X{id}] %X{project} "%X{groupPath}/%X{jobName}" (%X{method})%X{extraInfo}%n
-logger.apirequests.format=[%d{ISO8601}] %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} "%X{method} %X{uri}" (%X{userAgent})%n
-logger.access.format=[%d{ISO8601}] "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} [%X{contentType}] (%X{userAgent})%n
-logger.storage.format=[%d{ISO8601}] %X{action} %X{type} %X{path} %X{status} %X{metadata}%n
-logger.execevents.format=[%d{ISO8601}] %X{eventUser} %X{event} [%X{id}:%X{state}] %X{project} %X{user}/%X{abortedby} \
+logger.options.format=[%d{ISO8601}] %-5p %c{2} %X{httpStatusCode} %X{contentLength}B %X{durationTime}ms %X{lastModifiedDateTime} [%X{jobName}] %X{url} %X{contentSHA1}%n
+logger.jobchanges.format=[%d{ISO8601}] %-5p %c{2} %X{user} %X{change} [%X{id}] %X{project} "%X{groupPath}/%X{jobName}" (%X{method})%X{extraInfo}%n
+logger.apirequests.format=[%d{ISO8601}] %-5p %c{2} "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} (%X{userAgent})%n
+logger.access.format=[%d{ISO8601}] %-5p %c{2} "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} [%X{contentType}] (%X{userAgent})%n
+logger.storage.format=[%d{ISO8601}] %-5p %c{2} %X{action} %X{type} %X{path} %X{status} %X{metadata}%n
+logger.execevents.format=[%d{ISO8601}] %-5p %c{2} %X{eventUser} %X{event} [%X{id}:%X{state}] %X{project} %X{user}/%X{abortedby} \
   "%X{groupPath}/%X{jobName} %X{argString}"[%X{uuid}] %n
-
-logger.options.format=[%d{ISO8601}] %c{2} %X{httpStatusCode} %X{contentLength}B %X{durationTime}ms %X{lastModifiedDateTime} [%X{jobName}] %X{url} %X{contentSHA1}%n
-logger.jobchanges.format=[%d{ISO8601}] %c{2} %X{user} %X{change} [%X{id}] %X{project} "%X{groupPath}/%X{jobName}" (%X{method})%X{extraInfo}%n
-logger.apirequests.format=[%d{ISO8601}] %c{2} %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} "%X{method} %X{uri}" (%X{userAgent})%n
-logger.access.format=[%d{ISO8601}] %c{2} "%X{method} %X{uri}" %X{remoteHost} %X{secure} %X{remoteUser} %X{authToken} %X{duration} %X{project} [%X{contentType}] (%X{userAgent})%n
-logger.storage.format=[%d{ISO8601}] %c{2} %X{action} %X{type} %X{path} %X{status} %X{metadata}%n
-logger.execevents.format=[%d{ISO8601}] %c{2} %X{eventUser} %X{event} [%X{id}:%X{state}] %X{project} %X{user}/%X{abortedby} \
-  "%X{groupPath}/%X{jobName}"[%X{uuid}] %n

--- a/rundeckapp/templates/config/log4j.properties.template
+++ b/rundeckapp/templates/config/log4j.properties.template
@@ -76,7 +76,7 @@ log4j.appender.file.file=${rundeck.log.dir}${file.separator}rundeck.log
 log4j.appender.file.datePattern='.'yyyy-MM-dd
 log4j.appender.file.append=true
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=[%d{ISO8601}] %c{2} [%t] %-5p %c - %m%n
+log4j.appender.file.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} [%t] - %m%n
 
 
 #log4j.logger.org.codehaus.groovy.grails.plugins.quartz=debug,stdout
@@ -89,7 +89,7 @@ log4j.appender.audit=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.audit.file=${rundeck.log.dir}${file.separator}rundeck.audit.log
 log4j.appender.audit.append=true
 log4j.appender.audit.layout=org.apache.log4j.PatternLayout
-log4j.appender.audit.layout.ConversionPattern=[%d{ISO8601}] %c{2} - %m%n
+log4j.appender.audit.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} - %m%n
 
 
 #
@@ -167,4 +167,4 @@ log4j.appender.project=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.project.file=${rundeck.log.dir}${file.separator}rundeck.project.log
 log4j.appender.project.append=true
 log4j.appender.project.layout=org.apache.log4j.PatternLayout
-log4j.appender.project.layout.ConversionPattern=[%d{ISO8601}] %c{2} - %m%n
+log4j.appender.project.layout.ConversionPattern=[%d{ISO8601}] %-5p %c{2} - %m%n

--- a/rundeckapp/templates/config/log4j.properties.template
+++ b/rundeckapp/templates/config/log4j.properties.template
@@ -76,7 +76,7 @@ log4j.appender.file.file=${rundeck.log.dir}${file.separator}rundeck.log
 log4j.appender.file.datePattern='.'yyyy-MM-dd
 log4j.appender.file.append=true
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c - %m%n
+log4j.appender.file.layout.ConversionPattern=[%d{ISO8601}] %c{2} [%t] %-5p %c - %m%n
 
 
 #log4j.logger.org.codehaus.groovy.grails.plugins.quartz=debug,stdout
@@ -89,7 +89,7 @@ log4j.appender.audit=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.audit.file=${rundeck.log.dir}${file.separator}rundeck.audit.log
 log4j.appender.audit.append=true
 log4j.appender.audit.layout=org.apache.log4j.PatternLayout
-log4j.appender.audit.layout.ConversionPattern=%d{ISO8601} - %m%n
+log4j.appender.audit.layout.ConversionPattern=[%d{ISO8601}] %c{2} - %m%n
 
 
 #
@@ -167,4 +167,4 @@ log4j.appender.project=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.project.file=${rundeck.log.dir}${file.separator}rundeck.project.log
 log4j.appender.project.append=true
 log4j.appender.project.layout=org.apache.log4j.PatternLayout
-log4j.appender.project.layout.ConversionPattern=%d{ISO8601} - %m%n
+log4j.appender.project.layout.ConversionPattern=[%d{ISO8601}] %c{2} - %m%n


### PR DESCRIPTION
Purpose of this PR is to open a discussion about log formatting consistency.

For stream processing of log output that is not structured(json, xml, etc) it is handy to have a consistently formatted logging prefix to help with routing and parsing. Typical docker/container based deployments may send all logging output to stdout to be picked up and sent through a log processing system(fluentd, cloud watch logs, etc). This is a little bit different than writing, reading, and parsing separate log files where extra context can then be added. Structured logging would be preferred.

These changes propose a common prefix of:  
`[<ISO8601>] <logger.name> <level>`

Level and name could be swapped, however it appears some output currently does not include the level. We could add it.

Here is the PR output across logback and log4j:
```
[2018-08-27 18:13:38.099] rundeckapp.BootStrap                     INFO --- [           main] Preauthentication is disabled
[2018-08-27 18:13:38.128] rundeckapp.BootStrap                     INFO --- [           main] Rundeck is ACTIVE: executions can be run.
[2018-08-27 18:13:38.260] rundeckapp.BootStrap                     INFO --- [           main] Rundeck startup finished in 288ms
Grails application running at http://0.0.0.0:4440 in environment: production
[2018-08-27 18:13:52,146] web.requests "GET /user/login" 172.17.0.1 http  form 133 ? [] (Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36)
[2018-08-27 18:13:52,562] web.requests "GET /static/images/rundeck-full-logo-black.png" 172.17.0.1 http  form 13 ? [image/png] (Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36)
```