### PR TITLE
Retry Failed Nodes doesn't bring in failed nodes if Change the Target Nodes option was used

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2711,6 +2711,7 @@ class ScheduledExecutionController  extends ControllerBase{
             if (varfound) {
                 model.nodesetvariables = true
             }
+            def failedNodes = null
             if (params.retryFailedExecId) {
                 Execution e = Execution.get(params.retryFailedExecId)
                 if (e && e.scheduledExecution?.id == scheduledExecution.id) {
@@ -2719,6 +2720,13 @@ class ScheduledExecutionController  extends ControllerBase{
                         nset = ExecutionService.filtersAsNodeSet([filter: OptsUtil.join("name:", e.failedNodeList)])
                     }
                     model.nodesetvariables = false
+
+                    def failedSet = ExecutionService.filtersAsNodeSet([filter: OptsUtil.join("name:", e.failedNodeList)])
+                    failedNodes = frameworkService.filterAuthorizedNodes(
+                            scheduledExecution.project,
+                            new HashSet<String>(["read", "run"]),
+                            frameworkService.filterNodeSet(failedSet, scheduledExecution.project),
+                            authContext).nodes;
                 }
             }
             def nodes = frameworkService.filterAuthorizedNodes(
@@ -2738,6 +2746,18 @@ class ScheduledExecutionController  extends ControllerBase{
 
                 if(unselectedNodesFilter){
                     unselectedNodes = unselectedNodesFilter.nodes
+                }
+            }
+
+            if(failedNodes && failedNodes.size()>0){
+                //if failed nodes are not part of original node filter, it will be added
+                def failedNodeNotInNodes = failedNodes.findAll{ !nodes.contains( it ) }
+                if(failedNodeNotInNodes && failedNodeNotInNodes.size()>0){
+                    if(nodes){
+                        nodes.addAll(failedNodeNotInNodes)
+                    }else{
+                        nodes=failedNodeNotInNodes
+                    }
                 }
             }
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -29,6 +29,7 @@ import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.INodeEntry
+import com.dtolabs.rundeck.core.common.NodeSetImpl
 import com.dtolabs.rundeck.core.utils.NodeSet
 import com.dtolabs.rundeck.core.utils.OptsUtil
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
@@ -2753,11 +2754,12 @@ class ScheduledExecutionController  extends ControllerBase{
                 //if failed nodes are not part of original node filter, it will be added
                 def failedNodeNotInNodes = failedNodes.findAll{ !nodes.contains( it ) }
                 if(failedNodeNotInNodes && failedNodeNotInNodes.size()>0){
+                    def nodeImp = new NodeSetImpl()
                     if(nodes){
-                        nodes.addAll(failedNodeNotInNodes)
-                    }else{
-                        nodes=failedNodeNotInNodes
+                        nodeImp.putNodes(nodes)
                     }
+                    nodeImp.putNodes(failedNodeNotInNodes)
+                    nodes=nodeImp.getNodes()
                 }
             }
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -24,6 +24,7 @@ import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import com.dtolabs.rundeck.core.common.NodeSetImpl
 import com.dtolabs.rundeck.core.common.NodesSelector
 import com.dtolabs.rundeck.core.utils.NodeSet
+import com.dtolabs.rundeck.core.utils.OptsUtil
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import org.grails.plugins.codecs.URLCodec
@@ -1887,5 +1888,151 @@ class ScheduledExecutionControllerSpec extends Specification {
         null != model.selectedNodes
         expected.nodes*.nodename == model.selectedNodes
 
+    }
+
+    def "show job retry failed exec id empty filter"(){
+        given:
+
+        def se = new ScheduledExecution(
+                uuid: 'testUUID',
+                jobName: 'test1',
+                project: 'project1',
+                groupPath: 'testgroup',
+                doNodedispatch: true,
+                nodeFilterEditable: true,
+                filter:'',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [
+                                new CommandExec([
+                                        adhocRemoteString: 'test buddy',
+                                        argString: '-delay 12 -monkey cheese -particle'
+                                ])
+                        ]
+                )
+        ).save()
+        def exec = new Execution(
+                user: "testuser",
+                project: "project1",
+                loglevel: 'WARN',
+                status: 'FAILED',
+                doNodedispatch: true,
+                filter:'name: nodea',
+                succeededNodeList:'fwnode',
+                failedNodeList: 'nodec xyz,nodea',
+                workflow: new Workflow(commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]).save(),
+                scheduledExecution: se
+        ).save()
+
+
+        NodeSetImpl testNodeSetEmpty = new NodeSetImpl()
+        NodeSetImpl testNodeSetFailed = new NodeSetImpl()
+        testNodeSetFailed.putNode(new NodeEntryImpl("nodea"))
+        testNodeSetFailed.putNode(new NodeEntryImpl("nodec xyz"))
+
+        def failedSet = ExecutionService.filtersAsNodeSet([filter: OptsUtil.join("name:", exec.failedNodeList)])
+        def nset = ExecutionService.filtersAsNodeSet(se)
+
+        controller.frameworkService=Mock(FrameworkService){
+            authorizeProjectJobAny(_,_,_,_)>>true
+            filterAuthorizedNodes(_,_,_,_)>>{args-> args[2]}
+            filterNodeSet(nset,_)>>testNodeSetEmpty
+            filterNodeSet(failedSet,_)>>testNodeSetFailed
+            getRundeckFramework()>>Mock(Framework){
+                getFrameworkNodeName()>>'fwnode'
+            }
+        }
+        controller.scheduledExecutionService=Mock(ScheduledExecutionService){
+            getByIDorUUID(_)>>se
+        }
+        controller.notificationService=Mock(NotificationService)
+        controller.orchestratorPluginService=Mock(OrchestratorPluginService)
+        controller.pluginService = Mock(PluginService)
+        when:
+        request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
+
+        def model = controller.show()
+        then:
+        model != null
+        model.scheduledExecution != null
+        '' == model.nodefilter
+        false == model.nodesetvariables
+        'nodec xyz,nodea' == model.failedNodes
+        testNodeSetFailed.nodes.size() == model.nodes.size()
+    }
+
+    def "show job retry failed exec id when overwrite the filter"() {
+        given:
+
+        def se = new ScheduledExecution(
+                uuid: 'testUUID',
+                jobName: 'test1',
+                project: 'project1',
+                groupPath: 'testgroup',
+                doNodedispatch: true,
+                nodeFilterEditable: true,
+                filter: '.*',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [
+                                new CommandExec([
+                                        adhocRemoteString: 'test buddy',
+                                        argString        : '-delay 12 -monkey cheese -particle'
+                                ])
+                        ]
+                )
+        ).save()
+        def exec = new Execution(
+                user: "testuser",
+                project: "project1",
+                loglevel: 'WARN',
+                status: 'FAILED',
+                doNodedispatch: true,
+                filter: 'name: nodea',
+                succeededNodeList: 'fwnode',
+                failedNodeList: 'nodec xyz,nodea',
+                workflow: new Workflow(commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]).save(),
+                scheduledExecution: se
+        ).save()
+
+
+        NodeSetImpl testNodeSetFilter = new NodeSetImpl()
+        testNodeSetFilter.putNode(new NodeEntryImpl("node1"))
+        testNodeSetFilter.putNode(new NodeEntryImpl("node2"))
+        testNodeSetFilter.putNode(new NodeEntryImpl("node3"))
+        testNodeSetFilter.putNode(new NodeEntryImpl("node4"))
+
+        NodeSetImpl testNodeSetFailed = new NodeSetImpl()
+        testNodeSetFailed.putNode(new NodeEntryImpl("nodea"))
+        testNodeSetFailed.putNode(new NodeEntryImpl("nodec xyz"))
+
+        def failedSet = ExecutionService.filtersAsNodeSet([filter: OptsUtil.join("name:", exec.failedNodeList)])
+        def nset = ExecutionService.filtersAsNodeSet(se)
+
+        controller.frameworkService = Mock(FrameworkService) {
+            authorizeProjectJobAny(_, _, _, _) >> true
+            filterAuthorizedNodes(_, _, _, _) >> { args -> args[2] }
+            filterNodeSet(nset, _) >> testNodeSetFilter
+            filterNodeSet(failedSet, _) >> testNodeSetFailed
+            getRundeckFramework() >> Mock(Framework) {
+                getFrameworkNodeName() >> 'fwnode'
+            }
+        }
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService) {
+            getByIDorUUID(_) >> se
+        }
+        controller.notificationService = Mock(NotificationService)
+        controller.orchestratorPluginService = Mock(OrchestratorPluginService)
+        controller.pluginService = Mock(PluginService)
+        when:
+        request.parameters = [id: se.id.toString(), project: 'project1', retryFailedExecId: exec.id.toString()]
+
+        def model = controller.show()
+        then:
+        model != null
+        model.scheduledExecution != null
+        false == model.nodesetvariables
+        'nodec xyz,nodea' == model.failedNodes
+        model.nodes.size() == testNodeSetFailed.nodes.size() + testNodeSetFilter.nodes.size()
     }
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
fixing issue https://github.com/rundeck/rundeck/issues/4639

**Describe the solution you've implemented**
When failed set of nodes are not part original filter (for example when the original filter is overwritten), the failed nodes will be merged with the original node list filter result.

**Additional context**
<img width="1145" alt="Screenshot 2019-04-04 09 37 20" src="https://user-images.githubusercontent.com/6034968/55556180-52d4db80-56bd-11e9-98fb-c39bfb65e47c.png">
<img width="734" alt="Screenshot 2019-04-04 09 37 31" src="https://user-images.githubusercontent.com/6034968/55556181-52d4db80-56bd-11e9-98f1-6c83f64559be.png">
<img width="1007" alt="Screenshot 2019-04-04 09 37 46" src="https://user-images.githubusercontent.com/6034968/55556182-536d7200-56bd-11e9-9c01-4ac9d79abfa6.png">
