### PR TITLE
Fix VUE UI issue on webhook page

### DIFF
--- a/rundeckapp/grails-spa/src/pages/webhooks/views/WebhooksView.vue
+++ b/rundeckapp/grails-spa/src/pages/webhooks/views/WebhooksView.vue
@@ -171,7 +171,7 @@ export default {
         this.webhooks = response.data.hooks
         if (this.curHook) {
           this.curHook = this.webhooks.find(hk => hk.id === this.curHook.id)
-          this.setSelectedPlugin()
+          if(this.curHook) this.setSelectedPlugin()
         }
       })
     },


### PR DESCRIPTION
When a new webhook is saved there is no current hook selected from the list so don't try to match.
