### PR TITLE
Allows custom libraries to configure Jetty WebAppContext

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/init/CustomWebAppInitializer.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/init/CustomWebAppInitializer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dtolabs.rundeck.core.init;
+
+public interface CustomWebAppInitializer<T> {
+    /**
+     * This method will be given the org.eclipse.jetty.webapp.WebAppContext that
+     * comes from the running Rundeck with the embedded jetty servlet container
+     *
+     * The type information is not hard coded to avoid creating a hard dependency
+     * on jetty
+     * @param webAppContext
+     */
+    public void customizeWebAppContext(T webAppContext);
+}

--- a/rundeckapp/src/test/groovy/rundeckapp/init/servlet/JettyConfigPropsInitParameterConfigurationTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/init/servlet/JettyConfigPropsInitParameterConfigurationTest.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rundeckapp.init.servlet
+
+import com.dtolabs.rundeck.core.init.CustomWebAppInitializer
+import org.eclipse.jetty.security.ConstraintSecurityHandler
+import org.eclipse.jetty.security.SecurityHandler
+import org.eclipse.jetty.security.authentication.FormAuthenticator
+import org.eclipse.jetty.webapp.WebAppContext
+import spock.lang.Specification
+
+
+class JettyConfigPropsInitParameterConfigurationTest extends Specification {
+
+    def "PreConfigure no jetty customizer"() {
+        given:
+        JettyConfigPropsInitParameterConfiguration cfg = new JettyConfigPropsInitParameterConfiguration([:])
+        cfg.metaClass.getJettyCustomizers = { [] }
+        WebAppContext context = Mock(WebAppContext)
+
+        when:
+        0 * context.getSecurityHandler()
+        cfg.preConfigure(context)
+
+        then:
+        noExceptionThrown()
+
+    }
+
+    def "PreConfigure bad jetty customizer throws error"() {
+        given:
+        JettyConfigPropsInitParameterConfiguration cfg = new JettyConfigPropsInitParameterConfiguration([:])
+        cfg.metaClass.getJettyCustomizers = { [
+                new CustomWebAppInitializer<WebAppContext>() {
+
+                    @Override
+                    void customizeWebAppContext(final WebAppContext webAppContext) {
+                        webAppContext.getSecurityHandler().setAuthenticator("not a real authenticator class")
+                    }
+                }
+        ] }
+        WebAppContext context = Mock(WebAppContext)
+        SecurityHandler securityHandler = new ConstraintSecurityHandler()
+
+        when:
+        1 * context.getSecurityHandler() >> securityHandler
+        cfg.preConfigure(context)
+
+        then:
+        thrown(Exception)
+
+    }
+
+    def "PreConfigure jetty customizer"() {
+        given:
+        JettyConfigPropsInitParameterConfiguration cfg = new JettyConfigPropsInitParameterConfiguration([:])
+        def formAuth = new FormAuthenticator()
+
+        cfg.metaClass.getJettyCustomizers = { [
+                new CustomWebAppInitializer<WebAppContext>() {
+
+                    @Override
+                    void customizeWebAppContext(final WebAppContext webAppContext) {
+                        webAppContext.getSecurityHandler().setAuthenticator(formAuth)
+                    }
+                }
+        ] }
+        WebAppContext context = Mock(WebAppContext)
+        SecurityHandler securityHandler = new ConstraintSecurityHandler()
+
+        when:
+        1 * context.getSecurityHandler() >> securityHandler
+        cfg.preConfigure(context)
+
+        then:
+        securityHandler.authenticator == formAuth
+
+    }
+
+}


### PR DESCRIPTION
Some customers used the ability to configure the web.xml in Rundeck 2.x to enhance their installation. This PR provides a way for customers to customize the WebAppContext in Rundeck 3.x.

To use this feature follow these steps:
(These steps apply to Rundeck 3.0.7 or later)

1. Create a java project that has the dependencies: org.rundeck:rundeck-core:3.0.7+ and org.eclipse.jetty:jetty-webapp:9.4.11.v20180605
2. Create a class that implements the `com.dtolabs.rundeck.core.init.CustomWebAppInitializer` interface
3. Put your logic that customizes the Jetty `WebAppContext` object in the `customizeWebAppContext` method. The object being supplied to this method has the type: `org.eclipse.jetty.webapp.WebAppContext` 
4. Add a file called `com.dtolabs.rundeck.core.init.CustomWebAppInitializer` in the dir `src/main/resources/META-INF/services/`
5. In that file put the fully qualified name to your implementing class
6. Compile your project to a jar.
7. Drop the jar into the $rundeck_base/server/lib directory and restart your rundeck instance
8. When Rundeck bootstraps it will detect your custom loading code and will execute it