### PR TITLE
Avoid sensitive env variable propagation to local jobs

### DIFF
--- a/docker/official/lib/entry.sh
+++ b/docker/official/lib/entry.sh
@@ -32,6 +32,11 @@ echo "rundeck.server.uuid = ${RUNDECK_SERVER_UUID}" > ${REMCO_TMP_DIR}/framework
 cat ${REMCO_TMP_DIR}/framework/* >> etc/framework.properties
 cat ${REMCO_TMP_DIR}/rundeck-config/* >> server/config/rundeck-config.properties
 
+# Avoid secrets propagation to local jobs
+unset RUNDECK_JAAS_LDAP_BINDPASSWORD
+unset RUNDECK_DATABASE_PASSWORD
+unset RUNDECK_DATABASE_USERNAME
+
 exec java \
     -XX:+UnlockExperimentalVMOptions \
     -XX:MaxRAMFraction="${JVM_MAX_RAM_FRACTION}" \


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This enhancement avoid to propagate secret environment variables to jobs executing in the same rundeck server container. This change aims to make safer default rundeck enviornment for container based deployments.

**Describe the solution you've implemented**
Remediation by unset the sensitive variables after used by remco and before starting rundeck. after this point there is no need for keep those values as environment variables.

**Describe alternatives you've considered**
I have no other alternative to achieve this goal.

**Additional context**
This is only scoped to official container image.

Fixes #4904