### PR TITLE
Load full option object with lazy values on session object #5131 

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
@@ -728,14 +728,21 @@ class EditOptsController {
         if (params?.scheduledExecutionId) {
             optid = params.scheduledExecutionId
             if (null == session.editOPTS[optid]) {
-                ScheduledExecution sched = ScheduledExecution.getByIdOrUUID(params.scheduledExecutionId)
+                ScheduledExecution sched
+                if(params?.sched){
+                    sched = params.sched
+                }else{
+                    sched = ScheduledExecution.getByIdOrUUID(params.scheduledExecutionId)
+                }
                 if (!sched) {
                     session.editOPTS[optid] = [:]
                 }else if (sched.options) {
                     editopts = [:]
 
                     sched.options.each {Option opt ->
-                        editopts[opt.name] = opt.createClone()
+                        def cloneOpt = opt.createClone()
+                        cloneOpt.getOptionValues()
+                        editopts[opt.name] = cloneOpt
                     }
                     session.editOPTS[optid] = editopts
                 } else {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
@@ -631,4 +631,28 @@ class EditOptsControllerSpec extends Specification {
         then:
         result.isEmpty()
     }
+
+    def "get Session opts convert value list to pass full object to session"(){
+        given:
+        def optClone = Mock(Option) {
+
+        }
+        def opt = Mock(Option){
+            getName() >> 'blah'
+            createClone() >> optClone
+        }
+        SortedSet options = new TreeSet( [opt] )
+        def sched = Mock(ScheduledExecution){
+            getOptions() >> options
+        }
+        params.scheduledExecutionId = 1L
+        params.sched = sched
+        when:
+
+        def result2 = controller.getSessionOptions(session,params)
+        then:
+        result2
+        result2.blah
+        1 * optClone.getOptionValues() >> ['a', 'b']
+    }
 }


### PR DESCRIPTION
To prevent `failed to lazily initialize a collection of role: rundeck.Option.values, could not initialize proxy - no Session` error editing an option with `enforcedvalues` the object is stored pre loading the `optionValues`.

This problem was introduced here #4599 when the field `optionValues` was created.

fix #5131