### PR TITLE
Fix #5301 fix initProject, and clean old listeners

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/JobEventsService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobEventsService.groovy
@@ -46,7 +46,9 @@ class JobEventsService {
     }
 
     def removeListener(JobChangeListener plugin) {
-        listeners.remove(plugin)
+        if (plugin != null) {
+            listeners.remove(plugin)
+        }
     }
 
     @Subscriber


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #5301 

**Describe the solution you've implemented**

* prevents multiple listeners for the same project+integration plugin
from accumulating after repeated scm status queries
* same when scm plugins are re-enabled or re-configured

