### PR TITLE
Job state conditional plugin throws an exception on failure

### DIFF
--- a/plugins/job-state-plugin/src/main/java/org/rundeck/plugin/jobstate/JobStateFailureReason.java
+++ b/plugins/job-state-plugin/src/main/java/org/rundeck/plugin/jobstate/JobStateFailureReason.java
@@ -1,0 +1,10 @@
+package org.rundeck.plugin.jobstate;
+
+import com.dtolabs.rundeck.core.execution.workflow.steps.FailureReason;
+
+public enum JobStateFailureReason implements FailureReason {
+    /**
+     * State not match and failed marked true
+     */
+    ExecutionStateNotMatch
+}

--- a/plugins/job-state-plugin/src/main/java/org/rundeck/plugin/jobstate/JobStateWorkflowStep.java
+++ b/plugins/job-state-plugin/src/main/java/org/rundeck/plugin/jobstate/JobStateWorkflowStep.java
@@ -175,6 +175,12 @@ public class JobStateWorkflowStep implements StepPlugin {
         if(result!=equality) {
             context.getLogger().log(halt && fail ? 0 : 1, message);
             haltConditionally(context);
+            if(fail){
+                throw new StepException(
+                        "Execution State not match",
+                        JobStateFailureReason.ExecutionStateNotMatch
+                );
+            }
         }else{
             context.getLogger().log(2, message);
         }


### PR DESCRIPTION
Fix #4178 

if the `fail` condition is checked, and the status doesn't match. An error is thrown and the flow is interrupted.

`Halt`and `status` custom message properties not affected.