### PR TITLE
Add basic smtp/email settings to stock Docker config

### DIFF
--- a/docker/official/README.md
+++ b/docker/official/README.md
@@ -163,3 +163,17 @@ Specify location of a static tokens file. See [configuration file reference](htt
 ### `RUNDECK_SECURITY_HTTPHEADERS_PROVIDER_CSP_CONFIG_INCLUDEXWKCSPHEADER=false`
 ### `RUNDECK_SECURITY_HTTPHEADERS_PROVIDER_CSP_CONFIG_POLICY`
 Controls for CSP headers.
+
+
+### `RUNDECK_MAIL_SMTP_HOST`
+### `RUNDECK_MAIL_SMTP_PORT`
+### `RUNDECK_MAIL_SMTP_USERNAME`
+### `RUNDECK_MAIL_SMTP_PASSWORD`
+### `RUNDECK_MAIL_FROM`
+Default from address.
+### `RUNDECK_MAIL_DEFAULT_TEMPLATE_SUBJECT`
+### `RUNDECK_MAIL_DEFAULT_TEMPLATE_FILE`
+### `RUNDECK_MAIL_DEFAULT_TEMPLATE_LOG_FORMATTED`
+
+### `RUNDECK_MAIL_PROPS`
+Mail properties that get passed through to Grails. For example, to use StartTLS(required by many servers including AWS SES), `["mail.smtp.starttls.enable":"true","mail.smtp.port":"587"]`.

--- a/docker/official/remco/resources.d/rundeck-config-mail.properties.toml
+++ b/docker/official/remco/resources.d/rundeck-config-mail.properties.toml
@@ -1,0 +1,4 @@
+[[template]]
+    src         = "${REMCO_TEMPLATE_DIR}/rundeck-config-mail.properties"
+    dst         = "${REMCO_TMP_DIR}/rundeck-config/rundeck-config-mail.properties"
+    mode        = "0644"

--- a/docker/official/remco/templates/rundeck-config-mail.properties
+++ b/docker/official/remco/templates/rundeck-config-mail.properties
@@ -1,0 +1,36 @@
+
+{% if exists("/rundeck/mail/smtp/host") %}
+grails.mail.host={{ getv("/rundeck/mail/smtp/host") }}
+{% endif %}
+
+{%- if exists("/rundeck/mail/smtp/port") %}
+grails.mail.port={{ getv("/rundeck/mail/smtp/port", "587") }}
+{% endif %}
+
+{%- if exists("/rundeck/mail/smtp/username") %}
+grails.mail.username={{ getv("/rundeck/mail/smtp/username") }}
+{% endif %}
+
+{%- if exists("/rundeck/mail/smtp/password") %}
+grails.mail.password={{ getv("/rundeck/mail/smtp/password") }}
+{% endif %}
+
+{%- if exists("/rundeck/mail/props") %}
+grails.mail.props={{ getv("/rundeck/mail/props") }}
+{% endif %}
+
+{%- if exists("/rundeck/mail/from") %}
+grails.mail.default.from={{ getv("/rundeck/mail/from") }}
+{% endif %}
+
+{%- if exists("/rundeck/mail/default/template/subject") %}
+rundeck.mail.template.subject={{ getv("/rundeck/mail/default/template/subject") }}
+{% endif %}
+
+{%- if exists("/rundeck/mail/default/template/file") %}
+rundeck.mail.template.file={{ getv("/rundeck/mail/default/template/file") }}
+{% endif %}
+
+{%- if exists("/rundeck/mail/default/template/log/formatted") %}
+rundeck.mail.template.log.formatted={{ getv("/rundeck/mail/default/template/log/formatted") }}
+{% endif %}

--- a/docker/official/test/remco/test.yml
+++ b/docker/official/test/remco/test.yml
@@ -18,6 +18,20 @@ rundeck:
   features:
     repository:
       enabled: "true"
+  mail:
+    smtp:
+      host: foo.bar
+      port: '1234'
+      username: foo
+      password: bar
+    props: 'asdfasdfs'
+    default:
+      from: 'foo@foo.bar'
+      template:
+        file: /tmp/foo.md
+        # subject: "\"You've got mail\""
+        log:
+          formatted: 'true'
   security:
     httpheaders:
       enabled: "false"


### PR DESCRIPTION
Fixes #4539 

Enhancement to add basic SMTP/Email settings into the Docker config templates.

I had considered placing the keys under `/rundeck/grails/mail`. After a lot of back-and-forth with myself I opted to drop `grails` from that path and hide it as an implementation detail.