### PR TITLE
Cleanup: orchestrator node processor logging

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/OrchestratorNodeDispatcher.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/OrchestratorNodeDispatcher.java
@@ -161,7 +161,7 @@ public class OrchestratorNodeDispatcher implements NodeDispatcher {
         
         try {
             success = processor.execute();
-        } catch (ExecutionException e) {
+        } catch (OrchestratorNodeProcessor.NodeProcessorException e) {
             context.getExecutionListener().log(0, e.getMessage());
             if (!keepgoing) {
                 throw new DispatcherException(e);

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/OrchestratorNodeDispatcher.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/OrchestratorNodeDispatcher.java
@@ -139,12 +139,6 @@ public class OrchestratorNodeDispatcher implements NodeDispatcher {
                 tocall = dispatchableCallable(context, toDispatch, resultMap, node, failureMap);
             }
             nodeNames.add(node.getNodename());
-            context
-                .getExecutionListener()
-                .log(
-                    3,
-                    "Create " + (null != item ? "dispatched step" : "dispatchable workflow") + " for node: " + node.getNodename()
-                );
             executions.put(node, tocall);
         }
         if (null != failedListener) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/NodeFirstWorkflowExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/NodeFirstWorkflowExecutor.java
@@ -145,16 +145,6 @@ public class NodeFirstWorkflowExecutor extends BaseWorkflowExecutor {
                     stepFailures.putAll(workflowExecutionResult.getStepFailures());
                     sectionSuccess = workflowExecutionResult;
                     sectionData = workflowExecutionResult;
-                    //
-//                    sectionSuccess = executeWFSection(executionContext,
-//                                                      results,
-//                                                      failures,
-//                                                      stepFailures,
-//                                                      stepCount,
-//                                                      flowsection.getCommands(),
-//                                                      flowsection.isKeepgoing(),
-//                                                      wfCurrentContext
-//                    );
 
                 }
                 //combine output results for the section
@@ -362,52 +352,8 @@ public class NodeFirstWorkflowExecutor extends BaseWorkflowExecutor {
         }
         return wfSharedContext;
     }
-//
-//    /**
-//     * Execute non-dispatch steps of a workflow
-//     *
-//     * @return success if all steps were successful
-//     */
-//    private WorkflowStatusResult executeWFSection(
-//            final StepExecutionContext executionContext,
-//            final List<StepExecutionResult> results,
-//            final Map<String, Collection<StepExecutionResult>> failures,
-//            final Map<Integer, StepExecutionResult> stepFailures,
-//            final int stepCount,
-//            final List<StepExecutionItem> commands,
-//            final boolean keepgoing,
-//            WFSharedContext sharedContext
-//    )
-//    {
-//
-//        WorkflowStatusResult workflowsuccess = executeWorkflowItemsForNodeSet(
-//                executionContext,
-//                stepFailures,
-//                results,
-//                commands,
-//                keepgoing,
-//                stepCount,
-//                sharedContext
-//        );
-//
-//        logger.debug("Aggregate results: " + workflowsuccess + " " + results + ", " + stepFailures);
-//        Map<String, Collection<StepExecutionResult>> localFailure = convertFailures(stepFailures);
-//
-//        mergeFailure(failures, localFailure);
-//        return workflowsuccess;
-//    }
 
     private void mergeFailure(Map<String, Collection<StepExecutionResult>> destination, Map<String, Collection<StepExecutionResult>> source) {
-        for (final String s : source.keySet()) {
-            if (null == destination.get(s)) {
-                destination.put(s, new ArrayList<>());
-            }
-            destination.get(s).addAll(source.get(s));
-        }
-    }
-
-    private void mergeResult(HashMap<String, List<StatusResult>> destination,
-                             HashMap<String, List<StatusResult>> source) {
         for (final String s : source.keySet()) {
             if (null == destination.get(s)) {
                 destination.put(s, new ArrayList<>());


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Minor cleanup:

* orchestrator node dispatcher should capture and log any errors during node dispatch
* reduced debug verbosity