### PR TITLE
Fix: problems with multiple key storage backend definitions

### DIFF
--- a/rundeck-storage/rundeck-storage-api/src/main/java/org/rundeck/storage/api/PathUtil.java
+++ b/rundeck-storage/rundeck-storage-api/src/main/java/org/rundeck/storage/api/PathUtil.java
@@ -16,7 +16,6 @@
 
 package org.rundeck.storage.api;
 
-import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -102,6 +101,22 @@ public class PathUtil {
         return cleanPath(join(components, SEPARATOR));
     }
 
+    /**
+     * @param path path
+     * @return path components
+     */
+    public static String[] componentsFromPath(final Path path) {
+        return componentsFromPathString(path.getPath());
+    }
+
+    /**
+     * @param path path string
+     * @return path components
+     */
+    public static String[] componentsFromPathString(final String path) {
+        return cleanPath(path).split(SEPARATOR);
+    }
+
     private static String join(String[] components, String sep) {
         StringBuilder sb = new StringBuilder();
         for (String component : components) {
@@ -159,12 +174,21 @@ public class PathUtil {
     }
 
     /**
+     * @param patha path A
+     * @param pathb path B
+     * @return true if the paths are equal
+     */
+    public static boolean equals(Path patha, Path pathb) {
+        return cleanPath(patha.getPath()).equals(cleanPath(pathb.getPath()));
+    }
+
+    /**
      * Return the string representing the parent of the given path
      * @param path path string
      * @return parent path string
      */
     public static String parentPathString(String path) {
-        String[] split = cleanPath(path).split(SEPARATOR);
+        String[] split = componentsFromPathString(path);
         if (split.length > 1) {
             StringBuilder stringBuilder = new StringBuilder();
             for (int i = 0; i < split.length - 1; i++) {
@@ -194,7 +218,7 @@ public class PathUtil {
     }
 
     public static String pathName(String path) {
-        String[] split = cleanPath(path).split(SEPARATOR);
+        String[] split = componentsFromPathString(path);
         if (split.length > 0) {
             return split[split.length - 1];
         }

--- a/rundeck-storage/rundeck-storage-conf/src/main/java/org/rundeck/storage/conf/TreeStack.java
+++ b/rundeck-storage/rundeck-storage-conf/src/main/java/org/rundeck/storage/conf/TreeStack.java
@@ -20,10 +20,8 @@ import org.rundeck.storage.api.*;
 import org.rundeck.storage.impl.DelegateTree;
 import org.rundeck.storage.impl.ResourceBase;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Function;
 
 /**
  * tree that uses an ordered list of TreeHandlers to determine which underlying storage to use, and falls back to a
@@ -65,15 +63,22 @@ public class TreeStack<T extends ContentMeta> extends DelegateTree<T> {
         return null;
     }
 
+    private Map<String, Resource<T>> asMap(Set<Resource<T>> matchedList) {
+        HashMap<String, Resource<T>> map = new HashMap<>();
+        for (Resource<T> tResource : matchedList) {
+            map.put(tResource.getPath().getPath(), tResource);
+        }
+        return map;
+    }
     private Set<Resource<T>> merge(Set<Resource<T>> matchedList, Set<Resource<T>> subList) {
-        HashSet<Resource<T>> merge = new HashSet<Resource<T>>();
+        HashMap<String, Resource<T>> merge = new HashMap<>();
         if(null!=matchedList && matchedList.size()>0) {
-            merge.addAll(matchedList);
+            merge.putAll(asMap(matchedList));
         }
         if(null!=subList && subList.size()>0) {
-            merge.addAll(subList);
+            merge.putAll(asMap(subList));
         }
-        return merge;
+        return new HashSet<>(merge.values());
     }
 
     @Override

--- a/rundeck-storage/rundeck-storage-conf/src/main/java/org/rundeck/storage/conf/TreeStack.java
+++ b/rundeck-storage/rundeck-storage-conf/src/main/java/org/rundeck/storage/conf/TreeStack.java
@@ -32,8 +32,8 @@ public class TreeStack<T extends ContentMeta> extends DelegateTree<T> {
 
     public TreeStack(List<? extends SelectiveTree<T>> treeHandlerList, Tree<T> delegate) {
         super(delegate);
-        this.treeHandlerList = treeHandlerList;
         validatePaths(treeHandlerList);
+        this.treeHandlerList = sorted(treeHandlerList);
     }
 
     private void validatePaths(final List<? extends SelectiveTree<T>> treeHandlerList) {
@@ -48,6 +48,18 @@ public class TreeStack<T extends ContentMeta> extends DelegateTree<T> {
                 ));
             }
         }
+    }
+
+    private List<? extends SelectiveTree<T>> sorted(final List<? extends SelectiveTree<T>> treeHandlerList) {
+        ArrayList<? extends SelectiveTree<T>> list = new ArrayList<>(treeHandlerList);
+        //sort by path length longest to shortest
+        list.sort(new Comparator<SelectiveTree<T>>() {
+            @Override
+            public int compare(final SelectiveTree<T> o1, final SelectiveTree<T> o2) {
+                return o2.getSubPath().getPath().length() - o1.getSubPath().getPath().length();
+            }
+        });
+        return list;
     }
 
     @Override

--- a/rundeck-storage/rundeck-storage-conf/src/main/java/org/rundeck/storage/conf/TreeStack.java
+++ b/rundeck-storage/rundeck-storage-conf/src/main/java/org/rundeck/storage/conf/TreeStack.java
@@ -33,6 +33,21 @@ public class TreeStack<T extends ContentMeta> extends DelegateTree<T> {
     public TreeStack(List<? extends SelectiveTree<T>> treeHandlerList, Tree<T> delegate) {
         super(delegate);
         this.treeHandlerList = treeHandlerList;
+        validatePaths(treeHandlerList);
+    }
+
+    private void validatePaths(final List<? extends SelectiveTree<T>> treeHandlerList) {
+        HashSet<String> paths = new HashSet<>();
+        for (SelectiveTree<T> tSelectiveTree : treeHandlerList) {
+            if (!paths.contains(tSelectiveTree.getSubPath().getPath())) {
+                paths.add(tSelectiveTree.getSubPath().getPath());
+            } else {
+                throw new IllegalArgumentException(String.format(
+                    "Cannot create TreeStack: multiple subpaths defined for: %s",
+                    tSelectiveTree.getSubPath()
+                ));
+            }
+        }
     }
 
     @Override

--- a/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
+++ b/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
@@ -196,7 +196,51 @@ class TreeStackSpecification extends Specification {
         listingx2.first().path.path == 'test1/monkey'
     }
 
-    
+
+    def "multiple subpaths listed as subdirs"() {
+        given:
+            def sub1 = new SubPathTree(new MemoryTree(), "/test1/monkey", true)
+            def sub2 = new SubPathTree(new MemoryTree(), "/test1", true)
+            def sub3 = new SubPathTree(new MemoryTree(), "/test2/extra/zingo/zango", true)
+            def tree1 = new TreeStack([sub1, sub2, sub3], new MemoryTree())
+
+            def listing = tree1.listDirectory("/")
+            def listingx1 = tree1.listDirectorySubdirs("/")
+        expect:
+            listing.size() == 2
+            listing.every { it.directory }
+            listing.collect { it.path.path } contains 'test1'
+            listing.collect { it.path.path } contains 'test2'
+
+            listingx1.size() == 2
+            listingx1.every { it.directory }
+            listingx1.collect { it.path.path } contains 'test1'
+            listingx1.collect { it.path.path } contains 'test2'
+    }
+
+    def "intermediate subpaths listed as subdirs"() {
+        given:
+            def sub1 = new SubPathTree(new MemoryTree(), "/test1/monkey", true)
+            def sub2 = new SubPathTree(new MemoryTree(), "/test1", true)
+            def sub3 = new SubPathTree(new MemoryTree(), "/test2/extra/zingo/zango", true)
+            def tree1 = new TreeStack([sub1, sub2, sub3], new MemoryTree())
+
+            def listing = tree1.listDirectory(test)
+            def listingx1 = tree1.listDirectorySubdirs(test)
+        expect:
+            listing.size() == 1
+            listing.every { it.directory }
+            listing.collect { it.path.path } contains expected
+
+            listingx1.size() == 1
+            listingx1.every { it.directory }
+            listingx1.collect { it.path.path } contains expected
+
+        where:
+            test           | expected
+            '/test2'       | 'test2/extra'
+            '/test2/extra' | 'test2/extra/zingo'
+    }
     def "shadow dir in path is ignored"() {
         given:
             def sub1 = new SubPathTree(new MemoryTree(), "/test1/monkey", true)

--- a/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
+++ b/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
@@ -121,6 +121,18 @@ class TreeStackSpecification extends Specification {
             '/test1'        | '/test1/monkey' | '/test1/monkey2/balogna/flea' | "/test1/monkey/applesauce"
     }
 
+
+    def "create file in subtree root fails"() {
+        def sub1 = new SubPathTree(new MemoryTree(), "/test1/monkey", false)
+        def tree1 = new TreeStack([sub1], new MemoryTree())
+
+        when:
+            def result = tree1.createResource("/test1/monkey", dataWithText('monkey data'))
+
+        then:
+            IllegalArgumentException e = thrown()
+    }
+
     def "more specific subtree match"(){
         def mem1 = new MemoryTree()
         def sub1 = new SubPathTree(mem1, "/test1", true)

--- a/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
+++ b/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
@@ -94,6 +94,33 @@ class TreeStackSpecification extends Specification {
     public MemoryTree memory() {
         new MemoryTree()
     }
+
+    @Unroll
+    def "longest handler subpath has precedence"() {
+        given:
+
+            def mem1 = memory()
+            def sub1 = new SubPathTree(mem1, orderA, true)
+
+            def mem2 = memory()
+            def sub2 = new SubPathTree(mem2, orderB, true)
+            def mem3 = memory()
+            def tree1 = new TreeStack([sub1, sub2], mem3)
+
+            tree1.createResource(expectA, dataWithText('a data'))
+            tree1.createResource(expectB, dataWithText('b data'))
+        expect:
+            mem1.hasResource(expectA)
+            !mem2.hasResource(expectA)
+            !mem1.hasResource(expectB)
+            mem2.hasResource(expectB)
+
+        where:
+            orderA          | orderB          | expectA                       | expectB
+            '/test1/monkey' | '/test1'        | "/test1/monkey/applesauce"    | '/test1/monkey2/balogna/flea'
+            '/test1'        | '/test1/monkey' | '/test1/monkey2/balogna/flea' | "/test1/monkey/applesauce"
+    }
+
     def "more specific subtree match"(){
         def mem1 = new MemoryTree()
         def sub1 = new SubPathTree(mem1, "/test1", true)

--- a/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
+++ b/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
@@ -141,6 +141,19 @@ class TreeStackSpecification extends Specification {
         listingx2.first().directory
         listingx2.first().path.path == 'test1/monkey'
     }
+
+    def "shadow resource in stack is ignored"() {
+        given:
+            def sub1 = new SubPathTree(new MemoryTree(), "/test1/monkey", true)
+            def sub2 = new SubPathTree(new MemoryTree(), "/test1", true)
+            def tree1 = new TreeStack([sub1, sub2], new MemoryTree())
+            sub2.createResource('/test1/monkey', dataWithText('test data'))
+
+        expect:
+            !tree1.hasResource('/test1/monkey')
+            tree1.hasDirectory('/test1/monkey')
+
+    }
     def "subtrees exist as dirs in the parent"(){
         def mem1 = new MemoryTree()
         def sub1 = new SubPathTree(mem1, "/test1/monkey", true)

--- a/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
+++ b/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
@@ -142,6 +142,19 @@ class TreeStackSpecification extends Specification {
         listingx2.first().path.path == 'test1/monkey'
     }
 
+    
+    def "shadow dir in path is ignored"() {
+        given:
+            def sub1 = new SubPathTree(new MemoryTree(), "/test1/monkey", true)
+            def sub2 = new SubPathTree(new MemoryTree(), "/test1", true)
+            def tree1 = new TreeStack([sub1, sub2], new MemoryTree())
+            sub2.createResource('/test1/monkey/roomba', dataWithText('test data'))
+            def listing = tree1.listDirectory('/test1')
+        expect:
+            listing.size() == 1
+            listing.first().path.name == 'monkey'
+    }
+
     def "shadow resource in stack is ignored"() {
         given:
             def sub1 = new SubPathTree(new MemoryTree(), "/test1/monkey", true)

--- a/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
+++ b/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
@@ -135,22 +135,6 @@ class TreeStackSpecification extends Specification {
 
     def "more specific subtree match"(){
         def mem1 = new MemoryTree()
-        def sub1 = new SubPathTree(mem1, "/test1", true)
-        def mem2 = new MemoryTree()
-        def sub2 = new SubPathTree(mem2, "/test1", true)
-        def mem3 = new MemoryTree()
-        def tree1 = new TreeStack([sub1, sub2], mem3)
-
-        tree1.createResource("/test1/monkey", dataWithText('monkey data'))
-        tree1.createResource("/test1/monkey2/balogna/flea", dataWithText('monkey data'))
-        expect:
-        mem1.hasResource("/test1/monkey")
-        !mem2.hasResource("/test1/monkey")
-        mem1.hasResource("/test1/monkey2/balogna/flea")
-        !mem2.hasResource("/test1/monkey2/balogna/flea")
-    }
-    def "more specific subtree match"(){
-        def mem1 = new MemoryTree()
         def sub1 = new SubPathTree(mem1, "/test1/monkey", true)
         def mem2 = new MemoryTree()
         def sub2 = new SubPathTree(mem2, "/test1", true)
@@ -164,6 +148,23 @@ class TreeStackSpecification extends Specification {
         !mem2.hasResource("/test1/monkey")
         !mem1.hasResource("/test1/monkey2/balogna/flea")
         mem2.hasResource("/test1/monkey2/balogna/flea")
+    }
+
+    def "subtree ordering doesn't matter"() {
+        def mem1 = new MemoryTree()
+        def sub1 = new SubPathTree(mem1, "/test1/monkey", true)
+        def mem2 = new MemoryTree()
+        def sub2 = new SubPathTree(mem2, "/test1", true)
+        def mem3 = new MemoryTree()
+        def tree1 = new TreeStack([sub2, sub1], mem3)
+
+        tree1.createResource("/test1/monkey/ringo", dataWithText('monkey data'))
+        tree1.createResource("/test1/monkey2/balogna/flea", dataWithText('monkey data'))
+        expect:
+            mem1.hasResource("/test1/monkey/ringo")
+            !mem2.hasResource("/test1/monkey/ringo")
+            !mem1.hasResource("/test1/monkey2/balogna/flea")
+            mem2.hasResource("/test1/monkey2/balogna/flea")
     }
     def "subtrees are listed as dirs in the parent"(){
         def mem1 = new MemoryTree()

--- a/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
+++ b/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
@@ -80,7 +80,21 @@ class TreeStackSpecification extends Specification {
         !mem3.hasResource("/test1/monkey")
         mem3.hasResource("/test2/monkey")
     }
-    def "if multiple treehandlers match, first one is used"(){
+
+    def "cannot define two handlers with the same path"() {
+        def sub1 = new SubPathTree(memory(), "/test1", true)
+        def sub2 = new SubPathTree(memory(), "/test1", true)
+
+        when:
+            def tree1 = new TreeStack([sub1, sub2], memory())
+        then:
+            IllegalArgumentException e = thrown()
+    }
+
+    public MemoryTree memory() {
+        new MemoryTree()
+    }
+    def "more specific subtree match"(){
         def mem1 = new MemoryTree()
         def sub1 = new SubPathTree(mem1, "/test1", true)
         def mem2 = new MemoryTree()

--- a/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
+++ b/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/TreeStackSpecification.groovy
@@ -16,14 +16,11 @@
 
 package org.rundeck.storage.conf
 
-import org.rundeck.storage.data.DataUtil
+
 import spock.lang.Specification
 import org.rundeck.storage.data.MemoryTree
+import spock.lang.Unroll
 
-import static org.rundeck.storage.api.PathUtil.asPath
-import static org.rundeck.storage.api.PathUtil.asPath
-import static org.rundeck.storage.api.PathUtil.asPath
-import static org.rundeck.storage.api.PathUtil.asPath
 import static org.rundeck.storage.api.PathUtil.asPath
 import static org.rundeck.storage.data.DataUtil.dataWithText
 

--- a/rundeck-storage/rundeck-storage-data/src/main/java/org/rundeck/storage/data/MemoryTree.java
+++ b/rundeck-storage/rundeck-storage-data/src/main/java/org/rundeck/storage/data/MemoryTree.java
@@ -188,7 +188,7 @@ public class MemoryTree<T extends ContentMeta> extends StringToPathTree<T> imple
     }
 
     public Resource<T> createResource(Path path, T data) {
-        if (hasResource(path)) {
+        if (hasPath(path)) {
             throw new IllegalArgumentException("Resource exists for path: " + path);
         }
         DirRes<T> newRes = createRes(path, data);

--- a/rundeck-storage/rundeck-storage-data/src/test/groovy/org/rundeck/storage/data/MemoryTreeSpecification.groovy
+++ b/rundeck-storage/rundeck-storage-data/src/test/groovy/org/rundeck/storage/data/MemoryTreeSpecification.groovy
@@ -144,4 +144,23 @@ class MemoryTreeSpecification extends Specification {
         storage.hasDirectory("/abc")
         !storage.hasPath("/abc/def")
     }
+
+    def "can't create resource at dir path"() {
+        given: "basic storage"
+            def storage = new MemoryTree<ContentMeta>()
+
+        when: "store resource at existing dir path"
+            storage.createResource("/abc/def/ghi", dataWithText('blah'));
+
+            storage.createResource(existingDirPath, dataWithText('blah2'));
+
+        then: "error"
+            IllegalArgumentException e = thrown()
+
+        where:
+            existingDirPath | _
+            '/abc/def'      | _
+            '/'             | _
+
+    }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #4094 

**Describe the solution you've implemented**

Fix several problems related to configuration and behavior when multiple storage layers are defined.

* Key storage user interface problems due to backend issues
* Multiple folders with the same name shown
* Reading/writing key values was not storing in correct path

**Additional context**

Example configuration:

~~~
rundeck.storage.provider.1.type=db
rundeck.storage.provider.1.path=/
# alternate path that will also work:
#rundeck.storage.provider.1.path=/keys

rundeck.storage.provider.2.type=file
rundeck.storage.provider.2.path=/keys/extra
rundeck.storage.provider.2.config.baseDir=/tmp/rd-store-keys-extra
~~~

The behavior should be:

* anything stored under /keys/extra should read/write from filesystem
* anything stored elsewhere under /keys should read/write to DB

These problems were fixed:

* the config definition order affected the behavior, so the `/keys` path was occluding the `/keys/extra` path
* if a path `/keys/extra/other` was stored, then the `/keys/extra` entry was displayed twice, because the listing was reporting results from both path configurations
