### PR TITLE
Fixes #1654 to make cleanup on records in Workflow, workflow_step and workflow_workflow_step when executions are deleted

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Workflow.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Workflow.groovy
@@ -35,7 +35,8 @@ public class Workflow {
     Boolean keepgoing=false
     List<WorkflowStep> commands
     String strategy="node-first"
-    String pluginConfig;
+    String pluginConfig
+    static belongsTo = [Execution]
     static hasMany=[commands:WorkflowStep]
     static constraints = {
         strategy(nullable:false, maxSize: 256)

--- a/rundeckapp/grails-app/domain/rundeck/Workflow.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Workflow.groovy
@@ -36,7 +36,7 @@ public class Workflow {
     List<WorkflowStep> commands
     String strategy="node-first"
     String pluginConfig
-    static belongsTo = [Execution]
+    static belongsTo = [Execution, ScheduledExecution]
     static hasMany=[commands:WorkflowStep]
     static constraints = {
         strategy(nullable:false, maxSize: 256)

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionTest.groovy
@@ -993,4 +993,29 @@ class ScheduledExecutionTest  {
         assertNotNull(jobMap)
         assertEquals(true,jobMap.excludeFilterUncheck)
     }
+
+    void testDeleteScheduleExecutionWorkflowCascadeAll() {
+
+        WorkflowStep workflowStep = new CommandExec([adhocRemoteString: 'test1 buddy', argString: '-delay 12 -monkey cheese -particle'])
+
+        ScheduledExecution se1 = new ScheduledExecution(
+                uuid: 'test1',
+                jobName: 'red color',
+                project: 'Test',
+                groupPath: 'some',
+                description: 'a job',
+                argString: '-a b -c d',
+                workflow: new Workflow(keepgoing: true, commands: [workflowStep]).save(),
+        )
+
+        assert null != se1.save(flush: true)
+
+        assertNotNull ScheduledExecution.findById(se1.id)
+        assertNotNull Workflow.findById(se1.workflowId)
+
+        se1.delete(flush: true)
+
+        assertNull ScheduledExecution.findById(se1.id)
+        assertFalse Workflow.findAll().any {Workflow w -> w.id == se1.workflowId}
+    }
 }


### PR DESCRIPTION
Inserting the relationship attribute "belongsTo" for workflow class, so that the workflow record is deleted when an execution is deleted

**Is this a bugfix, or an enhancement? Please describe.**
Records in Workflow, workflow_step and workflow_workflow_step do not get cleaned up when executions are deleted causing orphaned records to remain in the tables

**Describe the solution you've implemented**
inserting the relationship attribute "belongsTo" on Workflow class, so that the workflow record is deleted when an execution is deleted
