### PR TITLE
add ldap nestedGroups setting to remco template

### DIFF
--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -49,6 +49,9 @@
     {% if exists("/rundeck/jaas/ldap/useremailattribute") -%}
         userEmailAttribute={{ getv("/rundeck/jaas/ldap/useremailattribute") }}
     {% endif %}
+    {% if exists("/rundeck/jaas/ldap/nestedgroups") -%}
+        nestedGroups={{ getv("/rundeck/jaas/ldap/nestedGroups") }}
+    {% endif %}
 
     ;
 {% endmacro %}


### PR DESCRIPTION
Add "nestedGroups" to the list of settings configurable via remco for the JAAS JettyCachingLdapLoginModule.