### PR TITLE
disable jobref stats

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2826,9 +2826,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 success = true
             }
         } catch (org.springframework.dao.ConcurrencyFailureException e) {
-            log.error("Caught ConcurrencyFailureException, will retry updateScheduledExecStatistics for ${eId}")
+            log.warn("Caught ConcurrencyFailureException, will retry updateScheduledExecStatistics for ${eId}")
         } catch (StaleObjectStateException e) {
-            log.error("Caught StaleObjectState, will retry updateScheduledExecStatistics for ${eId}")
+            log.warn("Caught StaleObjectState, will retry updateScheduledExecStatistics for ${eId}")
         }
         return success
     }

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -3112,6 +3112,128 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         0 * executionListener.log(_)
         ret.success
     }
+
+
+    def "disable stats for job ref execution by framework property"(){
+        given:
+        def jobname = 'abc'
+        def group = 'path'
+        def project = 'AProject'
+        ScheduledExecution job = new ScheduledExecution(
+                jobName: jobname,
+                project: project,
+                groupPath: group,
+                description: 'a job',
+                argString: '-args b -args2 d',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec(
+                                [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
+                        )]
+                ),
+                retry: '1',
+                uuid: 'bd80d431-b70a-42ad-8ea8-37ad4885ea0d'
+        )
+        job.save()
+        Execution e1 = new Execution(
+                project: project,
+                user: 'bob',
+                dateStarted: new Date(),
+                dateEnded: new Date(),
+                status: 'successful'
+
+        )
+        e1.save() != null
+
+        def datacontext = [job:[execid:e1.id]]
+
+
+        def nodeSet = new NodeSetImpl()
+        def node1 = new NodeEntryImpl('node1')
+        nodeSet.putNode(node1)
+
+        service.fileUploadService = Mock(FileUploadService)
+        service.executionUtilService = Mock(ExecutionUtilService)
+        service.storageService = Mock(StorageService)
+        service.jobStateService = Mock(JobStateService)
+        service.frameworkService = Mock(FrameworkService) {
+            authorizeProjectJobAll(*_) >> true
+            filterAuthorizedNodes(_, _, _, _) >> { args ->
+                nodeSet
+            }
+            getFrameworkProperties() >> (['rundeck.enable.ref.stats': propValue] as Properties)
+        }
+
+
+        def executionListener = Mock(ExecutionListener)
+
+        def origContext = Mock(StepExecutionContext){
+            getDataContext()>>datacontext
+            getStepNumber()>>1
+            getStepContext()>>[]
+            getNodes()>> nodeSet
+            getFramework() >> Mock(Framework)
+            getExecutionListener() >> executionListener
+
+        }
+        JobRefCommand item = ExecutionItemFactory.createJobRef(
+                null,
+                ['args', 'args2'] as String[],
+                false,
+                null,
+                true,
+                '.*',
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                'bd80d431-b70a-42ad-8ea8-37ad4885ea0d',
+        )
+
+
+        service.notificationService = Mock(NotificationService)
+        def dispatcherResult = Mock(DispatcherResult)
+        def wresult = Mock(WorkflowExecutionResult){
+            isSuccess()>>true
+        }
+
+
+        service.metricService = Mock(MetricService){
+            withTimer(_,_,_)>>{classname, name,  closure ->
+                [result:wresult]
+            }
+        }
+
+        def createFailure = { FailureReason reason, String msg ->
+            return new StepExecutionResultImpl(null, reason, msg)
+        }
+        def createSuccess = {
+            return new StepExecutionResultImpl()
+        }
+        when:
+        def ret = service.runJobRefExecutionItem(origContext,item,createFailure,createSuccess)
+        then:
+        def refexec = ReferencedExecution.findByScheduledExecution(job)
+        println(refexec)
+        println(expectedRef)
+        if(expectedRef){
+            refexec
+        }else{
+            !refexec
+        }
+        0 * executionListener.log(_)
+        ret.success
+        where:
+        propValue | expectedRef
+        'true'    | true
+        'false'   | false
+        ''        | false
+    }
     def "createJobReferenceContext import options"() {
         given:
         def context = ExecutionContextImpl.builder().


### PR DESCRIPTION
Disable the referenced jobs statistics for now, since they cause deadlocks on environments with a heavy load.

Modified `updateScheduledExecStatistics` to use `withTransaction` instead of `withSession` because with session it causes deadlock on parallel jobs too.

It can be enabled again using `rundeck.enable.ref.stats=true` in the `framework.properties` file. 

Fix #4302 