### PR TITLE
new version of python winrm plugin

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -66,7 +66,7 @@ dependencies {
                 project(':plugins:upvar-plugin'),
                 "com.github.Batix:rundeck-ansible-plugin:2.5.0",
                 "com.github.rundeck-plugins:aws-s3-model-source:v1.0",
-                "com.github.rundeck-plugins:py-winrm-plugin:1.0.10",
+                "com.github.rundeck-plugins:py-winrm-plugin:2.0.1",
                 "com.github.rundeck-plugins:openssh-node-execution:1.0.3"
 
     spa project(path: ':rundeck:grails-spa', configuration: 'spa')


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
New version of python winrm plugin
https://github.com/rundeck-plugins/py-winrm-plugin/releases/tag/2.0.1

**Describe the solution you've implemented**

**Describe alternatives you've considered**

**Additional context**
- better debug log
- fix for https://github.com/rundeck-plugins/py-winrm-plugin/issues/24
- compatibility for python3
- compatibility to use the plugin on a windows box
- new flag to disable TLS1.2 protocol (to connect to windows 2008 servers)
