### PR TITLE
Docker add rundeck.api.tokens.duration.max to remco template

### DIFF
--- a/docker/official/README.md
+++ b/docker/official/README.md
@@ -87,6 +87,8 @@ See the [Docker Zoo Exhibit](https://github.com/rundeck/docker-zoo/tree/master/c
 
 ## Environment Variables
 
+Not all rundeck configuration listed in the official documentation is available for setup yet. Please take a look at the templates to see all available variables.
+
 ### `JVM_MAX_RAM_FRACTION=1`
 
 The JVM will use `1/x` of the max RAM for heap. For example, a setting of `2` will cause

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -35,6 +35,8 @@ rundeck.security.authorization.preauthenticated.userRolesHeader={{ getv("/rundec
 rundeck.security.authorization.preauthenticated.redirectLogout={{ getv("/rundeck/preauth/redirect/logout", "false") }}
 rundeck.security.authorization.preauthenticated.redirectUrl={{ getv("/rundeck/preauth/redirect/url", "/oauth2/sign_in") }}
 
+rundeck.api.tokens.duration.max={{ getv("/rundeck/api/tokens/duration/max", "30d") }}
+
 rundeck.log4j.config.file=/home/rundeck/server/config/log4j.properties
 
 rundeck.gui.startpage=projectHome


### PR DESCRIPTION
This PR makes it possible to set the value of rundeck.api.tokens.duration.max in rundeck-config.properties for the official docker image

Also I added a hint in the readme about the availability of configuration variables.