### PR TITLE
Backport PR #4990 - Adds pagination of tokens on user profile

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/user/profile.js
+++ b/rundeckapp/grails-app/assets/javascripts/user/profile.js
@@ -29,6 +29,7 @@ function TokenCreator(data) {
     self.tokenTimeUnit = ko.observable(data.tokenTimeUnit || 'm');
     self.tokenUser = ko.observable(data.tokenUser || data.user);
     self.tokenRolesStr = ko.observable(data.tokenRoles);
+    self.tokenTableSummaryText = ko.observable(data.tokenTableSummaryText);
     self.generateData = ko.computed(function () {
         return {
             login: self.user(),
@@ -81,6 +82,92 @@ function RoleSet(list) {
     }
 }
 
+function TokenTableHandler(ctx) {
+
+    var self = this;
+    var context = ctx;
+    var tbody = jQuery('#apiTokenTableBody');
+
+    self.pageOffset = context.tokenPagingOffset;
+    self.pageMax = context.tokenPagingMax;
+    self.totalTokens = context.tokenTotal;
+
+    self.getTableBody = function () {
+        return tbody;
+    };
+
+    var updateSummary = function () {
+        tokencreator.tokenTableSummaryText(message("userController.page.profile.pager.summary", [
+            self.pageOffset + 1,
+            Math.min((self.pageOffset + self.pageMax), self.totalTokens),
+            self.totalTokens
+        ]));
+    };
+
+    var rows = function () {
+        return tbody.find(".apitokenform");
+    };
+
+    self.getNumRows = function () {
+        return rows().length;
+    };
+
+    self.currentPage = function () {
+        return Math.ceil(self.pageOffset / self.pageMax) + 1;
+    };
+
+    var calcPages = function (total) {
+        return Math.ceil(total / self.pageMax);
+    };
+
+    self.totalPages = function () {
+        return calcPages(self.totalTokens);
+    };
+
+    /**
+     * Determines whenever the number of pages changes if the total number of tokens changes.
+     * @param totalDiff Increment (or decrement if negative) on current total to check.
+     * @return {boolean} true if number of pages would change.
+     */
+    self.numPagesChanges = function (totalDiff) {
+        return self.totalPages() !== calcPages(self.totalTokens + totalDiff);
+    };
+
+    self.insertRow = function (tokenid, rowContent) {
+        var table = tokenTable.getTableBody();
+        table.prepend(rowContent);
+        var row = $('token-' + tokenid);
+        row.style.opacity = 0;
+        jQuery($(row)).fadeTo(1000, 1);
+
+        self.totalTokens++;
+        updateSummary();
+
+        // if numrows > max then drop last row.
+        if(self.getNumRows() > self.pageMax) {
+            rows().last().remove();
+        }
+    };
+
+    self.removeRow = function(elem) {
+        jQuery(elem).fadeOut("slow", function () {
+            $(this).remove();
+            self.totalTokens--;
+            updateSummary();
+        });
+    };
+
+    self.goToPage = function (pageNum) {
+        var params = {
+            login: context.user,
+            max: self.pageMax,
+            offset: self.pageMax * (pageNum - 1)
+        };
+        window.location = _genUrl(appLinks.userProfilePage, params);
+    };
+}
+
+
 function highlightNew() {
     jQuery(' .apitokenform.newtoken').fadeTo('slow', 1);
 }
@@ -89,18 +176,39 @@ function tokenAjaxError(msg) {
     jQuery('.gentokenerror').show();
 }
 
+
+function getNumRows() {
+    return jQuery('.apitokenform').length;
+}
+
 function addTokenRow(elem, login, tokenid) {
-    var table = $(elem).down('.apitokentable');
-    var row = new Element('tbody');
-    table.insert(row);
-    $(row).addClassName('apitokenform');
-    $(row).style.opacity = 0;
-    jQuery(row).load(
-        _genUrl(appLinks.userRenderApiToken, {login: login, tokenid: tokenid}),
-        function (resp, status, jqxhr) {
-            jQuery($(row)).fadeTo("slow",1);
-        }
-    );
+
+    // add the row dynamically only if we are at the first page, and the
+    // number of pages will not change.
+    if(tokenTable.currentPage() !== 1 || tokenTable.numPagesChanges(1)) {
+      tokenTable.goToPage(1);
+      return;
+    }
+
+    jQuery.get(_genUrl(appLinks.userRenderApiToken, {login: login, tokenid: tokenid}), function (response) {
+        tokenTable.insertRow(tokenid, response);
+    });
+
+}
+
+function removeTokenRow(elem, data) {
+
+    // Remove dynamically only if we are in last page
+    // and number of pages will not change.
+    if (tokenTable.currentPage() !== tokenTable.totalPages()
+      || tokenTable.numPagesChanges(-1)) {
+
+        // reload page.
+        window.location.reload();
+        return;
+    }
+
+    tokenTable.removeRow(elem);
 }
 
 function clearToken(elem) {
@@ -122,7 +230,7 @@ function clearToken(elem) {
                 tokenAjaxError(data.error);
             } else if (data.result) {
                 //remove row element
-                jQuery(elem).fadeOut("slow");
+                removeTokenRow(elem, data);
             }
         },
         error: function (jqxhr, status, error) {
@@ -132,6 +240,8 @@ function clearToken(elem) {
         }
     }).success(_ajaxReceiveTokens.curry('api_req_tokens'));
 }
+
+
 function generateUserToken(login, elem, data) {
     var dom = jQuery('#' + elem);
     jQuery.ajax({
@@ -197,8 +307,17 @@ jQuery(function () {
     var dom = jQuery('#gentokensection');
     if (dom.length == 1) {
         var roleset = new RoleSet(data.roles);
-        window.tokencreator = new TokenCreator({roleset: roleset, user: data.user, adminAuth: data.adminAuth,
-            userTokenAuth: data.userTokenAuth, svcTokenAuth: data.svcTokenAuth});
+        window.tokencreator = new TokenCreator({
+            roleset: roleset,
+            user: data.user,
+            adminAuth: data.adminAuth,
+            userTokenAuth: data.userTokenAuth,
+            svcTokenAuth: data.svcTokenAuth,
+            tokenTableSummaryText: data.tokenTableSummaryText
+        });
         ko.applyBindings(tokencreator, dom[0]);
+
+        // Token table handler
+        window.tokenTable = new TokenTableHandler(data);
     }
 });

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1165,6 +1165,7 @@ security.groups.description=The list of groups/roles names provided by the login
 userController.page.create.title=Create User Profile
 userController.page.profile.description=Email and Name can be used in Job executions, notifications, or by other plugins.
 userController.page.profile.title=User Profile
+userController.page.profile.pager.summary=Showing tokens {0} to {1} of {2} total.
 not.set=Not set
 scmController.action.saveCommit.userInfoMissing.message=SCM Export could not be performed
 scmController.action.saveCommit.userInfoMissing.errorHelp=Please update {{user/profile}} and enter the missing values.

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1135,6 +1135,7 @@ security.groups.description=La lista de grupos / nombres de funciones proporcion
 userController.page.create.title=Crear Perfil de Usuario
 userController.page.profile.description=Email y nombre se pueden utilizados en las ejecuciones de Trabajo, notificaciones, o por otros plugins.
 userController.page.profile.title=Perfil de Usuario
+userController.page.profile.pager.summary=Mostrando tokens {0} a {1} de {2} en total.
 not.set=No establecido
 scmController.action.saveCommit.userInfoMissing.message=SCM Exportación no pudo ser ejecutado
 scmController.action.saveCommit.userInfoMissing.errorHelp=Por favor, actualice {{user/profile}} e ingrese los valores faltantes.

--- a/rundeckapp/grails-app/i18n/messages_fr_FR.properties
+++ b/rundeckapp/grails-app/i18n/messages_fr_FR.properties
@@ -1094,6 +1094,7 @@ security.groups.description=La liste des noms de groupes / r\u00f4les fournis pa
 userController.page.create.title=Cr\u00e9er un profil utilisateur
 userController.page.profile.description=L\u02bcemail et le nom peuvent \u00eatre employ\u00e9s dans les ex\u00e9cutions de travail, les notifications, ou par d\u02bcautres plugins.
 userController.page.profile.title=Profil de l\u02bcutilisateur
+userController.page.profile.pager.summary=Montrant les jetons {0} à {1} sur un total de {2}
 not.set=Pas encore d\u00e9fini
 scmController.action.saveCommit.userInfoMissing.message=L\u02bcexportation SCM n\u02bca pas pu \u00eatre effectu\u00e9e
 scmController.action.saveCommit.userInfoMissing.errorHelp=Veuillez mettre \u00e0 jour {{user / profile}} et entrer les valeurs manquantes.

--- a/rundeckapp/grails-app/taglib/rundeck/BootstrapTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/BootstrapTagLib.groovy
@@ -1,5 +1,11 @@
 package rundeck
 
+import grails.util.TypeConvertingMap
+import grails.web.mapping.UrlMapping
+import org.grails.taglib.TagOutput
+import org.grails.taglib.encoder.OutputContextLookupHelper
+import org.springframework.web.servlet.support.RequestContextUtils
+
 class BootstrapTagLib {
     def static namespace = "bs"
     static defaultEncodeAs = [taglib: 'none']
@@ -181,4 +187,165 @@ class BootstrapTagLib {
         }
         return '#'
     }
+
+
+    /**
+     * Creates next/previous links to support pagination for the current controller, using bootstrap 4 markup<br/>
+     *
+     * &lt;bs:paginate total="${Account.count()}" /&gt;<br/>
+     *
+     * @emptyTag
+     *
+     * @attr total REQUIRED The total number of results to paginate
+     * @attr action the name of the action to use in the link, if not specified the default action will be linked
+     * @attr controller the name of the controller to use in the link, if not specified the current controller will be linked
+     * @attr id The id to use in the link
+     * @attr params A map containing request parameters
+     * @attr prev The text to display for the previous link (defaults to "Previous" as defined by default.paginate.prev property in I18n messages.properties)
+     * @attr next The text to display for the next link (defaults to "Next" as defined by default.paginate.next property in I18n messages.properties)
+     * @attr omitPrev Whether to not show the previous link (if set to true, the previous link will not be shown)
+     * @attr omitNext Whether to not show the next link (if set to true, the next link will not be shown)
+     * @attr omitFirst Whether to not show the first link (if set to true, the first link will not be shown)
+     * @attr omitLast Whether to not show the last link (if set to true, the last link will not be shown)
+     * @attr max The number of records displayed per page (defaults to 10). Used ONLY if params.max is empty
+     * @attr maxsteps The number of steps displayed for pagination (defaults to 10). Used ONLY if params.maxsteps is empty
+     * @attr offset Used only if params.offset is empty
+     * @attr mapping The named URL mapping to use to rewrite the link
+     * @attr fragment The link fragment (often called anchor tag) to use
+     */
+    Closure paginate = { Map attrsMap ->
+        TypeConvertingMap attrs = (TypeConvertingMap) attrsMap
+        def writer = out
+        if (attrs.total == null) {
+            throwTagError("Tag [paginate] is missing required attribute [total]")
+        }
+
+        def messageSource = grailsAttributes.messageSource
+        def locale = RequestContextUtils.getLocale(request)
+
+        def total = attrs.int('total') ?: 0
+        def offset = params.int('offset') ?: 0
+        def max = params.int('max')
+        def maxsteps = (attrs.int('maxsteps') ?: 10)
+
+        if (!offset) offset = (attrs.int('offset') ?: 0)
+        if (!max) max = (attrs.int('max') ?: 10)
+
+        Map linkParams = [:]
+        if (attrs.params instanceof Map) linkParams.putAll((Map) attrs.params)
+        linkParams.offset = offset - max
+        linkParams.max = max
+        if (params.sort) linkParams.sort = params.sort
+        if (params.order) linkParams.order = params.order
+
+        Map linkTagAttrs = [:]
+        def action
+        if (attrs.containsKey('mapping')) {
+            linkTagAttrs.mapping = attrs.mapping
+            action = attrs.action
+        } else {
+            action = attrs.action ?: params.action
+        }
+        if (action) {
+            linkTagAttrs.action = action
+        }
+        if (attrs.controller) {
+            linkTagAttrs.controller = attrs.controller
+        }
+        if (attrs.containsKey(UrlMapping.PLUGIN)) {
+            linkTagAttrs.put(UrlMapping.PLUGIN, attrs.get(UrlMapping.PLUGIN))
+        }
+        if (attrs.containsKey(UrlMapping.NAMESPACE)) {
+            linkTagAttrs.put(UrlMapping.NAMESPACE, attrs.get(UrlMapping.NAMESPACE))
+        }
+        if (attrs.id != null) {
+            linkTagAttrs.id = attrs.id
+        }
+        if (attrs.fragment != null) {
+            linkTagAttrs.fragment = attrs.fragment
+        }
+        linkTagAttrs.params = linkParams
+
+        // determine paging variables
+        def steps = maxsteps > 0
+        int currentstep = ((offset / max) as int) + 1
+        int firststep = 1
+        int laststep = Math.round(Math.ceil(total / max)) as int
+
+        // display previous link when not on firststep unless omitPrev is true
+        if (currentstep > firststep && !attrs.boolean('omitPrev')) {
+            linkTagAttrs.put('class', 'page-link')
+            linkParams.offset = offset - max
+            writer << """<li class="page-item">${callLink((Map) linkTagAttrs.clone()) {
+                (attrs.prev ?: messageSource.getMessage('paginate.prev', null, messageSource.getMessage('default.paginate.prev', null, 'Previous', locale), locale))
+            }}</li>"""
+        }
+
+        // display steps when steps are enabled and laststep is not firststep
+        if (steps && laststep > firststep) {
+            linkTagAttrs.put('class', 'page-link')
+
+            // determine begin and endstep paging variables
+            int beginstep = currentstep - (Math.round(maxsteps / 2.0d) as int) + (maxsteps % 2)
+            int endstep = currentstep + (Math.round(maxsteps / 2.0d) as int) - 1
+
+            if (beginstep < firststep) {
+                beginstep = firststep
+                endstep = maxsteps
+            }
+            if (endstep > laststep) {
+                beginstep = laststep - maxsteps + 1
+                if (beginstep < firststep) {
+                    beginstep = firststep
+                }
+                endstep = laststep
+            }
+
+            // display firststep link when beginstep is not firststep
+            if (beginstep > firststep && !attrs.boolean('omitFirst')) {
+                linkParams.offset = 0
+                writer << """<li class="page-item">${callLink((Map) linkTagAttrs.clone()) { firststep.toString() }}</li>"""
+            }
+            //show a gap if beginstep isn't immediately after firststep, and if were not omitting first or rev
+            if (beginstep > firststep + 1 && (!attrs.boolean('omitFirst') || !attrs.boolean('omitPrev'))) {
+                writer << '<li class="page-item"><span>...</span></li>'
+            }
+
+            // display paginate steps
+            (beginstep..endstep).each { int i ->
+                if (currentstep == i) {
+                    writer << """<li class="active"><span>${i}</span></li>"""
+                } else {
+                    linkParams.offset = (i - 1) * max
+                    writer << """<li class="page-item">${callLink((Map) linkTagAttrs.clone()) { i.toString() }}</li>"""
+                }
+            }
+
+            //show a gap if beginstep isn't immediately before firststep, and if were not omitting first or rev
+            if (endstep + 1 < laststep && (!attrs.boolean('omitLast') || !attrs.boolean('omitNext'))) {
+                writer << '<li class="page-item"><span>...</span></li>'
+            }
+            // display laststep link when endstep is not laststep
+            if (endstep < laststep && !attrs.boolean('omitLast')) {
+                linkParams.offset = (laststep - 1) * max
+                writer << """<li class="page-item">${callLink((Map) linkTagAttrs.clone()) { laststep.toString() }}</li>"""
+            }
+        }
+
+        // display next link when not on laststep unless omitNext is true
+        if (currentstep < laststep && !attrs.boolean('omitNext')) {
+            linkTagAttrs.put('class', 'page-link')
+            linkParams.offset = offset + max
+            writer << """<li class="page-item">${callLink((Map) linkTagAttrs.clone()) {
+                (attrs.next ? attrs.next : messageSource.getMessage('paginate.next', null, messageSource.getMessage('default.paginate.next', null, 'Next', locale), locale))
+            }}</li>"""
+        }
+    }
+
+
+    private callLink(Map attrs, Object body) {
+        TagOutput.captureTagOutput(tagLibraryLookup, 'g', 'link', attrs, body, OutputContextLookupHelper.lookupOutputContext())
+    }
+
+
 }

--- a/rundeckapp/grails-app/views/common/_js.gsp
+++ b/rundeckapp/grails-app/views/common/_js.gsp
@@ -72,6 +72,7 @@
         userGenerateUserToken: "${g.createLink(controller: 'user', action: 'generateUserToken',params:[format:'json'])}",
         userRevealTokenData: "${g.createLink(controller: 'user', action: 'renderUsertoken',params:[format:'json'])}",
         userRenderApiToken: "${g.createLink(controller: 'user', action: 'renderApiToken')}",
+        userProfilePage: "${g.createLink(controller: 'user', action: 'profile')}",
 
         workflowEdit: '${createLink(controller:"workflow",action:"edit",params:projParams)}',
         workflowCopy: '${createLink(controller:"workflow",action:"copy",params:projParams)}',

--- a/rundeckapp/grails-app/views/user/_token.gsp
+++ b/rundeckapp/grails-app/views/user/_token.gsp
@@ -22,6 +22,7 @@
 
 <g:set var="ukey" value="${g.rkey()}"/>
 <tr class="apitokenform ${token.token == flashToken ? 'newtoken' : ''}"
+    id="token-${token.uuid}"
     style="${token.token == flashToken ? 'opacity:0;' : ''}">
     <td width="20%" class="token-data-holder">
         <g:if test="${token.uuid}">
@@ -72,36 +73,41 @@
 
         <!-- Modal -->
 
-            <g:form controller="user" action="clearApiToken" useToken="true" >
-                <div class="modal fade clearconfirm" id="myModal${enc(attr: ukey)}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel"
-                     aria-hidden="true">
-                    <div class="modal-dialog modal-sm">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                                <h4 class="modal-title"><g:message code="userController.page.profile.heading.delete.token.title" /></h4>
-                            </div>
+        <g:form controller="user" action="clearApiToken" useToken="true">
+            <div class="modal fade clearconfirm" id="myModal${enc(attr: ukey)}" tabindex="-1" role="dialog"
+                 aria-labelledby="myModalLabel"
+                 aria-hidden="true">
+                <div class="modal-dialog modal-sm">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                            <h4 class="modal-title"><g:message
+                                    code="userController.page.profile.heading.delete.token.title"/></h4>
+                        </div>
 
-                            <div class="modal-body">
-                                <p><g:message code="userController.page.profile.delete.token.description" /></p>
-                            </div>
+                        <div class="modal-body">
+                            <p><g:message code="userController.page.profile.delete.token.description"/></p>
+                        </div>
 
-                            <div class="modal-footer">
-                                <g:hiddenField name="login" value="${user.login}"></g:hiddenField>
-                                <g:if test="${token.uuid}">
-                                    <g:hiddenField name="tokenid" value="${token.uuid}"></g:hiddenField>
-                                </g:if>
-                                <g:else>
-                                    <g:hiddenField name="token" value="${token.token}"></g:hiddenField>
-                                </g:else>
-                                <button type="button" class="btn btn-default" data-dismiss="modal"><g:message
+                        <div class="modal-footer">
+                            <g:hiddenField name="tokenPagingMax" value="${params.max}"></g:hiddenField>
+                            <g:hiddenField name="tokenPagingOffset" value="${params.offset}"></g:hiddenField>
+                            <g:hiddenField name="login" value="${user.login}"></g:hiddenField>
+                            <g:if test="${token.uuid}">
+                                <g:hiddenField name="tokenid" value="${token.uuid}"></g:hiddenField>
+                            </g:if>
+                            <g:else>
+                                <g:hiddenField name="token" value="${token.token}"></g:hiddenField>
+                            </g:else>
+                            <button type="button" class="btn btn-default" data-dismiss="modal"><g:message
                                     code="button.action.Cancel"/></button>
-                                <input type="submit" class="btn btn-danger yes" value="Delete" name="${message(code:'button.action.Delete')}">
+                            <input type="submit" class="btn btn-danger yes" value="Delete"
+                                   name="${message(code: 'button.action.Delete')}">
 
-                            </div>
-                        </div><!-- /.modal-content -->
-                    </div><!-- /.modal-dialog -->
-                </div><!-- /.modal -->
-            </g:form>
-        </td>
-    </tr>
+                        </div>
+                    </div><!-- /.modal-content -->
+                </div><!-- /.modal-dialog -->
+            </div><!-- /.modal -->
+        </g:form>
+    </td>
+</tr>

--- a/rundeckapp/grails-app/views/user/_tokenList.gsp
+++ b/rundeckapp/grails-app/views/user/_tokenList.gsp
@@ -17,6 +17,7 @@
 
 <g:set var="ukey" value="${g.rkey()}"/>
 <table width="100%" class="table table-condensed table-striped apitokentable">
+    <thead>
     <tr>
         <th class="table-header">
             <g:message code="token"/>
@@ -25,7 +26,7 @@
             <g:message code="expiration"/>
         </th>
         <th class="table-header">
-            <g:message code="token.username" />
+            <g:message code="token.username"/>
         </th>
         <th class="table-header">
             <g:message code="roles"/>
@@ -33,7 +34,10 @@
         <th class="table-header">
         </th>
     </tr>
+    </thead>
+    <tbody id="apiTokenTableBody">
     <g:each in="${tokenList}" var="token">
         <g:render template="token" model="${[user: user, token: token, flashToken: flashToken]}"/>
     </g:each>
+    </tbody>
 </table>

--- a/rundeckapp/grails-app/views/user/_user.gsp
+++ b/rundeckapp/grails-app/views/user/_user.gsp
@@ -150,7 +150,8 @@
                         </div>
 
                         <div class="modal-footer">
-
+                            <g:hiddenField name="tokenPagingMax" value="${params.max}"></g:hiddenField>
+                            <g:hiddenField name="tokenPagingOffset" value="${params.offset}"></g:hiddenField>
                             <g:hiddenField name="login" value="${user.login}"/>
                             <button type="button" class="btn btn-default" data-dismiss="modal"><g:message
                                     code="button.action.Cancel"/></button>
@@ -295,14 +296,14 @@
             </div><!-- /.modal-dialog -->
         </div><!-- /.modal -->
 
+
         <div class="row userapitoken">
             <div class="col-sm-12">
-                <g:set var="tokens"
-                       value="${(tokenAdmin) ? rundeck.AuthToken.findAll() :
-                               rundeck.AuthToken.findAllByCreator(user.login)}"/>
+                <div class="help-block"  data-bind="text: tokenTableSummaryText">
 
-                    <g:render template="tokenList" model="${[user:user, tokenList:tokens,flashToken:flash.newtoken]}"/>
+                </div>
 
+                <g:render template="tokenList" model="${[user: user, tokenList: tokens, flashToken: flash.newtoken]}"/>
 
                 <div style="display:none" class="gentokenerror alert alert-danger alert-dismissable">
                     <a class="close" data-dismiss="alert" href="#" aria-hidden="true">&times;</a>
@@ -310,5 +311,22 @@
                 </div>
 
             </div>
-        </div></div>
+        </div>
+
+        <div class="row">
+            <div class="col-sm-12">
+                <ul class="pagination pagination-sm">
+                    <bs:paginate
+                            total="${tokenTotal}"
+                            controller="user"
+                            action="profile"
+                            maxsteps="5"
+                            prev="&lt;"
+                            next="&gt;"/>
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
 </g:if>

--- a/rundeckapp/grails-app/views/user/profile.gsp
+++ b/rundeckapp/grails-app/views/user/profile.gsp
@@ -19,11 +19,6 @@
   - limitations under the License.
   --}%
 
-    <g:set var="tokenAdmin" value="${auth.resourceAllowedTest(
-            kind: 'user',
-            action: [AuthConstants.ACTION_ADMIN],
-            context: 'application'
-    )}"/>
     <g:set var="selfToken" value="${auth.resourceAllowedTest(
             kind: 'apitoken',
             action: [AuthConstants.GENERATE_USER_TOKEN],
@@ -43,16 +38,28 @@
         window.location.href = url + "?lang=" + jQuery("#language").val();
     }
     </script>
+
+    <g:jsMessages code="userController.page.profile.pager.summary"/>
+
     <g:set var="currentLang" value="${response.locale?.toString() ?: request.locale?.toString()}"/>
     <g:embedJSON
-        data="${[user         : user.login,
-                 roles        : authRoles,
-                 adminAuth    : tokenAdmin,
-                 userTokenAuth: selfToken,
-                 svcTokenAuth : serviceToken,
-                 language     : currentLang
+            data="${[user             : user.login,
+                     roles            : authRoles,
+                     adminAuth        : tokenAdmin,
+                     userTokenAuth    : selfToken,
+                     svcTokenAuth     : serviceToken,
+                     language         : currentLang,
+                     tokenPagingMax   : params.max,
+                     tokenPagingOffset: params.offset,
+                     tokenTotal       : tokenTotal,
+                     tokenTableSummaryText: message(code: "userController.page.profile.pager.summary",
+                             args: [
+                                     params.offset.toInteger() + 1,
+                                     Math.min((params.offset.toInteger() + params.max.toInteger()), tokenTotal),
+                                     tokenTotal
+                             ])
             ]}"
-        id="genPageData"/>
+            id="genPageData"/>
 </head>
 <body>
 <div class="container-fluid">
@@ -108,7 +115,7 @@
                   </div>
                   <div class="pageBody" id="userProfilePage">
                       <g:jsonToken id='api_req_tokens' url="${request.forwardURI}"/>
-                      <tmpl:user user="${user}" edit="${true}"/>
+                      <tmpl:user user="${user}" edit="${true}" tokens="${tokenList}" tokenTotal="${tokenTotal}" />
                   </div>
               </div>
           </div>


### PR DESCRIPTION
This PR adds pagination to the token section of the user profile page, in order to support a high amount of tokens.

The main changes on this PR are:

- Added a gsp-based paginator which will appear when the amount of tokens exeeds 50.
- Page limit can be configured using the rundeck.gui.user.profile.paginatetoken.max.per.page key.
- Depending on the paging conditions and amount of tokens, tokens will be added/deleted either via ajax or by reloading the page.
- Added a new pagination taglib in order to support gsp pagination using bootstrap markup.

For further details see https://github.com/rundeck/rundeck/pull/4990

Fixes issue https://github.com/rundeck/rundeck/issues/4831
