### PR TITLE
Sync Rundeck profile from LDAP user attributes for official docker image

### DIFF
--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -40,6 +40,16 @@
     {% if exists("/rundeck/jaas/ldap/tryfirstpass") -%}
         tryFirstPass={{ getv("/rundeck/jaas/ldap/tryfirstpass") }}
     {% endif %}
+    {% if exists("/rundeck/jaas/ldap/userlastnameattribute") -%}
+        userLastNameAttribute={{ getv("/rundeck/jaas/ldap/userlastnameattribute") }}
+    {% endif %}
+    {% if exists("/rundeck/jaas/ldap/userfirstnameattribute") -%}
+        userFirstNameAttribute={{ getv("/rundeck/jaas/ldap/userfirstnameattribute") }}
+    {% endif %}
+    {% if exists("/rundeck/jaas/ldap/useremailattribute") -%}
+        userEmailAttribute={{ getv("/rundeck/jaas/ldap/useremailattribute") }}
+    {% endif %}
+
     ;
 {% endmacro %}
 

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -36,6 +36,10 @@ rundeck.security.authorization.preauthenticated.userRolesHeader={{ getv("/rundec
 rundeck.security.authorization.preauthenticated.redirectLogout={{ getv("/rundeck/preauth/redirect/logout", "false") }}
 rundeck.security.authorization.preauthenticated.redirectUrl={{ getv("/rundeck/preauth/redirect/url", "/oauth2/sign_in") }}
 
+{% if exists("/rundeck/security/syncldapuser") %}
+rundeck.security.syncLdapUser={{ getv("/rundeck/security/syncldapuser") }}
+{% endif %}
+
 rundeck.api.tokens.duration.max={{ getv("/rundeck/api/tokens/duration/max", "30d") }}
 
 rundeck.log4j.config.file=/home/rundeck/server/config/log4j.properties
@@ -55,6 +59,4 @@ rundeck.feature.repository.enabled={{ getv("/rundeck/feature/repository/enabled"
 rundeck.features.{{ c }}.enabled={{ getv(enabled, "false") }}
 {% endfor %}
 
-{% if exists("/rundeck/security/syncldapuser") %}
-rundeck.security.syncLdapUser={{ getv("/rundeck/security/syncldapuser") }}
-{% endif %}
+

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -54,3 +54,7 @@ rundeck.feature.repository.enabled={{ getv("/rundeck/feature/repository/enabled"
     {% set enabled = printf("/rundeck/features/%s/enabled", c) -%}
 rundeck.features.{{ c }}.enabled={{ getv(enabled, "false") }}
 {% endfor %}
+
+{% if exists("/rundeck/security/syncldapuser") %}
+rundeck.security.syncLdapUser={{ getv("/rundeck/security/syncldapuser") }}
+{% endif %}


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
enhancement: exposing sync Rundeck profile from LDAP user attributes for official docker image.

**Describe the solution you've implemented**
Adding the following environment variables:

* RUNDECK_JAAS_LDAP_USERLASTNAMEATTRIBUTE
* RUNDECK_JAAS_LDAP_USERFIRSTNAMEATTRIBUTE
* RUNDECK_JAAS_LDAP_USEREMAILATTRIBUTE
* RUNDECK_SECURITY_SYNCLDAPUSER

**Describe alternatives you've considered**

**Additional context**

Example:

<img width="522" alt="Screenshot 2019-06-25 20 19 49" src="https://user-images.githubusercontent.com/6034968/60142248-f26aad00-9786-11e9-8a61-40e4a91833d3.png">
