### PR TITLE
on cluster environment , the job scheduled should respect the remote exec policies

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/schedule/JobScheduleManager.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/schedule/JobScheduleManager.java
@@ -95,5 +95,7 @@ public interface JobScheduleManager {
      *
      * @return true if successful
      */
-    boolean scheduleRemoteJob(Map data);
+    default boolean scheduleRemoteJob(Map data){
+        return false;
+    }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/schedule/JobScheduleManager.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/schedule/JobScheduleManager.java
@@ -87,4 +87,13 @@ public interface JobScheduleManager {
      * @return list dead cluster members
      */
     List<String> getDeadMembers(String uuid);
+
+    /**
+     * Schedule a job to run later
+     *
+     * @param data  dataRundeckproClusterGrailsPlugin
+     *
+     * @return true if successful
+     */
+    boolean scheduleRemoteJob(Map data);
 }

--- a/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
@@ -53,6 +53,11 @@ class JobSchedulerService implements JobScheduleManager {
     List<String> getDeadMembers(String uuid) {
         return rundeckJobScheduleManager.getDeadMembers(uuid);
     }
+
+    @Override
+    boolean scheduleRemoteJob(Map data) {
+        return rundeckJobScheduleManager.scheduleRemoteJob(data)
+    }
 }
 
 /**
@@ -65,7 +70,6 @@ class QuartzJobScheduleManager implements JobScheduleManager {
 
     @Autowired
     def FrameworkService frameworkService
-
 
     @Override
     void deleteJobSchedule(final String name, final String group) {
@@ -127,4 +131,10 @@ class QuartzJobScheduleManager implements JobScheduleManager {
     List<String> getDeadMembers(String uuid) {
         return null;
     }
+
+    @Override
+    boolean scheduleRemoteJob(Map data) {
+        false
+    }
+
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -2277,13 +2277,16 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
 
         boolean shouldreSchedule = false
+        def boolean renamed = oldjobname != scheduledExecution.generateJobScheduledName() || oldjobgroup != scheduledExecution.generateJobGroupName()
+
         if(frameworkService.isClusterModeEnabled()){
 
             if (originalCron != scheduledExecution.generateCrontabExression() ||
                 originalSchedule != scheduledExecution.scheduleEnabled ||
                 originalExecution != scheduledExecution.executionEnabled ||
                 originalTz != scheduledExecution.timeZone ||
-                oldsched != scheduledExecution.scheduled
+                oldsched != scheduledExecution.scheduled ||
+                renamed
             ) {
                 def data = [jobServerUUID: scheduledExecution.serverNodeUUID,
                             serverUUID   : frameworkService.serverUUID,
@@ -2305,7 +2308,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }else{
             shouldreSchedule = true
         }
-        def boolean renamed = oldjobname != scheduledExecution.generateJobScheduledName() || oldjobgroup != scheduledExecution.generateJobGroupName()
+
         if (renamed) {
             changeinfo.rename = true
             changeinfo.origName = oldjobname

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -628,17 +628,17 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     }
 
     def rescheduleJob(ScheduledExecution scheduledExecution) {
-        rescheduleJob(scheduledExecution, false, null, null)
+        rescheduleJob(scheduledExecution, false, null, null, false)
     }
 
-    def rescheduleJob(ScheduledExecution scheduledExecution, wasScheduled, oldJobName, oldJobGroup) {
+    def rescheduleJob(ScheduledExecution scheduledExecution, wasScheduled, oldJobName, oldJobGroup, boolean forceLocal) {
         if (scheduledExecution.shouldScheduleExecution() && shouldScheduleInThisProject(scheduledExecution.project)) {
             //verify cluster member is schedule owner
 
             def nextdate = null
             def nextExecNode = null
             try {
-                (nextdate, nextExecNode) = scheduleJob(scheduledExecution, oldJobName, oldJobGroup);
+                (nextdate, nextExecNode) = scheduleJob(scheduledExecution, oldJobName, oldJobGroup, forceLocal);
             } catch (SchedulerException e) {
                 log.error("Unable to schedule job: ${scheduledExecution.extid}: ${e.message}")
             }
@@ -685,7 +685,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             try {
                 def nexttime = null
                 def nextExecNode = null
-                (nexttime, nextExecNode) = scheduleJob(se, null, null)
+                (nexttime, nextExecNode) = scheduleJob(se, null, null, true)
                 succeededJobs << [job: se, nextscheduled: nexttime]
                 log.info("rescheduled job in project ${se.project}: ${se.extid}")
             } catch (Exception e) {
@@ -1068,7 +1068,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 AuthConstants.ACTION_RUN,se.project)
     }
 
-    def scheduleJob(ScheduledExecution se, String oldJobName, String oldGroupName) {
+    def scheduleJob(ScheduledExecution se, String oldJobName, String oldGroupName, boolean forceLocal=false) {
         def jobid = "${se.generateFullName()} [${se.extid}]"
         def jobDesc = "Attempt to schedule job $jobid in project $se.project"
         if (!executionService.executionsAreActive) {
@@ -1086,6 +1086,17 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                     "$jobDesc, but job execution is disabled."
             )
             return [null, null];
+        }
+
+        def data=["project": se.project,
+                  "jobId":se.uuid]
+
+        if(!forceLocal){
+            boolean remoteAssign = jobSchedulerService.scheduleRemoteJob(data)
+
+            if(remoteAssign){
+                return [null, null]
+            }
         }
 
         def jobDetail = createJobDetail(se)
@@ -2105,7 +2116,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
 
         if (scheduledExecution.save(flush: true)) {
-            rescheduleJob(scheduledExecution, oldSched, oldJobName, oldJobGroup)
+            rescheduleJob(scheduledExecution, oldSched, oldJobName, oldJobGroup, true)
             return [success: true, scheduledExecution: scheduledExecution]
         } else {
             scheduledExecution.discard()
@@ -2265,6 +2276,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             scheduledExecution.nextExecution = new Date(ScheduledExecutionService.TWO_HUNDRED_YEARS)
         }
 
+        boolean shouldreSchedule = false
         if(frameworkService.isClusterModeEnabled()){
 
             if (originalCron != scheduledExecution.generateCrontabExression() ||
@@ -2283,11 +2295,15 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 )
                 if (modify) {
                     scheduledExecution.serverNodeUUID = frameworkService.serverUUID
+                    //schedule meesage want sent , it should be ran locally
+                    shouldreSchedule = true
                 }
             }
             if (!scheduledExecution.serverNodeUUID) {
                 scheduledExecution.serverNodeUUID = frameworkService.serverUUID
             }
+        }else{
+            shouldreSchedule = true
         }
         def boolean renamed = oldjobname != scheduledExecution.generateJobScheduledName() || oldjobgroup != scheduledExecution.generateJobGroupName()
         if (renamed) {
@@ -2605,7 +2621,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             }
         }
         if (!failed && scheduledExecution.save(true)) {
-            if (scheduledExecution.shouldScheduleExecution() && shouldScheduleInThisProject(scheduledExecution.project)) {
+            if (scheduledExecution.shouldScheduleExecution() && shouldScheduleInThisProject(scheduledExecution.project) && shouldreSchedule) {
                 def nextdate = null
                 def nextExecNode = null
                 try {

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -180,10 +180,11 @@ class ScheduledExecutionServiceSpec extends Specification {
             getServerUUID() >> 'uuid'
             isClusterModeEnabled() >> clusterEnabled
         }
-        service.rundeckJobScheduleManager=Mock(JobScheduleManager){
+        service.jobSchedulerService=Mock(JobSchedulerService){
             determineExecNode(*_)>>{args->
                 return serverNodeUUID
             }
+            scheduleRemoteJob(_)>>false
         }
         def job = new ScheduledExecution(
                 createJobParams(
@@ -2685,7 +2686,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         def scheduleDate = new Date()
 
         when:
-        def result = service.scheduleJob(job, null, null)
+        def result = service.scheduleJob(job, null, null, true)
 
         then:
         1 * service.executionServiceBean.getExecutionsAreActive() >> executionsAreActive
@@ -3279,5 +3280,73 @@ class ScheduledExecutionServiceSpec extends Specification {
         false           | true              | 'dev'
         true            | null              | 'qa'
         null            | null              |' user'
+    }
+
+
+    @Unroll
+    def "cluster, should not scheduleJob because the remote policy"() {
+        given:
+        service.executionServiceBean = Mock(ExecutionService)
+        service.quartzScheduler = Mock(Scheduler) {
+            getListenerManager() >> Mock(ListenerManager)
+        }
+        def projectMock = Mock(IRundeckProject) {
+            getProjectProperties() >> [:]
+        }
+
+        def serverNodeUUID = "uuid"
+        def clusterEnabled = true
+
+        service.frameworkService = Mock(FrameworkService) {
+            getRundeckBase() >> ''
+            getFrameworkProject(_) >> projectMock
+            getServerUUID() >> serverNodeUUID
+            isClusterModeEnabled() >> clusterEnabled
+        }
+        service.jobSchedulerService=Mock(JobSchedulerService){
+            determineExecNode(*_)>>{args->
+                return serverNodeUUID
+            }
+            scheduleRemoteJob(_)>>true
+        }
+        def job = new ScheduledExecution(
+                createJobParams(
+                        scheduled: true,
+                        scheduleEnabled: true,
+                        executionEnabled: true,
+                        userRoleList: 'a,b'
+                )
+        ).save()
+
+        when:
+        def result = service.scheduleJob(job, null, null)
+
+        then:
+        0 * service.quartzScheduler.scheduleJob(_, _)
+        result == [null, null]
+    }
+
+    @Unroll
+    def "do update job on cluster must not call quartz scheduleJob"(){
+        given:
+        def serverUUID = '802d38a5-0cd1-44b3-91ff-824d495f8105'
+        def uuid = setupDoUpdate(true,serverUUID)
+
+        def jobOwnerUuid = '5e0e96a0-042a-426a-80a4-488f7f6a4f13'
+        def se = new ScheduledExecution(createJobParams([serverNodeUUID:jobOwnerUuid, scheduled: false])).save()
+        service.jobSchedulerService = Mock(JobSchedulerService)
+
+        def inparams = [jobName: 'newName', scheduled: true]
+        when:
+        def results = service._doupdate([id: se.id.toString()] + inparams, mockAuth())
+
+
+        then:
+        results.success
+        results.scheduledExecution.serverNodeUUID == jobOwnerUuid
+        1 * service.jobSchedulerService.updateScheduleOwner(_, _, _) >> false
+        0 * service.quartzScheduler.scheduleJob(_,_,_)
+
+
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -3327,26 +3327,36 @@ class ScheduledExecutionServiceSpec extends Specification {
     }
 
     @Unroll
-    def "do update job on cluster must not call quartz scheduleJob"(){
+    def "do update job on cluster, a schedule changed or name changed must not call local quartz scheduleJob if a takeover message was sent"(){
         given:
         def serverUUID = '802d38a5-0cd1-44b3-91ff-824d495f8105'
-        def uuid = setupDoUpdate(true,serverUUID)
+        setupDoUpdate(true,serverUUID)
 
         def jobOwnerUuid = '5e0e96a0-042a-426a-80a4-488f7f6a4f13'
-        def se = new ScheduledExecution(createJobParams([serverNodeUUID:jobOwnerUuid, scheduled: false])).save()
+        def se = new ScheduledExecution(createJobParams([serverNodeUUID:jobOwnerUuid])).save()
         service.jobSchedulerService = Mock(JobSchedulerService)
 
-        def inparams = [jobName: 'newName', scheduled: true]
         when:
         def results = service._doupdate([id: se.id.toString()] + inparams, mockAuth())
-
 
         then:
         results.success
         results.scheduledExecution.serverNodeUUID == jobOwnerUuid
-        1 * service.jobSchedulerService.updateScheduleOwner(_, _, _) >> false
-        0 * service.quartzScheduler.scheduleJob(_,_,_)
+        if(shouldChange) {
+            1 * service.jobSchedulerService.updateScheduleOwner(_, _, _) >> false
+            0 * service.quartzScheduler.scheduleJob(_,_,_)
+        }
 
+        where:
+        inparams                                        | shouldChange
+        [jobName: 'newName']                            | true
+        [jobName: 'newName', scheduled: false]          | true
+        [scheduled: true]                               | false
+        [groupPath: 'newGroup', timeZone: 'GMT+1']      | true
+        [groupPath: 'newGroup']                         | true
+        [dayOfMonth: '10']                              | true
 
     }
+
+
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Enhancement:
* on cluster environment, the job scheduled should respect the remote execution policies (if it is enabled).
* When the job is created, it will be checked if the job will be scheduled on another cluster member or locally. 
* When a job is updated, that was already considered. But, it was added a flag to avoid registering on the local quartz when the job is owned by another node.
* for takeover API, it will be forced to run locally

**Describe the solution you've implemented**
A new method was added to JobScheduleManager (scheduleRemoteJob) which will check if the remote policies are available on cluster env (and it will send the takeover message if it is enabled)

**Describe alternatives you've considered**

**Additional context**
