### PR TITLE
Fix #5083 - Fixing the regex expression to consider "." character when perform auto completions

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/application.js
+++ b/rundeckapp/grails-app/assets/javascripts/application.js
@@ -447,7 +447,7 @@ function _setupAceTextareaEditor(textarea, callback, autoCompleter) {
     });
     var extCompleter = {
       identifierRegexps: [
-        /[@%a-zA-Z_0-9\$\-\u00A2-\uFFFF]/
+        /[@%a-zA-Z_0-9\.\$\-\u00A2-\uFFFF]/
       ],
       getCompletions: function (editor, session, pos, prefix, callback) {
         if (prefix.length === 0) {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
If some characters are typed after @option. and then an item is selected from the autocomplete dropdown menu, @option. is inserted again at the beginning and an extra "@" is added at the end

**Describe the solution you've implemented**
This solution changes the regular expression to consider "." as a valid character on prefix input text when perform auto completions.

**Describe alternatives you've considered**
Initially, I was trying to custom the "getCompletions" function from auto completion tool library.
