### PR TITLE
[draft] Cleanup Workflow execution

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/MultiWorkflowExecutionServiceThread.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/MultiWorkflowExecutionServiceThread.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * WorkflowExecutionServiceThread.java
+ *
+ * User: Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
+ * Created: 3/29/11 12:00 PM
+ *
+ */
+package com.dtolabs.rundeck.core.execution;
+
+import com.dtolabs.rundeck.core.execution.workflow.*;
+import com.dtolabs.rundeck.core.logging.LoggingManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Implementation of {@link WorkflowExecutionServiceThread} which implements the chained execution of
+ * multiple workflows after the execution of a primary execution workflow.
+ *
+ * @author Alberto Hormazabal Cespedes (alberto@rundeck.com)
+ */
+public class MultiWorkflowExecutionServiceThread extends WorkflowExecutionServiceThread {
+
+    /**
+     * List of secondary workflows to execute.
+     */
+    List<WorkflowExecutionItem> cleanupWorkflowExecutionItems;
+
+    public MultiWorkflowExecutionServiceThread(
+            WorkflowExecutionService eservice,
+            WorkflowExecutionItem primaryWorkflowItem,
+            List<WorkflowExecutionItem> cleanupWorkflowExecutionItems,
+            StepExecutionContext econtext,
+            LoggingManager loggingManager) {
+
+        super(eservice, primaryWorkflowItem, econtext, loggingManager);
+
+        this.cleanupWorkflowExecutionItems = cleanupWorkflowExecutionItems;
+
+    }
+
+
+    @Override
+    public void run() {
+
+        if (null == this.weservice || null == this.weitem || null == context) {
+            throw new IllegalStateException("project or execution detail not instantiated");
+        }
+
+        try {
+
+            // Execute primary workflow
+            StaticWorkflowExecutionResult executionResult = runWorkflow(weitem);
+
+            setResult(executionResult.workflowResult);
+            success = executionResult.success;
+            thrown = executionResult.thrown;
+            resultObject = executionResult.workflowResult;
+
+            if (cleanupWorkflowExecutionItems != null && !cleanupWorkflowExecutionItems.isEmpty()) {
+                context.getExecutionLogger().log(2, "==Executing Cleanup Workflows");
+
+                List<StaticWorkflowExecutionResult> cleanupResults = new ArrayList<>();
+
+                for (WorkflowExecutionItem nextWorkflow : cleanupWorkflowExecutionItems) {
+
+                    try {
+                        StaticWorkflowExecutionResult nextResult = runWorkflow(nextWorkflow);
+                        context.getExecutionLogger().log(2, "Secondary Workflow Executed: " + nextResult.toString());
+                        cleanupResults.add(nextResult);
+
+                    } catch (Exception e) {
+                        context.getExecutionLogger().log(0, "Error executing secondary workflow: " +
+                                e.getMessage());
+                        e.printStackTrace(System.err);
+
+                        // TODO check state transition on secondary wf error.
+                    }
+                }
+            }
+        } catch (Throwable e) {
+            e.printStackTrace(System.err);
+            thrown = e;
+            return;
+        }
+    }
+}

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -29,7 +29,7 @@ class Execution extends ExecutionContext {
 
     ScheduledExecution scheduledExecution
     Date dateStarted
-    Date dateCompleted 
+    Date dateCompleted
     String status
     String outputfilepath
     String failedNodeList
@@ -38,6 +38,7 @@ class Execution extends ExecutionContext {
     boolean cancelled
     Boolean timedOut=false
     Workflow workflow
+    Workflow cleanupWorkflow
     String executionType
     Integer retryAttempt=0
     Boolean willRetry=false
@@ -58,6 +59,7 @@ class Execution extends ExecutionContext {
         })
         logFileStorageRequest(nullable:true)
         workflow(nullable:true)
+        cleanupWorkflow(nullable: true)
         argString(nullable:true)
         dateStarted(nullable:true)
         dateCompleted(nullable:true)

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -37,8 +37,10 @@ class Execution extends ExecutionContext {
     String abortedby
     boolean cancelled
     Boolean timedOut=false
+
     Workflow workflow
     Workflow cleanupWorkflow
+
     String executionType
     Integer retryAttempt=0
     Boolean willRetry=false


### PR DESCRIPTION
This PR allow to specify a second Workflow for a Job, to run as a "Cleanup Workflow".
Currently, if a cleanup workflow is defined for a job or an execution, the system will run the second workflow once the first workflow is completed (successful or not), using the same context.
If the second workflow fails, the succeed status of the first workflow will be preserved.

To create a job with a cleanup workflow, the job import api or the rd cli can be used, specifying a "cleanupSequence" section with the same format as the original "sequence" entry.  Example:
```
- defaultTab: nodes
  description: test description
  executionEnabled: true
  loglevel: INFO
  name: Testjob2
  nodeFilterEditable: false
  options:
  - label: wait
    name: wait
    regex: '[0-9]+'
    value: '15'
  scheduleEnabled: true
  sequence:
    commands:
    - script: |-
        echo "test @option.wait@:" $(date)
        echo "=================================="
        sleep @option.wait@
        echo "done" $(date)
    keepgoing: false
    strategy: node-first
  cleanupSequence:
    commands:
    - exec: echo "test" $(date)
    - exec: echo "testing"
    keepgoing: false
    strategy: node-first

```