### PR TITLE
Execution cleanup on a cluster

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/schedule/JobScheduleManager.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/schedule/JobScheduleManager.java
@@ -17,6 +17,7 @@
 package com.dtolabs.rundeck.core.schedule;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -78,4 +79,12 @@ public interface JobScheduleManager {
      * @return uuid of node for the scheduled execution
      */
     String determineExecNode(String name, String group, Map data, String project);
+
+
+    /**
+     * Return list dead cluster members.
+     *
+     * @return list dead cluster members
+     */
+    List<String> getDeadMembers(String uuid);
 }

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
@@ -210,12 +210,10 @@ class ExecutionsCleanUp implements InterruptableJob {
 
     private int totalAllExecutions(ExecutionService executionService, String project){
         ExecutionQuery query = new ExecutionQuery(projFilter: project)
-        def criteriaClos = { isCount ->
-            // Run main query criteria
+        def total = Execution.createCriteria().count{
             def queryCriteria = query.createCriteria(delegate)
             queryCriteria()
         }
-        def total = Execution.createCriteria().count(criteriaClos.curry(true))
         return null != total ? total : 0
     }
 

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -33,6 +33,7 @@ import com.dtolabs.rundeck.core.plugins.PluggableProviderRegistryService
 import com.dtolabs.rundeck.core.plugins.PluggableProviderService
 import com.dtolabs.rundeck.core.plugins.configuration.*
 import com.dtolabs.rundeck.core.resources.ResourceModelSourceFactory
+import com.dtolabs.rundeck.core.schedule.JobScheduleManager
 import com.dtolabs.rundeck.core.storage.StorageTree
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.server.authorization.AuthConstants
@@ -78,6 +79,7 @@ class FrameworkService implements ApplicationContextAware, AuthContextProcessor,
     def fileUploadService
     def AuthContextEvaluator rundeckAuthContextEvaluator
     StoragePluginProviderService storagePluginProviderService
+    JobSchedulerService jobSchedulerService
 
     def getRundeckBase(){
         return rundeckFramework.baseDir.absolutePath;
@@ -275,7 +277,8 @@ class FrameworkService implements ApplicationContextAware, AuthContextProcessor,
                             project: project,
                             logFileStorageService: logFileStorageService,
                             fileUploadService: fileUploadService,
-                            frameworkService: this
+                            frameworkService: this,
+                            jobSchedulerService: jobSchedulerService
                     ])
         }
     }
@@ -283,7 +286,7 @@ class FrameworkService implements ApplicationContextAware, AuthContextProcessor,
     def existsFrameworkProject(String project) {
         return rundeckFramework.getFrameworkProjectMgr().existsFrameworkProject(project)
     }
-    
+
     def getFrameworkProject(String project) {
         return rundeckFramework.getFrameworkProjectMgr().getFrameworkProject(project)
     }

--- a/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
@@ -48,6 +48,11 @@ class JobSchedulerService implements JobScheduleManager {
     String determineExecNode(String name, String group, Map data, String project) {
         return rundeckJobScheduleManager.determineExecNode(name, group, data, project)
     }
+
+    @Override
+    List<String> getDeadMembers(String uuid) {
+        return rundeckJobScheduleManager.getDeadMembers(uuid);
+    }
 }
 
 /**
@@ -116,5 +121,10 @@ class QuartzJobScheduleManager implements JobScheduleManager {
     @Override
     String determineExecNode(String name, String group, Map data, String project) {
         return frameworkService.serverUUID
+    }
+
+    @Override
+    List<String> getDeadMembers(String uuid) {
+        return null;
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionsCleanUpSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionsCleanUpSpec.groovy
@@ -25,6 +25,7 @@ import rundeck.*
 import rundeck.services.ExecutionService
 import rundeck.services.FileUploadService
 import rundeck.services.FrameworkService
+import rundeck.services.JobSchedulerService
 import rundeck.services.LogFileStorageService
 import spock.lang.Specification
 
@@ -81,6 +82,7 @@ class ExecutionsCleanUpSpec extends Specification {
         }
         def fileUploadService = Mock(FileUploadService)
         def logFileStorageService = Mock(LogFileStorageService)
+        def jobSchedulerService = Mock(JobSchedulerService)
 
         def datamap = new JobDataMap([
                 project: 'projectTest',
@@ -88,7 +90,8 @@ class ExecutionsCleanUpSpec extends Specification {
                 executionService : executionService,
                 frameworkService : frameworkService,
                 fileUploadService: fileUploadService,
-                logFileStorageService: logFileStorageService
+                logFileStorageService: logFileStorageService,
+                jobSchedulerService: jobSchedulerService
         ])
 
         ExecutionsCleanUp job = new ExecutionsCleanUp()
@@ -108,5 +111,89 @@ class ExecutionsCleanUpSpec extends Specification {
         daysToKeep              | executionsRemoved
         10                      | 1
         4                       | 0
+    }
+
+
+    def "execute cleaner job cluster with null on the list of deadMembers"() {
+        def jobName = 'abc'
+        def groupPath = 'elf'
+        def projectName = 'projectTest'
+        def jobUuid = '123'
+        def daysToKeep = 10
+
+        setup:
+        Date startDate = new Date(2015 - 1900, 2, 8)
+        Date endDate = ExecutionQuery.parseRelativeDate("${daysToKeep}d", startDate)
+        Date execDate = new Date(2015 - 1900, 02, 03)
+        ExecutionQuery query = new ExecutionQuery(projFilter: projectName)
+        if(null != endDate){
+            query.endbeforeFilter = endDate
+            query.doendbeforeFilter = true
+        }
+        def se = new ScheduledExecution(
+                jobName: jobName,
+                groupPath: groupPath,
+                project: projectName,
+                uuid: jobUuid,
+                workflow: new Workflow(commands:[new CommandExec(adhocRemoteString: 'echo hi')])
+        ).save()
+        def exec = new Execution(
+                scheduledExecution: se,
+                dateStarted: execDate,
+                dateCompleted: execDate,
+                user:'user',
+                status: 'success',
+                project: projectName,
+                scheduleNodeUUID: "aaaa"
+        ).save()
+        def executionService = Mock(ExecutionService) {
+            queryExecutions(*_) >> {
+                if(execDate.before(query.endbeforeFilter)){
+                    return [result: [exec], total: 1]
+                }
+
+                [result: [], total: 0]
+            }
+        }
+
+        def frameworkService = Mock(FrameworkService) {
+            isClusterModeEnabled() >> {
+                true
+            }
+            getServerUUID()>>{
+                "aaaa"
+            }
+        }
+        def fileUploadService = Mock(FileUploadService)
+        def logFileStorageService = Mock(LogFileStorageService)
+        def jobSchedulerService = Mock(JobSchedulerService){
+            getDeadMembers(_)>>{
+                ["bbbb","null"]
+            }
+        }
+
+        def datamap = new JobDataMap([
+                project: 'projectTest',
+                maxDaysToKeep: daysToKeep,
+                executionService : executionService,
+                frameworkService : frameworkService,
+                fileUploadService: fileUploadService,
+                logFileStorageService: logFileStorageService,
+                jobSchedulerService: jobSchedulerService
+        ])
+
+        ExecutionsCleanUp job = new ExecutionsCleanUp()
+        def context = Mock(JobExecutionContext) {
+            getJobDetail() >> Mock(JobDetail) {
+                getJobDataMap() >> datamap
+            }
+        }
+
+        when:
+        job.execute(context)
+
+        then:
+        2*executionService.queryExecutions(_)
+
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionsCleanUpSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionsCleanUpSpec.groovy
@@ -68,7 +68,7 @@ class ExecutionsCleanUpSpec extends Specification {
         def executionService = Mock(ExecutionService) {
             queryExecutions(*_) >> {
                 if(execDate.before(query.endbeforeFilter)){
-                    return [result: [exec], total: 1]
+                    return [result: [exec.id], total: 1]
                 }
 
                 [result: [], total: 0]
@@ -193,7 +193,8 @@ class ExecutionsCleanUpSpec extends Specification {
         job.execute(context)
 
         then:
-        2*executionService.queryExecutions(_)
+        1*jobSchedulerService.getDeadMembers(_)
+        1*executionService.queryExecutions(_)
 
     }
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Enhancement:
On a cluster environment where the serverNodeUUID of the cluster members normally changed (on docker o kubernetes env), the execution cleanup process doesn't work as expected. The main reason is each cluster member will try to remove its own executions (filtering by serverNodeUUID).

**Describe the solution you've implemented**
1.- A new method to get the list of dead members is added. Each active node will have a different list of dead members in order to not get the same list of executions to delete.
2.- if that list is not empty, then the execution query will search for those uuids (plus the uuid of the server).
3.- the list of dead member can include the "null" option. In this case, it will remove execution with the serverNodeUUID on null (cover cases when rundeck has migrated from not cluster to cluster env).
4.- Some optimizations were added (eg, query just for the execution ID, etc)

**Describe alternatives you've considered**

**Additional context**
