### PR TITLE
Adds data-container = body to popover handler

### DIFF
--- a/rundeckapp/grails-app/views/framework/_nodesEmbedKO.gsp
+++ b/rundeckapp/grails-app/views/framework/_nodesEmbedKO.gsp
@@ -26,6 +26,7 @@
            class="col-sm-3 node_ident embedded_node"
            data-toggle="popover"
            data-placement="auto"
+           data-container="body"
            data-delay="{&quot;show&quot;:0,&quot;hide&quot;:200}"
            data-popover-template-class="popover-wide"
 


### PR DESCRIPTION
Popover needed to be assigned a container - in this case the body element - in order to handle proper z-index over other elements.