### PR TITLE
scm_update acl special permission

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
@@ -974,7 +974,8 @@ public class AclTool extends BaseTool {
                     ACLConstants.ACTION_KILLAS,
                     ACLConstants.ACTION_CREATE,
                     ACLConstants.ACTION_TOGGLE_EXECUTION,
-                    ACLConstants.ACTION_TOGGLE_SCHEDULE
+                    ACLConstants.ACTION_TOGGLE_SCHEDULE,
+                    ACLConstants.ACTION_SCM_UPDATE
             );
     static final List<String> projectJobKindActions =
             Arrays.asList(
@@ -1986,6 +1987,7 @@ public class AclTool extends BaseTool {
         public static final String ACTION_DISABLE_EXECUTIONS = "disable_executions";
         public static final String ACTION_TOGGLE_SCHEDULE = "toggle_schedule";
         public static final String ACTION_TOGGLE_EXECUTION = "toggle_execution";
+        public static final String ACTION_SCM_UPDATE="scm_update";
 
         public static final String TYPE_SYSTEM = "system";
         public static final String TYPE_SYSTEM_ACL = "system_acl";

--- a/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
@@ -975,7 +975,9 @@ public class AclTool extends BaseTool {
                     ACLConstants.ACTION_CREATE,
                     ACLConstants.ACTION_TOGGLE_EXECUTION,
                     ACLConstants.ACTION_TOGGLE_SCHEDULE,
-                    ACLConstants.ACTION_SCM_UPDATE
+                    ACLConstants.ACTION_SCM_UPDATE,
+                    ACLConstants.ACTION_SCM_CREATE,
+                    ACLConstants.ACTION_SCM_DELETE
             );
     static final List<String> projectJobKindActions =
             Arrays.asList(
@@ -1988,6 +1990,8 @@ public class AclTool extends BaseTool {
         public static final String ACTION_TOGGLE_SCHEDULE = "toggle_schedule";
         public static final String ACTION_TOGGLE_EXECUTION = "toggle_execution";
         public static final String ACTION_SCM_UPDATE="scm_update";
+        public static final String ACTION_SCM_CREATE="scm_create";
+        public static final String ACTION_SCM_DELETE="scm_delete";
 
         public static final String TYPE_SYSTEM = "system";
         public static final String TYPE_SYSTEM_ACL = "system_acl";

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1628,7 +1628,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 def success = false
                 def errmsg
                 jobchange.change = 'modify'
-                if (!frameworkService.authorizeProjectJobAll(projectAuthContext, scheduledExecution, [AuthConstants.ACTION_UPDATE], scheduledExecution.project)) {
+                if (!frameworkService.authorizeProjectJobAny(projectAuthContext, scheduledExecution,
+                        [AuthConstants.ACTION_UPDATE,AuthConstants.SCM_UPDATE], scheduledExecution.project)) {
                     errmsg = "Unauthorized: Update Job ${scheduledExecution.id}"
                 } else {
                     try {

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmJobImporter.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmJobImporter.groovy
@@ -131,7 +131,7 @@ class ScmJobImporter implements ContextJobImporter {
         final String jobid
     )
     {
-        def res = scheduledExecutionService.deleteScheduledExecutionById(jobid, 'git-import-deleteJob')
+        def res = scheduledExecutionService.deleteScheduledExecutionById(jobid, 'scm-import')
         def result = new ImporterResult()
         if(res?.success){
             result.successful = true

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/authorization/AuthConstants.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/authorization/AuthConstants.java
@@ -57,6 +57,7 @@ public class AuthConstants {
     public static final String ACTION_TOGGLE_EXECUTION = "toggle_execution";
     public static final String GENERATE_USER_TOKEN = "generate_user_token";
     public static final String GENERATE_SERVICE_TOKEN="generate_service_token";
+    public static final String SCM_UPDATE="scm_update";
 
     public static final String TYPE_SYSTEM = "system";
     public static final String TYPE_SYSTEM_ACL = "system_acl";

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/authorization/AuthConstants.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/authorization/AuthConstants.java
@@ -58,6 +58,8 @@ public class AuthConstants {
     public static final String GENERATE_USER_TOKEN = "generate_user_token";
     public static final String GENERATE_SERVICE_TOKEN="generate_service_token";
     public static final String SCM_UPDATE="scm_update";
+    public static final String SCM_CREATE="scm_create";
+    public static final String SCM_DELETE="scm_delete";
 
     public static final String TYPE_SYSTEM = "system";
     public static final String TYPE_SYSTEM_ACL = "system_acl";

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -3003,8 +3003,6 @@ class ScheduledExecutionServiceSpec extends Specification {
 
         result.jobs.size() == 0
         result.errjobs.size() == 1
-        //result.errjobs[0].scheduledExecution.errors.hasErrors()
-        println(result.errjobs[0].errmsg)
         result.errjobs[0].errmsg.startsWith("Unauthorized: Update Job")
         1 * service.frameworkService.authorizeProjectJobAny(_,_,
                 [AuthConstants.ACTION_UPDATE, AuthConstants.SCM_UPDATE],_) >> false

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -3062,8 +3062,8 @@ class ScheduledExecutionServiceSpec extends Specification {
         then:
         result
         result.success?.job
-        1 * service.frameworkService.authorizeProjectJobAll(_,_,
-                [AuthConstants.SCM_DELETE],_) >> true
+        1 * service.frameworkService.authorizeProjectJobAny(_,_,
+                [AuthConstants.ACTION_DELETE,AuthConstants.SCM_DELETE],_) >> true
     }
 
     @Unroll
@@ -3105,10 +3105,8 @@ class ScheduledExecutionServiceSpec extends Specification {
 
         then:
         result.jobs.size()==1
-        1 * service.frameworkService.authorizeProjectResourceAll(_,AuthConstants.RESOURCE_TYPE_JOB,
-                [AuthConstants.ACTION_CREATE],'AProject') >> false
-        1 * service.frameworkService.authorizeProjectJobAny(_,_,
-                [AuthConstants.SCM_CREATE],_) >> true
+        1 * service.frameworkService.authorizeProjectResourceAny(_,AuthConstants.RESOURCE_TYPE_JOB,
+                [AuthConstants.ACTION_CREATE,AuthConstants.SCM_CREATE],'AProject') >> true
         1 * service.frameworkService.authorizeProjectJobAny(_,_,
                 [AuthConstants.ACTION_CREATE,AuthConstants.SCM_CREATE],_) >> true
 
@@ -3131,7 +3129,7 @@ class ScheduledExecutionServiceSpec extends Specification {
 
         then:
         result.jobs.size()==1
-        1 * service.frameworkService.authorizeProjectResourceAll(_,AuthConstants.RESOURCE_TYPE_JOB,
+        1 * service.frameworkService.authorizeProjectResourceAny(_,AuthConstants.RESOURCE_TYPE_JOB,
                 [AuthConstants.ACTION_CREATE],'AProject') >> true
         0 * service.frameworkService.authorizeProjectJobAny(_,_,
                 [AuthConstants.SCM_CREATE],_) >> false


### PR DESCRIPTION
Implements #4058 
A user with `scm_update` job permission can import SCM changes over a particular job.
A user with `update` permission still can edit or import scm changes normally.

acl example:
```
context:
  project: '.*'
for:
  job:
    -allow: [read,view,kill,scm_update]
```
