### PR TITLE
Remove unused project param in plugin validation method 

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
@@ -256,7 +256,7 @@ class PluginController extends ControllerBase {
         if (requireAjax(controller: 'menu', action: 'index')) {
             return
         }
-        if (requireParams(['project', 'service', 'name'])) {
+        if (requireParams(['service', 'name'])) {
             return
         }
         Map config = [:]

--- a/rundeckapp/src/test/groovy/rundeck/controllers/PluginControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/PluginControllerSpec.groovy
@@ -36,10 +36,8 @@ class PluginControllerSpec extends Specification implements ControllerUnitTest<P
             request.contentType = 'application/json'
             request.method = 'POST'
             request.addHeader('x-rundeck-ajax', 'true')
-            def project = 'Aproject'
             def service = 'AService'
             def name = 'someproperty'
-            params.project = project
             params.service = service
             params.name = name
             controller.pluginService = Mock(PluginService)


### PR DESCRIPTION
Remove unused project param in plugin validation method so plugins can be validated outside a project context.

This change will allow the pluginConfig component in ui-trellis to be used outside of project contexts.