### PR TITLE
New ACL for enterprise cluster view.

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
@@ -900,6 +900,7 @@ public class AclTool extends BaseTool {
                     ACLConstants.ACTION_READ,
                     ACLConstants.ACTION_ENABLE_EXECUTIONS,
                     ACLConstants.ACTION_DISABLE_EXECUTIONS,
+                    ACLConstants.ACTION_CLUSTER_VIEW,
                     ACLConstants.ACTION_ADMIN
             );
     static final List<String> appSystemAclKindActions =
@@ -1996,6 +1997,8 @@ public class AclTool extends BaseTool {
         public static final String ACTION_SCM_DELETE="scm_delete";
         public static final String ACTION_SCM_IMPORT = "scm_import";
         public static final String ACTION_SCM_EXPORT = "scm_export";
+        public static final String ACTION_CLUSTER_VIEW = "cluster";
+
 
         public static final String TYPE_SYSTEM = "system";
         public static final String TYPE_SYSTEM_ACL = "system_acl";

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/authorization/AuthConstants.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/authorization/AuthConstants.java
@@ -62,6 +62,8 @@ public class AuthConstants {
     public static final String SCM_DELETE="scm_delete";
     public static final String SCM_IMPORT = "scm_import";
     public static final String SCM_EXPORT = "scm_export";
+    public static final String ACTION_CLUSTER_VIEW = "cluster";
+
 
     public static final String TYPE_SYSTEM = "system";
     public static final String TYPE_SYSTEM_ACL = "system_acl";


### PR DESCRIPTION
Fix #5348 
Add new ACL rule for cluster view on Rundeck Enterprise

```
for:
  resource:
  - allow:
    - cluster
    equals:
      kind: system
context:
  application: rundeck
```