### PR TITLE
Fix #2975 multiple threads modify the map

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
@@ -51,6 +51,7 @@ import rundeck.services.logging.WorkflowStateFileLoader
 import rundeck.services.workflow.StateMapping
 
 import java.nio.file.Files
+import java.util.concurrent.ConcurrentHashMap
 
 class WorkflowService implements ApplicationContextAware,ExecutionFileProducer{
     public static final String STATE_FILE_FILETYPE = "state.json"
@@ -70,7 +71,7 @@ class WorkflowService implements ApplicationContextAware,ExecutionFileProducer{
     /**
      * in-memory states of executions while executions are running
      */
-    Map<Long, WorkflowState> activeStates = new HashMap<Long, WorkflowState>()
+    Map<Long, WorkflowState> activeStates = new ConcurrentHashMap<>()
     /**
      * initialized in bootstrap
      */


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #2975 

**Describe the solution you've implemented**

Use concurrent map since multiple threads may modify the map