### PR TITLE
Fix: run job with no options causes error

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_editOptions.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editOptions.gsp
@@ -23,7 +23,6 @@
 
 <g:set var="rkey" value="${g.rkey()}"/>
 
-<input type="hidden" name="id" value="${enc(attr:scheduledExecution?.extid)}"/>
 <div class="note error" style="display: none" id="editerror">
 
 </div>

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -18,6 +18,7 @@
 
 <g:uploadForm controller="scheduledExecution" method="post" useToken="true"
               params="[project: scheduledExecution.project]" role="form" >
+<input type="hidden" name="id" value="${enc(attr:scheduledExecution?.extid)}"/>
 <div id="exec_options_form">
     <!-- BEGIN: firefox hack https://bugzilla.mozilla.org/show_bug.cgi?id=1119063 -->
     <input type="text" style="display:none" class="ixnay">


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

fix regression caused by 163dfac03c3eff77240a6c3128e0446fd7dae1c2

- [x] run job form with no options causes error