### PR TITLE
Improvement for audit.log file size

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/Authorization.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/Authorization.java
@@ -60,4 +60,6 @@ public interface Authorization {
      */
     Set<Decision> evaluate(Set<Map<String, String>> resources, Subject subject, Set<String> actions, 
             Set<Attribute> environment);
+
+    default void setMulti(){}
 }


### PR DESCRIPTION
Configurable audit.log granularity:

`warn` log level on unauthorized validations. 
To log only the unauthorized validations you can edit the log4.properties file and modify the line:
`log4j.logger.com.dtolabs.rundeck.core.authorization=info, audit`
to 
`log4j.logger.com.dtolabs.rundeck.core.authorization=warn, audit`

Log on multi evaluation (system and project validation) the log is moved upper level to log on warn level only if any validation is unauthorized.


Fix #4435