### PR TITLE
UI updates 3.1: Part H

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/menu/jobs.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/jobs.js
@@ -119,10 +119,28 @@ function BulkEditor(data){
         }
     };
     self.expandAllComponents=function(){
-        jQuery('.expandComponent').show();
+        jQuery('.topgroup .expandComponent').show();
+        jQuery('#job_group_tree .expandComponent .expandComponentControl [data-expanding]').each(function(i,e){
+            if(jQuery(e).data('expanderOpenClass')){
+                jQuery(e).addClass(jQuery(e).data('expanderOpenClass'))
+            }
+            if(jQuery(e).data('expanderCloseClass')){
+                jQuery(e).removeClass(jQuery(e).data('expanderCloseClass'))
+            }
+        });
+        jQuery('#job_group_tree .expandComponent .expandComponentHolder').addClass('expanded');
     };
     self.collapseAllComponents=function(){
         jQuery('.topgroup .expandComponent').hide();
+        jQuery('#job_group_tree .expandComponent .expandComponentControl [data-expanding]').each(function(i,e){
+            if(jQuery(e).data('expanderOpenClass')){
+                jQuery(e).removeClass(jQuery(e).data('expanderOpenClass'))
+            }
+            if(jQuery(e).data('expanderCloseClass')){
+                jQuery(e).addClass(jQuery(e).data('expanderCloseClass'))
+            }
+        });
+        jQuery('#job_group_tree .expandComponent .expandComponentHolder').removeClass('expanded');
     };
     self.selectAll=function(){
         self.expandAllComponents();

--- a/rundeckapp/grails-app/assets/javascripts/scheduledExecution/jobRunFormOptionsKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/scheduledExecution/jobRunFormOptionsKO.js
@@ -19,6 +19,9 @@ function JobRunFormOptions (data) {
     var self = this
     self.nodeFilter = data.nodeFilter
     self.debug = ko.observable(data.debug === true || data.debug === 'true')
+    self.loglevel = ko.pureComputed(function () {
+        return self.debug() ? 'DEBUG' : 'NORMAL'
+    })
 
     self.canOverrideFilter = ko.observable(data.canOverrideFilter)
     self.changeTargetNodes = ko.observable(data.changeTargetNodes)

--- a/rundeckapp/grails-app/assets/scss/custom/jobs.scss
+++ b/rundeckapp/grails-app/assets/scss/custom/jobs.scss
@@ -69,3 +69,41 @@
     display: none;
   }
 }
+
+.job_list_row, .job_list_group_header {
+  clear: both;
+}
+
+.job_list_group_header {
+
+  border-radius: 3px;
+
+  &:hover {
+    background: #e0e0e0;
+  }
+
+  .jobgroupexpand {
+    padding: 3px;
+    display: block;
+    //color: #454545;
+    //text-decoration: underline;
+  }
+}
+
+.expandComponentHolder.expanded > .job_list_group_header > .jobgroupexpand {
+  //todo: emphasize expanded groups. but, expander widget doesn't correctly set expanded state for nested elements yet
+  //color: #454545;
+  //text-decoration: underline;
+}
+
+.job_list_row {
+  padding: 1px 0 1px 3px;
+  border-style: solid;
+  border-width: 0 0 3px 0;
+  border-color: transparent;
+
+  &:hover {
+    background: #F8f8f8;
+    border-color: #e8e8e8;
+  }
+}

--- a/rundeckapp/grails-app/assets/scss/custom/text.scss
+++ b/rundeckapp/grails-app/assets/scss/custom/text.scss
@@ -71,3 +71,10 @@
 .colon-after::after {
   content: ':'
 }
+
+pre.snippet .line{
+  display:block;
+  &.error{
+    color: red;
+  }
+}

--- a/rundeckapp/grails-app/assets/scss/custom/text.scss
+++ b/rundeckapp/grails-app/assets/scss/custom/text.scss
@@ -20,6 +20,7 @@
 
 .hover-reveal-hidden:hover .visibility-hidden {
   visibility: visible;
+  transition-delay: 0s;
 }
 
 .as-inline-block {

--- a/rundeckapp/grails-app/assets/scss/paper/_variables.scss
+++ b/rundeckapp/grails-app/assets/scss/paper/_variables.scss
@@ -241,10 +241,10 @@ $border-warning:        #ffff00 !default;
 $bg-danger:             #ffede6 !default;
 $border-danger:         #f97272 !default;
 
-$background-light-grey:     #E8E7E3 !default;
-$background-lighter-grey:   #F0EFEB !default;
-$font-background-light-grey: #9C9B99 !default;
-$font-hover-background-light-grey: #5E5E5C !default;
+$background-light-grey:     #E8E8E8 !default;
+$background-lighter-grey:   #F0F0F0 !default;
+$font-background-light-grey: #9C9C9C !default;
+$font-hover-background-light-grey: #5E5E5E !default;
 
 $topbar-x:             topbar-x !default;
 $topbar-back:          topbar-back !default;

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1801,3 +1801,4 @@ formatted.text=Formatted Text
 view=View
 start.time=Start time
 duration=Duration
+select.nodes=Select Nodes

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1716,3 +1716,4 @@ view=View
 execution.page.show.tab.Nodes.title=Nodes
 start.time=Start time
 duration=Duration
+select.nodes=Select Nodes

--- a/rundeckapp/grails-app/i18n/messages_fr_FR.properties
+++ b/rundeckapp/grails-app/i18n/messages_fr_FR.properties
@@ -1712,3 +1712,4 @@ view=View
 execution.page.show.tab.Nodes.title=Nodes
 start.time=Start time
 duration=Duration
+select.nodes=Select Nodes

--- a/rundeckapp/grails-app/i18n/messages_ja.properties
+++ b/rundeckapp/grails-app/i18n/messages_ja.properties
@@ -1341,3 +1341,4 @@ view=View
 execution.page.show.tab.Nodes.title=Nodes
 start.time=Start time
 duration=Duration
+select.nodes=Select Nodes

--- a/rundeckapp/grails-app/i18n/messages_pt_BR.properties
+++ b/rundeckapp/grails-app/i18n/messages_pt_BR.properties
@@ -1737,3 +1737,4 @@ view=View
 execution.page.show.tab.Nodes.title=Nodes
 start.time=Start time
 duration=Duration
+select.nodes=Select Nodes

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -1711,3 +1711,4 @@ view=View
 execution.page.show.tab.Nodes.title=Nodes
 start.time=Start time
 duration=Duration
+select.nodes=Select Nodes

--- a/rundeckapp/grails-app/views/common/_expander.gsp
+++ b/rundeckapp/grails-app/views/common/_expander.gsp
@@ -13,10 +13,10 @@
   - See the License for the specific language governing permissions and
   - limitations under the License.
   --}%
-<span class="${enc(attr:classnames?:'')} ${classnames&&classnames.indexOf('textbtn-')>=0?'': 'textbtn-default'} textbtn  expandComponentControl toggle ${open=='true'?'expanded':'closed'}" onmousedown="${raw(enc(attr:(key?'Expander.toggle(this,\''+enc(attr:enc(js:key))+'\')':jsfunc?jsfunc:'Expander.toggle(this)')))};return false;" style="padding:2px;${enc(attr:style)}" id="_exp_${enc(attr:key)}">
+<span class="${enc(attr:classnames?:'')} ${classnames&&classnames.indexOf('textbtn-')>=0?'': 'textbtn-default'} textbtn  expandComponentControl toggle ${open=='true'?'expanded':'closed'}" onmousedown="${raw(enc(attr:(key?'Expander.toggle(this,\''+enc(attr:enc(js:key))+'\')':jsfunc?jsfunc:'Expander.toggle(this)')))};return false;" style="${enc(attr:style)}" id="_exp_${enc(attr:key)}">
   <g:enc rawtext="${text != null && !imgfirst ? text:''}"/>
   <g:if test="${hideGlyphicon != 'true'}">
-    <b class="glyphicon glyphicon-chevron-${open == 'true' ? 'down' : 'right'}"></b>
+    <b class="glyphicon glyphicon-chevron-${open == 'true' ? 'down' : 'right'} ${iconCss?:''}" data-expanding data-expander-open-class="glyphicon-chevron-down"  data-expander-close-class="glyphicon-chevron-right"></b>
   </g:if>
   <g:enc rawtext="${text != null && imgfirst ? text:''}"/>
 </span>

--- a/rundeckapp/grails-app/views/menu/_groupTree.gsp
+++ b/rundeckapp/grails-app/views/menu/_groupTree.gsp
@@ -70,27 +70,31 @@
     </g:else>
     <g:set var="prevkey" value="${group.key}"/>
     <g:set var="groupopen" value="${(wasfiltered || jscallback || (level.size()<= jobExpandLevel || jobExpandLevel<0))}"/>
-    ${raw("<")}div class="expandComponentHolder panel panel-default ${groupopen ? 'expanded' : ''} " style="" ${raw(">")}
+    ${raw("<")}div class="expandComponentHolder  ${groupopen ? 'expanded' : ''} " style="" ${raw(">")}
         %{divcounts++;}%
-        <div class="panel-heading">
+        <div class="job_list_group_header hover-reveal-hidden">
         <g:if test="${jscallback}">
             <span class="expandComponentControl textbtn textbtn-success groupname jobgroupexpand"
                   title="Select this group"
                   onclick="groupChosen('${enc(js:prefix ? prefix + '/' + group.key : group.key)}'); return false;"
-                  style="padding-left:4px;">
+                  >
               <i class="glyphicon glyphicon-folder-close"></i> <g:enc>${displaygroup}</g:enc>
             </span>
         </g:if>
         <g:else>
             <g:set var="jsfunc" value="Expander.toggle(this,null,'.expandComponentHolder.sub_${currkey}_group');"/>
-            <g:expander open="${groupopen?'true':'false'}" jsfunc="${jsfunc}" imgfirst="true" style="padding-left:4px;" classnames="jobgroupexpand text-secondary">
-                <span class="foldertoggle">&nbsp;</span>
-                <g:if test="${jobsjscallback}">
-                    <g:enc>${displaygroup}</g:enc>
+            <g:expander open="${groupopen?'true':'false'}" jsfunc="${jsfunc}" imgfirst="true"  classnames="jobgroupexpand text-secondary autoclickable" iconCss="text-muted">
+
+                <g:enc>${displaygroup}</g:enc>
+
+                <g:if test="${!jobsjscallback}">
+                    <a class="groupname text-primary visibility-hidden "
+                    title="Browse job group: ${enc(attr:prefix ? prefix + '/' + group.key : group.key)}"
+                        href="${createLink(controller: 'menu', action: 'jobs', params: [project:params.project,groupPath: prefix ? prefix + '/' + group.key : group.key])}"><i class="glyphicon glyphicon-folder-open"></i></a>
                 </g:if>
             </g:expander>
             <g:if test="${!jobsjscallback}">
-            <a class="groupname secondary panel-title" href="${createLink(controller: 'menu', action: 'jobs', params: [project:params.project,groupPath: prefix ? prefix + '/' + group.key : group.key])}"><g:enc>${displaygroup}</g:enc></a>
+
                 <g:if test="${jobgroups[group.key]}">
                 <span class="" data-bind="visible: enabled">
                     &bull;
@@ -110,10 +114,10 @@
         </div>
 
         <g:timerEnd key="prepare"/>
-    ${raw("<")}div class="expandComponent panel-collapse sub_${currkey}_group sub_group" style="${wdgt.styleVisible(if: groupopen)}"${raw(">")}
+    ${raw("<")}div class="expandComponent  sub_${currkey}_group sub_group" style="${wdgt.styleVisible(if: groupopen)}"${raw(">")}
         %{ divcounts++;}%
         <g:if test="${jobgroups[group.key]}">
-            <div class="jobGroups subjobs list-group ">
+            <div class="jobGroups subjobs  ">
             <g:render template="jobslist" model="[hideSummary:true,jobslist:jobgroups[group.key],total:jobgroups[group.key]?.size(), clusterMap: clusterMap,nextExecutions:nextExecutions,jobauthorizations:jobauthorizations,authMap:authMap,max:max,offset:offset,paginateParams:paginateParams,sortEnabled:true,headers:false,wasfiltered:wasfiltered,small:small?true:false,jobsjscallback:jobsjscallback,runAuthRequired:runAuthRequired]"/>
             </div>
         </g:if>

--- a/rundeckapp/grails-app/views/menu/_jobslist.gsp
+++ b/rundeckapp/grails-app/views/menu/_jobslist.gsp
@@ -21,7 +21,7 @@
                 <g:if test="${jobslist.size()>0}">
                     <% def j=0 %>
                     <g:each in="${runAuthRequired?jobslist.findAll{ jobauthorizations&&jobauthorizations[AuthConstants.ACTION_RUN]?.contains(it.id.toString())}:jobslist}" var="scheduledExecution">
-                    <div class="list-group-item">
+                    <div class="">
                         <g:set var="nextExecution"
                                value="${ (nextExecutions)? nextExecutions[scheduledExecution.id] : null}"/>
                         <g:set var="clusterUUID"
@@ -31,7 +31,7 @@
                         %{-- select job view --}%
                         <g:if test="${jobsjscallback}">
                             <div class=" expandComponentHolder expanded" id="jobrow_${scheduledExecution.id}">
-                               <div class="jobname"
+                               <div class="jobname job_list_row"
                                    data-job-id="${scheduledExecution.extid}"
                                    data-job-name="${scheduledExecution.jobName}"
                                    data-job-group="${scheduledExecution.groupPath}"
@@ -50,7 +50,7 @@
                         <g:else>
                             %{--normal view--}%
                         <div class="sectionhead expandComponentHolder ${paginateParams?.idlist==scheduledExecution.id.toString()?'expanded':''}" id="jobrow_${scheduledExecution.id}">
-                            <div class="jobname"
+                            <div class="jobname job_list_row hover-reveal-hidden"
                                 data-job-id="${scheduledExecution.extid}"
                                 data-job-name="${scheduledExecution.jobName}"
                                 data-job-group="${scheduledExecution.groupPath}"
@@ -69,10 +69,8 @@
                                             <g:link controller="scheduledExecution"
                                                     action="execute"
                                                     id="${scheduledExecution.extid}"
-                                                    class=" btn btn-default btn-xs has_tooltip act_execute_job"
+                                                    class=" btn btn-success btn-simple btn-hover btn-xs act_execute_job"
                                                     params="[project: scheduledExecution.project]"
-                                                    data-toggle="tooltip"
-                                                    data-placement="auto right"
                                                     title="Choose options and Run Job"
                                                     data-job-id="${scheduledExecution.extid}"
                                             >
@@ -91,6 +89,12 @@
                                                 </span>
                                             </g:ifExecutionMode>
                                         </g:if>
+                                        <g:else>
+                                            <span class=" text-muted disabled   act_execute_job" style=" padding: 4px 5px;"
+                                                title="Cannot run job" disabled>
+                                                <b class="glyphicon glyphicon-minus"></b>
+                                            </span>
+                                        </g:else>
                                     </span>
 
                                 <g:set var="exportstatus" value="${scmExportEnabled ? scmStatus?.get(scheduledExecution.extid):null}"/>
@@ -115,13 +119,13 @@
                                 </span>
                                 <!-- /ko -->
 
-                                <div class="btn-group pull-right">
+                                <div class="btn-group pull-right visibility-hidden">
                                     <button type="button"
-                                            class="btn btn-default btn-sm dropdown-toggle act_job_action_dropdown"
-                                            title="${g.message(code: 'click.for.job.actions')}"
+                                            class="btn btn-secondary btn-xs dropdown-toggle act_job_action_dropdown"
                                             data-job-id="${enc(attr:scheduledExecution.extid)}"
                                             data-toggle="dropdown"
                                             aria-expanded="false">
+                                            <g:message code="actions" />
                                         <span class="caret"></span>
                                     </button>
                                     <ul class="dropdown-menu" role="menu">
@@ -131,7 +135,7 @@
                                 <g:link action="show"
                                         controller="scheduledExecution"
                                         id="${scheduledExecution.extid}"
-                                        class="hover_show_job_info"
+                                        class="hover_show_job_info text-primary"
                                         params="[project: scheduledExecution.project]"
                                         data-job-id="${scheduledExecution.extid}">
                                     <g:if test="${showIcon}">
@@ -139,19 +143,20 @@
                                     </g:if>
                                     <g:enc>${scheduledExecution.jobName}</g:enc>
                                 </g:link>
-                                <div>
+
                                   <g:render template="/scheduledExecution/description"
                                             model="[description: scheduledExecution?.description,
                                                     textCss:'text-secondary',
                                                     mode:'collapsed',
+                                                    firstLineOnly:true,
                                                     rkey:g.rkey(),
                                                     jobLinkId:scheduledExecution?.extid,
                                                     cutoffMarker: ScheduledExecution.RUNBOOK_MARKER
                                             ]"/>
-                                </div>
-                            </div>
+
+
                             <g:if test="${scheduledExecution.scheduled}">
-                            <div class="scheduletime" style="margin-top:5px; margin-left:5px;">
+                            <span class="scheduletime" >
                                 <g:if test="${scheduledExecution.scheduled && nextExecution}">
                                     <g:if test="${serverClusterNodeUUID && !remoteClusterNodeUUID}">
                                         <span class="text-warning has_tooltip" title="${message(code:"scheduledExecution.scheduled.cluster.orphan.title")}"
@@ -161,46 +166,44 @@
                                         </span>
                                     </g:if>
                                     <g:else>
-                                        <g:icon name="time"/>
+                                        <span class="text-success">
+                                            <g:icon name="time"/>
+                                        </span>
                                     </g:else>
-                                    <span title="${remoteClusterNodeUUID ? g.message(code: "scheduled.to.run.on.server.0", args:[remoteClusterNodeUUID]) : ''} at ${g.relativeDate(atDate: nextExecution)}">
-                                        <g:relativeDate elapsed="${nextExecution}" untilClass="timeuntil"/>
+                                    <span title="${remoteClusterNodeUUID ? g.message(code: "scheduled.to.run.on.server.0", args:[remoteClusterNodeUUID]) : ''} at ${g.relativeDate(atDate: nextExecution)}"
+                                            class="text-secondary">
+                                        <g:relativeDate elapsed="${nextExecution}" untilClass="timeuntil text-success"/>
                                     </span>
 
-                                    <g:if test="${remoteClusterNodeUUID}">
-                                        on
-                                        <span data-server-uuid="${remoteClusterNodeUUID}" data-server-name=" " class="rundeck-server-uuid text-primary">
-                                        </span>
-                                    </g:if>
                                 </g:if>
-                                <g:elseif test="${scheduledExecution.scheduled && !g.executionMode(is:'active', project:scheduledExecution.project)}">
-                                    <span class="scheduletime disabled has_tooltip" data-toggle="tooltip"
+                                <g:elseif test="${scheduledExecution.scheduled && !g.executionMode(is:'active', project:scheduledExecution.project)|| !scheduledExecution.hasExecutionEnabled()}">
+                                    <span class="scheduletime disabled has_tooltip text-secondary" data-toggle="tooltip"
                                           data-placement="auto right"
                                           title="${g.message(code: 'disabled.schedule.run')}">
-                                        <i class="glyphicon glyphicon-time"></i>
+                                        <i class="glyphicon glyphicon-pause"></i>
                                         <span class="detail"><g:message code="disabled" /></span>
                                     </span>
                                 </g:elseif>
                                 <g:elseif test="${!scheduledExecution.hasScheduleEnabled() && scheduledExecution.hasExecutionEnabled()}">
-                                    <span class="scheduletime disabled has_tooltip"
+                                    <span class="scheduletime disabled has_tooltip text-secondary"
                                           title="${g.message(code: 'scheduleExecution.schedule.disabled')}"
                                           data-toggle="tooltip"
                                           data-placement="auto right">
-                                        <i class="glyphicon glyphicon-time"></i>
+                                        <i class="glyphicon glyphicon-pause"></i>
                                         <span class="detail"><g:message code="never"/></span>
                                     </span>
                                 </g:elseif>
-                                <g:elseif test="${scheduledExecution.hasScheduleEnabled() && !g.scheduleMode(is:'active', project:scheduledExecution.project)}">
-                                    <span class="scheduletime disabled has_tooltip"
+                                <g:elseif test="${scheduledExecution.hasScheduleEnabled() && !g.scheduleMode(is:'active', project:scheduledExecution.project) }">
+                                    <span class="scheduletime disabled has_tooltip text-secondary"
                                           title="${g.message(code: 'project.schedule.disabled')}"
                                           data-toggle="tooltip"
                                           data-placement="auto left">
-                                        <i class="glyphicon glyphicon-time"></i>
+                                        <i class="glyphicon glyphicon-pause"></i>
                                         <span class="detail"><g:message code="never"/></span>
                                     </span>
                                 </g:elseif>
                                 <g:elseif test="${scheduledExecution.scheduled && !nextExecution}">
-                                    <span class="scheduletime willnotrun has_tooltip"
+                                    <span class="scheduletime willnotrun has_tooltip text-warning"
                                           title="${g.message(code: 'job.schedule.will.never.fire')}"
                                           data-toggle="tooltip"
                                           data-placement="auto left">
@@ -208,8 +211,9 @@
                                         <span class="detail"><g:message code="never"/></span>
                                     </span>
                                 </g:elseif>
-                            </div>
+                            </span>
                             </g:if>
+                            </div>
                         </div>
                         </g:else>
                         <% j++ %>

--- a/rundeckapp/grails-app/views/menu/_workflowsFull.gsp
+++ b/rundeckapp/grails-app/views/menu/_workflowsFull.gsp
@@ -286,10 +286,10 @@
     </g:if>
 
                     <span id="group_controls" data-ko-bind="bulkeditor">
-                      <span class="btn btn-default btn-xs" data-bind="click: expandAllComponents">
+                      <span class="btn btn-secondary btn-simple btn-hover btn-xs" data-bind="click: expandAllComponents">
                           <g:message code="expand.all" />
                       </span>
-                      <span class="btn btn-default btn-xs" data-bind="click: collapseAllComponents">
+                      <span class="btn btn-secondary btn-simple btn-hover btn-xs" data-bind="click: collapseAllComponents">
                           <g:message code="collapse.all" />
                       </span>
                     </span>
@@ -496,7 +496,7 @@
 
                         </div>
                     </div>
-                        <div id="job_group_tree" class="panel-group" data-ko-bind="bulkeditor">
+                        <div id="job_group_tree" data-ko-bind="bulkeditor">
                         <g:if test="${jobgroups}">
 
                             <g:timerStart key="groupTree"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -48,7 +48,7 @@
              data="${[filterName: params.filterName, filter: scheduledExecution?.asFilter(),filterExcludeName: params.filterExcludeName, filterExclude: scheduledExecution?.asExcludeFilter(),nodeExcludePrecedence: scheduledExecution?.nodeExcludePrecedence, excludeFilterUncheck: scheduledExecution?.excludeFilterUncheck]}"/>
 <g:embedJSON id="jobDefinitionJSON"
              data="${[jobName:scheduledExecution?.jobName,groupPath:scheduledExecution?.groupPath, uuid: scheduledExecution?.uuid,
-                     href:scheduledExecution?createLink(controller:'scheduledExecution',action:'show',params:[project:scheduledExecution.project,id:scheduledExecution.extid]):null
+                     href:scheduledExecution?.id?createLink(controller:'scheduledExecution',action:'show',params:[project:scheduledExecution.project,id:scheduledExecution.extid]):null
              ]}"/>
 
   <g:if test="${scheduledExecution && scheduledExecution.id}">

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -128,7 +128,7 @@
                                    value="cherrypick"
                                    data-bind="checked: nodeOverride"/>
                             <label for="cherrypickradio">
-                                Select Nodes
+                                <g:message code="select.nodes" />
                             </label>
                         </div>
 

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsFormButtons.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsFormButtons.gsp
@@ -26,8 +26,8 @@
                 </g:if>
 
                 <input type="hidden"
-                       name="extra.debug"
-                       data-bind="value: debug"
+                       name="extra.loglevel"
+                       data-bind="value: loglevel"
                        id="extra_loglevel"
 
                 />


### PR DESCRIPTION
UI fixes

- [x] job tree takes too much vertical space, too noisy (borders/bg colors)
- [x] fix: "output grouped by nodes" option shows blank
- [x] fix: job with debug mode default cannot execute in normal mode
- [x] Duplicate job action causes 500 error
- [ ] Job run: Override Node Filters, does not work? (needs-verification)