### PR TITLE
[Docker] unset envars before starting Rundeck

### DIFF
--- a/docker/official/README.md
+++ b/docker/official/README.md
@@ -17,6 +17,13 @@ The simplest way to persist data between container starts/upgrades is to
 utilize named volumes:  
 `$ docker run --name some-rundeck -v data:/home/rundeck/server/data rundeck/rundeck`
 
+## Security
+
+**Environment variables**  
+Locally run jobs run as the `rundeck` user, the same as the server, and may carry the
+environment variables used when starting the server. See `RUNDECK_ENVARS_UNSETALL` and
+`RUNDECK_ENVARS_UNSETS` below for unset options.
+
 ## ssh keys
 
 You can provide private ssh keys by mounting them into `/home/rundeck/.ssh`:  
@@ -187,3 +194,9 @@ Default from address.
 
 ### `RUNDECK_MAIL_PROPS`
 Mail properties that get passed through to Grails. For example, to use StartTLS(required by many servers including AWS SES), `["mail.smtp.starttls.enable":"true","mail.smtp.port":"587"]`.
+
+### `RUNDECK_ENVARS_UNSETALL`
+Set to `true` to unset all environment variables starting with `RUNDECK_` before starting Rundeck.
+
+### `RUNDECK_ENVARS_UNSETS`
+Set to a space-separated list of environment variables to unset before starting Rundeck.

--- a/docker/official/lib/entry.sh
+++ b/docker/official/lib/entry.sh
@@ -32,6 +32,21 @@ echo "rundeck.server.uuid = ${RUNDECK_SERVER_UUID}" > ${REMCO_TMP_DIR}/framework
 cat ${REMCO_TMP_DIR}/framework/* >> etc/framework.properties
 cat ${REMCO_TMP_DIR}/rundeck-config/* >> server/config/rundeck-config.properties
 
+
+# Store settings that may be unset in script variables
+SETTING_RUNDECK_FORWARDED="${RUNDECK_SERVER_FORWARDED:-false}"
+
+# Unset all RUNDECK_* environment variables
+if [[ "${RUNDECK_ENVARS_UNSETALL:-false}" = "true" ]] ; then
+    unset `env | awk -F '=' '{print $1}' | grep -e '^RUNDECK_'`
+fi
+
+# Unset specific environment variables
+if [[ ! -z "${RUNDECK_ENVARS_UNSETS:-}" ]] ; then
+    unset $RUNDECK_ENVARS_UNSETS
+    unset RUNDECK_ENVARS_UNSETS
+fi
+
 exec java \
     -XX:+UnlockExperimentalVMOptions \
     -XX:MaxRAMFraction="${JVM_MAX_RAM_FRACTION}" \
@@ -39,6 +54,6 @@ exec java \
     -Dloginmodule.conf.name=jaas-loginmodule.conf \
     -Dloginmodule.name=rundeck \
     -Drundeck.jaaslogin=true \
-    -Drundeck.jetty.connector.forwarded="${RUNDECK_SERVER_FORWARDED:-false}" \
+    -Drundeck.jetty.connector.forwarded="${SETTING_RUNDECK_FORWARDED}" \
     "${@}" \
     -jar rundeck.war


### PR DESCRIPTION
Back-port fix for #4904

Adds two environment variables for controlling environment variable unsets:

`RUNDECK_ENVARS_UNSETALL` Defaults to **false** and unsets all envars starting with `RUNDECK_` before starting Rundeck.
`RUNDECK_ENVARS_UNSETS` Can be used to explicitly unset environment variables before starting Rundeck.