### PR TITLE
Adjusting Welcome Page for PT_BR locale

### DIFF
--- a/rundeckapp/grails-app/i18n/messages_pt_BR.properties
+++ b/rundeckapp/grails-app/i18n/messages_pt_BR.properties
@@ -1375,22 +1375,22 @@ page.home.search.project.title={0} Projeto encontrado
 page.home.search.projects.input.placeholder=Busca de projeto: nome, label ou /regex/
 create.job.button.label=Criar job
 
-app.firstRun.md=! [image] (https://media.rundeck.org/images/app-logo-small.png?t=oss&v={{app/ident}})\n\
-        \n\
-        Obtenha seus [autocolantes gratuitos do Rundeck] (https://www.rundeck.com/free-stuff).\n\
-        \n\
-        Para ajuda, consulte os links abaixo ou clique em "ajuda" na parte superior da p\u00e1gina.\n\
-        \n\
-        <table class="table-condensed table">\n\
-        <tr>\n\
-        <td><a href="{{help/docs}}">Documenta\u00e7\u00e3o &raquo;</a></td>\n\
-        <td><a href="http://groups.google.com/group/rundeck-discuss"> Lista de e-mail & raquo; </a> </ td>\n\
-        </tr>\n\
-        <tr>\n\
-        <td><a href="http://webchat.freenode.net/?nick=rundeckuser.&channels=rundeck&prompt=1">Canal de IRC &raquo</a></td>\n\
-        <td><a href="https://github.com/rundeck/rundeck/issues">Relat\u00f3rio de problemas &raquo;</a></td>\n\
-        </tr>\n\
-        </table>\n
+app.firstRun.md=![image](https://media.rundeck.org/images/app-logo-small.png?t=oss&v={{app/ident}})\n\
+  \n\
+  Receba [adesivos do Rundeck gratuitamente](https://www.rundeck.com/free-stuff).\n\
+  \n\
+  Para ajuda, consulte os links abaixo ou clique em "ajuda" na parte superior da p\u00e1gina.\n\
+  \n\
+  <table class="table table-condensed">\n\
+  <tr>\n\
+  <td><a href="{{help/docs}}">Documenta\u00e7\u00e3o &raquo;</a></td>\n\
+  <td><a href="http://groups.google.com/group/rundeck-discuss">Lista de e-mail &raquo;</a></td>\n\
+  </tr>\n\
+  <tr>\n\
+  <td><a href="http://webchat.freenode.net/?nick=rundeckuser.&channels=rundeck&prompt=1">Canal de IRC &raquo</a></td>\n\
+  <td><a href="https://github.com/rundeck/rundeck/issues">Relat\u00f3rio de problemas &raquo;</a></td>\n\
+  </tr>\n\
+  </table>\n
 
 app.firstRun.title=Bem-vindo a {0} {1}
 welcome.button.use.rundeck=Use o Rundeck &raquo;


### PR DESCRIPTION
The Welcome Page is not showing correctly when using Brazilian Portuguese locale.
Apparently something messed with markdown formatting (I also adjusted spaces and identation to match english locale).

This is how the Welcome Page currently looks while using Brazilian Portuguese locale:

![image](https://user-images.githubusercontent.com/976809/58440267-4498af80-80af-11e9-836b-f3e215a5d284.png)
