### PR TITLE
oficial docke image: adding custom templates for repository feature.

### DIFF
--- a/docker/official/lib/entry.sh
+++ b/docker/official/lib/entry.sh
@@ -19,6 +19,7 @@ export REMCO_TMP_DIR=/tmp/remco-partials
 # Create temporary directories for config partials
 mkdir -p ${REMCO_TMP_DIR}/framework
 mkdir -p ${REMCO_TMP_DIR}/rundeck-config
+mkdir -p ${REMCO_TMP_DIR}/artifact-repositories
 
 remco -config ${REMCO_HOME}/config.toml
 
@@ -31,6 +32,7 @@ echo "rundeck.server.uuid = ${RUNDECK_SERVER_UUID}" > ${REMCO_TMP_DIR}/framework
 # Combine partial config files
 cat ${REMCO_TMP_DIR}/framework/* >> etc/framework.properties
 cat ${REMCO_TMP_DIR}/rundeck-config/* >> server/config/rundeck-config.properties
+cat ${REMCO_TMP_DIR}/artifact-repositories/* >> server/config/artifact-repositories.yaml
 
 
 # Store settings that may be unset in script variables

--- a/docker/official/remco/resources.d/artifact-repositories-private.yaml.toml
+++ b/docker/official/remco/resources.d/artifact-repositories-private.yaml.toml
@@ -1,0 +1,4 @@
+[[template]]
+    src         = "${REMCO_TEMPLATE_DIR}/artifact-repositories-private.yaml"
+    dst         = "${REMCO_TMP_DIR}/artifact-repositories/artifact-repositories-private.yaml"
+    mode        = "0644"

--- a/docker/official/remco/resources.d/rundeck-config-plugin-repository.properties.toml
+++ b/docker/official/remco/resources.d/rundeck-config-plugin-repository.properties.toml
@@ -1,0 +1,4 @@
+[[template]]
+    src         = "${REMCO_TEMPLATE_DIR}/rundeck-config-plugin-repository.properties"
+    dst         = "${REMCO_TMP_DIR}/rundeck-config/rundeck-config-plugin-repository.properties"
+    mode        = "0644"

--- a/docker/official/remco/templates/artifact-repositories-private.yaml
+++ b/docker/official/remco/templates/artifact-repositories-private.yaml
@@ -1,0 +1,21 @@
+{% set pluginProviderBase = "/rundeck/repository/artifacts/provider" %}
+
+repositories:
+  - repositoryName: official
+    enabled: true
+    type: HTTP
+    owner: RUNDECK
+
+  {%- macro plugin_provider(provider) %}
+  {%- set type = getv(printf("%s/type", provider), "file") %}
+  {%- set index = provider | base %}
+
+  - repositoryName: {% set name = printf("%s/name", provider) %} {{ getv(name, index)}}
+    type: STORAGE_TREE
+    configProperties:
+      storageTreePath: {% set path = printf("%s/path", provider) %} {{ getv(path, "/")}}
+  {% endmacro %}
+  {%- for p in lsdir(pluginProviderBase) -%}
+  {% set provider = printf("%s/%s", pluginProviderBase, p) -%}
+  {{ plugin_provider(provider) }}
+  {%- endfor %}

--- a/docker/official/remco/templates/artifact-repositories-private.yaml
+++ b/docker/official/remco/templates/artifact-repositories-private.yaml
@@ -1,4 +1,4 @@
-{% set pluginProviderBase = "/rundeck/repository/artifacts/provider" %}
+{% set artifactProviderBase = "/rundeck/repository/artifacts/provider" %}
 
 repositories:
   - repositoryName: official
@@ -6,7 +6,7 @@ repositories:
     type: HTTP
     owner: RUNDECK
 
-  {%- macro plugin_provider(provider) %}
+  {%- macro artifact_provider(provider) %}
   {%- set type = getv(printf("%s/type", provider), "file") %}
   {%- set index = provider | base %}
 
@@ -15,7 +15,7 @@ repositories:
     configProperties:
       storageTreePath: {% set path = printf("%s/path", provider) %} {{ getv(path, "/")}}
   {% endmacro %}
-  {%- for p in lsdir(pluginProviderBase) -%}
-  {% set provider = printf("%s/%s", pluginProviderBase, p) -%}
-  {{ plugin_provider(provider) }}
+  {%- for p in lsdir(artifactProviderBase) -%}
+  {% set provider = printf("%s/%s", artifactProviderBase, p) -%}
+  {{ artifact_provider(provider) }}
   {%- endfor %}

--- a/docker/official/remco/templates/rundeck-config-plugin-repository.properties
+++ b/docker/official/remco/templates/rundeck-config-plugin-repository.properties
@@ -1,0 +1,61 @@
+{% set pluginProviderBase = "/rundeck/repository/plugins/provider" %}
+{% set artifactProviderBase = "/rundeck/repository/artifacts/provider" %}
+
+{% if exists("/rundeck/feature/repository/synconbootstrap") %}
+rundeck.feature.repository.syncOnBootstrap={{ getv("/rundeck/feature/repository/synconbootstrap") }}
+{% endif %}
+
+{%- macro plugin_provider(provider) %}
+{%- set index = provider | base %}
+
+rundeck.repository.plugins.provider.{{index}}.type={% set type = printf("%s/type", provider) %}{{ getv(type, "file")}}
+rundeck.repository.plugins.provider.{{index}}.path={% set path = printf("%s/path", provider) %}{{ getv(path, "/")}}
+
+{%- set type = getv(printf("%s/type", provider), "file") %}
+
+{% if type == 'file' %}
+rundeck.repository.plugins.provider.{{index}}.config.baseDir={% set basedir = printf("%s/config/basedir", provider) %}{{ getv(basedir, "/")}}
+rundeck.feature.repository.installedPlugins.storageTreePath={% set basedir = printf("%s/config/basedir", provider) %}{{ getv(basedir, "/")}}
+{% endif %}
+
+{% if type == 'object' %}
+rundeck.repository.plugins.provider.{{index}}.config.bucket={% set bucket = printf("%s/config/bucket", provider) %}{{ getv(bucket)}}
+rundeck.repository.plugins.provider.{{index}}.config.objectStoreUrl={% set objectstoreurl = printf("%s/config/objectstoreurl", provider) %}{{ getv(objectstoreurl)}}
+rundeck.repository.plugins.provider.{{index}}.config.secretKey={% set secretkey = printf("%s/config/secretkey", provider) %}{{ getv(secretkey)}}
+rundeck.repository.plugins.provider.{{index}}.config.accessKey={% set accesskey = printf("%s/config/accesskey", provider) %}{{ getv(accesskey)}}
+{% endif %}
+{% endmacro %}
+
+{%- macro artifacts_provider(provider) %}
+{%- set index = provider | base %}
+
+rundeck.repository.artifacts.provider.{{index}}.type={% set type = printf("%s/type", provider) %}{{ getv(type, "file")}}
+rundeck.repository.artifacts.provider.{{index}}.path={% set path = printf("%s/path", provider) %}{{ getv(path, "/")}}
+
+{%- set type = getv(printf("%s/type", provider), "file") %}
+
+{% if type == 'file' %}
+rundeck.repository.artifacts.provider.{{index}}.config.baseDir={% set basedir = printf("%s/config/basedir", provider) %}{{ getv(basedir, "/")}}
+{% endif %}
+
+{% if type == 'object' %}
+rundeck.repository.artifacts.provider.{{index}}.config.bucket={% set bucket = printf("%s/config/bucket", provider) %}{{ getv(bucket)}}
+rundeck.repository.artifacts.provider.{{index}}.config.objectStoreUrl={% set objectstoreurl = printf("%s/config/objectstoreurl", provider) %}{{ getv(objectstoreurl)}}
+rundeck.repository.artifacts.provider.{{index}}.config.secretKey={% set secretkey = printf("%s/config/secretkey", provider) %}{{ getv(secretkey)}}
+rundeck.repository.artifacts.provider.{{index}}.config.accessKey={% set accesskey = printf("%s/config/accesskey", provider) %}{{ getv(accesskey)}}
+{% endif %}
+{% endmacro %}
+
+
+
+{%- for p in lsdir(pluginProviderBase) -%}
+{% set provider = printf("%s/%s", pluginProviderBase, p) -%}
+{{ plugin_provider(provider) }}
+{%- endfor %}
+
+
+{%- for p in lsdir(artifactProviderBase) -%}
+{% set provider = printf("%s/%s", artifactProviderBase, p) -%}
+{{ artifacts_provider(provider) }}
+{%- endfor %}
+


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
enhancement:
adding custom templates for plugin repository feature. it will expose using env variable the option to define an external or local plugin repository (for example using the s3 like storage)

**Describe the solution you've implemented**
new remco templates to add data to artifact-repositories.yaml and rundeck-config.properties based on env variables.

**Additional context**
Example of new variables

## Save artifacts and installed plugins to a Minio object store
```
version: '3'

services:
  rundeck1:
    hostname: rundeck1
    image: ${RUNDECK_IMAGE:-rundeck/rundeck:local}
    links:
      - minio
    tty: true
    environment:
      RUNDECK_GRAILS_URL: http://localhost:4444
      RUNDECK_FEATURE_REPOSITORY_ENABLE: "true"
      RUNDECK_FEATURE_REPOSITORY_SYNCONBOOTSTRAP: "true"
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_1_NAME: MinioTest
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_1_TYPE: object
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_1_PATH: /
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_1_CONFIG_BUCKET: artifacts
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_1_CONFIG_OBJECTSTOREURL: http://minio:9000
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_1_CONFIG_ACCESSKEY: ${STORAGE_ACCESS_KEY_ID}
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_1_CONFIG_SECRETKEY: ${STORAGE_SECRET_KEY}
      RUNDECK_REPOSITORY_PLUGINS_PROVIDER_1_NAME: MinioTest
      RUNDECK_REPOSITORY_PLUGINS_PROVIDER_1_TYPE: object
      RUNDECK_REPOSITORY_PLUGINS_PROVIDER_1_PATH: /
      RUNDECK_REPOSITORY_PLUGINS_PROVIDER_1_CONFIG_BUCKET: plugins
      RUNDECK_REPOSITORY_PLUGINS_PROVIDER_1_CONFIG_OBJECTSTOREURL: http://minio:9000
      RUNDECK_REPOSITORY_PLUGINS_PROVIDER_1_CONFIG_ACCESSKEY: ${STORAGE_ACCESS_KEY_ID}
      RUNDECK_REPOSITORY_PLUGINS_PROVIDER_1_CONFIG_SECRETKEY: ${STORAGE_SECRET_KEY}
    ports:
      - 4444:4440
```

## using multiples privates artifacts

```
version: '3'

services:
  rundeck1:
    hostname: rundeck1
    image: ${RUNDECK_IMAGE:-rundeck/rundeck:local}
    links:
      - minio
    tty: true
    environment:
      RUNDECK_GRAILS_URL: http://localhost:4444
      RUNDECK_FEATURE_REPOSITORY_ENABLE: "true"
      RUNDECK_FEATURE_REPOSITORY_SYNCONBOOTSTRAP: "true"
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_1_NAME: MinioTest
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_1_TYPE: object
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_1_PATH: /
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_1_CONFIG_BUCKET: artifacts
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_1_CONFIG_OBJECTSTOREURL: http://minio:9000
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_1_CONFIG_ACCESSKEY: ${STORAGE_ACCESS_KEY_ID}
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_1_CONFIG_SECRETKEY: ${STORAGE_SECRET_KEY}
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_2_NAME: Local
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_2_TYPE: file
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_2_PATH: /repo
      RUNDECK_REPOSITORY_ARTIFACTS_PROVIDER_2_CONFIG_BASEDIR: /home/rundeck/repo
    ports:
      - 4444:4440
``` 
