### PR TITLE
Ensure selected plugin matches curhook

### DIFF
--- a/rundeckapp/grails-spa/src/pages/webhooks/views/WebhooksView.vue
+++ b/rundeckapp/grails-spa/src/pages/webhooks/views/WebhooksView.vue
@@ -171,6 +171,7 @@ export default {
         this.webhooks = response.data.hooks
         if (this.curHook) {
           this.curHook = this.webhooks.find(hk => hk.id === this.curHook.id)
+          this.setSelectedPlugin()
         }
       })
     },


### PR DESCRIPTION
This ensures that when `getHooks` is called the selected plugin will be updated. Otherwise the selected plugin, used for save, will become disconnected from the `curhook`.