### PR TITLE
Travis env fix: use trusty distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env: MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=192m" GRADLE_OPTS="-Xmx1024m -XX:MaxP
   TERM="dumb"
 jdk:
 - oraclejdk8
+dist: trusty
 sudo: required
 services:
 - docker


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Trying to fix travis builds failing to install oracle jdk 8
