### PR TITLE
Disable toggle off of first run message

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2026,19 +2026,24 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         //first-run html info
         def isFirstRun=false
 
-        if(configurationService.getBoolean("startup.detectFirstRun",true) &&
-                frameworkService.rundeckFramework.hasProperty('framework.var.dir')) {
-            def vardir = frameworkService.rundeckFramework.getProperty('framework.var.dir')
-            String buildIdent = grailsApplication.metadata.getProperty('build.ident', String)
-            def vers = buildIdent.replaceAll('\\s+\\(.+\\)$','')
-            def file = new File(vardir, ".first-run-${vers}")
-            if(!file.exists()){
-                isFirstRun=true
-                file.withWriter("UTF-8"){out->
-                    out.write('#'+(new Date().toString()))
+        if(grailsApplication.config.rundeck?.firstRunMessage?.toggle?.off == "true") {
+            isFirstRun=true
+        }else{
+            if(configurationService.getBoolean("startup.detectFirstRun",true) &&
+                    frameworkService.rundeckFramework.hasProperty('framework.var.dir')) {
+                def vardir = frameworkService.rundeckFramework.getProperty('framework.var.dir')
+                String buildIdent = grailsApplication.metadata.getProperty('build.ident', String)
+                def vers = buildIdent.replaceAll('\\s+\\(.+\\)$','')
+                def file = new File(vardir, ".first-run-${vers}")
+                if(!file.exists()){
+                    isFirstRun=true
+                    file.withWriter("UTF-8"){out->
+                        out.write('#'+(new Date().toString()))
+                    }
                 }
             }
         }
+
         AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
         long start = System.currentTimeMillis()
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2026,7 +2026,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         //first-run html info
         def isFirstRun=false
 
-        if(grailsApplication.config.rundeck?.firstRunMessage?.toggle?.off == "true") {
+        if (configurationService.getBoolean('startup.alwaysFirstRun', false)) {
             isFirstRun=true
         }else{
             if(configurationService.getBoolean("startup.detectFirstRun",true) &&


### PR DESCRIPTION
Adding a config setting that prevents the first run message from being hidden so it remains visible.

If this setting is adding on rundeck-config, then the first run message is not hidden:

```
rundeck.startup.alwaysFirstRun=true
``` 