### PR TITLE
Fix problem deleting SCM configured project.

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -685,7 +685,22 @@ class ScmService {
      * @return
      */
     def removePluginConfiguration(String integration, String project, String type) {
-        disablePlugin(integration, project, type)
+        def loaded
+        if (integration == EXPORT) {
+            loaded = loadedExportPlugins.remove(project)
+            loaded?.close()
+            def changeListener = loadedExportListeners.remove(project)
+            jobEventsService.removeListener(changeListener)
+            //clear cached rename/delete info
+            renamedJobsCache.remove(project)
+            deletedJobsCache.remove(project)
+        } else {
+            loaded = loadedImportPlugins.remove(project)
+            loaded?.close()
+            def changeListener = loadedImportListeners.remove(project)
+            jobEventsService.removeListener(changeListener)
+        }
+        loaded?.provider?.cleanup()
         pluginConfigService.removePluginConfiguration(project, pathForConfigFile(integration))
     }
     /**

--- a/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
@@ -169,13 +169,13 @@ class ScmServiceSpec extends Specification {
         when:
         service.removePluginConfiguration(integration, 'test1', null)
         then:
-        1 * service.pluginConfigService.loadScmConfig(
+        0 * service.pluginConfigService.loadScmConfig(
                 'test1',
                 "etc/scm-${integration}.properties",
                 'scm.' + integration
         ) >> config
-        1 * config.setEnabled(false)
-        1 * service.pluginConfigService.storeConfig(config, 'test1', "etc/scm-${integration}.properties")
+        0 * config.setEnabled(false)
+        0 * service.pluginConfigService.storeConfig(config, 'test1', "etc/scm-${integration}.properties")
         1 * service.jobEventsService.removeListener(_)
         1 * service.pluginConfigService.removePluginConfiguration('test1', "etc/scm-${integration}.properties")
 
@@ -208,10 +208,10 @@ class ScmServiceSpec extends Specification {
         ) >> config2
         config.getType()>>'scm.import'
         config2.getType()>>'scm.export'
-        1 * config.setEnabled(false)
-        1 * config2.setEnabled(false)
-        1 * service.pluginConfigService.storeConfig(config, 'test1', "etc/scm-import.properties")
-        1 * service.pluginConfigService.storeConfig(config2, 'test1', "etc/scm-export.properties")
+        0 * config.setEnabled(false)
+        0 * config2.setEnabled(false)
+        0 * service.pluginConfigService.storeConfig(config, 'test1', "etc/scm-import.properties")
+        0 * service.pluginConfigService.storeConfig(config2, 'test1', "etc/scm-export.properties")
         2 * service.jobEventsService.removeListener(_)
         1 * service.pluginConfigService.removePluginConfiguration('test1', "etc/scm-import.properties")
         1 * service.pluginConfigService.removePluginConfiguration('test1', "etc/scm-export.properties")


### PR DESCRIPTION
ScmService `removePluginConfiguration` doesn't overwrite the same file that erases immediately.
fix #4623