### PR TITLE
Fix for Rundeck #4167 - Null NotificationPlugin config

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -396,7 +396,7 @@ public class NotificationService implements ApplicationContextAware{
                         config = DataContextUtils.replaceDataReferences(config, context)
                     }
 
-                    config = config.each {
+                    config = config?.each {
                         if(!it.value){
                             it.value=null
                         }

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -227,4 +227,40 @@ class NotificationServiceSpec extends Specification {
         1 * service.frameworkService.getFrameworkPropertyResolver(_, config)
 
     }
+
+    def "custom plugin notification no configuration"() {
+        given:
+        def (job, execution) = createTestJob()
+        def content = [
+                execution: execution,
+                context  : Mock(ExecutionContext) 
+        ]
+
+        job.notifications = [
+                new Notification(
+                        eventTrigger: 'onstart',
+                        type: 'SimpleNotificationPlugin'
+                )
+        ]
+        job.save()
+        service.frameworkService = Mock(FrameworkService) {
+            _ * getRundeckFramework() >> Mock(Framework) {
+                _ * getWorkflowStrategyService()
+            }
+            _* getPluginControlService(_) >> Mock(PluginControlService)
+
+        }
+
+        service.grailsLinkGenerator = Mock(LinkGenerator) {
+            _ * link(*_) >> 'alink'
+        }
+        service.pluginService = Mock(PluginService)
+
+        when:
+        service.triggerJobNotification('start', job, content)
+
+        then:
+        1 * service.frameworkService.getFrameworkPropertyResolver(_, null)
+
+    }
 }


### PR DESCRIPTION
Fix for Rundeck #4167 - Null NotificationPlugin config

This includes a test which fails before the fix is applied, and passes after the fix is applied.