### PR TITLE
Job detail in execution xml for log storage

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -255,7 +255,8 @@ class Execution extends ExecutionContext {
     def Map toMap(){
         def map=[:]
         if(scheduledExecution){
-            map.jobId=scheduledExecution.extid
+            map.jobId=scheduledExecution
+            map.fullJob=scheduledExecution.toMap()
         }
         map.dateStarted=dateStarted
         map.dateCompleted=dateCompleted

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -255,7 +255,7 @@ class Execution extends ExecutionContext {
     def Map toMap(){
         def map=[:]
         if(scheduledExecution){
-            map.jobId=scheduledExecution
+            map.jobId=scheduledExecution.extid
             map.fullJob=scheduledExecution.toMap()
         }
         map.dateStarted=dateStarted

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -190,7 +190,7 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
         }
         JobsXMLCodec.convertWorkflowMapForBuilder(map.workflow)
         if(map.fullJob){
-            JobsXMLCodec.convertWorkflowMapForBuilder(map.fullJob.sequence)
+            map.fullJob = JobsXMLCodec.convertJobMap(map.fullJob)
         }
         def xml = new MarkupBuilder(writer)
         builder.objToDom("executions", [execution: map], xml)

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -189,6 +189,9 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
             map.outputfilepath = logfilepath
         }
         JobsXMLCodec.convertWorkflowMapForBuilder(map.workflow)
+        if(map.fullJob){
+            JobsXMLCodec.convertWorkflowMapForBuilder(map.fullJob.sequence)
+        }
         def xml = new MarkupBuilder(writer)
         builder.objToDom("executions", [execution: map], xml)
     }

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionTest.groovy
@@ -16,6 +16,8 @@
 
 package rundeck
 
+import grails.test.mixin.Mock
+
 import static org.junit.Assert.*
 
 //import grails.test.GrailsUnitTestCase
@@ -29,6 +31,7 @@ import rundeck.services.ExecutionService
  * Time: 11:25 AM
  */
 @TestFor(Execution)
+@Mock([ ScheduledExecution])
 class ExecutionTest {
     void testValidateBasic() {
         Execution se = createBasicExecution()
@@ -578,5 +581,42 @@ class ExecutionTest {
         assertEquals(12, map.retryAttempt)
         assertEquals(exec1.id, map.retryExecutionId)
         assertEquals(true, map.willRetry)
+    }
+
+    void testToMapFullJob(){
+        ScheduledExecution job = new ScheduledExecution(
+                jobName: 'blue',
+                project: 'AProject',
+                groupPath: 'some/where',
+                description: 'a job',
+                argString: '-a b -c d',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec(
+                                [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
+                        )]
+                )
+        )
+        job.save()
+        def exec = new Execution(
+                scheduledExecution: job,
+                dateStarted: new Date(),
+                dateCompleted: null,
+                user: 'userB',
+                project: 'AProject',
+                workflow: new Workflow(
+                        commands: [new CommandExec(
+                                adhocRemoteString: 'test buddy'
+                        )]
+                )
+        )
+        assertNotNull(exec.save())
+
+        def map = exec.toMap()
+        assertNotNull(map)
+        assertNotNull(map.fullJob)
+        map.fullJob == job.toMap()
+
+
     }
 }


### PR DESCRIPTION
fix #4414 
Adds the full job in the current state to the execution XML exported. So, if you go through the files in alphabetical order you can get a list of job's definition to recreate them.