### PR TITLE
Updating transitive dependencies used in plugins

### DIFF
--- a/plugins/jasypt-encryption-plugin/build.gradle
+++ b/plugins/jasypt-encryption-plugin/build.gradle
@@ -40,8 +40,8 @@ repositories {
 
 dependencies {
     compile project(":core")
-    pluginLibs( [group: 'org.jasypt', name: 'jasypt', version: '1.9.2'],
-                [group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.51'])
+    compile(group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.62')
+    pluginLibs([group: 'org.jasypt', name: 'jasypt', version: '1.9.3'])
     testCompile(
         [group: 'junit', name: 'junit', version: '4.8.1',ext:'jar']
     )

--- a/plugins/object-store-plugin/build.gradle
+++ b/plugins/object-store-plugin/build.gradle
@@ -18,7 +18,9 @@ configurations{
 dependencies {
     // Use the latest Groovy version for building this library
     compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
-    pluginLibs("io.minio:minio:6.0.7")
+    pluginLibs("io.minio:minio:6.0.7") {
+        exclude(group: 'com.fasterxml.jackson.core')
+    }
 
     // Use the awesome Spock testing and specification framework
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

remove some transitive dependencies from embedded plugin libs, as updated versions are already available in the app libs

 * [ ] bouncycastle
    * [x] jasypt plugin
* [ ] jackson
    * [x] object store plugin