### PR TITLE
Use packaging project for deb and rpm builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,16 +86,16 @@ jobs:
     - script_block 'sync-artifacts' fetch_common_artifacts
     - script_block 'api-test' 'bash test/run-docker-tomcat-tests.sh 7-jre8'
 
-  - stage: test
-    env: JOB='Test deb install'
-    script:
-    - script_block 'sync-artifacts' fetch_common_artifacts
-    - script_block 'deb-test' 'bash test/test-docker-install-deb.sh'
+  # - stage: test
+  #   env: JOB='Test deb install'
+  #   script:
+  #   - script_block 'sync-artifacts' fetch_common_artifacts
+  #   - script_block 'deb-test' 'bash test/test-docker-install-deb.sh'
   
-  - env: JOB='Test rpm install'
-    script:
-    - script_block 'sync-artifacts' fetch_common_artifacts
-    - script_block 'rpm-test' 'bash test/test-docker-install-rpm.sh'
+  # - env: JOB='Test rpm install'
+  #   script:
+  #   - script_block 'sync-artifacts' fetch_common_artifacts
+  #   - script_block 'rpm-test' 'bash test/test-docker-install-rpm.sh'
 
   - env: JOB='Docker tests'
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,12 +147,12 @@ jobs:
     - script_block 'sync.commit' sync_commit_to_s3
     - export VCS_URL=https://github.com/rundeck/rundeck.git
     # Delete existing packages
-    - script_block 'delete.deb' 'bash scripts/delete-bintray-package.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck  dev-deb rundeck'
-    - script_block 'delete.rpm-rundeck' 'bash scripts/delete-bintray-package.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck dev-rpm rundeck'
+    # - script_block 'delete.deb' 'bash scripts/delete-bintray-package.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck  dev-deb rundeck'
+    # - script_block 'delete.rpm-rundeck' 'bash scripts/delete-bintray-package.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck dev-rpm rundeck'
     - script_block 'delete.mavan-rpm-config' 'bash scripts/delete-bintray-package.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck dev-rpm rundeck-config'
     # Deploy new snapshot packages
-    - script_block 'publish.deb' 'bash scripts/deploy-deb-snapshots.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck dev-deb'
-    - script_block 'publish.rpm' 'bash scripts/deploy-rpm-snapshots.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck dev-rpm'
+    # - script_block 'publish.deb' 'bash scripts/deploy-deb-snapshots.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck dev-deb'
+    # - script_block 'publish.rpm' 'bash scripts/deploy-rpm-snapshots.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck dev-rpm'
     - script_block 'publish.maven' 'bash scripts/deploy-maven-snapshots.sh "${BINTRAY_USER}" "${BINTRAY_API_KEY}" rundeck dev-maven "${RUNDECK_BUILD_NUMBER}"'
     # Seal artifacts
     - script_block 'seal-artifacts' seal_artifacts

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -20,13 +20,13 @@ main() {
 build() {
     ./gradlew -Penvironment="${ENV}" -x check install
     groovy testbuild.groovy --buildType="${ENV}"
-    make ENV="${ENV}" rpm deb
+    # make ENV="${ENV}" rpm deb
 }
 
 buildFork() {
     ./gradlew -Penvironment="${ENV}" install
     groovy testbuild.groovy --buildType="${ENV}"
-    make ENV="${ENV}" rpm deb
+    # make ENV="${ENV}" rpm deb
 }
 
 buildDocker() {

--- a/scripts/travis-helpers.sh
+++ b/scripts/travis-helpers.sh
@@ -125,7 +125,7 @@ sync_commit_to_s3() {
 copy_artifacts() {
     if [[ ! -d artifacts ]]; then mkdir artifacts; fi
     (
-        find ./packaging -regex '.*\.\(deb\|rpm\)' -exec cp --parents {} artifacts \;
+        # find ./packaging -regex '.*\.\(deb\|rpm\)' -exec cp --parents {} artifacts \;
         cp -r --parents core/build/libs artifacts/
         cp -r --parents core/build/poms artifacts/
         cp -r --parents rundeckapp/**/build/libs artifacts/
@@ -180,6 +180,7 @@ trigger_travis_build() {
             "config": {
                 "merge_mode": "deep_merge",
                 "env": { "global": {
+                    "DRY_RUN": "false",
                     "UPSTREAM_PROJECT": "rundeck",
                     "UPSTREAM_BUILD_NUMBER": "${RUNDECK_BUILD_NUMBER}",
                     "UPSTREAM_BRANCH": "${RUNDECK_BRANCH}",


### PR DESCRIPTION
Disables rpm and deb building/publishing in favor of the `packaging-core` project build.