### PR TITLE
Fix: rundeck build without existing nodejs install

### DIFF
--- a/rundeckapp/grails-spa/build.gradle
+++ b/rundeckapp/grails-spa/build.gradle
@@ -6,8 +6,8 @@ configurations{
   spa
 }
 node{
-    download = true
-    version='9.2.0'
+    download = project.hasProperty('node.install')
+    version = project.hasProperty('node.install') ? project.getProperty('node.install') : null
 }
 task runNpmBuild(type: NpmTask, group: 'build') {
     dependsOn npmInstall


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Replace https://github.com/rundeck/rundeck/pull/3978

**Describe the solution you've implemented**

Node can be installed by gradle by using the `-Pnode.install` property:

    ./gradlew -Pnode.install=9.2.0 build

If that property is not used, an existing node install is used