### PR TITLE
Fix locale not persisting via cookie correctly

### DIFF
--- a/grails-persistlocale/src/main/groovy/grails/persistlocale/PersistlocaleGrailsPlugin.groovy
+++ b/grails-persistlocale/src/main/groovy/grails/persistlocale/PersistlocaleGrailsPlugin.groovy
@@ -20,6 +20,7 @@ class PersistlocaleGrailsPlugin extends Plugin {
 use Cookie based resolver for Locale.
 '''
     def profiles = ['web']
+    def loadAfter = ['i18n']
 
     // URL to the plugin's documentation
     def documentation = "http://grails.org/plugin/grails-persistlocale"

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -69,8 +69,6 @@ dependencies {
     // Rundeck project dependencies.
     compile project(':core')
     compile project(':rundeck-storage:rundeck-storage-filesys')
-    compile project(':rundeck:metricsweb')
-    compile project(':grails-persistlocale')
 
     // From BuildConfig.groovy.
     compile 'org.quartz-scheduler:quartz:2.3.0'
@@ -156,6 +154,12 @@ dependencies {
     testRuntime "org.seleniumhq.selenium:selenium-firefox-driver"
     testRuntime "org.seleniumhq.selenium:selenium-remote-driver"
     testRuntime "org.seleniumhq.selenium:selenium-api"
+}
+grails{
+    plugins{
+        compile project(':rundeck:metricsweb')
+        compile project(':grails-persistlocale')
+    }
 }
 
 bootRun {

--- a/rundeckapp/src/integration-test/groovy/rundeck/grails_plugins/PersistLocaleIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/grails_plugins/PersistLocaleIntegrationSpec.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rundeck.grails_plugins
+
+import grails.gorm.transactions.Rollback
+import grails.testing.mixin.integration.Integration
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.servlet.LocaleResolver
+import org.springframework.web.servlet.i18n.CookieLocaleResolver
+import spock.lang.Specification
+
+
+@Integration
+@Rollback
+class PersistLocaleIntegrationSpec extends Specification {
+    @Autowired
+    LocaleResolver localeResolver
+
+    def "test locale "() {
+        expect: "locale resolver is cookie resolver"
+        localeResolver instanceof CookieLocaleResolver
+    }
+}


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Fix #3860 

**Describe the solution you've implemented**

persist locale plugin was not loading after i18n plugin, so `localeResolver` bean was not correctly overriding default session resolver.