### PR TITLE
Remove environment variable that hijacks jvm ssl settings

### DIFF
--- a/packaging/common/etc/rundeck/profile
+++ b/packaging/common/etc/rundeck/profile
@@ -91,8 +91,7 @@ RDECK_JVM="$RDECK_JVM $RDECK_JVM_SETTINGS"
 # SSL Configuration - Uncomment the following to enable.  Check SSL.properties for details.
 #
 if [ -n "$RUNDECK_WITH_SSL" ] ; then
-  RDECK_SSL_OPTS="${RDECK_SSL_OPTS:- -Djavax.net.ssl.trustStore=$RDECK_TRUSTSTORE_FILE -Djavax.net.ssl.trustStoreType=$RDECK_TRUSTSTORE_TYPE -Djava.protocol.handler.pkgs=com.sun.net.ssl.internal.www.protocol}"
-  RDECK_JVM="$RDECK_JVM -Drundeck.ssl.config=$RDECK_SERVER_CONFIG/ssl/ssl.properties -Dserver.https.port=${RDECK_HTTPS_PORT} ${RDECK_SSL_OPTS}"
+  RDECK_JVM="$RDECK_JVM -Drundeck.ssl.config=$RDECK_SERVER_CONFIG/ssl/ssl.properties -Dserver.https.port=${RDECK_HTTPS_PORT}"
 fi
 
 unset JRE_HOME


### PR DESCRIPTION
Https connections fail with `sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target` with this environment variable set. Once commented or removed they work fine. Removing this setting does not impact the Rundeck SSL configuration.
