### PR TITLE
Improves readability of options in job executions, answers #5044

### DIFF
--- a/rundeckapp/grails-app/assets/scss/custom/jobs.scss
+++ b/rundeckapp/grails-app/assets/scss/custom/jobs.scss
@@ -145,5 +145,5 @@
 // eventargs is typically a table > td
 // found here: /rundeckapp/grails-app/assets/scss/custom/table-events.scss
 .eventargs .argstring-scrollable {
-  display: none;
+  overflow-x: hidden;
 }

--- a/rundeckapp/grails-app/assets/scss/custom/jobs.scss
+++ b/rundeckapp/grails-app/assets/scss/custom/jobs.scss
@@ -15,7 +15,10 @@
  */
 
 .table.item_details {
-  &> tr > td:first-child, &> tbody > tr > td:first-child, td.displabel {
+
+  &>tr>td:first-child,
+  &>tbody>tr>td:first-child,
+  td.displabel {
     text-align: right;
     vertical-align: top;
 
@@ -31,8 +34,7 @@
 }
 
 .jobstats {
-  .job-stats-item {
-  }
+  .job-stats-item {}
 
   .job-stats-value {
     font-weight: bold;
@@ -51,7 +53,8 @@
 
 .exec-options-header {
   background: #e6e6e6;
-  .jobInfoSection{
+
+  .jobInfoSection {
     padding: 10px 0;
   }
 }
@@ -61,7 +64,8 @@
     text-decoration: line-through;
     color: $dark-gray;
   }
-  .cronselected{
+
+  .cronselected {
     font-weight: bold;
   }
 
@@ -70,7 +74,8 @@
   }
 }
 
-.job_list_row, .job_list_group_header {
+.job_list_row,
+.job_list_group_header {
   clear: both;
 }
 
@@ -90,7 +95,7 @@
   }
 }
 
-.expandComponentHolder.expanded > .job_list_group_header > .jobgroupexpand {
+.expandComponentHolder.expanded>.job_list_group_header>.jobgroupexpand {
   //todo: emphasize expanded groups. but, expander widget doesn't correctly set expanded state for nested elements yet
   //color: #454545;
   //text-decoration: underline;
@@ -106,4 +111,39 @@
     background: #F8f8f8;
     border-color: #e8e8e8;
   }
+}
+
+
+@media (min-width: 993px) {
+  .execution-aux-info.flex-item-1 {
+    max-width: calc(50vw - 115px);
+  }
+}
+
+.argstring-scrollable {
+  overflow: hidden;
+  word-break: break-all;
+  text-overflow: ellipsis;
+}
+
+.argstring-scrollable .text-secondary {
+  display: block;
+}
+
+.argstring-scrollable .optkey {
+  display: inline-block;
+}
+
+.argstring-scrollable .optvalue {
+  overflow: hidden;
+  word-break: break-all;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+}
+
+// eventargs is typically a table > td
+// found here: /rundeckapp/grails-app/assets/scss/custom/table-events.scss
+.eventargs .argstring-scrollable {
+  display: none;
 }


### PR DESCRIPTION
Answers and Fixes #5044

Improves the readability of options, stacking them one over the other, and implements word-breakage.

<img width="597" alt="Screen Shot 2019-07-30 at 8 43 37 PM" src="https://user-images.githubusercontent.com/265904/62175259-f43a0a00-b30a-11e9-8e91-4cd3e93ce02e.png">
 