### PR TITLE
Fix job group expansion applying to all levels

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/application.js
+++ b/rundeckapp/grails-app/assets/javascripts/application.js
@@ -120,8 +120,8 @@ var Expander = {
     if (content.length < 1) {
       holder = e.closest(".expandComponentHolder")
       if (holder) {
-        content = holder.find(".expandComponent")
-        icnh = holder.find(".expandComponentControl")
+        content = holder.find(".expandComponent").first()
+        icnh = holder.find(".expandComponentControl").first()
       }
     } else {
       if (e.hasClass('expandComponentControl')) {
@@ -130,7 +130,7 @@ var Expander = {
       if (e.hasClass('expandComponentHolder')) {
         holder = e;
         if (!icnh) {
-          icnh = holder.find(".expandComponentControl")
+          icnh = holder.find(".expandComponentControl").first()
         }
       } else {
         holder = e.closest(".expandComponentHolder")
@@ -140,7 +140,7 @@ var Expander = {
     if (content.length) {
       value = !content.is(':visible')
     } else if (icnh) {
-      var icn = icnh.find('.glyphicon')
+      var icn = icnh.find('.glyphicon').first()
       if (icn) {
         value = icn.hasClass('glyphicon-chevron-down')
       }
@@ -159,8 +159,8 @@ var Expander = {
     if (content.length < 1) {
       holder = e.closest(".expandComponentHolder")
       if (holder.length) {
-        content = holder.find(".expandComponent")
-        icnh = holder.find(".expandComponentControl")
+        content = holder.find(".expandComponent").first()
+        icnh = holder.find(".expandComponentControl").first()
       }
     }
     if (!holder.length || !icnh.length) {
@@ -170,7 +170,7 @@ var Expander = {
       if (e.hasClass('expandComponentHolder')) {
         holder = e;
         if (icnh.length) {
-          icnh = holder.find(".expandComponentControl")
+          icnh = holder.find(".expandComponentControl").first()
         }
       } else {
         holder = e.closest(".expandComponentHolder")


### PR DESCRIPTION
Fixes #5119 

**Is this a bugfix, or an enhancement? Please describe.**
Fixes a regression introduced in https://github.com/rundeck/rundeck/commit/0ffc45327e8947918a56ff18110ed34a694dd86b .


**Describe the solution you've implemented**
Prototype's `down` does not have a precise equivalent in JQuery; it returns the first descendant where as `find` returns all the matching descendants. Adding `first` approximates `down` all though it may be less performant..

![expando](https://user-images.githubusercontent.com/271965/66245375-0fdadb80-e6d3-11e9-805d-556a31de672a.gif)
