### PR TITLE
Stop holding DB connections during job execution

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3506,7 +3506,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         long startTime = System.currentTimeMillis()
 
         def wresult = metricService.withTimer(this.class.name, 'runJobReference') {
-            println("Made it!!!!")
             WorkflowExecutionService wservice = executionContext.getFramework().getWorkflowExecutionService()
 
             def timeoutms = 1000 * timeout

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -4034,4 +4034,113 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
             }
         }
     }
+
+    def "notification invocation on job ref pass ScheduledExecution directly"(){
+        given:
+        def jobname = 'abc'
+        def group = 'path'
+        def project = 'AProject'
+        ScheduledExecution job = new ScheduledExecution(
+                jobName: jobname,
+                project: project,
+                groupPath: group,
+                description: 'a job',
+                argString: '-args b -args2 d',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec(
+                                [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
+                        )]
+                ),
+                retry: '1'
+        )
+        job.save()
+        Execution e1 = new Execution(
+                project: project,
+                user: 'bob',
+                dateStarted: new Date(),
+                dateEnded: new Date(),
+                status: 'successful'
+
+        )
+        e1.save() != null
+
+        def datacontext = [job:[execid:e1.id]]
+
+
+        def nodeSet = new NodeSetImpl()
+        def node1 = new NodeEntryImpl('node1')
+        nodeSet.putNode(node1)
+
+        service.fileUploadService = Mock(FileUploadService)
+        service.executionUtilService = Mock(ExecutionUtilService)
+        service.storageService = Mock(StorageService)
+        service.jobStateService = Mock(JobStateService)
+        service.frameworkService = Mock(FrameworkService) {
+            authorizeProjectJobAll(*_) >> true
+            filterAuthorizedNodes(_, _, _, _) >> { args ->
+                nodeSet
+            }
+        }
+
+
+
+        def origContext = Mock(StepExecutionContext){
+            getDataContext()>>datacontext
+            getStepNumber()>>1
+            getStepContext()>>[]
+            getNodes()>> nodeSet
+            getFramework() >> Mock(Framework)
+
+        }
+        JobRefCommand item = ExecutionItemFactory.createJobRef(
+                group+'/'+jobname,
+                ['args', 'args2'] as String[],
+                false,
+                null,
+                true,
+                '.*',
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                project,
+                false,
+                false,
+                null
+        )
+
+
+        service.notificationService = Mock(NotificationService)
+        def dispatcherResult = Mock(DispatcherResult)
+        def wresult = Mock(WorkflowExecutionResult){
+            isSuccess()>>success
+        }
+
+
+        service.metricService = Mock(MetricService){
+            withTimer(_,_,_)>>{classname, name,  closure ->
+                closure()
+                [result:wresult]
+            }
+        }
+
+        def createFailure = { FailureReason reason, String msg ->
+            return new StepExecutionResultImpl(null, reason, msg)
+        }
+        def createSuccess = {
+            return new StepExecutionResultImpl()
+        }
+        when:
+        service.runJobRefExecutionItem(origContext,item,createFailure,createSuccess)
+        then:
+        1 * service.notificationService.triggerJobNotification('start', job, _)
+        1 * service.notificationService.triggerJobNotification(trigger, job, _)
+        where:
+        success      | trigger
+        true         | 'success'
+        false        | 'failure'
+    }
 }


### PR DESCRIPTION
Fixes #4459 

This builds off the work @jtobard completed in #4641.

During testing against MySQL with low `wait_timeout` I was still getting errors about the underlying connection being dead after the job finishes. This was strange as I could not see a running transaction in `show engine innodb status`.

### Test Setup
**MySQL**
```
SET GLOBAL wait_timeout=15
```
**Rundeck**
```
dataSource.properties.validationInterval=5000
dataSource.properties.testOnBorrow=true
dataSource.properties.testWhileIdle=true
dataSource.properties.testOnReturn=true
dataSource.properties.timeBetweenEvictionRunsMillis=5000
```

### Test Results
Running `show full processlist` would display something like the following:
```
mysql> show full processlist;
+-----+---------+------------------+---------+---------+------+----------+-----------------------+
| Id  | User    | Host             | db      | Command | Time | State    | Info                  |
+-----+---------+------------------+---------+---------+------+----------+-----------------------+
|   2 | root    | localhost        | rundeck | Query   |    0 | starting | show full processlist |
| 203 | rundeck | 172.22.0.1:56492 | rundeck | Sleep   |    2 |          | NULL                  |
| 204 | rundeck | 172.22.0.1:45448 | rundeck | Sleep   |    2 |          | NULL                  |
| 205 | rundeck | 172.22.0.1:48274 | rundeck | Sleep   |    2 |          | NULL                  |
| 206 | rundeck | 172.22.0.1:51028 | rundeck | Sleep   |    2 |          | NULL                  |
| 207 | rundeck | 172.22.0.1:53740 | rundeck | Sleep   |    2 |          | NULL                  |
| 208 | rundeck | 172.22.0.1:56334 | rundeck | Sleep   |    2 |          | NULL                  |
| 209 | rundeck | 172.22.0.1:58902 | rundeck | Sleep   |    2 |          | NULL                  |
| 210 | rundeck | 172.22.0.1:33372 | rundeck | Sleep   |    2 |          | NULL                  |
| 211 | rundeck | 172.22.0.1:36322 | rundeck | Sleep   |    2 |          | NULL                  |
| 212 | rundeck | 172.22.0.1:38970 | rundeck | Sleep   |    0 |          | NULL                  |
+-----+---------+------------------+---------+---------+------+----------+-----------------------+
```
The sleep command time would go up to 5 or at most 10, then it would reset as the tomcat JDBC pool runs the validation query. This indicates all open connections are in the pool.

Running a 20 second sleep job ref I could see one connection would go past 10 seconds and right up until the job finishes. This indicated that the connection was checked out of the pool even though there was no command running on it.

### Root Cause
It turns out that the `ExecutionService` class is marked `@Transactional` causing every method to be implicitly wrapped in a transaction and thus Hibernate session. This includes `executeWorkflowStep` which is the entry-point from the `ExecutionServiceImpl`.  Because of this implicit transaction, a hibernate session was being kept open in the background while the step was executed.

### Solution
Logically `runJobRefExecutionItem` is multiple units of work that were all being wrapped up as one:
* [T]Validation and book keeping
* Execute the workflow
* [T]Validation and book keeping

By adding `@Transactional(propagation = Propagation.NOT_SUPPORTED)` to `executeWorkflowStep` we opt out of the implicit transaction. From there sessions are manually opened via `withTransaction`, variables definitions used in the closures hoisted, and some general teasing apart allows for the execution to proceed without holding a database connection open.

