### PR TITLE
Enhance ACL policies to enable access rules that apply to users not in a group or not by username.

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/AclRule.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/AclRule.java
@@ -57,4 +57,6 @@ public interface AclRule {
 //    }
 
     public Set<String> getDenyActions();
+
+    public boolean isBy();
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/AclRuleBuilder.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/AclRuleBuilder.java
@@ -134,6 +134,11 @@ public class AclRuleBuilder {
         return this;
     }
 
+    public AclRuleBuilder by(final boolean isBy){
+        aclRuleImpl.by=isBy;
+        return this;
+    }
+
     public AclRule build() {
         return new AclRuleImpl(aclRuleImpl);
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/AclRuleImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/AclRuleImpl.java
@@ -43,6 +43,7 @@ public class AclRuleImpl implements AclRule {
     Set<String> allowActions;
     EnvironmentalContext environment;
     Set<String> denyActions;
+    boolean by;
 
     AclRuleImpl() {
 
@@ -66,6 +67,7 @@ public class AclRuleImpl implements AclRule {
         allowActions = (prototype.getAllowActions());
         denyActions = (prototype.getDenyActions());
         environment = (prototype.getEnvironment());
+        by = (prototype.isBy());
     }
 
 
@@ -138,7 +140,7 @@ public class AclRuleImpl implements AclRule {
                (null!=equalsResource? ", resource=" + equalsResource : "") +
                (subsetMatch?" subset " :"") +
                (null!=subsetResource? ", resource=" + subsetResource : "") +
-               " for: {"+
+                (by?" for":" not-for")+": {"+
                (null!=username?" username='" + username + '\'':"") +
                (null!=group?" group='" + group + '\'':"") +
                "}" +
@@ -170,5 +172,10 @@ public class AclRuleImpl implements AclRule {
     @Override
     public Map<String, Object> getEqualsResource() {
         return equalsResource;
+    }
+
+    @Override
+    public boolean isBy(){
+        return by;
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
@@ -118,31 +118,55 @@ public class RuleEvaluator implements Authorization, AclRuleSetSource {
             return false;
         }
 
+        if(rule.isBy()) {
+            if (subject.getUsername() != null && rule.getUsername() != null) {
 
-        if (subject.getUsername() != null && rule.getUsername() != null) {
-
-            if (subject.getUsername().equals(rule.getUsername())
-                || matchesPattern(subject.getUsername(), rule.getUsername())
-                    ) {
-                return true;
-            } else if (rule.getUsername() != null) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug(rule.toString() + ": username not matched: " + rule.getUsername());
+                if (subject.getUsername().equals(rule.getUsername())
+                        || matchesPattern(subject.getUsername(), rule.getUsername())
+                        ) {
+                    return true;
+                } else if (rule.getUsername() != null) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug(rule.toString() + ": username not matched: " + rule.getUsername());
+                    }
                 }
             }
-        }
 
 
-        if (subject.getGroups().size() > 0) {
-            // no username matched, check groups.
-            if (subject.getGroups().contains(rule.getGroup())
-                || matchesAnyPatterns(subject.getGroups(), rule.getGroup())) {
-                return true;
-            } else if (subject.getGroups().size() > 0) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug(rule.toString() + ": group not matched: " + rule.getGroup());
+            if (subject.getGroups().size() > 0) {
+                // no username matched, check groups.
+                if (subject.getGroups().contains(rule.getGroup())
+                        || matchesAnyPatterns(subject.getGroups(), rule.getGroup())) {
+                    return true;
+                } else if (subject.getGroups().size() > 0) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug(rule.toString() + ": group not matched: " + rule.getGroup());
+                    }
                 }
             }
+        }else { //notBy acl
+            if (subject.getUsername() != null && rule.getUsername() != null) {
+                if (subject.getUsername().equals(rule.getUsername())
+                        || matchesPattern(subject.getUsername(), rule.getUsername())
+                        ) {
+                    return false;
+                } else if (rule.getUsername() != null) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug(rule.toString() + ": username not excluded: " + rule.getUsername());
+                    }
+                }
+            }
+            if (subject.getGroups().size() > 0) {
+                if (subject.getGroups().contains(rule.getGroup())
+                        || matchesAnyPatterns(subject.getGroups(), rule.getGroup())) {
+                    return false;
+                } else if (subject.getGroups().size() > 0) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug(rule.toString() + ": group not excluded: " + rule.getGroup());
+                    }
+                }
+            }
+            return true;
         }
         return false;
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/Policy.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/Policy.java
@@ -65,4 +65,6 @@ public interface Policy extends AclRuleSetSource {
      * @return description of the policy
      */
     String getDescription();
+
+    public boolean isBy();
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/YamlParsePolicy.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/YamlParsePolicy.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
  */
 public class YamlParsePolicy implements Policy {
     public static final String BY_SECTION = "by";
+    public static final String NOT_BY_SECTION = "notBy";
     public static final String USERNAME_KEY = "username";
     public static final String GROUP_KEY = "group";
     ACLPolicyDoc policyDoc;
@@ -148,8 +149,15 @@ public class YamlParsePolicy implements Policy {
 
     private void parseByClause() {
 
-        final Object u = policyDoc.getBy().getUsername();
-        final Object g = policyDoc.getBy().getGroup();
+        Object u = null;
+        Object g = null;
+        if(null != policyDoc.getBy()) {
+            u = policyDoc.getBy().getUsername();
+            g = policyDoc.getBy().getGroup();
+        }else if(null != policyDoc.getNotBy()){
+            u = policyDoc.getNotBy().getUsername();
+            g = policyDoc.getNotBy().getGroup();
+        }
 
         if (null != u) {
             if (u instanceof String) {
@@ -227,12 +235,14 @@ public class YamlParsePolicy implements Policy {
     }
 
     private void validate() {
-        if (null == policyDoc.getBy()) {
+        if (null == policyDoc.getBy() && null == policyDoc.getNotBy()) {
             throw new AclPolicySyntaxException(
-                    "Required 'by:' section was not present"
+                    "Required 'by:' or 'not-by:' section was not present"
             );
         }
-        if (null == policyDoc.getBy().getGroup() && null == policyDoc.getBy().getUsername()) {
+
+        if (null != policyDoc.getBy() &&
+                (null == policyDoc.getBy().getGroup() && null == policyDoc.getBy().getUsername())) {
 
             throw new AclPolicySyntaxException(
                     "Section '" + BY_SECTION +
@@ -242,6 +252,19 @@ public class YamlParsePolicy implements Policy {
                     ":' and/or '" +
                     USERNAME_KEY +
                     ":'"
+            );
+        }
+        if (null != policyDoc.getNotBy() &&
+                (null == policyDoc.getNotBy().getGroup() && null == policyDoc.getNotBy().getUsername())) {
+
+            throw new AclPolicySyntaxException(
+                    "Section '" + NOT_BY_SECTION +
+                            ":' is not valid: " +
+                            " it must contain '" +
+                            GROUP_KEY +
+                            ":' and/or '" +
+                            USERNAME_KEY +
+                            ":'"
             );
         }
         if (null == policyDoc.getFor()) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/YamlParsePolicy.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/YamlParsePolicy.java
@@ -52,6 +52,7 @@ public class YamlParsePolicy implements Policy {
     private Set<String> usernames = new HashSet<String>();
     private Set<String> groups = new HashSet<String>();
     private Set<AclRule> rules = new HashSet<>();
+    private boolean isBy;
 
     private YamlParsePolicy(
             final Set<Attribute> context,
@@ -133,6 +134,7 @@ public class YamlParsePolicy implements Policy {
     private void enumerateRules() {
         String description = policyDoc.getDescription();
         AclRuleBuilder envProto = AclRuleBuilder.builder()
+                                                .by(isBy)
                                                 .environment(environment.toBasic())
                                                 .description(description)
                                                 .sourceIdentity(sourceIdent);
@@ -152,9 +154,11 @@ public class YamlParsePolicy implements Policy {
         Object u = null;
         Object g = null;
         if(null != policyDoc.getBy()) {
+            this.isBy = true;
             u = policyDoc.getBy().getUsername();
             g = policyDoc.getBy().getGroup();
         }else if(null != policyDoc.getNotBy()){
+            this.isBy=false;
             u = policyDoc.getNotBy().getUsername();
             g = policyDoc.getNotBy().getGroup();
         }
@@ -237,7 +241,7 @@ public class YamlParsePolicy implements Policy {
     private void validate() {
         if (null == policyDoc.getBy() && null == policyDoc.getNotBy()) {
             throw new AclPolicySyntaxException(
-                    "Required 'by:' or 'not-by:' section was not present"
+                    "Required 'by:' or 'notBy:' section was not present"
             );
         }
 
@@ -494,6 +498,11 @@ public class YamlParsePolicy implements Policy {
     @Override
     public EnvironmentalContext getEnvironment() {
         return environment.toBasic();
+    }
+
+    @Override
+    public boolean isBy(){
+        return isBy;
     }
 
     static private class YamlEnvironmentalContext {

--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/YamlParsePolicy.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/YamlParsePolicy.java
@@ -295,6 +295,18 @@ public class YamlParsePolicy implements Policy {
                 validateRule(type, typeIndex, typeRule.getAllow(), "allow");
                 validateRule(type, typeIndex, typeRule.getDeny(), "deny");
 
+                if(policyDoc.getNotBy()!= null){
+                    //check not by using only deny
+                    if(typeRule.getAllow() != null){
+                        throw new AclPolicySyntaxException(
+                                String.format(
+                                        "Type rule 'for: { %s: [...] }' entry at index [%d] Using notBy Can't be of type 'allow:' only'deny:'",
+                                        type,
+                                        typeIndex
+                                )
+                        );
+                    }
+                }
                 if (typeRule.isEmpty()) {
                     throw new AclPolicySyntaxException(
                             String.format(

--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/yaml/model/ACLPolicyDoc.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/yaml/model/ACLPolicyDoc.java
@@ -424,7 +424,7 @@ public class ACLPolicyDoc {
                ", description='" + description + '\'' +
                ", for=" + forSection +
                ", by=" + by +
-               ", not-by=" + notBy +
+               ", notBy=" + notBy +
                ", id='" + id + '\'' +
                '}';
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/yaml/model/ACLPolicyDoc.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/yaml/model/ACLPolicyDoc.java
@@ -48,6 +48,14 @@ public class ACLPolicyDoc {
         this.by = by;
     }
 
+    public NotBy getNotBy(){
+        return notBy;
+    }
+
+    public void setNotBy(NotBy notBy){
+        this.notBy = notBy;
+    }
+
     public Map<String, List<TypeRule>> getFor() {
         return forSection;
     }
@@ -372,12 +380,41 @@ public class ACLPolicyDoc {
         }
     }
 
+    public static class NotBy {
+        private Object username;
+        private Object group;
+
+        public Object getUsername() {
+            return username;
+        }
+
+        public void setUsername(Object username) {
+            this.username = username;
+        }
+
+        public Object getGroup() {
+            return group;
+        }
+
+        public void setGroup(Object group) {
+            this.group = group;
+        }
+
+        @Override
+        public String toString() {
+            return "NotBy{" +
+                    "username=" + username +
+                    ", group=" + group +
+                    '}';
+        }
+    }
 
     private Context context;
     private String description;
     //    private For forSection;
     private Map<String, List<TypeRule>> forSection;
     private By by;
+    private NotBy notBy;
     private String id;
 
     @Override
@@ -387,6 +424,7 @@ public class ACLPolicyDoc {
                ", description='" + description + '\'' +
                ", for=" + forSection +
                ", by=" + by +
+               ", not-by=" + notBy +
                ", id='" + id + '\'' +
                '}';
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/yaml/model/YamlPolicyDocConstructor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/providers/yaml/model/YamlPolicyDocConstructor.java
@@ -79,7 +79,7 @@ public class YamlPolicyDocConstructor extends Constructor {
     }
 
     static Set<String> ALLOWED_POLICY_KEYS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            "by", "id", "for", "context", "description"
+            "by", "notBy","id", "for", "context", "description"
     )));
     static Set<String> ALLOWED_CONTEXT_KEYS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             "project","application"

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
@@ -156,6 +156,7 @@ class RuleEvaluatorSpec extends Specification {
                         group: 'admin',
                         allowActions: ['EXECUTE'] as Set,
                         denyActions: ['DELETE'] as Set,
+                        by: true,
                         environment: BasicEnvironmentalContext.staticContextFor("application", "rundeck")
                 ),
         ] as Set
@@ -691,6 +692,63 @@ class RuleEvaluatorSpec extends Specification {
         result!=null
     }
 
+    def "test allow using notBy group"(){
+        given:
+        Authorization eval = new RuleEvaluator(basicRulesNotBy())
+        when:
+        def result = eval.evaluate(
+                [
+                        type   : 'job',
+                        jobName: 'bob'
+                ],
+                basicSubject("bob","test","user"),
+                "EXECUTE",
+                EnvironmentalContext.RUNDECK_APP_ENV
+        )
+        then:
+        result!=null
+        result.isAuthorized()
+        "EXECUTE"==result.action
+    }
+
+    def "test allow using notBy username"(){
+        given:
+        Authorization eval = new RuleEvaluator(basicRulesNotByUsername())
+        when:
+        def result = eval.evaluate(
+                [
+                        type   : 'job',
+                        jobName: 'bob'
+                ],
+                basicSubject("admin","admin","user"),
+                "EXECUTE",
+                EnvironmentalContext.RUNDECK_APP_ENV
+        )
+        then:
+        result!=null
+        result.isAuthorized()
+        "EXECUTE"==result.action
+    }
+
+    def "test reject using notBy username"(){
+        given:
+        Authorization eval = new RuleEvaluator(basicRulesNotByUsername())
+        when:
+        def result = eval.evaluate(
+                [
+                        type   : 'job',
+                        jobName: 'bob'
+                ],
+                basicSubject("bob","admin","user"),
+                "EXECUTE",
+                EnvironmentalContext.RUNDECK_APP_ENV
+        )
+        then:
+        result!=null
+        !result.isAuthorized()
+        "EXECUTE"==result.action
+    }
+
     Subject basicSubject(final String user, final String... groups) {
         def subject = new Subject()
         subject.principals<< new Username(user)
@@ -715,6 +773,7 @@ class RuleEvaluatorSpec extends Specification {
                             group         : 'admin',
                             allowActions  : ['EXECUTE'] as Set,
                             denyActions   : ['DELETE'] as Set,
+                            by: true,
                             environment   : BasicEnvironmentalContext.staticContextFor("application", "rundeck")
                     ] + detail
             )
@@ -738,6 +797,7 @@ class RuleEvaluatorSpec extends Specification {
                                 group         : 'admin',
                                 allowActions  : ['EXECUTE'] as Set,
                                 denyActions   : ['DELETE'] as Set,
+                                by: true,
                                 environment   : BasicEnvironmentalContext.staticContextFor("application", "rundeck")
                         ] + detail
                 ),
@@ -761,6 +821,7 @@ class RuleEvaluatorSpec extends Specification {
                         group: 'admin',
                         allowActions: ['EXECUTE'] as Set,
                         denyActions: ['DELETE'] as Set,
+                        by: true,
                         environment: BasicEnvironmentalContext.staticContextFor("application", "rundeck")
                 ),
         ] as Set
@@ -782,6 +843,7 @@ class RuleEvaluatorSpec extends Specification {
                         group         : 'admin',
                         allowActions  : ['EXECUTE'] as Set,
                         denyActions   : ['DELETE'] as Set,
+                        by: true,
                         environment   : BasicEnvironmentalContext.patternContextFor("project",".*")
                 ),
         ] as Set
@@ -801,6 +863,7 @@ class RuleEvaluatorSpec extends Specification {
                 username: null,
                 group: 'admin',
                 allowActions: ['READ'] as Set,
+                by: true,
                 environment: BasicEnvironmentalContext.staticContextFor("application", "rundeck")
         ),
         ] as Set
@@ -821,10 +884,56 @@ class RuleEvaluatorSpec extends Specification {
                 username: null,
                 group: 'admin',
                 allowActions: ['DELETE'] as Set,
+                by: true,
                 environment: BasicEnvironmentalContext.staticContextFor("application", "rundeck")
         ),
         ] as Set
         new AclRuleSetImpl(basicRules().rules + rules)
+    }
+
+    AclRuleSet basicRulesNotBy() {
+        def rules = [
+                new Rule(
+                        sourceIdentity: "test1",
+                        description: "bob job allow exec, deny delete for admin group",
+                        equalsResource: [
+                                jobName: 'bob'
+                        ],
+                        resourceType: 'job',
+                        regexMatch: false,
+                        containsMatch: false,
+                        equalsMatch: true,
+                        username: null,
+                        group: 'admin',
+                        allowActions: ['EXECUTE'] as Set,
+                        denyActions: ['DELETE'] as Set,
+                        by: false,
+                        environment: BasicEnvironmentalContext.staticContextFor("application", "rundeck")
+                ),
+        ] as Set
+        new AclRuleSetImpl(rules)
+    }
+    AclRuleSet basicRulesNotByUsername() {
+        def rules = [
+                new Rule(
+                        sourceIdentity: "test1",
+                        description: "bob job allow exec, deny delete for admin group",
+                        equalsResource: [
+                                jobName: 'bob'
+                        ],
+                        resourceType: 'job',
+                        regexMatch: false,
+                        containsMatch: false,
+                        equalsMatch: true,
+                        username: 'bob',
+                        group: null,
+                        allowActions: ['EXECUTE'] as Set,
+                        denyActions: ['DELETE'] as Set,
+                        by: false,
+                        environment: BasicEnvironmentalContext.staticContextFor("application", "rundeck")
+                ),
+        ] as Set
+        new AclRuleSetImpl(rules)
     }
     static class Rule implements AclRule{
         String sourceIdentity;
@@ -852,5 +961,6 @@ class RuleEvaluatorSpec extends Specification {
         EnvironmentalContext environment;
 
         Set<String> denyActions;
+        boolean by;
     }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/authorization/providers/YamlProviderSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/authorization/providers/YamlProviderSpec.groovy
@@ -601,4 +601,49 @@ id: any string
         validation.errors.size()==0
     }
 
+
+    @Unroll
+    def "validate notBy is valid using deny"(){
+        when:
+        def validation = validationForString """
+context:
+    project: test
+notBy:
+    username: elf
+    group: jank
+for:
+    type:
+        - deny: '*'
+description: blah
+id: any string
+---
+""", new ValidationSet()
+
+        then:
+        validation.valid
+        validation.errors.size()==0
+    }
+
+    @Unroll
+    def "validate notBy is not valid using allow"(){
+        when:
+        def validation = validationForString """
+context:
+    project: test
+notBy:
+    username: elf
+    group: jank
+for:
+    type:
+        - allow: '*'
+description: blah
+id: any string
+---
+""", new ValidationSet()
+
+        then:
+        !validation.valid
+        validation.errors.size()==1
+        validation.errors['test1[1]']==["Type rule 'for: { type: [...] }' entry at index [1] Using notBy Can't be of type 'allow:' only'deny:'"]
+    }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/authorization/providers/YamlProviderSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/authorization/providers/YamlProviderSpec.groovy
@@ -205,7 +205,7 @@ for:
         then:
         !validation.valid
         validation.errors.size()==1
-        validation.errors['test1[1]'] == ['Required \'by:\' section was not present']
+        validation.errors['test1[1]'] == ['Required \'by:\' or \'notBy:\' section was not present']
     }
     def "validate no for"(){
         when:

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -1266,7 +1266,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             meta.count = policiesvalidation?.policies?.countPolicies()
             //
             meta.policies = policiesvalidation?.policies?.policies.collect(){
-                def by = 'by:'
+                def by = it.isBy()?'by:':'notBy:'
                 if(it.groups?.size()>0){
                     by = by+' group: '+it.groups.join(", ")
                 }


### PR DESCRIPTION
A new ACL policy that applies to all users who are not in the specified group or username (including regular expression).

The new syntax replaces `by:` for `notBy:`

<img width="783" alt="acl editor" src="https://user-images.githubusercontent.com/2894508/56971135-b1636d00-6b36-11e9-81cb-533a30e8eb9b.png">

<img width="865" alt="acl page" src="https://user-images.githubusercontent.com/2894508/56971157-bde7c580-6b36-11e9-9453-a0292bf008de.png">

As an example:
```
notBy:
  username: dev
description: run-job
for:
  job:
  - allow:
    - run
    equals:
      name: cleanTempFolders
context:
  project: example
```
Everyone that is not the user `dev` can run a job called `cleanTempFolders` in the project `example`

fix #3810
