### PR TITLE
Update JobService: allow Map opts, return ReferencedExecution

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobExecutionError.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobExecutionError.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.core.jobs;
+
+public class JobExecutionError extends Exception {
+    private String jobName;
+    private String groupPath;
+    private String jobId;
+    private String project;
+
+    public JobExecutionError(String message, String jobId, String project) {
+        super(message);
+        this.jobId = jobId;
+        this.project = project;
+    }
+
+    public JobExecutionError(String message, String jobName, String groupPath, String project) {
+        super(message);
+        this.jobName = jobName;
+        this.groupPath = groupPath;
+        this.project = project;
+    }
+
+    public String getJobName() {
+        return jobName;
+    }
+
+    public String getGroupPath() {
+        return groupPath;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public String getProject() {
+        return project;
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobService.java
@@ -113,7 +113,18 @@ public interface JobService extends AppService {
      * @param asUser user to execute the job(null for the same user)
      * @return Id of the result execution
      */
-    String startJob(JobReference jobReference, String jobArgString, String jobFilter, String asUser)throws JobNotFound;
+    ExecutionReference startJob(JobReference jobReference, String jobArgString, String jobFilter, String asUser)
+        throws JobNotFound, JobExecutionError;
+
+    /**
+     * @param jobReference reference to a job
+     * @param options      option values
+     * @param jobFilter    filter for the execution
+     * @param asUser       user to execute the job(null for the same user)
+     * @return Id of the result execution
+     */
+    ExecutionReference startJob(JobReference jobReference, Map options, String jobFilter, String asUser)
+        throws JobNotFound, JobExecutionError;
 
     /**
      *

--- a/core/src/main/java/org/rundeck/app/spi/AuthorizedServicesProvider.java
+++ b/core/src/main/java/org/rundeck/app/spi/AuthorizedServicesProvider.java
@@ -17,6 +17,7 @@
 package org.rundeck.app.spi;
 
 import com.dtolabs.rundeck.core.authorization.AuthContext;
+import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext;
 
 /**
  * Provides Rundeck SPI services given an Auth context
@@ -27,5 +28,5 @@ public interface AuthorizedServicesProvider {
      *
      * @param authContext authorization context
      */
-    Services getServicesWith(AuthContext authContext);
+    Services getServicesWith(UserAndRolesAuthContext authContext);
 }

--- a/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
@@ -28,6 +28,7 @@ import com.dtolabs.rundeck.core.common.NodeSetImpl
 import com.dtolabs.rundeck.core.dispatcher.ExecutionState
 import com.dtolabs.rundeck.core.execution.ExecutionNotFound
 import com.dtolabs.rundeck.core.execution.ExecutionReference
+import com.dtolabs.rundeck.core.jobs.JobExecutionError
 import com.dtolabs.rundeck.core.jobs.JobNotFound
 import com.dtolabs.rundeck.core.jobs.JobReference
 import com.dtolabs.rundeck.core.jobs.JobService
@@ -132,7 +133,7 @@ class JobStateService implements AuthorizingJobService {
      * @param auth
      * @return a JobService which uses the auth context for authorization
      */
-    JobService jobServiceWithAuthContext(AuthContext auth) {
+    JobService jobServiceWithAuthContext(UserAndRolesAuthContext auth) {
         return new ResolvedAuthJobService(authContext: auth, authJobService: this)
     }
 
@@ -263,23 +264,51 @@ class JobStateService implements AuthorizingJobService {
 
 
     @Override
-    String startJob(AuthContext auth, JobReference jobReference, String jobArgString, String jobFilter, String asUser) throws JobNotFound {
+    ExecutionReference startJob(
+        UserAndRolesAuthContext auth,
+        JobReference jobReference,
+        String jobArgString,
+        String jobFilter,
+        String asUser
+    )
+        throws JobNotFound, JobExecutionError {
+        def inputOpts = ["argString": jobArgString]
+        return doRunJob(jobFilter, inputOpts, jobReference, auth, asUser)
+    }
+
+    @Override
+    ExecutionReference startJob(
+        UserAndRolesAuthContext auth,
+        JobReference jobReference,
+        Map optionData,
+        String jobFilter,
+        String asUser
+    )
+        throws JobNotFound, JobExecutionError {
         def inputOpts = [:]
-        inputOpts["argString"] = jobArgString
+        optionData.each { k, v ->
+            inputOpts['option.'+k] = v
+        }
+        return doRunJob(jobFilter, inputOpts, jobReference, auth, asUser)
+    }
+
+    ExecutionReference doRunJob(
+        String jobFilter,
+        Map inputOpts,
+        JobReference jobReference,
+        UserAndRolesAuthContext auth,
+        String asUser
+    ) {
         if (jobFilter) {
-            def filters = [filter:jobFilter]
-            inputOpts['_replaceNodeFilters']='true'
-            inputOpts['doNodedispatch']=true
-            filters.each {k, v ->
-                inputOpts[k] = v
-            }
-            if(null== inputOpts['nodeExcludePrecedence']){
+            inputOpts.filter = jobFilter
+            inputOpts['_replaceNodeFilters'] = 'true'
+            inputOpts['doNodedispatch'] = true
+            if (null == inputOpts['nodeExcludePrecedence']) {
                 inputOpts['nodeExcludePrecedence'] = true
             }
         }
 
         inputOpts['executionType'] = 'user'
-        String resultExecution = "";
 
         def se = ScheduledExecution.findByUuidAndProject(jobReference.id, jobReference.project)
         if (!se || !frameworkService.authorizeProjectJobAny(
@@ -290,14 +319,22 @@ class JobStateService implements AuthorizingJobService {
         )) {
             throw new JobNotFound("Not found", jobReference.id, jobReference.project)
         }
-        if(auth instanceof UserAndRolesAuthContext) {
-            def result = frameworkService.kickJob(se,
-                    auth, asUser, inputOpts)
-            if(result && result.executionId){
-                resultExecution += result.executionId
-            }
+        def result = frameworkService.kickJob(se, auth, asUser, inputOpts)
+        if (result && result.success && result.executionId) {
+            return new ExecutionReferenceImpl(
+                id: result.executionId,
+                job: jobReference,
+                filter: jobFilter,
+                options: result.execution?.argString,
+                dateStarted: result.execution?.dateStarted
+            )
+        } else {
+            throw new JobExecutionError(
+                result?.message ?: result?.error ?: "Unknown: ${result}",
+                jobReference.id,
+                jobReference.project
+            )
         }
-        return resultExecution
     }
 
 
@@ -384,6 +421,8 @@ class JobStateService implements AuthorizingJobService {
             if(se){
                 jobRef = new JobReferenceImpl(id: se.extid, jobName: se.jobName, groupPath: se.groupPath,
                         project: se.project)
+            } else {
+                jobRef = null
             }
             ExecutionReferenceImpl execRef = new ExecutionReferenceImpl(id:exec.id, options: exec.argString,
                     filter: exec.filter, job: jobRef, dateStarted: exec.dateStarted, dateCompleted:exec.dateCompleted,

--- a/rundeckapp/grails-app/services/rundeck/services/execution/ExecutionReferenceImpl.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/execution/ExecutionReferenceImpl.groovy
@@ -1,6 +1,7 @@
 package rundeck.services.execution
 
 import com.dtolabs.rundeck.core.execution.ExecutionReference
+import com.dtolabs.rundeck.core.jobs.JobReference
 import rundeck.services.JobReferenceImpl
 
 
@@ -8,7 +9,7 @@ class ExecutionReferenceImpl implements ExecutionReference {
     String options
     String filter
     String id
-    JobReferenceImpl job
+    JobReference job
     Date dateStarted
     Date dateCompleted
     String status

--- a/rundeckapp/grails-app/services/rundeck/services/jobs/AuthorizingJobService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/jobs/AuthorizingJobService.groovy
@@ -17,8 +17,10 @@
 package rundeck.services.jobs
 
 import com.dtolabs.rundeck.core.authorization.AuthContext
+import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.execution.ExecutionNotFound
 import com.dtolabs.rundeck.core.execution.ExecutionReference
+import com.dtolabs.rundeck.core.jobs.JobExecutionError
 import com.dtolabs.rundeck.core.jobs.JobNotFound
 import com.dtolabs.rundeck.core.jobs.JobReference
 import com.dtolabs.rundeck.core.jobs.JobState
@@ -44,7 +46,23 @@ interface AuthorizingJobService {
 
     ExecutionReference executionForId(AuthContext auth, String id, String project) throws ExecutionNotFound
 
-    String startJob(AuthContext auth, JobReference jobReference, String jobArgString, String jobFilter, String asUser) throws JobNotFound
+    ExecutionReference startJob(
+        UserAndRolesAuthContext auth,
+        JobReference jobReference,
+        String jobArgString,
+        String jobFilter,
+        String asUser
+    )
+        throws JobNotFound, JobExecutionError
+
+    ExecutionReference startJob(
+        UserAndRolesAuthContext auth,
+        JobReference jobReference,
+        Map optionData,
+        String jobFilter,
+        String asUser
+    )
+        throws JobNotFound, JobExecutionError
 
     Map deleteBulkExecutionIds(AuthContext auth, Collection ids, String asUser)
 

--- a/rundeckapp/grails-app/services/rundeck/services/jobs/ResolvedAuthJobService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/jobs/ResolvedAuthJobService.groovy
@@ -17,8 +17,10 @@
 package rundeck.services.jobs
 
 import com.dtolabs.rundeck.core.authorization.AuthContext
+import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.execution.ExecutionReference
 import com.dtolabs.rundeck.core.execution.ExecutionNotFound
+import com.dtolabs.rundeck.core.jobs.JobExecutionError
 import com.dtolabs.rundeck.core.jobs.JobNotFound
 import com.dtolabs.rundeck.core.jobs.JobReference
 import com.dtolabs.rundeck.core.jobs.JobService
@@ -29,7 +31,7 @@ import com.dtolabs.rundeck.core.jobs.JobState
  */
 class ResolvedAuthJobService implements JobService {
     AuthorizingJobService authJobService
-    AuthContext authContext
+    UserAndRolesAuthContext authContext
 
     @Override
     JobReference jobForID(String uuid, String project) throws JobNotFound {
@@ -65,8 +67,14 @@ class ResolvedAuthJobService implements JobService {
     }
 
 
-    String startJob(JobReference jobReference, String jobArgString, String jobFilter, String asUser) throws JobNotFound{
+    ExecutionReference startJob(JobReference jobReference, String jobArgString, String jobFilter, String asUser)
+        throws JobNotFound, JobExecutionError {
         authJobService.startJob(authContext, jobReference, jobArgString, jobFilter, asUser)
+    }
+
+    ExecutionReference startJob(JobReference jobReference, Map optionData, String jobFilter, String asUser)
+        throws JobNotFound, JobExecutionError {
+        authJobService.startJob(authContext, jobReference, optionData, jobFilter, asUser)
     }
 
     Map deleteBulkExecutionIds(Collection ids, String asUser){

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/RundeckAuthorizedServicesProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/RundeckAuthorizedServicesProvider.groovy
@@ -17,6 +17,7 @@
 package org.rundeck.app.authorization
 
 import com.dtolabs.rundeck.core.authorization.AuthContext
+import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.cluster.ClusterInfoService
 import com.dtolabs.rundeck.core.jobs.JobService
 import groovy.transform.CompileStatic
@@ -35,15 +36,15 @@ class RundeckAuthorizedServicesProvider implements AuthorizedServicesProvider {
     private static List<Class> SERVICE_TYPES = [(Class) JobService]
 
     @Override
-    Services getServicesWith(final AuthContext authContext) {
+    Services getServicesWith(final UserAndRolesAuthContext authContext) {
         return new AuthedServices(authContext, baseServices.services)
     }
 
     class AuthedServices implements Services {
-        final AuthContext authContext
+        final UserAndRolesAuthContext authContext
         final Services baseServices
 
-        AuthedServices(final AuthContext authContext, final Services baseServices) {
+        AuthedServices(final UserAndRolesAuthContext authContext, final Services baseServices) {
             this.authContext = authContext
             this.baseServices = baseServices
         }

--- a/rundeckapp/src/test/groovy/rundeck/services/JobStateServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/JobStateServiceSpec.groovy
@@ -51,6 +51,7 @@ class JobStateServiceSpec extends Specification {
             }
             kickJob(!null, !null, null,!null)>>{
                 Map<String, Object> ret = new HashMap<>()
+                ret.success = true
                 ret.executionId = '1'
                 ret
             }
@@ -475,10 +476,12 @@ class JobStateServiceSpec extends Specification {
         setTestExecutions(projectName,jobUuid)
 
         when:
-        def ref = service.startJob(auth,job, null,null,null)
+            def ref = service.startJob(auth, job, (String) null, null, null)
         then:
         ref
-        ref == '1'
+            ref.id == '1'
+            ref.job
+            ref.job.id == jobUuid
     }
 
     void "start job without auth"(){
@@ -494,7 +497,7 @@ class JobStateServiceSpec extends Specification {
         setTestExecutions(projectName,jobUuid)
 
         when:
-        def ref = service.startJob(null,job, null,null,null)
+            def ref = service.startJob(null, job, (String) null, null, null)
         then:
         !ref
         JobNotFound ex = thrown()


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Updates the JobService interface

* starting jobs returns ReferencedExecution
* use Map for option input 