### PR TITLE
Fix error on remote opts with enforced values for simple JSON object

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2702,8 +2702,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 if(opt.enforced && !(opt.optionValues || opt.optionValuesPluginType)){
                     Map remoteOptions = scheduledExecutionService.loadOptionsRemoteValues(scheduledExecution, [option: opt.name], authContext?.username)
                     if(!remoteOptions.err && remoteOptions.values){
-                        opt.optionValues = remoteOptions.values.collect {optValue ->
-                            if(optValue instanceof JSONObject){
+                        opt.optionValues = remoteOptions.values.collect { optValue ->
+                            if (optValue instanceof Map) {
                                 return optValue.value
                             } else {
                                 return optValue

--- a/rundeckapp/src/integration-test/groovy/rundeck/services/ExecutionServiceIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/services/ExecutionServiceIntegrationSpec.groovy
@@ -1,0 +1,4 @@
+package rundeck.services
+
+class ExecutionServiceIntegrationSpec {
+}

--- a/rundeckapp/src/integration-test/groovy/rundeck/services/ExecutionServiceIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/services/ExecutionServiceIntegrationSpec.groovy
@@ -1,4 +1,0 @@
-package rundeck.services
-
-class ExecutionServiceIntegrationSpec {
-}

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -1511,13 +1511,13 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         service.scheduledExecutionService = Mock(ScheduledExecutionService)
         when:
 
-        def validation = service.validateOptionValues(se, opts)
+        service.validateOptionValues(se, opts)
 
         then:
         1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_) >> {
             [
                     optionSelect : opt,
-                    values       : ["A", "B", "C"],
+                    values       : remoteValues,
                     srcUrl       : "cleanUrl",
                     err          : null
             ]
@@ -1525,6 +1525,9 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
 
         ExecutionServiceValidationException e = thrown()
+        e.errors.each { k, v ->
+            println("${k} ${v}")
+        }
         e.errors.containsKey('test1')
 
 
@@ -1532,7 +1535,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         opts                                           | remoteValues
         ['test1': 'somevalue']                         | ["A", "B", "C"]
         ['test1': 'somevalue']                         | [new JSONObject(name: "a", value:"A"), new JSONObject(name:"b", value:"B"), new JSONObject(name:"c", value:"C")]
-
+        ['test1': 'somevalue']                         | [[name: 'bar', value:'Bar']]
     }
 
     def "valid option values, opt enforced allowed values from Remote Url"() {
@@ -1543,7 +1546,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         service.scheduledExecutionService = Mock(ScheduledExecutionService)
         when:
 
-        def validation = service.validateOptionValues(se, opts)
+        service.validateOptionValues(se, opts)
 
         then:
         1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_) >> {
@@ -1560,8 +1563,9 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
         where:
         opts                                           | remoteValues
+        ['test1': 'Foo']                               | ["Foo", "Bar"]
         ['test1': 'A']                                 | [new JSONObject(name: "a", value:"A"), new JSONObject(name:"b", value:"B"), new JSONObject(name:"c", value:"C")]
-
+        ['test1': 'Bar']                               | [[name: 'bar', value:'Bar']]
     }
 
     def "remote url option validator does not attempt to validate option values plugin values"() {

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -1525,9 +1525,6 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
 
         ExecutionServiceValidationException e = thrown()
-        e.errors.each { k, v ->
-            println("${k} ${v}")
-        }
         e.errors.containsKey('test1')
 
 


### PR DESCRIPTION
Fixes #5314 

**Is this a bugfix, or an enhancement? Please describe.**
Fix

**Describe the solution you've implemented**
`loadOptionsRemoteValues` can return three(?) different shapes for results:
- `List(Collection)<String>` for `['foo','bar']`
- `List<JSONObject>` for `[{"name": "foo", "value": "bar"}]`
- `List<LinkedHashMap>` for `{"foo":"bar"}`

Changing to `instanceof Map` will match both JSONObject and the Groovy map.

**Additional**
I believe at some point the remote option loading could afford to be refactored out into a utility class. Breaking the logic out across multiple methods and ensuring a uniform(typed?) return schema regardless of the supported input JSON shape could help with test-ability and maintainability.