### PR TITLE
Concurrency improvements for workflow state

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowNodeStateImpl.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowNodeStateImpl.groovy
@@ -16,9 +16,12 @@
 
 package com.dtolabs.rundeck.app.internal.workflow
 
-import com.dtolabs.rundeck.core.execution.workflow.state.ExecutionState
+
 import com.dtolabs.rundeck.core.execution.workflow.state.StepIdentifier
 import com.dtolabs.rundeck.core.execution.workflow.state.StepState
+import groovy.transform.CompileStatic
+
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * $INTERFACE is ...
@@ -26,6 +29,7 @@ import com.dtolabs.rundeck.core.execution.workflow.state.StepState
  * Date: 11/13/13
  * Time: 11:43 AM
  */
+@CompileStatic
 class MutableWorkflowNodeStateImpl implements MutableWorkflowNodeState {
     String nodeName
     MutableStepState mutableNodeState
@@ -35,7 +39,7 @@ class MutableWorkflowNodeStateImpl implements MutableWorkflowNodeState {
     MutableWorkflowNodeStateImpl(String nodeName) {
         this.nodeName = nodeName
         mutableNodeState=new MutableStepStateImpl()
-        mutableStepStateMap=new HashMap<StepIdentifier,MutableStepState>()
+        mutableStepStateMap = new ConcurrentHashMap<>()
     }
 
     public StepState getNodeState() {

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStepState.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStepState.groovy
@@ -18,6 +18,7 @@ package com.dtolabs.rundeck.app.internal.workflow
 
 import com.dtolabs.rundeck.core.execution.workflow.state.StepIdentifier
 import com.dtolabs.rundeck.core.execution.workflow.state.StepState
+import com.dtolabs.rundeck.core.execution.workflow.state.StepStateChange
 import com.dtolabs.rundeck.core.execution.workflow.state.WorkflowState
 import com.dtolabs.rundeck.core.execution.workflow.state.WorkflowStepState
 
@@ -44,12 +45,28 @@ public interface MutableWorkflowStepState extends WorkflowStepState{
     Map<String, MutableStepState> getMutableNodeStateMap();
 
     /**
+     * Get or create the mutable step state for a node
+     * @param node
+     * @return mutable state
+     */
+    MutableStepState getOrCreateMutableNodeState(String node);
+
+    /**
      * Return a parameterized step state
      * @param ident
      * @param params
      * @return
      */
     public MutableWorkflowStepState getParameterizedStepState(StepIdentifier ident,Map<String,String> params);
+
+    /**
+     * Update the timestamp and state for a sub step in the workflow
+     * @param identifier
+     * @param index
+     * @param stepStateChange
+     * @param timestamp
+     */
+    void touchStateForSubStep(StepIdentifier identifier, int index, StepStateChange stepStateChange, Date timestamp);
 
     /**
      * Return a map of node name to step states for the step
@@ -67,10 +84,10 @@ public interface MutableWorkflowStepState extends WorkflowStepState{
     MutableWorkflowStepState getOwnerStepState();
 
     /**
-     * Creates a mutable sub workflow state and enables it
+     * Creates a mutable sub workflow state and enables it, or returns existing
      * @return
      */
-    MutableWorkflowState createMutableSubWorkflowState(List<String> nodeSet, long count);
+    MutableWorkflowState getOrCreateMutableSubWorkflowState(List<String> nodeSet, long count);
 
     /**
      * Indicates that the step is a node step with the given targets

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStateImplSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStateImplSpec.groovy
@@ -17,8 +17,10 @@
 package com.dtolabs.rundeck.app.internal.workflow
 
 import com.dtolabs.rundeck.core.execution.workflow.state.ExecutionState
+import com.dtolabs.rundeck.core.execution.workflow.state.StateUtils
 import com.dtolabs.rundeck.core.execution.workflow.state.StepContextId
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static com.dtolabs.rundeck.core.execution.workflow.state.StateUtils.*
 
@@ -189,4 +191,24 @@ class MutableWorkflowStateImplSpec extends Specification {
 
     }
 
+
+    def "locateStepWithContext"() {
+        given:
+            def wf = new MutableWorkflowStateImpl([], 5)
+            wf.mutableStepStates[2].getParameterizedStepState(stepIdentifierFromString('3@node=anode'), [node: 'anode'])
+        when:
+            def result = wf.locateStepWithContext(stepIdentifierFromString(stepId), ndx, ignore)
+        then:
+            result.stepIdentifier.toString() == expect
+        where:
+            stepId                 | ndx | ignore | expect
+            '1'                    | 0   | false  | '1'
+            '1/2/3/4/5'            | 0   | false  | '1'
+            '1/2/3/4/5'            | 1   | false  | '2'
+            '1/2/3/4/5'            | 2   | false  | '3'
+            '1/2/3@node=anode/4/5' | 2   | false  | '3@node=anode'
+            '1/2/3@node=anode/4/5' | 2   | true   | '3'
+            '1/2/3/4/5'            | 3   | false  | '4'
+            '1/2/3/4/5'            | 4   | false  | '5'
+    }
 }

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStateImplTest.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStateImplTest.groovy
@@ -730,6 +730,7 @@ class MutableWorkflowStateImplTest  {
             try{
                 processStateChange(mutableWorkflowState,change)
             }catch (Throwable t){
+                t.printStackTrace(System.err)
                 fail("Error processing change: ${t}: ${ndx}: ${change}")
             }
         }

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStepStateImplTest.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStepStateImplTest.groovy
@@ -58,7 +58,7 @@ class MutableWorkflowStepStateImplTest {
         assertNotNull(resultState)
         assertEquals(test, resultState.ownerStepState)
         assertEquals(identifier, resultState.stepIdentifier)
-        assertEquals([], resultState.mutableSubWorkflowState.nodeSet)
+        assertEquals(['test1'], resultState.mutableSubWorkflowState.nodeSet)
         assertEquals(1, resultState.mutableSubWorkflowState.stepCount)
     }
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Fix potential race conditions/concurrency issues found in the workflow state management code

**Describe the solution you've implemented**

* use ConcurrentHashMap, put/computeIfAbsent

**Additional context**

Unreproduced issue: large workflow with lots of concurrency can appear to having missing steps in the Node summary view, the state.json appears to miss some of the status info for some steps/nodes. the log reflects the steps as having correctly executed, but they are not shown in the Node step listing. Code review suggests potential race conditions due to unsafe concurrency.
