### PR TITLE
Display label instead of name for remote options

### DIFF
--- a/rundeckapp/grails-app/views/framework/_jobOptionsKO.gsp
+++ b/rundeckapp/grails-app/views/framework/_jobOptionsKO.gsp
@@ -116,7 +116,7 @@ data for configuring remote option cascading/dependencies
                         <span class="remotestatus"
                               data-bind=" css: {ok: !remoteError() && remoteValues().length>0 && remoteValues, error: remoteError()}">
                         </span>
-                        <span data-bind="text: name"></span>
+                        <span data-bind="text: label"></span>
                     </span>
                     <span data-bind="if: !hasRemote()">
                         <span data-bind="text: label"></span>


### PR DESCRIPTION
Fixes #3951 

I'm pretty sure that we always want to display the label onscreen instead of `name`. `label` falls back to `name` anyway if unset.
