### PR TITLE
Adds check for disabled flag for Community News

### DIFF
--- a/rundeckapp/grails-app/views/common/_sidebar.gsp
+++ b/rundeckapp/grails-app/views/common/_sidebar.gsp
@@ -229,11 +229,20 @@
 <div id="sidebar-bottom" style="border-top: 1px solid #3c3c3c;">
   <div id="community-news-notification">
     <div class="sidebar-footer-line-item">
-      <g:link controller="communityNews" action="index">
-        <span id="community-news-notification-vue"></span>
-      </g:link>
+      <g:if test="${grailsApplication.config.rundeck.communityNews.disabled in [true,'true']}">
+        <a href="https://www.rundeck.com/community-updates" target="_blank">
+          <div>
+            <i class="far fa-newspaper" style="margin-right:5px;"></i>
+            <span>Community News</span>
+          </div>
+        </a>
+      </g:if>
+      <g:else>
+        <g:link controller="communityNews" action="index">
+          <span id="community-news-notification-vue"></span>
+        </g:link>
+      </g:else>
     </div>
-
   </div>
   <div id="version-notification-vue"></div>
   <div id="snapshot-version" class="snapshot-version">

--- a/rundeckapp/grails-app/views/layouts/base.gsp
+++ b/rundeckapp/grails-app/views/layouts/base.gsp
@@ -77,7 +77,9 @@
     <!-- VUE CSS MODULES -->
     <asset:stylesheet href="static/css/components/motd.css"/>
     <asset:stylesheet href="static/css/components/tour.css"/>
-    <asset:stylesheet href="static/css/components/community-news-notification.css"/>
+    <g:if test="${grailsApplication.config.rundeck.communityNews.disabled.isEmpty() ||!grailsApplication.config.rundeck.communityNews.disabled in [false,'false']}">
+      <asset:stylesheet href="static/css/components/community-news-notification.css"/>
+    </g:if>
     <!-- /VUE CSS MODULES -->
 
     <script language="javascript">
@@ -238,7 +240,10 @@ disable for now because profiler plugin is not compatible with grails 3.x
 <!-- VUE JS MODULES -->
 <asset:javascript src="static/components/motd.js"/>
 <asset:javascript src="static/components/tour.js"/>
-<asset:javascript src="static/components/community-news-notification.js"/>
+<g:if test="${grailsApplication.config.rundeck.communityNews.disabled.isEmpty() ||!grailsApplication.config.rundeck.communityNews.disabled in [false,'false']}">
+  <asset:javascript src="static/components/community-news-notification.js"/>
+</g:if>
+
 <!-- /VUE JS MODULES -->
 
 </body>


### PR DESCRIPTION
Adds config check to disable Community News. Link persists. If user clicks on Community News, new tab is opened and page navigates to rundeck.com/community-updates