### PR TITLE
[RFC] Fix scrolling to bottom in log output

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/executionControl.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionControl.js
@@ -767,14 +767,16 @@ var FollowControl = function (eid, elem, params) {
     },
     isAtBottom: function()
     {
-        var a = document.documentElement.scrollHeight || document.body.scrollHeight;
-        var b = document.documentElement.scrollTop || document.body.scrollTop;
-        var c = document.documentElement.clientHeight || document.body.clientHeight;
+        var elem = document.querySelector( '#main-panel' );
+        var a = elem.scrollHeight;
+        var b = elem.scrollTop;
+        var c = elem.clientHeight;
         return ((a - b) <= (c*1.1));
     },
     scrollToBottom: function()
     {
-        window.scrollTo(0, document.documentElement.scrollHeight || document.body.scrollHeight);
+        var elem = document.querySelector( '#main-panel' );
+        elem.scrollTop = elem.scrollHeight;
     },
     genDataRowNodes: function(data, tbl) {
         this.reverseOutputTable(tbl);


### PR DESCRIPTION
Fixes #4047 

**Is this a bugfix, or an enhancement? Please describe.**

Scrolling log output doesn't work in 3.x as the scrolling element is no longer the `window.documentElement`, but div `#main-panel`.

**Describe the solution you've implemented**

Scroll the `#main-panel` element instead.

**Describe alternatives you've considered**

I suspect a more wholesome approach would be to initialise the `exectuionControl` with an element that represents the scrolling element, passed in from the page. It doesn't feel totally right that it 'knows' about the page structure in this sense.

I'm also not 100% sure that `document.querySelector` is best here. I know that `jQuery` is used elsewhere in the app and there is some Vue around, but this works in the one browser i tested it on.

# Additional context

* [X] Full build, test and package as RPM (on RHEL7)
* [X] Install & test (manually)

PR is "RFC" because I wouldn't describe it as being tested that thoroughly. This scrolling feature is just really important to us (our jobs product a _lot_ of output).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rundeck/rundeck/5322)
<!-- Reviewable:end -->
