### PR TITLE
Fix execution show page error when invalid parameter was set

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -1421,7 +1421,7 @@ setTimeout(function(){
         def completed=false
         def max= 0
         def lastlinesSupported= (ReverseSeekingStreamingLogReader.isInstance(logread))
-        def lastlines = params.lastlines?Long.parseLong(params.lastlines):0
+        def lastlines = params.long('lastlines',0)
         if(lastlines && lastlinesSupported){
             def ReverseSeekingStreamingLogReader reversing= (ReverseSeekingStreamingLogReader) logread
             reversing.openStreamFromReverseOffset(lastlines)
@@ -1429,10 +1429,7 @@ setTimeout(function(){
             max=lastlines+1
         }else{
             logread.openStream(offset)
-
-            if (null != params.maxlines) {
-                max = Integer.parseInt(params.maxlines)
-            }
+            max = Math.max(0,params.int('maxlines',0))
         }
 
         def String bufsizestr= servletContext.getAttribute("execution.follow.buffersize");
@@ -1587,7 +1584,7 @@ setTimeout(function(){
                 response.addHeader('X-Rundeck-ExecOutput-Completed', completed.toString())
                 response.addHeader('X-Rundeck-Exec-Completed', jobcomplete.toString())
                 response.addHeader('X-Rundeck-Exec-State', execState.toString())
-                response.addHeader('X-Rundeck-Exec-Status-String', statusString?.toString())
+                response.addHeader('X-Rundeck-Exec-Status-String', statusString?.toString()?:'')
                 response.addHeader('X-Rundeck-Exec-Duration', execDuration.toString())
                 response.addHeader('X-Rundeck-ExecOutput-LastModifed', lastmodl.toString())
                 response.addHeader('X-Rundeck-ExecOutput-TotalSize', totsize.toString())

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -322,6 +322,77 @@ class ExecutionControllerSpec extends Specification {
                 'class="ansi-mode-normal"></span>'
     }
 
+    def "tail exec output maxlines param"() {
+        given:
+            def assetTaglib = mockTagLib(AssetMethodTagLib)
+            assetTaglib.assetProcessorService = Mock(AssetProcessorService) {
+                assetBaseUrl(*_) >> ''
+                getAssetPath(*_) >> ''
+            }
+
+            Execution e1 = new Execution(
+                project: 'test1',
+                user: 'bob',
+                dateStarted: new Date(),
+                dateEnded: new Date(),
+                status: 'successful'
+
+            )
+            e1.save() != null
+            controller.loggingService = Mock(LoggingService)
+            controller.configurationService = Mock(ConfigurationService)
+            controller.apiService = Mock(ApiService)
+            controller.frameworkService = Mock(FrameworkService)
+            def reader = new ExecutionLogReader(state: ExecutionLogState.AVAILABLE)
+            reader.reader = new TestReader(
+                logs:
+                    [
+                        new DefaultLogEvent(
+                            eventType: LogUtil.EVENT_TYPE_LOG,
+                            datetime: new Date(),
+                            message: 'message1',
+                            metadata: [:],
+                            loglevel: LogLevel.NORMAL
+                        ),
+                        new DefaultLogEvent(
+                            eventType: LogUtil.EVENT_TYPE_LOG,
+                            datetime: new Date(),
+                            message: 'message2',
+                            metadata: [:],
+                            loglevel: LogLevel.NORMAL
+                        ),
+                        new DefaultLogEvent(
+                            eventType: LogUtil.EVENT_TYPE_LOG,
+                            datetime: new Date(),
+                            message: 'message3',
+                            metadata: [:],
+                            loglevel: LogLevel.NORMAL
+                        ),
+                    ]
+            )
+        when:
+            params.id = e1.id.toString()
+            params.maxlines = maxlines
+            request.addHeader('accept', 'text/plain')
+            controller.tailExecutionOutput()
+        then:
+            rescount == response.text.readLines().size()
+
+            1 * controller.apiService.requireExists(_, e1, _) >> true
+            1 * controller.frameworkService.getAuthContextForSubjectAndProject(_, _)
+            1 * controller.frameworkService.authorizeProjectExecutionAny(*_) >> true
+            1 * controller.loggingService.getLogReader(e1) >> reader
+
+        where:
+            maxlines | rescount
+            '0'      | 3
+            '1'      | 1
+            '2'      | 2
+            '3'      | 3
+            '-1'     | 3
+            'asdf'   | 3
+    }
+
     /**
      * compacted=true, the log entries returned will include only the changed
      * attributes, and if only the "log" is changed, will produce only a string instead of a map.


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix error on Execution show page, if an invalid "maxlines" parameter is sent, possibly due to misconfiguration.

**Describe the solution you've implemented**

Use grails parameter map conversion
