### PR TITLE
Update the way a plugin id is generated for java plugins.

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/JarPluginProviderLoader.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/JarPluginProviderLoader.java
@@ -273,7 +273,12 @@ public class JarPluginProviderLoader implements ProviderLoader,
         if (null == mainAttributes) {
             mainAttributes = getJarMainAttributes(pluginJar);
             String pluginName = mainAttributes.getValue(RUNDECK_PLUGIN_NAME);
-            if(pluginName == null) pluginName = pluginJar.getName();
+            if(pluginName == null) {
+                //Fallback to something that will rarely change
+                //This is not ideal, but old plugins do not always have a name
+                //set in the attributes
+                pluginName = mainAttributes.getValue(RUNDECK_PLUGIN_CLASSNAMES);
+            }
             pluginId = PluginUtils.generateShaIdFromName(pluginName);
         }
         return mainAttributes;


### PR DESCRIPTION
For java plugins that don't set a plugin name in the manifest attributes, fallback to generate the id off of the plugin class names attribute which is less likely to change than the jar file name.