### PR TITLE
reverting changes to allow schedule jobs to respect the remote policy

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2860,7 +2860,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
                 if (scheduledExecution.scheduled) {
                     scheduledExecution.nextExecution = scheduledExecutionService.nextExecutionTime(scheduledExecution)
-                    scheduledExecution.serverNodeUUID = scheduledExecutionService.nextExecNode(scheduledExecution)
                     if (scheduledExecution.save(flush: true)) {
                         log.info("updated scheduled Execution nextExecution")
                     } else {

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -644,9 +644,6 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             }
             def newsched = ScheduledExecution.get(scheduledExecution.id)
             newsched.nextExecution = nextdate
-            if(nextExecNode){
-                newsched.serverNodeUUID = nextExecNode
-            }
             if (!newsched.save()) {
                 log.error("Unable to save second change to scheduledExec.")
             }
@@ -1426,8 +1423,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         if(se.scheduled){
             data.put("userRoles", se.userRoleList)
             if(frameworkService.isClusterModeEnabled()){
-//                data.put("serverUUID", frameworkService.getServerUUID())
-                data.put("serverUUID", nextExecNode(se))
+                data.put("serverUUID", frameworkService.getServerUUID())
+                //data.put("serverUUID", nextExecNode(se))
             }
         }
 
@@ -2618,9 +2615,6 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
                 def newsched = ScheduledExecution.get(scheduledExecution.id)
                 newsched.nextExecution = nextdate
-                if(nextExecNode){
-                    newsched.serverNodeUUID = nextExecNode
-                }
                 if (!newsched.save()) {
                     log.error("Unable to save second change to scheduledExec.")
                 }
@@ -3207,9 +3201,6 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
                 def newsched = ScheduledExecution.get(scheduledExecution.id)
                 newsched.nextExecution = nextdate
-                if(nextExecNode){
-                    newsched.serverNodeUUID = nextExecNode
-                }
                 if (!newsched.save()) {
                     log.error("Unable to save second change to scheduledExec.")
                 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Bug:
reverting changes to allow schedule jobs to respect the remote policy execution if exists
https://github.com/rundeck/rundeck/pull/4799

Jobs scheduled can be removed from quartz, so the scheduled job won't be executed on any cluster member

**Describe the solution you've implemented**
the severNodeUUID cannot be changed, it just can be done when the job is saved.


