### PR TITLE
Strip date from doc url

### DIFF
--- a/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
@@ -836,7 +836,8 @@ class UtilityTagLib{
             }
         }
         def rdversion = grailsApplication.metadata.getProperty('info.app.version', String)
-        def helpBase='http://rundeck.org/' +( rdversion?.contains('SNAPSHOT')?'docs':rdversion)
+        def rdversionShort = rdversion.split('-')[0]
+        def helpBase='http://rundeck.org/' +( rdversion?.contains('SNAPSHOT')?'docs':rdversionShort )
         def helpUrl
         if(grailsApplication.config.rundeck?.gui?.helpLink){
             helpBase= grailsApplication.config.rundeck?.gui?.helpLink

--- a/version.properties
+++ b/version.properties
@@ -16,6 +16,6 @@
 
 version.number=3.0.10
 version.release.number=1
-version.tag=SNAPSHOT
-version.date=20181129
-version.version=3.0.10-SNAPSHOT-20181129
+version.tag=GA
+version.date=20181130
+version.version=3.0.10-20181130


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
The documentation URL's are being generated with the version date however the docs are setup under the short version.

**Describe the solution you've implemented**
Split the app version on `-` and take the first portion when generating the doc URL.