### PR TITLE
Add env variables for preauthenticated mode

### DIFF
--- a/docker/official/README.md
+++ b/docker/official/README.md
@@ -118,3 +118,14 @@ Set to anything enables audit logging. This can be very verbose so use with caut
 
 Configuration options for key storage providers and converts. These map to the
 [Storage Facility Docs](http://rundeck.org/docs/administration/configuration/storage-facility.html).
+
+### `RUNDECK_PREAUTH_ENABLED=false`
+### `RUNDECK_PREAUTH_ATTRIBUTE_NAME=REMOTE_USER_GROUPS`
+### `RUNDECK_PREAUTH_DELIMITER=,`
+### `RUNDECK_PREAUTH_USERNAME_HEADER=X-Forwarded-Uuid`
+### `RUNDECK_PREAUTH_ROLES_HEADER=X-Forwarded-Roles`
+### `RUNDECK_PREAUTH_REDIRECT_LOGOUT=false`
+### `RUNDECK_PREAUTH_REDIRECT_URL=/oauth2/sign_in`
+
+Configuration options for using the 
+[preauthenticated mode](http://rundeck.org/docs/administration/security/authenticating-users.html#preauthenticated-mode).

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -19,16 +19,16 @@ dataSource.password = {{ getv("/rundeck/database/password", "") }}
 
 
 # Pre Auth mode settings
-rundeck.security.authorization.preauthenticated.enabled=false
-rundeck.security.authorization.preauthenticated.attributeName=REMOTE_USER_GROUPS
-rundeck.security.authorization.preauthenticated.delimiter=,
+rundeck.security.authorization.preauthenticated.enabled={{ getv("rundeck/preauth/enabled", "false") }}
+rundeck.security.authorization.preauthenticated.attributeName={{ getv("rundeck/preauth/attribute/name", "REMOTE_USER_GROUPS") }}
+rundeck.security.authorization.preauthenticated.delimiter={{ getv("rundeck/preauth/delimiter", ",") }}
 # Header from which to obtain user name
-rundeck.security.authorization.preauthenticated.userNameHeader=X-Forwarded-Uuid
+rundeck.security.authorization.preauthenticated.userNameHeader={{ getv("rundeck/preauth/username/header", "X-Forwarded-Uuid") }}
 # Header from which to obtain list of roles
-rundeck.security.authorization.preauthenticated.userRolesHeader=X-Forwarded-Roles
+rundeck.security.authorization.preauthenticated.userRolesHeader={{ getv("rundeck/preauth/roles/header", "X-Forwarded-Roles") }}
 # Redirect to upstream logout url
-rundeck.security.authorization.preauthenticated.redirectLogout=false
-rundeck.security.authorization.preauthenticated.redirectUrl=/oauth2/sign_in
+rundeck.security.authorization.preauthenticated.redirectLogout={{ getv("rundeck/preauth/redirect/logout", "false") }}
+rundeck.security.authorization.preauthenticated.redirectUrl={{ getv("rundeck/preauth/redirect/url", "/oauth2/sign_in") }}
 
 rundeck.log4j.config.file=/home/rundeck/server/config/log4j.properties
 

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -18,17 +18,17 @@ dataSource.password = {{ getv("/rundeck/database/password", "") }}
 {% endif %}
 
 
-# Pre Auth mode settings
-rundeck.security.authorization.preauthenticated.enabled={{ getv("rundeck/preauth/enabled", "false") }}
-rundeck.security.authorization.preauthenticated.attributeName={{ getv("rundeck/preauth/attribute/name", "REMOTE_USER_GROUPS") }}
-rundeck.security.authorization.preauthenticated.delimiter={{ getv("rundeck/preauth/delimiter", ",") }}
+#Pre Auth mode settings
+rundeck.security.authorization.preauthenticated.enabled={{ getv("/rundeck/preauth/enabled", "false") }}
+rundeck.security.authorization.preauthenticated.attributeName={{ getv("/rundeck/preauth/attribute/name", "REMOTE_USER_GROUPS") }}
+rundeck.security.authorization.preauthenticated.delimiter={{ getv("/rundeck/preauth/delimiter", ",") }}
 # Header from which to obtain user name
-rundeck.security.authorization.preauthenticated.userNameHeader={{ getv("rundeck/preauth/username/header", "X-Forwarded-Uuid") }}
+rundeck.security.authorization.preauthenticated.userNameHeader={{ getv("/rundeck/preauth/username/header", "X-Forwarded-Uuid") }}
 # Header from which to obtain list of roles
-rundeck.security.authorization.preauthenticated.userRolesHeader={{ getv("rundeck/preauth/roles/header", "X-Forwarded-Roles") }}
+rundeck.security.authorization.preauthenticated.userRolesHeader={{ getv("/rundeck/preauth/roles/header", "X-Forwarded-Roles") }}
 # Redirect to upstream logout url
-rundeck.security.authorization.preauthenticated.redirectLogout={{ getv("rundeck/preauth/redirect/logout", "false") }}
-rundeck.security.authorization.preauthenticated.redirectUrl={{ getv("rundeck/preauth/redirect/url", "/oauth2/sign_in") }}
+rundeck.security.authorization.preauthenticated.redirectLogout={{ getv("/rundeck/preauth/redirect/logout", "false") }}
+rundeck.security.authorization.preauthenticated.redirectUrl={{ getv("/rundeck/preauth/redirect/url", "/oauth2/sign_in") }}
 
 rundeck.log4j.config.file=/home/rundeck/server/config/log4j.properties
 


### PR DESCRIPTION
In order to use the official container image with an oauth2 proxy
Or any other authentication layer, we need to add this environment
variables to the rundeck-config.properties template, since the
entrypoint of the image overwrites the rundeck-config.properties if
mounted. Also that's for adopting a better practice.

fixes  #4142