### PR TITLE
Add validation to check if a key exists on secure options

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1158,9 +1158,10 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      * @return
      */
     boolean canReadStoragePassword(AuthContext authContext, String storagePath, boolean failIfMissing){
+
         def keystore = storageService.storageTreeWithContext(authContext)
         try {
-            return keystore.readPassword(storagePath)!=null
+            return keystore.hasPassword(storagePath)
         } catch (StorageException e) {
             if (failIfMissing) {
                 throw new ExecutionServiceException(
@@ -1170,6 +1171,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             }
             return false;
         }
+
+        return false
     }
 
     /**
@@ -1201,6 +1204,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             def keystore = storageService.storageTreeWithContext(authContext)
             found?.each {
                 def defStoragePath = it.defaultStoragePath
+                def exists = false
+                def failReason =""
                 try {
                     //search and replace ${option.
                     if (args && defStoragePath?.contains('${option.')) {
@@ -1213,32 +1218,25 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                         } else {
                             secureOpts[it.name] = new String(password)
                         }
+                        exists = true
                     }else{
-                        if (it.required && failIfMissingRequired) {
-                            throw new ExecutionServiceException(
-                                    "Required option '${it.name}' default value could not be loaded from key storage " +
-                                            "path: ${defStoragePath}: not found"
-                            )
-                        } else {
-                            log.warn(
-                                    "Required option '${it.name}' default value could not be loaded from key storage " +
-                                            "path: ${defStoragePath}: not found"
-                            )
-                        }
+                        failReason="path: ${defStoragePath} not found"
                     }
 
                 } catch (StorageException e) {
+                    failReason = e.message
+                }
+
+                if(!exists){
                     if (it.required && failIfMissingRequired) {
                         throw new ExecutionServiceException(
                                 "Required option '${it.name}' default value could not be loaded from key storage " +
-                                        "path: ${defStoragePath}: ${e.message}",
-                                e
+                                        failReason
                         )
                     } else {
                         log.warn(
-                                "Required option '${it.name}' default value could not be loaded from key storage " +
-                                        "path: ${defStoragePath}: ${e.message}",
-                                e
+                                "for the Option '${it.name}', default value could not be loaded from key storage " +
+                                        failReason
                         )
                     }
                 }
@@ -2494,7 +2492,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
                         invalidOpt opt, lookupMessage(
                                 "domain.Option.validation.required.storageDefault.reason",
-                                [opt.name, opt.defaultStoragePath, e1.cause.message]
+                                [opt.name, opt.defaultStoragePath, e1.message]
 
                         )
                         return

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/storage/KeyStorageTree.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/storage/KeyStorageTree.groovy
@@ -110,4 +110,31 @@ interface KeyStorageTree extends StorageTree {
      */
     byte[] readPrivateKey(String path)
 
+
+    /**
+     *
+     * @param path path
+     * @return boolean
+     *
+     * @throws WrongContentType if not the right content type
+     */
+    boolean hasPassword(String path)
+
+    /**
+     *
+     * @param path path
+     * @return boolean
+     *
+     * @throws WrongContentType if not the right content type
+     */
+    boolean hasPrivateKey(String path)
+
+    /**
+     *
+     * @param path path
+     * @return boolean
+     *
+     * @throws WrongContentType if not the right content type
+     */
+    boolean hasPublicKey(String path)
 }

--- a/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/storage/KeyStorageTreeImpl.groovy
+++ b/rundeckapp/src/groovy/com/dtolabs/rundeck/server/plugins/storage/KeyStorageTreeImpl.groovy
@@ -64,6 +64,21 @@ class KeyStorageTreeImpl extends TypedStorageTreeImpl implements KeyStorageTree 
     }
 
     @Override
+    boolean hasPassword(String path) {
+        hasResourceWithType(PathUtil.asPath(path), KeyStorageLayer.PASSWORD_MIME_TYPE)
+    }
+
+    @Override
+    boolean hasPrivateKey(String path) {
+        hasResourceWithType(PathUtil.asPath(path), KeyStorageLayer.PRIVATE_KEY_MIME_TYPE)
+    }
+
+    @Override
+    boolean hasPublicKey(String path) {
+        hasResourceWithType(PathUtil.asPath(path), KeyStorageLayer.PUBLIC_KEY_MIME_TYPE)
+    }
+
+    @Override
     Resource<ResourceMeta> getPublicKey(final Path path) {
         getResourceWithType(path, KeyStorageLayer.PUBLIC_KEY_MIME_TYPE)
     }

--- a/rundeckapp/test/unit/ExecutionServiceSpec.groovy
+++ b/rundeckapp/test/unit/ExecutionServiceSpec.groovy
@@ -1419,6 +1419,7 @@ class ExecutionServiceSpec extends Specification {
         )
         service.storageService = Mock(StorageService) {
             storageTreeWithContext(_) >> Mock(KeyStorageTree) {
+                hasPassword('keys/opt1') >> true
                 readPassword('keys/opt1') >> 'asdf'.bytes
             }
         }
@@ -1898,7 +1899,7 @@ class ExecutionServiceSpec extends Specification {
 
         then:
         service.storageService.storageTreeWithContext(context) >> Mock(KeyStorageTree) {
-            1 * readPassword(path) >> {
+            1 * hasPassword(path) >> {
                 if (throwsexception) {
                     throw new StorageException(StorageException.Event.READ, PathUtil.asPath(path))
                 }

--- a/rundeckapp/test/unit/ExecutionServiceSpec.groovy
+++ b/rundeckapp/test/unit/ExecutionServiceSpec.groovy
@@ -733,9 +733,11 @@ class ExecutionServiceSpec extends Specification {
         newCtxt.privateDataContext['option'] == ['test1': 'newtest1']
 
         service.storageService.storageTreeWithContext(_) >> Mock(KeyStorageTree) {
+            1 * hasPassword('keys/test1') >> true
             1 * readPassword('keys/test1') >> {
                 return 'newtest1'.bytes
             }
+            1 * hasPassword('keys/test2') >> true
             1 * readPassword('keys/test2') >> {
                 return 'newtest2'.bytes
             }
@@ -1268,6 +1270,13 @@ class ExecutionServiceSpec extends Specification {
 
         then:
         1 * service.storageService.storageTreeWithContext(authContext) >> Mock(KeyStorageTree) {
+            hasPassword('keys/opt1') >> {
+                if (hasopt1) {
+                    return true
+                }else{
+                    return false
+                }
+            }
             readPassword('keys/opt1') >> {
                 if (hasopt1 && readopt1) {
                     return 'newopt1'.bytes
@@ -1285,6 +1294,13 @@ class ExecutionServiceSpec extends Specification {
                             StorageException.Event.READ,
                             PathUtil.asPath('keys/opt1')
                     )
+                }
+            }
+            hasPassword('keys/opt2') >> {
+                if (hasopt2) {
+                    return true
+                }else{
+                    return false
                 }
             }
             readPassword('keys/opt2') >> {
@@ -2405,14 +2421,26 @@ class ExecutionServiceSpec extends Specification {
 
         then:
         service.storageService.storageTreeWithContext(authContext) >> Mock(KeyStorageTree) {
+            hasPassword('keys/opta/pass')>>{
+                return true
+            }
             readPassword('keys/opta/pass') >> {
                     return 'pass1'.bytes
+            }
+            hasPassword('keys/optb/pass')>>{
+                return true
             }
             readPassword('keys/optb/pass') >> {
                     return 'pass2'.bytes
             }
+            hasPassword('keys/optc/pass')>>{
+                return true
+            }
             readPassword('keys/optc/pass') >> {
                     return 'pass3'.bytes
+            }
+            hasPassword(_) >> {
+                return true
             }
             readPassword(_) >> {
                 return ''.bytes


### PR DESCRIPTION
Add validation to check if a key exists when is called from a secure option on a job. This avoids that a transaction exception be generated, and the job fails
