### PR TITLE
Allow notification to use workflow exported variables #5061

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessor.java
@@ -185,7 +185,7 @@ class WorkflowEngineOperationsProcessor<DAT, RES extends WorkflowSystem.Operatio
     private void getContextGlobalData(final Map<String, String> changes){
         DAT inputData = null != sharedData ? sharedData.produceNext() : null;
         if(inputData != null && inputData instanceof WFSharedContext) {
-            DataContext globals = ((WFSharedContext) inputData).getData().get(ContextView.global());
+            DataContext globals = ((WFSharedContext) inputData).consolidate().getData().get(ContextView.global());
             if (null != globals) {
                 HashMap<String, String> stringStringHashMap = new HashMap<>();
                 for (String s : globals.keySet()) {

--- a/plugins/upvar-plugin/src/main/java/org/rundeck/plugin/vars/ExportVarWorkflowStep.java
+++ b/plugins/upvar-plugin/src/main/java/org/rundeck/plugin/vars/ExportVarWorkflowStep.java
@@ -1,5 +1,7 @@
 package org.rundeck.plugin.vars;
 
+import com.dtolabs.rundeck.core.data.DataContext;
+import com.dtolabs.rundeck.core.data.MultiDataContext;
 import com.dtolabs.rundeck.core.dispatcher.ContextView;
 import com.dtolabs.rundeck.core.execution.workflow.steps.FailureReason;
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepException;
@@ -10,11 +12,12 @@ import com.dtolabs.rundeck.plugins.descriptions.PluginProperty;
 import com.dtolabs.rundeck.plugins.step.PluginStepContext;
 import com.dtolabs.rundeck.plugins.step.StepPlugin;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Plugin(name = ExportVarWorkflowStep.PROVIDER_NAME, service = ServiceNameConstants.WorkflowStep)
 @PluginDescription(title = "Global Variable",
-        description = "Creates a global variable.")
+        description = "Creates a global variable to be used on other steps or in notifications.")
 
 
 public class ExportVarWorkflowStep implements StepPlugin {
@@ -65,6 +68,18 @@ public class ExportVarWorkflowStep implements StepPlugin {
             );
         }
         context.getOutputContext().addOutput(ContextView.global(),group,export,value);
+
+        MultiDataContext<ContextView, DataContext> sharedDataContext = context.getExecutionContext()
+                .getSharedDataContext()
+                .consolidate();
+
+        //move directly to global view to be used immediately on notifications.
+        DataContext data = sharedDataContext.getData(ContextView.global());
+        if( data!= null) {
+            HashMap<String, String> stringHashMap = new HashMap<>();
+            stringHashMap.put(export, value);
+            data.put(group, stringHashMap);
+        }
     }
 
     /**

--- a/plugins/upvar-plugin/src/main/java/org/rundeck/plugin/vars/ExportVarWorkflowStep.java
+++ b/plugins/upvar-plugin/src/main/java/org/rundeck/plugin/vars/ExportVarWorkflowStep.java
@@ -68,18 +68,6 @@ public class ExportVarWorkflowStep implements StepPlugin {
             );
         }
         context.getOutputContext().addOutput(ContextView.global(),group,export,value);
-
-        MultiDataContext<ContextView, DataContext> sharedDataContext = context.getExecutionContext()
-                .getSharedDataContext()
-                .consolidate();
-
-        //move directly to global view to be used immediately on notifications.
-        DataContext data = sharedDataContext.getData(ContextView.global());
-        if( data!= null) {
-            HashMap<String, String> stringHashMap = new HashMap<>();
-            stringHashMap.put(export, value);
-            data.put(group, stringHashMap);
-        }
     }
 
     /**

--- a/plugins/upvar-plugin/src/test/groovy/org/rundeck/plugins/vars/ExportVarWorkflowStepSpec.groovy
+++ b/plugins/upvar-plugin/src/test/groovy/org/rundeck/plugins/vars/ExportVarWorkflowStepSpec.groovy
@@ -1,6 +1,8 @@
 package org.rundeck.plugin.vars
 
+import com.dtolabs.rundeck.core.data.MultiDataContextImpl
 import com.dtolabs.rundeck.core.dispatcher.ContextView
+import com.dtolabs.rundeck.core.execution.ExecutionContext
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepException
 import com.dtolabs.rundeck.core.execution.workflow.SharedOutputContext
 import com.dtolabs.rundeck.plugins.step.PluginStepContext
@@ -43,6 +45,14 @@ class ExportVarWorkflowStepSpec extends Specification {
         then:
         1 * context.getOutputContext() >> Mock(SharedOutputContext) {
             1 * addOutput(ContextView.global(),group,name,value)
+        }
+
+        1 * context.getExecutionContext() >> Mock(ExecutionContext){
+            1 * getSharedDataContext() >> Mock(MultiDataContextImpl) {
+                1 * consolidate() >> Mock(MultiDataContextImpl) {
+                    1 * getData(ContextView.global())
+                }
+            }
         }
 
         where:

--- a/plugins/upvar-plugin/src/test/groovy/org/rundeck/plugins/vars/ExportVarWorkflowStepSpec.groovy
+++ b/plugins/upvar-plugin/src/test/groovy/org/rundeck/plugins/vars/ExportVarWorkflowStepSpec.groovy
@@ -47,14 +47,6 @@ class ExportVarWorkflowStepSpec extends Specification {
             1 * addOutput(ContextView.global(),group,name,value)
         }
 
-        1 * context.getExecutionContext() >> Mock(ExecutionContext){
-            1 * getSharedDataContext() >> Mock(MultiDataContextImpl) {
-                1 * consolidate() >> Mock(MultiDataContextImpl) {
-                    1 * getData(ContextView.global())
-                }
-            }
-        }
-
         where:
         group    | name     | value
         'grp'    | 'name'   | 'value'

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -16,6 +16,7 @@
 
 package rundeck.services
 
+import com.dtolabs.rundeck.core.dispatcher.ContextView
 import com.dtolabs.rundeck.core.dispatcher.DataContextUtils
 import com.dtolabs.rundeck.core.execution.workflow.WorkflowStrategy
 import com.dtolabs.rundeck.core.logging.LogEvent
@@ -544,7 +545,7 @@ public class NotificationService implements ApplicationContextAware{
             userData['user.lastName'] = user.lastName
         }
         //pass data context
-        def dcontext = content['context']?.dataContext ?: [:]
+        def dcontext = content.context?.getSharedDataContext()?.getData(ContextView.global())?.getData() ?: [:] //usage of modified global context
         def mailcontext = DataContextUtils.addContext("job", userData, null)
         def context = DataContextUtils.merge(dcontext, mailcontext)
         context

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -20,6 +20,8 @@ import com.dtolabs.rundeck.app.internal.logging.DefaultLogEvent
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.PluginControlService
 import com.dtolabs.rundeck.core.data.BaseDataContext
+import com.dtolabs.rundeck.core.data.SharedDataContextUtils
+import com.dtolabs.rundeck.core.dispatcher.ContextView
 import com.dtolabs.rundeck.core.execution.ExecutionContext
 import com.dtolabs.rundeck.core.logging.LogEvent
 import com.dtolabs.rundeck.core.logging.LogLevel
@@ -100,10 +102,13 @@ class NotificationServiceSpec extends Specification {
     def "mail recipients in context var"() {
         given:
         def (job, execution) = createTestJob()
+        def globalContext = new BaseDataContext([globals: globals])
+        def shared = SharedDataContextUtils.sharedContext()
+        shared.merge(ContextView.global(), globalContext)
         def content = [
                 execution: execution,
                 context  : Mock(ExecutionContext) {
-                    getDataContext() >> new BaseDataContext([globals: globals])
+                    1 * getSharedDataContext() >> shared
                 }
         ]
         job.notifications = [


### PR DESCRIPTION
Notification Service now uses modified global context instead of the original allowing it to read new variables created during workflow.

And export variable workflow plugin creates the variable directly on global  `ContextView`.


Example workflow using notification plugin (Splunk notification plugin):
![Workflow](https://user-images.githubusercontent.com/2894508/62703765-e72ab400-b9b7-11e9-9696-ea258b10e8ab.png)

![Notification setup](https://user-images.githubusercontent.com/2894508/62703774-ec87fe80-b9b7-11e9-8820-b8cfd57f6ae0.png)


![Notification Result](https://user-images.githubusercontent.com/2894508/62703855-1c370680-b9b8-11e9-961b-4dc36e89f863.png)



fix #5061