### PR TITLE
Add @DirtyCheck annotation to ScheduledExecution superclasses

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/BaseNodeFilters.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/BaseNodeFilters.groovy
@@ -18,6 +18,7 @@ package com.dtolabs.rundeck.app.support
 
 import com.dtolabs.rundeck.core.utils.NodeSet
 import com.dtolabs.rundeck.core.utils.OptsUtil
+import grails.gorm.dirty.checking.DirtyCheck
 import grails.validation.Validateable
 
 /*
@@ -31,6 +32,7 @@ import grails.validation.Validateable
 /**
  * Represents a query corresponding to the filters available for a NodeSet
  */
+@DirtyCheck
 public class BaseNodeFilters implements Validateable{
 
     String nodeInclude

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ExecutionContext.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ExecutionContext.groovy
@@ -16,10 +16,12 @@
 
 package com.dtolabs.rundeck.app.support
 
-import com.dtolabs.rundeck.app.support.BaseNodeFilters
+import grails.gorm.dirty.checking.DirtyCheck
+
 /**
  * ExecutionContext
  */
+@DirtyCheck
 abstract class ExecutionContext extends BaseNodeFilters{
     String project
     String argString


### PR DESCRIPTION
Recent versions of Gorm change the way dirty checks work on domain class superclasses. You either need to use setter methods or annotate the super class with @DirtyCheck.

https://github.com/grails/grails-data-mapping/issues/1097