### PR TITLE
Fix: LDAP user credentials should not be exposed

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
@@ -401,7 +401,7 @@ public class JettyCachingLdapLoginModule extends AbstractLoginModule {
             throw new LoginException("Root context binding failure.");
         }
 
-        LOG.debug("user cred is: " + ldapCredential);
+        LOG.debug("user cred is present: " + (ldapCredential != null));
 
         return ldapCredential;
     }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix: user LDAP credentials potentially exposed in server log.

**Describe the solution you've implemented**

Don't log user credentials.

**Additional context**

User credentials may be exposed in the rundeck server log in these conditions:

* using JettyCachingLdapLoginModule or JettyCombinedLdapLoginModule
* using `forceBindingLogin="false"` in the jaas.conf

If user credentials in the LDAP server are stored unencrypted, then the server log may print them in plainttext.

Workarounds:

* use `forceBindingLogin="true"` in jaas conf for the JettyCachingLdapLoginModule
