### PR TITLE
Change in the async call for SCM gui #4998

### DIFF
--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -300,16 +300,13 @@ search
 
             var pageParams = loadJsonData('pageParams');
             var nextScheduled = loadJsonData('nextScheduled');
-            var nextSchedList="";
-            for(var i=0; i< nextScheduled.length; i++){
-                nextSchedList = nextSchedList+nextScheduled[i]+",";
-            }
 
             jQuery.ajax({
                 dataType:'json',
-                method: "POST",
-                url:_genUrl(appLinks.scmjobs, {nextScheduled:nextSchedList}),
-                params:nextScheduled,
+                type: "POST",
+                url: appLinks.scmjobs,
+                data: JSON.stringify(nextScheduled),
+                contentType: 'application/json; charset=utf-8',
                 success:function(data,status,xhr){
                     bulkeditor.scmExportEnabled(data.scmExportEnabled);
                     bulkeditor.scmStatus(data.scmStatus);

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -968,6 +968,8 @@ class MenuControllerSpec extends Specification {
 
         when:
         request.method = 'POST'
+        request.JSON = []
+        request.format = 'json'
         params.project = project
         controller.listExport()
         then:
@@ -1003,6 +1005,8 @@ class MenuControllerSpec extends Specification {
 
         when:
         request.method = 'POST'
+        request.JSON = []
+        request.format = 'json'
         params.project = project
         controller.listExport()
         then:


### PR DESCRIPTION
Change the ajax call to `scmjobs` endpoint. Pass the data through the body of the ajax call instead of the URL to prevent 'URI is too large' problem.

fix #4998