### PR TITLE
Adding a flag on the Render Formatted Data filter to add table-striped style

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/RenderDatatypeFilterPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/RenderDatatypeFilterPlugin.groovy
@@ -123,6 +123,14 @@ class RenderDatatypeFilterPlugin implements LogFilterPlugin {
     )
     @SelectLabels(values = ['JSON', 'Java Properties', 'CSV', 'HTML', 'Markdown'])
     String datatype = null
+
+    @PluginProperty(
+            title = "Table striped",
+            description = '''Display the rows striped.''',
+            required = false
+    )
+    boolean striped = false
+
     private StringBuilder buffer;
 
     @Override
@@ -170,12 +178,19 @@ class RenderDatatypeFilterPlugin implements LogFilterPlugin {
             if (buffer.length() > 0) {
                 buffer.append("\n")
             }
+
+            def meta = [
+                    'content-data-type': SYNONYMS[datatype.toLowerCase()] ?: datatype
+            ]
+
+            if(striped){
+                meta << ['content-meta:css-class' : 'table-striped']
+            }
+
             context.log(
                     2,
                     buffer.toString(),
-                    [
-                            'content-data-type': SYNONYMS[datatype.toLowerCase()] ?: datatype
-                    ]
+                    meta
             )
         }
         buffer = new StringBuilder()


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
enhancement
Adding a flag on the Render Formatted Data filter to display the table with table-striped style
 (zebra-striping to any table row)

**Describe the solution you've implemented**
passing extra CSS metadata to the HTMLTableViewConverter Plugin 

**Additional context**
<img width="621" alt="Screenshot 2019-03-20 14 55 03" src="https://user-images.githubusercontent.com/6034968/54708242-bb4e8500-4b21-11e9-8cc9-f61062741cd6.png">
<img width="1126" alt="Screenshot 2019-03-20 14 54 54" src="https://user-images.githubusercontent.com/6034968/54708247-bee20c00-4b21-11e9-9da5-fc48fec49610.png">
