### PR TITLE
Convert encryptorType variable within storage configuration template to lower-case

### DIFF
--- a/docker/official/remco/templates/rundeck-config-storage.properties
+++ b/docker/official/remco/templates/rundeck-config-storage.properties
@@ -16,7 +16,7 @@ rundeck.storage.provider.{{index}}.path={% set path = printf("%s/path", provider
     {%- set index = converter | base %}
 rundeck.storage.converter.{{index}}.type={% set type = printf("%s/type", converter) %}{{ getv(type, "jasypt-encryption") }}
 rundeck.storage.converter.{{index}}.path={% set type = printf("%s/type", converter) %}{{ getv(type, "keys") }}
-rundeck.storage.converter.{{index}}.config.encryptorType={% set type = printf("%s/config/encryptorType", converter) %}{{ getv(type, "custom") }}
+rundeck.storage.converter.{{index}}.config.encryptorType={% set type = printf("%s/config/encryptortype", converter) %}{{ getv(type, "custom") }}
 rundeck.storage.converter.{{index}}.config.password={% set type = printf("%s/config/password", converter) %}{{ getv(type) }}
 rundeck.storage.converter.{{index}}.config.algorithm={% set type = printf("%s/config/algorithm", converter) %}{{ getv(type, "PBEWITHSHA256AND128BITAES-CBC-BC") }}
 rundeck.storage.converter.{{index}}.config.provider={% set type = printf("%s/config/provider", converter) %}{{ getv(type, "BC") }}
@@ -26,7 +26,7 @@ rundeck.storage.converter.{{index}}.config.provider={% set type = printf("%s/con
     {%- set index = converter | base %}
 rundeck.config.storage.converter.{{index}}.type={% set type = printf("%s/type", converter) %}{{ getv(type, "jasypt-encryption") }}
 rundeck.config.storage.converter.{{index}}.path={% set type = printf("%s/type", converter) %}{{ getv(type, "keys") }}
-rundeck.config.storage.converter.{{index}}.config.encryptorType={% set type = printf("%s/config/encryptorType", converter) %}{{ getv(type, "custom") }}
+rundeck.config.storage.converter.{{index}}.config.encryptorType={% set type = printf("%s/config/encryptortype", converter) %}{{ getv(type, "custom") }}
 rundeck.config.storage.converter.{{index}}.config.password={% set type = printf("%s/config/password", converter) %}{{ getv(type) }}
 rundeck.config.storage.converter.{{index}}.config.algorithm={% set type = printf("%s/config/algorithm", converter) %}{{ getv(type, "PBEWITHSHA256AND128BITAES-CBC-BC") }}
 rundeck.config.storage.converter.{{index}}.config.provider={% set type = printf("%s/config/provider", converter) %}{{ getv(type, "BC") }}

--- a/docker/official/remco/templates/rundeck-config-storage.properties
+++ b/docker/official/remco/templates/rundeck-config-storage.properties
@@ -15,7 +15,7 @@ rundeck.storage.provider.{{index}}.path={% set path = printf("%s/path", provider
 {%- macro storage_converter(converter) %}
     {%- set index = converter | base %}
 rundeck.storage.converter.{{index}}.type={% set type = printf("%s/type", converter) %}{{ getv(type, "jasypt-encryption") }}
-rundeck.storage.converter.{{index}}.path={% set type = printf("%s/type", converter) %}{{ getv(type, "keys") }}
+rundeck.storage.converter.{{index}}.path={% set path = printf("%s/path", converter) %}{{ getv(path, "keys") }}
 rundeck.storage.converter.{{index}}.config.encryptorType={% set type = printf("%s/config/encryptortype", converter) %}{{ getv(type, "custom") }}
 rundeck.storage.converter.{{index}}.config.password={% set type = printf("%s/config/password", converter) %}{{ getv(type) }}
 rundeck.storage.converter.{{index}}.config.algorithm={% set type = printf("%s/config/algorithm", converter) %}{{ getv(type, "PBEWITHSHA256AND128BITAES-CBC-BC") }}
@@ -25,7 +25,7 @@ rundeck.storage.converter.{{index}}.config.provider={% set type = printf("%s/con
 {%- macro config_storage_converter(converter) %}
     {%- set index = converter | base %}
 rundeck.config.storage.converter.{{index}}.type={% set type = printf("%s/type", converter) %}{{ getv(type, "jasypt-encryption") }}
-rundeck.config.storage.converter.{{index}}.path={% set type = printf("%s/type", converter) %}{{ getv(type, "keys") }}
+rundeck.config.storage.converter.{{index}}.path={% set path = printf("%s/path", converter) %}{{ getv(path, "keys") }}
 rundeck.config.storage.converter.{{index}}.config.encryptorType={% set type = printf("%s/config/encryptortype", converter) %}{{ getv(type, "custom") }}
 rundeck.config.storage.converter.{{index}}.config.password={% set type = printf("%s/config/password", converter) %}{{ getv(type) }}
 rundeck.config.storage.converter.{{index}}.config.algorithm={% set type = printf("%s/config/algorithm", converter) %}{{ getv(type, "PBEWITHSHA256AND128BITAES-CBC-BC") }}


### PR DESCRIPTION
Variables within remco templates need to be lower-case.