### PR TITLE
add capability to use ${global.x} on Storage Path options

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1249,6 +1249,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     if (job && defStoragePath?.contains('${job.')) {
                         defStoragePath = DataContextUtils.replaceDataReferencesInString(defStoragePath, DataContextUtils.addContext("job", job, null)).trim()
                     }
+                    if (job && defStoragePath?.contains('${global.')) {
+                        defStoragePath = DataContextUtils.replaceDataReferencesInString(defStoragePath, DataContextUtils.addContext("global", job, null)).trim()
+                    }
                     def password
                     def nodeDeferred = false
                     if (defStoragePath?.contains('${node.')) {


### PR DESCRIPTION
Add capability to use ${global.x} on Storage Path options.

![image](https://user-images.githubusercontent.com/2133666/59441067-46c17480-8df8-11e9-89fa-f47434a4d711.png)
