### PR TITLE
Notification Plugin required properties not allowing project/framework defaults

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -392,7 +392,6 @@ public class NotificationService implements ApplicationContextAware{
                     execMap.job=jobMap
                     execMap.context=context
                     Map config= n.configuration
-                    println(config.toString())
                     if (context && config) {
                         config = DataContextUtils.replaceDataReferences(config, context)
                     }

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -392,8 +392,15 @@ public class NotificationService implements ApplicationContextAware{
                     execMap.job=jobMap
                     execMap.context=context
                     Map config= n.configuration
+                    println(config.toString())
                     if (context && config) {
                         config = DataContextUtils.replaceDataReferences(config, context)
+                    }
+
+                    config = config.each {
+                        if(!it.value){
+                            it.value=null
+                        }
                     }
 
                     didsend=triggerPlugin(trigger,execMap,n.type, frameworkService.getFrameworkPropertyResolver(source.project, config))


### PR DESCRIPTION
For notification plugins, fix the issue when the plugin properties are defined at project or framework level. 
For https://github.com/rundeck/rundeck/issues/3459
