### PR TITLE
Average notification didnt pass the execution context

### DIFF
--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -390,6 +390,7 @@ class ExecutionJob implements InterruptableJob {
                                                                     thread?.context?.dataContext
                                     )
 
+        def context = execmap?.thread?.context
         boolean never=true
         while (thread.isAlive() || never) {
             never=false
@@ -405,7 +406,7 @@ class ExecutionJob implements InterruptableJob {
                             execmap.scheduledExecution.id,
                             [
                                     execution: execmap.execution,
-                                    context:execmap
+                                    context:context
                             ]
                     )
                     avgNotificationSent=true


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
A fix for Fixing https://github.com/rundeck/rundeck/issues/4895.


**Describe the solution you've implemented**
Passing the right context values to the average notification

