### PR TITLE
Consider plugin title in search

### DIFF
--- a/rundeckapp/grails-spa/src/pages/repository/views/PluginConfigurationView.vue
+++ b/rundeckapp/grails-spa/src/pages/repository/views/PluginConfigurationView.vue
@@ -316,7 +316,7 @@ const FuseSearchOptions = {
   // distance: 100,
   // maxPatternLength: 32,
   minMatchCharLength: 1,
-  keys: ["display", "name"]
+  keys: ["display", "name", "title"]
 };
 
 import axios from "axios";

--- a/rundeckapp/grails-spa/src/pages/repository/views/PluginRepositoryView.vue
+++ b/rundeckapp/grails-spa/src/pages/repository/views/PluginRepositoryView.vue
@@ -84,7 +84,7 @@ const FuseSearchOptions = {
   // distance: 100,
   // maxPatternLength: 32,
   minMatchCharLength: 1,
-  keys: ["display", "name"]
+  keys: ["display", "name", "title"]
 };
 
 export default {


### PR DESCRIPTION
Fixes #5287 

Add "title" to search keys so that keywords in plugin titles will contribute to results.