### PR TITLE
Capability to compare between variables using ruleset. fixes #5050 

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/KeyValueEqualsCondition.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/KeyValueEqualsCondition.java
@@ -18,7 +18,12 @@ public class KeyValueEqualsCondition implements Condition {
         if (value == null) {
             return anObject == null;
         }
-        return value.equals(anObject);
+        String nValue = input.getState().get(value);
+        if(nValue == null){
+            return value.equals(anObject);
+        }else{
+            return nValue.equals(anObject);
+        }
     }
 
     @Override

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericEqualsCondition.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericEqualsCondition.java
@@ -18,7 +18,13 @@ public class NumericEqualsCondition implements Condition {
         if (value == null) {
             return false;
         }
-        Float fValue = NumericCondition.extractFloat(value);
+        Float fValue;
+        String nValue = input.getState().get(value);
+        if(nValue == null){
+            fValue = NumericCondition.extractFloat(value);
+        }else{
+            fValue = NumericCondition.extractFloat(nValue);
+        }
         Float fObject = NumericCondition.extractFloat(anObject);
         return (Math.abs(fValue - fObject) < THRESHOLD);
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericGreaterThanCondition.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericGreaterThanCondition.java
@@ -16,7 +16,13 @@ public class NumericGreaterThanCondition implements Condition {
         if (value == null) {
             return false;
         }
-        Float fValue = NumericCondition.extractFloat(value);
+        Float fValue;
+        String nValue = input.getState().get(value);
+        if(nValue == null){
+            fValue = NumericCondition.extractFloat(value);
+        }else{
+            fValue = NumericCondition.extractFloat(nValue);
+        }
         Float fObject = NumericCondition.extractFloat(anObject);
         return fObject>fValue;
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericLessThanCondition.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericLessThanCondition.java
@@ -16,7 +16,13 @@ public class NumericLessThanCondition implements Condition {
         if (value == null) {
             return false;
         }
-        Float fValue = NumericCondition.extractFloat(value);
+        Float fValue;
+        String nValue = input.getState().get(value);
+        if(nValue == null){
+            fValue = NumericCondition.extractFloat(value);
+        }else{
+            fValue = NumericCondition.extractFloat(nValue);
+        }
         Float fObject = NumericCondition.extractFloat(anObject);
         return fObject<fValue;
     }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/rules/RulesSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/rules/RulesSpec.groovy
@@ -198,4 +198,37 @@ class RulesSpec extends Specification {
 
 
     }
+
+    def "numeric equals condition key value using state"() {
+        given:
+        def cond = Rules.eqCondition("a", "b")
+
+        expect:
+        cond.test(States.state(a: '1', b: '1'))
+        cond.test(States.state("a", "b"))
+        !cond.test(States.state("a", "1"))
+        !cond.test(States.state(a: '0', b: '1'))
+    }
+
+    def "less than condition key value using state"() {
+        given:
+        def cond = Rules.ltCondition("a", "b")
+
+        expect:
+        cond.test(States.state(a: '1', b: '2'))
+        !cond.test(States.state(a: '1', b: '1'))
+        !cond.test(States.state(a: '2', b: '1'))
+
+    }
+
+    def "greater than condition key value using state "() {
+        given:
+        def cond = Rules.gtCondition("a", "b")
+
+        expect:
+        !cond.test(States.state(a: '1', b: '2'))
+        !cond.test(States.state(a: '1', b: '1'))
+        cond.test(States.state(a: '2', b: '1'))
+
+    }
 }


### PR DESCRIPTION
Add the ability to compare between variables to Rules.
It checks if the `value` is a variable, if not (new value is `null`) it just uses the `value`.