### PR TITLE
cleanup argstring display in activity list and exec page

### DIFF
--- a/rundeckapp/grails-app/assets/scss/custom/jobs.scss
+++ b/rundeckapp/grails-app/assets/scss/custom/jobs.scss
@@ -121,29 +121,23 @@
 }
 
 .argstring-scrollable {
-  overflow: hidden;
-  word-break: break-all;
-  text-overflow: ellipsis;
-}
-
-.argstring-scrollable .text-secondary {
-  display: block;
-}
-
-.argstring-scrollable .optkey {
-  display: inline-block;
-}
-
-.argstring-scrollable .optvalue {
-  overflow: hidden;
-  word-break: break-all;
-  text-overflow: ellipsis;
+  overflow-x: hidden;
   white-space: nowrap;
+}
+
+.exec-args-section.argstring-scrollable  .optkey , .exec-args-section.argstring-scrollable  .optvalue{
   display: block;
 }
 
 // eventargs is typically a table > td
 // found here: /rundeckapp/grails-app/assets/scss/custom/table-events.scss
-.eventargs .argstring-scrollable {
-  overflow-x: hidden;
+.eventargs.argstring-scrollable {
+  overflow-x: auto;
+  white-space: nowrap;
+  max-width: 250px;
+}
+
+.exec-args-section.argstring-scrollable {
+  overflow-y: auto;
+  max-height: 200px;
 }

--- a/rundeckapp/grails-app/assets/scss/custom/workflow-editor.scss
+++ b/rundeckapp/grails-app/assets/scss/custom/workflow-editor.scss
@@ -40,4 +40,8 @@ span.autoedit:hover {
 
 .optkey {
   color: $primary-color;
+
+  &:after {
+    content: ':';
+  }
 }

--- a/rundeckapp/grails-app/views/execution/_execArgString.gsp
+++ b/rundeckapp/grails-app/views/execution/_execArgString.gsp
@@ -17,7 +17,7 @@
 <g:set var="parsed" value="${g.parseOptsFromString(args: argString)}"/>
 <g:if test="${parsed}">
     <g:each in="${parsed}" var="entry">
-        <span class="optkey"><g:enc>${entry.key}</g:enc></span>:
+        <span class="optkey"><g:enc>${entry.key}</g:enc></span>
         <g:if test="${entry.value}">
             <g:if test="${inputFilesMap && inputFilesMap[entry.value]}">
                 <g:set var="frkey" value="${g.rkey()}"/>

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -472,7 +472,7 @@ search
                                 ]"/>
 
                       <g:if test="${execution.argString}">
-                          <section class=" section-space argstring-scrollable">
+                          <section class=" section-space exec-args-section argstring-scrollable">
                               <span class="text-secondary"><g:message code="options.prompt"/></span>
                               <g:render template="/execution/execArgString"
                                         model="[argString: execution.argString, inputFilesMap: inputFilesMap]"/>

--- a/rundeckapp/grails-spa/src/components/activity/activityList.vue
+++ b/rundeckapp/grails-spa/src/components/activity/activityList.vue
@@ -216,10 +216,10 @@
                     {{exec.job.name}}
                 </td>
 
-                <td class="eventargs" v-if="exec.job">
+                <td class="eventargs argstring-scrollable" v-if="exec.job">
                   <span v-if="exec.job.options">
                       <span v-for="(value,key) in exec.job.options" :key="key">
-                          {{key}}:
+                          <span class="optkey">{{key}}</span>
                           <code  class="optvalue">{{value}}</code>
                       </span>
                   </span>
@@ -306,8 +306,8 @@
                     <span class="exec-status-text custom-status" >{{rpt.execution.status}}</span>
                 </span>
             </td>
-            <td class="eventargs " >
-                <div class="argstring-scrollable">
+            <td class="eventargs argstring-scrollable" >
+
                 <span v-if="rpt.execution.jobArguments">
                     <span v-for="(value,key) in rpt.execution.jobArguments" :key="key">
                         {{key}}:
@@ -317,7 +317,7 @@
 
                 <span v-if="!rpt.execution.jobArguments">{{rpt.execution.argString}}</span>
 
-                </div>
+
             </td>
 
             <td class="text-right">


### PR DESCRIPTION
activity list: don't wrap, allow horizontal overflow scroll
exec page: show values on separate blocks, max height to scroll on y axis


**Is this a bugfix, or an enhancement? Please describe.**
Update display of argstrings values in activity list and execution page, ref #5044 #5105 

![Screen Shot 2019-09-19 at 1 47 07 PM](https://user-images.githubusercontent.com/55603/65279854-0272fe00-dae4-11e9-9efb-3ae09b3403a7.png)
![Screen Shot 2019-09-19 at 1 47 00 PM](https://user-images.githubusercontent.com/55603/65279869-069f1b80-dae4-11e9-8b5d-af9bc3b99f40.png)
