### PR TITLE
[Docker] Add template option for setting contextPath

### DIFF
--- a/docker/official/README.md
+++ b/docker/official/README.md
@@ -103,6 +103,11 @@ to a default for getting started, this should be set manually for more advanced 
 Controls the base URL the app will use for links, redirects, etc.
 This is the URL users will use to access the site.
 
+### `RUNDECK_SERVER_CONTEXTPATH=/`
+
+Set to path Rundeck is running under(i.e. `http://localhost/rundeck`). Useful if running Rundeck
+behind a reverse proxy under a path on the hostname.
+
 ### `RUNDECK_GRAILS_UPLOAD_MAXSIZE`
 
 Controls both the `maxFileSize` and `maxRequest` for the grails controller config.

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -7,6 +7,7 @@ rss.enabled=false
 
 # Bind address and server URL
 server.address={{ getv("/rundeck/server/address", "0.0.0.0") }}
+server.contextPath={{ getv("/rundeck/server/contextpath", "/") }}
 grails.serverURL={{ getv("/rundeck/grails/url", "http://127.0.0.1:4440") }}
 
 server.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}


### PR DESCRIPTION
Fixes #4774

Adds the ability to set the context path through the environment variable `RUNDECK_SERVER_CONTEXTPATH`.