### PR TITLE
Fix api token total count on user profile page.

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -131,6 +131,7 @@ class UserController extends ControllerBase{
             if (!tokenAdmin) {
                 eq("creator", u.login)
             }
+            eq("type", AuthTokenType.USER)
         }
 
         int max = (params.max && params.max.isInteger()) ? params.max.toInteger() :


### PR DESCRIPTION
Token count was not filtering out webhook tokens, so the count was incorrect.