### PR TITLE
Sets default nodeJS version for bulding.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,4 @@ groovyVersion = 2.4.15
 jettyVersion=9.4.11.v20180605
 mavenCentralUrl = http://repo1.maven.org/maven2/
 grailsCentralUrl = http://grails.org/plugins
+node.install=10.16.0


### PR DESCRIPTION
I noticed that the build of grails-spa fails if node is not installed on the building machine. I replicated this behavior on Ubuntu, OSX and Windows 7, even if i clone a fresh copy of master.

Setting a default value for node.install property solves the problem and eliminates the need of installing nodejs on the building machine.

I chose to set it on the general gradle.properties instead of grails-spa gradle.properties to keep al versions settings on the same file.
