### PR TITLE
fix npm unavailability : grails-spa

### DIFF
--- a/rundeckapp/grails-spa/build.gradle
+++ b/rundeckapp/grails-spa/build.gradle
@@ -2,6 +2,11 @@ plugins {
   id "com.moowork.node" version "1.2.0"
 }
 
+node {
+    download = true
+    version='9.2.0'
+}
+
 task buildSpa(type: NpmTask, group: 'build') {
     dependsOn npmInstall
 


### PR DESCRIPTION
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".

**Is this a bugfix, or an enhancement? Please describe.**
This is a bugfix. Npm is unavailable or not available in PATH on docker images (eg. maven:3-jdk-8, java:openjdk-8) when trying to build the source code. This results in the below error during gradle build:
```
...
...
> Task :rundeck:buildProperties
> Task :rundeck:processResources
> Task :rundeck:classes
> Task :rundeck:compileTestJava NO-SOURCE
> Task :rundeck:compileTestGroovy NO-SOURCE
> Task :rundeck:findMainClass
> Task :rundeck:grails-spa:nodeSetup SKIPPED
> Task :rundeck:grails-spa:npmSetup SKIPPED
> Task :rundeck:grails-spa:npmInstall FAILED

BUILD FAILED in 8m 34s
79 actionable tasks: 59 executed, 20 up-to-date

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':rundeck:grails-spa:npmInstall'.
> A problem occurred starting process 'command 'npm''
```

**Describe the solution you've implemented**
By default, the plugin will not download NodeJS/NPM unless we add:

```
node {
    download = true
}
```

in the build.gradle for grails-spa

Otherwise, it is expected that Node is installed and npm is available on the path.

**Additional context**

rundeckapp/grails-spa/build.gradle:

```
plugins {
  id "com.moowork.node" version "1.2.0"
}

node {
    download = true
    version='9.2.0'
}

task buildSpa(type: NpmTask, group: 'build') {
    dependsOn npmInstall

    inputs.dir 'build'
    inputs.dir 'config'
    inputs.dir 'src'

    outputs.dir("$buildDir")
    args = ['run', 'build']
}

```