### PR TITLE
Fix #5080 by sending the chosen file copier plugin type even if it has no config properties.

### DIFF
--- a/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
@@ -295,6 +295,7 @@
                     </span>
                 </span>
                 <input type="hidden" name="default_${serviceDefaults.service}" data-bind="value: defaults['${serviceDefaults.service}'].type"/>
+                <input type="hidden" name="${serviceDefaults.prefix}.default.type" data-bind="value: defaults['${serviceDefaults.service}'].type"/>
             </div>
         </div>
         <g:each in="${serviceDefaults.descriptions}" var="description" status="nex">
@@ -307,8 +308,6 @@
           <div class=" " id="${enc(attr: nkey) + '_det'}"
                data-bind="if: defaults['${serviceDefaults.service}'].type()==='${enc(attr: description.name)}'">
               <hr/>
-              <g:hiddenField name="${serviceDefaults.prefix}.default.type"
-                             value="${description.name}"/>
 
             <g:render template="/framework/pluginConfigPropertiesInputs" model="${[
                     service            : serviceDefaults.service,


### PR DESCRIPTION
If the chosen file copier had no config properties, the plugin name wasn't being sent to the server with the expected form property name which caused the save to fail.