### PR TITLE
Fix error when attempting to download text log

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -781,6 +781,7 @@ class ExecutionController extends ControllerBase{
         def iterator = reader.reader
         iterator.openStream(0)
         def lineSep=System.getProperty("line.separator")
+        boolean nooutput = true
         iterator.each { LogEvent msgbuf ->
             if (msgbuf.eventType != LogUtil.EVENT_TYPE_LOG) {
                 return
@@ -792,9 +793,11 @@ class ExecutionController extends ControllerBase{
                 } catch (Exception exc) {
                 }
             }
+            nooutput = false
             appendOutput(response, (isFormatted?"${logFormater.format(msgbuf.datetime)} [${msgbuf.metadata?.user}@${msgbuf.metadata?.node} ${msgbuf.metadata?.stepctx?:'_'}][${msgbuf.loglevel}] ${message}" : message))
             appendOutput(response, lineSep)
         }
+        if(nooutput) appendOutput(response, "No output")
         iterator.close()
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -19,6 +19,8 @@ package rundeck.controllers
 import asset.pipeline.grails.AssetMethodTagLib
 import asset.pipeline.grails.AssetProcessorService
 import com.dtolabs.rundeck.app.internal.logging.DefaultLogEvent
+import com.dtolabs.rundeck.app.internal.logging.FSStreamingLogReader
+import com.dtolabs.rundeck.app.internal.logging.RundeckLogFormat
 import com.dtolabs.rundeck.app.support.ExecutionQuery
 import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
@@ -32,6 +34,7 @@ import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import grails.test.mixin.TestMixin
 import grails.test.mixin.web.GroovyPageUnitTestMixin
+import groovy.mock.interceptor.MockFor
 import groovy.xml.MarkupBuilder
 import org.grails.plugins.codecs.JSONCodec
 import org.rundeck.app.AppConstants
@@ -871,5 +874,39 @@ class ExecutionControllerSpec extends Specification {
             true         | "true"      |  true          | "false" | false
             true         | "true"      |  false         | null    | false
 
+    }
+
+    void "downloadOutput with no entries in log"(){
+
+        setup:
+        File tf1 = File.createTempFile("test.", "txt")
+        tf1.deleteOnExit()
+        def fos = new OutputStreamWriter(new FileOutputStream(tf1))
+        fos << """^text/x-rundeck-log-v2.0^
+^2019-07-09T12:56:35Z|stepbegin||{node=server-node|step=1|stepctx=1|user=admin}|^
+^2019-07-09T12:56:35Z|nodebegin||{node=remote-node|step=1|stepctx=1|user=remote}|^
+^2019-07-09T12:56:45Z|nodeend||{node=remote-node|step=1|stepctx=1|user=remote}|^
+^2019-07-09T12:56:45Z|stepend||{node=server-node|step=1|stepctx=1|user=admin}|^
+^END^"""
+        fos.close()
+
+        Execution e1 = new Execution(outputfilepath: tf1.absolutePath,project:'test1',user:'bob',dateStarted: new Date())
+        e1.save()
+        controller.loggingService = Mock(LoggingService) {
+            getLogReader(_) >> new ExecutionLogReader(state: ExecutionFileState.AVAILABLE, reader: new FSStreamingLogReader(tf1, "UTF-8", new RundeckLogFormat()))
+        }
+        controller.frameworkService = Mock(FrameworkService) {
+            getFrameworkPropertyResolver(_,_) >> null
+        }
+
+        when:
+        params.id = e1.id.toString()
+        params.formatted = 'true'
+        params.timeZone = 'GMT'
+
+        controller.downloadOutput()
+
+        then:
+        response.text == "No output"
     }
 }


### PR DESCRIPTION
Fixes #5358. If there are no log entries in the log then "No output" will be written to the output stream to avoid triggering a grails error.
