### PR TITLE
Fix: Job mail notifications respect allow unsanitized property

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -43,6 +43,7 @@ import groovy.transform.PackageScope
 import org.hibernate.criterion.CriteriaSpecification
 import org.hibernate.type.StandardBasicTypes
 import org.quartz.JobExecutionContext
+import org.rundeck.app.AppConstants
 import org.springframework.dao.DataAccessResourceFailureException
 import rundeck.CommandExec
 import rundeck.Execution
@@ -62,9 +63,6 @@ import java.util.stream.Collectors
 * ExecutionController
 */
 class ExecutionController extends ControllerBase{
-    static final String FRAMEWORK_OUTPUT_ALLOW_UNSANITIZED = "framework.output.allowUnsanitized"
-    static final String PROJECT_OUTPUT_ALLOW_UNSANITIZED = "project.output.allowUnsanitized"
-
     FrameworkService frameworkService
     ExecutionService executionService
     LoggingService loggingService
@@ -949,12 +947,12 @@ setTimeout(function(){
     }
 
     boolean checkAllowUnsanitized(String project) {
-        if(frameworkService.getRundeckFramework().hasProperty(FRAMEWORK_OUTPUT_ALLOW_UNSANITIZED)) {
+        if(frameworkService.getRundeckFramework().hasProperty(AppConstants.FRAMEWORK_OUTPUT_ALLOW_UNSANITIZED)) {
             if ("true" != frameworkService.getRundeckFramework().
-                    getProperty(FRAMEWORK_OUTPUT_ALLOW_UNSANITIZED)) return false
+                    getProperty(AppConstants.FRAMEWORK_OUTPUT_ALLOW_UNSANITIZED)) return false
             def projectConfig = frameworkService.getRundeckFramework().projectManager.loadProjectConfig(project)
-            if(projectConfig.hasProperty(PROJECT_OUTPUT_ALLOW_UNSANITIZED)) {
-                return "true" == projectConfig.getProperty(PROJECT_OUTPUT_ALLOW_UNSANITIZED)
+            if(projectConfig.hasProperty(AppConstants.PROJECT_OUTPUT_ALLOW_UNSANITIZED)) {
+                return "true" == projectConfig.getProperty(AppConstants.PROJECT_OUTPUT_ALLOW_UNSANITIZED)
             }
             return false
         }

--- a/rundeckapp/grails-app/views/execution/mailNotification/_newStatus.gsp
+++ b/rundeckapp/grails-app/views/execution/mailNotification/_newStatus.gsp
@@ -762,7 +762,12 @@
               <tr>
                 <td style="padding: 20px;">
                   <pre>
-                    ${enc(sanitize:logOutput)}
+                    <g:if test="${allowUnsanitized}">
+                      ${enc(rawtext:logOutput)}
+                    </g:if>
+                    <g:else>
+                      ${enc(sanitize:logOutput)}
+                    </g:else>
                   </pre>
                 </td>
               </tr>

--- a/rundeckapp/grails-app/views/execution/mailNotification/_oldStatus.gsp
+++ b/rundeckapp/grails-app/views/execution/mailNotification/_oldStatus.gsp
@@ -363,8 +363,12 @@ div.progressContainer div.progressContent{
 
 <div class="content">
     <g:if test="${logOutput}">
-        <h3>Log OUTPUT</h3>
-        ${enc(sanitize:logOutput)}
+        <g:if test="${allowUnsanitized}">
+            ${enc(rawtext:logOutput)}
+        </g:if>
+        <g:else>
+            ${enc(sanitize:logOutput)}
+        </g:else>
     </g:if>
 </div>
 <div class="foot">

--- a/rundeckapp/src/main/groovy/org/rundeck/app/AppConstants.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/AppConstants.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.rundeck.app
+
+
+class AppConstants {
+    static final String FRAMEWORK_OUTPUT_ALLOW_UNSANITIZED = "framework.output.allowUnsanitized"
+    static final String PROJECT_OUTPUT_ALLOW_UNSANITIZED = "project.output.allowUnsanitized"
+}

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -34,6 +34,7 @@ import grails.test.mixin.TestMixin
 import grails.test.mixin.web.GroovyPageUnitTestMixin
 import groovy.xml.MarkupBuilder
 import org.grails.plugins.codecs.JSONCodec
+import org.rundeck.app.AppConstants
 import rundeck.Execution
 import rundeck.UtilityTagLib
 import rundeck.codecs.AnsiColorCodec
@@ -842,15 +843,15 @@ class ExecutionControllerSpec extends Specification {
 
         when:
         def prjCfg = Mock(IRundeckProjectConfig) {
-            hasProperty(controller.PROJECT_OUTPUT_ALLOW_UNSANITIZED) >> projectHasProp
-            getProperty(controller.PROJECT_OUTPUT_ALLOW_UNSANITIZED) >> project
+            hasProperty(AppConstants.PROJECT_OUTPUT_ALLOW_UNSANITIZED) >> projectHasProp
+            getProperty(AppConstants.PROJECT_OUTPUT_ALLOW_UNSANITIZED) >> project
         }
         def prjMgr = Mock(ProjectManager) {
             loadProjectConfig("proj1") >> prjCfg
         }
         def fwk = Mock(Framework) {
-            hasProperty(controller.FRAMEWORK_OUTPUT_ALLOW_UNSANITIZED) >> frameworkHasProp
-            getProperty(controller.FRAMEWORK_OUTPUT_ALLOW_UNSANITIZED) >> framework
+            hasProperty(AppConstants.FRAMEWORK_OUTPUT_ALLOW_UNSANITIZED) >> frameworkHasProp
+            getProperty(AppConstants.FRAMEWORK_OUTPUT_ALLOW_UNSANITIZED) >> framework
             getProjectManager() >> prjMgr
         }
         controller.frameworkService = Mock(FrameworkService) {


### PR DESCRIPTION
Fix #5140 by making sure mail notification renderer checks the allow unsanitized property when rendering the mail.
