### PR TITLE
Remove refresh of Execution state from database on Notification rundeck/rundeck#3961

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -478,7 +478,6 @@ public class NotificationService implements ApplicationContextAware{
     }
 
     protected Map exportExecutionData(Execution e) {
-        e = Execution.get(e.id)
         def emap = [
             id: e.id,
             href: grailsLinkGenerator.link(controller: 'execution', action: 'follow', id: e.id, absolute: true,


### PR DESCRIPTION
Rundeck issue rundeck/rundeck#3961 shows an out of date execution status being sent to Notification plugins.  I believe that this is due to the call to `Execution.get(e.id)` which refreshes the execution state from the database, however I think the end state of the execution hasn't yet been committed to the database, so the previous running state is fetched.

This passes all tests , and in my local testing addresses the issue - although I can't be sure why this was originally added.