### PR TITLE
Fix #4179 kill job reference thread when parent is killed

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3448,7 +3448,11 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 try {
                     thread.join(1000)
                 } catch (InterruptedException e) {
-                    //do nada
+                    //interrupt
+                    interrupt = true
+                }
+                if (thread.interrupted) {
+                    interrupt = true
                 }
                 def duration = System.currentTimeMillis() - startTime
                 if (shouldCheckTimeout


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #4179 

**Describe the solution you've implemented**

Handle thread interruption in job reference execution to properly abort the child job

**Additional context**

Job ref thread was continuing until completion even if parent job was killed.