### PR TITLE
Darkens the list delimiter input to differentiate between inline label

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
@@ -489,7 +489,7 @@
             </div>
 
             <div class="input-group col-sm-3 ${hasErrors(bean: option, field: 'delimiter', 'has-error')}">
-                <div class="input-group-addon">
+                <div class="input-group-addon" style="background-color:#e0e0e0;">
                     <g:message code="form.option.valuesDelimiter.label" />
                 </div>
                 <input type="text"
@@ -577,7 +577,7 @@
                     <g:radio id="option-hidden-no" name="hidden" value="false" checked="${!option || !option.hidden}"/>
                     <label for="option-hidden-no">
                         <g:message code="no" />
-                    </label>    
+                    </label>
                 </div>
                 <div class="radio radio-inline">
                     <g:radio id="option-hidden-yes" name="hidden" value="true" checked="${option?.hidden}"/>


### PR DESCRIPTION
Before:

![image (5)](https://user-images.githubusercontent.com/265904/64912295-180ab100-d6fb-11e9-85d0-abe96f43f0a9.png)

After:

<img width="647" alt="Screen Shot 2019-09-13 at 4 43 59 PM" src="https://user-images.githubusercontent.com/265904/64912299-26f16380-d6fb-11e9-85c0-361706d04b56.png">

