### PR TITLE
Fix invalid default value error on startup against SQL Server

### DIFF
--- a/rundeckapp/webhooks/grails-app/domain/webhooks/Webhook.groovy
+++ b/rundeckapp/webhooks/grails-app/domain/webhooks/Webhook.groovy
@@ -33,6 +33,5 @@ class Webhook {
 
     static mapping = {
         pluginConfigurationJson type: 'text'
-        enabled defaultValue: "true"
     }
 }


### PR DESCRIPTION
Fixes #5326

**Is this a bugfix, or an enhancement? Please describe.**
SQL Server uses a bit for boolean values and will not accept "true" as a default for the column. Hibernate seems to not translate the default, string or boolean, to a 1 or 0 in the DDL statement.

**Describe the solution you've implemented**
Remove the database default value and rely on the default value in the domain object..

**Describe alternatives you've considered**
- Creating a custom dialect(yuck)
- Creating custom per-database create statements(double yuck)

**Additional context**
I'm not aware of any great hibernate provided solutions for this that would be applicable across all supported databases.
