### PR TITLE
Fix #3452 and #3987 by adding a login module that can hot reload realm.properties

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/jaas/jetty/JettyAuthPropertyFileLoginModule.java
+++ b/rundeckapp/src/main/groovy/org/rundeck/jaas/jetty/JettyAuthPropertyFileLoginModule.java
@@ -16,9 +16,12 @@
 
 package org.rundeck.jaas.jetty;
 
+import org.eclipse.jetty.jaas.spi.AbstractLoginModule;
 import org.eclipse.jetty.jaas.spi.PropertyFileLoginModule;
 import org.eclipse.jetty.jaas.spi.UserInfo;
 import org.rundeck.jaas.AbstractSharedLoginModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
@@ -28,22 +31,27 @@ import java.io.IOException;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
 
 /**
  * Augments Jetty property file login module {@link PropertyFileLoginModule}, to only perform authentication
  * via property file login, handles shared credentials logic, and does not use property file roles.
  */
 public class JettyAuthPropertyFileLoginModule extends AbstractSharedLoginModule {
-    public static final Logger logger = Logger.getLogger(JettyAuthPropertyFileLoginModule.class.getName());
-    PropertyFileLoginModule module;
-    UserInfo userInfo;
+    public static final Logger logger = LoggerFactory.getLogger(JettyAuthPropertyFileLoginModule.class.getName());
+    AbstractLoginModule module;
+    UserInfo            userInfo;
 
     @Override
     public void initialize(Subject subject, CallbackHandler callbackHandler, Map shared, Map options) {
         super.initialize(subject, callbackHandler, shared, options);
-        module = new PropertyFileLoginModule();
+        if(options.containsKey("hotReload") && options.get("hotReload").equals("true")) {
+            logger.debug("using reloadable realm property file reader");
+            module = new ReloadablePropertyFileLoginModule();
+        } else {
+            logger.error("using static realm property file reader");
+            module = new PropertyFileLoginModule();
+        }
         module.initialize(subject, callbackHandler, shared, options);
     }
 
@@ -123,6 +131,6 @@ public class JettyAuthPropertyFileLoginModule extends AbstractSharedLoginModule 
      * @param message
      */
     protected void debug(String message) {
-        logger.log(Level.INFO, message);
+        logger.info(message);
     }
 }

--- a/rundeckapp/src/main/groovy/org/rundeck/jaas/jetty/JettyAuthPropertyFileLoginModule.java
+++ b/rundeckapp/src/main/groovy/org/rundeck/jaas/jetty/JettyAuthPropertyFileLoginModule.java
@@ -49,7 +49,6 @@ public class JettyAuthPropertyFileLoginModule extends AbstractSharedLoginModule 
             logger.debug("using reloadable realm property file reader");
             module = new ReloadablePropertyFileLoginModule();
         } else {
-            logger.error("using static realm property file reader");
             module = new PropertyFileLoginModule();
         }
         module.initialize(subject, callbackHandler, shared, options);

--- a/rundeckapp/src/main/groovy/org/rundeck/jaas/jetty/ReloadablePropertyFileLoginModule.java
+++ b/rundeckapp/src/main/groovy/org/rundeck/jaas/jetty/ReloadablePropertyFileLoginModule.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.rundeck.jaas.jetty;
+
+import org.eclipse.jetty.jaas.spi.AbstractLoginModule;
+import org.eclipse.jetty.jaas.spi.UserInfo;
+import org.eclipse.jetty.security.PropertyUserStore;
+import org.eclipse.jetty.server.UserIdentity;
+import org.eclipse.jetty.util.security.Credential;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ReloadablePropertyFileLoginModule extends AbstractLoginModule {
+        public static final String DEFAULT_FILENAME = "realm.properties";
+
+        private static final Logger LOG = LoggerFactory.getLogger(ReloadablePropertyFileLoginModule.class);
+
+        private static ConcurrentHashMap<String, PropertyUserStore> _propertyUserStores = new ConcurrentHashMap<String, PropertyUserStore>();
+
+        private int _refreshInterval = 0;
+        private String _filename = DEFAULT_FILENAME;
+
+
+
+        /**
+         * Read contents of the configured property file.
+         *
+         * @see javax.security.auth.spi.LoginModule#initialize(javax.security.auth.Subject, javax.security.auth.callback.CallbackHandler, java.util.Map,
+         *      java.util.Map)
+         *
+         * @param subject the subject
+         * @param callbackHandler the callback handler
+         * @param sharedState the shared state map
+         * @param options the options map
+         */
+        @Override
+        public void initialize(Subject subject, CallbackHandler callbackHandler, Map< String, ?> sharedState, Map < String, ?> options)
+        {
+            super.initialize(subject,callbackHandler,sharedState,options);
+            setupPropertyUserStore(options);
+        }
+
+        private void setupPropertyUserStore(Map<String, ?> options)
+        {
+            parseConfig(options);
+
+            if (_propertyUserStores.get(_filename) == null)
+            {
+                PropertyUserStore propertyUserStore = new PropertyUserStore();
+                propertyUserStore.setHotReload(true);
+                propertyUserStore.setConfig(_filename);
+
+                PropertyUserStore prev = _propertyUserStores.putIfAbsent(_filename, propertyUserStore);
+                if (prev == null)
+                {
+                    LOG.debug("setupPropertyUserStore: Starting new PropertyUserStore. PropertiesFile: " + _filename + " refreshInterval: " + _refreshInterval);
+
+                    try
+                    {
+                        propertyUserStore.start();
+                    }
+                    catch (Exception e)
+                    {
+                        LOG.warn("Exception while starting propertyUserStore: ",e);
+                    }
+                }
+            }
+        }
+
+        private void parseConfig(Map<String, ?> options)
+        {
+            String tmp = (String)options.get("file");
+            _filename = (tmp == null? DEFAULT_FILENAME : tmp);
+            tmp = (String)options.get("refreshInterval");
+            _refreshInterval = (tmp == null?_refreshInterval:Integer.parseInt(tmp));
+        }
+
+        /**
+         *
+         *
+         * @param userName the user name
+         * @throws Exception if unable to get the user information
+         */
+        @Override
+        public UserInfo getUserInfo(String userName) throws Exception
+        {
+            PropertyUserStore propertyUserStore = _propertyUserStores.get(_filename);
+            if (propertyUserStore == null)
+                throw new IllegalStateException("PropertyUserStore should never be null here!");
+
+            LOG.debug("Checking PropertyUserStore "+_filename+" for "+userName);
+            UserIdentity userIdentity = propertyUserStore.getUserIdentity(userName);
+            if (userIdentity==null)
+                return null;
+
+            //TODO in future versions change the impl of PropertyUserStore so its not
+            //storing Subjects etc, just UserInfo
+            Set<Principal> principals = userIdentity.getSubject().getPrincipals();
+
+            List<String> roles = new ArrayList<String>();
+
+            for ( Principal principal : principals )
+            {
+                roles.add( principal.getName() );
+            }
+
+            Credential credential = (Credential)userIdentity.getSubject().getPrivateCredentials().iterator().next();
+            LOG.debug("Found: " + userName + " in PropertyUserStore "+_filename);
+            return new UserInfo(userName, credential, roles);
+        }
+
+    }

--- a/rundeckapp/src/test/groovy/org/rundeck/jaas/jetty/JettyAuthPropertyFileLoginModuleTest.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/jaas/jetty/JettyAuthPropertyFileLoginModuleTest.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.rundeck.jaas.jetty
+
+import org.eclipse.jetty.jaas.spi.PropertyFileLoginModule
+import spock.lang.Specification
+
+import javax.security.auth.Subject
+
+
+class JettyAuthPropertyFileLoginModuleTest extends Specification {
+    def "Initialize without hotReload set"() {
+        when:
+        JettyAuthPropertyFileLoginModule module = new JettyAuthPropertyFileLoginModule()
+        module.initialize(new Subject(),null,[:],[:])
+
+        then:
+        module.module instanceof PropertyFileLoginModule
+    }
+
+    def "Initialize hotReload set to true"() {
+        when:
+        JettyAuthPropertyFileLoginModule module = new JettyAuthPropertyFileLoginModule()
+        module.initialize(new Subject(),null,[:],[hotReload:"true"])
+
+        then:
+        module.module instanceof ReloadablePropertyFileLoginModule
+    }
+}


### PR DESCRIPTION
Jetty PropertyUserStore has a hot reload flag, but the default Jetty property file login module doesn't set it. This PR adds a module that sets the flag when the module is initialized.