### PR TITLE
Add server.session.timeout to docker remco template

### DIFF
--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -5,6 +5,7 @@ rdeck.base=/home/rundeck
 #rss.enabled if set to true enables RSS feeds that are public (non-authenticated)
 rss.enabled=false
 server.address={{ getv("/rundeck/server/address", "0.0.0.0") }}
+server.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
 grails.serverURL={{ getv("/rundeck/grails/url", "http://127.0.0.1:4440") }}
 dataSource.dbCreate = {{ getv("/rundeck/database/create", "update") }}
 dataSource.url = {{ getv("/rundeck/database/url", "jdbc:h2:file:/home/rundeck/server/data/grailsdb;MVCC=true") }}

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -4,9 +4,13 @@ rdeck.base=/home/rundeck
 
 #rss.enabled if set to true enables RSS feeds that are public (non-authenticated)
 rss.enabled=false
+
+# Bind address and server URL
 server.address={{ getv("/rundeck/server/address", "0.0.0.0") }}
-server.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
 grails.serverURL={{ getv("/rundeck/grails/url", "http://127.0.0.1:4440") }}
+
+server.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
+
 dataSource.dbCreate = {{ getv("/rundeck/database/create", "update") }}
 dataSource.url = {{ getv("/rundeck/database/url", "jdbc:h2:file:/home/rundeck/server/data/grailsdb;MVCC=true") }}
 dataSource.username = {{ getv("/rundeck/database/username", "") }}


### PR DESCRIPTION
Setting server.session.timeout for the docker image doesn't work, because it's not included in the remco template. This PR resolves that.