### PR TITLE
Add multiple jobs ids to scheduler/takeover endpoint

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -4486,7 +4486,7 @@ class ScheduledExecutionController  extends ControllerBase{
             if(jobid){
                 jobIds << jobid
             }
-            if(data?.jobs){
+            if(request.api_version >= ApiVersions.V31 && data?.jobs){
                 data?.jobs.each{job->
                     jobIds << job.id
                 }
@@ -4500,10 +4500,17 @@ class ScheduledExecutionController  extends ControllerBase{
                 serverUUID = data.server?.'@uuid'?.text()?:null
                 serverAll = data.server?.'@all'?.text()=='true'
                 project = data.project?.'@name'?.text()?:null
-                if(data.job?.size()>0){
-                    data.job?.each{ job ->
-                        jobIds << job?.'@id'?.text()
+                if(request.api_version >= ApiVersions.V31){
+                    if(data.job?.size()>0){
+                        data.job?.each{ job ->
+                            jobIds << job?.'@id'?.text()
 
+                        }
+                    }
+                }else{
+                    jobid = data.job?.'@id'?.text()?:null
+                    if(jobid){
+                        jobIds << jobid
                     }
                 }
             }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -508,7 +508,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             String fromServerUUID = null,
             boolean selectAll = false,
             String projectFilter = null,
-            String jobid = null
+            List<String> jobids = null
     )
     {
         Map claimed = [:]
@@ -551,8 +551,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 if (queryProject) {
                     eq('project', queryProject)
                 }
-                if (jobid){
-                    eq('uuid', jobid)
+                if (jobids){
+                    'in'('uuid', jobids)
                 }
             }.each { ScheduledExecution se ->
                 def orig = se.serverNodeUUID
@@ -789,12 +789,12 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
      * @param fromServerUUID server UUID to claim scheduling of jobs from
      * @return map of job ID to [success:boolean, job:ScheduledExecution] indicating reclaim was successful or not.
      */
-    def reclaimAndScheduleJobs(String fromServerUUID, boolean all=false, String project=null, String id=null) {
+    def reclaimAndScheduleJobs(String fromServerUUID, boolean all=false, String project=null, List<String> ids=null) {
         def toServerUuid = frameworkService.getServerUUID()
         if (toServerUuid == fromServerUUID) {
             return [:]
         }
-        def claimed = claimScheduledJobs(toServerUuid, fromServerUUID, all, project, id)
+        def claimed = claimScheduledJobs(toServerUuid, fromServerUUID, all, project, ids)
         if (claimed.find { it.value.success }) {
             rescheduleJobs(toServerUuid)
         }

--- a/rundeckapp/src/integration-test/groovy/rundeck/services/ScheduledExecutionServiceIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/services/ScheduledExecutionServiceIntegrationSpec.groovy
@@ -98,7 +98,7 @@ class ScheduledExecutionServiceIntegrationSpec extends Specification {
 
 
         when:
-        def results = service.reclaimAndScheduleJobs(TEST_UUID1, true, project, jobUuid)
+        def results = service.reclaimAndScheduleJobs(TEST_UUID1, true, project, [jobUuid])
 //        ScheduledExecution.withSession { session ->
 //            session.flush()
 //            se.refresh()

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -379,7 +379,19 @@ class ScheduledExecutionControllerSpec extends Specification {
             1 * isClusterModeEnabled()>>true
         }
         controller.scheduledExecutionService=Mock(ScheduledExecutionService){
-            1 * reclaimAndScheduleJobs(requestUUID,allserver,project,jobid)>>[:]
+            if(jobid){
+                1 * reclaimAndScheduleJobs(requestUUID,allserver,project,_)>>{args ->
+                    def jobids = jobid.split(',')
+                    if(args[3]?.size()==jobids.size()){
+                        if(args[3].containsAll(jobids)){
+                            return [:]
+                        }
+                    }
+                    null
+                }
+            }else{
+                1 * reclaimAndScheduleJobs(requestUUID,allserver,project,null)>>[:]
+            }
             0 * _(*_)
         }
         when:
@@ -400,6 +412,7 @@ class ScheduledExecutionControllerSpec extends Specification {
         '<takeoverSchedule><server all="true" /><project name="asdf"/></takeoverSchedule>'                      | null        | true      | 'asdf'  | null
         '<takeoverSchedule><server all="true" /><job id="ajobid"/></takeoverSchedule>'                          | null        | true      | null    | 'ajobid'
         "<takeoverSchedule><server uuid='${TEST_UUID1}' /><project name='asdf'/></takeoverSchedule>".toString() | TEST_UUID1  | false     | 'asdf'  | null
+        '<takeoverSchedule><server all="true" /><job id="ajobid"/><job id="ajobidb"/></takeoverSchedule>'       | null        | true      | null    | 'ajobid,ajobidb'
     }
 
 


### PR DESCRIPTION
Currently, the takeover endpoint allows specifying only one job id or leave it empty for every job.
With this enhancement, using API v31 or greater you can specify multiple job ids using the same endpoint.

ENDPOINT: `/api/31/scheduler/takeover`

application/json 
``` 
{
	"server": {
    "all": true
  },
  "jobs":[
  	{
    "id": "15f66e9e-4034-4eb4-9fb7-4d4a739f691b"
	},
	{
    "id": "e4b6fdeb-85dd-4080-b723-1571ca3e1097"
	}
  ]
}
```

application/xml
```
<takeoverSchedule>
	<server all="true"/>
	<job id="15f66e9e-4034-4eb4-9fb7-4d4a739f691b"/>
	<job id="e4b6fdeb-85dd-4080-b723-1571ca3e1097"/>
</takeoverSchedule>
```


fix #4725