### PR TITLE
Dedupe setps on stepctx

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -873,8 +873,25 @@ function RDNode(name, steps,flow){
      * @param steps
      */
     self.loadData=function(data){
+        self.dedupeSteps(data.steps);
         self.updateSummary(data.summary);
         self.updateSteps(data.steps);
+    };
+    self.dedupeSteps=function(steps) {
+        var seen = []
+        var dupes = []
+
+        steps.forEach(function(s) {
+            if (seen.indexOf(s.stepctx) > -1) {
+                dupes.push(s)
+            }
+
+            seen.push(s.stepctx)
+        })
+
+        dupes.forEach(function(d) {
+            steps.splice(steps.indexOf(d), 1)
+        })
     };
     self.updateSteps=function(steps){
         ko.mapping.fromJS({steps: steps}, mapping, this);


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Fixes #5157

**Describe the solution you've implemented**
The issue can occur if there are duplicate steps in the state log. KO can't handle duplicate keys. It won't complain out right about them, but `undefined`s will appear in the observable array causing errors in mapping and other parts of the code.

This fix addresses the issue in the front end. After data is loaded the steps are de-duped on `stepctx` before being passed through to get mapped and summarized.

**Describe alternatives you've considered**
I considered de-duplicating the data in the backend however this information is actually present in the state file. It's unclear to me at this point if it serves a purpose to have multiple entries for the same `stepctx` in the steps array.

