### PR TITLE
Fix in app plugin configuration display 

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
@@ -244,6 +244,8 @@ class PluginController extends ControllerBase {
             pluginName,
             desc.properties
         )
+        terseDesc.projectMapping = desc.propertiesMapping
+        terseDesc.fwkMapping = desc.fwkPropertiesMapping
         if(instance) {
             //Check for custom config vue component
             def customConfigProp = PluginAdapterUtility.getCustomConfigAnnotation(instance)

--- a/rundeckapp/grails-spa/src/pages/repository/components/ConfigureFrameworkString.vue
+++ b/rundeckapp/grails-spa/src/pages/repository/components/ConfigureFrameworkString.vue
@@ -7,15 +7,8 @@ export default {
   props: ["serviceName", "provider", "prop"],
   computed: {
     returnedString: function() {
-      if (this.prop.defaultValue) {
-        return `framework.plugin.${this.serviceName}.${this.provider.name}.${
-          this.prop.name
-        }=${this.prop.defaultValue}`;
-      } else {
-        return `framework.plugin.${this.serviceName}.${this.provider.name}.${
-          this.prop.name
-        }`;
-      }
+      let propName = this.provider.fwkMapping[this.prop.name] || `framework.plugin.${this.serviceName}.${this.provider.name}.${this.prop.name}`
+      return `${propName}=${this.prop.defaultValue || 'value'}`;
     }
   }
 };

--- a/rundeckapp/grails-spa/src/pages/repository/views/PluginConfigurationView.vue
+++ b/rundeckapp/grails-spa/src/pages/repository/views/PluginConfigurationView.vue
@@ -208,7 +208,8 @@
                             <div>{{prop.desc}}</div>
                             <div>
                               <strong>Configure Project:</strong>
-                              <code>project.plugin.{{details.provider.serviceName}}.{{details.response.name}}.{{prop.name}}={{prop.defaultValue}}</code>
+                              <code v-if="details.response.projectMapping[prop.name]">{{details.response.projectMapping[prop.name]}}={{prop.defaultValue || 'value'}}</code>
+                              <code v-else>project.plugin.{{details.provider.serviceName}}.{{details.response.name}}.{{prop.name}}={{prop.defaultValue || 'value'}}</code>
                             </div>
                             <div>
                               <strong>Configure Framework:</strong>
@@ -271,7 +272,8 @@
               <div>{{prop.desc}}</div>
               <div>
                 <strong>Configure Project:</strong>
-                <code>project.plugin.{{serviceName}}.{{provider.name}}.{{prop.name}}={{prop.defaultValue}}</code>
+                <code v-if="provider.projectMapping[prop.name]">{{provider.projectMapping[prop.name]}}={{prop.defaultValue || 'value'}}</code>
+                <code v-else>project.plugin.{{serviceName}}.{{provider.name}}.{{prop.name}}={{prop.defaultValue || 'value'}}</code>
               </div>
               <div>
                 <strong>Configure Framework:</strong>


### PR DESCRIPTION
In app plugin configuration display now correctly uses project and framework mapping for plugin
properties configured with mappings. Fixes #5244.
