### PR TITLE
Flow Control fail flag right behavior

### DIFF
--- a/plugins/flow-control-plugin/build.gradle
+++ b/plugins/flow-control-plugin/build.gradle
@@ -21,6 +21,7 @@
 ext.pluginClassNames = 'org.rundeck.plugin.flowcontrol.FlowControlWorkflowStep'
 ext.pluginName = 'Flow Control'
 ext.pluginDescription = 'Control execution flow'
+apply plugin: "groovy"
 
 jar {
     manifest {
@@ -28,6 +29,12 @@ jar {
         attributes 'Rundeck-Plugin-Name': pluginName
         attributes 'Rundeck-Plugin-Description': pluginDescription
     }
+}
+dependencies{
+
+    testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
+    testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
+    testCompile "cglib:cglib-nodep:2.2.2"
 }
 
 task('createPom').doLast {

--- a/plugins/flow-control-plugin/src/main/java/org/rundeck/plugin/flowcontrol/FlowControlWorkflowStep.java
+++ b/plugins/flow-control-plugin/src/main/java/org/rundeck/plugin/flowcontrol/FlowControlWorkflowStep.java
@@ -63,7 +63,7 @@ public class FlowControlWorkflowStep implements StepPlugin {
             if (null != status) {
                 context.getFlowControl().Halt(status);
             } else {
-                context.getFlowControl().Halt(fail);
+                context.getFlowControl().Halt(!fail);
             }
         } else if (context.getFlowControl() != null) {
             context.getFlowControl().Continue();

--- a/plugins/flow-control-plugin/src/test/groovy/org/rundeck/plugin/flowcontrol/FlowControlWorkflowStepSpec.groovy
+++ b/plugins/flow-control-plugin/src/test/groovy/org/rundeck/plugin/flowcontrol/FlowControlWorkflowStepSpec.groovy
@@ -1,0 +1,48 @@
+package org.rundeck.plugin.flowcontrol
+
+import com.dtolabs.rundeck.core.execution.workflow.FlowControl
+import com.dtolabs.rundeck.plugins.PluginLogger
+import com.dtolabs.rundeck.plugins.step.PluginStepContext
+import spock.lang.Specification
+
+class FlowControlWorkflowStepSpec extends Specification{
+
+
+    def "correct halt function"() {
+        given:
+        def plugin = new FlowControlWorkflowStep()
+        plugin.halt = halt
+        plugin.fail = fail
+
+        def flowCtrl = Mock(FlowControl)
+
+
+        def context = Mock(PluginStepContext) {
+            getLogger() >> Mock(PluginLogger)
+            getFlowControl() >> flowCtrl
+        }
+
+
+        when:
+        plugin.executeStep(context, [:])
+
+        then:
+        if(halt) {
+            1 * flowCtrl.Halt(suceess)
+            0 * flowCtrl.Continue()
+        }else {
+            0 * flowCtrl.Halt(_)
+            1 * flowCtrl.Continue()
+
+        }
+        where:
+        halt    | fail          | suceess
+        true    | true          | false
+        true    | false         | true
+        false   | true          | _
+        false   | false         | _
+
+    }
+
+
+}


### PR DESCRIPTION
 `FlowControl.java` interface defines the Halt method:
`public void Halt(boolean success);`

Currently `FlowControlWorkflowStep` plugin passes `fail` boolean instead of success, to fix this the plugin should call `Halt(!fail)`.

Unit test added to ensure the correct use of `halt` and `fail` properties.