### PR TITLE
Disable JobStats because it produces a deadlock on mssql.

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -393,6 +393,7 @@ public class NotificationService implements ApplicationContextAware{
                                     if(attachlogbody){
                                         outputBuffer=copyExecOutputToStringBuffer(exec,isFormatted)
                                     }
+                                    def renderJobStats = false
 
                                     body(
                                             view: "/execution/mailNotification/status",
@@ -403,7 +404,8 @@ public class NotificationService implements ApplicationContextAware{
                                                     execstate         : state,
                                                     nodestatus        : content.nodestatus,
                                                     jobref            : content.jobref,
-                                                    logOutput         : outputBuffer!=null? outputBuffer.toString(): null
+                                                    logOutput         : outputBuffer!=null? outputBuffer.toString(): null,
+                                                    renderJobStats    : renderJobStats
                                             ]
                                     )
                                 }

--- a/rundeckapp/grails-app/views/execution/mailNotification/status.gsp
+++ b/rundeckapp/grails-app/views/execution/mailNotification/status.gsp
@@ -303,7 +303,7 @@ div.progressContainer div.progressContent{
             </table>
 
                     </td>
-                    <g:if test="${scheduledExecution}">
+                    <g:if test="${scheduledExecution && renderJobStats}">
                         <td style="vertical-align:top;" class="toolbar small">
                             <g:render template="/scheduledExecution/renderJobStats"
                                       model="${[scheduledExecution: scheduledExecution]}"/>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is a bug using mssql database, described here: https://github.com/rundeck/rundeck/issues/4458

**Describe the solution you've implemented**
For now we will disable the jobStats on the email notification view.

**Describe alternatives you've considered**
Move the queries outside the view, but they are blocked anyway

**Additional context**
Rundeck using MSSQL as external database, and running a simple job with a email notification using the default view template.

