### PR TITLE
Change in the async call for SCM gui #4998

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/menu/jobs.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/jobs.js
@@ -211,13 +211,13 @@ function BulkEditor(data){
             exportStatus = self.scmStatus()[jobid].synchState.name;
             switch(exportStatus) {
                 case "EXPORT_NEEDED":
-                    text = self.message['scm.export.status.EXPORT_NEEDED.description'];
+                    text = self.messages['scm.export.status.EXPORT_NEEDED.description'];
                     break;
                 case "CREATE_NEEDED":
-                    text = self.message['scm.export.status.CREATE_NEEDED.description'];
+                    text = self.messages['scm.export.status.CREATE_NEEDED.description'];
                     break;
                 case "CLEAN":
-                    text = self.message['scm.export.status.CLEAN.description'];
+                    text = self.messages['scm.export.status.CLEAN.description'];
                     break;
                 default:
                     text = exportStatus;
@@ -232,19 +232,19 @@ function BulkEditor(data){
             importStatus = self.scmImportJobStatus()[jobid].synchState.name;
             switch(importStatus) {
                 case "IMPORT_NEEDED":
-                    text += self.message['scm.import.status.IMPORT_NEEDED.description'];
+                    text += self.messages['scm.import.status.IMPORT_NEEDED.description'];
                     break;
                 case "DELETE_NEEDED":
-                    text += self.message['scm.import.status.DELETE_NEEDED.description'];
+                    text += self.messages['scm.import.status.DELETE_NEEDED.description'];
                     break;
                 case "CLEAN":
-                    text += self.message['scm.import.status.CLEAN.description'];
+                    text += self.messages['scm.import.status.CLEAN.description'];
                     break;
                 case "REFRESH_NEEDED":
-                    text += self.message['scm.import.status.REFRESH_NEEDED.description'];
+                    text += self.messages['scm.import.status.REFRESH_NEEDED.description'];
                     break;
                 case "UNKNOWN":
-                    text += self.message['scm.import.status.UNKNOWN.description'];
+                    text += self.messages['scm.import.status.UNKNOWN.description'];
                     break;
                 default:
                     text += importStatus;
@@ -343,19 +343,19 @@ function BulkEditor(data){
             var text = null;
             switch(self.exportState()) {
                 case "EXPORT_NEEDED":
-                    text = self.message['scm.export.status.EXPORT_NEEDED.display.text'];
+                    text = self.messages['scm.export.status.EXPORT_NEEDED.display.text'];
                     break;
                 case "CREATE_NEEDED":
-                    text = self.message['scm.export.status.CREATE_NEEDED.display.text'];
+                    text = self.messages['scm.export.status.CREATE_NEEDED.display.text'];
                     break;
                 case "REFRESH_NEEDED":
-                    text = self.message['scm.export.status.REFRESH_NEEDED.display.text'];
+                    text = self.messages['scm.export.status.REFRESH_NEEDED.display.text'];
                     break;
                 case "DELETED":
-                    text = self.message['scm.export.status.DELETED.display.text'];
+                    text = self.messages['scm.export.status.DELETED.display.text'];
                     break;
                 case "CLEAN":
-                    text = self.message['scm.export.status.CLEAN.display.text'];
+                    text = self.messages['scm.export.status.CLEAN.display.text'];
                     break;
             }
             if(!text){
@@ -371,16 +371,16 @@ function BulkEditor(data){
             var text = null;
             switch(self.importState()) {
                 case "IMPORT_NEEDED":
-                    text = self.message['scm.import.status.IMPORT_NEEDED.display.text'];
+                    text = self.messages['scm.import.status.IMPORT_NEEDED.display.text'];
                     break;
                 case "REFRESH_NEEDED":
-                    text = self.message['scm.import.status.REFRESH_NEEDED.display.text'];
+                    text = self.messages['scm.import.status.REFRESH_NEEDED.display.text'];
                     break;
                 case "UNKNOWN":
-                    text = self.message['scm.import.status.UNKNOWN.display.text'];
+                    text = self.messages['scm.import.status.UNKNOWN.display.text'];
                     break;
                 case "CLEAN":
-                    text = self.message['scm.import.status.CLEAN.display.text'];
+                    text = self.messages['scm.import.status.CLEAN.display.text'];
                     break;
             }
             if(!text){

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -300,16 +300,13 @@ search
 
             var pageParams = loadJsonData('pageParams');
             var nextScheduled = loadJsonData('nextScheduled');
-            var nextSchedList="";
-            for(var i=0; i< nextScheduled.length; i++){
-                nextSchedList = nextSchedList+nextScheduled[i]+",";
-            }
 
             jQuery.ajax({
                 dataType:'json',
-                method: "POST",
-                url:_genUrl(appLinks.scmjobs, {nextScheduled:nextSchedList}),
-                params:nextScheduled,
+                type: "POST",
+                url: appLinks.scmjobs,
+                data: JSON.stringify(nextScheduled),
+                contentType: 'application/json; charset=utf-8',
                 success:function(data,status,xhr){
                     bulkeditor.scmExportEnabled(data.scmExportEnabled);
                     bulkeditor.scmStatus(data.scmStatus);

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -968,6 +968,8 @@ class MenuControllerSpec extends Specification {
 
         when:
         request.method = 'POST'
+        request.JSON = []
+        request.format = 'json'
         params.project = project
         controller.listExport()
         then:
@@ -1003,6 +1005,8 @@ class MenuControllerSpec extends Specification {
 
         when:
         request.method = 'POST'
+        request.JSON = []
+        request.format = 'json'
         params.project = project
         controller.listExport()
         then:


### PR DESCRIPTION
Change the ajax call to `scmjobs` endpoint. Pass the data through the body of the ajax call instead of the URL to prevent 'URI is too large' problem.

fix #4998