### PR TITLE
Fix not supporting and testing all supported remote option schemas

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2634,11 +2634,25 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 if(opt.enforced && !(opt.optionValues || opt.optionValuesPluginType)){
                     Map remoteOptions = scheduledExecutionService.loadOptionsRemoteValues(scheduledExecution, [option: opt.name], authContext?.username)
                     if(!remoteOptions.err && remoteOptions.values){
-                        opt.optionValues = remoteOptions.values.collect {optValue ->
-                            if(optValue instanceof JSONObject){
-                                return optValue.value
-                            } else {
-                                return optValue
+                        /**
+                         * Form of { "Label": "Value"}
+                         */
+                        if (remoteOptions.values instanceof JSONObject) {
+                            opt.optionValues = remoteOptions.values.collect { node ->
+                                node.value
+                            }
+                        }
+
+                        /**
+                         * Form of [{ "name":"Name", "value":"Value"}] or ["Value1", "Value2"]
+                         */
+                        else {
+                            opt.optionValues = remoteOptions.values.collect { optValue ->
+                                if (optValue instanceof JSONObject) {
+                                    return optValue.value
+                                } else {
+                                    return optValue
+                                }
                             }
                         }
                     }

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -1498,13 +1498,13 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         service.scheduledExecutionService = Mock(ScheduledExecutionService)
         when:
 
-        def validation = service.validateOptionValues(se, opts)
+        service.validateOptionValues(se, opts)
 
         then:
         1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_) >> {
             [
                     optionSelect : opt,
-                    values       : ["A", "B", "C"],
+                    values       : remoteValues,
                     srcUrl       : "cleanUrl",
                     err          : null
             ]
@@ -1512,6 +1512,9 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
 
         ExecutionServiceValidationException e = thrown()
+        e.errors.each { k, v ->
+            println("${k} ${v}")
+        }
         e.errors.containsKey('test1')
 
 
@@ -1519,6 +1522,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         opts                                           | remoteValues
         ['test1': 'somevalue']                         | ["A", "B", "C"]
         ['test1': 'somevalue']                         | [new JSONObject(name: "a", value:"A"), new JSONObject(name:"b", value:"B"), new JSONObject(name:"c", value:"C")]
+        ['test1': 'somevalue']                         | new JSONObject('foo': 'bar')
 
     }
 
@@ -1530,7 +1534,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         service.scheduledExecutionService = Mock(ScheduledExecutionService)
         when:
 
-        def validation = service.validateOptionValues(se, opts)
+        service.validateOptionValues(se, opts)
 
         then:
         1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_) >> {
@@ -1547,8 +1551,9 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
         where:
         opts                                           | remoteValues
+        ['test1': 'Foo']                               | ["Foo", "Bar"]
         ['test1': 'A']                                 | [new JSONObject(name: "a", value:"A"), new JSONObject(name:"b", value:"B"), new JSONObject(name:"c", value:"C")]
-
+        ['test1': 'Bar']                               | new JSONObject(foo: "Bar")
     }
 
     def "remote url option validator does not attempt to validate option values plugin values"() {


### PR DESCRIPTION
Fixes #5314

**Is this a bugfix, or an enhancement? Please describe.**
Bug fix.

**Describe the solution you've implemented**
The code was not setup to handle the simple object JSON format for remote options: https://docs.rundeck.com/docs/manual/job-options.html#option-model-provider. Collect supplies a `HashMap.Node` in this case, not a `JSONObject`.

The positive validation tests were missing two of the three forms, and the invalid test was not using the `remoteOptions` data variable. These have been fixed and a failing test was produced before the fix.