### PR TITLE
Fix: empty project list shows white box on home page

### DIFF
--- a/rundeckapp/grails-app/views/menu/home.gsp
+++ b/rundeckapp/grails-app/views/menu/home.gsp
@@ -212,7 +212,7 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col-xs-12">
-      <div class="card">
+      <div class="card" data-bind="if:  projectCount()>0 ">
         <div class="card-content">
           <div data-bind="if: !loadedProjectNames() && projectCount()<1">
             <div class="">


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fixed: If no projects exists, the home page still shows a white card box with nothing in it.