### PR TITLE
fixing Scheduling using crontab displays warning

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -2276,7 +2276,6 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             scheduledExecution.nextExecution = new Date(ScheduledExecutionService.TWO_HUNDRED_YEARS)
         }
 
-        boolean shouldreSchedule = false
         def boolean renamed = oldjobname != scheduledExecution.generateJobScheduledName() || oldjobgroup != scheduledExecution.generateJobGroupName()
 
         if(frameworkService.isClusterModeEnabled()){
@@ -2298,15 +2297,11 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 )
                 if (modify) {
                     scheduledExecution.serverNodeUUID = frameworkService.serverUUID
-                    //schedule meesage want sent , it should be ran locally
-                    shouldreSchedule = true
                 }
             }
             if (!scheduledExecution.serverNodeUUID) {
                 scheduledExecution.serverNodeUUID = frameworkService.serverUUID
             }
-        }else{
-            shouldreSchedule = true
         }
 
         if (renamed) {
@@ -2624,7 +2619,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             }
         }
         if (!failed && scheduledExecution.save(true)) {
-            if (scheduledExecution.shouldScheduleExecution() && shouldScheduleInThisProject(scheduledExecution.project) && shouldreSchedule) {
+            if (scheduledExecution.shouldScheduleExecution() && shouldScheduleInThisProject(scheduledExecution.project)) {
+
                 def nextdate = null
                 def nextExecNode = null
                 try {

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -3326,37 +3326,4 @@ class ScheduledExecutionServiceSpec extends Specification {
         result == [null, null]
     }
 
-    @Unroll
-    def "do update job on cluster, a schedule changed or name changed must not call local quartz scheduleJob if a takeover message was sent"(){
-        given:
-        def serverUUID = '802d38a5-0cd1-44b3-91ff-824d495f8105'
-        setupDoUpdate(true,serverUUID)
-
-        def jobOwnerUuid = '5e0e96a0-042a-426a-80a4-488f7f6a4f13'
-        def se = new ScheduledExecution(createJobParams([serverNodeUUID:jobOwnerUuid])).save()
-        service.jobSchedulerService = Mock(JobSchedulerService)
-
-        when:
-        def results = service._doupdate([id: se.id.toString()] + inparams, mockAuth())
-
-        then:
-        results.success
-        results.scheduledExecution.serverNodeUUID == jobOwnerUuid
-        if(shouldChange) {
-            1 * service.jobSchedulerService.updateScheduleOwner(_, _, _) >> false
-            0 * service.quartzScheduler.scheduleJob(_,_,_)
-        }
-
-        where:
-        inparams                                        | shouldChange
-        [jobName: 'newName']                            | true
-        [jobName: 'newName', scheduled: false]          | true
-        [scheduled: true]                               | false
-        [groupPath: 'newGroup', timeZone: 'GMT+1']      | true
-        [groupPath: 'newGroup']                         | true
-        [dayOfMonth: '10']                              | true
-
-    }
-
-
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
**Bugfix**
Fixing issue https://github.com/rundeck/rundeck/issues/5134
If a scheduled job (with cluster mode enabled) is modified without changing the scheduled or the name/group,  the deleteJob method (that removes the job from the quartz) shouldn't be called.


**Describe the solution you've implemented**

SOLUTION:  removing the `if statement` which produced the `quartz.deleteJob` method was called when a job was editing (without renamed it or changed the scheduled)

Also, the flag added on the previous PR (in order to not register the job on the local server when it was taken for another cluster member) was removed because it produces a warning message while the job is registering on the new cluster member, which could take a few seconds.

So, the previous behavior (registering the job on the local quartz despite if the job is owned on a different cluster member) will be restored. The local quartz will be removed on the first execution in case the job will be scheduled on another node. 
This will avoid the warning message after the job is updated.

**Describe alternatives you've considered**
Just fix the main issue and continue with the new flag that checks if it is necessary to register or not the job locally, but it could be confusing for the user because of the warning message.

