### PR TITLE
Fixes #115. 

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
@@ -698,8 +698,8 @@ public class JettyCachingLdapLoginModule extends AbstractLoginModule {
      */
     protected boolean authenticate(final String webUserName, final Object webCredential) throws LoginException {
         try {
-
-            if (isEmptyOrNull(webUserName) || isEmptyOrNull(webCredential)) {
+            if (isEmptyOrNull(webUserName) || isEmptyOrNull(webCredential) || (webCredential instanceof char[] && ((char[]) webCredential).length == 0)) {
+                LOG.info("empty username or password not allowed");
                 setAuthenticated(false);
                 return isAuthenticated();
             }

--- a/rundeckapp/src/test/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModuleTest2.java
+++ b/rundeckapp/src/test/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModuleTest2.java
@@ -235,7 +235,7 @@ public class JettyCachingLdapLoginModuleTest2 {
     }
 
 
-    private CallbackHandler createCallbacks(final String user1, final String password) {
+    private CallbackHandler createCallbacks(final String user1, final Object password) {
         return new CallbackHandler() {
             @Override
             public void handle(final Callback[] callbacks) throws IOException, UnsupportedCallbackException {
@@ -271,6 +271,15 @@ public class JettyCachingLdapLoginModuleTest2 {
         JettyCachingLdapLoginModule module = new JettyCachingLdapLoginModule();
         module._debug = true;
         module.setCallbackHandler(createCallbacks("user1", null));
+        expectLoginException(module);
+    }
+
+    @Test
+    public void testDisallowEmptyCharArrayPasword() {
+        JettyCachingLdapLoginModule module = new JettyCachingLdapLoginModule();
+        module._debug = true;
+        char[] empty = {};
+        module.setCallbackHandler(createCallbacks("user1", empty));
         expectLoginException(module);
     }
 


### PR DESCRIPTION
Null or empty passwords are disallowed which fixes the bug. 
An additional condition was added to check for an empty char array being provided as the password.
