### PR TITLE
add env for LDAP auth in docker  and fix Misspelled words 

### DIFF
--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -22,7 +22,9 @@
         rolePrefix="{{ getv("/rundeck/jaas/ldap/rolePrefix", "") }}"
         cacheDurationMillis="{{ getv("/rundeck/jaas/ldap/cachedurationmillis", "600000") }}"
         reportStatistics="{{ getv("/rundeck/jaas/ldap/reportstatistics", "true") }}"
-	roleUsernameMemberAttribute="{{ getv("/rundeck/jaas/ldap/rolessernamememberattribute", "memberUid") }}"
+    {% if exists("/rundeck/jaas/ldap/roleusernamememberattribute") -%}
+        roleUsernameMemberAttribute="{{ getv("/rundeck/jaas/ldap/roleusernamememberattribute") }}"
+    {% endif %}
     {% if exists("/rundeck/jaas/ldap/ignoreRoles") -%}
         ignoreRoles={{ getv("/rundeck/jaas/ldap/ignoreRoles") }}
     {% endif %}

--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -22,6 +22,7 @@
         rolePrefix="{{ getv("/rundeck/jaas/ldap/rolePrefix", "") }}"
         cacheDurationMillis="{{ getv("/rundeck/jaas/ldap/cachedurationmillis", "600000") }}"
         reportStatistics="{{ getv("/rundeck/jaas/ldap/reportstatistics", "true") }}"
+	roleUsernameMemberAttribute="{{ getv("/rundeck/jaas/ldap/rolessernamememberattribute", "memberUid") }}"
     {% if exists("/rundeck/jaas/ldap/ignoreRoles") -%}
         ignoreRoles={{ getv("/rundeck/jaas/ldap/ignoreRoles") }}
     {% endif %}
@@ -49,7 +50,7 @@
 
 rundeck {
     {% for module in getvs("/rundeck/jaas/modules/*") %}
-        {% if modlue == "JettyCachingLdapLoginModule" -%}
+        {% if module == "JettyCachingLdapLoginModule" -%}
             {{ JettyCachingLdapLoginModule("JettyCachingLdapLoginModule") }}
         {% elif module == "JettyCombinedLdapLoginModule" -%}
             {{ JettyCachingLdapLoginModule("JettyCombinedLdapLoginModule") }}


### PR DESCRIPTION
for non-docker configuration document https://rundeck.org/docs/administration/security/authenticating-users.html#login-module-configuration , there's`roleUsernameMemberAttribute="memberUid"` in `Login module configuration`, but not found in docker. it's needed to map LDAP group to rundeck roles.

fix the Misspelled words of `module` 