### PR TITLE
Fix empty error when node exec validation fails

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -1448,7 +1448,11 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             final validation = frameworkService.validateServiceConfig(type, identifier+".${ndx}.config.", params, service)
             if (!validation.valid) {
                 report = validation.report
-                errors << validation.error ? "${title} configuration was invalid: " + validation.error : "${title} configuration was invalid"
+                errors << (
+                        validation.error ?
+                        "${title} configuration was invalid: " + validation.error :
+                        "${title} configuration was invalid"
+                )
             }
         }
         [type, config, report]


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

problem: Project config page shows an error with an empty list if Default Node Executor/File Copier plugin validation fails.