### PR TITLE
Fix stacktrace on menu controller caused by typo. 

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -223,9 +223,9 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                         params:[project:it.scheduledExecution.project]
                 )
                 if (it.scheduledExecution){
-                    def seStats = it.scheduledExecution.getStats()
-                    if(scheduledExecution.getAverageDuration() > 0) {
-                        data['jobAverageDuration'] = scheduledExecution.getAverageDuration()
+                    def avgDur = it.scheduledExecution.getAverageDuration()
+                    if(avgDur > 0) {
+                        data['jobAverageDuration'] = avgDur
                     }
                 }
                 if (it.argString) {


### PR DESCRIPTION
Fix stacktrace on menu controller caused by typo. Made call more efficient.
