### PR TITLE
Fix #5125. Correct timezone offset on execution node status.

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -629,20 +629,16 @@ function RDNodeStep(data, node, flow){
     self.executionState = ko.observable(data.executionState || null);
     self.parameterizedStep = ko.observable(data.stepctx.indexOf('@')>=0);
     self.startTimeSimple=ko.pureComputed(function(){
-        //TODO: fix incorrect startTime format: it is not actually UTC time
-        return MomentUtil.formatTimeSimpleUTC(self.startTime());
+        return MomentUtil.formatTimeSimple(self.startTime());
     });
     self.startTimeFormat=function(format){
-        //TODO: fix incorrect startTime format: it is not actually UTC time
-        return MomentUtil.formatTimeUTC(self.startTime(),format);
+        return MomentUtil.formatTime(self.startTime(),format);
     };
     self.endTimeSimple=ko.pureComputed(function(){
-        //TODO: fix incorrect endTime format: it is not actually UTC time
-        return MomentUtil.formatTimeSimpleUTC(self.endTime());
+        return MomentUtil.formatTimeSimple(self.endTime());
     });
     self.endTimeFormat= function (format) {
-        //TODO: fix incorrect endTime format: it is not actually UTC time
-        return MomentUtil.formatTimeUTC(self.endTime(), format);
+        return MomentUtil.formatTime(self.endTime(), format);
     };
     self.durationCalc=ko.pureComputed(function(){
         var dur=self.duration();


### PR DESCRIPTION
This pull request correct the time zone offset display on the node status summary at the execution detail page.

Fixes: https://github.com/rundeck/rundeck/issues/5125
