### PR TITLE
removed UUID validation of jobRef

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
@@ -1139,17 +1139,6 @@ class WorkflowController extends ControllerBase {
             if (!exec.jobName && !exec.uuid) {
                 exec.errors.rejectValue('jobName', 'commandExec.jobName.blank.message')
             }
-            if(exec.uuid && exec.jobName){
-                def refSe = ScheduledExecution.findScheduledExecution(null,null,null,exec.uuid);
-                if(!refSe){
-                    //"Job doesnt exists, using only the uuid to reference the job
-                    exec.uuid = null
-                }else if(refSe?.generateFullName()!=ScheduledExecution.generateFullName(exec.jobGroup, exec.jobName)){
-                    exec.jobName = null
-                    exec.jobGroup = null
-                    //using only the uuid
-                }
-            }
             if(exec.uuid && !exec.jobName){
                 def refSe = ScheduledExecution.findScheduledExecution(null,null,null,exec.uuid);
                 if(refSe){

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
@@ -1141,7 +1141,10 @@ class WorkflowController extends ControllerBase {
             }
             if(exec.uuid && exec.jobName){
                 def refSe = ScheduledExecution.findScheduledExecution(null,null,null,exec.uuid);
-                if(refSe?.generateFullName()!=ScheduledExecution.generateFullName(exec.jobGroup, exec.jobName)){
+                if(!refSe){
+                    //"Job doesnt exists, using only the uuid to reference the job
+                    exec.uuid = null
+                }else if(refSe?.generateFullName()!=ScheduledExecution.generateFullName(exec.jobGroup, exec.jobName)){
                     exec.jobName = refSe?.jobName
                     exec.jobGroup = refSe?.groupPath
                     exec.errors.rejectValue('jobName', 'commandExec.jobName.wrong.name.message')

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
@@ -1145,9 +1145,9 @@ class WorkflowController extends ControllerBase {
                     //"Job doesnt exists, using only the uuid to reference the job
                     exec.uuid = null
                 }else if(refSe?.generateFullName()!=ScheduledExecution.generateFullName(exec.jobGroup, exec.jobName)){
-                    exec.jobName = refSe?.jobName
-                    exec.jobGroup = refSe?.groupPath
-                    exec.errors.rejectValue('jobName', 'commandExec.jobName.wrong.name.message')
+                    exec.jobName = null
+                    exec.jobGroup = null
+                    //using only the uuid
                 }
             }
             if(exec.uuid && !exec.jobName){

--- a/rundeckapp/src/test/groovy/rundeck/controllers/WorkflowControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/WorkflowControllerSpec.groovy
@@ -445,18 +445,18 @@ class WorkflowControllerSpec extends Specification {
     }
 
 
-    def "insert jobexec using uuid"() {
+    def "insert jobexec using uuid from unexisting job doesnt fails"() {
         given:
         Workflow wf = new Workflow(threadcount: 1, keepgoing: true)
         wf.commands = new ArrayList()
-        def inputparams = [jobName: 'blah', jobGroup: 'test/test']
         //wf.commands << new JobExec( inputparams)
         controller.frameworkService = Mock(FrameworkService)
+        def uuid= '6b310826-8186-4cf3-96cd-e556d2f3ff5e'
 
         when:
         def result = controller._applyWFEditAction(
                 wf, [action: 'insert', num: 0,
-                     params: [jobName: jobName, jobGroup: jobGroup, jobProject: jobProject, uuid:jobUuid,
+                     params: [uuid:uuid,
                               description:'desc1',newitemtype: 'job']]
         )
 
@@ -464,23 +464,9 @@ class WorkflowControllerSpec extends Specification {
         //assertEquals(expectedError,result.error)
         1 * controller.frameworkService.projectNames(_) >> ['proj','proj2']
 
-        if(!fieldname){
-            assertNull(result.error)
-        }else{
-            assertNotNull(result.error)
-            result.item.errors.hasFieldErrors(fieldname)
-        }
 
+        assertNull(result.error)
 
-
-        where:
-        jobName     |jobUuid    | jobGroup | jobProject | fieldname
-        'blah'      |null       | 'ble/ble'| null       | null
-        null        |null       | 'ble/ble'| null       | 'jobName'
-        null        |'as'       | 'ble/ble'| null       | null
-        'blah'      |null       | null     | null       | null
-        'blah'      |null       | 'ble/ble'| 'proj'     | null
-        'blah'      |'as'       | null     | null       | 'jobName'
 
     }
 

--- a/test/api/test-jobs-import-jobref-renamed.sh
+++ b/test/api/test-jobs-import-jobref-renamed.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+#test /api/jobs/import
+
+DIR=$(cd `dirname $0` && pwd)
+source $DIR/include.sh
+
+args="echo hello there"
+
+project=$2
+if [ "" == "$2" ] ; then
+    project="test"
+fi
+
+#escape the string for xml
+xmlargs=$($XMLSTARLET esc "$args")
+xmlproj=$($XMLSTARLET esc "$project")
+
+#produce job.xml content corresponding to the dispatch request
+cat > $DIR/temp.out <<END
+<joblist>
+  <job>
+    <context>
+      <options preserveOrder='true'>
+        <option name='Time' required='true' />
+      </options>
+    </context>
+    <defaultTab>summary</defaultTab>
+    <description></description>
+    <executionEnabled>true</executionEnabled>
+    <group>Manage</group>
+    <id>28a1fc62-92a1-4a45-bbc3-02a8b0f46af8</id>
+    <loglevel>INFO</loglevel>
+    <name>RefMe</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <scheduleEnabled>true</scheduleEnabled>
+    <sequence keepgoing='false' strategy='node-first'>
+      <command>
+        <exec>sleep \${option.Time}</exec>
+      </command>
+    </sequence>
+    <uuid>28a1fc62-92a1-4a45-bbc3-02a8b0f46af8</uuid>
+  </job>
+  <job>
+    <context>
+      <options preserveOrder='true'>
+        <option name='Foo' />
+      </options>
+    </context>
+    <defaultTab>summary</defaultTab>
+    <description></description>
+    <executionEnabled>true</executionEnabled>
+    <group>Manage</group>
+    <id>a6d88d66-920b-492b-b7c4-1a22da67333b</id>
+    <loglevel>INFO</loglevel>
+    <name>Wrapper</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <scheduleEnabled>true</scheduleEnabled>
+    <sequence keepgoing='false' strategy='node-first'>
+      <command>
+        <jobref name='RefMe'>
+          <arg line='-Time \${option.Foo}' />
+          <uuid>28a1fc62-92a1-4a45-bbc3-02a8b0f46af8</uuid>
+        </jobref>
+      </command>
+    </sequence>
+    <uuid>a6d88d66-920b-492b-b7c4-1a22da67333b</uuid>
+  </job>
+</joblist>
+
+END
+
+# now submit req
+runurl="${APIURL}/project/$project/jobs/import"
+
+params=""
+
+# specify the file for upload with curl, named "xmlBatch"
+ulopts="-F xmlBatch=@$DIR/temp.out"
+
+# get listing
+docurl $ulopts  ${runurl}?${params} > $DIR/curl.out
+if [ 0 != $? ] ; then
+    errorMsg "ERROR: failed query request"
+    exit 2
+fi
+
+$SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
+
+#result will contain list of failed and succeeded jobs, in this
+#case there should only be 1 failed or 1 succeeded since we submit only 1
+
+succount=$($XMLSTARLET sel -T -t -v "/result/succeeded/@count" $DIR/curl.out)
+jobid="a6d88d66-920b-492b-b7c4-1a22da67333b"
+#$($XMLSTARLET sel -T -t -v "/result/succeeded/job/id" $DIR/curl.out)
+
+if [ "2" != "$succount" -o "" == "$jobid" ] ; then
+    errorMsg  "Upload was not successful."
+    exit 2
+fi
+
+
+rm $DIR/curl.out
+echo "OK"

--- a/test/selenium/__image_snapshots__/create-test-ts-job-has-not-visually-regressed-1-snap.png
+++ b/test/selenium/__image_snapshots__/create-test-ts-job-has-not-visually-regressed-1-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2c58bd638da20db95356f423b75b6ddfe82e64afb9eaa719b678e23085d6ea1
-size 91540
+oid sha256:9706b84dcd8055e5d814ad43bdb3a2b80a90031179e85432a64585b632470117
+size 91531

--- a/test/selenium/docker-compose.yml
+++ b/test/selenium/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     expose: ['4440']
 
   selenium:
-    image: rundeck/selenium@sha256:282dcc49fdc7f354e082e8512d0ce19d841005516220ab8df1576fa0a176d010
+    image: rundeck/selenium@sha256:08415b30ec219399e17a5adaebea6bd94428e60c3cec6199229ddc79c1759532
     tty: true
     links:
     - rundeck

--- a/test/selenium/docker-local-compose.yml
+++ b/test/selenium/docker-local-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   selenium:
-    image: rundeck/selenium@sha256:a7579fed4d16004f3e32d1cfd12ce4b4fbc81c58041cb9e324902caedeb36447
+    image: rundeck/selenium@sha256:08415b30ec219399e17a5adaebea6bd94428e60c3cec6199229ddc79c1759532
     network_mode: host
     tty: true
     volumes:

--- a/test/selenium/package.json
+++ b/test/selenium/package.json
@@ -26,7 +26,7 @@
     "aws-sdk": "^2.318.0",
     "axios": "^0.18.0",
     "chalk": "^2.4.1",
-    "chromedriver": "^2.38.3",
+    "chromedriver": "2.46.0",
     "indent-string": "^3.2.0",
     "jest": "^23.2.0",
     "jest-image-snapshot": "^2.5.0",


### PR DESCRIPTION
Job reference step using UUID and job name pointing to a job that doesn't exist won't fail it will only remove the `UUID` component and leave just the `jobname` reference.

Fix #4451 and 4471
