### PR TITLE
Attempt to fix #4286 by putting a sync lock around the service loader.

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/plugins/ServiceTypes.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/ServiceTypes.java
@@ -120,6 +120,7 @@ public class ServiceTypes {
     private static ServiceLoader<PluginProviderServices>
         pluginProviderServiceLoader =
         ServiceLoader.load(PluginProviderServices.class);
+    private static final Object providerLoaderSync = new Object();
 
     /**
      * Get a pluggable service implementation for the given plugin type, if available via {@link ServiceLoader}
@@ -134,9 +135,11 @@ public class ServiceTypes {
         ServiceProviderLoader loader
     )
     {
-        for (PluginProviderServices pluginProviderServices : pluginProviderServiceLoader) {
-            if (pluginProviderServices.hasServiceFor(serviceType, serviceName)) {
-                return pluginProviderServices.getServiceProviderFor(serviceType, serviceName, loader);
+        synchronized (providerLoaderSync) {
+            for (PluginProviderServices pluginProviderServices : pluginProviderServiceLoader) {
+                if (pluginProviderServices.hasServiceFor(serviceType, serviceName)) {
+                    return pluginProviderServices.getServiceProviderFor(serviceType, serviceName, loader);
+                }
             }
         }
         return null;


### PR DESCRIPTION
The ServiceLoader class is not thread safe, so the behavior can be non-deterministic if multiple threads try to access the method. 

The reported issue is not regularly reproducible, but I have seen the error enough to try to address it with this sync lock.