### PR TITLE
Execution mode status API with failing code when status is passive.

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -2257,7 +2257,7 @@ setTimeout(function(){
      */
     def apiExecutionModeStatus() {
 
-        if (!apiService.requireVersion(request, response, ApiVersions.V31)) {
+        if (!apiService.requireVersion(request, response, ApiVersions.V32)) {
             return
         }
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -2255,6 +2255,46 @@ setTimeout(function(){
      *
      * @return
      */
+    def apiExecutionModeStatus() {
+
+        if (!apiService.requireVersion(request, response, ApiVersions.V31)) {
+            return
+        }
+
+        AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
+        if (!frameworkService.authorizeApplicationResource(authContext, AuthConstants.RESOURCE_TYPE_SYSTEM,
+                AuthConstants.ACTION_READ)) {
+            return apiService.renderErrorFormat(response,
+                    [
+                            status: HttpServletResponse.SC_FORBIDDEN,
+                            code  : "api.error.item.unauthorized",
+                            args  : ["Read execution status", "Rundeck", '']
+                    ])
+        }
+
+        def executionStatus = configurationService.executionModeActive
+        int respStatus = executionStatus ? HttpServletResponse.SC_OK : HttpServletResponse.SC_SERVICE_UNAVAILABLE
+
+        withFormat {
+            json {
+                render(status: respStatus,  contentType: "application/json") {
+                    delegate.executionMode(executionStatus ? 'active' : 'passive')
+                }
+            }
+            xml {
+                render(status: respStatus, contentType: "application/xml") {
+                    delegate.'executions'(executionMode: executionStatus ? 'active' : 'passive')
+                }
+            }
+        }
+
+
+    }
+
+    /**
+     *
+     * @return
+     */
     def apiExecutionModeActive() {
         apiExecutionMode(true)
     }

--- a/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
+++ b/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
@@ -203,6 +203,7 @@ class UrlMappings {
         "/api/$api_version/system/logstorage"(controller: 'menu', action: 'apiLogstorageInfo')
         "/api/$api_version/system/logstorage/incomplete/resume"(controller: 'menu', action: 'apiResumeIncompleteLogstorage')
         "/api/$api_version/system/logstorage/incomplete"(controller: 'menu', action: 'apiLogstorageListIncompleteExecutions')
+        "/api/$api_version/system/executions/status"(controller: 'execution', action: 'apiExecutionModeStatus')
         "/api/$api_version/system/executions/enable"(controller: 'execution', action: 'apiExecutionModeActive')
         "/api/$api_version/system/executions/disable"(controller: 'execution', action: 'apiExecutionModePassive')
         "/api/$api_version/system/acl/$path**"(controller: 'framework',action: 'apiSystemAcls')

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerTests.groovy
@@ -711,12 +711,12 @@ class ExecutionControllerTests  {
 
         def controller = new ExecutionController()
 
-        controller.request.api_version = 31
+        controller.request.api_version = 32
         controller.request.contentType = "application/json"
 
         def apiMock = new MockFor(ApiService, false)
         apiMock.demand.requireVersion { request, response, int min ->
-            assertEquals(31, min)
+            assertEquals(32, min)
             return true
         }
         controller.apiService = apiMock.proxyInstance()
@@ -748,12 +748,12 @@ class ExecutionControllerTests  {
 
         def controller = new ExecutionController()
 
-        controller.request.api_version = 31
+        controller.request.api_version = 32
         controller.request.contentType = "application/json"
 
         def apiMock = new MockFor(ApiService, false)
         apiMock.demand.requireVersion { request, response, int min ->
-            assertEquals(31, min)
+            assertEquals(32, min)
             return true
         }
         controller.apiService = apiMock.proxyInstance()


### PR DESCRIPTION
Issue: https://github.com/rundeckpro/rundeckpro/issues/606

This PR creates a new API endpoing ``/api/V/system/executions/status`` which returns the current
execution mode using the same response format as ``/api/V/system/executions/active`` and ``/api/V/system/executions/passive``.

Additionally, the endpoint will respond with a HTTP status of ``503 - Service Unavailable`` when the current status is **passive**.

