### PR TITLE
[3.0.x backport] fix: js console error 404 "manifest.js" #4873

### DIFF
--- a/rundeckapp/grails-app/views/layouts/base.gsp
+++ b/rundeckapp/grails-app/views/layouts/base.gsp
@@ -70,7 +70,6 @@
     <g:render template="/common/css"/>
 
     <!-- VUE JS REQUIREMENTS -->
-    <asset:javascript src="static/manifest.js"/>
     <asset:javascript src="static/vendor.js"/>
     <!-- /VUE JS REQUIREMENTS -->
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

backport: Fix #4873 

