### PR TITLE
Fix: 500 error for pluginDetail if plugin not found

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
@@ -186,7 +186,7 @@ class PluginController extends ControllerBase {
         def desc = pluginService.getPluginDescriptor(pluginName, service)?.description
         if(!desc) {
             def psvc = frameworkService.rundeckFramework.getService(service)
-            desc = psvc.listDescriptions().find { it.name == pluginName }
+            desc = psvc?.listDescriptions()?.find { it.name == pluginName }
         }
         if (!desc) {
             response.status = 404

--- a/rundeckapp/src/test/groovy/rundeck/controllers/PluginControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/PluginControllerSpec.groovy
@@ -95,6 +95,31 @@ class PluginControllerSpec extends Specification implements ControllerUnitTest<P
         rp2.apiData
     }
 
+    void "plugin detail no plugin or framework service"() {
+        given:
+            controller.pluginService = Mock(PluginService)
+            def fwksvc = Mock(FrameworkService)
+            def fwk = Mock(Framework)
+            fwksvc.getRundeckFramework() >> fwk
+            fwk.getPluginManager() >> Mock(ServiceProviderLoader)
+            controller.frameworkService = fwksvc
+            controller.uiPluginService = Mock(UiPluginService)
+            controller.pluginApiService = Mock(PluginApiService)
+
+        when:
+            def fakePluginDesc = new PluginApiServiceSpec.FakePluginDescription()
+            params.name = "fake"
+            params.service = "Notification"
+
+            controller.pluginDetail()
+
+        then:
+            response.status == 404
+            1 * controller.pluginService.getPluginDescriptor("fake", 'Notification') >> null
+            1 * controller.frameworkService.rundeckFramework.getService('Notification') >> null
+
+    }
+
     def "plugin service descriptions"() {
         given:
             controller.pluginService = Mock(PluginService)


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix: 500 error for pluginDetail ajax request is plugin is not found