### PR TITLE
adding bind address to jsch

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutor.java
@@ -108,6 +108,10 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
     public static final String FWK_PROP_SET_PTY = FWK_PROP_PREFIX + NODE_ATTR_ALWAYS_SET_PTY;
     public static final String PROJ_PROP_SET_PTY = PROJ_PROP_PREFIX + NODE_ATTR_ALWAYS_SET_PTY;
 
+    public static final String NODE_BRIND_ADDRESS = "bind-address";
+    public static final String FWK_PROP_BRIND_ADDRESS = FWK_PROP_PREFIX + NODE_BRIND_ADDRESS;
+    public static final String PROJ_PROP_BRIND_ADDRESS = PROJ_PROP_PREFIX + NODE_BRIND_ADDRESS;
+
     public static final String FWK_PROP_SSH_AUTHENTICATION = FWK_PROP_PREFIX + NODE_ATTR_SSH_AUTHENTICATION;
     public static final String PROJ_PROP_SSH_AUTHENTICATION = PROJ_PROP_PREFIX + NODE_ATTR_SSH_AUTHENTICATION;
 
@@ -175,6 +179,7 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
     public static final String CONFIG_SET_PTY = "always-set-pty";
     public static final String CONFIG_CON_TIMEOUT = "ssh-connection-timeout";
     public static final String CONFIG_COMMAND_TIMEOUT = "ssh-command-timeout";
+    public static final String CONFIG_BIND_ADDRESS = "ssh-bind-address";
 
     static final Description DESC ;
 
@@ -239,6 +244,15 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
             "0"
     );
 
+
+    public static final Property PROP_BIND_ADDRESS = PropertyUtil.string(
+            CONFIG_BIND_ADDRESS,
+            "Bind Address",
+            "Set a bind address from the server",
+            false,
+            null
+    );
+
     static {
         DescriptionBuilder builder = DescriptionBuilder.builder();
         builder.name(SERVICE_PROVIDER_TYPE)
@@ -254,6 +268,7 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
         builder.property(ALWAYS_SET_PTY);
         builder.property(PROP_CON_TIMEOUT);
         builder.property(PROP_COMMAND_TIMEOUT);
+        builder.property(PROP_BIND_ADDRESS);
 
         builder.mapping(CONFIG_KEYPATH, PROJ_PROP_SSH_KEYPATH);
         builder.frameworkMapping(CONFIG_KEYPATH, FWK_PROP_SSH_KEYPATH);
@@ -274,6 +289,9 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
 
         builder.mapping(CONFIG_COMMAND_TIMEOUT, PROJ_PROP_COMMAND_TIMEOUT);
         builder.frameworkMapping(CONFIG_COMMAND_TIMEOUT, FWK_PROP_COMMAND_TIMEOUT);
+
+        builder.mapping(CONFIG_BIND_ADDRESS, PROJ_PROP_BRIND_ADDRESS);
+        builder.frameworkMapping(CONFIG_BIND_ADDRESS, FWK_PROP_BRIND_ADDRESS);
 
         DESC=builder.build();
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschScpFileCopier.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschScpFileCopier.java
@@ -66,6 +66,7 @@ public class JschScpFileCopier extends BaseFileCopier implements MultiFileCopier
         .property(JschNodeExecutor.SSH_PASSWORD_STORAGE_PROP)
         .property(JschNodeExecutor.SSH_AUTH_TYPE_PROP)
         .property(JschNodeExecutor.SSH_PASSPHRASE_STORAGE_PROP)
+        .property(JschNodeExecutor.PROP_BIND_ADDRESS)
         .mapping(JschNodeExecutor.CONFIG_KEYPATH, JschNodeExecutor.PROJ_PROP_SSH_KEYPATH)
         .mapping(JschNodeExecutor.CONFIG_AUTHENTICATION, JschNodeExecutor.PROJ_PROP_SSH_AUTHENTICATION)
         .mapping(JschNodeExecutor.CONFIG_KEYSTORE_PATH, JschNodeExecutor.PROJ_PROP_SSH_KEY_RESOURCE)
@@ -76,6 +77,8 @@ public class JschScpFileCopier extends BaseFileCopier implements MultiFileCopier
         .frameworkMapping(JschNodeExecutor.CONFIG_AUTHENTICATION, JschNodeExecutor.FWK_PROP_SSH_AUTHENTICATION)
         .mapping(JschNodeExecutor.CONFIG_PASSPHRASE_STORE_PATH, JschNodeExecutor.PROJ_PROP_SSH_KEY_PASSPHRASE_STORAGE_PATH)
         .frameworkMapping(JschNodeExecutor.CONFIG_PASSPHRASE_STORE_PATH, JschNodeExecutor.FWK_PROP_SSH_KEY_PASSPHRASE_STORAGE_PATH)
+        .mapping(JschNodeExecutor.CONFIG_BIND_ADDRESS, JschNodeExecutor.PROJ_PROP_BRIND_ADDRESS)
+        .frameworkMapping(JschNodeExecutor.CONFIG_BIND_ADDRESS, JschNodeExecutor.FWK_PROP_BRIND_ADDRESS)
         .build();
 
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/NodeSSHConnectionInfo.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/NodeSSHConnectionInfo.java
@@ -376,4 +376,9 @@ final class NodeSSHConnectionInfo implements SSHTaskBuilder.SSHConnectionInfo {
         }
         return config;
     }
+
+    @Override
+    public String getBindAddress() {
+        return resolve(JschNodeExecutor.NODE_BRIND_ADDRESS);
+    }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/BindAddressSocketFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/BindAddressSocketFactory.java
@@ -1,0 +1,37 @@
+package com.dtolabs.rundeck.core.tasks.net;
+
+import com.jcraft.jsch.SocketFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+public class BindAddressSocketFactory implements SocketFactory {
+    private String bindAddress;
+    private Long timeout;
+
+    public BindAddressSocketFactory(String bindAddress, Long timeout) {
+        this.bindAddress = bindAddress;
+        this.timeout = timeout;
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        Socket socket = new Socket();
+        socket.bind(new InetSocketAddress(bindAddress, 0));
+        socket.connect(new InetSocketAddress(host, port), timeout.intValue());
+        return socket;
+    }
+
+    @Override
+    public InputStream getInputStream(Socket socket) throws IOException {
+        return socket.getInputStream();
+    }
+
+    @Override
+    public OutputStream getOutputStream(Socket socket) throws IOException {
+        return socket.getOutputStream();
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/ExtSSHExec.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/ExtSSHExec.java
@@ -80,6 +80,7 @@ public class ExtSSHExec extends SSHBase implements SSHTaskBuilder.SSHExecInterfa
     private Boolean enableSSHAgent=false;
     private Integer ttlSSHAgent=0;
     private SSHAgentProcess sshAgentProcess=null;
+    private String bindAddress;
 
     public static final String COMMAND_TIMEOUT_MESSAGE =
         "Timeout period exceeded, connection dropped.";
@@ -665,5 +666,15 @@ public class ExtSSHExec extends SSHBase implements SSHTaskBuilder.SSHExecInterfa
     @Override
     public Integer getTtlSSHAgent() {
       return this.ttlSSHAgent;
+    }
+
+    @Override
+    public void setBindAddress(String bindAddress) {
+        this.bindAddress=bindAddress;
+    }
+
+    @Override
+    public String getBindAddress() {
+        return bindAddress;
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/ExtScp.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/ExtScp.java
@@ -46,6 +46,7 @@ public class ExtScp extends Scp implements SSHTaskBuilder.SCPInterface {
     private PluginLogger        pluginLogger;
     private String toDir;
     private List<FileSet> fileSets;
+    private String bindAddress;
 
     @Override
     public void setTodir(final String aToUri) {
@@ -137,6 +138,16 @@ public class ExtScp extends Scp implements SSHTaskBuilder.SCPInterface {
 
     public Integer getTtlSSHAgent() {
         return 0;
+    }
+
+    @Override
+    public void setBindAddress(String bindAddress) {
+        this.bindAddress=bindAddress;
+    }
+
+    @Override
+    public String getBindAddress() {
+        return bindAddress;
     }
 
     public String getIfaceToDir() {

--- a/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/SSHTaskBuilder.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/SSHTaskBuilder.java
@@ -37,6 +37,7 @@ import com.jcraft.jsch.agentproxy.AgentProxyException;
 import com.jcraft.jsch.agentproxy.Connector;
 import com.jcraft.jsch.agentproxy.ConnectorFactory;
 import com.jcraft.jsch.agentproxy.RemoteIdentityRepository;
+import com.jcraft.jsch.SocketFactory;
 import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.optional.ssh.SSHUserInfo;
@@ -171,6 +172,13 @@ public class SSHTaskBuilder {
         }
         SSHTaskBuilder.configureSession(base.getSshConfig(), session);
 
+        //add  bind address server
+        String bindAddress=base.getBindAddress();
+        if(bindAddress!=null){
+            SocketFactory sfactory = new BindAddressSocketFactory(bindAddress, conTimeout);
+            session.setSocketFactory(sfactory);
+        }
+
         session.connect();
         return session;
     }
@@ -288,6 +296,9 @@ public class SSHTaskBuilder {
         public void setTtlSSHAgent(Integer ttlSSHAgent);
         
         public Integer getTtlSSHAgent();
+
+        public void setBindAddress(String bindAddress);
+        public String getBindAddress();
     }
 
     static interface SSHExecInterface extends SSHBaseInterface, DataContextUtils.EnvironmentConfigurable {
@@ -484,6 +495,16 @@ public class SSHTaskBuilder {
         @Override
         public void setPluginLogger(PluginLogger pluginLogger) {
             instance.setPluginLogger(pluginLogger);
+        }
+
+        @Override
+        public void setBindAddress(String bingAddress) {
+            instance.setBindAddress(bingAddress);
+        }
+
+        @Override
+        public String getBindAddress() {
+            return instance.getBindAddress();
         }
     }
 
@@ -742,6 +763,7 @@ public class SSHTaskBuilder {
         sshbase.setEnableSSHAgent(sshConnectionInfo.getLocalSSHAgent());
         sshbase.setTtlSSHAgent(sshConnectionInfo.getTtlSSHAgent());
         sshbase.setPluginLogger(logger);
+        sshbase.setBindAddress(sshConnectionInfo.getBindAddress());
     }
 
     public static Scp buildScp(final INodeEntry nodeentry, final Project project,
@@ -977,6 +999,8 @@ public class SSHTaskBuilder {
         public Integer getTtlSSHAgent();
 
         public Map<String,String> getSshConfig();
+
+        public String getBindAddress();
     }
 
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/tasks/net/SSHTaskBuilderSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/tasks/net/SSHTaskBuilderSpec.groovy
@@ -342,4 +342,44 @@ class SSHTaskBuilderSpec extends Specification {
 
     }
 
+    def "buildSsh with bind address"() {
+        given:
+        def node = Mock(INodeEntry) {
+            extractHostname() >> 'ahostname'
+        }
+        def project = new Project()
+
+        def nodeAuthentication = Mock(SSHTaskBuilder.SSHConnectionInfo) {
+            getUsername() >> 'bob'
+            getAuthenticationType() >> SSHTaskBuilder.AuthenticationType.privateKey
+            getPrivateKeyStoragePath() >> 'keys/fake/path'
+            getPrivateKeyStorageData() >> {
+                new ByteArrayInputStream('data'.bytes)
+            }
+            getBindAddress() >> "192.168.0.120"
+        }
+        def listener = Mock(ExecutionListener)
+
+        String[] command=["ls"]
+        def datacontext=[:]
+
+        when:
+        def result = SSHTaskBuilder.build(
+                node,
+                command,
+                project,
+                datacontext,
+                nodeAuthentication,
+                0,
+                listener
+        );
+        then:
+        result != null
+        result instanceof ExtSSHExec
+        ExtSSHExec built = (ExtSSHExec) result
+
+        built.getBindAddress() == "192.168.0.120"
+
+    }
+
 }

--- a/core/src/test/java/com/dtolabs/rundeck/core/tasks/net/TestSSHTaskBuilder.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/tasks/net/TestSSHTaskBuilder.java
@@ -73,6 +73,7 @@ public class TestSSHTaskBuilder extends TestCase {
         private Boolean enableSSHAgent;
         private SSHAgentProcess sshAgentProcess;
         private Integer ttlSSHAgent;
+        private String bindAddress;
 
         public void setFailonerror(boolean failonerror) {
             this.failonerror = failonerror;
@@ -208,6 +209,16 @@ public class TestSSHTaskBuilder extends TestCase {
         }
 
         @Override
+        public void setBindAddress(String bindAddress) {
+            this.bindAddress = bindAddress;
+        }
+
+        @Override
+        public String getBindAddress() {
+            return this.bindAddress;
+        }
+
+        @Override
         public long getConnectTimeout() {
             return connectTimeout;
         }
@@ -300,6 +311,7 @@ public class TestSSHTaskBuilder extends TestCase {
         private byte[] sudoPasswordStorageData;
         private String privateKeyPassphraseStoragePath;
         private byte[] privateKeyPassphraseStorageData;
+        String bindAddress;
 
         public SSHTaskBuilder.AuthenticationType getAuthenticationType() {
             return authenticationType;
@@ -364,6 +376,11 @@ public class TestSSHTaskBuilder extends TestCase {
 
         public Map<String, String> getSshConfig() {
             return sshConfig;
+        }
+
+        @Override
+        public String getBindAddress() {
+            return bindAddress;
         }
 
         @Override


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
enhancement: adding bind address to jsch plugin 
for https://github.com/rundeck/rundeck/issues/4932

**Describe the solution you've implemented**
Adding a socket factory with the bind address. The variable is added to the plugin settings

**Describe alternatives you've considered**

**Additional context**
<img width="808" alt="Screenshot 2019-06-25 16 20 25" src="https://user-images.githubusercontent.com/6034968/60130441-38167e00-9765-11e9-82fa-2d3400962457.png">
