### PR TITLE
Fix #5248. Option validator error

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2631,6 +2631,18 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                         return
                     }
                 }
+                if(opt.enforced && !(opt.optionValues || opt.optionValuesPluginType)){
+                    Map remoteOptions = scheduledExecutionService.loadOptionsRemoteValues(scheduledExecution, [option: opt.name], authContext?.username)
+                    if(!remoteOptions.err && remoteOptions.values){
+                        opt.optionValues = remoteOptions.values.collect {optValue ->
+                            if(optValue instanceof JSONObject){
+                                return optValue.value
+                            } else {
+                                return optValue
+                            }
+                        }
+                    }
+                }
                 if (opt.multivalued) {
                     if (opt.regex && !opt.enforced && optparams[opt.name]) {
                         def val
@@ -2647,18 +2659,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                         if (fail) {
                             invalidOpt opt,lookupMessage("domain.Option.validation.regex.values",[opt.name,optparams[opt.name],opt.regex])
                             return
-                        }
-                    }
-                    if(opt.enforced && !opt.optionValues){
-                        Map remoteOptions = scheduledExecutionService.loadOptionsRemoteValues(scheduledExecution, [option: opt.name], authContext?.username)
-                        if(!remoteOptions.err && remoteOptions.values){
-                            opt.optionValues = remoteOptions.values.collect {optValue ->
-                                if(optValue instanceof JSONObject){
-                                    return optValue.value
-                                } else {
-                                    return optValue
-                                }
-                            }
                         }
                     }
                     if (opt.enforced && opt.optionValues && optparams[opt.name]) {
@@ -2681,18 +2681,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                                     : lookupMessage("domain.Option.validation.regex.invalid",[opt.name,optparams[opt.name],opt.regex])
 
                             return
-                        }
-                    }
-                    if(opt.enforced && !opt.optionValues){
-                        Map remoteOptions = scheduledExecutionService.loadOptionsRemoteValues(scheduledExecution, [option: opt.name], authContext?.username)
-                        if(!remoteOptions.err && remoteOptions.values){
-                            opt.optionValues = remoteOptions.values.collect {optValue ->
-                                if(optValue instanceof JSONObject){
-                                    return optValue.value
-                                } else {
-                                    return optValue
-                                }
-                            }
                         }
                     }
                     if (opt.enforced && opt.optionValues &&

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -1551,6 +1551,22 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
     }
 
+    def "remote url option validator does not attempt to validate option values plugin values"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution()
+        Option opt = new Option(name: 'test1', enforced: true, optionValues: null, optionValuesPluginType: 'test_opt_val_plugin')
+        se.addToOptions(opt)
+        service.scheduledExecutionService = Mock(ScheduledExecutionService)
+        when:
+
+        def validation = service.validateOptionValues(se, ["test":"A"])
+
+        then:
+        0 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_)
+        noExceptionThrown()
+
+    }
+
     def "opt enforced allowed values from Remote Url with or without default value"() {
         given:
         ScheduledExecution se = new ScheduledExecution()


### PR DESCRIPTION
Options that have an option values plugin should not be run through the remote values validation.

This PR reduces the code duplication in the remote options validator, and excludes options that specify an option validator plugin.