### PR TITLE
Allow control of property variable blank substitution

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/StepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/StepPluginAdapter.java
@@ -40,6 +40,7 @@ import org.rundeck.app.spi.Services;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -93,6 +94,13 @@ class StepPluginAdapter implements StepExecutor, Describable, DynamicProperties{
                                                    final StepExecutionItem item) throws StepException
         {
         Map<String, Object> instanceConfiguration = getStepConfiguration(item);
+            Description description = getDescription();
+            Map<String,Boolean> blankIfUnexMap = new HashMap<>();
+            if(description != null) {
+                description.getProperties().forEach(p -> {
+                    blankIfUnexMap.put(p.getName(), p.isBlankIfUnexpandable());
+                });
+            }
         if (null != instanceConfiguration) {
             instanceConfiguration = SharedDataContextUtils.replaceDataReferences(
                     instanceConfiguration,
@@ -101,7 +109,7 @@ class StepPluginAdapter implements StepExecutor, Describable, DynamicProperties{
                     null,
                     executionContext.getSharedDataContext(),
                     false,
-                    true
+                    blankIfUnexMap
             );
         }
         final String providerName = item.getType();
@@ -111,7 +119,7 @@ class StepPluginAdapter implements StepExecutor, Describable, DynamicProperties{
                 providerName
         );
         final PluginStepContext stepContext = PluginStepContextImpl.from(executionContext);
-        final Map<String, Object> config = PluginAdapterUtility.configureProperties(resolver, getDescription(),
+        final Map<String, Object> config = PluginAdapterUtility.configureProperties(resolver, description,
                 plugin, PropertyScope.InstanceOnly);
         try {
             plugin.executeStep(stepContext, config);

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtility.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtility.java
@@ -248,6 +248,8 @@ public class PluginAdapterUtility {
 
             pbuild.renderingOption(StringRenderingConstants.DISPLAY_TYPE_KEY, renderBehaviour);
 
+            ReplaceDataVariablesWithBlanks blankReplaceAnnotation = field.getAnnotation(ReplaceDataVariablesWithBlanks.class);
+            if(blankReplaceAnnotation != null) pbuild.blankIfUnexpandable(blankReplaceAnnotation.value());
 
             for (RenderingOption renderingOption : field.getAnnotationsByType(RenderingOption.class)) {
                 pbuild.renderingOption(renderingOption.key(), renderingOption.value());

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/Property.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/Property.java
@@ -121,4 +121,10 @@ public interface Property {
      * @return a map of optional rendering options for the UI
      */
     public Map<String, Object> getRenderingOptions();
+
+    /**
+     * @return if true, variable that cannot be expanded will be replaced by a blank string
+     * otherwise unexpanded variables will be left as is
+     */
+    public default boolean isBlankIfUnexpandable() { return true; }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PropertyBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PropertyBase.java
@@ -42,6 +42,7 @@ abstract class PropertyBase implements Property {
     private final PropertyValidator validator;
     private final PropertyScope scope;
     private final Map<String, Object> renderingOptions;
+    private final boolean blankIfUnexpanded;
 
     public PropertyBase(final String name, final String title, final String description, final boolean required,
                         final String defaultValue, final PropertyValidator validator) {
@@ -57,6 +58,13 @@ abstract class PropertyBase implements Property {
     public PropertyBase(final String name, final String title, final String description, final boolean required,
                         final String defaultValue, final PropertyValidator validator, final PropertyScope scope,
                         final Map<String, Object> renderingOptions) {
+        this(name, title, description, required, defaultValue, validator, scope, renderingOptions == null ? Collections.<String, Object> emptyMap() : Collections
+                .unmodifiableMap(renderingOptions),true);
+    }
+
+    public PropertyBase(final String name, final String title, final String description, final boolean required,
+                        final String defaultValue, final PropertyValidator validator, final PropertyScope scope,
+                        final Map<String, Object> renderingOptions, final boolean blankIfUnexpanded) {
         this.title = title;
         this.name = name;
         this.description = description;
@@ -66,6 +74,7 @@ abstract class PropertyBase implements Property {
         this.scope = scope;
         this.renderingOptions = renderingOptions == null ? Collections.<String, Object> emptyMap() : Collections
                 .unmodifiableMap(renderingOptions);
+        this.blankIfUnexpanded = blankIfUnexpanded;
     }
 
     public String getTitle() {
@@ -112,6 +121,11 @@ abstract class PropertyBase implements Property {
     }
 
     @Override
+    public boolean isBlankIfUnexpandable() {
+        return blankIfUnexpanded;
+    }
+
+    @Override
     public String toString() {
         return "PropertyBase{" +
                "name='" + name + '\'' +
@@ -122,6 +136,7 @@ abstract class PropertyBase implements Property {
                (validator != null ? ", validator=" + validator : "") +
                (scope != null ? ", scope=" + scope : "") +
                (renderingOptions != null ? ", renderingOptions=" + renderingOptions : "") +
+               ", blankIfUnexpanded="+blankIfUnexpanded+
                '}';
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PropertyUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PropertyUtil.java
@@ -168,6 +168,49 @@ public class PropertyUtil {
                                    final Map<String, Object> renderingOptions,
                                    final boolean dynamicValues
     ) {
+        return forType(
+                type,
+                name,
+                title,
+                description,
+                required,
+                defaultValue,
+                values,
+                null,
+                validator,
+                scope,
+                renderingOptions,
+                false,
+                true
+        );
+    }
+    /**
+     * @param type type
+     * @param name name
+     * @param title optional title
+     * @param description optional description
+     * @param required true if required
+     * @param defaultValue optional default value
+     * @param values optional values list
+     * @param validator validator
+     * @param scope resolution scope
+     * @param renderingOptions options
+     * @return a property instance for a particular simple type
+     */
+    public static Property forType(final Property.Type type,
+                                   final String name,
+                                   final String title,
+                                   final String description,
+                                   final boolean required,
+                                   final String defaultValue,
+                                   final List<String> values,
+                                   final Map<String, String> labels,
+                                   final PropertyValidator validator,
+                                   final PropertyScope scope,
+                                   final Map<String, Object> renderingOptions,
+                                   final boolean dynamicValues,
+                                   final boolean blankIfUnexpandable
+    ) {
         switch (type) {
             case Integer:
                 return integer(name, title, description, required, defaultValue, validator, scope, renderingOptions);
@@ -211,7 +254,7 @@ public class PropertyUtil {
                         renderingOptions
                 );
             default:
-                return string(name, title, description, required, defaultValue, validator, scope, renderingOptions);
+                return string(name, title, description, required, defaultValue, validator, scope, renderingOptions,blankIfUnexpandable);
         }
     }
 
@@ -281,7 +324,27 @@ public class PropertyUtil {
                                   final boolean required,
                                   final String defaultValue, final PropertyValidator validator,
                                   final PropertyScope scope, final Map<String, Object> renderingOptions) {
-        return new StringProperty(name, title, description, required, defaultValue, validator, scope, renderingOptions);
+        return string(name, title, description, required, defaultValue, validator, scope, renderingOptions,true);
+    }
+
+    /**
+     *
+     * @param name name
+     * @param title optional title
+     * @param description optional description
+     * @param required true if required
+     * @param defaultValue optional default value
+     * @param validator validator
+     * @param scope resolution scope
+     * @param renderingOptions options
+     * @return Return a string property
+     */
+    public static Property string(final String name, final String title, final String description,
+                                  final boolean required,
+                                  final String defaultValue, final PropertyValidator validator,
+                                  final PropertyScope scope, final Map<String, Object> renderingOptions,
+                                  final boolean blankIfUnexpandable) {
+        return new StringProperty(name, title, description, required, defaultValue, validator, scope, renderingOptions, blankIfUnexpandable);
     }
 
     /**
@@ -805,8 +868,9 @@ public class PropertyUtil {
                               final String defaultValue,
                               final PropertyValidator validator,
                               final PropertyScope scope,
-                              final Map<String, Object> renderingOptions) {
-            super(name, title, description, required, defaultValue, validator, scope, renderingOptions);
+                              final Map<String, Object> renderingOptions,
+                              final boolean blankIfUnexpandable) {
+            super(name, title, description, required, defaultValue, validator, scope, renderingOptions,blankIfUnexpandable);
         }
 
         public Type getType() {

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/descriptions/ReplaceDataVariablesWithBlanks.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/descriptions/ReplaceDataVariablesWithBlanks.java
@@ -1,0 +1,16 @@
+package com.dtolabs.rundeck.plugins.descriptions;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ReplaceDataVariablesWithBlanks {
+    /**
+     * @return Replace unexpandable variables with blanks if true,
+     * otherwise leave value intact
+     */
+    boolean value() default true;
+}

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/util/PropertyBuilder.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/util/PropertyBuilder.java
@@ -40,6 +40,7 @@ public class PropertyBuilder {
     private PropertyScope scope;
     private Map<String, Object> renderingOptions = new HashMap<String, Object>();
     private boolean dynamicValues;
+    private boolean blankIfUnexpandabled = true;
 
     private PropertyBuilder() {
 
@@ -68,6 +69,7 @@ public class PropertyBuilder {
             .validator(orig.getValidator())
             .scope(orig.getScope())
             .renderingOptions(orig.getRenderingOptions())
+            .blankIfUnexpandable(orig.isBlankIfUnexpandable())
             ;
     }
 
@@ -208,6 +210,17 @@ public class PropertyBuilder {
      */
     public PropertyBuilder required(final boolean required) {
         this.required = required;
+        return this;
+    }
+
+    /**
+     * Set blankIfUnexpandable
+     * @param blankIfUnexpandable true if unexpanded variables get replaced with blanks
+     *
+     * @return this builder
+     */
+    public PropertyBuilder blankIfUnexpandable(final boolean blankIfUnexpandable) {
+        this.blankIfUnexpandabled = blankIfUnexpandable;
         return this;
     }
 
@@ -356,7 +369,8 @@ public class PropertyBuilder {
                 validator,
                 scope,
                 renderingOptions,
-                dynamicValues
+                dynamicValues,
+                blankIfUnexpandabled
         );
     }
 

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtilitySpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtilitySpec.groovy
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.core.plugins.Plugin
 import com.dtolabs.rundeck.plugins.descriptions.PluginMeta
 import com.dtolabs.rundeck.plugins.descriptions.PluginMetadata
 import com.dtolabs.rundeck.plugins.descriptions.PluginProperty
+import com.dtolabs.rundeck.plugins.descriptions.ReplaceDataVariablesWithBlanks
 import com.dtolabs.rundeck.plugins.descriptions.SelectLabels
 import com.dtolabs.rundeck.plugins.descriptions.SelectValues
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
@@ -92,6 +93,10 @@ class PluginAdapterUtilitySpec extends Specification {
         long testlong1;
         @PluginProperty
         Long testlong2;
+
+        @PluginProperty
+        @ReplaceDataVariablesWithBlanks(value = false)
+        String blankNotExpanded;
     }
 
     static class mapResolver implements PropertyResolver {
@@ -375,5 +380,16 @@ class PluginAdapterUtilitySpec extends Specification {
             desc.metadata.size() == 2
             desc.metadata['asdf'] == 'xyz'
             desc.metadata['1234'] == '908'
+    }
+
+    def "Turn off blank replacements for unexpanded variabled"() {
+        when:
+        def testProp = PluginAdapterUtility.buildFieldProperties(Configuretest1).find { it.name == "testString"}
+        def blankProp = PluginAdapterUtility.buildFieldProperties(Configuretest1).find { it.name == "blankNotExpanded"}
+
+        then:
+        !blankProp.blankIfUnexpandable
+        testProp.blankIfUnexpandable
+
     }
 }

--- a/core/src/test/java/com/dtolabs/rundeck/plugins/util/PropertyBuilderTest.java
+++ b/core/src/test/java/com/dtolabs/rundeck/plugins/util/PropertyBuilderTest.java
@@ -331,4 +331,12 @@ public class PropertyBuilderTest extends TestCase {
                        true,
                        test1.isRequired());
     }
+    public void testStringWithBlankIfUnexpandableTrue() {
+        PropertyBuilder b = PropertyBuilder.builder().string("str-test");
+        b.blankIfUnexpandable(false);
+        Property str = b.build();
+
+        assertFalse(str.isBlankIfUnexpandable());
+
+    }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/UserServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/UserServiceSpec.groovy
@@ -81,7 +81,6 @@ class UserServiceSpec extends Specification implements ServiceUnitTest<UserServi
         when:
         boolean errorCalled = false
         service.log.metaClass.static.error =  { String msg, Throwable ex ->
-            println "log called"
             errorCalled = true
         }
 


### PR DESCRIPTION
Allow node step and workflow step java plugins to disable the substitution of a blank string if the variable is not found in the context.

This lets step plugins allow user scripts to contain bash array specifiers and other script structures that use the '${}' control characters to specify variables.

