### PR TITLE
Turn off autocomplete on password field

### DIFF
--- a/rundeckapp/grails-app/views/user/login.gsp
+++ b/rundeckapp/grails-app/views/user/login.gsp
@@ -150,7 +150,7 @@
 
                     <div class="form-group">
                         <label for="password"><g:message code="user.login.password.label"/></label>
-                        <input type="password" name="j_password" id="password" class="form-control input-no-border"/>
+                        <input type="password" name="j_password" id="password" class="form-control input-no-border" autocomplete="off"/>
                     </div>
                         <div class="card-footer text-center">
                             <button type="submit" id="btn-login" class="btn btn-fill btn-wd "><g:message code="user.login.login.button"/></button>


### PR DESCRIPTION
To satisfy Qualys Vulnerability scanning.
Even though it isn't best practice, because best practice is to use password managers to autocomplete the login fields.
However, it won't be honored by the browsers (for the above reason https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields), so users won't get affected.
So this change is only good to silence a vulnerability scanner, it doesn't actually close a vulnerability.

Closes #5205