### PR TITLE
Fix #5261. Do not set not null constraint on AuthToken type. 

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -131,7 +131,11 @@ class UserController extends ControllerBase{
             if (!tokenAdmin) {
                 eq("creator", u.login)
             }
-            eq("type", AuthTokenType.USER)
+            or {
+                eq("type", AuthTokenType.USER)
+                isNull("type")
+            }
+
         }
 
         int max = (params.max && params.max.isInteger()) ? params.max.toInteger() :
@@ -160,7 +164,10 @@ class UserController extends ControllerBase{
             if (max) {
                 maxResults(max)
             }
-            eq("type", AuthTokenType.USER)
+            or {
+                eq("type", AuthTokenType.USER)
+                isNull("type")
+            }
             order("dateCreated", "desc")
         }
         params.max = max

--- a/rundeckapp/grails-app/domain/rundeck/AuthToken.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/AuthToken.groovy
@@ -30,7 +30,7 @@ class AuthToken implements AuthenticationToken {
     Date expiration
     Date dateCreated
     Date lastUpdated
-    AuthTokenType type
+    AuthTokenType type = AuthTokenType.USER
     static belongsTo = [user:User]
     static transients = ['printableToken','ownerName']
     static constraints = {
@@ -42,6 +42,7 @@ class AuthToken implements AuthenticationToken {
         expiration(nullable: true)
         lastUpdated(nullable: true)
         dateCreated(nullable: true)
+        type(nullable: true)
     }
     static mapping = {
         authRoles type: 'text'


### PR DESCRIPTION
Handle null like AuthTokenType.USER.

Tested upgrade from pre 3.1.1 version to 3.1.1 snapshot and worked with no errors reported.
