### PR TITLE
Fix #5000 highlight workflow editor unsaved changes issues

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/jobedit.js
+++ b/rundeckapp/grails-app/assets/javascripts/jobedit.js
@@ -639,6 +639,8 @@ function _showWFItemControls() {
     _enableWFDragdrop();
     _updateEmptyMessage();
     _iseditting=null;
+
+    jobeditor.clearError('workflow')
 }
 function _hideWFItemControlsAddEH(num){
     var lielem=jQuery('#wfli_'+num);
@@ -939,6 +941,7 @@ function _showOptControls() {
     _showOptEmptyMessage();
     _enableOptDragDrop();
     clearHtml('optsload');
+    jobeditor.clearError('option')
 }
 
 var optsDragger;

--- a/rundeckapp/grails-app/assets/javascripts/scheduledExecution/jobEditorKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/scheduledExecution/jobEditorKO.js
@@ -21,4 +21,22 @@ function JobEditor(data){
     self.groupPath=ko.observable(data.groupPath)
     self.uuid=ko.observable(data.uuid)
     self.href=ko.observable(data.href)
+    self.errorTabs = ko.observableArray()
+
+    self.optionError=ko.pureComputed(function () {
+        return self.errorTabs.indexOf('option') >= 0
+    })
+    self.workflowError=ko.pureComputed(function () {
+        return self.errorTabs.indexOf('workflow') >= 0
+    })
+    self.clearError = function (name) {
+        if (self.errorTabs.indexOf(name) >= 0) {
+            self.errorTabs.remove(name)
+        }
+    }
+    self.addError = function (name) {
+        if (self.errorTabs.indexOf(name) < 0) {
+            self.errorTabs.push(name)
+        }
+    }
 }

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1810,3 +1810,4 @@ follow.output=Follow output
 project.edit.page.tab.details.title=Details
 start=Start
 end=End
+job.editor.workflow.unsavedchanges.warning=Some changes to the workflow have not been completed.

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1731,3 +1731,4 @@ follow.output=Follow output
 project.edit.page.tab.details.title=Details
 start=Start
 end=End
+job.editor.workflow.unsavedchanges.warning=Some changes to the workflow have not been completed.

--- a/rundeckapp/grails-app/i18n/messages_fr_FR.properties
+++ b/rundeckapp/grails-app/i18n/messages_fr_FR.properties
@@ -1727,3 +1727,4 @@ follow.output=Follow output
 project.edit.page.tab.details.title=Details
 start=Start
 end=End
+job.editor.workflow.unsavedchanges.warning=Some changes to the workflow have not been completed.

--- a/rundeckapp/grails-app/i18n/messages_ja.properties
+++ b/rundeckapp/grails-app/i18n/messages_ja.properties
@@ -1356,3 +1356,4 @@ follow.output=Follow output
 project.edit.page.tab.details.title=Details
 start=Start
 end=End
+job.editor.workflow.unsavedchanges.warning=Some changes to the workflow have not been completed.

--- a/rundeckapp/grails-app/i18n/messages_pt_BR.properties
+++ b/rundeckapp/grails-app/i18n/messages_pt_BR.properties
@@ -1752,3 +1752,4 @@ follow.output=Follow output
 project.edit.page.tab.details.title=Details
 start=Start
 end=End
+job.editor.workflow.unsavedchanges.warning=Some changes to the workflow have not been completed.

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -1726,3 +1726,4 @@ follow.output=Follow output
 project.edit.page.tab.details.title=Details
 start=Start
 end=End
+job.editor.workflow.unsavedchanges.warning=Some changes to the workflow have not been completed.

--- a/rundeckapp/grails-app/views/execution/_wfitemEdit.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfitemEdit.gsp
@@ -710,10 +710,6 @@
         <g:hiddenField name="scheduledExecutionId" value="${scheduledExecutionId}"/>
         <div class="floatr" style="margin:10px 0;">
             <g:set var="msgItem" value="${isErrorHandler ? 'stepErrorHandler' : 'step'}"/>
-            <span class="warn note cancelsavemsg" style="display:none;">
-                <g:message code="scheduledExecution.workflow.${msgItem}.Item.unsaved.warning"
-                           default="Discard or save changes to this Workflow Step before completing changes to the job"/>
-            </span>
             <g:if test="${newitemtype||newitem}">
                 <g:hiddenField name="newitem" value="true"/>
                 <g:hiddenField name="newitemtype" value="${newitemtype}"/>
@@ -738,6 +734,10 @@
                 <span class="btn btn-primary btn-sm" onclick="_wfisave('${key}',${num}, 'wfiedit_${rkey}', ${ isErrorHandler?true:false});"
                       title="${message(code:"Workflow."+msgItem+".save.title")}"><g:message code="button.action.Save" /></span>
             </g:else>
+            <span class="text-warning cancelsavemsg" style="display:none;">
+                <g:message code="scheduledExecution.workflow.${msgItem}.Item.unsaved.warning"
+                           default="Discard or save changes to this Workflow Step before completing changes to the job"/>
+            </span>
         </div>
         <div class="clear"></div>
     </div>

--- a/rundeckapp/grails-app/views/scheduledExecution/_createForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_createForm.gsp
@@ -44,19 +44,13 @@
             <tmpl:tabsEdit scheduledExecution="${scheduledExecution}" crontab="${crontab}" authorized="${authorized}"
                            command="${command}"/>
         </div>
-            <g:javascript>
-                <wdgt:eventHandlerJS for="scheduledTrue" state="unempty" >
-                    <wdgt:action visible="true" targetSelector=".cformAllowSaveOnly"/>
-                    <wdgt:action visible="false" targetSelector=".cformAllowRun"/>
-                </wdgt:eventHandlerJS>
-            </g:javascript>
         <div class="card-footer" data-ko-bind="jobeditor">
             <div id="schedCreateButtons">
                 <g:actionSubmit id="createFormCancelButton" value="${g.message(code:'cancel')}"
                                 onclick="if(typeof(jobEditCancelled)=='function'){jobEditCancelled();}"
                                 class="btn btn-default reset_page_confirm"/>
                 <g:submitButton name="Create" value="${g.message(code: 'button.action.Create')}"
-                                    class="cformAllowSave cformAllowSaveOnly btn btn-primary reset_page_confirm" />
+                                    class="btn btn-primary reset_page_confirm" />
 
                 <span data-bind="if: errorTabs().length" class="text-warning">
                     <g:message code="job.editor.workflow.unsavedchanges.warning" />

--- a/rundeckapp/grails-app/views/scheduledExecution/_createForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_createForm.gsp
@@ -44,13 +44,13 @@
             <tmpl:tabsEdit scheduledExecution="${scheduledExecution}" crontab="${crontab}" authorized="${authorized}"
                            command="${command}"/>
         </div>
-        <div class="card-footer">
             <g:javascript>
                 <wdgt:eventHandlerJS for="scheduledTrue" state="unempty" >
                     <wdgt:action visible="true" targetSelector=".cformAllowSaveOnly"/>
                     <wdgt:action visible="false" targetSelector=".cformAllowRun"/>
                 </wdgt:eventHandlerJS>
             </g:javascript>
+        <div class="card-footer" data-ko-bind="jobeditor">
             <div id="schedCreateButtons">
                 <g:actionSubmit id="createFormCancelButton" value="${g.message(code:'cancel')}"
                                 onclick="if(typeof(jobEditCancelled)=='function'){jobEditCancelled();}"
@@ -58,6 +58,9 @@
                 <g:submitButton name="Create" value="${g.message(code: 'button.action.Create')}"
                                     class="cformAllowSave cformAllowSaveOnly btn btn-primary reset_page_confirm" />
 
+                <span data-bind="if: errorTabs().length" class="text-warning">
+                    <g:message code="job.editor.workflow.unsavedchanges.warning" />
+                </span>
             </div>
             <div id="schedCreateSpinner" class="spinner block" style="display:none;">
                 <img src="${resource(dir:'images',file:'icon-tiny-disclosure-waiting.gif')}" alt="Spinner"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -1048,25 +1048,26 @@ function getCurSEID(){
          *
          */
          function validateJobEditForm(form){
-             var wfitem=$(form).down('div.wfitemEditForm');
-             if(wfitem && !wascancelled){
-                 doyft(wfitem.identify());
-                 $(wfitem).scrollTo();
-                 if ($(wfitem).down("span.cancelsavemsg")) {
-                     $(wfitem).down("span.cancelsavemsg").show();
+             var wfitem=jQuery(form).find('div.wfitemEditForm');
+             let valid=true
+             if(wfitem.length && !wascancelled){
+                 jobeditor.addError('workflow');
+                 wfitem.addClass('alert-warning')
+                 if (wfitem.find("span.cancelsavemsg").length) {
+                     wfitem.find("span.cancelsavemsg").show();
                  }
-                 return false;
+                 valid= false;
              }
-            var optedit= $(form).down('div.optEditForm');
-            if (optedit && !wascancelled) {
-                doyft(optedit.identify());
-                $(optedit).scrollTo();
-                if($(optedit).down("span.cancelsavemsg")){
-                    $(optedit).down("span.cancelsavemsg").show();
+            var optedit= jQuery(form).find('div.optEditForm');
+            if (optedit.length && !wascancelled) {
+                jobeditor.addError('option');
+                optedit.addClass('alert-warning')
+                if(optedit.find("span.cancelsavemsg").length){
+                    optedit.find("span.cancelsavemsg").show();
                 }
-                return false;
+                valid= false;
             }
-             return true;
+             return valid;
          }
         function _updateBoxInfo(name, data) {
 

--- a/rundeckapp/grails-app/views/scheduledExecution/_editForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editForm.gsp
@@ -59,12 +59,15 @@
                        command="${command}"/>
     </div>
 
-    <div class="card-footer">
+    <div class="card-footer" data-ko-bind="jobeditor">
       <g:actionSubmit id="editFormCancelButton" value="${g.message(code: 'cancel')}"
                       onclick="if(typeof(jobEditCancelled)=='function'){jobEditCancelled();}"
                       class="btn btn-default reset_page_confirm"
                       action="Cancel"/>
       <g:actionSubmit value="${g.message(code: 'button.action.Save')}" action="Update" class="btn btn-primary reset_page_confirm "/>
+        <span data-bind="if: errorTabs().length" class="text-warning">
+            <g:message code="job.editor.workflow.unsavedchanges.warning" />
+        </span>
     </div>
 
 </div>

--- a/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
@@ -731,9 +731,6 @@
 
         <g:hiddenField name="scheduledExecutionId" value="${scheduledExecutionId}"/>
         <div class="floatr" style="margin:10px 0;">
-            <span class="warn note cancelsavemsg" style="display:none;">
-                <g:message code="scheduledExecution.option.unsaved.warning"/>
-            </span>
             <g:if test="${newoption}">
                 <g:hiddenField name="newoption" value="true"/>
                 <span class="btn btn-default btn-sm" onclick="_optcancelnew();"
@@ -752,6 +749,9 @@
                 <span class="btn btn-primary btn-sm" onclick="_optsave('optedit_${enc(attr:rkey)}','reqtoken_${enc(attr:rkey)}',$(this).up('li.optEntry'));"
                       title="${g.message(code:'form.option.save.title', encodeAs: 'HTMLAttribute')}"><g:message code="save" /></span>
             </g:else>
+            <span class="text-warning cancelsavemsg" style="display:none;">
+                <g:message code="scheduledExecution.option.unsaved.warning"/>
+            </span>
         </div>
         <g:jsonToken id="reqtoken_${rkey}" url="${request.forwardURI}"/>
     </div>

--- a/rundeckapp/grails-app/views/scheduledExecution/_tabsEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_tabsEdit.gsp
@@ -19,7 +19,7 @@
 <div class="vue-tabs">
     <div class="nav-tabs-navigation">
         <div class="nav-tabs-wrapper">
-            <ul class="nav nav-tabs" id="job_edit_tabs">
+            <ul class="nav nav-tabs" id="job_edit_tabs" data-ko-bind="jobeditor">
                 <li class="active">
                     <a href="#tab_details" data-toggle="tab">
                         <g:message code="job.edit.page.tab.details.title"/>
@@ -28,6 +28,9 @@
                 <li>
                     <a href="#tab_workflow" data-toggle="tab">
                         <g:message code="job.edit.page.tab.workflow.title"/>
+                        <!-- ko if: workflowError() || optionError() -->
+                        <b class="text-warning fas fa-exclamation-circle"></b>
+                        <!-- /ko -->
                     </a>
                 </li>
                 <li>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fixes #5000 

**Describe the solution you've implemented**

When a job Option or workflow Step edit panel is open and the create/save button is clicked, this adds a warning indicator the the Workflow tab, adds warning text by the form submit button, and highlights the unsaved job Option or workflow Step section inside the workflow tab.

![Screen Shot 2019-06-30 at 11 46 56 AM](https://user-images.githubusercontent.com/55603/60400745-3239e780-9b2d-11e9-9c82-bdc6d63eba43.png)

![Screen Shot 2019-06-30 at 11 47 06 AM](https://user-images.githubusercontent.com/55603/60400750-382fc880-9b2d-11e9-8701-2e74c46c3302.png)

![Screen Shot 2019-06-30 at 11 47 27 AM](https://user-images.githubusercontent.com/55603/60400751-3e25a980-9b2d-11e9-9838-7338abb2465e.png)
