### PR TITLE
Small improvement to the API forecast

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2871,7 +2871,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         //future scheduled executions forecast
         def time = params.time? params.time : '1d'
 
-        def retro = params.past=='true'
+        def retro = ((request.api_version >= ApiVersions.V32) && (params.past=='true'))
 
         Date futureDate = futureRelativeDate(time,retro)
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2871,7 +2871,9 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         //future scheduled executions forecast
         def time = params.time? params.time : '1d'
 
-        Date futureDate = futureRelativeDate(time)
+        def retro = params.past=='true'
+
+        Date futureDate = futureRelativeDate(time,retro)
 
         def max = null
         if (params.max) {
@@ -2882,7 +2884,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         }
 
         if (scheduledExecution.shouldScheduleExecution()) {
-            extra.futureScheduledExecutions = scheduledExecutionService.nextExecutions(scheduledExecution, futureDate)
+            extra.futureScheduledExecutions = scheduledExecutionService.nextExecutions(scheduledExecution, futureDate, retro)
             if (max
                     && extra.futureScheduledExecutions
                     && extra.futureScheduledExecutions.size() > max) {
@@ -2904,7 +2906,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         )
     }
 
-    private Date futureRelativeDate(String recentFilter){
+    private Date futureRelativeDate(String recentFilter, boolean negative=false){
         Calendar n = GregorianCalendar.getInstance()
         n.setTime(new Date())
         def matcher = recentFilter =~ /^(\d+)([hdwmyns])$/
@@ -2934,8 +2936,11 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     ndx = Calendar.YEAR
                     break
             }
-            n.add(ndx, i)
-
+            if(negative){
+                n.add(ndx, i*-1)
+            }else {
+                n.add(ndx, i)
+            }
             return n.getTime()
         }
         null

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3940,12 +3940,16 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
      * @param to Date in the future
      * @return list of dates
      */
-    List<Date> nextExecutions(ScheduledExecution se, Date to){
+    List<Date> nextExecutions(ScheduledExecution se, Date to, boolean past = false){
         def trigger = createTrigger(se)
         Calendar cal = new BaseCalendar()
         if(se.timeZone){
             cal.setTimeZone(TimeZone.getTimeZone(se.timeZone))
         }
-        return TriggerUtils.computeFireTimesBetween(trigger, cal, new Date(), to)
+        if(past){
+            return TriggerUtils.computeFireTimesBetween(trigger, cal, to,new Date())
+        }else {
+            return TriggerUtils.computeFireTimesBetween(trigger, cal, new Date(), to)
+        }
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1401,6 +1401,7 @@ class MenuControllerSpec extends Specification {
         job1.save()
 
         when:
+        request.api_version = 32
         params.id=testUUID
         params.past='true'
         response.format='json'

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1370,7 +1370,53 @@ class MenuControllerSpec extends Specification {
         1 * controller.frameworkService.authorizeProjectJobAny(_, job1, ['read','view'], 'AProject') >> true
         1 * controller.apiService.apiHrefForJob(job1) >> 'api/href'
         1 * controller.apiService.guiHrefForJob(job1) >> 'gui/href'
-        1 * controller.scheduledExecutionService.nextExecutions(_,_) >> [new Date()]
+        1 * controller.scheduledExecutionService.nextExecutions(_,_,false) >> [new Date()]
+
+        response.json != null
+        response.json.id  == testUUID
+        response.json.description  == 'a job'
+        response.json.name  == 'job1'
+        response.json.group  == 'some/where'
+        response.json.href  == 'api/href'
+        response.json.permalink  == 'gui/href'
+        response.json.futureScheduledExecutions != null
+        response.json.futureScheduledExecutions.size() == 1
+    }
+
+
+    def "api job forecast json past mode"() {
+        given:
+        def testUUID = UUID.randomUUID().toString()
+        def testUUID2 = UUID.randomUUID().toString()
+        controller.apiService = Mock(ApiService)
+        controller.frameworkService = Mock(FrameworkService)
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService){
+            createTrigger(_) >> org.quartz.TriggerBuilder.newTrigger().build();
+        }
+        ScheduledExecution job1 = new ScheduledExecution(createJobParams(jobName: 'job1', uuid:testUUID))
+        job1.serverNodeUUID = testUUID2
+        job1.totalTime=200*1000
+        job1.execCount=100
+        job1.scheduled=true
+        job1.save()
+
+        when:
+        params.id=testUUID
+        params.past='true'
+        response.format='json'
+        def result = controller.apiJobForecast()
+
+        then:
+        1 * controller.apiService.requireVersion(_, _, 31) >> true
+        1 * controller.apiService.requireParameters(_, _, ['id']) >> true
+        1 * controller.scheduledExecutionService.getByIDorUUID(testUUID) >> job1
+        1 * controller.apiService.requireExists(_, job1, _) >> true
+        1 * controller.frameworkService.getAuthContextForSubjectAndProject(_, 'AProject') >>
+                Mock(UserAndRolesAuthContext)
+        1 * controller.frameworkService.authorizeProjectJobAny(_, job1, ['read','view'], 'AProject') >> true
+        1 * controller.apiService.apiHrefForJob(job1) >> 'api/href'
+        1 * controller.apiService.guiHrefForJob(job1) >> 'gui/href'
+        1 * controller.scheduledExecutionService.nextExecutions(_,_,true) >> [new Date()]
 
         response.json != null
         response.json.id  == testUUID


### PR DESCRIPTION
fix #4985 

For those strange cases in which you need to check when a job should have run.

This is a new parameter for the endpoint:
```
GET /api/31/job/[ID]/forecast
```

Adding the parameter `past=true` will return an inverse forecast, that is, considering the current scheduler, when it should have run.
This forecast is only referential, since it will not take into account if the job could have been disabled or not yet been created.

A couple of people in the community channels requested this functionality as a nice to have for administration purpose.

