### PR TITLE
Notification email template with log output: use blank when not included

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -326,7 +326,7 @@ public class NotificationService implements ApplicationContextAware{
 
                             //check if the custom template is calling ${logoutput.data}
                             def templateLogOutput=false
-                            if(template.text.indexOf('${logoutput.data}')>0){
+                            if(template.text.indexOf('${logoutput.data}')>=0){
                                 templateLogOutput=true
                             }
                             def contextOutput=[:]


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Enhancement: https://github.com/rundeck/rundeck/issues/4443

**Describe the solution you've implemented**
Adding an empty string to ${logoutput.data} context variable when that variable is set on the template, and the flag attachLogInline is false.
 
**Additional context**
For issue https://github.com/rundeck/rundeck/issues/4443
