### PR TITLE
Fix proxy initialization exception for avg duration notifications

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3635,15 +3635,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
         }
 
-        def duration = System.currentTimeMillis() - startTime
-        if ((!jitem.ignoreNotifications) && (averageDuration > 0) && (duration > averageDuration)) {
-            avgDurationExceeded(id, [
-                    execution: exec,
-                    context  : newContext,
-                    jobref   : jitem.jobIdentifier
-            ])
-        }
-
         if (!wresult.result || !wresult.result.success || wresult.interrupt) {
             result = createFailure(JobReferenceFailureReason.JobFailed, "Job [${jitem.jobIdentifier}] failed")
 
@@ -3652,6 +3643,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         }
 
         ScheduledExecution.withTransaction {
+            def duration = System.currentTimeMillis() - startTime
+
             if (wresult.result) {
                 def savedJobState = false
                 if (!disableRefStats) {
@@ -3678,6 +3671,15 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
             if(!jitem.ignoreNotifications) {
                 // Get a new object attached to the new session
+
+                if (averageDuration > 0 && duration > averageDuration) {
+                    avgDurationExceeded(id, [
+                            execution: execution,
+                            context  : newContext,
+                            jobref   : jitem.jobIdentifier
+                    ])
+                }
+
                 def scheduledExecution = ScheduledExecution.get(id)
                 notificationService.triggerJobNotification(
                         wresult?.result.success ? 'success' : 'failure',
@@ -3692,7 +3694,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             }
 
             result.sourceResult = wresult.result
-
 
             Map<String, String> data = ((WorkflowExecutionResult) wresult.result)?.getSharedContext()?.getData(ContextView.global())?.get("export")
             if (data) {


### PR DESCRIPTION
Fixes #5149

This moves the average duration notification into the same transaction/session as the success/failure notification. This will ensure the session for the proxy object is still active when accessed in the notification service.