### PR TITLE
Query optimization 2.11

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -141,6 +141,7 @@ class Execution extends ExecutionContext {
             index 'EXEC_IDX_2', ['dateStarted', 'status']
             index 'EXEC_IDX_3', ['project', 'dateCompleted']
             index 'EXEC_IDX_4', ['dateCompleted', 'scheduledExecution']
+            index 'EXEC_IDX_5', ['scheduledExecution', 'status']
         }
     }
 

--- a/rundeckapp/grails-app/domain/rundeck/ReferencedExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ReferencedExecution.groovy
@@ -1,5 +1,7 @@
 package rundeck
 
+import com.dtolabs.rundeck.app.support.DomainIndexHelper
+
 class ReferencedExecution {
     ScheduledExecution scheduledExecution
     String status
@@ -12,6 +14,13 @@ class ReferencedExecution {
         status(nullable:true)
         execution(nullable: false)
 
+    }
+
+    static mapping = {
+
+        DomainIndexHelper.generate(delegate) {
+            index 'REFEXEC_IDX_1', ['scheduledExecution', 'status']
+        }
     }
 
     static List<ScheduledExecution> parentList(ScheduledExecution se, int max = 0){

--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -598,7 +598,9 @@ class LogFileStorageService implements InitializingBean,ApplicationContextAware{
         request
     }
     public Map getStorageStats() {
-        def missing = countMissingLogStorageExecutions()
+        def props=frameworkService.getFrameworkProperties()
+        def countMissing = props.getProperty('framework.storage.missing')
+        def missing = countMissing=='true'?countMissingLogStorageExecutions():0
         def incompleteRequests = countIncompleteLogStorageRequests()
         def queued = storageQueueCounter.count
         def failed = storageFailedCounter.count

--- a/rundeckapp/grails-app/views/scheduledExecution/_renderJobStats.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_renderJobStats.gsp
@@ -20,9 +20,9 @@
 <g:set var="reflastrun"
        value="${scheduledExecution.id ? ReferencedExecution.findByScheduledExecution(scheduledExecution, [max: 1]) : null}"/>
 <g:set var="successcount"
-       value="${scheduledExecution.id ? Execution.countByScheduledExecutionAndStatusInList(scheduledExecution, ['true','succeeded','scheduled']) : 0}"/>
+       value="${scheduledExecution.id ? Execution.countByScheduledExecutionAndStatus(scheduledExecution, 'succeeded') : 0}"/>
 <g:set var="refsuccesscount"
-       value="${scheduledExecution.id ? ReferencedExecution.countByScheduledExecutionAndStatusInList(scheduledExecution, ['true','succeeded','scheduled']) : 0}"/>
+       value="${scheduledExecution.id ? ReferencedExecution.countByScheduledExecutionAndStatus(scheduledExecution, 'succeeded') : 0}"/>
 <g:set var="execCount"
        value="${scheduledExecution.id ? Execution.countByScheduledExecution(scheduledExecution) : 0}"/>
 <g:set var="refexecCount"


### PR DESCRIPTION
* Optimization execution count query, creating new indexes and removing legacy execution status `true`.
* Disabled count missing log storage. This query takes a lot of time on databases with over 1 million records on `log_file_storage_request` and `execution`. It can be enabled using `framework.storage.missing=true` on `framework.properties`. This is not used in the current code so it could be removed completely on future releases.
