### PR TITLE
Docker - Fix key for project storage type

### DIFF
--- a/docker/official/remco/templates/rundeck-config-storage.properties
+++ b/docker/official/remco/templates/rundeck-config-storage.properties
@@ -48,7 +48,7 @@ rundeck.storage.provider.1.path=keys
     {{ storage_converter(converter) }}
 {%- endfor %}
 
-rundeck.projectsStorageType={{ getv("rundeck/projectsStorageType", "db") }}
+rundeck.projectsStorageType={{ getv("/rundeck/projectsStorageType", "db") }}
 
 {% for c in lsdir(configConverterBase) %}
     {% set converter = printf("%s/%s", configConverterBase, c) -%}

--- a/docker/official/test/remco/test.yml
+++ b/docker/official/test/remco/test.yml
@@ -1,4 +1,5 @@
 rundeck:
+  projectsStorageType: file
   grails:
     upload:
       maxsize: '50000000'


### PR DESCRIPTION
Makes it possible to change project storage type in the Docker container through the template system.

fixes #4445