### PR TITLE
Improve interactivity of page when loading execution log

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/util/compactMapList.js
+++ b/rundeckapp/grails-app/assets/javascripts/util/compactMapList.js
@@ -27,6 +27,7 @@
  * @private
  */
 function _decompactMapList(entries, compactedAttr, func) {
+    var decomp = []
     var odata = {};
     for (var i = 0; i < entries.length; i++) {
         var e = entries[i];
@@ -51,5 +52,7 @@ function _decompactMapList(entries, compactedAttr, func) {
         }
         odata = e;
         func(e);
+        decomp.push(e)
     }
+    return decomp
 }

--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -211,7 +211,8 @@ rundeck:
             tail:
                 lines:
                     default: 20
-                    max: 500
+                    max: 2000
+
         job:
             description:
                 disableHTML: false


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This improves the interactivity of the page while loading the execution log.

**Describe the solution you've implemented**
To reduce the amount of time JS is blocking the UI(scrolling primarily) the table rows are being added in chunks. Prior there was an implicit chunking due to the `500` max line limit fetched from the server at one time, however this chunk size proved to feel quite laggy in my testing.

This change decouples the DOM update batching from the data fetching. Until there are over **20k** lines of output the batch size will be 50. Around **20k** the reflow starts to take up a much larger portion of the update time and is constant for the input size. At this point the batch size is raised back to `500` to prevent a much longer loading time for larger logs.

The impact to user experience is that the page will feel much smoother when loading small to medium logs, and will feel smoother for the start of loading larger logs without impacting their overall total loading time.

**Describe alternatives you've considered**
The use of tables for very large lists is generally considered a poor choice from a performance perspective. Table updates cause long style, layout, and render events to occur. These become progressively worse as more table elements are added:
![image](https://user-images.githubusercontent.com/271965/64940994-10e2c080-d82b-11e9-8890-cdd1761e0d76.png)

This can be mitigated with very careful, conservative CSS rules along with a fixed table layout however it may not be able to be fully addressed. Moving to elements(divs) and a page layout that does not require long reflows would be ideal however it would also be a much more significant change.
