### PR TITLE
New scheduled execution stats table 

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -359,9 +359,8 @@ class ExecutionController extends ControllerBase{
         def execState = e.executionState
         def execDuration = (e.dateCompleted ? e.dateCompleted.getTime() : System.currentTimeMillis()) - e.dateStarted.getTime()
         def jobAverage=-1L
-        if (e.scheduledExecution && e.scheduledExecution.totalTime >= 0 && e.scheduledExecution.execCount > 0) {
-            def long avg = Math.floor(e.scheduledExecution.totalTime / e.scheduledExecution.execCount)
-            jobAverage = avg
+        if (e.scheduledExecution && e.scheduledExecution.getAverageDuration() > 0) {
+            jobAverage = e.scheduledExecution.getAverageDuration()
         }
         def isClusterExec = frameworkService.isClusterModeEnabled() && e.serverNodeUUID !=
                 frameworkService.getServerUUID()

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -222,8 +222,11 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                         id: it.scheduledExecution.extid,
                         params:[project:it.scheduledExecution.project]
                 )
-                if (it.scheduledExecution && it.scheduledExecution.totalTime >= 0 && it.scheduledExecution.execCount > 0) {
-                    data['jobAverageDuration']= Math.floor(it.scheduledExecution.totalTime / it.scheduledExecution.execCount)
+                if (it.scheduledExecution){
+                    def seStats = it.scheduledExecution.getStats()
+                    if(seStats?.totalTime >= 0 && seStats?.execCount > 0) {
+                        data['jobAverageDuration'] = Math.floor(seStats.totalTime / seStats.execCount)
+                    }
                 }
                 if (it.argString) {
                     data.jobArguments = FrameworkService.parseOptsFromString(it.argString)
@@ -412,9 +415,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                             }
                         }
                     }
-                    if (se.totalTime >= 0 && se.execCount > 0) {
-                        def long avg = Math.floor(se.totalTime / se.execCount)
-                        data.averageDuration = avg
+                    if (se.getAverageDuration() > 0) {
+                        data.averageDuration = se.getAverageDuration()
                     }
                     JobInfo.from(
                             se,
@@ -2690,9 +2692,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             extra.serverNodeUUID = scheduledExecution.serverNodeUUID
             extra.serverOwner = scheduledExecution.serverNodeUUID == serverNodeUUID
         }
-        if (scheduledExecution.totalTime >= 0 && scheduledExecution.execCount > 0) {
-            def long avg = Math.floor(scheduledExecution.totalTime / scheduledExecution.execCount)
-            extra.averageDuration = avg
+        if (scheduledExecution.getAverageDuration()>0) {
+            extra.averageDuration = scheduledExecution.getAverageDuration()
         }
         if(scheduledExecution.shouldScheduleExecution()){
             extra.nextScheduledExecution=scheduledExecutionService.nextExecutionTime(scheduledExecution)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -224,8 +224,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 )
                 if (it.scheduledExecution){
                     def seStats = it.scheduledExecution.getStats()
-                    if(seStats?.totalTime >= 0 && seStats?.execCount > 0) {
-                        data['jobAverageDuration'] = Math.floor(seStats.totalTime / seStats.execCount)
+                    if(scheduledExecution.getAverageDuration() > 0) {
+                        data['jobAverageDuration'] = scheduledExecution.getAverageDuration()
                     }
                 }
                 if (it.argString) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -448,8 +448,8 @@ class ScheduledExecutionController  extends ControllerBase{
             Execution.countByScheduledExecution(scheduledExecution)
         }
         def reftotal = 0
-        if(scheduledExecution.refExecCount) {
-            reftotal = scheduledExecution.refExecCount
+        if(scheduledExecution.getStats()?.refExecCount) {
+            reftotal = scheduledExecution.getStats()?.refExecCount
         }
 
         def remoteClusterNodeUUID=null

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -448,8 +448,8 @@ class ScheduledExecutionController  extends ControllerBase{
             Execution.countByScheduledExecution(scheduledExecution)
         }
         def reftotal = 0
-        if(scheduledExecution.getStats()?.refExecCount) {
-            reftotal = scheduledExecution.getStats()?.refExecCount
+        if(scheduledExecution.getRefExecCountStats()) {
+            reftotal = scheduledExecution.getRefExecCountStats()
         }
 
         def remoteClusterNodeUUID=null

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -1052,8 +1052,9 @@ class ScheduledExecution extends ExecutionContext {
     }
 
     long getAverageDuration() {
-        if (totalTime && execCount) {
-            return Math.floor(totalTime / execCount)
+        def stats = getStats()
+        if (stats?.totalTime && stats?.execCount) {
+            return Math.floor(stats.totalTime / stats.execCount)
         }
         return 0;
     }
@@ -1102,6 +1103,18 @@ class ScheduledExecution extends ExecutionContext {
                 return nodeThreadcountDynamic
             }
         }
+    }
+
+    ScheduledExecutionStats getStats() {
+        def stats = ScheduledExecutionStats.findByScheduledExecutionId(id)
+        if (!stats) {
+            stats = new ScheduledExecutionStats(scheduledExecutionId: this.id,
+                    execCount: this.execCount,
+                    totalTime: this.totalTime,
+                    refExecCount: this.refExecCount
+            ).save()
+        }
+        stats
     }
 
 }

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -1053,8 +1053,9 @@ class ScheduledExecution extends ExecutionContext {
 
     long getAverageDuration() {
         def stats = getStats()
-        if (stats?.totalTime && stats?.execCount) {
-            return Math.floor(stats.totalTime / stats.execCount)
+        def statsContent= stats?.getContentMap()
+        if (statsContent && statsContent.totalTime && statsContent.execCount) {
+            return Math.floor(statsContent.totalTime / statsContent.execCount)
         }
         return 0;
     }
@@ -1106,16 +1107,45 @@ class ScheduledExecution extends ExecutionContext {
     }
 
     ScheduledExecutionStats getStats() {
-        def stats = ScheduledExecutionStats.findByScheduledExecutionId(id)
-        if (!stats) {
-            stats = new ScheduledExecutionStats(scheduledExecutionId: this.id,
-                    execCount: this.execCount,
-                    totalTime: this.totalTime,
-                    refExecCount: this.refExecCount
-            ).save()
+        def stats
+        if(this.id) {
+            stats = ScheduledExecutionStats.findBySe(this)
+            if (!stats) {
+                def content = [execCount   : this.execCount,
+                               totalTime   : this.totalTime,
+                               refExecCount: this.refExecCount]
+
+                stats = new ScheduledExecutionStats(se: this, contentMap: content).save()
+            }
         }
         stats
     }
 
+    Long getRefExecCountStats(){
+        def stats = this.getStats()
+        def statsContent= stats?.getContentMap()
+        if (statsContent?.refExecCount) {
+            return statsContent.refExecCount
+        }
+        return 0;
+    }
+
+    Long getTotalTimeStats(){
+        def stats = this.getStats()
+        def statsContent= stats?.getContentMap()
+        if (statsContent?.totalTime) {
+            return statsContent.totalTime
+        }
+        return 0;
+    }
+
+    Long getExecCountStats(){
+        def stats = this.getStats()
+        def statsContent= stats?.getContentMap()
+        if (statsContent?.execCount) {
+            return statsContent.execCount
+        }
+        return 0;
+    }
 }
 

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecutionStats.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecutionStats.groovy
@@ -1,0 +1,15 @@
+package rundeck
+
+class ScheduledExecutionStats {
+
+    Long totalTime = 0
+    Long execCount = 0
+    Long refExecCount = 0
+    Long scheduledExecutionId = 0
+
+    static belongsTo=[ScheduledExecution]
+
+    static constraints = {
+        scheduledExecutionId(unique: true)
+    }
+}

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecutionStats.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecutionStats.groovy
@@ -1,15 +1,41 @@
 package rundeck
 
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.databind.ObjectMapper
+
 class ScheduledExecutionStats {
 
-    Long totalTime = 0
-    Long execCount = 0
-    Long refExecCount = 0
-    Long scheduledExecutionId = 0
+    String content
 
-    static belongsTo=[ScheduledExecution]
+    static belongsTo=[se:ScheduledExecution]
+    static transients = ['contentMap']
 
-    static constraints = {
-        scheduledExecutionId(unique: true)
+    static mapping = {
+        content type: 'text'
     }
+
+    public Map getContentMap() {
+        if (null != content) {
+            final ObjectMapper objMapper = new ObjectMapper()
+            try{
+                return objMapper.readValue(content, Map.class)
+            }catch (JsonParseException e){
+                return null
+            }
+        } else {
+            return null
+        }
+
+    }
+
+
+    public void setContentMap(Map obj) {
+        if (null != obj) {
+            final ObjectMapper objMapper = new ObjectMapper()
+            content = objMapper.writeValueAsString(obj)
+        } else {
+            content = null
+        }
+    }
+
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
@@ -961,8 +961,8 @@ class ApiService {
                     if (e.scheduledExecution) {
                         def jobparams = [id: e.scheduledExecution.extid]
                         def seStats = e.scheduledExecution.getStats()
-                        if (seStats?.totalTime >= 0 && seStats?.execCount > 0) {
-                            def long avg = Math.floor(seStats.totalTime / seStats.execCount)
+                        if(e.scheduledExecution.getAverageDuration() > 0) {
+                            def long avg = e.scheduledExecution.getAverageDuration()
                             jobparams.averageDuration = avg
                         }
                         jobparams.'href'=(apiHrefForJob(e.scheduledExecution))
@@ -1052,8 +1052,8 @@ class ApiService {
                 if (e.scheduledExecution) {
                     def jobparams = [id: e.scheduledExecution.extid]
                     def seStats = e.scheduledExecution.getStats()
-                    if (seStats?.totalTime >= 0 && seStats?.execCount > 0) {
-                        def long avg = Math.floor(seStats.totalTime / seStats.execCount)
+                    if (e.scheduledExecution.getAverageDuration() > 0) {
+                        def long avg = e.scheduledExecution.getAverageDuration()
                         jobparams.averageDuration = avg
                     }
                     execMap.job=jobparams

--- a/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
@@ -960,8 +960,9 @@ class ApiService {
                     }
                     if (e.scheduledExecution) {
                         def jobparams = [id: e.scheduledExecution.extid]
-                        if (e.scheduledExecution.totalTime >= 0 && e.scheduledExecution.execCount > 0) {
-                            def long avg = Math.floor(e.scheduledExecution.totalTime / e.scheduledExecution.execCount)
+                        def seStats = e.scheduledExecution.getStats()
+                        if (seStats?.totalTime >= 0 && seStats?.execCount > 0) {
+                            def long avg = Math.floor(seStats.totalTime / seStats.execCount)
                             jobparams.averageDuration = avg
                         }
                         jobparams.'href'=(apiHrefForJob(e.scheduledExecution))
@@ -1050,8 +1051,9 @@ class ApiService {
                 }
                 if (e.scheduledExecution) {
                     def jobparams = [id: e.scheduledExecution.extid]
-                    if (e.scheduledExecution.totalTime >= 0 && e.scheduledExecution.execCount > 0) {
-                        def long avg = Math.floor(e.scheduledExecution.totalTime / e.scheduledExecution.execCount)
+                    def seStats = e.scheduledExecution.getStats()
+                    if (seStats?.totalTime >= 0 && seStats?.execCount > 0) {
+                        def long avg = Math.floor(seStats.totalTime / seStats.execCount)
                         jobparams.averageDuration = avg
                     }
                     execMap.job=jobparams

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -63,6 +63,7 @@ import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
 import org.springframework.context.MessageSource
 import org.springframework.transaction.TransactionDefinition
+import org.springframework.dao.DuplicateKeyException
 import org.springframework.validation.ObjectError
 import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.servlet.support.RequestContextUtils as RCU
@@ -2790,47 +2791,104 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      * @param execution
      * @return
      */
-    def updateScheduledExecStatistics(Long schedId, eId, long time, boolean jobRef = false){
+    def updateScheduledExecStatistics(Long schedId, eId, long time) {
         def success = false
         try {
-            ScheduledExecution.withTransaction {
+            ScheduledExecutionStats.withTransaction {
                 def scheduledExecution = ScheduledExecution.get(schedId)
+                def seStats = scheduledExecution.getStats()
+
 
                 if (scheduledExecution.scheduled) {
                     scheduledExecution.nextExecution = scheduledExecutionService.nextExecutionTime(scheduledExecution)
-                }
-                //TODO: record job stats in separate domain class
-                if (null == scheduledExecution.execCount || 0 == scheduledExecution.execCount || null == scheduledExecution.totalTime || 0 == scheduledExecution.totalTime) {
-                    scheduledExecution.execCount = 1
-                    scheduledExecution.totalTime = time
-                } else if (scheduledExecution.execCount > 0 && scheduledExecution.execCount < 10) {
-                    scheduledExecution.execCount++
-                    scheduledExecution.totalTime += time
-                } else if (scheduledExecution.execCount >= 10) {
-                    def popTime = scheduledExecution.totalTime.intdiv(scheduledExecution.execCount)
-                    scheduledExecution.totalTime -= popTime
-                    scheduledExecution.totalTime += time
-                }
-                if(jobRef){
-                    if(!scheduledExecution.refExecCount){
-                        scheduledExecution.refExecCount=1
-                    }else{
-                        scheduledExecution.refExecCount++
+                    if (scheduledExecution.save(flush: true)) {
+                        log.info("updated scheduled Execution nextExecution")
+                    } else {
+                        scheduledExecution.errors.allErrors.each { log.warn(it.defaultMessage) }
+                        log.warn("failed saving scheduled Execution nextExecution")
                     }
+                }
 
+                if (null == seStats.execCount || 0 == seStats.execCount || null == seStats.totalTime || 0 == seStats.totalTime) {
+                    seStats.execCount = 1
+                    seStats.totalTime = time
+                } else if (seStats.execCount > 0 && seStats.execCount < 10) {
+                    seStats.execCount++
+                    seStats.totalTime += time
+                } else if (seStats.execCount >= 10) {
+                    def popTime = seStats.totalTime.intdiv(seStats.execCount)
+                    seStats.totalTime -= popTime
+                    seStats.totalTime += time
                 }
-                if (scheduledExecution.save(flush:true)) {
-                    log.info("updated scheduled Execution")
-                } else {
-                    scheduledExecution.errors.allErrors.each {log.warn(it.defaultMessage)}
-                    log.warn("failed saving execution to history")
+
+                if (seStats.validate()) {
+                    if (seStats.save(flush: true)) {
+                        log.info("updated scheduled Execution Stats")
+                    } else {
+                        seStats.errors.allErrors.each { log.warn(it.defaultMessage) }
+                        log.warn("failed saving execution to history")
+                    }
+                    success = true
                 }
-                success = true
+
+
             }
         } catch (org.springframework.dao.ConcurrencyFailureException e) {
             log.warn("Caught ConcurrencyFailureException, will retry updateScheduledExecStatistics for ${eId}")
         } catch (StaleObjectStateException e) {
             log.warn("Caught StaleObjectState, will retry updateScheduledExecStatistics for ${eId}")
+        } catch (DuplicateKeyException ve) {
+            log.warn("Caught DuplicateKeyException for migrated stats, will retry updateScheduledExecStatistics for ${eId}")
+        }
+        return success
+    }
+
+    /**
+     * Update jobref stats
+     * @param schedId
+     * @param time
+     * @return
+     */
+    def updateJobRefScheduledExecStatistics(Long schedId, long time) {
+        def success = false
+        try {
+            def seStats = ScheduledExecutionStats.findByScheduledExecutionId(schedId)
+
+            if (null == seStats.execCount || 0 == seStats.execCount || null == seStats.totalTime || 0 == seStats.totalTime) {
+                seStats.execCount = 1
+                seStats.totalTime = time
+            } else if (seStats.execCount > 0 && seStats.execCount < 10) {
+                seStats.execCount++
+                seStats.totalTime += time
+            } else if (seStats.execCount >= 10) {
+                def popTime = seStats.totalTime.intdiv(seStats.execCount)
+                seStats.totalTime -= popTime
+                seStats.totalTime += time
+            }
+
+            if (!seStats.refExecCount) {
+                seStats.refExecCount = 1
+            } else {
+                seStats.refExecCount++
+            }
+
+
+            if (seStats.validate()) {
+                if (seStats.save(flush: true)) {
+                    log.info("updated referenced Job Stats")
+                } else {
+                    seStats.errors.allErrors.each { log.warn(it.defaultMessage) }
+                    log.warn("failed saving referenced Job Stats")
+                }
+                success = true
+            }
+        } catch (org.springframework.dao.ConcurrencyFailureException e) {
+            log.warn("Caught ConcurrencyFailureException, dismissed statistic for referenced Job")
+        } catch (StaleObjectStateException e) {
+            log.warn("Caught StaleObjectState, dismissed statistic for for referenced Job")
+        } catch (DuplicateKeyException ve) {
+            // Do something ...
+            log.warn("Caught DuplicateKeyException for migrated stats, dismissed statistic for referenced Job")
         }
         return success
     }
@@ -3498,10 +3556,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         if(wresult.result) {
             def savedJobState = false
             if(!disableRefStats) {
-                savedJobState = updateScheduledExecStatistics(id, 'jobref', duration, true)
-                if (!savedJobState) {
-                    log.info("ExecutionJob: Failed to update job statistics for jobref")
-                }
+                updateJobRefScheduledExecStatistics(id, duration)
             }
             ReferencedExecution.withTransaction { status ->
                 refExec.status=wresult.result.success?EXECUTION_SUCCEEDED:EXECUTION_FAILED

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -599,9 +599,8 @@ public class NotificationService implements ApplicationContextAware{
                 project: scheduledExecution.project,
                 description: scheduledExecution.description
         ]
-        if (scheduledExecution.totalTime >= 0 && scheduledExecution.execCount > 0) {
-            def long avg = Math.floor(scheduledExecution.totalTime / scheduledExecution.execCount)
-            job.averageDuration = avg
+        if (scheduledExecution.getAverageDuration() > 0) {
+            job.averageDuration = scheduledExecution.getAverageDuration()
         }
         job
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -926,7 +926,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                         '" it is currently being executed: {{Execution ' + found.id + '}}'
                 return [success:false,error:errmsg]
             }
-            def stats= ScheduledExecutionStats.findAllByScheduledExecutionId(scheduledExecution.id)
+            def stats= ScheduledExecutionStats.findAllBySe(scheduledExecution)
             if(stats){
                 stats.each { st ->
                     st.delete()
@@ -3195,10 +3195,10 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             scheduledExecution.uuid = UUID.randomUUID().toString()
         }
         if (!failed && scheduledExecution.save(flush:true)) {
-            def stats = ScheduledExecutionStats.findByScheduledExecutionId(scheduledExecution.id)
+            def stats = ScheduledExecutionStats.findAllBySe(scheduledExecution)
             if (!stats) {
-                stats = new ScheduledExecutionStats(scheduledExecutionId: scheduledExecution.id)
-                        .save()
+                stats = new ScheduledExecutionStats(se: scheduledExecution)
+                        .save(flush:true)
             }
             rescheduleJob(scheduledExecution)
             def event = createJobChangeEvent(JobChangeEvent.JobChangeEventType.CREATE, scheduledExecution)

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -926,6 +926,12 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                         '" it is currently being executed: {{Execution ' + found.id + '}}'
                 return [success:false,error:errmsg]
             }
+            def stats= ScheduledExecutionStats.findAllByScheduledExecutionId(scheduledExecution.id)
+            if(stats){
+                stats.each { st ->
+                    st.delete()
+                }
+            }
             def refExec = ReferencedExecution.findAllByScheduledExecution(scheduledExecution)
             if(refExec){
                 refExec.each { re ->
@@ -3189,6 +3195,11 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             scheduledExecution.uuid = UUID.randomUUID().toString()
         }
         if (!failed && scheduledExecution.save(flush:true)) {
+            def stats = ScheduledExecutionStats.findByScheduledExecutionId(scheduledExecution.id)
+            if (!stats) {
+                stats = new ScheduledExecutionStats(scheduledExecutionId: scheduledExecution.id)
+                        .save()
+            }
             rescheduleJob(scheduledExecution)
             def event = createJobChangeEvent(JobChangeEvent.JobChangeEventType.CREATE, scheduledExecution)
             return [success: true, scheduledExecution: scheduledExecution,jobChangeEvent: event]

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -888,8 +888,8 @@
       <g:if test="${!authChecks[AuthConstants.ACTION_KILL]}">
           killjobhtml: "",
       </g:if>
-        totalDuration : '${enc(js:scheduledExecution?.getStats()?.totalTime ?: -1)}',
-        totalCount: '${enc(js:scheduledExecution?.getStats()?.execCount ?: -1)}'
+        totalDuration : '${enc(js:scheduledExecution?.getTotalTimeStats()?: -1)}',
+        totalCount: '${enc(js:scheduledExecution?.getExecCountStats()?: -1)}'
       });
       nodeflowvm=new NodeFlowViewModel(
         workflow,

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -888,8 +888,8 @@
       <g:if test="${!authChecks[AuthConstants.ACTION_KILL]}">
           killjobhtml: "",
       </g:if>
-        totalDuration : '${enc(js:scheduledExecution?.totalTime ?: -1)}',
-        totalCount: '${enc(js:scheduledExecution?.execCount ?: -1)}'
+        totalDuration : '${enc(js:scheduledExecution?.getStats()?.totalTime ?: -1)}',
+        totalCount: '${enc(js:scheduledExecution?.getStats()?.execCount ?: -1)}'
       });
       nodeflowvm=new NodeFlowViewModel(
         workflow,

--- a/rundeckapp/grails-app/views/menu/_runningExecutions.gsp
+++ b/rundeckapp/grails-app/views/menu/_runningExecutions.gsp
@@ -104,8 +104,8 @@
                         </span>
                     </g:if>
                     <g:else>
-                        <g:if test="${scheduledExecution && scheduledExecution.execCount>0 && scheduledExecution.totalTime > 0 && execution.dateStarted && timeNow >= execution.dateStarted.getTime()}">
-                            <g:set var="avgTime" value="${(Long)(scheduledExecution.totalTime/scheduledExecution.execCount)}"/>
+                        <g:if test="${scheduledExecution && scheduledExecution.getAverageDuration() > 0 && execution.dateStarted && timeNow >= execution.dateStarted.getTime()}">
+                            <g:set var="avgTime" value="${(Long)(scheduledExecution.getAverageDuration())}"/>
                             <g:set var="completePercent" value="${(int)Math.floor((double)(100 * (timeNow - execution.dateStarted.getTime())/(avgTime)))}"/>
                             <g:set var="estEndTime" value="${(long)(execution.dateStarted.getTime() + (long)avgTime)}"/>
                             <g:set var="completeEstimate" value="${new Date(estEndTime)}"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
@@ -127,7 +127,7 @@
             </h4>
           </div>
           <div class="card-content">
-            <g:render template="/reports/activityLinks" model="[scheduledExecution: scheduledExecution, knockoutBinding:true, includeJobRef:(scheduledExecution.getStats().refExecCount?true:false)]"/>
+            <g:render template="/reports/activityLinks" model="[scheduledExecution: scheduledExecution, knockoutBinding:true, includeJobRef:(scheduledExecution.getRefExecCountStats()?true:false)]"/>
           </div>
         </div>
       </div>

--- a/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
@@ -127,7 +127,7 @@
             </h4>
           </div>
           <div class="card-content">
-            <g:render template="/reports/activityLinks" model="[scheduledExecution: scheduledExecution, knockoutBinding:true, includeJobRef:(scheduledExecution.refExecCount?true:false)]"/>
+            <g:render template="/reports/activityLinks" model="[scheduledExecution: scheduledExecution, knockoutBinding:true, includeJobRef:(scheduledExecution.getStats().refExecCount?true:false)]"/>
           </div>
         </div>
       </div>

--- a/rundeckapp/grails-app/views/scheduledExecution/_showStats.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_showStats.gsp
@@ -49,7 +49,7 @@
       </div>
     </div>
   </g:if>
-  <g:if test="${scheduledExecution.execCount > 0}">
+  <g:if test="${scheduledExecution.getAverageDuration() > 0}">
     <div class="col-xs-4">
       <div class="card">
         <div class="card-header">
@@ -57,7 +57,7 @@
             <g:message code="average.duration" />
           </h4>
           <div class="card-content">
-              <g:set var="avgduration" value="${scheduledExecution.execCount>0?  scheduledExecution.totalTime /scheduledExecution.execCount  : 0}"/>
+              <g:set var="avgduration" value="${scheduledExecution.getAverageDuration()}"/>
             <span class="h3 " data-avgduration="${avgduration}">
                 <g:timeDuration time="${avgduration}"/>
             </span>

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -57,7 +57,7 @@ import java.time.ZoneId
 class ExecutionServiceSpec extends Specification implements ServiceUnitTest<ExecutionService>, DataTest, AutowiredTest {
 
     Class[] getDomainClassesToMock() {
-        [Execution, ScheduledExecution, Workflow, CommandExec, Option, ExecReport, LogFileStorageRequest, ReferencedExecution]
+        [Execution, ScheduledExecution, Workflow, CommandExec, Option, ExecReport, LogFileStorageRequest, ReferencedExecution, ScheduledExecutionStats]
     }
 
     private Map createJobParams(Map overrides = [:]) {
@@ -3219,12 +3219,11 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         def ret = service.runJobRefExecutionItem(origContext,item,createFailure,createSuccess)
         then:
         def refexec = ReferencedExecution.findByScheduledExecution(job)
-        println(refexec)
-        println(expectedRef)
+        def seStats = ScheduledExecutionStats.findByScheduledExecutionId(job.id)
         if(expectedRef){
-            refexec
+            seStats.refExecCount==0
         }else{
-            !refexec
+            seStats.refExecCount==1
         }
         0 * executionListener.log(_)
         ret.success

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -3219,11 +3219,11 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         def ret = service.runJobRefExecutionItem(origContext,item,createFailure,createSuccess)
         then:
         def refexec = ReferencedExecution.findByScheduledExecution(job)
-        def seStats = ScheduledExecutionStats.findByScheduledExecutionId(job.id)
+        def seStats = ScheduledExecutionStats.findBySe(job)
         if(expectedRef){
-            seStats.refExecCount==0
+            seStats.getContentMap().refExecCount==0
         }else{
-            seStats.refExecCount==1
+            seStats.getContentMap().refExecCount==1
         }
         0 * executionListener.log(_)
         ret.success

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -39,6 +39,7 @@ import rundeck.CommandExec
 import rundeck.Execution
 import rundeck.Project
 import rundeck.ScheduledExecution
+import rundeck.ScheduledExecutionStats
 import rundeck.User
 import rundeck.Workflow
 import rundeck.services.ApiService
@@ -60,7 +61,7 @@ import javax.servlet.http.HttpServletResponse
  * Created by greg on 3/15/16.
  */
 @TestFor(MenuController)
-@Mock([ScheduledExecution, CommandExec, Workflow, Project, Execution, User, AuthToken])
+@Mock([ScheduledExecution, CommandExec, Workflow, Project, Execution, User, AuthToken, ScheduledExecutionStats])
 class MenuControllerSpec extends Specification {
     def "api job detail xml"() {
         given:

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -40,7 +40,7 @@ import javax.security.auth.Subject
  * Created by greg on 7/14/15.
  */
 @TestFor(ScheduledExecutionController)
-@Mock([ScheduledExecution, Option, Workflow, CommandExec, Execution, JobExec, ReferencedExecution])
+@Mock([ScheduledExecution, Option, Workflow, CommandExec, Execution, JobExec, ReferencedExecution, ScheduledExecutionStats])
 class ScheduledExecutionControllerSpec extends Specification {
     def setup() {
         mockCodec(URIComponentCodec)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerTests.groovy
@@ -19,6 +19,7 @@ package rundeck.controllers
 import com.dtolabs.rundeck.core.common.PluginControlService
 import groovy.mock.interceptor.MockFor
 import rundeck.services.optionvalues.OptionValuesService
+import rundeck.ScheduledExecutionStats
 
 import static org.junit.Assert.*
 
@@ -67,7 +68,7 @@ import javax.servlet.http.HttpServletResponse
 * $Id$
 */
 @TestFor(ScheduledExecutionController)
-@Mock([ScheduledExecution,Option,Workflow,CommandExec,Execution,JobExec, ReferencedExecution])
+@Mock([ScheduledExecution,Option,Workflow,CommandExec,Execution,JobExec, ReferencedExecution, ScheduledExecutionStats])
 class ScheduledExecutionControllerTests  {
     /**
      * utility method to mock a class

--- a/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
@@ -25,6 +25,7 @@ import org.quartz.Scheduler
 import rundeck.CommandExec
 import rundeck.Option
 import rundeck.ScheduledExecution
+import rundeck.ScheduledExecutionStats
 import rundeck.Workflow
 import rundeck.Execution
 import rundeck.services.ExecutionService
@@ -35,7 +36,7 @@ import spock.lang.Specification
 /**
  * Created by greg on 4/12/16.
  */
-@Mock([ScheduledExecution, Workflow, CommandExec, Execution])
+@Mock([ScheduledExecution, Workflow, CommandExec, Execution,ScheduledExecutionStats])
 class ExecutionJobSpec extends Specification {
     def "execute missing job"() {
         given:

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -32,6 +32,7 @@ import rundeck.CommandExec
 import rundeck.Execution
 import rundeck.Notification
 import rundeck.ScheduledExecution
+import rundeck.ScheduledExecutionStats
 import rundeck.User
 import rundeck.Workflow
 import spock.lang.Specification
@@ -40,7 +41,7 @@ import spock.lang.Specification
  * Created by greg on 7/12/16.
  */
 @TestFor(NotificationService)
-@Mock([Execution, ScheduledExecution, Notification, Workflow, CommandExec, User])
+@Mock([Execution, ScheduledExecution, Notification, Workflow, CommandExec, User, ScheduledExecutionStats])
 class NotificationServiceSpec extends Specification {
 
     private List createTestJob() {

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -16,6 +16,7 @@
 
 package rundeck.services
 
+import rundeck.ScheduledExecutionStats
 
 import static org.junit.Assert.*
 
@@ -59,7 +60,7 @@ import spock.lang.Unroll
  */
 @TestFor(ScheduledExecutionService)
 @Mock([Workflow, ScheduledExecution, CommandExec, Notification, Option, PluginStep, JobExec,
-        WorkflowStep, Execution, ReferencedExecution])
+        WorkflowStep, Execution, ReferencedExecution, ScheduledExecutionStats])
 class ScheduledExecutionServiceSpec extends Specification {
 
     public static final String TEST_UUID1 = 'BB27B7BB-4F13-44B7-B64B-D2435E2DD8C7'

--- a/test/api/include.sh
+++ b/test/api/include.sh
@@ -139,7 +139,7 @@ api_waitfor_execution(){
     local status='running'
 
     local rsleep=3
-    local rmax=10
+    local rmax=${3:-10}
     local rc=0
     
     while [[ ( $status == "running" || $status == "scheduled" ) && $rc -lt $rmax ]]; do

--- a/test/api/test-job-run-without-deadlock.sh
+++ b/test/api/test-job-run-without-deadlock.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+
+#test  /api/job/{id}/run
+
+DIR=$(cd `dirname $0` && pwd)
+source $DIR/include.sh
+
+###
+# setup: create a new job and acquire the ID
+###
+
+# job exec
+args="echo hello there"
+
+project=$2
+if [ "" == "$2" ] ; then
+    project="test"
+fi
+
+#escape the string for xml
+xmlargs=$($XMLSTARLET esc "$args")
+xmlproj=$($XMLSTARLET esc "$project")
+
+#produce job.xml content corresponding to the dispatch request
+cat > $DIR/temp.out <<END
+<joblist>
+  <job>
+    <context>
+      <options preserveOrder='true'>
+        <option name='maxWaitTimeSecs' value='0' />
+      </options>
+    </context>
+    <defaultTab>summary</defaultTab>
+    <description></description>
+    <executionEnabled>true</executionEnabled>
+    <id>3cce5f70-71aa-4e6c-b99e-9e866732448a</id>
+    <loglevel>INFO</loglevel>
+    <multipleExecutions>true</multipleExecutions>
+    <name>job_c</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <scheduleEnabled>true</scheduleEnabled>
+    <sequence keepgoing='false' strategy='node-first'>
+      <command>
+        <script><![CDATA[sleep @option.maxWaitTimeSecs@]]></script>
+        <scriptargs />
+      </command>
+      <command>
+        <exec>echo "regular job before parallel"</exec>
+      </command>
+    </sequence>
+    <uuid>3cce5f70-71aa-4e6c-b99e-9e866732448a</uuid>
+  </job>
+  <job>
+    <defaultTab>summary</defaultTab>
+    <description></description>
+    <executionEnabled>true</executionEnabled>
+    <id>7d6d0958-7987-4a35-9ec3-7720f0985ae4</id>
+    <loglevel>INFO</loglevel>
+    <multipleExecutions>true</multipleExecutions>
+    <name>job_d</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <scheduleEnabled>true</scheduleEnabled>
+    <sequence keepgoing='false' strategy='parallel'>
+      <command>
+        <jobref name='job_c' nodeStep='true'>
+          <arg line='-maxWaitTimeSecs 20 -oldmaxWaitTimeSecs 2100' />
+        </jobref>
+      </command>
+      <command>
+        <jobref name='job_c' nodeStep='true'>
+          <arg line='-maxWaitTimeSecs 60 -oldmaxWaitTimeSecs 2400' />
+        </jobref>
+      </command>
+    </sequence>
+    <uuid>7d6d0958-7987-4a35-9ec3-7720f0985ae4</uuid>
+  </job>
+  <job>
+    <defaultTab>summary</defaultTab>
+    <description></description>
+    <executionEnabled>true</executionEnabled>
+    <id>165ef9b9-61dc-470c-91aa-3f6dc248249d</id>
+    <loglevel>INFO</loglevel>
+    <multipleExecutions>true</multipleExecutions>
+    <name>job_b</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <scheduleEnabled>true</scheduleEnabled>
+    <sequence keepgoing='false' strategy='node-first'>
+      <command>
+        <jobref name='job_c' nodeStep='true' />
+      </command>
+      <command>
+        <jobref name='job_d' nodeStep='true' />
+      </command>
+    </sequence>
+    <uuid>165ef9b9-61dc-470c-91aa-3f6dc248249d</uuid>
+  </job>
+  <job>
+    <defaultTab>summary</defaultTab>
+    <description></description>
+    <executionEnabled>true</executionEnabled>
+    <id>06ba3dce-ba4f-4964-8ac2-349c3a2267bd</id>
+    <loglevel>INFO</loglevel>
+    <multipleExecutions>true</multipleExecutions>
+    <name>job_a</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <scheduleEnabled>true</scheduleEnabled>
+    <sequence keepgoing='false' strategy='node-first'>
+      <command>
+        <exec>echo "start job_a"</exec>
+      </command>
+      <command>
+        <jobref name='job_b' nodeStep='true' />
+      </command>
+    </sequence>
+    <uuid>06ba3dce-ba4f-4964-8ac2-349c3a2267bd</uuid>
+  </job>
+</joblist>
+
+END
+
+# now submit req
+runurl="${APIURL}/project/$project/jobs/import"
+
+params=""
+
+# specify the file for upload with curl, named "xmlBatch"
+ulopts="-F xmlBatch=@$DIR/temp.out"
+
+# get listing
+docurl $ulopts  ${runurl}?${params} > $DIR/curl.out
+if [ 0 != $? ] ; then
+    errorMsg "ERROR: failed query request"
+    exit 2
+fi
+
+$SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
+
+#result will contain list of failed and succeeded jobs, in this
+#case there should only be 1 failed or 1 succeeded since we submit only 1
+
+succount=$($XMLSTARLET sel -T -t -v "/result/succeeded/@count" $DIR/curl.out)
+jobid="06ba3dce-ba4f-4964-8ac2-349c3a2267bd"
+#$($XMLSTARLET sel -T -t -v "/result/succeeded/job/id" $DIR/curl.out)
+
+if [ "4" != "$succount" -o "" == "$jobid" ] ; then
+    errorMsg  "Upload was not successful."
+    exit 2
+fi
+
+
+###
+# Run the chosen id, expect success message
+###
+
+echo "TEST: POST job/id/run should succeed"
+
+
+# now submit req
+runurl="${APIURL}/job/${jobid}/run"
+params=""
+execargs="-opt2 a"
+
+# get listing
+$CURL -H "$AUTHHEADER" -X POST  ${runurl}?${params} > $DIR/curl.out || fail "failed request: ${runurl}"
+
+$SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
+
+#get execid
+
+execcount=$($XMLSTARLET sel -T -t -v "/result/executions/@count" $DIR/curl.out)
+execid=$($XMLSTARLET sel -T -t -v "/result/executions/execution/@id" $DIR/curl.out)
+
+if [ "1" == "${execcount}" -a "" != "${execid}" ] ; then
+    :
+else
+    errorMsg "FAIL: expected run success message for execution id. (count: ${execcount}, id: ${execid})"
+    exit 2
+fi
+
+#running in parallel the same job to force concurrency.
+$CURL -H "$AUTHHEADER" -X POST  ${runurl}?${params} > $DIR/curl.out || fail "failed request: ${runurl}"
+$CURL -H "$AUTHHEADER" -X POST  ${runurl}?${params} > $DIR/curl.out || fail "failed request: ${runurl}"
+$CURL -H "$AUTHHEADER" -X POST  ${runurl}?${params} > $DIR/curl.out || fail "failed request: ${runurl}"
+
+#wait for execution to complete
+echo "TEST: POST job/id/run should succeed $execid"
+api_waitfor_execution $execid true 40 || fail "Failed waiting for execution $execid to complete"
+
+# test execution status
+# 
+runurl="${APIURL}/execution/${execid}"
+
+params=""
+
+# get listing
+docurl ${runurl}?${params} > $DIR/curl.out
+if [ 0 != $? ] ; then
+    errorMsg "ERROR: failed query request"
+    exit 2
+fi
+
+$SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
+
+#Check projects list
+itemcount=$($XMLSTARLET sel -T -t -v "/result/executions/@count" $DIR/curl.out)
+assert "1" "$itemcount" "execution count should be 1"
+status=$($XMLSTARLET sel -T -t -v "/result/executions/execution/@status" $DIR/curl.out)
+assert "succeeded" "$status" "execution status should be succeeded"
+
+
+grep -i "Deadlock" /home/rundeck/var/log/service.log -q
+found=$?
+if [ 1 != $found ] ; then
+    errorMsg "ERROR: Deadlock found on multiple executions"
+    exit 2
+fi
+rm $DIR/curl.out
+echo "OK"
+

--- a/test/docker/dockers/rundeck/scripts/start_rundeck.sh
+++ b/test/docker/dockers/rundeck/scripts/start_rundeck.sh
@@ -79,6 +79,8 @@ rundeck.tokens.file=$HOME/etc/tokens.properties
 
 # force UTF-8
 #framework.remote.charset.default=UTF-8
+
+rundeck.enable.ref.stats=true
 END
 
 cat > $HOME/etc/profile <<END


### PR DESCRIPTION
New domain table `ScheduledExecutionStats` to use instead of `ScheduledExecution` on statistics.

The objective of this change is to reduce the direct use of the `ScheduledExecution` table at updating or consulting the average time statistics.

Reduces the appearance of deadlocks by updating the statistics in the referenced jobs.

Docker test included to detect the appearance of deadlocks on parallel usage of the table:
`test/api/test-job-run-without-deadlock.sh`

New jobs will be created with a field on the `ScheduledExecutionStats` table and existing fields will be migrated in usage or retrieve of the data.