### PR TITLE
Support multiple repositories, support auto syncing

### DIFF
--- a/rundeckapp/grails-spa/src/pages/repository/App.vue
+++ b/rundeckapp/grails-spa/src/pages/repository/App.vue
@@ -95,7 +95,7 @@ export default {
       axios({
         method: 'post',
         headers: {'x-rundeck-ajax': true},
-        url: `${this.rdBase}repository/install/${pluginId}`,
+        url: `${this.rdBase}repository/${repoName}/install/${pluginId}`,
         withCredentials: true
       }).then((response) => {
         let repo = this.repositories.find(r => r.repositoryName === repoName)

--- a/rundeckapp/repository/build.gradle
+++ b/rundeckapp/repository/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     compile "org.grails.plugins:gsp"
 
     compile project(":core")
-    compile('com.github.rundeck:repository:0.8.3') {
+    compile('com.github.rundeck:repository:0.8.4') {
         exclude(group:"org.rundeck", module:"rundeck-core")
         exclude(group:"com.squareup.okhttp3", module:"okhttp")
         exclude(group:"javax.mail", module:"mailapi")

--- a/rundeckapp/repository/grails-app/controllers/repository/RepositoryController.groovy
+++ b/rundeckapp/repository/grails-app/controllers/repository/RepositoryController.groovy
@@ -31,13 +31,11 @@ class RepositoryController {
                 specifyUnauthorizedError()
                 return
             }
-            String repoName = params.repoName ?: getOnlyRepoInListOrNullIfMultiple()
-            if(!repoName) {
-                specifyRepoError()
-                return
-            }
+            String repoName = params.repoName
+
             def installedPluginIds = pluginApiService.listInstalledPluginIds()
-            def artifacts = repoClient.listArtifactsByRepository(repoName,params.offset?.toInteger(),params.limit?.toInteger())
+            def artifacts = repoName ? repoClient.listArtifactsByRepository(repoName,params.offset?.toInteger(),params.limit?.toInteger())
+                                     : repoClient.listArtifacts(params.offset?.toInteger(),params.limit?.toInteger())
             artifacts.each {
                 it.results.each {
                     it.installed = installedPluginIds.contains(it.id)
@@ -50,11 +48,6 @@ class RepositoryController {
         def searchArtifacts() {
             if (!authorized(PLUGIN_RESOURCE,"read")) {
                 specifyUnauthorizedError()
-                return
-            }
-            String repoName = params.repoName ?: getOnlyRepoInListOrNullIfMultiple()
-            if(!repoName) {
-                specifyRepoError()
                 return
             }
             String searchTerm
@@ -89,11 +82,7 @@ class RepositoryController {
                 specifyUnauthorizedError()
                 return
             }
-            String repoName = params.repoName ?: getOnlyRepoInListOrNullIfMultiple()
-            if(!repoName) {
-                specifyRepoError()
-                return
-            }
+
             def installedPluginIds = pluginApiService.listInstalledPluginIds()
             def artifacts = repoClient.listArtifacts(0,-1)*.results.flatten()
             def installedArtifacts = []

--- a/rundeckapp/repository/grails-app/controllers/repository/UrlMappings.groovy
+++ b/rundeckapp/repository/grails-app/controllers/repository/UrlMappings.groovy
@@ -69,6 +69,10 @@ class UrlMappings {
                     controller: "repository",
                     action: "installArtifact"
             )
+            post "/repository/${repoName}/install/$artifactId/$artifactVersion?"(
+                    controller: "repository",
+                    action: "installArtifact"
+            )
         }
 
         "/"(view:"/index")

--- a/rundeckapp/repository/grails-app/init/repository/BootStrap.groovy
+++ b/rundeckapp/repository/grails-app/init/repository/BootStrap.groovy
@@ -1,11 +1,17 @@
 package repository
 
 class BootStrap {
-
+    RepositoryPluginService repositoryPluginService
     def grailsApplication
 
     def init = { servletContext ->
-        log.debug("Repository enabled: " + grailsApplication.config.rundeck.features.repository.enabled)
+        boolean enabled = grailsApplication.config.rundeck.features.repository.enabled in [true, 'true']
+        boolean sync = grailsApplication.config.rundeck.features.repository.syncOnBootstrap in [true,'true']
+        log.debug("Repository enabled: " + enabled)
+        if(enabled && sync) {
+            log.debug("Syncing installed plugins to this server")
+            repositoryPluginService.syncInstalledArtifactsToPluginTarget()
+        }
     }
     def destroy = {
     }

--- a/rundeckapp/repository/src/test/groovy/repository/BootStrapTest.groovy
+++ b/rundeckapp/repository/src/test/groovy/repository/BootStrapTest.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package repository
+
+import grails.core.GrailsApplication
+import org.grails.testing.GrailsUnitTest
+import spock.lang.Specification
+
+import javax.servlet.ServletContext
+
+
+class BootStrapTest extends Specification implements GrailsUnitTest {
+
+    def "init with sync enabled"() {
+
+        setup:
+        grailsApplication.config.rundeck.features.repository.enabled=true
+        grailsApplication.config.rundeck.features.repository.syncOnBootstrap=true
+
+        when:
+        BootStrap bootStrap = new BootStrap()
+        bootStrap.grailsApplication = grailsApplication
+        bootStrap.repositoryPluginService = Mock(RepositoryPluginService)
+        1 * bootStrap.repositoryPluginService.syncInstalledArtifactsToPluginTarget()
+        bootStrap.init(Stub(ServletContext))
+
+        then:
+        true
+
+    }
+
+    def "init with sync disabled"() {
+
+        setup:
+        grailsApplication.config.rundeck.features.repository.enabled=true
+        grailsApplication.config.rundeck.features.repository.syncOnBootstrap=false
+
+        when:
+        BootStrap bootStrap = new BootStrap()
+        bootStrap.grailsApplication = grailsApplication
+        bootStrap.repositoryPluginService = Mock(RepositoryPluginService)
+        0 * bootStrap.repositoryPluginService.syncInstalledArtifactsToPluginTarget()
+        bootStrap.init(Stub(ServletContext))
+
+        then:
+        true
+
+    }
+
+    def "init with repository disabled"() {
+
+        setup:
+        grailsApplication.config.rundeck.features.repository.enabled=false
+        grailsApplication.config.rundeck.features.repository.syncOnBootstrap=true
+
+        when:
+        BootStrap bootStrap = new BootStrap()
+        bootStrap.grailsApplication = grailsApplication
+        bootStrap.repositoryPluginService = Mock(RepositoryPluginService)
+        0 * bootStrap.repositoryPluginService.syncInstalledArtifactsToPluginTarget()
+        bootStrap.init(Stub(ServletContext))
+
+        then:
+        true
+
+    }
+}

--- a/rundeckapp/repository/src/test/groovy/repository/RepositoryControllerSpec.groovy
+++ b/rundeckapp/repository/src/test/groovy/repository/RepositoryControllerSpec.groovy
@@ -41,13 +41,12 @@ class RepositoryControllerSpec extends Specification implements ControllerUnitTe
 
     }
 
-    void "list artifacts no repo specified and only 1 repo defined"() {
+    void "list artifacts no repo specified"() {
         given:
         controller.pluginApiService.installedPluginIds = [PluginUtils.generateShaIdFromName("InstalledPlugin")]
 
         when:
-        1 * client.listRepositories() >> [new RepositoryDefinition(repositoryName: "private", owner: RepositoryOwner.PRIVATE)]
-        1 * client.listArtifactsByRepository(_,_,_) >> testArtifactList("private")
+        1 * client.listArtifacts(_,_) >> testArtifactList("private")
         controller.listArtifacts()
 
         then:
@@ -75,10 +74,9 @@ class RepositoryControllerSpec extends Specification implements ControllerUnitTe
 
     }
 
-    void "search artifacts no repo specified and only 1 repo defined"() {
+    void "search artifacts"() {
 
         when:
-        1 * client.listRepositories() >> [new RepositoryDefinition(repositoryName: "private", owner: RepositoryOwner.PRIVATE)]
         1 * client.searchManifests(_) >> testSearch("private")
         params.searchTerm = "artifactType: script-plugin"
         controller.searchArtifacts()
@@ -92,13 +90,12 @@ class RepositoryControllerSpec extends Specification implements ControllerUnitTe
 
     }
 
-    void "list installed artifacts no repo specified and only 1 repo defined"() {
+    void "list installed artifacts"() {
         given:
         def installedPluginId = PluginUtils.generateShaIdFromName("InstalledPlugin")
         controller.pluginApiService.installedPluginIds = [installedPluginId]
 
         when:
-        1 * client.listRepositories() >> [new RepositoryDefinition(repositoryName: "private", owner: RepositoryOwner.PRIVATE)]
         1 * client.listArtifacts(_,_) >> testArtifactList("private")
         controller.listInstalledArtifacts()
 


### PR DESCRIPTION
Multiple repositories can be used to host available plugins. Auto sync feature will allow an instance to pull in plugins from a central location into libext on bootstrap.