### PR TITLE
Basic numeric rules condition

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericCondition.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericCondition.java
@@ -1,0 +1,25 @@
+package com.dtolabs.rundeck.core.rules;
+
+import com.dtolabs.rundeck.core.Constants;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class NumericCondition {
+    final static String DOUBLE_PATTERN = "^([0-9]+\\.?[0-9]*).*";
+
+    public static Float extractFloat(final String value){
+        if(value == null){
+            return 0f;
+        }
+        Pattern pattern = Pattern.compile(DOUBLE_PATTERN);
+        Matcher matcher = pattern.matcher(value);
+        if(matcher.matches()){
+            String val = matcher.group(1);
+            Float nValue = Float.parseFloat(val);
+            return nValue;
+        }else{
+            return 0f;
+        }
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericEqualsCondition.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericEqualsCondition.java
@@ -1,0 +1,39 @@
+package com.dtolabs.rundeck.core.rules;
+
+
+public class NumericEqualsCondition implements Condition {
+    private String key;
+    private String value;
+
+    final double THRESHOLD = .00001;
+
+    public NumericEqualsCondition(final String key, final String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public boolean test(final StateObj input) {
+        String anObject = input.getState().get(key);
+        if (value == null) {
+            return false;
+        }
+        Float fValue = NumericCondition.extractFloat(value);
+        Float fObject = NumericCondition.extractFloat(anObject);
+        return (Math.abs(fValue - fObject) < THRESHOLD);
+    }
+
+    @Override
+    public String toString() {
+        return "(" + value + " == '" + key + '\'' + ")";
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericGreaterThanCondition.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericGreaterThanCondition.java
@@ -1,0 +1,48 @@
+package com.dtolabs.rundeck.core.rules;
+
+
+public class NumericGreaterThanCondition implements Condition {
+    private String key;
+    private String value;
+
+    public NumericGreaterThanCondition(final String key, final String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public boolean test(final StateObj input) {
+        String anObject = input.getState().get(key);
+        if (value == null) {
+            return false;
+        }
+        Float fValue = extractFloat(value);
+        Float fObject = extractFloat(anObject);
+        return fObject>fValue;
+    }
+
+    @Override
+    public String toString() {
+        return "(" + value + " > '" + key + '\'' + ")";
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    private Float extractFloat(final String value){
+        if(value == null){
+            return 0f;
+        }
+        try{
+            Float nValue = Float.parseFloat(value);
+            return nValue;
+        }catch (NumberFormatException ne){
+            return 0f;
+        }
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericGreaterThanCondition.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericGreaterThanCondition.java
@@ -16,8 +16,8 @@ public class NumericGreaterThanCondition implements Condition {
         if (value == null) {
             return false;
         }
-        Float fValue = extractFloat(value);
-        Float fObject = extractFloat(anObject);
+        Float fValue = NumericCondition.extractFloat(value);
+        Float fObject = NumericCondition.extractFloat(anObject);
         return fObject>fValue;
     }
 
@@ -34,15 +34,4 @@ public class NumericGreaterThanCondition implements Condition {
         return value;
     }
 
-    private Float extractFloat(final String value){
-        if(value == null){
-            return 0f;
-        }
-        try{
-            Float nValue = Float.parseFloat(value);
-            return nValue;
-        }catch (NumberFormatException ne){
-            return 0f;
-        }
-    }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericLessThanCondition.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericLessThanCondition.java
@@ -16,8 +16,8 @@ public class NumericLessThanCondition implements Condition {
         if (value == null) {
             return false;
         }
-        Float fValue = extractFloat(value);
-        Float fObject = extractFloat(anObject);
+        Float fValue = NumericCondition.extractFloat(value);
+        Float fObject = NumericCondition.extractFloat(anObject);
         return fObject<fValue;
     }
 
@@ -34,15 +34,4 @@ public class NumericLessThanCondition implements Condition {
         return value;
     }
 
-    private Float extractFloat(final String value){
-        if(value == null){
-            return 0f;
-        }
-        try{
-            Float nValue = Float.parseFloat(value);
-            return nValue;
-        }catch (NumberFormatException ne){
-            return 0f;
-        }
-    }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericLessThanCondition.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericLessThanCondition.java
@@ -1,0 +1,48 @@
+package com.dtolabs.rundeck.core.rules;
+
+
+public class NumericLessThanCondition implements Condition {
+    private String key;
+    private String value;
+
+    public NumericLessThanCondition(final String key, final String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public boolean test(final StateObj input) {
+        String anObject = input.getState().get(key);
+        if (value == null) {
+            return false;
+        }
+        Float fValue = extractFloat(value);
+        Float fObject = extractFloat(anObject);
+        return fObject<fValue;
+    }
+
+    @Override
+    public String toString() {
+        return "(" + value + " < '" + key + '\'' + ")";
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    private Float extractFloat(final String value){
+        if(value == null){
+            return 0f;
+        }
+        try{
+            Float nValue = Float.parseFloat(value);
+            return nValue;
+        }catch (NumberFormatException ne){
+            return 0f;
+        }
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/Rules.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/Rules.java
@@ -232,4 +232,14 @@ public class Rules {
     public static Condition gtCondition(String key, String value) {
         return new NumericGreaterThanCondition(key, value);
     }
+
+    /**
+     * Compare two numeric values. If the value is'nt a valid float number, it will default to zero.
+     * @param key
+     * @param value
+     * @return new Condition
+     */
+    public static Condition eqCondition(String key, String value) {
+        return new NumericEqualsCondition(key, value);
+    }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/Rules.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/Rules.java
@@ -211,4 +211,25 @@ public class Rules {
     public static Function<? super Rule, Optional<StateObj>> applyRule(final StateObj state) {
         return input -> Optional.ofNullable(input.evaluate(state));
     }
+
+
+    /**
+     * Compare two numeric values. If the value is'nt a valid float number, it will default to zero.
+     * @param key
+     * @param value
+     * @return new Condition
+     */
+    public static Condition ltCondition(String key, String value) {
+        return new NumericLessThanCondition(key, value);
+    }
+
+    /**
+     * Compare two numeric values. If the value is'nt a valid float number, it will default to zero.
+     * @param key
+     * @param value
+     * @return new Condition
+     */
+    public static Condition gtCondition(String key, String value) {
+        return new NumericGreaterThanCondition(key, value);
+    }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/rules/RulesSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/rules/RulesSpec.groovy
@@ -163,6 +163,7 @@ class RulesSpec extends Specification {
         !cond.test(States.state("a", "2"))
         cond.test(States.state("a", "test"))
         cond.test(States.state("c", "2"))
+        !cond.test(States.state("a", "1-test"))
 
     }
 
@@ -175,8 +176,26 @@ class RulesSpec extends Specification {
         cond.test(States.state("a", "1.5"))
         !cond.test(States.state("a", "1"))
         cond.test(States.state("a", "2"))
+        cond.test(States.state("a", "2 test"))
         !cond.test(States.state("a", "test"))
         !cond.test(States.state("c", "2"))
+
+    }
+
+    def "numeric equals condition key value"() {
+        given:
+        def cond = Rules.eqCondition("a", "1")
+
+        expect:
+        !cond.test(States.state("a", "0"))
+        cond.test(States.state("a", "1"))
+        cond.test(States.state("a", "0.9999999"))
+        cond.test(States.state("a", "1-test"))
+        cond.test(States.state("a", "1 test"))
+        !cond.test(States.state("a", "test-1"))
+        !cond.test(States.state("a", "2"))
+        !cond.test(States.state("a", "2-test"))
+
 
     }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/rules/RulesSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/rules/RulesSpec.groovy
@@ -151,4 +151,32 @@ class RulesSpec extends Specification {
         cond.test(States.state(a: 'b', c: 'd'))
         cond.test(States.state(a: 'b', c: 'd', e: 'f'))
     }
+
+    def "less than condition key value"() {
+        given:
+        def cond = Rules.ltCondition("a", "1")
+
+        expect:
+        cond.test(States.state("a", "0"))
+        cond.test(States.state("a", "0.5"))
+        !cond.test(States.state("a", "1"))
+        !cond.test(States.state("a", "2"))
+        cond.test(States.state("a", "test"))
+        cond.test(States.state("c", "2"))
+
+    }
+
+    def "greater than condition key value"() {
+        given:
+        def cond = Rules.gtCondition("a", "1")
+
+        expect:
+        !cond.test(States.state("a", "0"))
+        cond.test(States.state("a", "1.5"))
+        !cond.test(States.state("a", "1"))
+        cond.test(States.state("a", "2"))
+        !cond.test(States.state("a", "test"))
+        !cond.test(States.state("c", "2"))
+
+    }
 }


### PR DESCRIPTION
Support for basic numeric integer and float Condition for ruleset.

Less than, Greater than and Equals using only the number portion.