### PR TITLE
Fixes for dynamic properties

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/StepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/StepPluginAdapter.java
@@ -65,7 +65,7 @@ class StepPluginAdapter implements StepExecutor, Describable, DynamicProperties{
     }
 
     @Override
-    public Map<String, List<String>> dynamicProperties(Map<String, Object> projectAndFrameworkValues, Services services){
+    public Map<String, Object> dynamicProperties(Map<String, Object> projectAndFrameworkValues, Services services){
         if(plugin instanceof DynamicProperties){
             return ((DynamicProperties)plugin).dynamicProperties(projectAndFrameworkValues, services);
         }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
@@ -68,7 +68,7 @@ class NodeStepPluginAdapter implements NodeStepExecutor, Describable, DynamicPro
     }
 
     @Override
-    public Map<String, List<String>> dynamicProperties(Map<String, Object> projectAndFrameworkValues, Services services){
+    public Map<String, Object> dynamicProperties(Map<String, Object> projectAndFrameworkValues, Services services){
         if(plugin instanceof DynamicProperties){
             return ((DynamicProperties)plugin).dynamicProperties(projectAndFrameworkValues, services);
         }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/DynamicProperties.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/DynamicProperties.java
@@ -14,7 +14,7 @@ public interface DynamicProperties {
      *
      * @param projectAndFrameworkValues config values for this plugin resolved from the framework/project
      */
-    default Map<String, List<String>> dynamicProperties(Map<String, Object> projectAndFrameworkValues) {
+    default Map<String, Object> dynamicProperties(Map<String, Object> projectAndFrameworkValues) {
         return null;
     }
 
@@ -24,7 +24,7 @@ public interface DynamicProperties {
      * @param projectAndFrameworkValues config values for this plugin resolved from the framework/project
      * @param services                  authorized services access
      */
-    default Map<String, List<String>> dynamicProperties(
+    default Map<String, Object> dynamicProperties(
         Map<String, Object> projectAndFrameworkValues,
         Services services
     )

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -898,12 +898,9 @@ class FrameworkService implements ApplicationContextAware, AuthContextProvider, 
             PropertyScope.Project
         );
 
-        final Map<String, Object> configProject = getProjectProperties(project)
-        configProject.putAll(config)
-
         def plugin = pluginDescriptor.instance
         if(plugin instanceof DynamicProperties){
-            return plugin.dynamicProperties(configProject, services)
+            return plugin.dynamicProperties(config, services)
         }
         return null
     }


### PR DESCRIPTION
1. Fix an error when a script workflow step/node step plugin was added/edited on a job
2. Returning a map of objects on DynamicProperties interface (allows passing list or maps to the views)
