### PR TITLE
Externalize Vue

### DIFF
--- a/rundeckapp/grails-app/views/layouts/base.gsp
+++ b/rundeckapp/grails-app/views/layouts/base.gsp
@@ -1,3 +1,4 @@
+<%@ page import="grails.util.Environment" %>
 %{--
 - Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
 -
@@ -20,6 +21,12 @@
 <!--[if IE 9 ]>    <html class="ie9"> <![endif]-->
 <!--[if (gt IE 9)|!(IE)]><!--> <html lang="${response.locale.language}"><!--<![endif]-->
 <head>
+    <g:if test="${Environment.isDevelopmentEnvironmentAvailable()}">
+        <asset:javascript src="vue.js"/>
+    </g:if>
+    <g:else>
+        <asset:javascript src="vue.min.js"/>
+    </g:else>
     <title>
       <g:layoutTitle default="${g.appTitle()}"/>
     </title>
@@ -38,8 +45,6 @@
     <asset:stylesheet href="ansicolor.css"/>
     <asset:stylesheet href="github-markdown.css"/>
     <asset:stylesheet href="jquery-ui.css"/>
-
-    <asset:javascript src="vue.min.js"/>
 
     <!--[if lt IE 9]>
     <asset:javascript src="respond.min.js"/>
@@ -156,7 +161,6 @@
     </g:if>
 
     <g:jsonToken id="ui_token" url="${request.forwardURI}"/>
-    <g:layoutHead/>
     <script type=text/javascript>
         window._rundeck = Object.assign(window._rundeck || {}, {
         rdBase: '${g.createLink(uri:"/",absolute:true)}',
@@ -171,6 +175,7 @@
         })
     </script>
     <asset:javascript src="static/components/central.js"/>
+    <g:layoutHead/>
 </head>
 <body class="${_sidebarClass}">
   <div class="wrapper">

--- a/rundeckapp/grails-spa/build/webpack.base.conf.js
+++ b/rundeckapp/grails-spa/build/webpack.base.conf.js
@@ -135,6 +135,10 @@ module.exports = {
     child_process: 'empty'
   },
 
+  externals: {
+    "vue": "Vue"
+  },
+
   plugins: [
     new VueLoaderPlugin(),
     new MiniCssExtractPlugin({

--- a/rundeckapp/grails-spa/package.json
+++ b/rundeckapp/grails-spa/package.json
@@ -21,7 +21,7 @@
     "vue": "2.5.17",
     "vue-cookies": "^1.5.6",
     "vue-fuse": "^2.0.2",
-    "vue-i18n": "^8.8.0",
+    "vue-i18n": "^8.14.0",
     "vue-moment": "^4.0.0",
     "vue-property-decorator": "^7.3.0",
     "vue-router": "^3.0.6",

--- a/rundeckapp/grails-spa/src/components/central/main.ts
+++ b/rundeckapp/grails-spa/src/components/central/main.ts
@@ -1,4 +1,15 @@
+import moment from 'moment'
+import Vue from 'vue'
+import * as uiv from 'uiv'
+import VueCookies from 'vue-cookies'
+import VueI18n from 'vue-i18n'
+import VueMoment from 'vue-moment'
 import {getRundeckContext, getSynchronizerToken, RundeckBrowser} from '@rundeck/ui-trellis'
+
+Vue.use(uiv)
+Vue.use(VueCookies)
+Vue.use(VueI18n)
+Vue.use(VueMoment, {moment})
 
 
 const context = getRundeckContext()

--- a/rundeckapp/grails-spa/src/components/community-news-notification/main.js
+++ b/rundeckapp/grails-spa/src/components/community-news-notification/main.js
@@ -7,7 +7,6 @@ import * as uiv from 'uiv'
 import international from './i18n'
 import uivLang from '../../utilities/uivi18n'
 import VueCookies from 'vue-cookies'
-import VueMoment from 'vue-moment'
 import moment from 'moment'
 // Component Files
 import VueI18n from 'vue-i18n'
@@ -23,7 +22,7 @@ let messages = international.messages
 let locale = window._rundeck.locale || 'en_US'
 let lang = window._rundeck.language || 'en'
 moment.locale(locale)
-Vue.use(VueMoment,{moment})
+
 
 // include any i18n injected in the page by the app
 messages =

--- a/rundeckapp/grails-spa/src/components/tour/main.js
+++ b/rundeckapp/grails-spa/src/components/tour/main.js
@@ -1,6 +1,8 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 import Vue from 'vue'
+import VueI18n from 'vue-i18n'
+import uivLang from '../../utilities/uivi18n'
 import * as uiv from 'uiv'
 import axios from 'axios'
 import TourConstants from '@/components/tour/constants'
@@ -11,6 +13,21 @@ import {
 } from '../../utilities/vueEventBus.js'
 
 Vue.config.productionTip = false
+
+let messages =
+{
+  en_US: Object.assign(
+    {},
+    uivLang['en_US'] || uivLang['en'] || {},
+    window.Messages
+  )
+}
+
+const i18n = new VueI18n({
+  silentTranslationWarn: true,
+  locale: 'en', // set locale
+  messages // set locale messages,
+})
 
 Vue.use(uiv)
 const project = window._rundeck.projectName
@@ -42,7 +59,8 @@ axios.get(TourConstants.tourManifestUrl, cfg)
         components: {
           TourPicker
         },
-        template: '<tour-picker :event-bus="EventBus"/>'
+        template: '<tour-picker :event-bus="EventBus"/>',
+        i18n
       })
 
       // creating the dom element that will contain the tour application
@@ -66,7 +84,8 @@ axios.get(TourConstants.tourManifestUrl, cfg)
         components: {
           TourDisplay
         },
-        template: '<tour-display :event-bus="EventBus"/>'
+        template: '<tour-display :event-bus="EventBus"/>',
+        i18n
       })
     }
   })

--- a/rundeckapp/grails-spa/src/components/version-notification/main.js
+++ b/rundeckapp/grails-spa/src/components/version-notification/main.js
@@ -6,7 +6,6 @@ import Vue from 'vue'
 import * as uiv from 'uiv'
 import international from './i18n'
 import uivLang from '../../utilities/uivi18n'
-import VueMoment from 'vue-moment'
 import moment from 'moment'
 // Component Files
 import VueI18n from 'vue-i18n'
@@ -21,7 +20,6 @@ let messages = international.messages
 let locale = window._rundeck.locale || 'en_US'
 let lang = window._rundeck.language || 'en'
 moment.locale(locale)
-Vue.use(VueMoment,{moment})
 
 // include any i18n injected in the page by the app
 messages =

--- a/rundeckapp/grails-spa/src/pages/community-news/main.js
+++ b/rundeckapp/grails-spa/src/pages/community-news/main.js
@@ -6,7 +6,6 @@ import Vue from 'vue'
 import * as uiv from 'uiv'
 import international from './i18n'
 import uivLang from '../../utilities/uivi18n'
-import VueMoment from 'vue-moment'
 import VueCookies from 'vue-cookies'
 import moment from 'moment'
 // Component Files
@@ -23,7 +22,6 @@ let messages = international.messages
 let locale = window._rundeck.locale || 'en_US'
 let lang = window._rundeck.language || 'en'
 moment.locale(locale)
-Vue.use(VueMoment,{moment})
 
 // include any i18n injected in the page by the app
 messages =

--- a/rundeckapp/grails-spa/src/pages/project-activity/main.js
+++ b/rundeckapp/grails-spa/src/pages/project-activity/main.js
@@ -9,7 +9,6 @@ import * as uiv from 'uiv'
 import international from './i18n'
 import VueI18n from 'vue-i18n'
 import moment from 'moment'
-import VueMoment from 'vue-moment'
 import {
   EventBus
 } from '../../utilities/vueEventBus.js'
@@ -28,7 +27,6 @@ let messages = international.messages
 let locale = window._rundeck.locale || 'en_US'
 let lang = window._rundeck.language || 'en'
 moment.locale(locale)
-Vue.use(VueMoment,{moment})
 
 // include any i18n injected in the page by the app
 messages =

--- a/rundeckapp/grails-spa/src/pages/project-dashboard/main.js
+++ b/rundeckapp/grails-spa/src/pages/project-dashboard/main.js
@@ -7,13 +7,11 @@ import App from './App'
 import * as uiv from 'uiv'
 import international from '../project-activity/i18n'
 import VueI18n from 'vue-i18n'
-import VueMoment from 'vue-moment'
 import moment from 'moment'
 import {
   EventBus
 } from '../../utilities/vueEventBus.js'
 import uivLang from '../../utilities/uivi18n'
-
 
 Vue.config.productionTip = false
 
@@ -26,7 +24,6 @@ let messages = international.messages
 let locale = window._rundeck.locale || 'en_US'
 let lang = window._rundeck.language || 'en'
 moment.locale(locale)
-Vue.use(VueMoment,{moment})
 
 // include any i18n injected in the page by the app
 messages =

--- a/rundeckapp/grails-spa/src/pages/repository/main.js
+++ b/rundeckapp/grails-spa/src/pages/repository/main.js
@@ -5,6 +5,8 @@ import Vue2Filters from 'vue2-filters'
 import VueCookies from 'vue-cookies'
 import VueScrollTo from 'vue-scrollto'
 import VueFuse from 'vue-fuse'
+import VueI18n from 'vue-i18n'
+import uivLang from '../../utilities/uivi18n'
 import * as uiv from 'uiv'
 
 import store from './stores'
@@ -19,6 +21,21 @@ Vue.use(VueFuse)
 Vue.use(Vue2Filters)
 Vue.use(uiv)
 
+let messages =
+{
+  en_US: Object.assign(
+    {},
+    uivLang['en_US'] || uivLang['en'] || {},
+    window.Messages
+  )
+}
+
+const i18n = new VueI18n({
+  silentTranslationWarn: true,
+  locale: 'en', // set locale
+  messages // set locale messages,
+})
+
 /* eslint-disable no-new */
 new Vue({
   el: '#repository-vue',
@@ -27,5 +44,6 @@ new Vue({
   components: {
     App
   },
-  template: '<App/>'
+  template: '<App/>',
+  i18n
 })

--- a/rundeckapp/grails-spa/src/pages/webhooks/main.js
+++ b/rundeckapp/grails-spa/src/pages/webhooks/main.js
@@ -5,6 +5,8 @@ import VueScrollTo from 'vue-scrollto'
 import VueFuse from 'vue-fuse'
 import * as uiv from 'uiv'
 import App from './App.vue'
+import VueI18n from 'vue-i18n'
+import uivLang from '../../utilities/uivi18n'
 
 Vue.config.productionTip = false
 
@@ -14,8 +16,24 @@ Vue.use(VueFuse)
 Vue.use(Vue2Filters)
 Vue.use(uiv)
 
+let messages =
+{
+  en_US: Object.assign(
+    {},
+    uivLang['en_US'] || uivLang['en'] || {},
+    window.Messages
+  )
+}
+
+const i18n = new VueI18n({
+  silentTranslationWarn: true,
+  locale: 'en', // set locale
+  messages // set locale messages,
+})
+
 // eslint-disable-next-line no-new
 new Vue({
+  i18n,
   el: '#webhook-vue',
   components: { App },
   template: "<App/>"

--- a/rundeckapp/grails-spa/src/types.d.ts
+++ b/rundeckapp/grails-spa/src/types.d.ts
@@ -1,0 +1,1 @@
+declare module 'vue-moment'


### PR DESCRIPTION
* Loads development `Vue` when in development environment
* Externalizes `Vue` in build so anything requiring `Vue` gets the global `Vue`
* Configures `VueMoment` once so errors do not prevent loading
* Ensures every `new Vue({})` instance receives an `i18n` to prevent errors and expose internationalization support to Webhooks and plugin components