### PR TITLE
Update versions for plugins and libraries with reported vulnerabilities.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     compile 'org.apache.ant:ant:1.8.3',
         'log4j:log4j:1.2.17',
         'commons-codec:commons-codec:1.10',
-        'commons-beanutils:commons-beanutils:1.9.3',
+        'commons-beanutils:commons-beanutils:1.9.4',
         'commons-collections:commons-collections:3.2.2',
         'commons-logging:commons-logging:1.2',
         'commons-lang:commons-lang:2.6',
@@ -79,8 +79,8 @@ dependencies {
         'com.jcraft:jsch.agentproxy.core:0.0.9',
         "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}",
         'org.yaml:snakeyaml:1.17',
-        'com.squareup.retrofit2:retrofit:2.6.0',
-        'com.squareup.retrofit2:converter-jackson:2.6.0'
+        'com.squareup.retrofit2:retrofit:2.6.1',
+        'com.squareup.retrofit2:converter-jackson:2.6.1'
 
 
     compile ('commons-httpclient:commons-httpclient:3.0.1') {
@@ -92,7 +92,7 @@ dependencies {
 
     testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
     testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
-    testCompile "com.squareup.retrofit2:retrofit-mock:2.6.0"
+    testCompile "com.squareup.retrofit2:retrofit-mock:2.6.1"
     testCompile "cglib:cglib-nodep:2.2.2"
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,13 +19,13 @@
 group=org.rundeck
 currentVersion = 3.1.1
 grailsVersion=3.3.8
-gormVersion=6.1.10.RELEASE
-hibernateVersion=5.1.13.Final
+gormVersion=6.1.11.RELEASE
+hibernateVersion=5.1.17.Final
 gradleWrapperVersion=3.5
 groovyVersion=2.4.15
 mavenCentralUrl=http://repo1.maven.org/maven2/
 grailsCentralUrl=http://grails.org/plugins
-jacksonDatabindVersion=2.9.9.2
+jacksonDatabindVersion=2.9.9.3
 #
 # Override of spring-boot dependencies versions.
 # available properties at:
@@ -34,6 +34,7 @@ jacksonDatabindVersion=2.9.9.2
 jackson.version=2.9.9
 logback.version=1.2.3
 spring-security.version=4.2.13.RELEASE
-#jetty.version=9.4.11.v20180605
+jetty.version=9.4.20.v20190813
 tomcat.version=8.5.43
 spring.version=4.3.24.RELEASE
+

--- a/plugins/object-store-plugin/build.gradle
+++ b/plugins/object-store-plugin/build.gradle
@@ -18,7 +18,7 @@ configurations{
 dependencies {
     // Use the latest Groovy version for building this library
     compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
-    pluginLibs("io.minio:minio:6.0.7") {
+    pluginLibs("io.minio:minio:6.0.10") {
         exclude(group: 'com.fasterxml.jackson.core')
     }
 

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -63,7 +63,7 @@ dependencies {
                 project(':plugins:source-refresh-plugin'),
                 project(':plugins:upvar-plugin'),
                 "com.github.Batix:rundeck-ansible-plugin:2.5.0",
-                "com.github.rundeck-plugins:aws-s3-model-source:v1.0",
+                "com.github.rundeck-plugins:aws-s3-model-source:v1.0.2",
                 "com.github.rundeck-plugins:py-winrm-plugin:2.0.3",
                 "com.github.rundeck-plugins:openssh-node-execution:1.0.3",
                 "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.0.0",
@@ -76,7 +76,7 @@ dependencies {
     compile project(':rundeck-storage:rundeck-storage-filesys')
 
     // From BuildConfig.groovy.
-    compile 'org.quartz-scheduler:quartz:2.3.0'
+    compile 'org.quartz-scheduler:quartz:2.3.1'
     compile 'org.grails.plugins:quartz:2.0.13'
     //
     //TODO: update to official mail plugin 2.0.1 once released
@@ -92,6 +92,7 @@ dependencies {
     compile 'org.owasp.encoder:encoder:1.2.1'
     compile 'org.grails.plugins:external-config:1.1.2'
     compile 'commons-fileupload:commons-fileupload:1.3.3'
+    compile 'commons-beanutils:commons-beanutils:1.9.4'
 
 
     // Grails Plugins.
@@ -139,6 +140,7 @@ dependencies {
     compile 'ca.juliusdavies:not-yet-commons-ssl:0.3.17'
     compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
     compile "javax.xml.bind:jaxb-api:2.3.0"
+    compile 'org.dom4j:dom4j:2.1.1'
     console "org.grails:grails-console"
     profile "org.grails.profiles:web"
 //    runtime "org.springframework:spring-test:5.0.3.RELEASE"
@@ -154,7 +156,7 @@ dependencies {
 
 
     runtime "org.apache.tomcat:tomcat-jdbc"
-    runtime "com.bertramlabs.plugins:asset-pipeline-grails:2.14.7"
+    runtime "com.bertramlabs.plugins:asset-pipeline-grails:2.14.10"
     runtime "org.slf4j:jcl-over-slf4j:1.7.25"
     assets 'com.bertramlabs.plugins:less-asset-pipeline:3.0.5'
     assets 'com.bertramlabs.plugins:sass-asset-pipeline:3.0.5'

--- a/testbuild.groovy
+++ b/testbuild.groovy
@@ -46,7 +46,7 @@ def debug=Boolean.getBoolean('debug')?:("-debug" in args)
 //versions of dependency we want to verify
 def versions=[
         mysql:'5.1.47',
-        jetty:'9.4.11.v20180605',
+        jetty:'9.4.20.v20190813',
         servlet:'api-3.1.0'
 ]
 


### PR DESCRIPTION
This PR updates rundeck dependencies to address many vulnerabilities reported on CVEs. Updates include both new versions of plugins with revised dependencies and updated versions for libraries with known vulnerabilities.

Libraries updated and CVEs addressed:

Library | New Version | CVE
-- | -- | --
adapter-rxjava | 2.6.1 | CVE-2018-1000844
asset-pipeline-grails | 2.14.10 | CVE-2018-1000817
aws-java-sdk | 1.11.616 | CVE-2013-4366
bouncycastle | 1.62 | CVE-2018-1000613
commons-beanutils | 1.9.4 | CVE-2019-10086
commons-collections | 3.2.2 | CVE-2017-15708
dom4j | 2.1.1 | CVE-2018-1000632
gorm | 6.1.11 | CVE-2017-7536
hibernate | 5.1.17 | CVE-2017-7536
jackson-databind | 2.9.9.3 | CVE-2019-14439     CVE-2019-14379
jackson-jq | 0.0.10 | CVE-2019-14439     CVE-2019-14379
jetty | 9.4.20.v20190813 | CVE-2019-10247
minio | 6.0.10 | CVE-2018-1000538
quartz | 2.3.1 | CVE-2019-13990
retrofit | 2.6.1 | CVE-2018-1000850     CVE-2018-1000844
xerces | 2.12.0 | CVE-2012-0881




