### PR TITLE
Fixes #5030 - This changes make validations if the options from URL is a json object or a simple array list of options…

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -58,6 +58,7 @@ import groovy.transform.ToString
 import org.apache.commons.io.FileUtils
 import org.apache.log4j.Logger
 import org.apache.log4j.MDC
+import org.grails.web.json.JSONObject
 import org.hibernate.StaleObjectStateException
 import org.hibernate.criterion.CriteriaSpecification
 import org.hibernate.type.StandardBasicTypes
@@ -2621,7 +2622,13 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     if(opt.enforced && !opt.optionValues){
                         Map remoteOptions = scheduledExecutionService.loadOptionsRemoteValues(scheduledExecution, [option: opt.name], authContext?.username)
                         if(!remoteOptions.err && remoteOptions.values){
-                            opt.optionValues = remoteOptions.values
+                            opt.optionValues = remoteOptions.values.collect {optValue ->
+                                if(optValue instanceof JSONObject){
+                                    return optValue.value
+                                } else {
+                                    return optValue
+                                }
+                            }
                         }
                     }
                     if (opt.enforced && opt.optionValues && optparams[opt.name]) {
@@ -2649,7 +2656,13 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     if(opt.enforced && !opt.optionValues){
                         Map remoteOptions = scheduledExecutionService.loadOptionsRemoteValues(scheduledExecution, [option: opt.name], authContext?.username)
                         if(!remoteOptions.err && remoteOptions.values){
-                            opt.optionValues = remoteOptions.values
+                            opt.optionValues = remoteOptions.values.collect {optValue ->
+                                if(optValue instanceof JSONObject){
+                                    return optValue.value
+                                } else {
+                                    return optValue
+                                }
+                            }
                         }
                     }
                     if (opt.enforced && opt.optionValues &&

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -1490,7 +1490,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
     }
 
-    def "validate option values, opt enforced allowed values from Remote Url"() {
+    def "invalid option values, opt enforced allowed values from Remote Url"() {
         given:
         ScheduledExecution se = new ScheduledExecution()
         Option opt = new Option(name: 'test1', enforced: true, optionValues: null)
@@ -1510,17 +1510,44 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
             ]
         }
 
-        validation == validationResult
 
         ExecutionServiceValidationException e = thrown()
-        if(!validationResult) e.errors.containsKey('test1')
+        e.errors.containsKey('test1')
 
 
         where:
-        opts                                           | remoteValues                                                                                                     | validationResult
-        ['test1': 'somevalue']                         | ["A", "B", "C"]                                                                                                  | null
-        ['test1': 'somevalue']                         | [new JSONObject(name: "a", value:"A"), new JSONObject(name:"b", value:"B"), new JSONObject(name:"c", value:"C")] | null
-        ['test1': 'A']                                 | [new JSONObject(name: "a", value:"A"), new JSONObject(name:"b", value:"B"), new JSONObject(name:"c", value:"C")] | true
+        opts                                           | remoteValues
+        ['test1': 'somevalue']                         | ["A", "B", "C"]
+        ['test1': 'somevalue']                         | [new JSONObject(name: "a", value:"A"), new JSONObject(name:"b", value:"B"), new JSONObject(name:"c", value:"C")]
+
+    }
+
+    def "valid option values, opt enforced allowed values from Remote Url"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution()
+        Option opt = new Option(name: 'test1', enforced: true, optionValues: null)
+        se.addToOptions(opt)
+        service.scheduledExecutionService = Mock(ScheduledExecutionService)
+        when:
+
+        def validation = service.validateOptionValues(se, opts)
+
+        then:
+        1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_) >> {
+            [
+                    optionSelect : opt,
+                    values       : ["A", "B", "C"],
+                    srcUrl       : "cleanUrl",
+                    err          : null
+            ]
+        }
+
+        noExceptionThrown()
+
+
+        where:
+        opts                                           | remoteValues
+        ['test1': 'A']                                 | [new JSONObject(name: "a", value:"A"), new JSONObject(name:"b", value:"B"), new JSONObject(name:"c", value:"C")]
 
     }
 

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -43,6 +43,7 @@ import grails.testing.services.ServiceUnitTest
 import grails.testing.spring.AutowiredTest
 import org.grails.events.bus.SynchronousEventBus
 import org.grails.plugins.metricsweb.MetricService
+import org.grails.web.json.JSONObject
 import org.rundeck.storage.api.PathUtil
 import org.rundeck.storage.api.StorageException
 import org.springframework.context.MessageSource
@@ -1509,12 +1510,17 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
             ]
         }
 
+        validation == validationResult
+
         ExecutionServiceValidationException e = thrown()
-        e.errors.containsKey('test1')
+        if(!validationResult) e.errors.containsKey('test1')
+
 
         where:
-        opts                                           | _
-        ['test1': 'somevalue']                         | _
+        opts                                           | remoteValues                                                                                                     | validationResult
+        ['test1': 'somevalue']                         | ["A", "B", "C"]                                                                                                  | null
+        ['test1': 'somevalue']                         | [new JSONObject(name: "a", value:"A"), new JSONObject(name:"b", value:"B"), new JSONObject(name:"c", value:"C")] | null
+        ['test1': 'A']                                 | [new JSONObject(name: "a", value:"A"), new JSONObject(name:"b", value:"B"), new JSONObject(name:"c", value:"C")] | true
 
     }
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
The remote URL options validation fail if the json uses a json object format

**Describe the solution you've implemented**
The validation was considering just a simple array list values, so, when the json uses a object format, the validation failed. I changed this validation to consider a json object format when it is used