### PR TITLE
3.1: UI: project config form tabs

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/framework/editProject.js
+++ b/rundeckapp/grails-app/assets/javascripts/framework/editProject.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+//= require momentutil
+//= require knockout.min
+//= require knockout-mapping
+//= require knockout-onenter
+//= require storageBrowseKO
+//= require koBind
+
+function ProjectDefaultPlugin (data) {
+    var self = this
+    self.service = ko.observable(data.service)
+    self.type = ko.observable(data.type)
+    self.index = ko.observable(data.index)
+}
+
+function EditProject (data) {
+    var self = this
+    self.create = ko.observable(data.create || !data.name)
+    self.name = ko.observable(data.name)
+    self.defaults = {
+        'NodeExecutor': new ProjectDefaultPlugin({service: 'NodeExecutor', type: data.defaultNodeExec}),
+        'FileCopier': new ProjectDefaultPlugin({service: 'FileCopier', type: data.defaultFileCopier})
+    }
+}
+
+jQuery(function () {
+    var projectData = loadJsonData('projectDataJSON')
+    window.projectEditor = new EditProject(projectData)
+    initKoBind(null, {editProject: projectEditor})
+})

--- a/rundeckapp/grails-app/assets/javascripts/jobEditPage_bundle.js
+++ b/rundeckapp/grails-app/assets/javascripts/jobEditPage_bundle.js
@@ -21,6 +21,7 @@
 //= require knockout-onenter
 //= require ko/handler-bootstrapTooltip
 //= require ko/handler-bootstrapPopover
+//= require plugins/pluginMetadata
 //= require workflowStepEditorKO
 //= require nodeFiltersKO
 //= require optionEditKO

--- a/rundeckapp/grails-app/assets/javascripts/plugins/pluginMetadata.js
+++ b/rundeckapp/grails-app/assets/javascripts/plugins/pluginMetadata.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+/**
+ * plugin description info
+ * @param data
+ * @constructor
+ */
+function PluginMetadata(data) {
+    "use strict";
+    var self = this;
+    self.type = ko.observable(data.type);
+    self.title = ko.observable(data.title);
+    self.description = ko.observable(data.description);
+    self.iconSrc = ko.observable(data.iconSrc);
+    self.providerMeta = ko.observable(data.providerMeta)
+    self.selected = ko.observable(false);
+    self.glyphicon  = ko.computed(function () {
+        return self.providerMeta() && self.providerMeta().glyphicon
+    })
+    self.faicon = ko.computed(function () {
+        return self.providerMeta() && self.providerMeta().faicon
+    })
+    self.fabicon = ko.computed(function () {
+        return self.providerMeta() && self.providerMeta().fabicon
+    })
+    self.descriptionFirstLine = ko.computed(function () {
+        var desc = self.description();
+        if (desc) {
+            return desc.indexOf('\n') > 0 ? desc.substring(0, desc.indexOf('\n')) : desc;
+        }
+        return desc;
+    });
+    ko.mapping.fromJS(data, {}, this);
+}

--- a/rundeckapp/grails-app/assets/javascripts/workflowStepEditorKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/workflowStepEditorKO.js
@@ -54,7 +54,7 @@ function WorkflowEditor() {
                     return ko.utils.unwrapObservable(data.type);
                 },
                 create: function (options) {
-                    return new StepFilterPlugin(options.data);
+                    return new PluginMetadata(options.data);
                 }
             }
         }, self);
@@ -422,38 +422,7 @@ function ScriptStep(data) {
     //bind in the input data
     ko.mapping.fromJS(data, {}, this);
 }
-/**
- * plugin description info
- * @param data
- * @constructor
- */
-function StepFilterPlugin(data) {
-    "use strict";
-    var self = this;
-    self.type = ko.observable(data.type);
-    self.title = ko.observable(data.title);
-    self.description = ko.observable(data.description);
-    self.iconSrc = ko.observable(data.iconSrc);
-    self.providerMeta = ko.observable(data.providerMeta)
-    self.selected = ko.observable(false);
-    self.glyphicon  = ko.computed(function () {
-        return self.providerMeta() && self.providerMeta().glyphicon
-    })
-    self.faicon = ko.computed(function () {
-        return self.providerMeta() && self.providerMeta().faicon
-    })
-    self.fabicon = ko.computed(function () {
-        return self.providerMeta() && self.providerMeta().fabicon
-    })
-    self.descriptionFirstLine = ko.computed(function () {
-        var desc = self.description();
-        if (desc) {
-            return desc.indexOf('\n') > 0 ? desc.substring(0, desc.indexOf('\n')) : desc;
-        }
-        return desc;
-    });
-    ko.mapping.fromJS(data, {}, this);
-}
+
 /**
  * A single filter instance,
  * @param data

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -837,8 +837,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             errors << cleanerHistoryPeriodError
         }
 
-        if (params.defaultNodeExec) {
-            def ndx = params.defaultNodeExec
+        if (params.default_NodeExecutor) {
+            def ndx = 'default'
             (defaultNodeExec, nodeexec) = parseServiceConfigInput(params, "nodeexec", ndx)
             if (!(defaultNodeExec =~ /^[-_a-zA-Z0-9+][-\._a-zA-Z0-9+]*\u0024/)) {
                 errors << "Default Node Executor provider name is invalid"
@@ -860,8 +860,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                 }
             }
         }
-        if (params.defaultFileCopy) {
-            def ndx = params.defaultFileCopy
+        if (params.default_FileCopier) {
+            def ndx = 'default'
             (defaultFileCopy, fcopy) = parseServiceConfigInput(params, "fcopy", ndx)
             if (!(defaultFileCopy =~ /^[-_a-zA-Z0-9+][-\._a-zA-Z0-9+]*\u0024/)) {
                 errors << "Default File copier provider name is invalid"
@@ -1310,8 +1310,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             }
 
             def Set<String> removePrefixes=[]
-            if (params.defaultNodeExec) {
-                (defaultNodeExec, nodeexec, nodeexecreport) = parseDefaultPluginConfig(errors, params.defaultNodeExec, "nodeexec", frameworkService.getNodeExecutorService(),'Node Executor')
+            if (params.default_NodeExecutor) {
+                (defaultNodeExec, nodeexec, nodeexecreport) = parseDefaultPluginConfig(errors, 'default', "nodeexec", frameworkService.getNodeExecutorService(),'Node Executor')
                 try {
                     execPasswordFieldsService.untrack(
                             [[config: [type: defaultNodeExec, props: nodeexec], index: 0]],
@@ -1323,8 +1323,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                     errors << e.getMessage()
                 }
             }
-            if (params.defaultFileCopy) {
-                (defaultFileCopy, fcopy, fcopyreport) = parseDefaultPluginConfig(errors, params.defaultFileCopy, "fcopy", frameworkService.getFileCopierService(),'File Copier')
+            if (params.default_FileCopier) {
+                (defaultFileCopy, fcopy, fcopyreport) = parseDefaultPluginConfig(errors, 'default', "fcopy", frameworkService.getFileCopierService(),'File Copier')
                 try {
                     fcopyPasswordFieldsService.untrack(
                             [[config: [type: defaultFileCopy, props: fcopy], index: 0]],

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1803,3 +1803,4 @@ start.time=Start time
 duration=Duration
 select.nodes=Select Nodes
 follow.output=Follow output
+project.edit.page.tab.details.title=Details

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1718,3 +1718,4 @@ start.time=Start time
 duration=Duration
 select.nodes=Select Nodes
 follow.output=Follow output
+project.edit.page.tab.details.title=Details

--- a/rundeckapp/grails-app/i18n/messages_fr_FR.properties
+++ b/rundeckapp/grails-app/i18n/messages_fr_FR.properties
@@ -1714,3 +1714,4 @@ start.time=Start time
 duration=Duration
 select.nodes=Select Nodes
 follow.output=Follow output
+project.edit.page.tab.details.title=Details

--- a/rundeckapp/grails-app/i18n/messages_ja.properties
+++ b/rundeckapp/grails-app/i18n/messages_ja.properties
@@ -1343,3 +1343,4 @@ start.time=Start time
 duration=Duration
 select.nodes=Select Nodes
 follow.output=Follow output
+project.edit.page.tab.details.title=Details

--- a/rundeckapp/grails-app/i18n/messages_pt_BR.properties
+++ b/rundeckapp/grails-app/i18n/messages_pt_BR.properties
@@ -1739,3 +1739,4 @@ start.time=Start time
 duration=Duration
 select.nodes=Select Nodes
 follow.output=Follow output
+project.edit.page.tab.details.title=Details

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -1713,3 +1713,4 @@ start.time=Start time
 duration=Duration
 select.nodes=Select Nodes
 follow.output=Follow output
+project.edit.page.tab.details.title=Details

--- a/rundeckapp/grails-app/views/framework/_createProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_createProjectForm.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page contentType="text/html;charset=UTF-8" %>
+<%@ page import="com.dtolabs.rundeck.plugins.ServiceNameConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <g:set var="rkey" value="${g.rkey()}"/>
@@ -22,12 +22,18 @@
     <meta name="layout" content="base"/>
     <meta name="tabpage" content="nodes"/>
     <title><g:message code="domain.Project.choose.title" default="Create a Project"/></title>
-
+    <g:embedJSON id="projectDataJSON" data="${[
+            create: true,
+            name:params.newproject,
+            defaultFileCopier:defaultFileCopy,
+            defaultNodeExec:defaultNodeExec
+    ]}"/>
     <asset:javascript src="prototype/effects"/>
-    <asset:javascript src="storageBrowseKO.js"/>
+    <asset:javascript src="framework/editProject.js"/>
     <g:javascript>
 
     function init(){
+
         $$('input').each(function(elem){
             if(elem.type=='text'){
                 elem.observe('keypress',noenter);
@@ -53,11 +59,32 @@
       <div class="col-xs-12">
         <div class="card" id="createform">
           <g:form action="createProject" useToken="true" method="post" onsubmit="return configControl.checkForm();">
-            <div class="card-header">
+            <div class="card-header" data-ko-bind="editProject">
               <h4 class="card-title"><g:message code="domain.Project.create.message" default="Create a new Project"/></h4>
             </div>
             <div class="card-content">
-              <tmpl:editProjectFormTabs/>
+
+                <g:set var="serviceDefaultsList" value="${[
+                        [
+                                service     : ServiceNameConstants.NodeExecutor,
+                                descriptions: nodeExecDescriptions,
+                                prefix      : 'nodeexec',
+                                errreport   : nodeexecreport,
+                                selectedType: defaultNodeExec,
+                                config      : nodeexecconfig
+
+                        ],
+                        [
+                                service     : ServiceNameConstants.FileCopier,
+                                descriptions: fileCopyDescriptions,
+                                prefix      : 'fcopy',
+                                errreport   : fcopyreport,
+                                selectedType: defaultFileCopy,
+                                config      : fcopyconfig
+
+                        ]
+                ]}"/>
+              <tmpl:editProjectFormTabs serviceDefaultsList="${serviceDefaultsList}"/>
             </div>
             <div class="card-footer">
               <g:submitButton name="cancel" value="${g.message(code: 'button.action.Cancel', default: 'Cancel')}" class="btn btn-default"/>

--- a/rundeckapp/grails-app/views/framework/_createProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_createProjectForm.gsp
@@ -22,12 +22,59 @@
     <meta name="layout" content="base"/>
     <meta name="tabpage" content="nodes"/>
     <title><g:message code="domain.Project.choose.title" default="Create a Project"/></title>
+    <g:set var="nodeExecutorPluginsData" value="${nodeExecDescriptions.collect {
+        [
+                type       : it.name,
+                iconSrc    : stepplugin.pluginIconSrc(service: 'NodeExecutor', name: it.name),
+                providerMeta    : stepplugin.pluginProviderMeta(service: 'NodeExecutor', name: it.name),
+                title      :
+                        stepplugin.messageText(
+                                service: 'NodeExecutor',
+                                name: it.name,
+                                code: 'plugin.title',
+                                default: it.title
+                        ),
+                description:
+                        stepplugin.messageText(
+                                service: 'NodeExecutor',
+                                name: it.name,
+                                code: 'plugin.description',
+                                default: it.description
+                        )
+        ]
+    }}"/>
+    <g:set var="fileCopierPluginsData" value="${fileCopyDescriptions.collect {
+        [
+                type       : it.name,
+                iconSrc    : stepplugin.pluginIconSrc(service: 'FileCopier', name: it.name),
+                providerMeta    : stepplugin.pluginProviderMeta(service: 'FileCopier', name: it.name),
+                title      :
+                        stepplugin.messageText(
+                                service: 'FileCopier',
+                                name: it.name,
+                                code: 'plugin.title',
+                                default: it.title
+                        ),
+                description:
+                        stepplugin.messageText(
+                                service: 'FileCopier',
+                                name: it.name,
+                                code: 'plugin.description',
+                                default: it.description
+                        )
+        ]
+    }}" />
     <g:embedJSON id="projectDataJSON" data="${[
             create: true,
             name:params.newproject,
             defaultFileCopier:defaultFileCopy,
-            defaultNodeExec:defaultNodeExec
+            defaultNodeExec:defaultNodeExec,
+            descriptions: [
+                    NodeExecutor: nodeExecutorPluginsData,
+                    FileCopier: fileCopierPluginsData,
+            ]
     ]}"/>
+
     <asset:javascript src="prototype/effects"/>
     <asset:javascript src="framework/editProject.js"/>
     <g:javascript>

--- a/rundeckapp/grails-app/views/framework/_createProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_createProjectForm.gsp
@@ -57,7 +57,7 @@
               <h4 class="card-title"><g:message code="domain.Project.create.message" default="Create a new Project"/></h4>
             </div>
             <div class="card-content">
-              <tmpl:editProjectForm/>
+              <tmpl:editProjectFormTabs/>
             </div>
             <div class="card-footer">
               <g:submitButton name="cancel" value="${g.message(code: 'button.action.Cancel', default: 'Cancel')}" class="btn btn-default"/>

--- a/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
@@ -20,7 +20,7 @@
    Created: 8/1/11 11:38 AM
 --%>
 
-<%@ page import="rundeck.UtilityTagLib; com.dtolabs.rundeck.core.plugins.configuration.PropertyScope" contentType="text/html;charset=UTF-8" %>
+<%@ page import="com.dtolabs.rundeck.plugins.ServiceNameConstants; rundeck.UtilityTagLib; com.dtolabs.rundeck.core.plugins.configuration.PropertyScope" contentType="text/html;charset=UTF-8" %>
 <g:render template="/common/messages" model="[notDismissable:true]"/>
 <script type="text/javascript">
     function changeCronExpression(elem){
@@ -76,7 +76,8 @@
         <label for="project" class="required">
           <g:message code="domain.Project.field.name" default="Project Name"/>
         </label>
-        <g:textField name="newproject" size="50" autofocus="true" value="${newproject}" class="form-control"/>
+          <g:textField name="newproject" size="50" autofocus="true" value="${newproject}" class="form-control"
+                       data-bind="value: name"/>
         <g:if test="${projectNameError}">
           <div class="text-warning"><g:enc>${projectNameError}</g:enc></div>
         </g:if>
@@ -210,97 +211,87 @@
               ]}"/>
     </div>
   </g:each>
-  <g:if test="${nodeExecDescriptions}">
-    <div class="tab-pane" id="tab_nodeexec">
-      <span class="h4">Default <g:message code="framework.service.NodeExecutor.label" /></span>
-      <span class="help-block"><g:message code="domain.Project.edit.NodeExecutor.explanation" /></span>
-      <g:each in="${nodeExecDescriptions}" var="description" status="nex">
-        <g:set var="nkey" value="${g.rkey()}"/>
-        <g:set var="isSelected" value="${defaultNodeExec == description.name}"/>
-        <div class="radio">
-          <g:radio
-            name="defaultNodeExec"
-            value="${nex}"
-            class="nexec"
-            id="${nkey+'_input'}"
-            checked="${isSelected}"/>
-            <label>
-              <b><g:enc>${description.title}</g:enc></b>
-            </label>
-            <span class="help-block"><g:enc>${description.description}</g:enc></span>
-        </div>
-        <g:hiddenField name="nodeexec.${nex}.type" value="${description.name}"/>
-        <g:set var="nodeexecprefix" value="nodeexec.${nex}.config."/>
-        <wdgt:eventHandler state="checked" for="${nkey+'_input'}">
-          <wdgt:action visible="false" targetSelector=".nexecDetails"/>
-        </wdgt:eventHandler>
-        <g:if test="${description && description.properties}">
-          <wdgt:eventHandler state="checked" for="${nkey+'_input'}">
-            <wdgt:action visible="true" target="${nkey+'_det'}"/>
-          </wdgt:eventHandler>
-          <div class="well well-sm nexecDetails" id="${enc(attr:nkey) + '_det'}" style="${wdgt.styleVisible(if: isSelected)}">
-            <div class="form-horizontal " >
-              <g:render template="/framework/pluginConfigPropertiesInputs" model="${[
-                        service:com.dtolabs.rundeck.plugins.ServiceNameConstants.NodeExecutor,
-                        provider:description.name,
-                        properties:description.properties,
-                        report:nodeexecreport?.errors && isSelected ? nodeexecreport : null,
-                        prefix:nodeexecprefix,
-                        values:isSelected ? nodeexecconfig : null,
-                        fieldnamePrefix:nodeexecprefix,
-                        origfieldnamePrefix:'orig.' + nodeexecprefix,
-                        allowedScope: PropertyScope.Project
-              ]}"/>
+
+<g:each in="${serviceDefaultsList}" var="serviceDefaults">
+
+    <div class="tab-pane form-horizontal" id="tab_svc_${serviceDefaults.service}">
+
+        <div class="form-group">
+            <div class=" col-sm-12 help-block"><g:message
+                    code="domain.Project.edit.${serviceDefaults.service}.explanation"/>
             </div>
-          </div>
-        </g:if>
-      </g:each>
-    </div>
-  </g:if>
-  <g:if test="${fileCopyDescriptions}">
-    <div class="tab-pane" id="tab_filecopy">
-    <span class="h4">Default Node <g:message code="framework.service.FileCopier.label"/></span>
-    <span class="help-block"><g:message code="domain.Project.edit.FileCopier.explanation" /></span>
-    <g:each in="${fileCopyDescriptions}" var="description" status="nex">
-      <g:set var="nkey" value="${g.rkey()}"/>
-      <g:set var="isSelected" value="${defaultFileCopy == description.name}"/>
-      <div class="radio">
-        <g:radio
-            name="defaultFileCopy"
-            value="${nex}"
-            class="fcopy"
-            id="${nkey+'_input'}"
-            checked="${isSelected}"/>
-        <label>
-          <b><g:enc>${description.title}</g:enc></b>
-        </label>
-        <span class="help-block"><g:enc>${description.description}</g:enc></span>
-      </div>
-      <g:hiddenField name="fcopy.${nex}.type" value="${description.name}"/>
-      <g:set var="fcopyprefix" value="fcopy.${nex}.config."/>
-      <wdgt:eventHandler state="checked" for="${nkey+'_input'}">
-          <wdgt:action visible="false" targetSelector=".fcopyDetails"/>
-      </wdgt:eventHandler>
+        </div>
+
+        <div class=" form-group">
+            <label class="col-sm-2 control-label " for="default_${serviceDefaults.service}">Default <g:message
+                    code="framework.service.${serviceDefaults.service}.label"/></label>
+
+            <div class="col-sm-10">
+                <select name="default_${serviceDefaults.service}"
+                        data-bind="value: defaults['${serviceDefaults.service}'].type" class="form-control"
+                        id="default_${serviceDefaults.service}">
+                    <option value="" disabled>-- Select a <g:message
+                            code="framework.service.${serviceDefaults.service}.label"/> --</option>
+                    <g:each in="${serviceDefaults.descriptions}" var="description" status="nex">
+                        <option value="${enc(attr: description.name)}">${description.title}</option>
+                    </g:each>
+                </select>
+            </div>
+        </div>
+        <g:each in="${serviceDefaults.descriptions}" var="description" status="nex">
+            <g:set var="nkey" value="${g.rkey()}"/>
+            <g:set var="isSelected" value="${serviceDefaults.selectedType == description.name}"/>
+
+            <g:set var="fcopyprefix" value="${serviceDefaults.prefix}.default.config."/>
       <g:if test="${description && description.properties}">
-        <wdgt:eventHandler state="checked" for="${nkey+'_input'}">
-          <wdgt:action visible="true" target="${nkey+'_det'}"/>
-        </wdgt:eventHandler>
-        <div class="well well-sm fcopyDetails" id="${enc(attr:nkey) + '_det'}" style="${wdgt.styleVisible(if: isSelected)}">
-          <div class="form-horizontal">
+          <g:set var="isSelected" value="${defaultNodeExec == description.name}"/>
+          <div class=" fcopyDetails" id="${enc(attr: nkey) + '_det'}"
+               data-bind="if: defaults['${serviceDefaults.service}'].type()==='${enc(attr: description.name)}'">
+              <g:hiddenField name="${serviceDefaults.prefix}.default.type"
+                             value="${description.name}"/>
+              <div class="form-group">
+                  <div class=" col-sm-12 ">
+                      <stepplugin:pluginIcon service="${serviceDefaults.service}"
+                                             name="${description.name}"
+                                             width="16px"
+                                             height="16px">
+                          <i class="rdicon icon-small plugin"></i>
+                      </stepplugin:pluginIcon>
+                      <stepplugin:message
+                              service="${serviceDefaults.service}"
+                              name="${description.name}"
+                              code="plugin.title"
+                              default="${description.title}"/>
+                      -
+                      <g:render template="/scheduledExecution/description"
+                                model="[description: stepplugin.messageText(
+                                        service: serviceDefaults.service,
+                                        name: description.name,
+                                        code: 'plugin.description',
+                                        default: description.description
+                                ),
+                                        textCss    : 'text-info',
+                                        mode       : 'collapsed',
+                                        rkey       : g.rkey()]"/>
+
+                  </div>
+              </div>
             <g:render template="/framework/pluginConfigPropertiesInputs" model="${[
-                      service:com.dtolabs.rundeck.plugins.ServiceNameConstants.FileCopier,
-                      provider:description.name,
-                      properties:description.properties,
-                      report:fcopyreport?.errors && isSelected ? fcopyreport : null,
-                      prefix:fcopyprefix,
-                      values:isSelected?fcopyconfig:null,
-                      fieldnamePrefix:fcopyprefix,
-                      origfieldnamePrefix:'orig.'+fcopyprefix,
-                      allowedScope:PropertyScope.Project
+                    service            : serviceDefaults.service,
+                    provider           : description.name,
+                    properties         : description.properties,
+                    report             : serviceDefaults.errreport?.errors && isSelected ? serviceDefaults.errreport :
+                                         null,
+                    prefix             : fcopyprefix,
+                    values             : isSelected ? serviceDefaults.config : null,
+                    fieldnamePrefix    : fcopyprefix,
+                    origfieldnamePrefix: 'orig.' + fcopyprefix,
+                    allowedScope       : PropertyScope.Project
             ]}"/>
-          </div>
+
         </div>
       </g:if>
     </g:each>
     </div>
-  </g:if>
+
+</g:each>

--- a/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
@@ -67,12 +67,11 @@
         }
     }
 </script>
-<div class="list-group">
   <g:if test="${editOnly}">
     <g:hiddenField name="project" value="${project}"/>
   </g:if>
+<div class="tab-pane active" id="tab_details">
   <g:if test="${!editOnly}">
-    <div class="list-group-item">
       <div class="form-group ${projectNameError?'has-error':''}">
         <label for="project" class="required">
           <g:message code="domain.Project.field.name" default="Project Name"/>
@@ -82,9 +81,7 @@
           <div class="text-warning"><g:enc>${projectNameError}</g:enc></div>
         </g:if>
       </div>
-    </div>
   </g:if>
-  <div class="list-group-item">
     <div class="form-group ">
         <label for="label">
             <g:message code="domain.Project.label.label" default="Label"/>
@@ -102,7 +99,7 @@
     </div>
   </div>
 <feature:enabled name="cleanExecutionsHistoryJob">
-  <div class="list-group-item">
+  <div class="tab-pane" id="tab_history">
       <label class=" control-label"><g:message code="execution.history.cleanup.label" default="Execution History Clean"/>:</label>
       <div class="row">
           <div class="col-sm-4">
@@ -115,7 +112,7 @@
                           id="${nkey+'enable_cleaner_input'}"
                           onchange='cleanerchkbox(this)'
                           checked="${isSelected}"/>
-                  <label>
+                  <label for="${nkey+'enable_cleaner_input'}">
                       <b><g:enc>Enable</g:enc></b>
                   </label>
                   <span class="help-block"><g:enc>Enable cleaner executions history</g:enc></span>
@@ -151,7 +148,7 @@
             </g:if>
         </div>
         <div class="form-group">
-            %{--<div class="panel panel-default panel-tab-content crontab tabtarget"  >--}%
+            %{--<div class="panel panel-default panel-tab-pane crontab tabtarget"  >--}%
             <div class="${labelColSize}  control-label text-form-label">
                 <g:message code="execution.history.cleanup.schedule" default="Schedule clean history job (Cron expression). Default: 0 0 0 1/1 * ? * (Every days on 12:00 AM)"/>
             </div>
@@ -203,7 +200,7 @@
 </feature:enabled>
   <g:set var="categories" value="${new HashSet(extraConfig?.values()?.collect { it.configurable.categories?.values() }.flatten())}"/>
   <g:each in="${categories.sort() - 'resourceModelSource'}" var="category">
-    <div class="list-group-item">
+    <div class="tab-pane" id="tab_category_${category}">
     <g:render template="projectConfigurableForm"
               model="${[extraConfigSet: extraConfig?.values(),
                           category      : category,
@@ -214,7 +211,7 @@
     </div>
   </g:each>
   <g:if test="${nodeExecDescriptions}">
-    <div class="list-group-item">
+    <div class="tab-pane" id="tab_nodeexec">
       <span class="h4">Default <g:message code="framework.service.NodeExecutor.label" /></span>
       <span class="help-block"><g:message code="domain.Project.edit.NodeExecutor.explanation" /></span>
       <g:each in="${nodeExecDescriptions}" var="description" status="nex">
@@ -261,7 +258,7 @@
     </div>
   </g:if>
   <g:if test="${fileCopyDescriptions}">
-    <div class="list-group-item">
+    <div class="tab-pane" id="tab_filecopy">
     <span class="h4">Default Node <g:message code="framework.service.FileCopier.label"/></span>
     <span class="help-block"><g:message code="domain.Project.edit.FileCopier.explanation" /></span>
     <g:each in="${fileCopyDescriptions}" var="description" status="nex">
@@ -307,4 +304,3 @@
     </g:each>
     </div>
   </g:if>
-</div>

--- a/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
@@ -222,20 +222,79 @@
             </div>
         </div>
 
-        <div class=" form-group">
-            <label class="col-sm-2 control-label " for="default_${serviceDefaults.service}">Default <g:message
-                    code="framework.service.${serviceDefaults.service}.label"/></label>
+        <div class=" form-group spacing-lg">
+            <div class="col-sm-12">
+                <div class="btn-group btn-group-lg">
+                    <button type="button" class="btn btn-simple btn-hover  btn-secondary dropdown-toggle" data-toggle="dropdown"
+                            aria-haspopup="true" aria-expanded="false">
 
-            <div class="col-sm-10">
-                <select name="default_${serviceDefaults.service}"
-                        data-bind="value: defaults['${serviceDefaults.service}'].type" class="form-control"
-                        id="default_${serviceDefaults.service}">
-                    <option value="" disabled>-- Select a <g:message
-                            code="framework.service.${serviceDefaults.service}.label"/> --</option>
-                    <g:each in="${serviceDefaults.descriptions}" var="description" status="nex">
-                        <option value="${enc(attr: description.name)}">${description.title}</option>
-                    </g:each>
-                </select>
+                        <span class="caret"></span>
+
+                        <span data-bind="if: defaults['${serviceDefaults.service}'].type() ">
+
+                            <span data-bind="if: defaults['${serviceDefaults.service}'].description() ">
+                                <span data-bind="with: defaults['${serviceDefaults.service}'].description">
+                                <!-- ko if: iconSrc -->
+                                <img width="24px" height="24px" data-bind="attr: {src: iconSrc}"/>
+                                <!-- /ko -->
+                                <!-- ko if: glyphicon -->
+                                <i data-bind="css: 'glyphicon glyphicon-'+glyphicon()"></i>
+                                <!-- /ko -->
+                                <!-- ko if: faicon -->
+                                <i data-bind="css: 'fas fa-'+faicon()"></i>
+                                <!-- /ko -->
+                                <!-- ko if: fabicon -->
+                                <i data-bind="css: 'fab fa-'+fabicon()"></i>
+                                <!-- /ko -->
+                                <!-- ko if: !iconSrc() && !glyphicon() && !faicon() && !fabicon() -->
+                                <i class="rdicon icon-small plugin"></i>
+                                <!-- /ko -->
+                                <span data-bind="text: title"></span>
+                                </span>
+                            </span>
+                        </span>
+                        <span data-bind="if: !defaults['${serviceDefaults.service}'].type()">
+                            Select a <g:message
+                                    code="framework.service.${serviceDefaults.service}.label"/>
+                        </span>
+
+                        <span class="sr-only">Toggle Dropdown</span>
+                    </button>
+
+
+                    <ul class="dropdown-menu ">
+
+                            <li data-bind="foreach: descriptions['${serviceDefaults.service}']">
+                                <a href="#" data-bind="click: function(){$parent.defaults['${serviceDefaults.service}'].type(type())}">
+                                    <!-- ko if: iconSrc -->
+                                    <img width="16px" height="16px" data-bind="attr: {src: iconSrc}"/>
+                                    <!-- /ko -->
+                                    <!-- ko if: glyphicon -->
+                                    <i data-bind="css: 'glyphicon glyphicon-'+glyphicon()"></i>
+                                    <!-- /ko -->
+                                    <!-- ko if: faicon -->
+                                    <i data-bind="css: 'fas fa-'+faicon()"></i>
+                                    <!-- /ko -->
+                                    <!-- ko if: fabicon -->
+                                    <i data-bind="css: 'fab fa-'+fabicon()"></i>
+                                    <!-- /ko -->
+                                    <!-- ko if: !iconSrc() && !glyphicon() && !faicon() && !fabicon() -->
+                                    <i class="rdicon icon-small plugin"></i>
+                                    <!-- /ko -->
+                                    <span data-bind="text: title"></span>
+
+                                </a>
+                            </li>
+                    </ul>
+                </div>
+                <span data-bind="if: defaults['${serviceDefaults.service}'].description() ">
+                    <span data-bind="with: defaults['${serviceDefaults.service}'].description">
+                        <span class="text-info">
+                            <span data-bind="text: descriptionFirstLine"></span>
+                        </span>
+                    </span>
+                </span>
+                <input type="hidden" name="default_${serviceDefaults.service}" data-bind="value: defaults['${serviceDefaults.service}'].type"/>
             </div>
         </div>
         <g:each in="${serviceDefaults.descriptions}" var="description" status="nex">
@@ -245,37 +304,12 @@
             <g:set var="fcopyprefix" value="${serviceDefaults.prefix}.default.config."/>
       <g:if test="${description && description.properties}">
           <g:set var="isSelected" value="${defaultNodeExec == description.name}"/>
-          <div class=" fcopyDetails" id="${enc(attr: nkey) + '_det'}"
+          <div class=" " id="${enc(attr: nkey) + '_det'}"
                data-bind="if: defaults['${serviceDefaults.service}'].type()==='${enc(attr: description.name)}'">
+              <hr/>
               <g:hiddenField name="${serviceDefaults.prefix}.default.type"
                              value="${description.name}"/>
-              <div class="form-group">
-                  <div class=" col-sm-12 ">
-                      <stepplugin:pluginIcon service="${serviceDefaults.service}"
-                                             name="${description.name}"
-                                             width="16px"
-                                             height="16px">
-                          <i class="rdicon icon-small plugin"></i>
-                      </stepplugin:pluginIcon>
-                      <stepplugin:message
-                              service="${serviceDefaults.service}"
-                              name="${description.name}"
-                              code="plugin.title"
-                              default="${description.title}"/>
-                      -
-                      <g:render template="/scheduledExecution/description"
-                                model="[description: stepplugin.messageText(
-                                        service: serviceDefaults.service,
-                                        name: description.name,
-                                        code: 'plugin.description',
-                                        default: description.description
-                                ),
-                                        textCss    : 'text-info',
-                                        mode       : 'collapsed',
-                                        rkey       : g.rkey()]"/>
 
-                  </div>
-              </div>
             <g:render template="/framework/pluginConfigPropertiesInputs" model="${[
                     service            : serviceDefaults.service,
                     provider           : description.name,

--- a/rundeckapp/grails-app/views/framework/_editProjectFormTabs.gsp
+++ b/rundeckapp/grails-app/views/framework/_editProjectFormTabs.gsp
@@ -1,0 +1,69 @@
+%{--
+  - Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  --}%
+<div class="vue-tabs">
+    <div class="nav-tabs-navigation">
+        <div class="nav-tabs-wrapper">
+            <ul class="nav nav-tabs" id="job_edit_tabs">
+                <li class="active">
+                    <a href="#tab_details" data-toggle="tab">
+                        <g:message code="project.edit.page.tab.details.title"/>
+                    </a>
+                </li>
+
+                <feature:enabled name="cleanExecutionsHistoryJob">
+                    <li>
+                        <a href="#tab_history" data-toggle="tab">
+                            <g:message code="execution.history.cleanup.label" default="Execution History Clean"/>
+                        </a>
+                    </li>
+                </feature:enabled>
+                <g:set var="categories" value="${new HashSet(
+                        extraConfig?.values()?.
+                                collect { it.configurable.categories?.values() }.
+                                flatten()
+                )}"/>
+                <g:each in="${categories.sort() - 'resourceModelSource'}" var="category">
+                    <li>
+                        <a href="#tab_category_${category}" data-toggle="tab">
+                            <g:message code="project.configuration.extra.category.${category}.title"
+                                       default="${category}"/>
+                        </a>
+                    </li>
+                </g:each>
+                <g:if test="${nodeExecDescriptions}">
+                    <li>
+                        <a href="#tab_nodeexec" data-toggle="tab">
+                            Default <g:message code="framework.service.NodeExecutor.label" />
+                        </a>
+                    </li>
+                </g:if>
+                <g:if test="${fileCopyDescriptions}">
+                    <li>
+                        <a href="#tab_filecopy" data-toggle="tab">
+                            Default Node <g:message code="framework.service.FileCopier.label"/>
+                        </a>
+                    </li>
+                </g:if>
+
+            </ul>
+        </div>
+    </div>
+</div>
+
+
+<div class="tab-content spacing-lg" id="page_job_edit">
+    <g:render template="editProjectForm" model="${[editOnly: editOnly, project: project]}"/>
+</div>

--- a/rundeckapp/grails-app/views/framework/_editProjectFormTabs.gsp
+++ b/rundeckapp/grails-app/views/framework/_editProjectFormTabs.gsp
@@ -13,7 +13,7 @@
   - See the License for the specific language governing permissions and
   - limitations under the License.
   --}%
-<div class="vue-tabs">
+<div class="vue-tabs"  data-ko-bind="editProject">
     <div class="nav-tabs-navigation">
         <div class="nav-tabs-wrapper">
             <ul class="nav nav-tabs" id="job_edit_tabs">
@@ -43,20 +43,13 @@
                         </a>
                     </li>
                 </g:each>
-                <g:if test="${nodeExecDescriptions}">
+                <g:each in="${serviceDefaultsList}" var="serviceDefaults">
                     <li>
-                        <a href="#tab_nodeexec" data-toggle="tab">
-                            Default <g:message code="framework.service.NodeExecutor.label" />
+                        <a href="#tab_svc_${serviceDefaults.service}" data-toggle="tab">
+                            Default <g:message code="framework.service.${serviceDefaults.service}.label"/>
                         </a>
                     </li>
-                </g:if>
-                <g:if test="${fileCopyDescriptions}">
-                    <li>
-                        <a href="#tab_filecopy" data-toggle="tab">
-                            Default Node <g:message code="framework.service.FileCopier.label"/>
-                        </a>
-                    </li>
-                </g:if>
+                </g:each>
 
             </ul>
         </div>
@@ -64,6 +57,6 @@
 </div>
 
 
-<div class="tab-content spacing-lg" id="page_job_edit">
-    <g:render template="editProjectForm" model="${[editOnly: editOnly, project: project]}"/>
+<div class="tab-content spacing-lg" id="page_job_edit" data-ko-bind="editProject">
+    <g:render template="editProjectForm" model="${[editOnly: editOnly, project: project,serviceDefaultsList:serviceDefaultsList]}"/>
 </div>

--- a/rundeckapp/grails-app/views/framework/editProject.gsp
+++ b/rundeckapp/grails-app/views/framework/editProject.gsp
@@ -78,7 +78,7 @@
           </h3>
         </div>
         <div class="card-content">
-          <g:render template="editProjectForm" model="${[editOnly:true,project: params.project ?: request.project]}"/>
+          <g:render template="editProjectFormTabs" model="${[editOnly:true,project: params.project ?: request.project]}"/>
         </div>
         <div class="card-footer">
           <g:submitButton name="cancel" value="${g.message(code:'button.action.Cancel',default:'Cancel')}" class="btn btn-default reset_page_confirm"/>

--- a/rundeckapp/grails-app/views/framework/editProject.gsp
+++ b/rundeckapp/grails-app/views/framework/editProject.gsp
@@ -31,10 +31,56 @@
     <meta name="projconfigselected" content="edit-project"/>
     <title><g:message code="edit.configuration" /></title>
     <g:set var="projectName" value="${params.project ?: request.project}"/>
+    <g:set var="nodeExecutorPluginsData" value="${nodeExecDescriptions.collect {
+        [
+                type       : it.name,
+                iconSrc    : stepplugin.pluginIconSrc(service: 'NodeExecutor', name: it.name),
+                providerMeta    : stepplugin.pluginProviderMeta(service: 'NodeExecutor', name: it.name),
+                title      :
+                        stepplugin.messageText(
+                                service: 'NodeExecutor',
+                                name: it.name,
+                                code: 'plugin.title',
+                                default: it.title
+                        ),
+                description:
+                        stepplugin.messageText(
+                                service: 'NodeExecutor',
+                                name: it.name,
+                                code: 'plugin.description',
+                                default: it.description
+                        )
+        ]
+    }}"/>
+    <g:set var="fileCopierPluginsData" value="${fileCopyDescriptions.collect {
+        [
+                type       : it.name,
+                iconSrc    : stepplugin.pluginIconSrc(service: 'FileCopier', name: it.name),
+                providerMeta    : stepplugin.pluginProviderMeta(service: 'FileCopier', name: it.name),
+                title      :
+                        stepplugin.messageText(
+                                service: 'FileCopier',
+                                name: it.name,
+                                code: 'plugin.title',
+                                default: it.title
+                        ),
+                description:
+                        stepplugin.messageText(
+                                service: 'FileCopier',
+                                name: it.name,
+                                code: 'plugin.description',
+                                default: it.description
+                        )
+        ]
+    }}" />
     <g:embedJSON id="projectDataJSON" data="${[
             project          : projectName,
             defaultFileCopier: defaultFileCopy,
-            defaultNodeExec  : defaultNodeExec
+            defaultNodeExec  : defaultNodeExec,
+            descriptions: [
+                    NodeExecutor: nodeExecutorPluginsData,
+                    FileCopier: fileCopierPluginsData,
+            ]
     ]}"/>
     <asset:javascript src="prototype/effects"/>
     <asset:javascript src="leavePageConfirm.js"/>

--- a/rundeckapp/grails-app/views/framework/editProject.gsp
+++ b/rundeckapp/grails-app/views/framework/editProject.gsp
@@ -20,7 +20,7 @@
    Created: Dec 29, 2010 6:28:51 PM
 --%>
 
-<%@ page contentType="text/html;charset=UTF-8" %>
+<%@ page import="com.dtolabs.rundeck.plugins.ServiceNameConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <g:set var="rkey" value="${g.rkey()}"/>
@@ -30,10 +30,15 @@
     <meta name="projtabtitle" content="${message(code:'configuration')}"/>
     <meta name="projconfigselected" content="edit-project"/>
     <title><g:message code="edit.configuration" /></title>
-
+    <g:set var="projectName" value="${params.project ?: request.project}"/>
+    <g:embedJSON id="projectDataJSON" data="${[
+            project          : projectName,
+            defaultFileCopier: defaultFileCopy,
+            defaultNodeExec  : defaultNodeExec
+    ]}"/>
     <asset:javascript src="prototype/effects"/>
     <asset:javascript src="leavePageConfirm.js"/>
-    <asset:javascript src="storageBrowseKO.js"/>
+    <asset:javascript src="framework/editProject.js"/>
     <g:jsMessages code="page.unsaved.changes"/>
     <g:javascript>
 
@@ -61,24 +66,45 @@
     <g:form action="saveProject" method="post" useToken="true" onsubmit="return configControl.checkForm();" class="form">
     <div class="col-xs-12">
       <div class="card"  id="createform">
-        <div class="card-header">
+          <div class="card-header" data-ko-bind="editProject">
           <h3 class="card-title">
-            <g:message code="domain.Project.edit.message" default="Configure Project"/>: <g:enc>${params.project ?: request.project}</g:enc>
+              <g:message code="domain.Project.edit.message" default="Configure Project"/>: <g:enc>${projectName}</g:enc>
             <g:link controller="framework" action="editProjectConfig"
-              params="[project: params.project ?: request.project]"
-              class="has_tooltip pull-right btn btn-sm"
-              data-placement="bottom"
-              title="${message(
+                    params="[project: projectName]"
+                    class="has_tooltip pull-right btn btn-sm"
+                    data-placement="bottom"
+                    title="${message(
                       code: 'page.admin.EditProjectConfigFile.title',
                       default: 'Advanced: Edit config file directly'
               )}">
-              <!-- <g:icon name="file"/> -->
-              <g:message code="page.admin.EditProjectConfigFile.button" default="Edit Configuration File"/>
+
+                <g:message code="page.admin.EditProjectConfigFile.button" default="Edit Configuration File"/>
             </g:link>
           </h3>
         </div>
         <div class="card-content">
-          <g:render template="editProjectFormTabs" model="${[editOnly:true,project: params.project ?: request.project]}"/>
+            <g:set var="serviceDefaultsList" value="${[
+                    [
+                            service     : ServiceNameConstants.NodeExecutor,
+                            descriptions: nodeExecDescriptions,
+                            prefix      : 'nodeexec',
+                            errreport   : nodeexecreport,
+                            selectedType: defaultNodeExec,
+                            config      : nodeexecconfig
+
+                    ],
+                    [
+                            service     : ServiceNameConstants.FileCopier,
+                            descriptions: fileCopyDescriptions,
+                            prefix      : 'fcopy',
+                            errreport   : fcopyreport,
+                            selectedType: defaultFileCopy,
+                            config      : fcopyconfig
+
+                    ]
+            ]}"/>
+            <g:render template="editProjectFormTabs"
+                      model="${[editOnly: true, project: projectName, serviceDefaultsList: serviceDefaultsList]}"/>
         </div>
         <div class="card-footer">
           <g:submitButton name="cancel" value="${g.message(code:'button.action.Cancel',default:'Cancel')}" class="btn btn-default reset_page_confirm"/>

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerTest.groovy
@@ -441,9 +441,9 @@ class FrameworkControllerTest {
         request.method = "POST"
 
         params.project = "TestSaveProject"
-        params.defaultNodeExec = 1
+        params.default_NodeExecutor = 'foobar'
         params.nodeexec = [
-                "1": [
+                "default": [
                         type  : "foobar",
                         config: [
                                 specialvalue1: "foobar",
@@ -692,9 +692,9 @@ class FrameworkControllerTest {
         request.method = "POST"
 
         params.project = "TestSaveProject"
-        params.defaultNodeExec = 1
+        params.default_NodeExecutor = 'foobar'
         params.nodeexec = [
-            "1": [
+            "default": [
                 type  : "foobar",
                 config: [
                     specialvalue1: "foobar",


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Refactor project config/create form to use tabs instead of a long form

Replace the default Node Executor/File Copier selection UI so it doesn't use radio buttons

![Screen Shot 2019-06-11 at 12 32 55 PM](https://user-images.githubusercontent.com/55603/59300884-2604ed80-8c45-11e9-88a0-79d32a26a3d2.png)
