### PR TITLE
Reduce log level of ERROR message for incompatible plugins

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/JarPluginProviderLoader.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/JarPluginProviderLoader.java
@@ -750,11 +750,11 @@ public class JarPluginProviderLoader implements ProviderLoader,
             String rundeckCompat = mainAttributes.getValue(RUNDECK_PLUGIN_RUNDECK_COMPAT_VER);
             if(rundeckCompat == null) throw new InvalidManifestException("Jar plugin manifest attribute missing: " + RUNDECK_PLUGIN_RUNDECK_COMPAT_VER);
             ArrayList<String> errors = new ArrayList<>();
-            PluginMetadataValidator.validateRundeckCompatibility(errors, rundeckCompat);
-            if(!errors.isEmpty()) {
-                StringBuilder b = new StringBuilder();
-                for(String err : errors) { b.append(err);b.append("\n"); }
-                throw new InvalidManifestException(b.toString());
+            PluginValidation.State
+                state =
+                PluginMetadataValidator.validateRundeckCompatibility(errors, rundeckCompat);
+            if (!state.isValid()) {
+                throw new InvalidManifestException(String.join("\n", errors));
             }
         }
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginMetadataValidator.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginMetadataValidator.java
@@ -26,48 +26,53 @@ public class PluginMetadataValidator {
     private static String INCOMPATIBLE_PLUGIN_VER_MSG = "Plugin is not compatible with this version of Rundeck";
     public final static String OS_TYPE = System.getProperty("os.name").toLowerCase();
 
-    public static void validateTargetHostCompatibility(
+    public static PluginValidation.State validateTargetHostCompatibility(
             final List<String> errors,
             final String targetHostCompatibility
     ) {
         if(targetHostCompatibility == null) {
-            errors.add("No targetHostCompatibility property specified");
-            return;
+            errors.add("No targetHostCompatibility property specified in metadata");
+            return PluginValidation.State.INVALID;
         }
-        if(targetHostCompatibility.equals("all")) return;
+        if(targetHostCompatibility.equals("all")) return PluginValidation.State.VALID;
         if(!HOST_TYPES.contains(targetHostCompatibility)) {
             errors.add("Unknown target host type specified: " + targetHostCompatibility + ". Allowed types: " +
                        Arrays.toString(HOST_TYPES.toArray()));
+            return PluginValidation.State.INVALID;
         }
 
         if((targetHostCompatibility.equals("unix") && OS_TYPE.startsWith("windows")) ||
            (targetHostCompatibility.equals("windows") && !OS_TYPE.startsWith("windows"))) {
             errors.add("Plugin target host("+targetHostCompatibility+") is incompatible with this Rundeck instance: " + OS_TYPE);
+            return PluginValidation.State.INCOMPATIBLE;
         }
+        return PluginValidation.State.VALID;
     }
 
-    public static void validateRundeckCompatibility(
+    public static PluginValidation.State validateRundeckCompatibility(
             final List<String> errors,
             final String rundeckCompatibilityVersion
     ) {
         if(rundeckCompatibilityVersion == null) {
-            errors.add("rundeckCompatibilityVersion cannot be null");
-            return;
+            errors.add("rundeckCompatibilityVersion cannot be null in metadata");
+            return PluginValidation.State.INVALID;
         }
         VersionCompare rundeckVer = VersionCompare.forString(VersionConstants.VERSION);
         VersionCompare compatVer = VersionCompare.forString(rundeckCompatibilityVersion);
         if(!compatVer.majString.equals(rundeckVer.majString)) {
             errors.add(INCOMPATIBLE_PLUGIN_VER_MSG);
-            return;
+            return PluginValidation.State.INCOMPATIBLE;
         }
         boolean ignorePatch = compatVer.minString.matches("x|\\d\\+");
         if(!checkVer(rundeckVer.min,compatVer.minString)) {
             errors.add(INCOMPATIBLE_PLUGIN_VER_MSG);
-            return;
+            return PluginValidation.State.INCOMPATIBLE;
         }
         if(!ignorePatch && !checkVer(rundeckVer.patch,compatVer.patchString)) {
             errors.add(INCOMPATIBLE_PLUGIN_VER_MSG);
+            return PluginValidation.State.INCOMPATIBLE;
         }
+        return PluginValidation.State.VALID;
     }
 
     private static boolean checkVer(final Integer rdVer, final String compVer) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginValidation.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginValidation.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.core.plugins;
+
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * Defines a validation state for a plugin
+ */
+@Builder
+@ToString()
+@Data
+public class PluginValidation {
+    /**
+     * The validation state
+     */
+    private State state;
+    /**
+     * Validation messages if it is not a valid state
+     */
+    @Singular
+    private final List<String> messages;
+
+    /**
+     * Validity states
+     */
+    public static enum State {
+        /**
+         * Valid state
+         */
+        VALID(true),
+        /**
+         * Incompatible state
+         */
+        INCOMPATIBLE(false),
+        /**
+         * Invalid state
+         */
+        INVALID(false);
+        /**
+         * True if the state is valid
+         */
+        @Getter
+        private boolean valid;
+
+        State(boolean validity) {
+            this.valid = validity;
+        }
+
+        /**
+         * Returns the state with greater precedence of this state or the other
+         *
+         * @param other other state
+         * @return state with precedence
+         */
+        State or(State other) {
+            return this.ordinal() > other.ordinal() ? this : other;
+        }
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/ScriptPluginScanner.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/ScriptPluginScanner.java
@@ -77,14 +77,21 @@ public class ScriptPluginScanner extends DirPluginScanner {
             final ZipInputStream zipinput = new ZipInputStream(new FileInputStream(file));
             final PluginMeta metadata = ScriptPluginProviderLoader.loadMeta(file, zipinput);
             zipinput.close();
-            boolean valid = false;
-            if(null!=metadata) {
-                valid = ScriptPluginProviderLoader.validatePluginMeta(metadata, file);
+            PluginValidation validation = ScriptPluginProviderLoader.validatePluginMeta(metadata, file);
+            if (validation.getState() == PluginValidation.State.INVALID) {
+                log.error(String.format(
+                    "Skipping plugin file: metadata was invalid: %s: %s",
+                    file.getAbsolutePath(),
+                    validation.getMessages()
+                ));
+            } else if (validation.getState() == PluginValidation.State.INCOMPATIBLE) {
+                log.info(String.format(
+                    "Skipping plugin file: plugin is incompatible: %s: %s",
+                    file.getAbsolutePath(),
+                    validation.getMessages()
+                ));
             }
-            if (!valid) {
-                log.error("Skipping plugin file: metadata was invalid: " + file.getAbsolutePath());
-            }
-            return valid;
+            return validation.getState().isValid();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/PluginValidationSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/PluginValidationSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.core.plugins
+
+import spock.lang.Specification
+
+import static com.dtolabs.rundeck.core.plugins.PluginValidation.State.INCOMPATIBLE
+import static com.dtolabs.rundeck.core.plugins.PluginValidation.State.INVALID
+import static com.dtolabs.rundeck.core.plugins.PluginValidation.State.VALID
+
+class PluginValidationSpec extends Specification {
+    def "combine states #input and #with is #out"() {
+        expect:
+            input.or(with) == out
+
+        where:
+            input        | with         | out
+            VALID        | VALID        | VALID
+            VALID        | INVALID      | INVALID
+            VALID        | INCOMPATIBLE | INCOMPATIBLE
+            INVALID      | VALID        | INVALID
+            INVALID      | INVALID      | INVALID
+            INVALID      | INCOMPATIBLE | INVALID
+            INCOMPATIBLE | VALID        | INCOMPATIBLE
+            INCOMPATIBLE | INCOMPATIBLE | INCOMPATIBLE
+            INCOMPATIBLE | INVALID      | INVALID
+    }
+}

--- a/core/src/test/java/com/dtolabs/rundeck/core/plugins/TestJarPluginProviderLoader.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/plugins/TestJarPluginProviderLoader.java
@@ -778,8 +778,7 @@ public class TestJarPluginProviderLoader extends AbstractBaseTest {
         try {
             jarPluginProviderLoader.createCachedJar(invalidCacheDir,jarPluginProviderLoader.generateCachedJarName(ident));
             fail("Should fail to create cached jar");
-        } catch (PluginException e) {
-            e.printStackTrace();
+        } catch (PluginException ignored) {
         }
         invalidCacheDir.delete();
     }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix issue: ERROR log output at startup when an incompatible (target host or rundeck version) plugin is loaded using plugin version 2.0

**Describe the solution you've implemented**

Use INFO log level only for incompatible plugins (this level is hidden by default)


** note**

User can increase log level for plugin loading in log4j.properties:

    log4j.logger.com.dtolabs.rundeck.core.plugins=INFO