### PR TITLE
Add spec unit test for saveProjectNodeSources

### DIFF
--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -1132,4 +1132,32 @@ class FrameworkControllerSpec extends Specification {
             [filter: 'abc', name: 'filter1', project: project],
         ]
     }
+
+    def "save project node sources"() {
+        given:
+        controller.frameworkService = Mock(FrameworkService)
+        controller.resourcesPasswordFieldsService = Mock(PasswordFieldsService)
+
+        setupFormTokens(params)
+        def project = 'testProj'
+
+        when:
+        request.method = "POST"
+        params.project = project
+        def result = controller.saveProjectNodeSources()
+        then:
+        1 * controller.frameworkService.getAuthContextForSubject(*_)
+        1 * controller.frameworkService.authResourceForProject(project)
+        1 * controller.frameworkService.getRundeckFramework()
+        1 * controller.frameworkService.listResourceModelSourceDescriptions()
+        1 * controller.frameworkService.authorizeApplicationResourceAny(*_) >> true
+        1 * controller.frameworkService.validateProjectConfigurableInput(*_) >> [props: [:], remove: []]
+        1 * controller.frameworkService.updateFrameworkProjectConfig(project, _, _) >> [success: true]
+        0 * controller.frameworkService._(*_)
+        1 * controller.resourcesPasswordFieldsService.reset()
+
+        response.redirectedUrl == "/project/$project/nodes/sources"
+        flash.message == "Project ${project} Node Sources saved"
+        result == null
+    }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Add a test for saveProjectNodeSources

**Additional context**

~~~
groovy.lang.MissingPropertyException: No such property: FrameworkProject for class: rundeck.controllers.FrameworkController
    at grails.artefact.gsp.TagLibraryInvoker$Trait$Helper.propertyMissing(TagLibraryInvoker.groovy:121)
    at rundeck.controllers.FrameworkController.saveProjectNodeSources(FrameworkController.groovy:1394)
~~~

caused by https://github.com/rundeck/rundeck/commit/7d055f5f11b55cf3fe51ee82991ea9d7b5c6f182