### PR TITLE
fixes #1378 Improve Logs using apache-log4j-extras

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     }
     compile 'org.apache.ant:ant:1.8.3',
         'log4j:log4j:1.2.17',
+        'log4j:apache-log4j-extras:1.2.17',
         'commons-codec:commons-codec:1.10',
         'commons-beanutils:commons-beanutils:1.9.3',
         'commons-collections:commons-collections:3.2.2',


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
fixes #1378
Logs created by rundeck /var/log/rundeck/... are not compressed, and it can cause disk usage issues.
Logs are  handled with log4j, and using the class org.apache.log4j.DailyRollingFileAppender, which allows log rotation. Unfortunately, this last does not support automatic file compression.

**Describe the solution you've implemented**
Easy solution is to use class org.apache.log4j.rolling.RollingFileAppender, but it cannot as it is part of apache-log4j-extras (and not core log4j), we need to import this library.

**Describe alternatives you've considered**
Zipping files in a crontab seemed a good solution, but then handles poorly log rotation.
I tried using also org.apache.log4j.RollingFileAppender (different from org.apache.log4j.rolling.RollingFileAppender), but didn't achieve to compress files with this one.

**Additional context**
