### PR TITLE
Use shared UI client to maintain synchronizer tokens

### DIFF
--- a/rundeckapp/grails-spa/src/pages/project-nodes-config/ProjectNodeSourcesConfig.vue
+++ b/rundeckapp/grails-spa/src/pages/project-nodes-config/ProjectNodeSourcesConfig.vue
@@ -30,16 +30,14 @@
 </template>
 <script lang="ts">
 
-import axios from 'axios'
 import Vue from 'vue'
 import {
     getRundeckContext,
     RundeckContext
 } from "@rundeck/ui-trellis"
 
-import {client} from '@rundeck/ui-trellis/src/modules/rundeckClient'
 import ProjectPluginConfig from './ProjectPluginConfig.vue'
-import {getProjectNodeSources,NodeSourceResources,NodeSource} from './nodeSourcesUtil'
+import {getProjectNodeSources,NodeSource} from './nodeSourcesUtil'
 
 export default Vue.extend({
   props:{

--- a/rundeckapp/grails-spa/src/pages/project-nodes-config/ProjectPluginConfig.vue
+++ b/rundeckapp/grails-spa/src/pages/project-nodes-config/ProjectPluginConfig.vue
@@ -132,10 +132,8 @@
 import axios from 'axios'
 import Vue from 'vue'
 import { Notification } from 'uiv'
-import Trellis, {
+import {
     getRundeckContext,
-    getSynchronizerToken,
-    RundeckBrowser,
     RundeckContext
 } from "@rundeck/ui-trellis"
 

--- a/rundeckapp/grails-spa/src/pages/project-nodes-config/ProjectPluginConfig.vue
+++ b/rundeckapp/grails-spa/src/pages/project-nodes-config/ProjectPluginConfig.vue
@@ -144,7 +144,6 @@ import PluginInfo from '@rundeck/ui-trellis/src/components/plugins/PluginInfo.vu
 import PluginConfig from '@rundeck/ui-trellis/src/components/plugins/pluginConfig.vue'
 import pluginService from '@rundeck/ui-trellis/src/modules/pluginService'
 import PluginValidation from '@rundeck/ui-trellis/src/interfaces/PluginValidation'
-import {client} from '@rundeck/ui-trellis/src/modules/rundeckClient'
 
 interface PluginConf{
   readonly type:string
@@ -317,7 +316,7 @@ export default Vue.extend({
       async saveProjectPluginConfig(project:string,configPrefix:string,serviceName:string,data:ProjectPluginConfigEntry[]){
         const serializedData=data.map(this.serializeConfigEntry)
 
-        const resp = await client.sendRequest({
+        const resp = await this.rundeckContext.rundeckClient.sendRequest({
           url: `/framework/saveProjectPluginsAjax`,
           method: 'POST',
           queryParameters: {

--- a/rundeckapp/grails-spa/src/pages/project-nodes-config/WriteableProjectNodeSources.vue
+++ b/rundeckapp/grails-spa/src/pages/project-nodes-config/WriteableProjectNodeSources.vue
@@ -38,15 +38,10 @@
   </div>
 </template>
 <script lang="ts">
-import axios from "axios"
 import Vue from "vue"
-import { getRundeckContext, RundeckContext } from "@rundeck/ui-trellis"
-
-import { client } from "@rundeck/ui-trellis/src/modules/rundeckClient"
 import PluginConfig from "@rundeck/ui-trellis/src/components/plugins/pluginConfig.vue"
 import {
   getProjectNodeSources,
-  NodeSourceResources,
   NodeSource
 } from "./nodeSourcesUtil"
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fixes client js error if multiple POST requests made using different Vue components