### PR TITLE
Backport PR #5005 - EnhancedNodeService bean was not loaded

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -161,7 +161,7 @@ beans={
     frameworkFilesystem(FrameworkFactory,rdeckBase){ bean->
         bean.factoryMethod='createFilesystemFramework'
     }
-    filesystemProjectManager(FrameworkFactory,frameworkFilesystem,ref('nodeService')){ bean->
+    filesystemProjectManager(FrameworkFactory,frameworkFilesystem,ref('rundeckNodeService')){ bean->
         bean.factoryMethod='createProjectManager'
     }
 


### PR DESCRIPTION
EnhancedNodeService bean was not being loaded then the node enhancement was not processed.
Backport PR #5005 