### PR TITLE
Fixing issue #4107, NPE running job reference jobs with secure option with default values

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3140,14 +3140,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             )
         }
 
-        if (!newargs){
-            def props = [:]
-            HashMap optparams = validateJobInputOptions(props, se, null)
-            optparams = removeSecureOptionEntries(se, optparams)
-
-            newargs = generateJobArgline(se, optparams)
-        }
-
         def jobOptsMap = frameworkService.parseOptsFromArray(newargs)
         if(importOptions && executionContext.dataContext?.option) {
             jobOptsMap = addImportedOptions(se,jobOptsMap, executionContext)

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -3464,4 +3464,73 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         newCtxt.dataContext['option'] == ['test1.delimiter':',', 'test1':'A,B']
 
     }
+
+    def "createJobReferenceContext default values secure option"() {
+        given:
+        def context = ExecutionContextImpl.builder()
+                                          .
+                threadCount(1)
+                                          .
+                keepgoing(false)
+                                          .
+                dataContext(['option': ['monkey': 'wakeful'], 'secureOption': [:], 'job': ['execid': '123']])
+                                          .
+                privateDataContext(['option': [:],])
+                                          .
+                user('aUser')
+                                          .
+                build()
+        ScheduledExecution se = new ScheduledExecution(
+                jobName: 'blue',
+                project: 'AProject',
+                groupPath: 'some/where',
+                description: 'a job',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec(
+                                [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
+                        )]
+                ),
+                options: [
+                        new Option(
+                                name: 'pass',
+                                secureInput: true,
+                                secureExposed: true,
+                                defaultStoragePath: "keys/admin/pass"
+                        )
+                ]
+                )
+        null != se
+        null != se.save()
+        service.frameworkService = Mock(FrameworkService) {
+            1 * filterNodeSet(null, 'AProject')
+            1 * filterAuthorizedNodes(*_)
+            1 * getProjectGlobals(*_)
+            0 * _(*_)
+        }
+
+        service.storageService = Mock(StorageService)
+        service.jobStateService = Mock(JobStateService)
+        service.storageService = Mock(StorageService)
+        def authContext = Mock(AuthContext)
+        when:
+
+        def newCtxt = service.createJobReferenceContext(
+                se,
+                null,
+                context,
+                [] as String[],
+                null, null, null, null, null, null, false, false, false
+        )
+
+        then:
+
+        2*service.storageService.storageTreeWithContext(_) >> Mock(KeyStorageTree) {
+            readPassword('keys/admin/pass') >> {
+                return 'pass1'.bytes
+            }
+        }
+
+        newCtxt.dataContext['secureOption'] == ['pass': 'pass1']
+    }
 }


### PR DESCRIPTION
It fixes issue https://github.com/rundeck/rundeck/issues/4107

It was produced for a not-necessary code added on https://github.com/rundeck/rundeck/pull/4071, which was added to get the default options values from child jobs (using job reference). That feature already existed on the code.
I added a test for the case that the default value is a secure option with a default value (issue #4107).
