### PR TITLE
Fix camelcase keys in remco template for docker image

### DIFF
--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -35,7 +35,7 @@
         clearPass={{ getv("/rundeck/jaas/ldap/clearpass") }}
     {% endif %}
     {% if exists("/rundeck/jaas/ldap/usefirstpass") -%}
-        useFirstPass={{ getv("/rundeck/jaas/ldap/clearpass") }}
+        useFirstPass={{ getv("/rundeck/jaas/ldap/usefirstpass") }}
     {% endif %}
     {% if exists("/rundeck/jaas/ldap/tryfirstpass") -%}
         tryFirstPass={{ getv("/rundeck/jaas/ldap/tryfirstpass") }}

--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -19,26 +19,26 @@
         roleNameAttribute="{{ getv("/rundeck/jaas/ldap/rolenameattribute", "cn") }}"
         roleMemberAttribute="{{ getv("/rundeck/jaas/ldap/rolememberattribute", "uniqueMember") }}"
         roleObjectClass="{{ getv("/rundeck/jaas/ldap/roleobjectclass", "groupOfUniqueNames") }}"
-        rolePrefix="{{ getv("/rundeck/jaas/ldap/rolePrefix", "") }}"
+        rolePrefix="{{ getv("/rundeck/jaas/ldap/roleprefix", "") }}"
         cacheDurationMillis="{{ getv("/rundeck/jaas/ldap/cachedurationmillis", "600000") }}"
         reportStatistics="{{ getv("/rundeck/jaas/ldap/reportstatistics", "true") }}"
     {% if exists("/rundeck/jaas/ldap/roleusernamememberattribute") -%}
         roleUsernameMemberAttribute="{{ getv("/rundeck/jaas/ldap/roleusernamememberattribute") }}"
     {% endif %}
-    {% if exists("/rundeck/jaas/ldap/ignoreRoles") -%}
-        ignoreRoles={{ getv("/rundeck/jaas/ldap/ignoreRoles") }}
+    {% if exists("/rundeck/jaas/ldap/ignoreroles") -%}
+        ignoreRoles={{ getv("/rundeck/jaas/ldap/ignoreroles") }}
     {% endif %}
-    {% if exists("/rundeck/jaas/ldap/storePass") -%}
-        storePass={{ getv("/rundeck/jaas/ldap/storePass") }}
+    {% if exists("/rundeck/jaas/ldap/storepass") -%}
+        storePass={{ getv("/rundeck/jaas/ldap/storepass") }}
     {% endif %}
-    {% if exists("/rundeck/jaas/ldap/clearPass") -%}
-        clearPass={{ getv("/rundeck/jaas/ldap/clearPass") }}
+    {% if exists("/rundeck/jaas/ldap/clearpass") -%}
+        clearPass={{ getv("/rundeck/jaas/ldap/clearpass") }}
     {% endif %}
-    {% if exists("/rundeck/jaas/ldap/useFirstPass") -%}
-        useFirstPass={{ getv("/rundeck/jaas/ldap/clearPass") }}
+    {% if exists("/rundeck/jaas/ldap/usefirstpass") -%}
+        useFirstPass={{ getv("/rundeck/jaas/ldap/clearpass") }}
     {% endif %}
-    {% if exists("/rundeck/jaas/ldap/tryFirstPass") -%}
-        tryFirstPass={{ getv("/rundeck/jaas/ldap/tryFirstPass") }}
+    {% if exists("/rundeck/jaas/ldap/tryfirstpass") -%}
+        tryFirstPass={{ getv("/rundeck/jaas/ldap/tryfirstpass") }}
     {% endif %}
     ;
 {% endmacro %}


### PR DESCRIPTION
This fixes #4203

Env Variables in the remco template were referenced with camelcase keys which doesn't work. They have to be lowercase. Without this fix the default value for `getv` is always used.
