### PR TITLE
Rename flag for execution xml for log storage

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
@@ -70,7 +70,7 @@ class ExecutionUtilService {
     def  finishExecutionLogging(Map execMap) {
         def ServiceThreadBase<WorkflowExecutionResult> thread = execMap.thread
         def ExecutionLogWriter loghandler = execMap.loghandler
-        def exportJobDef = grailsApplication.config?.rundeck?.backup?.jobs?.enabled in [true,'true']
+        def exportJobDef = grailsApplication.config?.rundeck?.execution?.logs?.fileStorage?.generateExecutionXml in [true,'true',null]
         if(exportJobDef){
             //creating xml file
             String parentFolder = loghandler.filepath.getParent()
@@ -337,7 +337,7 @@ class ExecutionUtilService {
     File getExecutionXmlFileForExecution(Execution execution, String path = null) {
         File executionXmlfile
         if(path){
-            executionXmlfile  = new File(path, "execution-${execution.id}.xml")
+            executionXmlfile  = new File(path, "${execution.id}.execution.xml")
         }else{
             executionXmlfile = File.createTempFile("execution-${execution.id}", ".xml")
         }
@@ -377,7 +377,7 @@ class ExecutionUtilService {
             map.outputfilepath = logfilepath
         }
         JobsXMLCodec.convertWorkflowMapForBuilder(map.workflow)
-        def exportJobDef = grailsApplication.config?.rundeck?.backup?.jobs?.enabled in [true,'true']
+        def exportJobDef = grailsApplication.config?.rundeck?.execution?.logs?.fileStorage?.generateExecutionXml in [true,'true', null]
         if(exportJobDef && exec.scheduledExecution){
             map.fullJob = JobsXMLCodec.convertJobMap(exec.scheduledExecution.toMap())
         }

--- a/rundeckapp/src/test/groovy/ProjectServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/ProjectServiceTests.groovy
@@ -955,7 +955,7 @@ class ProjectServiceTests  {
         svc.workflowService= workflowmock.proxyInstance()
 
         svc.executionUtilService = new ExecutionUtilService()
-        svc.executionUtilService.grailsApplication = [:]
+        svc.executionUtilService.grailsApplication =  [config:[rundeck:[execution:[logs:[fileStorage:[generateExecutionXml:false]]]]]]
         svc.exportExecution(zip,exec,outfilename)
         def str=outwriter.toString()
         assertEquals EXEC_XML_TEST6, str

--- a/rundeckapp/src/test/groovy/ProjectServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/ProjectServiceTests.groovy
@@ -1020,12 +1020,7 @@ class ProjectServiceTests  {
         svc.executionUtilService = new ExecutionUtilService()
 
 
-        def enabled = [enabled:'true']
-        def jobp = [jobs:enabled]
-        def backupp= [backup:jobp]
-        def rundeckp = [rundeck:backupp]
-
-        svc.executionUtilService.grailsApplication = [config:rundeckp]
+        svc.executionUtilService.grailsApplication = [:]
         svc.exportExecution(zip,exec,outfilename)
         def str=outwriter.toString()
         assertEquals EXEC_XML_TEST7, str

--- a/rundeckapp/src/test/groovy/rundeck/services/ExecutionUtilServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ExecutionUtilServiceTests.groovy
@@ -94,7 +94,7 @@ class ExecutionUtilServiceTests {
         }
         def loghandler=logcontrol.proxyInstance()
 
-        executionUtilService.grailsApplication = [:]
+        executionUtilService.grailsApplication =  [config:[rundeck:[execution:[logs:[fileStorage:[generateExecutionXml:false]]]]]]
         executionUtilService.sysThreadBoundOut=new MockForThreadOutputStream(null)
         executionUtilService.sysThreadBoundErr=new MockForThreadOutputStream(null)
 
@@ -164,7 +164,7 @@ class ExecutionUtilServiceTests {
         logcontrol.demand.close(1..1){->
         }
         def loghandler=logcontrol.proxyInstance()
-        executionUtilService.grailsApplication = [:]
+        executionUtilService.grailsApplication =  [config:[rundeck:[execution:[logs:[fileStorage:[generateExecutionXml:false]]]]]]
 
         executionUtilService.sysThreadBoundOut=new MockForThreadOutputStream(null)
         executionUtilService.sysThreadBoundErr=new MockForThreadOutputStream(null)
@@ -192,7 +192,7 @@ class ExecutionUtilServiceTests {
         logcontrol.demand.close(1..1){->
         }
         def loghandler=logcontrol.proxyInstance()
-        executionUtilService.grailsApplication = [:]
+        executionUtilService.grailsApplication =  [config:[rundeck:[execution:[logs:[fileStorage:[generateExecutionXml:false]]]]]]
         executionUtilService.sysThreadBoundOut=new MockForThreadOutputStream(null)
         executionUtilService.sysThreadBoundErr=new MockForThreadOutputStream(null)
 
@@ -219,7 +219,7 @@ class ExecutionUtilServiceTests {
         }
         logcontrol.demand.close(1..1){-> }
         def loghandler=logcontrol.proxyInstance()
-        executionUtilService.grailsApplication = [:]
+        executionUtilService.grailsApplication =  [config:[rundeck:[execution:[logs:[fileStorage:[generateExecutionXml:false]]]]]]
         executionUtilService.sysThreadBoundOut=new MockForThreadOutputStream(null)
         executionUtilService.sysThreadBoundErr=new MockForThreadOutputStream(null)
 


### PR DESCRIPTION
flag renamed to `rundeck.execution.logs.fileStorage.generateExecutionXml`. 
Execution file changed to `{id}.execution.xml`.
fix #4744