### PR TITLE
Adding attribute-match-node-enhancer plugin to the rundeck oss core

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -68,7 +68,8 @@ dependencies {
                 "com.github.rundeck-plugins:aws-s3-model-source:v1.0",
                 "com.github.rundeck-plugins:py-winrm-plugin:2.0.3",
                 "com.github.rundeck-plugins:openssh-node-execution:1.0.3",
-                "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.0.0"
+                "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.0.0",
+                "com.github.rundeck-plugins:attribute-match-node-enhancer:v0.1.3"
 
     spa project(path: ':rundeck:grails-spa', configuration: 'spa')
 

--- a/testbuild.groovy
+++ b/testbuild.groovy
@@ -56,7 +56,7 @@ def coreJarFile = "core/${target}/rundeck-core-${version}.jar"
 
 //the list of bundled plugins to verify in the war and jar
 def plugins=['script','stub','localexec','copyfile','job-state','flow-control','jasypt-encryption','git','object-store','orchestrator', 'source-refresh','upvar']
-def externalPlugins=['rundeck-ansible-plugin','aws-s3-model-source','py-winrm-plugin','openssh-node-execution','multiline-regex-datacapture-filter']
+def externalPlugins=['rundeck-ansible-plugin','aws-s3-model-source','py-winrm-plugin','openssh-node-execution','multiline-regex-datacapture-filter', 'attribute-match-node-enhancer']
 
 //manifest describing expected build results
 def manifest=[


### PR DESCRIPTION
fixes rundeckpro/rundeckpro#607 

**Is this a bugfix, or an enhancement? Please describe.**
When a node have the osFamily attribute with value "Windows", the job with an inline script step dispatch a .bat file even though this node needs to run a .sh file (using cygwin)

**Describe the solution you've implemented**
This plugin (https://github.com/rundeck-plugins/attribute-match-node-enhancer) can be used to solve this issue (https://github.com/rundeckpro/rundeckpro/issues/607) from support that causes the osFamily attribute do define the file extension to be dispatched to a node 

**Describe alternatives you've considered**
I considered to use the advanced settings on script step the override the file extension default, however, this is not a friendly solution when it comes to several jobs since user would have to set them all individually.
