### PR TITLE
Fix issue with plugin select value with multiOption

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
@@ -679,7 +679,8 @@ class WorkflowController extends ControllerBase {
     private Map cleanLineEndings(Map input){
         def result = [:]
         input.each {k,v->
-            result[k]=v.replaceAll(/\r?\n/,'\n')
+            if(v instanceof String)result[k]=v.replaceAll(/\r?\n/,'\n')
+            else if(v instanceof String[] || v instanceof Collection) result[k]=v.collect { it.replaceAll(/\r?\n/,'\n') }.join(",")
         }
         result
     }

--- a/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
+++ b/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
@@ -162,15 +162,16 @@
 
             <g:each in="${propSelectValues}" var="propval" status="n">
                 <div class="optionvaluemulti checkbox">
-                  <g:checkBox name="${fieldname}" checked="${propval.value in defvalset}" value="${propval.value}" id="f_${fieldid}_p_${n}"/>
-                  <label class="grid-row optionvaluemulti" for="f_${fieldid}_p_${n}">
-                    ${propval.label}
-                  </label>
-                </div>
-            </g:each>
-        </div>
-        </div>
-    </g:elseif>
+              <g:set var="ischecked" value="${propval.value in defvalset ? 'checked="checked"' : ''}"/>
+            <input type="checkbox" id="${fieldname}" name="${fieldname}" ${ischecked} value="${propval.value}"/>
+            <label class="grid-row optionvaluemulti">
+              ${propval.label}
+            </label>
+          </div>
+      </g:each>
+  </div>
+  </div>
+</g:elseif>
 <g:else>
     <g:set var="fieldid" value="${g.rkey()}"/>
     <g:set var="hasStorageSelector" value="${prop.renderingOptions?.(StringRenderingConstants.SELECTION_ACCESSOR_KEY) in [StringRenderingConstants.SelectionAccessor.STORAGE_PATH,'STORAGE_PATH']}"/>

--- a/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
+++ b/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
@@ -163,8 +163,8 @@
             <g:each in="${propSelectValues}" var="propval" status="n">
                 <div class="optionvaluemulti checkbox">
               <g:set var="ischecked" value="${propval.value in defvalset ? 'checked="checked"' : ''}"/>
-            <input type="checkbox" id="${fieldname}" name="${fieldname}" ${ischecked} value="${propval.value}"/>
-            <label class="grid-row optionvaluemulti" for="${fieldname}">
+            <input type="checkbox" id="${enc(attr:fieldname)}" name="${enc(attr:fieldname)}" ${ischecked} value="${enc(attr:propval.value)}"/>
+            <label class="grid-row optionvaluemulti" for="${enc(attr:fieldname)}">
               ${propval.label}
             </label>
           </div>

--- a/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
+++ b/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
@@ -164,7 +164,7 @@
                 <div class="optionvaluemulti checkbox">
               <g:set var="ischecked" value="${propval.value in defvalset ? 'checked="checked"' : ''}"/>
             <input type="checkbox" id="${fieldname}" name="${fieldname}" ${ischecked} value="${propval.value}"/>
-            <label class="grid-row optionvaluemulti">
+            <label class="grid-row optionvaluemulti" for="${fieldname}">
               ${propval.label}
             </label>
           </div>

--- a/rundeckapp/src/test/groovy/rundeck/controllers/WorkflowControllerTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/WorkflowControllerTests.groovy
@@ -156,9 +156,11 @@ class WorkflowControllerTests {
         def inputValue2 = 'abc\ndef\n\nrbc\n'
         def expectedValue2 = 'abc\ndef\n\nrbc\n'
         def pluginConfig=[monkey: 'tree',
+                          ape:['land','tree'],
                           multilineconfig: inputValue,
                           unixlines: inputValue2]
         def expectedConfig=[monkey:'tree',
+                            ape:'land,tree',
                             multilineconfig: expectedValue,
                             unixlines: expectedValue2]
 


### PR DESCRIPTION
Java plugins with a property that came from @SelectValues with multOption=true did not send their values to the server correctly. The server wasn't handling the value type correctly. That is now fixed too.