### PR TITLE
Fix config storage tree errors using file provider

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ConfigStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ConfigStorageService.groovy
@@ -67,8 +67,8 @@ class ConfigStorageService implements StorageManager {
      * @return
      */
     List<String> listDirPaths(String path, String pattern = null) {
-        def storagePath = (path.startsWith("/") ? path : "/${path}")
-        def resources = getStorage().listDirectory(storagePath)
+        def storagePath = (path.startsWith("/") ? path : "/${path}").toString()
+        Collection<Resource<ResourceMeta>> resources = getStorage().hasDirectory(storagePath)?getStorage().listDirectory(storagePath):[]
         def outprefix = path.endsWith('/') ? path.substring(0, path.length() - 1) : path
         resources.collect { Resource<ResourceMeta> res ->
             def pathName = res.path.name + (res.isDirectory() ? '/' : '')

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -306,7 +306,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
     List<String> listProjectDirPaths(String projectName, String path, String pattern=null) {
         def prefix = 'projects/' + projectName
         def storagePath = prefix + (path.startsWith("/")?path:"/${path}")
-        def resources = getStorage().listDirectory(storagePath)
+        def resources = getStorage().hasDirectory(storagePath)?getStorage().listDirectory(storagePath):[]
         def outprefix=path.endsWith('/')?path.substring(0,path.length()-1):path
         resources.collect{Resource<ResourceMeta> res->
             def pathName=res.path.name + (res.isDirectory()?'/':'')

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -583,7 +583,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
             throw new IllegalArgumentException("project does not exist: " + projectName)
         }
         def res = loadProjectConfigResource(projectName)
-        def oldprops = res.config
+        Properties oldprops = res?.config?:new Properties()
         Properties newprops = mergeProperties(removePrefixes, oldprops, properties)
         Map newres=storeProjectConfig(projectName, newprops)
         newres

--- a/rundeckapp/src/test/groovy/rundeck/services/ConfigStorageServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ConfigStorageServiceSpec.groovy
@@ -83,6 +83,19 @@ class ConfigStorageServiceSpec extends Specification {
         service.listDirPaths("my-dir")==['my-dir/file1','my-dir/file2','my-dir/etc/']
         service.listDirPaths("not-my-resource")==[]
     }
+
+    void "list dir paths should check dir exists"() {
+        given: 'storage backend which throws exception on listDirectory for non-existent dir'
+        service.rundeckConfigStorageTree = Stub(StorageTree) {
+            hasDirectory('/my-dir') >> false
+            listDirectory('/my-dir') >> {
+                throw StorageException.listException(PathUtil.asPath('/my-dir'), "dne")
+            }
+        }
+        expect: 'result is empty instead of exception'
+        [] == service.listDirPaths('my-dir')
+    }
+    
     void "storage list paths regex"(){
         given:
         service.rundeckConfigStorageTree=Stub(StorageTree){

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
@@ -731,6 +731,18 @@ class ProjectManagerServiceSpec extends Specification {
         service.listProjectDirPaths("test1","my-dir")==['my-dir/file1','my-dir/file2','my-dir/etc/']
         service.listProjectDirPaths("test1","not-my-resource")==[]
     }
+
+    void "list project dir paths when tree throws exception"() {
+        given:
+        service.storage = Stub(StorageTree) {
+            hasDirectory("projects/test1/my-dir") >> false
+            listDirectory("projects/test1/my-dir") >> {
+                throw StorageException.listException(PathUtil.asPath('projects/test1/my-dir'), 'dne')
+            }
+        }
+        expect:
+        service.listProjectDirPaths("test1", "my-dir") == []
+    }
     void "storage list paths regex"(){
         given:
         service.storage=Stub(StorageTree){


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #3960 

**Describe the solution you've implemented**

- [x] Check hasDirectory before calling listDirectory, for both config service and project config
- [x] handle case where project config does not exist when saving new config

**Additional context**

Only occurs when using `file` provider for config storage backend.
