### PR TITLE
Refactor: move project configurable interface to core

### DIFF
--- a/core/src/main/java/org/rundeck/core/projects/ProjectConfigurable.java
+++ b/core/src/main/java/org/rundeck/core/projects/ProjectConfigurable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,28 +14,30 @@
  * limitations under the License.
  */
 
-package rundeck.services.framework
+package org.rundeck.core.projects;
 
-import com.dtolabs.rundeck.core.plugins.configuration.Property
+import com.dtolabs.rundeck.core.plugins.configuration.Property;
+
+import java.util.List;
+import java.util.Map;
 
 /**
- * defines a set of project-level configuration properties for a grails service/spring bean
+ * Defines project level configuration properties for a component
  */
-interface RundeckProjectConfigurable {
+public interface ProjectConfigurable {
     /**
      * Return configuration categories for the properties, keyed by property name
-     * @return
      */
-    Map<String, String> getCategories()
+    Map<String, String> getCategories();
 
     /**
      * List of properties
-     * @return
      */
-    List<Property> getProjectConfigProperties()
+    List<Property> getProjectConfigProperties();
 
     /**
      * @return a map of config prop names to project config property names
      */
     public Map<String, String> getPropertiesMapping();
+
 }

--- a/rundeckapp/grails-app/services/rundeck/controllers/MenuService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/controllers/MenuService.groovy
@@ -3,10 +3,10 @@ package rundeck.controllers
 import com.dtolabs.rundeck.core.common.IRundeckProjectConfig
 import com.dtolabs.rundeck.core.plugins.configuration.Property
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder
-import rundeck.services.framework.RundeckProjectConfigurable
+import org.rundeck.core.projects.ProjectConfigurable
 
 
-class MenuService implements RundeckProjectConfigurable {
+class MenuService implements ProjectConfigurable {
     static transactional = false
     public static final List<Property> ProjectConfigProperties = [
             PropertyBuilder.builder().with {

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -40,12 +40,12 @@ import com.dtolabs.rundeck.core.plugins.DescribedPlugin
 import com.dtolabs.rundeck.server.plugins.loader.ApplicationContextPluginFileSource
 import grails.core.GrailsApplication
 import org.rundeck.app.spi.Services
+import org.rundeck.core.projects.ProjectConfigurable
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
 import rundeck.Execution
 import rundeck.PluginStep
 import rundeck.ScheduledExecution
-import rundeck.services.framework.RundeckProjectConfigurable
 
 import javax.security.auth.Subject
 import java.util.function.Predicate
@@ -1299,8 +1299,8 @@ class FrameworkService implements ApplicationContextAware, AuthContextProvider, 
      * @return Map of [(beanName): Map [ name: String, configurable: Bean, values: demapped value Map, prefix: bean prefix] ]
      */
     Map<String, Map> loadProjectConfigurableInput(String prefix, Map projectInputProps, String category = null) {
-        Map<String, RundeckProjectConfigurable> projectConfigurableBeans = applicationContext.getBeansOfType(
-                RundeckProjectConfigurable
+        Map<String, ProjectConfigurable> projectConfigurableBeans = applicationContext.getBeansOfType(
+                ProjectConfigurable
         )
 
         Map<String, Map> extraConfig = [:]
@@ -1342,15 +1342,15 @@ class FrameworkService implements ApplicationContextAware, AuthContextProvider, 
      * @return map [errors:List, config: Map, props: Map, remove: List]
      */
     Map validateProjectConfigurableInput(Map<String, Map> inputMap, String prefix, Predicate<String> categoryPredicate = null) {
-        Map<String, RundeckProjectConfigurable> projectConfigurableBeans = applicationContext.getBeansOfType(
-                RundeckProjectConfigurable
+        Map<String, ProjectConfigurable> projectConfigurableBeans = applicationContext.getBeansOfType(
+                ProjectConfigurable
         )
         def errors = []
         def extraConfig = [:]
         def projProps = [:]
         def removePrefixes = []
 
-        projectConfigurableBeans.each { k, RundeckProjectConfigurable v ->
+        projectConfigurableBeans.each { k, ProjectConfigurable v ->
             if (k.endsWith('Profiled')) {
                 //skip profiled versions of beans
                 return

--- a/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
@@ -36,9 +36,9 @@ import com.google.common.cache.RemovalNotification
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.ListenableFutureTask
+import org.rundeck.core.projects.ProjectConfigurable
 import org.springframework.beans.factory.InitializingBean
 import org.springframework.core.task.AsyncListenableTaskExecutor
-import rundeck.services.framework.RundeckProjectConfigurable
 import rundeck.services.nodes.CachedProjectNodes
 
 import java.util.concurrent.TimeUnit
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit
 /**
  * Provides asynchronous loading and caching of nodesets for projects
  */
-class NodeService implements InitializingBean, RundeckProjectConfigurable,IProjectNodesFactory, ProjectNodeService {
+class NodeService implements InitializingBean, ProjectConfigurable, IProjectNodesFactory, ProjectNodeService {
     public static final String PROJECT_NODECACHE_DELAY = 'project.nodeCache.delay'
     public static final String PROJECT_NODECACHE_ENABLED = 'project.nodeCache.enabled'
     public static final String PROJECT_NODECACHE_FIRSTLOAD_SYNCH = 'project.nodeCache.firstLoadSynch'

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -61,7 +61,7 @@ import rundeck.controllers.ScheduledExecutionController
 import rundeck.controllers.WorkflowController
 import rundeck.quartzjobs.ExecutionJob
 import rundeck.services.events.ExecutionPrepareEvent
-import rundeck.services.framework.RundeckProjectConfigurable
+import org.rundeck.core.projects.ProjectConfigurable
 
 import javax.annotation.PreDestroy
 import javax.servlet.http.HttpSession
@@ -73,7 +73,7 @@ import java.util.concurrent.TimeUnit
  *  ScheduledExecutionService manages scheduling jobs with the Quartz scheduler
  */
 @Transactional
-class ScheduledExecutionService implements ApplicationContextAware, InitializingBean, RundeckProjectConfigurable, EventPublisher {
+class ScheduledExecutionService implements ApplicationContextAware, InitializingBean, ProjectConfigurable, EventPublisher {
     static transactional = true
     public static final String CONF_GROUP_EXPAND_LEVEL = 'project.jobs.gui.groupExpandLevel'
     public static final String CONF_PROJECT_DISABLE_EXECUTION = 'project.disable.executions'

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -36,6 +36,7 @@ import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 import org.grails.plugins.metricsweb.MetricService
+import org.rundeck.core.projects.ProjectConfigurable
 import rundeck.NodeFilter
 import rundeck.User
 import rundeck.services.ApiService

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -47,7 +47,7 @@ import rundeck.services.ScheduledExecutionService
 import rundeck.services.StorageManager
 import rundeck.services.UserService
 import rundeck.services.authorization.PoliciesValidation
-import rundeck.services.framework.RundeckProjectConfigurable
+
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -980,7 +980,7 @@ class FrameworkControllerSpec extends Specification {
         params[SynchronizerTokensHolder.TOKEN_URI] = '/test'
     }
 
-    static class TestConfigurableBean implements RundeckProjectConfigurable {
+    static class TestConfigurableBean implements ProjectConfigurable {
 
         Map<String, String> categories = [:]
 

--- a/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
@@ -32,7 +32,7 @@ import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder
 import grails.test.mixin.TestFor
 import org.rundeck.app.spi.Services
-import rundeck.services.framework.RundeckProjectConfigurable
+import org.rundeck.core.projects.ProjectConfigurable
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -166,7 +166,7 @@ class FrameworkServiceSpec extends Specification {
         prefix = ''
     }
 
-    static class TestConfigurableBean implements RundeckProjectConfigurable {
+    static class TestConfigurableBean implements ProjectConfigurable {
 
         Map<String, String> categories = [:]
 


### PR DESCRIPTION
rename to ProjectConfigurable

**Is this a bugfix, or an enhancement? Please describe.**

Move the project configurable interface to core for use by other modules