### PR TITLE
Fix #4703 node detail popup cannot be dismissed

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/application.js
+++ b/rundeckapp/grails-app/assets/javascripts/application.js
@@ -821,7 +821,9 @@ function _initPopoverContentRef(parent, options) {
     var opts = {
       html: true,
       content: function () {
-        return jQuery(ref).html();
+        const id = generateId()
+        const html = jQuery(ref).html()
+        return html.replace(/\$CREF\$/g, id)
       },
       trigger: jQuery(e).data('trigger') || options.trigger || 'click'
     };
@@ -834,8 +836,14 @@ function _initPopoverContentRef(parent, options) {
     }
     jQuery(e).popover(opts).on('shown.bs.popover', function () {
       jQuery(e).toggleClass('active');
+      if (typeof (options.onShown) === 'function') {
+        options.onShown(e)
+      }
     }).on('hidden.bs.popover', function () {
       jQuery(e).toggleClass('active');
+      if (typeof (options.onHidden) === 'function') {
+        options.onHidden(e)
+      }
     });
     jQuery(e).data('popover-content-ref-inited', 'true');
   });
@@ -1124,6 +1132,18 @@ function _initMarkdeep() {
       _applyMarkdeep(el);
     });
   }
+}
+
+function _initPopoverMousedownCatch (sel, allowed, callback) {
+  jQuery(sel || 'body').on('mousedown', function (e) {
+    if (jQuery(e.target).closest(allowed).length < 1) {
+
+      jQuery(sel || 'body').off('mousedown')
+      if (typeof (callback) === 'function') {
+        callback(e)
+      }
+    }
+  })
 }
 (function () {
   window.markdeepOptions = {

--- a/rundeckapp/grails-app/assets/javascripts/ko/handler-bootstrapPopover.js
+++ b/rundeckapp/grails-app/assets/javascripts/ko/handler-bootstrapPopover.js
@@ -25,7 +25,14 @@
 ko.bindingHandlers.bootstrapPopover = {
     init: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
         if(allBindings.get('bootstrapPopoverContentRef')){
-            _initPopoverContentRef(null,{element:element,contentRef:ko.unwrap(allBindings.get('bootstrapPopoverContentRef'))});
+            _initPopoverContentRef(null,{element:element,contentRef:ko.unwrap(allBindings.get('bootstrapPopoverContentRef')),
+                onShown:function(){_initPopoverMousedownCatch('body','._mousedown_popup_allowed',function (e) {
+                    jQuery(element).popover("hide")
+                })}}
+                );
+            ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
+                jQuery(element).popover("destroy")
+            })
         }else if (allBindings.get('bootstrapPopoverContentFor')) {
             _initPopoverContentFor(null,{element:element,target:ko.unwrap(allBindings.get('bootstrapPopoverContentFor'))});
         }

--- a/rundeckapp/grails-app/views/framework/_nodeDetailsSimpleKO.gsp
+++ b/rundeckapp/grails-app/views/framework/_nodeDetailsSimpleKO.gsp
@@ -173,7 +173,7 @@
       <tr class="">
           <td class="key namespace">
               <a href="#"
-                 data-bind="attr: { href: '#ns_'+$index()+'_'+$parentContext.$index()}"
+                 data-bind="attr: { href: '#ns_${crefText}_'+$index()+'_'+$parentContext.$index()}"
                   data-toggle="collapse"
                     class="textbtn textbtn-muted textbtn-saturated ">
                   <span data-bind="text: namespace.ns"></span>
@@ -184,7 +184,7 @@
               <span data-bind="text: namespace.values.size()"></span>
           </td>
       </tr>
-          <tbody class="subattrs collapse collapse-expandable" data-bind="attr: {id: 'ns_'+$index()+'_'+$parentContext.$index()}" >
+          <tbody class="subattrs collapse collapse-expandable" data-bind="attr: {id: 'ns_${crefText}_'+$index()+'_'+$parentContext.$index()}" >
           <!-- ko foreach: { data: $data.values , as: 'nsattr' } -->
                 <tr  class="hover-action-holder">
 

--- a/rundeckapp/grails-app/views/framework/_nodesEmbedKO.gsp
+++ b/rundeckapp/grails-app/views/framework/_nodesEmbedKO.gsp
@@ -18,13 +18,13 @@
 <g:set var="xkey" value="${g.rkey()}"/>
 <div  class="nodes-embed ansicolor-on matchednodes embed embed_clean" data-bind="">
     <div data-bind="foreach: {data: nodeSet().nodes, 'as': 'node'} ">
-        <!-- tabindex="0"
-           data-trigger="focus"
-            role="button"
-      -->
         <a
            class="col-sm-3 node_ident embedded_node"
            data-toggle="popover"
+           tabindex="0"
+           role="button"
+           data-trigger="click"
+           data-viewport="#main-panel"
            data-placement="auto"
            data-container="body"
            data-delay="{&quot;show&quot;:0,&quot;hide&quot;:200}"
@@ -63,22 +63,23 @@
              style="display:none;"
              class="detailpopup node_entry tooltipcontent node_filter_link_holder"
              data-node-filter-link-id="${enc(attr: nodefilterLinkId ?: '')}">
+            <div class="_mousedown_popup_allowed">
+                <span>
+                    <i class="fas fa-hdd"></i>
+                    <span data-bind="text: nodename"></span>
+                </span>
 
-            <span>
-                <i class="fas fa-hdd"></i>
-                <span data-bind="text: nodename"></span>
-            </span>
+                <node-filter-link params="
+                    filterkey: 'name',
+                    filterval: nodename,
+                    linkicon: 'glyphicon glyphicon-circle-arrow-right'
+                    "></node-filter-link>
 
-            <node-filter-link params="
-                filterkey: 'name',
-                filterval: nodename,
-                linkicon: 'glyphicon glyphicon-circle-arrow-right'
-                "></node-filter-link>
+                <span class="nodedesc"></span>
 
-            <span class="nodedesc"></span>
-
-            <div class="nodedetail" style="overflow-x: scroll;">
-                <g:render template="/framework/nodeDetailsSimpleKO" model="[useNamespace:true]"/>
+                <div class="nodedetail" style="overflow-x: scroll;">
+                    <g:render template="/framework/nodeDetailsSimpleKO" model="[useNamespace: true, crefText:'$CREF$']"/>
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
* add knockout dom disposal callback
* constrain popup viewport to main-panel
* add mousedown handler to close popup for event outside of popup
* create unique id for interactive elements in referenced html content when copied to popup


**Is this a bugfix, or an enhancement? Please describe.**

Fix #4703 
