### PR TITLE
New ACL for job writers #5078

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
@@ -868,7 +868,9 @@ public class AclTool extends BaseTool {
                     ACLConstants.ACTION_DELETE,
                     ACLConstants.ACTION_IMPORT,
                     ACLConstants.ACTION_EXPORT,
-                    ACLConstants.ACTION_DELETE_EXECUTION
+                    ACLConstants.ACTION_DELETE_EXECUTION,
+                    ACLConstants.ACTION_SCM_IMPORT,
+                    ACLConstants.ACTION_SCM_EXPORT
             );
     static final List<String> appProjectAclActions =
             Arrays.asList(
@@ -1992,6 +1994,8 @@ public class AclTool extends BaseTool {
         public static final String ACTION_SCM_UPDATE="scm_update";
         public static final String ACTION_SCM_CREATE="scm_create";
         public static final String ACTION_SCM_DELETE="scm_delete";
+        public static final String ACTION_SCM_IMPORT = "scm_import";
+        public static final String ACTION_SCM_EXPORT = "scm_export";
 
         public static final String TYPE_SYSTEM = "system";
         public static final String TYPE_SYSTEM_ACL = "system_acl";

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -479,7 +479,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                                                  frameworkService.authResourceForProject(
                                                                          params.project
                                                                  ),
-                                                                 [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT]
+                                                                 [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT, AuthConstants.SCM_EXPORT]
             )) {
                 if(frameworkService.isClusterModeEnabled()){
                     if (!scmService.projectHasConfiguredExportPlugin(params.project)) {
@@ -513,7 +513,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                                                  frameworkService.authResourceForProject(
                                                                          params.project
                                                                  ),
-                                                                 [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT]
+                                                                 [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT, AuthConstants.SCM_IMPORT]
             )) {
                 if(frameworkService.isClusterModeEnabled()){
                     if (!scmService.projectHasConfiguredImportPlugin(params.project)) {
@@ -548,7 +548,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     frameworkService.authResourceForProject(
                             params.project
                     ),
-                    [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT, AuthConstants.ACTION_IMPORT]
+                    [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT, AuthConstants.ACTION_IMPORT,
+                     AuthConstants.SCM_IMPORT, AuthConstants.SCM_EXPORT]
             )) {
                 if (minScm) {
                     def pluginData = [:]
@@ -3240,7 +3241,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     frameworkService.authResourceForProject(
                             params.project
                     ),
-                    [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT]
+                    [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT,  AuthConstants.SCM_EXPORT]
             )) {
                 def pluginData = [:]
                 if (frameworkService.isClusterModeEnabled()) {
@@ -3266,7 +3267,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     frameworkService.authResourceForProject(
                             params.project
                     ),
-                    [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT]
+                    [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT, AuthConstants.SCM_IMPORT]
             )) {
                 if (frameworkService.isClusterModeEnabled()) {
                     //initialize if in another node

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -282,7 +282,8 @@ class ScheduledExecutionController  extends ControllerBase{
 
             if (frameworkService.authorizeApplicationResourceAny(authContext,
                                                                  frameworkService.authResourceForProject(params.project),
-                                                                 [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT])) {
+                                                                 [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT,
+                                                                  AuthConstants.SCM_EXPORT])) {
                 if(scmService.projectHasConfiguredExportPlugin(params.project)) {
                     model.scmExportEnabled = true
                     model.scmExportStatus = scmService.exportStatusForJobs(authContext, [scheduledExecution])
@@ -291,7 +292,8 @@ class ScheduledExecutionController  extends ControllerBase{
             }
             if (frameworkService.authorizeApplicationResourceAny(authContext,
                                                                  frameworkService.authResourceForProject(params.project),
-                                                                 [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT])) {
+                                                                 [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT,
+                                                                  AuthConstants.SCM_IMPORT])) {
                 if(scmService.projectHasConfiguredPlugin('import',params.project)) {
                     model.scmImportEnabled = true
                     model.scmImportStatus = scmService.importStatusForJobs(authContext, [scheduledExecution])
@@ -490,7 +492,8 @@ class ScheduledExecutionController  extends ControllerBase{
         def projectResource = frameworkService.authResourceForProject(params.project)
         if (frameworkService.authorizeApplicationResourceAny(authContext,
                                                              projectResource,
-                                                             [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT])) {
+                                                             [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT,
+                                                              AuthConstants.SCM_EXPORT])) {
             if(scmService.projectHasConfiguredExportPlugin(params.project)){
                 dataMap.scmExportEnabled = true
                 dataMap.scmExportStatus = scmService.exportStatusForJob(scheduledExecution)
@@ -499,7 +502,8 @@ class ScheduledExecutionController  extends ControllerBase{
         }
         if (frameworkService.authorizeApplicationResourceAny(authContext,
                                                              projectResource,
-                                                             [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT])) {
+                                                             [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT,
+                                                              AuthConstants.SCM_IMPORT])) {
             if(scmService.projectHasConfiguredPlugin('import',params.project)) {
                 dataMap.scmImportEnabled = true
                 dataMap.scmImportStatus = scmService.importStatusForJobs(authContext, [scheduledExecution])

--- a/rundeckapp/grails-app/views/scheduledExecution/_jobActionButtonMenuContent.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_jobActionButtonMenuContent.gsp
@@ -189,7 +189,7 @@
     </li>
 </g:if>
 
-<g:if test="${authProjectExport && scmExportEnabled && scmExportStatus?.get(scheduledExecution.extid)}">
+<g:if test="${scmExportEnabled && scmExportStatus?.get(scheduledExecution.extid)}">
     %{renderedActions++}%
     <g:if test="${authRead}">
         <li class="divider"></li>

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/authorization/AuthConstants.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/authorization/AuthConstants.java
@@ -60,6 +60,8 @@ public class AuthConstants {
     public static final String SCM_UPDATE="scm_update";
     public static final String SCM_CREATE="scm_create";
     public static final String SCM_DELETE="scm_delete";
+    public static final String SCM_IMPORT = "scm_import";
+    public static final String SCM_EXPORT = "scm_export";
 
     public static final String TYPE_SYSTEM = "system";
     public static final String TYPE_SYSTEM_ACL = "system_acl";

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -979,8 +979,12 @@ class MenuControllerSpec extends Specification {
                                                                         offset:0,
                                                                         paginateParams:[:],
                                                                         displayParams:[:]]
-        1 * controller.frameworkService.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT]) >> true
-        1 * controller.frameworkService.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT]) >> true
+        1 * controller.frameworkService.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN,
+                                                                               AuthConstants.ACTION_EXPORT,
+                                                                                AuthConstants.SCM_EXPORT]) >> true
+        1 * controller.frameworkService.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN,
+                                                                               AuthConstants.ACTION_IMPORT,
+                                                                               AuthConstants.SCM_IMPORT]) >> true
         1 * controller.scmService.projectHasConfiguredExportPlugin(project) >> true
         1 * controller.scmService.projectHasConfiguredImportPlugin(project) >> false
         1 * controller.scmService.loadScmConfig(project,'export') >> scmConfig
@@ -1016,8 +1020,12 @@ class MenuControllerSpec extends Specification {
                                                                         offset:0,
                                                                         paginateParams:[:],
                                                                         displayParams:[:]]
-        1 * controller.frameworkService.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT]) >> true
-        1 * controller.frameworkService.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT]) >> true
+        1 * controller.frameworkService.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN,
+                                                                               AuthConstants.ACTION_EXPORT,
+                                                                               AuthConstants.SCM_EXPORT]) >> true
+        1 * controller.frameworkService.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN,
+                                                                               AuthConstants.ACTION_IMPORT,
+                                                                                AuthConstants.SCM_IMPORT]) >> true
         1 * controller.scmService.projectHasConfiguredExportPlugin(project) >> true
         1 * controller.scmService.projectHasConfiguredImportPlugin(project) >> false
         1 * controller.scmService.loadScmConfig(project,'export') >> scmConfig


### PR DESCRIPTION
New ACL `scm_import` and `scm_export` allow users to use SCM actions using without having the `import` or `export` rule (permissions used in exporting and importing project files).

Example of job writer able to export and import using scm but not export and import project files:

```
description: Global write permissions to job_writer role
context:
  project: '.*'
for:
  resource:
  - equals:
      kind: 'node'
    allow: [read,refresh]
  - equals:
      kind: job
    allow: [create, delete]
  - equals:
      kind: event
    allow: [read]
  job:
  - allow: [create,read,update,delete,run,kill,scm_update, scm_create, scm_delete, admin]
    match:
      name: '.*'
  node:
  - allow: [read, run, refresh]
    match:
      nodename: '.*'
  project:
    - match:
        name: '.*'
      allow: [read]
  system:
    - match:
        name: '.*'
      allow: [read]
by:
  group: job_writer
---
by:
  group: job_writer
description: Job writer
for:
  resource:
  - allow:
    - admin
    equals:
      kind: job
  project:
    - allow: [view,scm_import, scm_export] 
context:
  application: rundeck

```

This is the job writer view, without project admin but with the icons of SCM actions:
![job_writer_view](https://user-images.githubusercontent.com/2894508/63440317-9d04f200-c3fd-11e9-9f58-7fc66b92d684.png)
