### PR TITLE
Add creation date to project list on api

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProject.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProject.java
@@ -196,6 +196,11 @@ public class FrameworkProject extends FrameworkResource implements IRundeckProje
         return projectConfig.getConfigLastModifiedTime();
     }
 
+    @Override
+    public Date getConfigCreatedTime(){
+        return projectConfig.getConfigCreatedTime();
+    }
+
     /**
      * list the configurations of resource model providers.
      * @return a list of maps containing:

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProjectConfig.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProjectConfig.java
@@ -23,6 +23,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Date;
 import java.util.Map;
 import java.util.Properties;
@@ -335,6 +338,18 @@ public class FrameworkProjectConfig implements IRundeckProjectConfig, IRundeckPr
         return new Date(getPropertyFile().lastModified());
     }
 
+    @Override
+    public Date getConfigCreatedTime(){
+        Path file = getPropertyFile().toPath();
+        try {
+            BasicFileAttributes attr = Files.readAttributes(file, BasicFileAttributes.class);
+            return new Date(attr.creationTime().toMillis());
+        } catch (IOException e) {
+            logger.error(e);
+        }
+        return null;
+
+    }
     @Override
     public Map<String, String> getProperties() {
         return lookup.getPropertiesMap();

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/IRundeckProject.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/IRundeckProject.java
@@ -95,6 +95,13 @@ public interface IRundeckProject extends IRundeckProjectConfig {
     Date getConfigLastModifiedTime();
 
     /**
+     * @return creation time for configuration in epoch time
+     */
+    default Date getConfigCreatedTime(){
+        return null;
+    }
+
+    /**
      * @return the project nodes interface
      */
     IProjectNodes getProjectNodes();

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/IRundeckProjectConfig.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/IRundeckProjectConfig.java
@@ -54,4 +54,9 @@ public interface IRundeckProjectConfig {
      * @return last modified time for configuration in epoch time
      */
     Date getConfigLastModifiedTime();
+
+    /**
+     * @return creation date time for configuration in epoch time
+     */
+    Date getConfigCreatedTime();
 }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
@@ -498,6 +498,9 @@ class ProjectController extends ControllerBase{
         delegate.'project'(pmap) {
             name(data.name)
             description(data.description)
+            if (vers >= ApiVersions.V33) {
+                created(data.created)
+            }
             if (vers >= ApiVersions.V26) {
                 if (pject.hasProperty("project.label")) {
                     label(data.label)
@@ -549,20 +552,22 @@ class ProjectController extends ControllerBase{
     }
 
     private Map basicProjectDetails(def pject, def version) {
+        def name = pject.name
+        def retMap = [
+                url:generateProjectApiUrl(pject.name),
+                name: name,
+                description: pject.getProjectProperties()?.get("project.description")?:''
+        ]
         if(version>=ApiVersions.V26){
-            [
-                    url:generateProjectApiUrl(pject.name),
-                    name:pject.name,
-                    description: pject.getProjectProperties()?.get("project.description")?:'',
-                    label: pject.getProjectProperties()?.get("project.label")?:''
-            ]
-        }else{
-            [
-                    url:generateProjectApiUrl(pject.name),
-                    name:pject.name,
-                    description: pject.getProjectProperties()?.get("project.description")?:''
-            ]
+            retMap.label = pject.getProjectProperties()?.get("project.label")?:''
         }
+        if(version>=ApiVersions.V33){
+            def created = pject.getConfigCreatedTime()
+            if(created){
+                retMap.created = created?:''
+            }
+        }
+        retMap
 
     }
 

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -514,7 +514,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
         def rdprojectconfig = new RundeckProjectConfig(projectName,
                                                        createProjectPropertyLookup(projectName, res.config ?: new Properties()),
                                                        createDirectProjectPropertyLookup(projectName, res.config ?: new Properties()),
-                                                       res.lastModified
+                                                       res.lastModified, res.creationTime
         )
 
         def newproj= new RundeckProject(rdprojectconfig, this)
@@ -566,7 +566,8 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
         def rdprojectconfig = new RundeckProjectConfig(project.name,
                                                        createProjectPropertyLookup(project.name, resource.config ?: new Properties()),
                                                        createDirectProjectPropertyLookup(project.name, resource.config ?: new Properties()),
-                                                       resource.lastModified
+                                                       resource.lastModified,
+                                                        resource.creationTime
         )
         project.projectConfig=rdprojectconfig
         project.nodesFactory = rundeckNodeService
@@ -616,7 +617,8 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
         def rdprojectconfig = new RundeckProjectConfig(project.name,
                                                        createProjectPropertyLookup(project.name, resource.config ?: new Properties()),
                                                        createDirectProjectPropertyLookup(project.name, resource.config ?: new Properties()),
-                                                       resource.lastModified
+                                                       resource.lastModified,
+                resource.creationTime
         )
         project.projectConfig=rdprojectconfig
         project.nodesFactory = rundeckNodeService
@@ -703,7 +705,8 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
                                                          project,
                                                          resource.config ?: new Properties()
                                                  ),
-                                                 resource.lastModified
+                                                 resource.lastModified,
+                resource.creationTime
         )
         return rdprojectconfig
     }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/projects/RundeckProject.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/projects/RundeckProject.java
@@ -124,6 +124,10 @@ public class RundeckProject implements IRundeckProject{
         return projectConfig.getConfigLastModifiedTime();
     }
 
+    public Date getConfigCreatedTime(){
+        return projectConfig.getConfigCreatedTime();
+    }
+
 
     public IProjectNodes getProjectNodes() {
         return getNodesFactory().getNodes(getName());

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/projects/RundeckProjectConfig.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/projects/RundeckProjectConfig.java
@@ -29,6 +29,7 @@ import java.util.Map;
 public class RundeckProjectConfig implements IRundeckProjectConfig {
     private String name;
     private Date lastModifiedTime;
+    private Date createdTime;
     private IPropertyLookup lookup;
     private IPropertyLookup projectLookup;
 
@@ -36,13 +37,15 @@ public class RundeckProjectConfig implements IRundeckProjectConfig {
             final String name,
             final IPropertyLookup lookup,
             final IPropertyLookup projectLookup,
-            final Date lastModifiedTime
+            final Date lastModifiedTime,
+            final Date createdTime
     )
     {
         this.name = name;
         this.setLookup(lookup);
         this.setProjectLookup(projectLookup);
         this.setLastModifiedTime(lastModifiedTime);
+        this.setCreatedTime(createdTime);
 
     }
 
@@ -112,6 +115,14 @@ public class RundeckProjectConfig implements IRundeckProjectConfig {
 
     public void setLastModifiedTime(final Date lastModifiedTime) {
         this.lastModifiedTime = lastModifiedTime;
+    }
+
+    public void setCreatedTime(final Date createdTime){
+        this.createdTime = createdTime;
+    }
+
+    public Date getConfigCreatedTime(){
+        return createdTime;
     }
 
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/NodeServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NodeServiceSpec.groovy
@@ -116,6 +116,11 @@ class NodeServiceSpec extends Specification {
         }
 
         @Override
+        Date getConfigCreatedTime() {
+            return null
+        }
+
+        @Override
         String getProperty(final String property) {
             projectProperties.get(property)
         }


### PR DESCRIPTION
fix #5099

on `GET /api/33/projects` endpoint adds `created` field.

This data is extracted from the property file if using `projectsStorageType` `file` or the creation date on the DB if using `projectsStorageType` `db`

XML:
```
<project url='http://wintermute:4440/api/33/project/bugbear'>
        <name>bugbear</name>
        <description>Test from issues and enhancement requests</description>
        <created>Mon Sep 09 10:45:38 CLST 2019</created>
        <label>Bugbear</label>
    </project>
```

JSON:
```
{
        "url": "http://wintermute:4440/api/33/project/bugbear",
        "name": "bugbear",
        "description": "Test from issues and enhancement requests",
        "label": "Bugbear",
        "created": "2019-09-09T13:45:38Z"
    },
```