### PR TITLE
File node source: clarify use of file extension for format

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/FileResourceModelSource.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/FileResourceModelSource.java
@@ -60,7 +60,7 @@ public class FileResourceModelSource extends BaseFileResourceModelSource impleme
                 .property(p -> p
                         .freeSelect(Configuration.FORMAT)
                         .title("Format")
-                        .description("Format of the file")
+                        .description("Format of the file. If unspecified, the format will be determined by the file extension.")
                         .values(formats)
                 )
                 .property(p -> p


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Update description for `format` property of File node source plugin, to clarify that the file extension will be used if the format is not specified.