### PR TITLE
Allow loading images from any source

### DIFF
--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -174,7 +174,7 @@ rundeck:
                         style-src: 'self unsafe-inline'
                         script-src: 'self unsafe-inline unsafe-eval'
                         font-src: 'self data:'
-                        img-src: 'self https://media.rundeck.org https://www.rundeck.com'
+                        img-src: '*'
                         form-action: 'self'
 
     storage:


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
The introduction of CSP headers in #4405 has caused a situation where loading images, among other things, from different sources requires updating the header configs. For users with custom images in their README and MOTD markdowns, as well as our Tour functionality, this has resulted in *surprising* behavior. 


**Describe the solution you've implemented**
I have allowed images to be loaded from any source by default. This is a low risk default and will prevent surprises and constant updating of defaults on new releases..

**Describe alternatives you've considered**
I considered disabling CSP headers by default to revert all behavior. The downside to this is that `form-action: self` is a very good default as it effectively breaks insecure setups posting to `HTTP` from `HTTPS` when a reverse proxy is not sending `X-Fowarded-Proto`. A lot of people were and would unknowingly be posting login data over HTTPS.
