### PR TITLE
Add common web-app security headers

### DIFF
--- a/grails-securityheaders/build.gradle
+++ b/grails-securityheaders/build.gradle
@@ -1,0 +1,66 @@
+buildscript {
+    repositories {
+        mavenLocal()
+        maven { url "https://repo.grails.org/grails/core" }
+    }
+    dependencies {
+        classpath "org.grails:grails-gradle-plugin:$grailsVersion"
+        classpath "com.bertramlabs.plugins:asset-pipeline-gradle:2.14.2"
+    }
+}
+
+group "org.rundeck.grails.plugins.securityheaders"
+
+apply plugin:"eclipse"
+apply plugin:"idea"
+apply plugin:"org.grails.grails-plugin"
+apply plugin:"org.grails.grails-plugin-publish"
+apply plugin:"asset-pipeline"
+apply plugin:"org.grails.grails-gsp"
+
+repositories {
+    mavenLocal()
+    maven { url "https://repo.grails.org/grails/core" }
+}
+
+dependencies {
+    compile "org.springframework.boot:spring-boot-starter-logging"
+    compile "org.springframework.boot:spring-boot-autoconfigure"
+    compile "org.grails:grails-core"
+    compile "org.springframework.boot:spring-boot-starter-actuator"
+    provided "org.springframework.boot:spring-boot-starter-jetty"
+    compile "org.grails:grails-web-boot"
+    compile "org.grails:grails-logging"
+    compile "org.grails:grails-plugin-rest"
+    compile "org.grails:grails-plugin-databinding"
+    compile "org.grails:grails-plugin-i18n"
+    compile "org.grails:grails-plugin-services"
+    compile "org.grails:grails-plugin-url-mappings"
+    compile "org.grails:grails-plugin-interceptors"
+    compile "org.grails.plugins:cache"
+    compile "org.grails.plugins:async"
+    compile "org.grails.plugins:scaffolding"
+    compile "org.grails.plugins:gsp"
+    console "org.grails:grails-console"
+    profile "org.grails.profiles:web-plugin"
+    provided "org.grails:grails-plugin-services"
+    provided "org.grails:grails-plugin-domain-class"
+    runtime "com.bertramlabs.plugins:asset-pipeline-grails:2.14.2"
+    testCompile "org.grails:grails-gorm-testing-support"
+    testCompile "org.grails:grails-plugin-testing"
+    testCompile "org.grails:grails-web-testing-support"
+}
+
+bootRun {
+    jvmArgs('-Dspring.output.ansi.enabled=always')
+    addResources = true
+    String springProfilesActive = 'spring.profiles.active'
+    systemProperty springProfilesActive, System.getProperty(springProfilesActive)
+}
+// enable if you wish to package this plugin as a standalone application
+bootRepackage.enabled = false
+
+
+assets {
+    packagePlugin = true
+}

--- a/grails-securityheaders/gradle.properties
+++ b/grails-securityheaders/gradle.properties
@@ -1,0 +1,3 @@
+grailsVersion=3.3.8
+gormVersion=6.1.10.RELEASE
+gradleWrapperVersion=3.5

--- a/grails-securityheaders/grails-app/conf/application.yml
+++ b/grails-securityheaders/grails-app/conf/application.yml
@@ -1,0 +1,83 @@
+---
+grails:
+    profile: web-plugin
+    codegen:
+        defaultPackage: grails.securityheaders
+    gorm:
+        reactor:
+            # Whether to translate GORM events into Reactor events
+            # Disabled by default for performance reasons
+            events: false
+info:
+    app:
+        name: '@info.app.name@'
+        version: '@info.app.version@'
+        grailsVersion: '@info.app.grailsVersion@'
+spring:
+    main:
+        banner-mode: "off"
+    groovy:
+        template:
+            check-template-location: false
+
+# Spring Actuator Endpoints are Disabled by Default
+endpoints:
+    enabled: false
+    jmx:
+        enabled: true
+
+---
+grails:
+    mime:
+        disable:
+            accept:
+                header:
+                    userAgents:
+                        - Gecko
+                        - WebKit
+                        - Presto
+                        - Trident
+        types:
+            all: '*/*'
+            atom: application/atom+xml
+            css: text/css
+            csv: text/csv
+            form: application/x-www-form-urlencoded
+            html:
+              - text/html
+              - application/xhtml+xml
+            js: text/javascript
+            json:
+              - application/json
+              - text/json
+            multipartForm: multipart/form-data
+            pdf: application/pdf
+            rss: application/rss+xml
+            text: text/plain
+            hal:
+              - application/hal+json
+              - application/hal+xml
+            xml:
+              - text/xml
+              - application/xml
+    urlmapping:
+        cache:
+            maxsize: 1000
+    controllers:
+        defaultScope: singleton
+    converters:
+        encoding: UTF-8
+    views:
+        default:
+            codec: html
+        gsp:
+            encoding: UTF-8
+            htmlcodec: xml
+            codecs:
+                expression: html
+                scriptlets: html
+                taglib: none
+                staticparts: none
+endpoints:
+    jmx:
+        unique-names: true

--- a/grails-securityheaders/grails-app/conf/logback.groovy
+++ b/grails-securityheaders/grails-app/conf/logback.groovy
@@ -1,0 +1,36 @@
+import grails.util.BuildSettings
+import grails.util.Environment
+import org.springframework.boot.logging.logback.ColorConverter
+import org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter
+
+import java.nio.charset.Charset
+
+conversionRule 'clr', ColorConverter
+conversionRule 'wex', WhitespaceThrowableProxyConverter
+
+// See http://logback.qos.ch/manual/groovy.html for details on configuration
+appender('STDOUT', ConsoleAppender) {
+    encoder(PatternLayoutEncoder) {
+        charset = Charset.forName('UTF-8')
+
+        pattern =
+                '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} ' + // Date
+                        '%clr(%5p) ' + // Log level
+                        '%clr(---){faint} %clr([%15.15t]){faint} ' + // Thread
+                        '%clr(%-40.40logger{39}){cyan} %clr(:){faint} ' + // Logger
+                        '%m%n%wex' // Message
+    }
+}
+
+def targetDir = BuildSettings.TARGET_DIR
+if (Environment.isDevelopmentMode() && targetDir != null) {
+    appender("FULL_STACKTRACE", FileAppender) {
+        file = "${targetDir}/stacktrace.log"
+        append = true
+        encoder(PatternLayoutEncoder) {
+            pattern = "%level %logger - %msg%n"
+        }
+    }
+    logger("StackTrace", ERROR, ['FULL_STACKTRACE'], false)
+}
+root(ERROR, ['STDOUT'])

--- a/grails-securityheaders/grails-app/controllers/grails/securityheaders/UrlMappings.groovy
+++ b/grails-securityheaders/grails-app/controllers/grails/securityheaders/UrlMappings.groovy
@@ -1,0 +1,16 @@
+package grails.securityheaders
+
+class UrlMappings {
+
+    static mappings = {
+        "/$controller/$action?/$id?(.$format)?"{
+            constraints {
+                // apply constraints here
+            }
+        }
+
+        "/"(view:"/index")
+        "500"(view:'/error')
+        "404"(view:'/notFound')
+    }
+}

--- a/grails-securityheaders/grails-app/init/grails/securityheaders/Application.groovy
+++ b/grails-securityheaders/grails-app/init/grails/securityheaders/Application.groovy
@@ -1,0 +1,12 @@
+package grails.securityheaders
+
+import grails.boot.*
+import grails.boot.config.GrailsAutoConfiguration
+import grails.plugins.metadata.*
+
+@PluginSource
+class Application extends GrailsAutoConfiguration {
+    static void main(String[] args) {
+        GrailsApp.run(Application, args)
+    }
+}

--- a/grails-securityheaders/grails-app/init/grails/securityheaders/BootStrap.groovy
+++ b/grails-securityheaders/grails-app/init/grails/securityheaders/BootStrap.groovy
@@ -1,0 +1,9 @@
+package grails.securityheaders
+
+class BootStrap {
+
+    def init = { servletContext ->
+    }
+    def destroy = {
+    }
+}

--- a/grails-securityheaders/grails-app/views/error.gsp
+++ b/grails-securityheaders/grails-app/views/error.gsp
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+    <head>
+        <title><g:if env="development">Grails Runtime Exception</g:if><g:else>Error</g:else></title>
+        <meta name="layout" content="main">
+        <g:if env="development"><asset:stylesheet src="errors.css"/></g:if>
+    </head>
+    <body>
+        <g:if env="development">
+            <g:if test="${Throwable.isInstance(exception)}">
+                <g:renderException exception="${exception}" />
+            </g:if>
+            <g:elseif test="${request.getAttribute('javax.servlet.error.exception')}">
+                <g:renderException exception="${request.getAttribute('javax.servlet.error.exception')}" />
+            </g:elseif>
+            <g:else>
+                <ul class="errors">
+                    <li>An error has occurred</li>
+                    <li>Exception: ${exception}</li>
+                    <li>Message: ${message}</li>
+                    <li>Path: ${path}</li>
+                </ul>
+            </g:else>
+        </g:if>
+        <g:else>
+            <ul class="errors">
+                <li>An error has occurred</li>
+            </ul>
+        </g:else>
+    </body>
+</html>

--- a/grails-securityheaders/grails-app/views/index.gsp
+++ b/grails-securityheaders/grails-app/views/index.gsp
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+<head>
+    <meta name="layout" content="main"/>
+    <title>Welcome to Grails</title>
+</head>
+<body>
+    <content tag="nav">
+        <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Application Status <span class="caret"></span></a>
+            <ul class="dropdown-menu">
+                <li><a href="#">Environment: ${grails.util.Environment.current.name}</a></li>
+                <li><a href="#">App profile: ${grailsApplication.config.grails?.profile}</a></li>
+                <li><a href="#">App version:
+                    <g:meta name="info.app.version"/></a>
+                </li>
+                <li role="separator" class="divider"></li>
+                <li><a href="#">Grails version:
+                    <g:meta name="info.app.grailsVersion"/></a>
+                </li>
+                <li><a href="#">Groovy version: ${GroovySystem.getVersion()}</a></li>
+                <li><a href="#">JVM version: ${System.getProperty('java.version')}</a></li>
+                <li role="separator" class="divider"></li>
+                <li><a href="#">Reloading active: ${grails.util.Environment.reloadingAgentEnabled}</a></li>
+            </ul>
+        </li>
+        <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Artefacts <span class="caret"></span></a>
+            <ul class="dropdown-menu">
+                <li><a href="#">Controllers: ${grailsApplication.controllerClasses.size()}</a></li>
+                <li><a href="#">Domains: ${grailsApplication.domainClasses.size()}</a></li>
+                <li><a href="#">Services: ${grailsApplication.serviceClasses.size()}</a></li>
+                <li><a href="#">Tag Libraries: ${grailsApplication.tagLibClasses.size()}</a></li>
+            </ul>
+        </li>
+        <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Installed Plugins <span class="caret"></span></a>
+            <ul class="dropdown-menu">
+                <g:each var="plugin" in="${applicationContext.getBean('pluginManager').allPlugins}">
+                    <li><a href="#">${plugin.name} - ${plugin.version}</a></li>
+                </g:each>
+            </ul>
+        </li>
+    </content>
+
+    <div class="svg" role="presentation">
+        <div class="grails-logo-container">
+            <asset:image src="grails-cupsonly-logo-white.svg" class="grails-logo"/>
+        </div>
+    </div>
+
+    <div id="content" role="main">
+        <section class="row colset-2-its">
+            <h1>Welcome to Grails</h1>
+
+            <p>
+                Congratulations, you have successfully started your first Grails application! At the moment
+                this is the default page, feel free to modify it to either redirect to a controller or display
+                whatever content you may choose. Below is a list of controllers that are currently deployed in
+                this application, click on each to execute its default action:
+            </p>
+
+            <div id="controllers" role="navigation">
+                <h2>Available Controllers:</h2>
+                <ul>
+                    <g:each var="c" in="${grailsApplication.controllerClasses.sort { it.fullName } }">
+                        <li class="controller">
+                            <g:link controller="${c.logicalPropertyName}">${c.fullName}</g:link>
+                        </li>
+                    </g:each>
+                </ul>
+            </div>
+        </section>
+    </div>
+
+</body>
+</html>

--- a/grails-securityheaders/grails-app/views/layouts/main.gsp
+++ b/grails-securityheaders/grails-app/views/layouts/main.gsp
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <title>
+        <g:layoutTitle default="Grails"/>
+    </title>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <asset:link rel="icon" href="favicon.ico" type="image/x-ico" />
+
+    <asset:stylesheet src="application.css"/>
+
+    <g:layoutHead/>
+</head>
+<body>
+
+    <div class="navbar navbar-default navbar-static-top" role="navigation">
+        <div class="container">
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+                <a class="navbar-brand" href="/#">
+		    <asset:image src="grails.svg" alt="Grails Logo"/>
+                </a>
+            </div>
+            <div class="navbar-collapse collapse" aria-expanded="false" style="height: 0.8px;">
+                <ul class="nav navbar-nav navbar-right">
+                    <g:pageProperty name="page.nav" />
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <g:layoutBody/>
+
+    <div class="footer" role="contentinfo"></div>
+
+    <div id="spinner" class="spinner" style="display:none;">
+        <g:message code="spinner.alt" default="Loading&hellip;"/>
+    </div>
+
+    <asset:javascript src="application.js"/>
+
+</body>
+</html>

--- a/grails-securityheaders/grails-app/views/notFound.gsp
+++ b/grails-securityheaders/grails-app/views/notFound.gsp
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Page Not Found</title>
+        <meta name="layout" content="main">
+        <g:if env="development"><asset:stylesheet src="errors.css"/></g:if>
+    </head>
+    <body>
+        <ul class="errors">
+            <li>Error: Page Not Found (404)</li>
+            <li>Path: ${request.forwardURI}</li>
+        </ul>
+    </body>
+</html>

--- a/grails-securityheaders/src/main/groovy/grails/securityheaders/GrailsSecurityheadersGrailsPlugin.groovy
+++ b/grails-securityheaders/src/main/groovy/grails/securityheaders/GrailsSecurityheadersGrailsPlugin.groovy
@@ -39,6 +39,9 @@ Brief summary/description of the plugin.
                 name = 'custom'
                 defaultEnabled = false
             }
+            /**
+             * defines Content-Security-Policy
+             */
             cspSecurityHeaderProvider(CSPSecurityHeaderProvider) {
                 name = 'csp'
                 defaultEnabled = false

--- a/grails-securityheaders/src/main/groovy/grails/securityheaders/GrailsSecurityheadersGrailsPlugin.groovy
+++ b/grails-securityheaders/src/main/groovy/grails/securityheaders/GrailsSecurityheadersGrailsPlugin.groovy
@@ -2,6 +2,7 @@ package grails.securityheaders
 
 import grails.plugins.*
 import org.rundeck.grails.plugins.securityheaders.CSPSecurityHeaderProvider
+import org.rundeck.grails.plugins.securityheaders.CustomSecurityHeaderProvider
 import org.rundeck.grails.plugins.securityheaders.RundeckSecurityHeadersFilter
 import org.rundeck.grails.plugins.securityheaders.XCTOSecurityHeaderProvider
 import org.rundeck.grails.plugins.securityheaders.XFOSecurityHeaderProvider
@@ -33,7 +34,11 @@ Brief summary/description of the plugin.
 
     Closure doWithSpring() {
         { ->
-            //define security header providers
+            //can define custom headers
+            customSecurityHeaderProvider(CustomSecurityHeaderProvider) {
+                name = 'custom'
+                defaultEnabled = false
+            }
             cspSecurityHeaderProvider(CSPSecurityHeaderProvider) {
                 name = 'csp'
                 defaultEnabled = false

--- a/grails-securityheaders/src/main/groovy/grails/securityheaders/GrailsSecurityheadersGrailsPlugin.groovy
+++ b/grails-securityheaders/src/main/groovy/grails/securityheaders/GrailsSecurityheadersGrailsPlugin.groovy
@@ -1,0 +1,74 @@
+package grails.securityheaders
+
+import grails.plugins.*
+import org.rundeck.grails.plugins.securityheaders.CSPSecurityHeaderProvider
+import org.rundeck.grails.plugins.securityheaders.RundeckSecurityHeadersFilter
+import org.rundeck.grails.plugins.securityheaders.XCTOSecurityHeaderProvider
+import org.rundeck.grails.plugins.securityheaders.XFOSecurityHeaderProvider
+import org.rundeck.grails.plugins.securityheaders.XXSSPSecurityHeaderProvider
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+
+class GrailsSecurityheadersGrailsPlugin extends Plugin {
+
+    // the version or versions of Grails the plugin is designed for
+    def grailsVersion = "3.3.8 > *"
+    // resources that are excluded from plugin packaging
+    def pluginExcludes = [
+            "grails-app/views/error.gsp"
+    ]
+
+    // TODO Fill in these fields
+    def title = "Grails Securityheaders" // Headline display name of the plugin
+    def author = "Your name"
+    def authorEmail = ""
+    def description = '''\
+Brief summary/description of the plugin.
+'''
+    def profiles = ['web']
+    def loadBefore = ['asset-pipeline']
+
+    // URL to the plugin's documentation
+    def documentation = "https://github.com/rundeck/rundeck"
+
+
+    Closure doWithSpring() {
+        { ->
+            //define security header providers
+            cspSecurityHeaderProvider(CSPSecurityHeaderProvider) {
+                name = 'csp'
+                defaultEnabled = false
+            }
+            /**
+             * X-Content-Type-Options: nosniff
+             */
+            xctoSecurityHeaderProvider(XCTOSecurityHeaderProvider) {
+                name = 'xcto'
+                defaultEnabled = true
+            }
+
+            /**
+             * X-XSS-Protection: 1
+             */
+            xxsspSecurityHeaderProvider(XXSSPSecurityHeaderProvider) {
+                name = 'xxssp'
+                defaultEnabled = true
+            }
+
+            /**
+             * X-Frame-Options: deny
+             */
+            xfoSecurityHeaderProvider(XFOSecurityHeaderProvider) {
+                name = 'xfo'
+                defaultEnabled = true
+            }
+            rundeckSecurityHeadersFilter(RundeckSecurityHeadersFilter) {
+                enabled = grailsApplication.config.rundeck?.security?.httpHeaders?.enabled in [true, 'true']
+                config = grailsApplication.config.rundeck?.security?.httpHeaders?.provider
+            }
+            rundeckSecHeadersFilterReg(FilterRegistrationBean) {
+                filter = ref("rundeckSecurityHeadersFilter")
+                enabled = true
+            }
+        }
+    }
+}

--- a/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/CSPSecurityHeaderProvider.groovy
+++ b/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/CSPSecurityHeaderProvider.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.grails.plugins.securityheaders
+
+import groovy.transform.CompileStatic
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@CompileStatic
+class CSPSecurityHeaderProvider implements SecurityHeaderProvider {
+
+    public static final String CSP_HEADER_NAME = 'Content-Security-Policy'
+
+    String name = 'csp'
+    Boolean defaultEnabled = false
+    Map<String, String> directives
+
+    @Override
+    List<SecurityHeader> getSecurityHeaders(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            Map config
+    ) {
+        List<SecurityHeader> headers = []
+        List<String> valueParts = []
+
+        DIRECTIVES.each { String directive ->
+            String uri = request.requestURI
+            List<String> parts = uri.split(/\//).toList().findAll { it }
+
+            String defCsp = config.get(directive + '.default')
+            String uriCsp = config.get(directive + '.uri.' + parts.join('.'))
+
+
+            List<String> allowed = uriCsp.split(/\s+/).toList()
+            String cspString = generateCspHeader(directive, allowed)
+            valueParts << cspString
+
+        }
+
+        if (valueParts) {
+            headers << new SecurityHeaderImpl(name: CSP_HEADER_NAME, value: valueParts.join(';'))
+        }
+
+        headers
+    }
+
+    static String generateCspHeader(String directive, List<String> allowed) {
+        allowed = allowed?.findAll { it }
+        if (!allowed) {
+            allowed = ['none']
+        }
+        directive + ' ' + allowed.collect { "'${it}'" }.join(" ")
+    }
+
+    static final List<String> DIRECTIVES = Collections.unmodifiableList(
+            [
+                    'base-uri',
+                    'default-src',
+                    'script-src',
+                    'object-src',
+                    'style-src',
+                    'img-src',
+                    'media-src',
+                    'frame-src',
+                    'child-src',
+                    'frame-ancestors',
+                    'font-src',
+                    'connect-src',
+                    'manifest-src',
+                    'form-action',
+                    'sandbox',
+                    'script-nonce',
+                    'plugin-types',
+                    'reflected-xss',
+                    'block-all-mixed-content',
+                    'upgrade-insecure-requests',
+                    'referrer',
+                    'report-uri',
+                    'report-to',
+                    'worker-src'
+            ]
+    )
+}

--- a/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/CSPSecurityHeaderProvider.groovy
+++ b/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/CSPSecurityHeaderProvider.groovy
@@ -94,10 +94,10 @@ class CSPSecurityHeaderProvider implements SecurityHeaderProvider {
                     List<SecurityHeader> built = []
 
                     built << new SecurityHeaderImpl(name: CSP_HEADER_NAME, value: headerValue)
-                    if (getBoolean(config, CONFIG_INCLUDE_X_CSP_HEADER, true)) {
+                    if (getBoolean(config, CONFIG_INCLUDE_X_CSP_HEADER, false)) {
                         built << new SecurityHeaderImpl(name: XCSP_HEADER_NAME, value: headerValue)
                     }
-                    if (getBoolean(config, CONFIG_INCLUDE_X_WEBKIT_CSP_HEADER, true)) {
+                    if (getBoolean(config, CONFIG_INCLUDE_X_WEBKIT_CSP_HEADER, false)) {
                         built << new SecurityHeaderImpl(name: X_WEBKIT_CSP_HEADER_NAME, value: headerValue)
                     }
 

--- a/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/CustomSecurityHeaderProvider.groovy
+++ b/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/CustomSecurityHeaderProvider.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.grails.plugins.securityheaders
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * Allows custom header definitions.
+ * Config:
+ * rundeck.security.httpHeaders.provider.custom.enabled=true
+ * rundeck.security.httpHeaders.provider.custom.config.name=header name
+ * rundeck.security.httpHeaders.provider.custom.config.value=header value
+ * # add additional name/value pairs starting at index 2:
+ * rundeck.security.httpHeaders.provider.custom.config.name2=header 2 name
+ * rundeck.security.httpHeaders.provider.custom.config.value2=header 2 value
+ */
+class CustomSecurityHeaderProvider implements SecurityHeaderProvider {
+    String name = 'generic'
+    Boolean defaultEnabled = false
+
+    @Override
+    List<SecurityHeader> getSecurityHeaders(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final Map config
+    ) {
+        List<SecurityHeader> results = []
+        String name = config.get("name")
+        String value = config.get("value")
+        if (name && value) {
+            results << new SecurityHeaderImpl(name: name, value: value)
+        }
+        int count = 2
+        while (config.get("name$count") && config.get("value$count")) {
+            results << new SecurityHeaderImpl(name: config.get("name$count"), value: config.get("value$count"))
+            count++
+        }
+
+        results
+    }
+}

--- a/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/RundeckSecurityHeadersFilter.groovy
+++ b/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/RundeckSecurityHeadersFilter.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.grails.plugins.securityheaders
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
+import org.springframework.web.filter.GenericFilterBean
+import org.springframework.web.filter.OncePerRequestFilter
+
+import javax.servlet.FilterChain
+import javax.servlet.ServletException
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class RundeckSecurityHeadersFilter extends OncePerRequestFilter implements ApplicationContextAware {
+    private static final transient Logger LOG = LoggerFactory.getLogger(RundeckSecurityHeadersFilter.class);
+
+    def Map config
+
+    ApplicationContext applicationContext
+    boolean enabled
+
+    @Override
+    void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain)
+            throws IOException, ServletException {
+
+        if (enabled) {
+            def securityHeaders = applicationContext.getBeansOfType(SecurityHeaderProvider)
+            for (SecurityHeaderProvider provider : securityHeaders.values()) {
+                def provSettings = config.get(provider.name)
+                def confEnabled = provSettings?.get('enabled')
+                if (confEnabled == null) {
+                    confEnabled = provider.defaultEnabled
+                } else {
+                    confEnabled = confEnabled == 'true'
+                }
+                if (confEnabled) {
+                    Map provConf = provSettings?.get('config') ?: [:]
+                    def list = provider.getSecurityHeaders(request, response, provConf)
+                    if (list) {
+                        list.each { SecurityHeader header ->
+                            response.addHeader(header.name, header.value)
+                        }
+                    }
+                }
+            }
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/RundeckSecurityHeadersFilter.groovy
+++ b/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/RundeckSecurityHeadersFilter.groovy
@@ -51,7 +51,7 @@ class RundeckSecurityHeadersFilter extends OncePerRequestFilter implements Appli
                 if (confEnabled == null) {
                     confEnabled = provider.defaultEnabled
                 } else {
-                    confEnabled = confEnabled == 'true'
+                    confEnabled = confEnabled in ['true', true]
                 }
                 if (confEnabled) {
                     Map provConf = provSettings?.get('config') ?: [:]

--- a/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/SecurityHeader.groovy
+++ b/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/SecurityHeader.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.grails.plugins.securityheaders
+
+import groovy.transform.CompileStatic
+
+/**
+ * A single header name/value
+ */
+@CompileStatic
+interface SecurityHeader {
+    String getName()
+    String getValue()
+}

--- a/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/SecurityHeaderImpl.groovy
+++ b/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/SecurityHeaderImpl.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.grails.plugins.securityheaders
+
+import groovy.transform.CompileStatic
+
+
+@CompileStatic
+class SecurityHeaderImpl implements SecurityHeader {
+    String name
+    String value
+}

--- a/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/SecurityHeaderProvider.groovy
+++ b/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/SecurityHeaderProvider.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.grails.plugins.securityheaders
+
+import groovy.transform.CompileStatic
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+
+/**
+ * provides headers to add to the response
+ */
+@CompileStatic
+interface SecurityHeaderProvider {
+    /**
+     * provider name
+     * @return
+     */
+    String getName()
+
+    /**
+     *
+     * @return true if enabled by default
+     */
+    Boolean getDefaultEnabled()
+
+    /**
+     *
+     * @param request
+     * @param response
+     * @param config
+     * @return list of headers to add to response
+     */
+    List<SecurityHeader> getSecurityHeaders(HttpServletRequest request, HttpServletResponse response, Map config)
+}

--- a/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/XCTOSecurityHeaderProvider.groovy
+++ b/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/XCTOSecurityHeaderProvider.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.grails.plugins.securityheaders
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * Defines 'X-Content-Type-Options: nosniff' header
+ */
+class XCTOSecurityHeaderProvider implements SecurityHeaderProvider {
+    public static final String X_CONTENT_TYPE_OPTIONS_HEADER_NAME = 'X-Content-Type-Options'
+    public static final String XCTO_HEADER_VALUE_NOSNIFF = 'nosniff'
+    public static final SecurityHeaderImpl XCTO_HEADER = new SecurityHeaderImpl(
+            name: X_CONTENT_TYPE_OPTIONS_HEADER_NAME,
+            value: XCTO_HEADER_VALUE_NOSNIFF
+    )
+    String name = 'xcto'
+    Boolean defaultEnabled = true
+
+    @Override
+    List<SecurityHeader> getSecurityHeaders(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final Map config
+    ) {
+        [XCTO_HEADER]
+    }
+}

--- a/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/XFOSecurityHeaderProvider.groovy
+++ b/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/XFOSecurityHeaderProvider.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.grails.plugins.securityheaders
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * Define 'X-Frame-Options' header, default value 'deny',
+ * config values: 'sameorigin' enables value 'sameorigin',
+ * config value 'allowFrom' defines domain used in `allow-from: DOMAIN`
+ * see: <a href="https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#xfo">OWASP</a>
+ */
+class XFOSecurityHeaderProvider implements SecurityHeaderProvider {
+    public static final String XFO_HEADER_NAME = 'X-Frame-Options'
+    public static final String XFO_VALUE_DENY = 'deny'
+    public static final String XFO_VALUE_SAME_ORIGIN = 'sameorigin'
+    public static final String XFO_VALUE_ALLOW_FROM_PREFIX = 'allow-from: '
+    String name = 'xfo'
+    Boolean defaultEnabled = true
+
+    String defaultValue = XFO_VALUE_DENY
+
+    @Override
+    List<SecurityHeader> getSecurityHeaders(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final Map config
+    ) {
+        def value = defaultValue
+        if (config?.sameorigin in ['true', true]) {
+            value = XFO_VALUE_SAME_ORIGIN
+        } else if (config?.allowFrom instanceof String) {
+            value = XFO_VALUE_ALLOW_FROM_PREFIX + config.allowFrom
+        }
+        [
+                new SecurityHeaderImpl(name: XFO_HEADER_NAME, value: value)
+        ]
+    }
+}

--- a/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/XXSSPSecurityHeaderProvider.groovy
+++ b/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/XXSSPSecurityHeaderProvider.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.grails.plugins.securityheaders
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * Adds `X-XSS-Protection: 1`  by default,
+ * config 'block' value of true sends `X-XSS-Protection: 1; mode=block`
+ * config `report: uri` value sends `X-XSS-Protection: 1; report=uri`
+ * See:
+ * <a href="https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#xxxsp">OWASP</a>
+ */
+class XXSSPSecurityHeaderProvider implements SecurityHeaderProvider {
+    public static final String X_XSS_PROTECTION_HEADER_NAME = 'X-XSS-Protection'
+    String name = 'xxssp'
+    Boolean defaultEnabled = true
+
+    @Override
+    List<SecurityHeader> getSecurityHeaders(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final Map config
+    ) {
+        def value = '1'
+        if (config.block in ['true', true]) {
+            value = '1; mode=block'
+        } else if (config.report) {
+            value = '1; report=' + config.report
+        }
+
+        [
+                new SecurityHeaderImpl(name: X_XSS_PROTECTION_HEADER_NAME, value: value)
+        ]
+    }
+}

--- a/grails-securityheaders/src/test/groovy/org/rundeck/grails/plugins/securityheaders/CSPSecurityHeaderProviderSpec.groovy
+++ b/grails-securityheaders/src/test/groovy/org/rundeck/grails/plugins/securityheaders/CSPSecurityHeaderProviderSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.security
+
+import org.grails.spring.beans.factory.InstanceFactoryBean
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.mock.http.client.MockClientHttpRequest
+import org.springframework.mock.http.client.MockClientHttpResponse
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import rundeck.services.ConfigurationService
+import spock.lang.Specification
+
+class CSPSecurityHeaderProviderSpec extends Specification {
+
+    def "test csp response default"() {
+        given:
+            def request = new MockHttpServletRequest('GET', "/test/uri")
+            def response = new MockHttpServletResponse()
+            def secHeaderProvider = new CSPSecurityHeaderProvider()
+
+            def config = ['frame-ancestors': defCsp]
+        when: "A request without specific uri setting"
+            def list = secHeaderProvider.getSecurityHeaders(request, response, config)
+        then: "The interceptor does match"
+            list != null
+            list.size() == 1
+            list[0].name == 'Content-Security-Policy'
+            list[0].value == result
+
+        where:
+            defCsp                                     | result
+            null                                       | "frame-ancestors 'none'"
+            'none'                                     | "frame-ancestors 'none'"
+            'self'                                     | "frame-ancestors 'self'"
+            '*.somesite.com https://myfriend.site.com' | "frame-ancestors '*.somesite.com' 'https://myfriend.site.com'"
+    }
+
+    def "test csp response uri config"() {
+        given:
+            def request = new MockHttpServletRequest('GET', reqUri)
+            def response = new MockHttpServletResponse()
+            def secHeaderProvider = new CSPSecurityHeaderProvider()
+
+            def config = ['frame-ancestors': defCsp, 'uri.test2.uri': confCsp]
+        when: "A request without specific uri setting"
+            def list = secHeaderProvider.getSecurityHeaders(request, response, config)
+        then: "The interceptor does match"
+            list != null
+            list.size() == 1
+            list[0].name == 'Content-Security-Policy'
+            list[0].value == result
+
+        where:
+            reqUri       | defCsp | confCsp | result
+            '/test/uri'  | null   | 'self'  | "frame-ancestors 'none'"
+            '/test/uri'  | 'none' | 'self'  | "frame-ancestors 'none'"
+            '/test/uri'  | 'self' | 'none'  | "frame-ancestors 'self'"
+            '/test2/uri' | 'none' | 'self'  | "frame-ancestors 'self'"
+            '/test2/uri' | 'self' | 'none'  | "frame-ancestors 'none'"
+            '/test2/uri' | null   | 'self'  | "frame-ancestors 'self'"
+    }
+
+}

--- a/grails-securityheaders/src/test/groovy/org/rundeck/grails/plugins/securityheaders/CSPSecurityHeaderProviderSpec.groovy
+++ b/grails-securityheaders/src/test/groovy/org/rundeck/grails/plugins/securityheaders/CSPSecurityHeaderProviderSpec.groovy
@@ -123,12 +123,24 @@ class CSPSecurityHeaderProviderSpec extends Specification {
             list[2].value == result
 
         where:
-            directive         | confVal                     | result
-            'frame-ancestors' | 'none'                      | "frame-ancestors 'none' ;"
-            'frame-ancestors' | "'none'"                    | "frame-ancestors 'none' ;"
-            'frame-ancestors' | 'self'                      | "frame-ancestors 'self' ;"
-            'frame-ancestors' | "'self'"                    | "frame-ancestors 'self' ;"
-            'frame-ancestors' | '*.somesite.com'            | "frame-ancestors *.somesite.com ;"
-            'frame-ancestors' | 'https://myfriend.site.com' | "frame-ancestors https://myfriend.site.com ;"
+            directive         | confVal                      | result
+            'frame-ancestors' | 'none'                       | "frame-ancestors 'none' ;"
+            'frame-ancestors' | "'none'"                     | "frame-ancestors 'none' ;"
+            'frame-ancestors' | 'self'                       | "frame-ancestors 'self' ;"
+            'frame-ancestors' | "'self'"                     | "frame-ancestors 'self' ;"
+            'frame-ancestors' | "unsafe-inline"              | "frame-ancestors 'unsafe-inline' ;"
+            'frame-ancestors' | "'unsafe-inline'"            | "frame-ancestors 'unsafe-inline' ;"
+            'frame-ancestors' | "unsafe-eval"                | "frame-ancestors 'unsafe-eval' ;"
+            'frame-ancestors' | "'unsafe-eval'"              | "frame-ancestors 'unsafe-eval' ;"
+            'frame-ancestors' | "nonce-asdfasdf"             | "frame-ancestors 'nonce-asdfasdf' ;"
+            'frame-ancestors' | "'nonce-asdfasdf'"           | "frame-ancestors 'nonce-asdfasdf' ;"
+            'frame-ancestors' | "sha256-asdfasdf"            | "frame-ancestors 'sha256-asdfasdf' ;"
+            'frame-ancestors' | "'sha256-asdfasdf'"          | "frame-ancestors 'sha256-asdfasdf' ;"
+            'frame-ancestors' | '*'                          | "frame-ancestors * ;"
+            'frame-ancestors' | '*.somesite.com'             | "frame-ancestors *.somesite.com ;"
+            'frame-ancestors' | 'https://myfriend.site.com'  | "frame-ancestors https://myfriend.site.com ;"
+            'frame-ancestors' | 'https:'                     | "frame-ancestors https: ;"
+            'frame-ancestors' | 'data:'                      | "frame-ancestors data: ;"
+            'frame-ancestors' | 'self data: unsafe-inline *' | "frame-ancestors 'self' data: 'unsafe-inline' * ;"
     }
 }

--- a/grails-securityheaders/src/test/groovy/org/rundeck/grails/plugins/securityheaders/CSPSecurityHeaderProviderSpec.groovy
+++ b/grails-securityheaders/src/test/groovy/org/rundeck/grails/plugins/securityheaders/CSPSecurityHeaderProviderSpec.groovy
@@ -55,13 +55,10 @@ class CSPSecurityHeaderProviderSpec extends Specification {
             def list = secHeaderProvider.getSecurityHeaders(request, response, config)
         then: "The interceptor does match"
             list != null
-            list.size() == 3
+            list.size() == 1
             list[0].name == 'Content-Security-Policy'
             list[0].value == policy
-            list[1].name == 'X-Content-Security-Policy'
-            list[1].value == policy
-            list[2].name == 'X-WebKit-CSP'
-            list[2].value == policy
+
 
         where:
             policy << ["default-src 'none' ;",
@@ -92,14 +89,12 @@ class CSPSecurityHeaderProviderSpec extends Specification {
 
 
         where:
-            config                             | expectCount | includeXcsp | includeXwkcsp
-            [:]                                | 3           | true        | true
-            ['include-xcsp-header': 'false']   | 2           | false       | true
-            ['include-xwkcsp-header': 'false'] | 2           | true        | false
-            ['include-xwkcsp-header': 'false',
-             'include-xcsp-header'  : 'false'] | 1           | false       | false
+            config                            | expectCount | includeXcsp | includeXwkcsp
+            [:]                               | 1           | false       | false
+            ['include-xcsp-header': 'true']   | 2           | true        | false
+            ['include-xwkcsp-header': 'true'] | 2           | false       | true
             ['include-xwkcsp-header': 'true',
-             'include-xcsp-header'  : 'true']  | 3           | true        | true
+             'include-xcsp-header'  : 'true'] | 3           | true        | true
     }
 
     @Unroll
@@ -114,13 +109,9 @@ class CSPSecurityHeaderProviderSpec extends Specification {
             def list = secHeaderProvider.getSecurityHeaders(request, response, config)
         then: "The interceptor does match"
             list != null
-            list.size() == 3
+            list.size() == 1
             list[0].name == 'Content-Security-Policy'
             list[0].value == result
-            list[1].name == 'X-Content-Security-Policy'
-            list[1].value == result
-            list[2].name == 'X-WebKit-CSP'
-            list[2].value == result
 
         where:
             directive         | confVal                      | result

--- a/grails-securityheaders/src/test/groovy/org/rundeck/grails/plugins/securityheaders/RundeckSecurityHeadersFilterSpec.groovy
+++ b/grails-securityheaders/src/test/groovy/org/rundeck/grails/plugins/securityheaders/RundeckSecurityHeadersFilterSpec.groovy
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.grails.plugins.securityheaders
+
+import org.springframework.context.ApplicationContext
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.servlet.FilterChain
+
+class RundeckSecurityHeadersFilterSpec extends Specification {
+
+    @Unroll
+    def "test filter disabled"() {
+        given:
+            def filter = new RundeckSecurityHeadersFilter()
+            filter.enabled = false
+            filter.applicationContext = Mock(ApplicationContext)
+            def request = new MockHttpServletRequest('GET', "/test/uri")
+            def response = new MockHttpServletResponse()
+            def chain = Mock(FilterChain)
+
+        when:
+            filter.doFilter(request, response, chain)
+        then:
+            0 * filter.applicationContext.getBeansOfType(SecurityHeaderProvider)
+            1 * chain.doFilter(request, response)
+    }
+
+
+    @Unroll
+    def "test filter with provider disabled, default enabled #defEnabled config #confEnabled"() {
+        given:
+            def provider1 = Mock(SecurityHeaderProvider) {
+                getDefaultEnabled() >> defEnabled
+                getName() >> 'testprovider1'
+            }
+            def filter = new RundeckSecurityHeadersFilter()
+            filter.config = [testprovider1: [enabled: confEnabled]]
+            filter.enabled = true
+            filter.applicationContext = Mock(ApplicationContext)
+            def request = new MockHttpServletRequest('GET', "/test/uri")
+            def response = new MockHttpServletResponse()
+            def chain = Mock(FilterChain)
+
+        when:
+            filter.doFilter(request, response, chain)
+        then:
+            1 * filter.applicationContext.getBeansOfType(SecurityHeaderProvider) >> [
+                    testbean1: provider1
+            ]
+            1 * chain.doFilter(request, response)
+            response.getHeader('x-test1') == null
+
+
+        where:
+            defEnabled | confEnabled
+            false      | null
+            true       | false
+            true       | 'false'
+    }
+
+    @Unroll
+    def "test filter with provider default enabled #defEnabled config #confEnabled"() {
+        given:
+            def provider1 = Mock(SecurityHeaderProvider) {
+                getDefaultEnabled() >> defEnabled
+                getName() >> 'testprovider1'
+            }
+            def filter = new RundeckSecurityHeadersFilter()
+            filter.config = [testprovider1: [enabled: confEnabled]]
+            filter.enabled = true
+            filter.applicationContext = Mock(ApplicationContext)
+            def request = new MockHttpServletRequest('GET', "/test/uri")
+            def response = new MockHttpServletResponse()
+            def chain = Mock(FilterChain)
+
+        when:
+            filter.doFilter(request, response, chain)
+        then:
+            1 * filter.applicationContext.getBeansOfType(SecurityHeaderProvider) >> [
+                    testbean1: provider1
+            ]
+            1 * chain.doFilter(request, response)
+            1 * provider1.getSecurityHeaders(request, response, [:]) >>
+            new ArrayList<SecurityHeader>([new SecurityHeaderImpl(name: 'x-test1', value: 'x-value1')])
+            response.getHeader('x-test1') == 'x-value1'
+
+        where:
+            defEnabled | confEnabled
+            true       | null
+            false      | 'true'
+    }
+}

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -169,6 +169,7 @@ grails{
     plugins{
         compile project(':rundeck:metricsweb')
         compile project(':grails-persistlocale')
+        compile project(':grails-securityheaders')
         compile project(':rundeck:repository')
     }
 }

--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -164,6 +164,19 @@ rundeck:
         useHMacRequestTokens: true
         httpHeaders:
             enabled: true
+            provider:
+                csp:
+                    enabled: true
+                    comment: the following policy definition should work in default rundeck install
+                    config:
+                        default-src: 'none'
+                        connect-src: 'self'
+                        style-src: 'self unsafe-inline'
+                        script-src: 'self unsafe-inline unsafe-eval'
+                        font-src: 'self data:'
+                        img-src: 'self https://media.rundeck.org'
+                        form-action: 'self'
+
     storage:
     execution:
         finalize:

--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -162,6 +162,8 @@ rundeck:
                 userRolesHeader: null
                 delimiter: ','
         useHMacRequestTokens: true
+        httpHeaders:
+            enabled: true
     storage:
     execution:
         finalize:

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1366,7 +1366,7 @@ page.home.search.project.title={0} Project found
 page.home.search.projects.input.placeholder=Project search: name, label or /regex/
 create.job.button.label=Create Job
 
-app.firstRun.md=![image](https://s3.amazonaws.com/media.rundeck.org/images/app-logo-small.png?t=oss&v={{app/ident}})\n\
+app.firstRun.md=![image](https://media.rundeck.org/images/app-logo-small.png?t=oss&v={{app/ident}})\n\
   \n\
   Get your [free Rundeck stickers](https://www.rundeck.com/free-stuff).\n\
   \n\

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1344,7 +1344,7 @@ page.home.search.project.title.plural={0} Projects found
 page.home.search.project.title={0} Project found
 page.home.search.projects.input.placeholder=Project search
 create.job.button.label=Create Job
-app.firstRun.md=![image](https://s3.amazonaws.com/media.rundeck.org/images/app-logo-small.png?t=oss&v={{app/ident}})\n\
+app.firstRun.md=![image](https://media.rundeck.org/images/app-logo-small.png?t=oss&v={{app/ident}})\n\
   \n\
   Get your [free Rundeck stickers](https://www.rundeck.com/free-stuff).\n\
   \n\

--- a/rundeckapp/grails-app/i18n/messages_fr_FR.properties
+++ b/rundeckapp/grails-app/i18n/messages_fr_FR.properties
@@ -1303,7 +1303,7 @@ page.home.search.project.title.plural={0} Projets trouv\u00e9s
 page.home.search.project.title={0} Projet trouv\u00e9
 page.home.search.projects.input.placeholder=Recherche de projet
 create.job.button.label=Cr\u00e9er un travail
-app.firstRun.md=![image](https://s3.amazonaws.com/media.rundeck.org/images/app-logo-small.png?t=oss&v={{app/ident}})\n\
+app.firstRun.md=![image](https://media.rundeck.org/images/app-logo-small.png?t=oss&v={{app/ident}})\n\
   \n\
   Obtenez vos [autocollants Rundeck gratuitement](https://www.rundeck.com/free-stuff).\n\
   \n\

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -1348,7 +1348,7 @@ page.home.search.project.title=\u627E\u5230{0}\u4E2A\u9879\u76EE
 page.home.search.projects.input.placeholder=\u641C\u7D22\u9879\u76EE
 create.job.button.label=\u521B\u5EFA\u4EFB\u52A1
 
-app.firstRun.md=![image](https://s3.amazonaws.com/media.rundeck.org/images/app-logo-small.png?t=oss&v={{app/ident}})\n\
+app.firstRun.md=![image](https://media.rundeck.org/images/app-logo-small.png?t=oss&v={{app/ident}})\n\
   \n\
   Get your [free Rundeck stickers](https://www.rundeck.com/free-stuff).\n\
   \n\

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,6 +38,7 @@ include	'rundeck-storage',
     'rundeckapp:metricsweb',
     'rundeckapp:grails-spa',
     'grails-persistlocale',
+    'grails-securityheaders',
     'rundeckapp:repository',
     'docker'
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Adds some default HTTP security headers to the application.

**Describe the solution you've implemented**

Default set of enabled security headers, and allows configuration of all headers.

* `X-Content-Type-Options: nosniff`
* `X-XSS-protection: 1`
* `X-Frame-Options: deny`
* `Content-Security-Policy` header with a default policy (and `X-Content-Security-Policy`, `X-WebKit-CSP`)
* Optional custom headers, if security policy differs or there are new requirements.

**Additional context**

Improves web-app security against common attacks.

Modifies the src URL for the first-run external image loaded to use https://media.rundeck.org and allows access in the CSP.

## Configuration via rundeck-config.properties

The default configuration values are shown below.

~~~ .properties

# enable security headers filter to add these headers (default: true)
rundeck.security.httpHeaders.enabled=true

#########
# enable x-content-type-options: nosniff  (default: true)
rundeck.security.httpHeaders.provider.xcto.enabled=true

#########
# enable x-xss-protection: 1  (default: true)

rundeck.security.httpHeaders.provider.xxssp.enabled=true

# Alternates for x-xss-protection:
#
# use x-xss-protection: 1; mode=block
#

# rundeck.security.httpHeaders.provider.xxssp.config.block=true

#
# use x-xss-protection: 1; report=https://some-uri

# rundeck.security.httpHeaders.provider.xxssp.config.report=https://some-uri

########
# enable x-frame-options: deny  (default: true)

rundeck.security.httpHeaders.provider.xfo.enabled=true

# Alternate settings for x-frame-options:
#
# use x-frame-options: sameorigin

# rundeck.security.httpHeaders.provider.xfo.config.sameorigin=true

#
# use x-frame-options: allow-from: src

# rundeck.security.httpHeaders.provider.xfo.config.allowFrom=src

#######
# enable Content-Security-Policy header (default:true)

rundeck.security.httpHeaders.provider.csp.enabled=true

# You can disable the `X-` variants of Content-Security-Policy if desired, but they are enabled by default:
#
# This disables the X-Content-Security-Policy header name

# rundeck.security.httpHeaders.provider.csp.config.include-xcsp-header=false

#
# This disables the X-WebKit-CSP header name

# rundeck.security.httpHeaders.provider.csp.config.include-xwkcsp-header=false

# You can specify an explicit policy, which will override directives declared below
#

# rundeck.security.httpHeaders.provider.csp.config.policy=default-src 'none'; connect-src 'self' ; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' data: ; img-src 'self' https://media.rundeck.org ; form-action 'self' ;

#
# Or you can specify individual directives:
#

rundeck.security.httpHeaders.provider.csp.config.default-src=none
rundeck.security.httpHeaders.provider.csp.config.connect-src=self
rundeck.security.httpHeaders.provider.csp.config.style-src=self unsafe-inline
rundeck.security.httpHeaders.provider.csp.config.script-src=self unsafe-inline unsafe-eval
rundeck.security.httpHeaders.provider.csp.config.font-src=self data:
rundeck.security.httpHeaders.provider.csp.config.img-src=self https://media.rundeck.org
rundeck.security.httpHeaders.provider.csp.config.form-action=self

#######
# enable any custom additional headers (default: false)
# 
# rundeck.security.httpHeaders.provider.custom.enabled=true
# rundeck.security.httpHeaders.provider.custom.config.name=X-Other-Security-Policy
# rundeck.security.httpHeaders.provider.custom.config.value=default-src 'none'; 
# rundeck.security.httpHeaders.provider.custom.config.name2=X-other-header
# rundeck.security.httpHeaders.provider.custom.config.value2=some value

~~~

References:

* https://www.owasp.org/index.php/OWASP_Secure_Headers_Project
* https://content-security-policy.com

