### PR TITLE
Working Search, DocsLink for Private Repos

### DIFF
--- a/rundeckapp/grails-spa/package-lock.json
+++ b/rundeckapp/grails-spa/package-lock.json
@@ -6140,7 +6140,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6161,12 +6162,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6181,17 +6184,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6308,7 +6314,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6320,6 +6327,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6334,6 +6342,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6341,12 +6350,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6365,6 +6376,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6445,7 +6457,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6457,6 +6470,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6542,7 +6556,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6578,6 +6593,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6597,6 +6613,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6640,12 +6657,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -15592,6 +15611,15 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-2.0.7.tgz",
       "integrity": "sha512-pvLc+H+x2prwBj/uSEIITyxjz/7ZUVVK8uYbrYMmhDvMXnzh9OvQvVEwcOSBQjsubd4Eq41/CSJaWzy4hemMNQ=="
+    },
+    "vue-fuse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vue-fuse/-/vue-fuse-2.0.2.tgz",
+      "integrity": "sha512-5oLkKy8NX9jX+s2FkkY+1cjATgNcEw/wSLEIhK/5iNAr0deBiSyd8Pu1xJJcZwBai6HEUTFbhqYilfeprQ7m1w==",
+      "requires": {
+        "fuse.js": "^3.2.0",
+        "vue": "^2.5.17"
+      }
     },
     "vue-hot-reload-api": {
       "version": "2.3.3",

--- a/rundeckapp/grails-spa/package.json
+++ b/rundeckapp/grails-spa/package.json
@@ -18,6 +18,7 @@
     "uiv": "^0.27.0",
     "vue": "2.5.17",
     "vue-cookies": "^1.5.6",
+    "vue-fuse": "^2.0.2",
     "vue-i18n": "^8.8.0",
     "vue-moment": "^4.0.0",
     "vue-property-decorator": "^7.3.0",

--- a/rundeckapp/grails-spa/src/pages/repository/PluginCard.vue
+++ b/rundeckapp/grails-spa/src/pages/repository/PluginCard.vue
@@ -36,7 +36,7 @@
               >
                 <i class="fas fa-file-alt"></i>
               </a>
-              <a v-if="result.docsLink" :href="docsLink" target="_blank">
+              <a v-if="result.docsLink" :href="result.docsLink" target="_blank">
                 <i class="fas fa-file-alt"></i>
               </a>
             </div>

--- a/rundeckapp/grails-spa/src/pages/repository/PluginCard.vue
+++ b/rundeckapp/grails-spa/src/pages/repository/PluginCard.vue
@@ -36,6 +36,9 @@
               >
                 <i class="fas fa-file-alt"></i>
               </a>
+              <a v-if="result.docsLink" :href="docsLink" target="_blank">
+                <i class="fas fa-file-alt"></i>
+              </a>
             </div>
           </div>
           <div class="col-xs-12 col-sm-6">

--- a/rundeckapp/grails-spa/src/pages/repository/Repository.vue
+++ b/rundeckapp/grails-spa/src/pages/repository/Repository.vue
@@ -10,8 +10,13 @@
       </a>
     </div>
     <div v-show="visible">
-      <div class="repo-meta">{{repo.results.length}} plugins in repo</div>
-      <div class="artifact-grid row row-flex row-flex-wrap">
+      <div class="repo-meta">
+        <span
+          v-if="type === 'search'"
+        >{{repo.results.length}} {{ repo.results.length | pluralize('plugin')}} found in this repo that match the search term</span>
+        <span v-else>{{repo.results.length}} {{ repo.results.length | pluralize('plugin')}} in repo</span>
+      </div>
+      <div class="artifact-grid row row-flex row-flex-wrap" :class="repo.repositoryName">
         <PluginCard
           :result="result"
           :repo="repo"
@@ -30,7 +35,7 @@ import { mapState } from "vuex";
 
 export default {
   name: "RepositoryRow",
-  props: ["repo"],
+  props: ["repo", "type"],
   components: {
     PluginCard
   },
@@ -55,6 +60,26 @@ export default {
 .repository {
   margin-top: 2em;
 }
+// .artifact-grid.official {
+//   min-height: 100px;
+//   max-height: 800px;
+//   overflow-y: hidden;
+//   &:after {
+//     position: absolute;
+//     z-index: 1;
+//     bottom: 0;
+//     left: 0;
+//     pointer-events: none;
+//     background-image: linear-gradient(
+//       to bottom,
+//       rgba(244, 243, 239, 0),
+//       #f4f3ef 90%
+//     );
+//     width: 100%;
+//     height: 4em;
+//   }
+// }
+
 .repo-header {
   background: #e5e2de;
   color: #5d5d5d;
@@ -69,23 +94,9 @@ export default {
   .visibility-toggle {
     line-height: 35px;
     display: inline-block;
-
-    // line-height: 35px;
-    // font-size: 1.2em;
-    // font-weight: bold;
-    // .fa-sort-up:after {
-    //   content: "Hide";
-    //   font-size: 12px;
-    // }
-    // .fa-sort-down:after {
-    //   content: "Show";
-    //   font-size: 12px;
-    // }
     i.fa-sort-up,
     i.fa-sort-down {
       line-height: inherit;
-      // margin-top: 5px;
-      // vertical-align: sub;
     }
     i.fa-sort-up {
       margin-top: 8px;

--- a/rundeckapp/grails-spa/src/pages/repository/main.js
+++ b/rundeckapp/grails-spa/src/pages/repository/main.js
@@ -3,15 +3,18 @@
 import Vue from 'vue'
 import Vue2Filters from 'vue2-filters'
 import VueCookies from 'vue-cookies'
-import App from './App'
 import VueScrollTo from 'vue-scrollto'
+import VueFuse from 'vue-fuse'
+
 import store from './store'
+import App from './App'
 
 Vue.config.productionTip = false
 
-Vue.use(Vue2Filters)
 Vue.use(VueCookies)
 Vue.use(VueScrollTo)
+Vue.use(VueFuse)
+Vue.use(Vue2Filters)
 
 /* eslint-disable no-new */
 new Vue({


### PR DESCRIPTION
* Adds the search feature to Repos. Current sensitivity set to .2 (0 to 1, 1 being least sensitive) as requested. Searches only "display" or "name" properties.
* Adds "docsLink" link to plugin card footer for Private Repos. "docsLink" must be present as a property for the private repo->plugin in order for this to display.