### PR TITLE
JNDI info in the configuration page #5010

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -1296,7 +1296,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 AuthConstants.ACTION_READ, 'System configuration')) {
             return
         }
-        if(grailsApplication.config.dataSource.driverClassName=='org.h2.Driver'){
+        if(!grailsApplication.config.dataSource.jndiName &&
+                grailsApplication.config.dataSource.driverClassName=='org.h2.Driver'){
             flash.error=message(code: "development.mode.warning")
         }
         [rundeckFramework: frameworkService.rundeckFramework]
@@ -1970,7 +1971,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 AuthConstants.ACTION_READ, 'System configuration')) {
             return
         }
-        if(grailsApplication.config.dataSource.driverClassName=='org.h2.Driver'){
+        if(!grailsApplication.config.dataSource.jndiName &&
+                grailsApplication.config.dataSource.driverClassName=='org.h2.Driver'){
             flash.error=message(code: "development.mode.warning")
         }
 

--- a/rundeckapp/grails-app/views/menu/systemConfig.gsp
+++ b/rundeckapp/grails-app/views/menu/systemConfig.gsp
@@ -65,8 +65,12 @@
 
             <h4>Datasource</h4>
             <div class="text-primary"><g:enc>${System.properties['rundeck.config.location']}</g:enc>:</div>
-            <g:render template="displayConfigProps" model="[map: flatConfig, keys: ['dataSource.url']]"/>
-
+            <g:if test="${flatConfig.dataSource.jndiName}">
+                <g:render template="displayConfigProps" model="[map: flatConfig, keys: ['dataSource.jndiName']]"/>
+            </g:if>
+            <g:else>
+                <g:render template="displayConfigProps" model="[map: flatConfig, keys: ['dataSource.url']]"/>
+            </g:else>
             <hr>
 
             <h4>Plugins</h4>


### PR DESCRIPTION
If the data source is configured using JNDI show that information instead of a default h2 URL.

fix #5010


Screenshot:
![image](https://user-images.githubusercontent.com/2894508/60364396-0c3d0780-99b4-11e9-9bc6-31185905ca0a.png)

