### PR TITLE
Enabling ui plugins on all pages by default

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/ControllerBaseInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/ControllerBaseInterceptor.groovy
@@ -63,7 +63,8 @@ class ControllerBaseInterceptor {
         def uiplugins = [:]
 
         def addPath=false
-        if(configurationService.getBoolean('ui.plugin.enableAllPages', false)){
+        def enableAllPages = configurationService.getBoolean('ui.plugin.enableAllPages', true)
+        if(enableAllPages){
             addPath=true
         }else if((path in UIPLUGIN_PAGES)){
             addPath=true
@@ -112,7 +113,7 @@ class ControllerBaseInterceptor {
 
     boolean after() {
         if(!currentRequestAttributes().isRequestActive()) return true
-        if(InterceptorHelper.matchesStaticAssets(controllerName, request) || !model) return true
+        if(InterceptorHelper.matchesStaticAssets(controllerName, request) || !view) return true
         model.uiplugins = loadUiPlugins(controllerName + "/" + actionName)
         model.uipluginsorder = sortUiPlugins(model.uiplugins)
         model.uipluginsPath = controllerName + "/" + actionName


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
- Enabling ui plugins on all pages by default
- fixing an issue that produces the following pages were not considerate for loading UI plugins:  Key Storage , Log Storage , Password Utility , User Summary

**Describe the solution you've implemented**
by default, all pages loads UI plugins
