### PR TITLE
Fix #3413. Bump jetty version to 9.4.13.v20181111 for java 9+ support.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,6 @@ gormVersion=6.1.10.RELEASE
 hibernateVersion=5.1.13.Final
 gradleWrapperVersion=3.5
 groovyVersion = 2.4.15
-jettyVersion=9.4.11.v20180605
+jettyVersion=9.4.13.v20181111
 mavenCentralUrl = http://repo1.maven.org/maven2/
 grailsCentralUrl = http://grails.org/plugins

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -130,6 +130,9 @@ dependencies {
     compile "org.eclipse.jetty:jetty-jaas:${jettyVersion}"
     compile "org.eclipse.jetty:jetty-util:${jettyVersion}"
     compile "org.eclipse.jetty:jetty-security:${jettyVersion}"
+    compile "org.eclipse.jetty:jetty-server:${jettyVersion}"
+    compile "org.eclipse.jetty:jetty-http:${jettyVersion}"
+    compile "org.eclipse.jetty:jetty-io:${jettyVersion}"
     compile 'org.grails.plugins:spring-security-core:3.2.1'
     compile 'org.kohsuke:libpam4j:1.10'
     compile 'ca.juliusdavies:not-yet-commons-ssl:0.3.17'

--- a/testbuild.groovy
+++ b/testbuild.groovy
@@ -46,7 +46,7 @@ def debug=Boolean.getBoolean('debug')?:("-debug" in args)
 //versions of dependency we want to verify
 def versions=[
         mysql:'5.1.42',
-        jetty:'9.4.11.v20180605',
+        jetty:'9.4.13.v20181111',
         servlet:'api-3.1.0'
 ]
 
@@ -100,8 +100,8 @@ def manifest=[
         "WEB-INF/lib/jetty-jaas-${versions.jetty}.jar",
         "WEB-INF/lib/jetty-server-${versions.jetty}.jar",
         "WEB-INF/lib/jetty-util-${versions.jetty}.jar",
-        "WEB-INF/lib-provided/jetty-http-${versions.jetty}.jar",
-        "WEB-INF/lib-provided/jetty-io-${versions.jetty}.jar",
+        "WEB-INF/lib/jetty-http-${versions.jetty}.jar",
+        "WEB-INF/lib/jetty-io-${versions.jetty}.jar",
         "WEB-INF/lib/jetty-security-${versions.jetty}.jar",
         "WEB-INF/lib/log4j-1.2.17.jar",
         "WEB-INF/lib-provided/javax.servlet-${versions.servlet}.jar",


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
fixes #3413

**Describe the solution you've implemented**
@gschueler did great work for 2/3rds of that issue, but I recently wanted to try out RD with java 11, as i'm having some perf issues, and decided to deep dive on this. Turns out, Jetty realized this was a breaking change in https://github.com/eclipse/jetty.project/commit/83b2abebb7cdc4411ffd7a285ee968041f0e77d5, and un-broke the change. All I did was update, ran a build, watched the tests, scp'd to my stage instance of rundeck, and verified LDAP worked for me while on java 11

**Describe alternatives you've considered**
Nil. Could have figured out a workaround for this, poked around at that, it seemed more involved that this.