### PR TITLE
fix: grails-spa build, don't include extraneous assets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,6 @@ allprojects {
 subprojects {
     // set the eclipse project naming convention to rundeck:<path>:<projectName>
     // so it matches the logical hierarchy more closely
-    apply from: "${rootDir}/gradle/java.gradle"
     apply plugin: 'eclipse'
     eclipse.project.name = "${project.getParent().eclipse.project.name}:${name}"
 }
@@ -147,6 +146,7 @@ gradle.taskGraph.whenReady { taskGraph ->
 //subproject libs that are uploaded to maven central
 exportedProjects.each {
     project(it) {
+        apply from: "${rootDir}/gradle/java.gradle"
 
         configurations {
             existing

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -1,3 +1,6 @@
+plugins{
+    id 'base'
+}
 project.evaluationDependsOn(":rundeck")
 
 def providedTags = findProperty('dockerTags')?: ''

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -26,6 +26,7 @@ eclipse.project.name =  "${project.getParent().eclipse.project.name}:plugins";
 ext.rundeckPluginVersion= '1.2'
 subprojects{
 
+    apply from: "${rootDir}/gradle/java.gradle"
 
     defaultTasks 'clean','build'
     archivesBaseName = "rundeck-$project.name"

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -35,6 +35,7 @@ configurations {
     pluginFiles {
         transitive = false
     }
+    spa //dependency on grails-spa
 }
 
 repositories {
@@ -66,6 +67,8 @@ dependencies {
                 "com.github.rundeck-plugins:aws-s3-model-source:v1.0",
                 "com.github.rundeck-plugins:py-winrm-plugin:1.0.7",
                 "com.github.rundeck-plugins:openssh-node-execution:1.0.3"
+
+    spa project(path: ':rundeck:grails-spa', configuration: 'archives')
 
     // Rundeck project dependencies.
     compile project(':core')
@@ -268,8 +271,9 @@ task('copyPluginLibs').dependsOn(configurations.pluginFiles).doLast {
 }
 
 task copySpa(type: Copy) {
-    dependsOn ':rundeck:grails-spa:buildSpa'
-    from project(':rundeck:grails-spa').buildDir
+    from( configurations.spa){
+        include('provided/**')
+    }
     into "$projectDir/grails-app/assets"
     outputs.dir "$projectDir/grails-app/assets/provided"
 }

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -68,7 +68,7 @@ dependencies {
                 "com.github.rundeck-plugins:py-winrm-plugin:1.0.7",
                 "com.github.rundeck-plugins:openssh-node-execution:1.0.3"
 
-    spa project(path: ':rundeck:grails-spa', configuration: 'archives')
+    spa project(path: ':rundeck:grails-spa', configuration: 'spa')
 
     // Rundeck project dependencies.
     compile project(':core')

--- a/rundeckapp/grails-spa/build.gradle
+++ b/rundeckapp/grails-spa/build.gradle
@@ -6,8 +6,6 @@ configurations{
   spa
 }
 
-archivesBaseName = "rundeckapp-spa"
-
 task runNpmBuild(type: NpmTask, group: 'build') {
     dependsOn npmInstall
 

--- a/rundeckapp/grails-spa/build.gradle
+++ b/rundeckapp/grails-spa/build.gradle
@@ -1,14 +1,23 @@
 plugins {
   id "com.moowork.node" version "1.2.0"
+  id 'base'
 }
 
-task buildSpa(type: NpmTask, group: 'build') {
+archivesBaseName = "rundeckapp-spa"
+
+task runNpmBuild(type: NpmTask, group: 'build') {
     dependsOn npmInstall
 
     inputs.dir 'build'
     inputs.dir 'config'
     inputs.dir 'src'
 
-    outputs.dir("$buildDir")
+    outputs.dir(buildDir)
     args = ['run', 'build']
+}
+
+assemble.dependsOn runNpmBuild
+
+artifacts {
+  archives(file: buildDir, name: "${project.name}", type: 'directory', builtBy: runNpmBuild)
 }

--- a/rundeckapp/grails-spa/build.gradle
+++ b/rundeckapp/grails-spa/build.gradle
@@ -2,6 +2,9 @@ plugins {
   id "com.moowork.node" version "1.2.0"
   id 'base'
 }
+configurations{
+  spa
+}
 
 archivesBaseName = "rundeckapp-spa"
 
@@ -19,5 +22,5 @@ task runNpmBuild(type: NpmTask, group: 'build') {
 assemble.dependsOn runNpmBuild
 
 artifacts {
-  archives(file: buildDir, name: "${project.name}", type: 'directory', builtBy: runNpmBuild)
+  spa(file: buildDir, name: "${project.name}", type: 'directory', builtBy: runNpmBuild)
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

the rundeckapp/grails-spa build was including extraneous files (jars) in the assets dir

**Describe the solution you've implemented**

Update node based gradle build for grails-spa to use gradle base plugin, define archives, and update the rundeck app grails build to only copy the correct assets.
