### PR TITLE
Support quartz.threadPool.threadCount parameter in Docker image

### DIFF
--- a/docker/official/README.md
+++ b/docker/official/README.md
@@ -210,3 +210,6 @@ to utilize the `RUNDECK_ENVARS_UNSETS` option.
 
 ### `RUNDECK_ENVARS_UNSETS`
 Set to a space-separated list of environment variables to unset before starting Rundeck.
+
+### `RUNDECK_QUARTZ_THREADPOOL_THREADCOUNT`
+Set the threadCount value to the max number of threads you want to run concurrently. If not set, default to 10.

--- a/docker/official/remco/resources.d/rundeck-config-quartz.properties.toml
+++ b/docker/official/remco/resources.d/rundeck-config-quartz.properties.toml
@@ -1,0 +1,4 @@
+[[template]]
+    src         = "${REMCO_TEMPLATE_DIR}/rundeck-config-quartz.properties"
+    dst         = "${REMCO_TMP_DIR}/rundeck-config/rundeck-config-quartz.properties"
+    mode        = "0644"

--- a/docker/official/remco/templates/rundeck-config-quartz.properties
+++ b/docker/official/remco/templates/rundeck-config-quartz.properties
@@ -1,0 +1,5 @@
+
+{% if exists("/rundeck/quartz/threadpool/threadcount") %}
+quartz.threadPool.threadCount={{ getv("/rundeck/quartz/threadpool/threadcount") }}
+{% endif %}
+


### PR DESCRIPTION
Hi :wave: 

**Is this a bugfix, or an enhancement? Please describe.**
It is an enhancement in the official docker image by supporting the quartz thread count configuration parameter through an environment variable.

**Describe the solution you've implemented**
Added in remco templates the possibility to set `RUNDECK_QUARTZ_THREADPOOL_THREADCOUNT` in `rundeck-config.properties` to override the default limit of 10 threads.

**Describe alternatives you've considered**
N/A.

**Additional context**
This will allow users to extends the thread count easily if they are running rundeck inside container and/or in Kubernetes.

