### PR TITLE
Implement tini as pid 1 to reap processes

### DIFF
--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -1,4 +1,4 @@
-FROM rundeck/ubuntu-base@sha256:18c1cc7f9a50e4cbd651268eca4de659d0c522bdf12a1b2b0f67aabf9da8400b
+FROM rundeck/ubuntu-base@sha256:591a682e8028226e2eabff328c516189b39af85e1a5cb457f23a672cbc47982e
 
 COPY --chown=rundeck:rundeck .build .
 RUN java -jar rundeck.war --installonly
@@ -10,4 +10,4 @@ COPY --chown=rundeck:rundeck etc etc
 VOLUME ["/home/rundeck/server/data"]
 
 EXPOSE 4440
-ENTRYPOINT [ "docker-lib/entry.sh" ]
+ENTRYPOINT [ "/tini", "--", "docker-lib/entry.sh" ]

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -4,7 +4,7 @@ FROM golang
 
 RUN go get github.com/HeavyHorst/remco/cmd/remco
 RUN cd $GOPATH/src/github.com/HeavyHorst/remco && \
-    git checkout ec5c624a154f175f82f42eeda8e687d8915cfc35
+    git checkout 316b72d05ff25448ae66d0ecdbd6e3d9393a80e3
 RUN go install github.com/HeavyHorst/remco/cmd/remco
 
 # Build base container
@@ -24,6 +24,7 @@ RUN set -euxo pipefail \
     && sed -i -e 's#http://\(archive\|security\)#mirror://mirrors#' -e 's#/ubuntu/#/mirrors.txt#' /etc/apt/sources.list \
     && apt-get -y update && apt-get -y --no-install-recommends install \
         curl \
+        gnupg2 \
         ssh-client \
         sudo \
         openjdk-8-jdk-headless \
@@ -36,6 +37,14 @@ RUN set -euxo pipefail \
     && addgroup rundeck sudo \
     && echo | sudo -u rundeck ssh-keygen -N '' \
     && echo 'PATH=$PATH:$HOME/tools/bin' >> /home/rundeck/.bashrc
+
+# Add Tini
+ENV TINI_VERSION v0.18.0
+RUN wget -O /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
+    && wget -O /tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc \
+    && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+    && gpg --batch --verify /tini.asc /tini \
+    && chmod +x /tini
 
 COPY --from=0 /go/bin/remco /usr/local/bin/remco
 


### PR DESCRIPTION
Fixes #4402

* Adds [tini](https://github.com/krallin/tini) to the entrypoint to serve as pid 1
* Update [remco](https://github.com/HeavyHorst/remco) to latest release