### PR TITLE
Update Options property type behavior

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtility.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtility.java
@@ -545,40 +545,51 @@ public class PluginAdapterUtility {
             }
             resolvedValue = boolvalue;
         } else if (type == Property.Type.Options) {
+            final List<String> splitList;
             if (value instanceof String) {
                 String valstring = (String) value;
-                Set<String> resolvedValueSet=null;
-                //not a String field
-                if (field.getType().isAssignableFrom(Set.class)) {
-                    HashSet<String> strings = new HashSet<>();
-                    strings.addAll(Arrays.asList(valstring.split(", *")));
-                    resolvedValueSet = strings;
-                    resolvedValue = strings;
-                } else if (field.getType().isAssignableFrom(List.class)) {
-                    ArrayList<String> strings = new ArrayList<>();
-                    strings.addAll(Arrays.asList(valstring.split(", *")));
-                    resolvedValueSet = new HashSet<>(strings);
-                    resolvedValue = strings;
-                } else if (field.getType() == String[].class) {
-                    ArrayList<String> strings = new ArrayList<>();
-                    strings.addAll(Arrays.asList(valstring.split(", *")));
-                    resolvedValueSet = new HashSet<>(strings);
-                    resolvedValue = strings.toArray(new String[strings.size()]);
-                } else if (field.getType() == String.class) {
-                    resolvedValueSet = new HashSet<>();
-                    resolvedValueSet.addAll(Arrays.asList(valstring.split(", *")));
-                    resolvedValue = value;
-                } else {
-                    return false;
-                }
-                if (!property.getSelectValues().containsAll(resolvedValueSet)) {
-                    throw new RuntimeException(
-                            "Some options values were not allowed for property " + property.getName() + ": " + resolvedValue);
-                }
+                splitList = Arrays.asList(valstring.split(", *"));
+            } else if (value instanceof List) {
+                splitList = (List<String>) value;
+            } else if (value instanceof Set) {
+                splitList = new ArrayList<>((Set) value);
+            } else if (value.getClass() == String[].class) {
+                splitList = Arrays.asList((String[]) value);
             } else {
-                //XXX
                 return false;
             }
+            Set<String> resolvedValueSet = null;
+            //not a String field
+            if (field.getType().isAssignableFrom(Set.class)) {
+                HashSet<String> strings = new HashSet<>();
+                strings.addAll(splitList);
+                resolvedValueSet = strings;
+                resolvedValue = strings;
+            } else if (field.getType().isAssignableFrom(List.class)) {
+                ArrayList<String> strings = new ArrayList<>();
+                strings.addAll(splitList);
+                resolvedValueSet = new HashSet<>(strings);
+                resolvedValue = strings;
+            } else if (field.getType() == String[].class) {
+                ArrayList<String> strings = new ArrayList<>();
+                strings.addAll(splitList);
+                resolvedValueSet = new HashSet<>(strings);
+                resolvedValue = strings.toArray(new String[strings.size()]);
+            } else if (field.getType() == String.class) {
+                resolvedValueSet = new HashSet<>();
+                resolvedValueSet.addAll(splitList);
+                resolvedValue = value;
+            } else {
+                return false;
+            }
+            if (property.getSelectValues() != null && !property.getSelectValues().containsAll(resolvedValueSet)) {
+                throw new RuntimeException(String.format(
+                        "Some options values were not allowed for property %s: %s",
+                        property.getName(),
+                        resolvedValue
+                ));
+            }
+
         } else if (type == Property.Type.String || type == Property.Type.FreeSelect) {
             if (value instanceof String) {
                 resolvedValue = value;

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PropertyUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PropertyUtil.java
@@ -951,6 +951,9 @@ public class PropertyUtil {
         }
 
         public boolean isValid(final String value) throws ValidationException {
+            if (selectValues == null) {
+                return true;
+            }
             Set<String> propvalset = new HashSet<>();
             if (value.indexOf(',') > 0) {
                 Stream<String> stream = Arrays.stream(value.split(", *"));

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/Validator.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/Validator.java
@@ -153,7 +153,7 @@ public class Validator {
                     if (null != validator) {
                         try {
                             if (!validator.isValid(value)) {
-                                report.errors.put(key, "Invalid value");
+                                report.errors.put(key, "Invalid value: " + value);
                             }
                         } catch (ValidationException e) {
                             report.errors.put(key, "Invalid value: " + e.getMessage());

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtilitySpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtilitySpec.groovy
@@ -77,6 +77,9 @@ class PluginAdapterUtilitySpec extends Specification {
         @SelectLabels(values = ["A", "B", "C"])
         String testSelect10;
 
+        @PluginProperty(description = 'String List multioption')
+        List<String> testSelect11;
+
         @PluginProperty
         Boolean testbool1;
         @PluginProperty
@@ -105,7 +108,7 @@ class PluginAdapterUtilitySpec extends Specification {
     }
 
 
-    def "configure options value string"() {
+    def "configure options field string"() {
         given:
         Configuretest1 test = new Configuretest1();
         when:
@@ -124,7 +127,7 @@ class PluginAdapterUtilitySpec extends Specification {
         'a,b,c' | _
     }
 
-    def "configure options value set"() {
+    def "configure options field set"() {
         given:
         Configuretest1 test = new Configuretest1();
         when:
@@ -144,7 +147,7 @@ class PluginAdapterUtilitySpec extends Specification {
         'a,c'   | ['a', 'c']
     }
 
-    def "configure options value array"() {
+    def "configure options field array"() {
         given:
         Configuretest1 test = new Configuretest1();
         when:
@@ -163,7 +166,8 @@ class PluginAdapterUtilitySpec extends Specification {
         'a,b,c' | ['a', 'b', 'c']
         'a,c'   | ['a', 'c']
     }
-    def "configure options value list"() {
+
+    def "configure options field list"() {
         given:
         Configuretest1 test = new Configuretest1();
         when:
@@ -181,6 +185,66 @@ class PluginAdapterUtilitySpec extends Specification {
         'a,b'   | ['a', 'b']
         'a,b,c' | ['a', 'b', 'c']
         'a,c'   | ['a', 'c']
+    }
+
+    def "configure options value list"() {
+        given:
+            Configuretest1 test = new Configuretest1();
+        when:
+
+            HashMap<String, Object> configuration = new HashMap<String, Object>();
+            configuration.put("testSelect11", value);
+            PluginAdapterUtility.configureProperties(new mapResolver(configuration), test);
+
+        then:
+            test.testSelect11 == expect
+
+        where:
+            value           | expect
+            ['a']           | ['a']
+            ['a', 'b']      | ['a', 'b']
+            ['a', 'b', 'c'] | ['a', 'b', 'c']
+            ['a', 'c']      | ['a', 'c']
+    }
+
+    def "configure options value array"() {
+        given:
+            Configuretest1 test = new Configuretest1();
+        when:
+
+            HashMap<String, Object> configuration = new HashMap<String, Object>();
+            configuration.put("testSelect11", value);
+            PluginAdapterUtility.configureProperties(new mapResolver(configuration), test);
+
+        then:
+            test.testSelect11 == expect
+
+        where:
+            value                                  | expect
+            ['a'].toArray(new String[1])           | ['a']
+            ['a', 'b'].toArray(new String[2])      | ['a', 'b']
+            ['a', 'b', 'c'].toArray(new String[3]) | ['a', 'b', 'c']
+            ['a', 'c'].toArray(new String[2])      | ['a', 'c']
+    }
+
+    def "configure options value set"() {
+        given:
+            Configuretest1 test = new Configuretest1();
+        when:
+
+            HashMap<String, Object> configuration = new HashMap<String, Object>();
+            configuration.put("testSelect11", new HashSet<String>(value));
+            PluginAdapterUtility.configureProperties(new mapResolver(configuration), test);
+
+        then:
+            test.testSelect11 == expect
+
+        where:
+            value           | expect
+            ['a']           | ['a']
+            ['a', 'b']      | ['a', 'b']
+            ['a', 'b', 'c'] | ['a', 'b', 'c']
+            ['a', 'c']      | ['a', 'c']
     }
 
     def "build String select property with value labels"() {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Updates behavior of Options plugin property type

* allow List,Set,String[] input values
* only enforce allowed values if not null

This enables a `List<String>` property option which doesn't have a predefined allowed values set, so any values can be used.