### PR TITLE
Changing context variable names for step script 

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -95,6 +95,8 @@ dependencies {
     testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
     testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
     testCompile "com.squareup.retrofit2:retrofit-mock:2.2.0"
+    testCompile "cglib:cglib-nodep:2.2.2"
+
 }
 buildConfig {
     clsName = 'BuildConfig'

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/RemoteScriptNodeStepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/RemoteScriptNodeStepPluginAdapter.java
@@ -33,6 +33,9 @@ import com.dtolabs.rundeck.core.execution.service.FileCopierException;
 import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext;
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.impl.DefaultScriptFileNodeStepUtils;
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.impl.ScriptFileNodeStepUtils;
+import com.dtolabs.rundeck.core.plugins.ScriptPluginProvider;
+import com.dtolabs.rundeck.core.plugins.ScriptPluginProviderLoader;
+import com.dtolabs.rundeck.core.plugins.VersionCompare;
 import com.dtolabs.rundeck.core.plugins.configuration.PluginAdapterUtility;
 import com.dtolabs.rundeck.core.execution.workflow.steps.PluginStepContextImpl;
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolver;
@@ -141,12 +144,23 @@ class RemoteScriptNodeStepPluginAdapter implements NodeStepExecutor, Describable
             stringconfig.put(objectEntry.getKey(), objectEntry.getValue().toString());
         }
 
+        ExecutionContextImpl newContext = ExecutionContextImpl
+                .builder(context)
+                .setContext("config", stringconfig)
+                .build();
+
+        if(plugin.hasAdditionalConfigVarGroupName()){
+            //new context variable name
+            newContext = ExecutionContextImpl
+                    .builder(context)
+                    .setContext("config", stringconfig)
+                    .setContext("nodestep", stringconfig)
+                    .build();
+        }
+
+
         return executeRemoteScript(
-                ExecutionContextImpl
-                        .builder(context)
-                        .setContext("config", stringconfig)
-                        .setContext("nodestep", stringconfig)
-                        .build(),
+                newContext,
                 node,
                 script,
                 context.getDataContextObject().resolve("job", "execid"),

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/RemoteScriptNodeStepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/RemoteScriptNodeStepPluginAdapter.java
@@ -145,6 +145,7 @@ class RemoteScriptNodeStepPluginAdapter implements NodeStepExecutor, Describable
                 ExecutionContextImpl
                         .builder(context)
                         .setContext("config", stringconfig)
+                        .setContext("nodestep", stringconfig)
                         .build(),
                 node,
                 script,

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/ScriptBasedRemoteScriptNodeStepPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/ScriptBasedRemoteScriptNodeStepPlugin.java
@@ -28,9 +28,7 @@ import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.dispatcher.DataContextUtils;
 import com.dtolabs.rundeck.core.data.MutableDataContext;
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepFailureReason;
-import com.dtolabs.rundeck.core.plugins.BaseScriptPlugin;
-import com.dtolabs.rundeck.core.plugins.PluginException;
-import com.dtolabs.rundeck.core.plugins.ScriptPluginProvider;
+import com.dtolabs.rundeck.core.plugins.*;
 import com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException;
 import com.dtolabs.rundeck.core.plugins.configuration.Description;
 import com.dtolabs.rundeck.core.utils.MapData;
@@ -62,6 +60,8 @@ class ScriptBasedRemoteScriptNodeStepPlugin extends BaseScriptPlugin implements 
     public boolean isAllowCustomProperties() {
         return true;
     }
+
+
 
     static void validateScriptPlugin(final ScriptPluginProvider plugin) throws PluginException {
         try {
@@ -130,6 +130,16 @@ class ScriptBasedRemoteScriptNodeStepPlugin extends BaseScriptPlugin implements 
                 provider.getInterpreterArgsQuoted(),
                 configData
         );
+    }
+
+    @Override
+    public boolean hasAdditionalConfigVarGroupName() {
+        VersionCompare pluginVersionObject = VersionCompare.forString(getProvider().getPluginMeta().getRundeckPluginVersion());
+        if(pluginVersionObject.atLeast(VersionCompare.forString(ScriptPluginProviderLoader.VERSION_2_0))){
+            return true;
+        }
+
+        return false;
     }
 
     static String getFileExtension(final String name) {
@@ -203,5 +213,7 @@ class ScriptBasedRemoteScriptNodeStepPlugin extends BaseScriptPlugin implements 
             }
         };
     }
+
+
 
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPlugin.java
@@ -359,8 +359,10 @@ public abstract class AbstractDescribableScriptPlugin implements Describable {
                 description.getProperties()
         );
 
-
-        return DataContextUtils.addContext("config", data, localDataContext);
+        //new context variable name
+        Map<String, Map<String, String>> newLocalDataContext = DataContextUtils.addContext(serviceName.toLowerCase(), data, localDataContext);
+        //using "config" name to old plugins
+        return DataContextUtils.addContext("config", data, newLocalDataContext);
     }
 
     /**

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPlugin.java
@@ -359,9 +359,15 @@ public abstract class AbstractDescribableScriptPlugin implements Describable {
                 description.getProperties()
         );
 
-        //new context variable name
-        Map<String, Map<String, String>> newLocalDataContext = DataContextUtils.addContext(serviceName.toLowerCase(), data, localDataContext);
-        //using "config" name to old plugins
+        Map<String, Map<String, String>> newLocalDataContext = localDataContext;
+
+        VersionCompare pluginVersion = VersionCompare.forString(provider.getPluginMeta().getRundeckPluginVersion());
+        if(pluginVersion.atLeast(VersionCompare.forString(ScriptPluginProviderLoader.VERSION_2_0))){
+            //new context variable name
+            newLocalDataContext = DataContextUtils.addContext(serviceName.toLowerCase(), data, localDataContext);
+        }
+
+                //using "config" name to old plugins
         return DataContextUtils.addContext("config", data, newLocalDataContext);
     }
 

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/step/RemoteScriptNodeStepPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/step/RemoteScriptNodeStepPlugin.java
@@ -25,6 +25,7 @@ package com.dtolabs.rundeck.plugins.step;
 
 import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepException;
+import com.dtolabs.rundeck.core.plugins.ScriptPluginProvider;
 
 import java.util.Map;
 
@@ -48,4 +49,13 @@ public interface RemoteScriptNodeStepPlugin {
     public GeneratedScript generateScript(final PluginStepContext context,
                                           final Map<String, Object> configuration,
                                           final INodeEntry entry) throws NodeStepException;
+
+
+    /**
+     * Additional Group name for config variables, other than 'config'
+     * @return true to include additional config var group 'nodestep'
+     */
+    default boolean hasAdditionalConfigVarGroupName(){
+        return false;
+    }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/RemoteScriptNodeStepPluginAdapterSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/RemoteScriptNodeStepPluginAdapterSpec.groovy
@@ -34,6 +34,7 @@ import com.dtolabs.rundeck.core.execution.service.NodeExecutorResult
 import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext
 import com.dtolabs.rundeck.core.execution.workflow.WFSharedContext
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.impl.ScriptFileNodeStepUtils
+import com.dtolabs.rundeck.core.plugins.ScriptPluginProvider
 import com.dtolabs.rundeck.core.plugins.configuration.Describable
 import com.dtolabs.rundeck.core.plugins.configuration.Description
 import com.dtolabs.rundeck.core.tools.AbstractBaseTest
@@ -94,6 +95,8 @@ class RemoteScriptNodeStepPluginAdapterSpec extends Specification {
     }
 
     static class TestPlugin implements Describable, RemoteScriptNodeStepPlugin {
+
+
         //Description description =
         @Override
         Description getDescription() {
@@ -105,12 +108,29 @@ class RemoteScriptNodeStepPluginAdapterSpec extends Specification {
         }
         List<String> pluginPropNames
         GeneratedScript script
+        String version = "1.0"
 
         @Override
         GeneratedScript generateScript(PluginStepContext context, Map<String, Object> configuration, INodeEntry entry) throws NodeStepException {
             script
         }
+
+        @Override
+        boolean hasAdditionalConfigVarGroupName() {
+            if(version=="2.0"){
+                true
+            }else{
+                false
+            }
+        }
+
+        void setVersion(String version){
+            this.version=version
+        }
+
+
     }
+
 
     def "step config does not replace missing configs with blank"() {
         given:
@@ -311,5 +331,50 @@ class RemoteScriptNodeStepPluginAdapterSpec extends Specification {
         !result.isSuccess()
         result.failureReason.toString() == 'ConfigurationFailure'
         result.failureMessage == 'Generated script must have a command or script defined'
+    }
+
+    def "nodestep variable names for 2.x plugin"() {
+        given:
+        framework.frameworkServices = Mock(IFrameworkServices)
+        DataContext dataContext = DataContextUtils.context()
+        WFSharedContext sharedContext = SharedDataContextUtils.sharedContext()
+
+        StepExecutionContext context = Mock(StepExecutionContext) {
+            getFramework() >> framework
+            getFrameworkProject() >> PROJECT_NAME
+            getDataContextObject() >> dataContext
+            getSharedDataContext() >> sharedContext
+        }
+        def node = new NodeEntryImpl('node')
+        def script = Mock(FileExtensionGeneratedScript) {
+            getArgs() >> ['someargs'].toArray()
+        }
+        def plugin = new TestPlugin(script: script, pluginPropNames: ['abc', 'def', 'xyz'])
+        plugin.setVersion("2.0")
+        def adapter = new RemoteScriptNodeStepPluginAdapter(plugin)
+        adapter.scriptUtils = Mock(ScriptFileNodeStepUtils)
+
+        def instanceConfig = [
+                abc: 'buddy',
+                def: 'shampoo/${config.dne}/asdf',
+                xyz: 'test/${config.abc}',
+        ]
+        def item = new TestExecItem(stepConfiguration: instanceConfig)
+
+
+        when:
+        def result = adapter.executeNodeStep(context, item, node)
+
+        then:
+        _ * script.getScript() >> 'a script'
+        1 * adapter.scriptUtils.executeRemoteScript({ ExecutionContext ctx ->
+            ctx.getDataContext().get('nodestep') == instanceConfig
+        }, _, node, ['someargs'].toArray(), _) >>
+                Mock(NodeStepResult) {
+                    isSuccess() >> true
+                }
+        _ * framework.frameworkServices.getExecutionService() >> Mock(ExecutionService) {
+            1 * fileCopyScriptContent(_, _, node, _) >> { args -> args[3] }
+        }
     }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/RemoteScriptNodeStepPluginAdapterSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/RemoteScriptNodeStepPluginAdapterSpec.groovy
@@ -203,7 +203,9 @@ class RemoteScriptNodeStepPluginAdapterSpec extends Specification {
             getArgs() >> ['someargs'].toArray()
             getScriptFile() >> tempFile
         }
-        def adapter = new RemoteScriptNodeStepPluginAdapter(null)
+
+        def plugin = Mock(RemoteScriptNodeStepPlugin)
+        def adapter = new RemoteScriptNodeStepPluginAdapter(plugin)
         adapter.scriptUtils = Mock(ScriptFileNodeStepUtils)
 
         when:

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/ScriptBasedRemoteScriptNodeStepPluginSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/ScriptBasedRemoteScriptNodeStepPluginSpec.groovy
@@ -23,6 +23,7 @@ import com.dtolabs.rundeck.core.data.BaseDataContext
 import com.dtolabs.rundeck.core.execution.ExecutionContext
 import com.dtolabs.rundeck.core.plugins.ScriptPluginProvider
 import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants
+import com.dtolabs.rundeck.core.plugins.metadata.PluginMeta
 import com.dtolabs.rundeck.core.storage.ResourceMeta
 import com.dtolabs.rundeck.core.storage.StorageTree
 import com.dtolabs.rundeck.core.tools.AbstractBaseTest
@@ -281,5 +282,47 @@ class ScriptBasedRemoteScriptNodeStepPluginSpec extends Specification {
         'false'   | null
         false     | null
         null      | 'ribbit'
+    }
+
+
+    @Unroll
+    def "has Additional Config Var GroupName"() {
+        given:
+        File tempFile = File.createTempFile("test", ".ribbit");
+        tempFile.deleteOnExit()
+        File basedir = File.createTempFile("test", "dir");
+        basedir.deleteOnExit()
+
+        def metadata = []
+        def pluginMeta = Mock(PluginMeta){
+            getRundeckPluginVersion() >> version
+        }
+        def provider = Mock(ScriptPluginProvider) {
+            getName() >> 'test1'
+            getDefaultMergeEnvVars() >> false
+            getMetadata() >> metadata
+            getArchiveFile() >> tempFile
+            getScriptFile() >> tempFile
+            getContentsBasedir() >> basedir
+            getScriptArgs() >> 'test -blah x'
+            getPluginMeta() >> pluginMeta
+        }
+        def plugin = new ScriptBasedRemoteScriptNodeStepPlugin(provider, framework)
+
+
+        when:
+        def result = plugin.hasAdditionalConfigVarGroupName()
+
+        then:
+        result != null
+        result == expected
+
+        where:
+        version   | expected
+        '1.0'     | false
+        '1.2'     | false
+        '2.0'     | true
+        false     | false
+        null      | false
     }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPluginSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPluginSpec.groovy
@@ -1,0 +1,173 @@
+package com.dtolabs.rundeck.core.plugins
+
+import com.dtolabs.rundeck.core.common.Framework
+import com.dtolabs.rundeck.core.common.FrameworkProject
+import com.dtolabs.rundeck.core.data.BaseDataContext
+import com.dtolabs.rundeck.core.execution.ExecutionContext
+import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
+import com.dtolabs.rundeck.core.plugins.metadata.PluginMeta
+import com.dtolabs.rundeck.core.tools.AbstractBaseTest
+import com.dtolabs.rundeck.plugins.PluginLogger
+import com.dtolabs.rundeck.plugins.ServiceNameConstants
+import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class AbstractDescribableScriptPluginSpec extends Specification{
+
+    public static final String PROJECT_NAME = 'BaseScriptPluginSpec'
+    Framework framework
+    FrameworkProject testProject
+    def instanceData
+    def localDataContext
+    def pluginMetaData
+
+
+    def setup() {
+        framework = AbstractBaseTest.createTestFramework()
+        testProject = framework.getFrameworkProjectMgr().createFrameworkProject(PROJECT_NAME)
+        instanceData =  [
+                'password' : 'key/path/some.pass',
+                'example' : 'this is an example',
+                'debug' : 'true'
+        ]
+
+        localDataContext = [
+                config   : []
+        ]
+
+        pluginMetaData = [
+                config                                      :
+                        [
+                                [
+                                        type            : 'String',
+                                        name            : 'password',
+                                        title           : 'Password',
+                                        required        : true,
+                                        scope           : PropertyScope.Instance
+                                ],
+                                [
+                                        type            : 'String',
+                                        name            : 'example',
+                                        scope           : PropertyScope.Instance
+                                ],
+                                [
+                                        type            : 'String',
+                                        name            : 'debug',
+                                        scope           : PropertyScope.Instance
+                                ],
+                        ]
+        ]
+    }
+
+    def cleanup() {
+        framework.getFrameworkProjectMgr().removeFrameworkProject(PROJECT_NAME)
+    }
+
+    class TestScriptPlugin extends AbstractDescribableScriptPlugin {
+
+        protected TestScriptPlugin(ScriptPluginProvider provider, Framework framework) {
+            super(provider, framework);
+        }
+
+        @Override
+        boolean isAllowCustomProperties() {
+            return true
+        }
+
+        @Override
+        boolean isUseConventionalPropertiesMapping() {
+            return true
+        }
+
+        def getConfigData(ExecutionContext context, Map<String, Object> instaceData, Map<String, Map<String, String>> localDataContext,String serviceName){
+            DescriptionBuilder builder = DescriptionBuilder.builder()
+            createDescription(provider, isAllowCustomProperties(), isUseConventionalPropertiesMapping(), builder)
+            def description = builder.build()
+            return loadConfigData(context, instaceData, localDataContext, description, serviceName)
+        }
+    }
+
+    @Unroll
+    def "check envs variables for plugin 1.x"() {
+        given:
+        File tempFile = File.createTempFile("test", "zip")
+        tempFile.deleteOnExit()
+        File basedir = File.createTempFile("test", "dir")
+        basedir.deleteOnExit()
+
+        when:
+
+        def pluginMeta = Mock(PluginMeta){
+            getRundeckPluginVersion() >> "1.2"
+        }
+        ScriptPluginProvider provider = Mock(ScriptPluginProvider) {
+            getName() >> 'test1'
+            getMetadata() >> pluginMetaData
+            getPluginMeta() >> pluginMeta
+            getContentsBasedir() >> basedir
+            getService() >> ServiceNameConstants.NodeExecutor
+        }
+
+        ExecutionContext context = Mock(ExecutionContext) {
+            getFrameworkProject() >> PROJECT_NAME
+            getFramework() >> framework
+            getDataContext() >> new BaseDataContext(localDataContext)
+            getLogger() >> Mock(PluginLogger)
+            getExecutionContext() >> Mock(ExecutionContext) {
+                getFramework() >> framework
+                getFrameworkProject() >> PROJECT_NAME
+            }
+        }
+
+        TestScriptPlugin plugin = new TestScriptPlugin(provider, framework)
+        def result = plugin.getConfigData(context, instanceData,localDataContext, ServiceNameConstants.NodeExecutor)
+
+        then:
+
+        result!=null
+        result==[config:[debug:"true", example:"this is an example",password : "key/path/some.pass"]]
+
+    }
+
+    @Unroll
+    def "check envs variables for plugin 2.x"() {
+        given:
+        File tempFile = File.createTempFile("test", "zip")
+        tempFile.deleteOnExit()
+        File basedir = File.createTempFile("test", "dir")
+        basedir.deleteOnExit()
+
+        when:
+
+        def pluginMeta = Mock(PluginMeta){
+            getRundeckPluginVersion() >> "2.0"
+        }
+        ScriptPluginProvider provider = Mock(ScriptPluginProvider) {
+            getName() >> 'test1'
+            getMetadata() >> pluginMetaData
+            getPluginMeta() >> pluginMeta
+            getContentsBasedir() >> basedir
+        }
+
+        ExecutionContext context = Mock(ExecutionContext) {
+            getFrameworkProject() >> PROJECT_NAME
+            getFramework() >> framework
+            getDataContext() >> new BaseDataContext([:])
+            getLogger() >> Mock(PluginLogger)
+            getExecutionContext() >> Mock(ExecutionContext) {
+                getFramework() >> framework
+                getFrameworkProject() >> PROJECT_NAME
+            }
+        }
+
+        TestScriptPlugin plugin = new TestScriptPlugin(provider, framework)
+        def result = plugin.getConfigData(context, instanceData,localDataContext, ServiceNameConstants.NodeExecutor)
+
+        then:
+
+        result!=null
+        result==[config:[debug:"true", example:"this is an example",password : "key/path/some.pass"],nodeexecutor:[debug:"true", example:"this is an example",password : "key/path/some.pass"]]
+
+    }
+}

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/service/TestScriptPluginFileCopier.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/service/TestScriptPluginFileCopier.java
@@ -79,6 +79,7 @@ public class TestScriptPluginFileCopier {
         private File scriptFile;
         private boolean interpreterArgsQuoted;
         private Map<String, Object> metadata;
+        private PluginMeta pluginMeta;
 
         @Override public String getName() {
             return name;
@@ -159,7 +160,11 @@ public class TestScriptPluginFileCopier {
 
         @Override
         public PluginMeta getPluginMeta() {
-            return null;
+            return pluginMeta;
+        }
+
+        public void setPluginMeta(PluginMeta pluginMeta) {
+            this.pluginMeta = pluginMeta;
         }
 
         @Override
@@ -358,6 +363,9 @@ public class TestScriptPluginFileCopier {
         testProvider.setMetadata(new HashMap<String, Object>());
         testProvider.setName("test-plugin");
         testProvider.setScriptArgs("");
+        PluginMeta pluginMeta = new PluginMeta();
+        pluginMeta.setRundeckPluginVersion("1.2");
+        testProvider.setPluginMeta(pluginMeta);
 
         ScriptPluginFileCopier scriptPluginFileCopier = new ScriptPluginFileCopier(testProvider, framework);
         scriptPluginFileCopier.setScriptExecHelper(
@@ -434,6 +442,9 @@ public class TestScriptPluginFileCopier {
         testProvider.setMetadata(new HashMap<String, Object>());
         testProvider.setName("test-plugin");
         testProvider.setScriptArgs("");
+        PluginMeta pluginMeta = new PluginMeta();
+        pluginMeta.setRundeckPluginVersion("1.2");
+        testProvider.setPluginMeta(pluginMeta);
 
         ScriptPluginFileCopier scriptPluginFileCopier = new ScriptPluginFileCopier(testProvider, framework);
         scriptPluginFileCopier.setScriptExecHelper(
@@ -511,6 +522,9 @@ public class TestScriptPluginFileCopier {
         testProvider.setMetadata(new HashMap<String, Object>());
         testProvider.setName("test-plugin");
         testProvider.setScriptArgs("");
+        PluginMeta pluginMeta = new PluginMeta();
+        pluginMeta.setRundeckPluginVersion("1.2");
+        testProvider.setPluginMeta(pluginMeta);
 
         final String testOutputFilepath = "/another/test/path";
 


### PR DESCRIPTION
Fixing an issue produced when a remote script plugin is used along with a node executor/file copier script plugin. Remote script plugin's config variables were overwritten by the node executor script plugin.

The workaround is changing context variable names for step script plugin and node executor/file copier plugin, in order to avoid the overwrite:
* step plugin will use **RD_NODESTEP_XXX** 
* node executor will use **RD_NODEEXECUTOR_XXX**
* file copier will use **RD_FILECOPIER_XXXX**

Old names variables (RD_CONFIG_XX)  will be maintained in order to not break old plugins.



