### PR TITLE
 Move AuthConstants.java from grails app to core 

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
@@ -22,6 +22,7 @@ import com.dtolabs.rundeck.core.authentication.Username;
 import com.dtolabs.rundeck.core.authorization.*;
 import com.dtolabs.rundeck.core.authorization.providers.*;
 import com.dtolabs.rundeck.core.cli.*;
+import com.dtolabs.rundeck.core.common.AuthConstants;
 import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.common.FrameworkProject;
 import org.apache.commons.cli.*;
@@ -616,7 +617,7 @@ public class AclTool extends BaseTool {
         if(null!=argProject){
             HashMap<String, Object> res = new HashMap<>();
             res.put("name", argProject);
-            Map<String,Object> resourceMap = AuthorizationUtil.resourceRule(ACLConstants.TYPE_PROJECT, res);
+            Map<String,Object> resourceMap = AuthorizationUtil.resourceRule(AuthConstants.TYPE_PROJECT, res);
 
             logDecisions(
                     "project named \"" + argProject+"\"",
@@ -632,7 +633,7 @@ public class AclTool extends BaseTool {
         if(null!=argProjectAcl){
             HashMap<String, Object> res = new HashMap<>();
             res.put("name", argProjectAcl);
-            Map<String,Object> resourceMap = AuthorizationUtil.resourceRule(ACLConstants.TYPE_PROJECT_ACL, res);
+            Map<String,Object> resourceMap = AuthorizationUtil.resourceRule(AuthConstants.TYPE_PROJECT_ACL, res);
 
             logDecisions(
                     "project_acl for Project named \"" + argProjectAcl+"\"",
@@ -828,124 +829,124 @@ public class AclTool extends BaseTool {
 
     static final Set<String> projectTypes = new HashSet<>(
             Arrays.asList(
-                    ACLConstants.TYPE_ADHOC,
-                    ACLConstants.TYPE_JOB,
-                    ACLConstants.TYPE_NODE
+                    AuthConstants.TYPE_ADHOC,
+                    AuthConstants.TYPE_JOB,
+                    AuthConstants.TYPE_NODE
             )
     );
     static final Set<String> projectKinds = new HashSet<>(
             Arrays.asList(
-                    ACLConstants.TYPE_JOB,
-                    ACLConstants.TYPE_NODE,
-                    ACLConstants.TYPE_EVENT
+                    AuthConstants.TYPE_JOB,
+                    AuthConstants.TYPE_NODE,
+                    AuthConstants.TYPE_EVENT
             )
     );
     static final Set<String> appTypes = new HashSet<>(
             Arrays.asList(
-                    ACLConstants.TYPE_PROJECT,
-                    ACLConstants.TYPE_PROJECT_ACL,
-                    ACLConstants.TYPE_STORAGE,
-                    ACLConstants.TYPE_APITOKEN
+                    AuthConstants.TYPE_PROJECT,
+                    AuthConstants.TYPE_PROJECT_ACL,
+                    AuthConstants.TYPE_STORAGE,
+                    AuthConstants.TYPE_APITOKEN
             )
     );
     static final Set<String> appKinds = new HashSet<>(
             Arrays.asList(
-                    ACLConstants.TYPE_PROJECT,
-                    ACLConstants.TYPE_SYSTEM,
-                    ACLConstants.TYPE_SYSTEM_ACL,
-                    ACLConstants.TYPE_USER,
-                    ACLConstants.TYPE_JOB,
-                    ACLConstants.TYPE_APITOKEN,
-                    ACLConstants.TYPE_PLUGIN
+                    AuthConstants.TYPE_PROJECT,
+                    AuthConstants.TYPE_SYSTEM,
+                    AuthConstants.TYPE_SYSTEM_ACL,
+                    AuthConstants.TYPE_USER,
+                    AuthConstants.TYPE_JOB,
+                    AuthConstants.TYPE_APITOKEN,
+                    AuthConstants.TYPE_PLUGIN
             )
     );
 
     static final List<String> appProjectActions =
             Arrays.asList(
-                    ACLConstants.ACTION_ADMIN,
-                    ACLConstants.ACTION_READ,
-                    ACLConstants.ACTION_CONFIGURE,
-                    ACLConstants.ACTION_DELETE,
-                    ACLConstants.ACTION_IMPORT,
-                    ACLConstants.ACTION_EXPORT,
-                    ACLConstants.ACTION_DELETE_EXECUTION,
-                    ACLConstants.ACTION_SCM_IMPORT,
-                    ACLConstants.ACTION_SCM_EXPORT
+                    AuthConstants.ACTION_ADMIN,
+                    AuthConstants.ACTION_READ,
+                    AuthConstants.ACTION_CONFIGURE,
+                    AuthConstants.ACTION_DELETE,
+                    AuthConstants.ACTION_IMPORT,
+                    AuthConstants.ACTION_EXPORT,
+                    AuthConstants.ACTION_DELETE_EXECUTION,
+                    AuthConstants.ACTION_SCM_IMPORT,
+                    AuthConstants.ACTION_SCM_EXPORT
             );
     static final List<String> appProjectAclActions =
             Arrays.asList(
-                    ACLConstants.ACTION_READ,
-                    ACLConstants.ACTION_CREATE,
-                    ACLConstants.ACTION_UPDATE,
-                    ACLConstants.ACTION_DELETE,
-                    ACLConstants.ACTION_ADMIN
+                    AuthConstants.ACTION_READ,
+                    AuthConstants.ACTION_CREATE,
+                    AuthConstants.ACTION_UPDATE,
+                    AuthConstants.ACTION_DELETE,
+                    AuthConstants.ACTION_ADMIN
             );
     static final List<String> appStorageActions =
             Arrays.asList(
-                    ACLConstants.ACTION_CREATE,
-                    ACLConstants.ACTION_READ,
-                    ACLConstants.ACTION_UPDATE,
-                    ACLConstants.ACTION_DELETE
+                    AuthConstants.ACTION_CREATE,
+                    AuthConstants.ACTION_READ,
+                    AuthConstants.ACTION_UPDATE,
+                    AuthConstants.ACTION_DELETE
             );
     static final List<String> appApitokenActions =
             Arrays.asList(
-                    ACLConstants.ACTION_CREATE
+                    AuthConstants.ACTION_CREATE
             );
     static final List<String> appProjectKindActions =
             Arrays.asList(
-                    ACLConstants.ACTION_CREATE
+                    AuthConstants.ACTION_CREATE
             );
     static final List<String> appSystemKindActions =
             Arrays.asList(
-                    ACLConstants.ACTION_READ,
-                    ACLConstants.ACTION_ENABLE_EXECUTIONS,
-                    ACLConstants.ACTION_DISABLE_EXECUTIONS,
-                    ACLConstants.ACTION_ADMIN
+                    AuthConstants.ACTION_READ,
+                    AuthConstants.ACTION_ENABLE_EXECUTIONS,
+                    AuthConstants.ACTION_DISABLE_EXECUTIONS,
+                    AuthConstants.ACTION_ADMIN
             );
     static final List<String> appSystemAclKindActions =
             Arrays.asList(
-                    ACLConstants.ACTION_READ,
-                    ACLConstants.ACTION_CREATE,
-                    ACLConstants.ACTION_UPDATE,
-                    ACLConstants.ACTION_DELETE,
-                    ACLConstants.ACTION_ADMIN
+                    AuthConstants.ACTION_READ,
+                    AuthConstants.ACTION_CREATE,
+                    AuthConstants.ACTION_UPDATE,
+                    AuthConstants.ACTION_DELETE,
+                    AuthConstants.ACTION_ADMIN
             );
     static final List<String> appUserKindActions =
             Arrays.asList(
-                    ACLConstants.ACTION_ADMIN
+                    AuthConstants.ACTION_ADMIN
             );
     static final List<String> appJobKindActions =
             Arrays.asList(
-                    ACLConstants.ACTION_ADMIN
+                    AuthConstants.ACTION_ADMIN
             );
     static final List<String> appApitokenKindActions =
             Arrays.asList(
-                    ACLConstants.ACTION_ADMIN,
-                    ACLConstants.ACTION_GENERATE_USER_TOKEN,
-                    ACLConstants.ACTION_GENERATE_SERVICE_TOKEN
+                    AuthConstants.ACTION_ADMIN,
+                    AuthConstants.ACTION_GENERATE_USER_TOKEN,
+                    AuthConstants.ACTION_GENERATE_SERVICE_TOKEN
             );
     static final Map<String, List<String>> appResActionsByType;
     static final Map<String, List<String>> appResAttrsByType;
 
-    static final List<String> appPluginActions = Arrays.asList(ACLConstants.ACTION_READ,
-                                                            ACLConstants.ACTION_INSTALL,
-                                                            ACLConstants.ACTION_UNINSTALL,
-                                                            ACLConstants.ACTION_ADMIN);
+    static final List<String> appPluginActions = Arrays.asList(AuthConstants.ACTION_READ,
+                                                            AuthConstants.ACTION_INSTALL,
+                                                            AuthConstants.ACTION_UNINSTALL,
+                                                            AuthConstants.ACTION_ADMIN);
 
     static {
         appResActionsByType = new HashMap<>();
-        appResActionsByType.put(ACLConstants.TYPE_PROJECT, appProjectActions);
-        appResActionsByType.put(ACLConstants.TYPE_PROJECT_ACL, appProjectAclActions);
-        appResActionsByType.put(ACLConstants.TYPE_STORAGE, appStorageActions);
-        appResActionsByType.put(ACLConstants.TYPE_APITOKEN, appApitokenActions);
+        appResActionsByType.put(AuthConstants.TYPE_PROJECT, appProjectActions);
+        appResActionsByType.put(AuthConstants.TYPE_PROJECT_ACL, appProjectAclActions);
+        appResActionsByType.put(AuthConstants.TYPE_STORAGE, appStorageActions);
+        appResActionsByType.put(AuthConstants.TYPE_APITOKEN, appApitokenActions);
     }
 
     static {
         appResAttrsByType = new HashMap<>();
-        appResAttrsByType.put(ACLConstants.TYPE_PROJECT, Collections.singletonList("name"));
-        appResAttrsByType.put(ACLConstants.TYPE_PROJECT_ACL, Collections.singletonList("name"));
-        appResAttrsByType.put(ACLConstants.TYPE_STORAGE, Arrays.asList("path", "name"));
-        appResAttrsByType.put(ACLConstants.TYPE_APITOKEN, Arrays.asList("username", "roles"));
+        appResAttrsByType.put(AuthConstants.TYPE_PROJECT, Collections.singletonList("name"));
+        appResAttrsByType.put(AuthConstants.TYPE_PROJECT_ACL, Collections.singletonList("name"));
+        appResAttrsByType.put(AuthConstants.TYPE_STORAGE, Arrays.asList("path", "name"));
+        appResAttrsByType.put(AuthConstants.TYPE_APITOKEN, Arrays.asList("username", "roles"));
 
     }
 
@@ -954,67 +955,67 @@ public class AclTool extends BaseTool {
     static {
 
         appKindActionsByType = new HashMap<>();
-        appKindActionsByType.put(ACLConstants.TYPE_PROJECT, appProjectKindActions);
-        appKindActionsByType.put(ACLConstants.TYPE_SYSTEM, appSystemKindActions);
-        appKindActionsByType.put(ACLConstants.TYPE_SYSTEM_ACL, appSystemAclKindActions);
-        appKindActionsByType.put(ACLConstants.TYPE_USER, appUserKindActions);
-        appKindActionsByType.put(ACLConstants.TYPE_JOB, appJobKindActions);
-        appKindActionsByType.put(ACLConstants.TYPE_APITOKEN, appApitokenKindActions);
-        appKindActionsByType.put(ACLConstants.TYPE_PLUGIN, appPluginActions);
+        appKindActionsByType.put(AuthConstants.TYPE_PROJECT, appProjectKindActions);
+        appKindActionsByType.put(AuthConstants.TYPE_SYSTEM, appSystemKindActions);
+        appKindActionsByType.put(AuthConstants.TYPE_SYSTEM_ACL, appSystemAclKindActions);
+        appKindActionsByType.put(AuthConstants.TYPE_USER, appUserKindActions);
+        appKindActionsByType.put(AuthConstants.TYPE_JOB, appJobKindActions);
+        appKindActionsByType.put(AuthConstants.TYPE_APITOKEN, appApitokenKindActions);
+        appKindActionsByType.put(AuthConstants.TYPE_PLUGIN, appPluginActions);
     }
 
 
     static final List<String> projectJobActions =
             Arrays.asList(
-                    ACLConstants.ACTION_READ,
-                    ACLConstants.ACTION_VIEW,
-                    ACLConstants.ACTION_UPDATE,
-                    ACLConstants.ACTION_DELETE,
-                    ACLConstants.ACTION_RUN,
-                    ACLConstants.ACTION_RUNAS,
-                    ACLConstants.ACTION_KILL,
-                    ACLConstants.ACTION_KILLAS,
-                    ACLConstants.ACTION_CREATE,
-                    ACLConstants.ACTION_TOGGLE_EXECUTION,
-                    ACLConstants.ACTION_TOGGLE_SCHEDULE,
-                    ACLConstants.ACTION_SCM_UPDATE,
-                    ACLConstants.ACTION_SCM_CREATE,
-                    ACLConstants.ACTION_SCM_DELETE
+                    AuthConstants.ACTION_READ,
+                    AuthConstants.ACTION_VIEW,
+                    AuthConstants.ACTION_UPDATE,
+                    AuthConstants.ACTION_DELETE,
+                    AuthConstants.ACTION_RUN,
+                    AuthConstants.ACTION_RUNAS,
+                    AuthConstants.ACTION_KILL,
+                    AuthConstants.ACTION_KILLAS,
+                    AuthConstants.ACTION_CREATE,
+                    AuthConstants.ACTION_TOGGLE_EXECUTION,
+                    AuthConstants.ACTION_TOGGLE_SCHEDULE,
+                    AuthConstants.ACTION_SCM_UPDATE,
+                    AuthConstants.ACTION_SCM_CREATE,
+                    AuthConstants.ACTION_SCM_DELETE
             );
     static final List<String> projectJobKindActions =
             Arrays.asList(
-                    ACLConstants.ACTION_CREATE,
-                    ACLConstants.ACTION_DELETE
+                    AuthConstants.ACTION_CREATE,
+                    AuthConstants.ACTION_DELETE
             );
     static final List<String> projectAdhocActions =
             Arrays.asList(
-                    ACLConstants.ACTION_READ,
-                    ACLConstants.ACTION_VIEW,
-                    ACLConstants.ACTION_RUN,
-                    ACLConstants.ACTION_RUNAS,
-                    ACLConstants.ACTION_KILL,
-                    ACLConstants.ACTION_KILLAS
+                    AuthConstants.ACTION_READ,
+                    AuthConstants.ACTION_VIEW,
+                    AuthConstants.ACTION_RUN,
+                    AuthConstants.ACTION_RUNAS,
+                    AuthConstants.ACTION_KILL,
+                    AuthConstants.ACTION_KILLAS
             );
     static final List<String> projectNodeActions =
             Arrays.asList(
-                    ACLConstants.ACTION_READ,
-                    ACLConstants.ACTION_RUN
+                    AuthConstants.ACTION_READ,
+                    AuthConstants.ACTION_RUN
             );
     static final Map<String, List<String>> projResActionsByType;
     static final Map<String, List<String>> projResAttrsByType;
 
     static {
         projResActionsByType = new HashMap<>();
-        projResActionsByType.put(ACLConstants.TYPE_JOB, projectJobActions);
-        projResActionsByType.put(ACLConstants.TYPE_ADHOC, projectAdhocActions);
-        projResActionsByType.put(ACLConstants.TYPE_NODE, projectNodeActions);
+        projResActionsByType.put(AuthConstants.TYPE_JOB, projectJobActions);
+        projResActionsByType.put(AuthConstants.TYPE_ADHOC, projectAdhocActions);
+        projResActionsByType.put(AuthConstants.TYPE_NODE, projectNodeActions);
     }
 
 
     static {
         projResAttrsByType = new HashMap<>();
-        projResAttrsByType.put(ACLConstants.TYPE_JOB, Arrays.asList("group", "name", "uuid"));
-        projResAttrsByType.put(ACLConstants.TYPE_ADHOC, new ArrayList<String>());
+        projResAttrsByType.put(AuthConstants.TYPE_JOB, Arrays.asList("group", "name", "uuid"));
+        projResAttrsByType.put(AuthConstants.TYPE_ADHOC, new ArrayList<String>());
         List<String> nodeAttributeNames = Arrays.asList(
                 "nodename",
                 "rundeck_server",
@@ -1024,29 +1025,29 @@ public class AclTool extends BaseTool {
                 "osVersion",
                 "(etc. any node attribute)"
         );
-        projResAttrsByType.put(ACLConstants.TYPE_NODE, nodeAttributeNames);
+        projResAttrsByType.put(AuthConstants.TYPE_NODE, nodeAttributeNames);
     }
 
     static final List<String> projectNodeKindActions =
             Arrays.asList(
-                    ACLConstants.ACTION_READ,
-                    ACLConstants.ACTION_CREATE,
-                    ACLConstants.ACTION_UPDATE,
-                    ACLConstants.ACTION_REFRESH
+                    AuthConstants.ACTION_READ,
+                    AuthConstants.ACTION_CREATE,
+                    AuthConstants.ACTION_UPDATE,
+                    AuthConstants.ACTION_REFRESH
             );
     static final List<String> projectEventKindActions =
             Arrays.asList(
-                    ACLConstants.ACTION_READ,
-                    ACLConstants.ACTION_CREATE
+                    AuthConstants.ACTION_READ,
+                    AuthConstants.ACTION_CREATE
             );
     static final Map<String, List<String>> projKindActionsByType;
 
     static {
 
         projKindActionsByType = new HashMap<>();
-        projKindActionsByType.put(ACLConstants.TYPE_JOB, projectJobKindActions);
-        projKindActionsByType.put(ACLConstants.TYPE_NODE, projectNodeKindActions);
-        projKindActionsByType.put(ACLConstants.TYPE_EVENT, projectEventKindActions);
+        projKindActionsByType.put(AuthConstants.TYPE_JOB, projectJobKindActions);
+        projKindActionsByType.put(AuthConstants.TYPE_NODE, projectNodeKindActions);
+        projKindActionsByType.put(AuthConstants.TYPE_EVENT, projectEventKindActions);
     }
 
     private AuthRequest createAuthRequestFromArgs()
@@ -1106,11 +1107,11 @@ public class AclTool extends BaseTool {
         } else if (argContext == Context.application && argProject != null) {
             HashMap<String, Object> res = new HashMap<>();
             res.put("name", argProject);
-            resourceMap = AuthorizationUtil.resourceRule(ACLConstants.TYPE_PROJECT, res);
+            resourceMap = AuthorizationUtil.resourceRule(AuthConstants.TYPE_PROJECT, res);
         } else if (argContext == Context.application && argProjectAcl != null) {
             HashMap<String, Object> res = new HashMap<>();
             res.put("name", argProjectAcl);
-            resourceMap = AuthorizationUtil.resourceRule(ACLConstants.TYPE_PROJECT_ACL, res);
+            resourceMap = AuthorizationUtil.resourceRule(AuthConstants.TYPE_PROJECT_ACL, res);
         } else if (argContext == Context.application && argAppStorage != null) {
             resourceMap = createStorageResource();
         } else if (argContext == Context.project && argProjectJob != null) {
@@ -1231,7 +1232,7 @@ public class AclTool extends BaseTool {
         if (null != attrsMap && attrsMap.size() > 0) {
             resourceMap.putAll(attrsMap);
         } else if (attrHelp && null != argResource
-                   && !argResource.equalsIgnoreCase(ACLConstants.TYPE_ADHOC)) {
+                   && !argResource.equalsIgnoreCase(AuthConstants.TYPE_ADHOC)) {
             List<String> possibleAttrs =
                     (argContext == Context.application ? appResAttrsByType : projResAttrsByType)
                             .get(argResource.toLowerCase());
@@ -1348,7 +1349,7 @@ public class AclTool extends BaseTool {
         if(null!=argTags) {
             res.put("tags", tagsSet);
         }
-        resourceMap = AuthorizationUtil.resourceRule(ACLConstants.TYPE_NODE, res);
+        resourceMap = AuthorizationUtil.resourceRule(AuthConstants.TYPE_NODE, res);
         return resourceMap;
     }
 
@@ -1362,19 +1363,19 @@ public class AclTool extends BaseTool {
             res.put("group", "");
             res.put("name", argProjectJob);
         }
-        resourceMap = AuthorizationUtil.resourceRule(ACLConstants.TYPE_JOB, res);
+        resourceMap = AuthorizationUtil.resourceRule(AuthConstants.TYPE_JOB, res);
         return resourceMap;
     }
 
     private Map<String, Object> createProjectJobUUIDResource() {
         final Map<String, Object> resourceMap;HashMap<String, Object> res = new HashMap<>();
         res.put("uuid", argProjectJobUUID);
-        resourceMap = AuthorizationUtil.resourceRule(ACLConstants.TYPE_JOB, res);
+        resourceMap = AuthorizationUtil.resourceRule(AuthConstants.TYPE_JOB, res);
         return resourceMap;
     }
     
     private Map<String, Object> createProjectAdhocResource() {
-        return AuthorizationUtil.resourceRule(ACLConstants.TYPE_ADHOC, new HashMap<String, Object>());
+        return AuthorizationUtil.resourceRule(AuthConstants.TYPE_ADHOC, new HashMap<String, Object>());
     }
 
     private Map<String, Object> createStorageResource() {
@@ -1387,7 +1388,7 @@ public class AclTool extends BaseTool {
             res.put("path", argAppStorage);
             res.put("name", argAppStorage);
         }
-        resourceMap = AuthorizationUtil.resourceRule(ACLConstants.TYPE_STORAGE, res);
+        resourceMap = AuthorizationUtil.resourceRule(AuthConstants.TYPE_STORAGE, res);
         return resourceMap;
     }
 
@@ -1965,63 +1966,6 @@ public class AclTool extends BaseTool {
         if (null != clilogger) {
             clilogger.debug(message);
         }
-    }
-
-    class ACLConstants {
-        public static final String ACTION_CREATE = "create";
-        public static final String ACTION_READ = "read";
-        public static final String ACTION_VIEW = "view";
-        public static final String ACTION_UPDATE = "update";
-        public static final String ACTION_DELETE = "delete";
-        public static final String ACTION_RUN = "run";
-        public static final String ACTION_KILL = "kill";
-        public static final String ACTION_ADMIN = "admin";
-        public static final String ACTION_GENERATE_USER_TOKEN = "generate_user_token";
-        public static final String ACTION_GENERATE_SERVICE_TOKEN = "generate_service_token";
-        public static final String ACTION_REFRESH = "refresh";
-        public static final String ACTION_RUNAS = "runAs";
-        public static final String ACTION_KILLAS = "killAs";
-        public static final String ACTION_CONFIGURE = "configure";
-        public static final String ACTION_IMPORT = "import";
-        public static final String ACTION_EXPORT = "export";
-        public static final String ACTION_INSTALL = "install";
-        public static final String ACTION_UNINSTALL = "uninstall";
-        public static final String ACTION_DELETE_EXECUTION = "delete_execution";
-        public static final String ACTION_ENABLE_EXECUTIONS = "enable_executions";
-        public static final String ACTION_DISABLE_EXECUTIONS = "disable_executions";
-        public static final String ACTION_TOGGLE_SCHEDULE = "toggle_schedule";
-        public static final String ACTION_TOGGLE_EXECUTION = "toggle_execution";
-        public static final String ACTION_SCM_UPDATE="scm_update";
-        public static final String ACTION_SCM_CREATE="scm_create";
-        public static final String ACTION_SCM_DELETE="scm_delete";
-        public static final String ACTION_SCM_IMPORT = "scm_import";
-        public static final String ACTION_SCM_EXPORT = "scm_export";
-
-        public static final String TYPE_SYSTEM = "system";
-        public static final String TYPE_SYSTEM_ACL = "system_acl";
-        public static final String TYPE_NODE = "node";
-        public static final String TYPE_JOB = "job";
-        public static final String TYPE_APITOKEN = "apitoken";
-        public static final String TYPE_ADHOC = "adhoc";
-        public static final String TYPE_PROJECT = "project";
-        public static final String TYPE_PROJECT_ACL = "project_acl";
-        public static final String TYPE_PLUGIN = "plugin";
-        public static final String TYPE_EVENT = "event";
-        public static final String TYPE_USER = "user";
-        public static final String TYPE_STORAGE = "storage";
-
-        private Map<String, String> resType(String type) {
-            return Collections.unmodifiableMap(AuthorizationUtil.resourceType(type));
-        }
-
-        public final Map<String, String> RESOURCE_TYPE_SYSTEM = resType(TYPE_SYSTEM);
-        public final Map<String, String> RESOURCE_TYPE_NODE = resType(TYPE_NODE);
-        public final Map<String, String> RESOURCE_TYPE_JOB = resType(TYPE_JOB);
-        public final Map<String, String> RESOURCE_TYPE_EVENT = resType(TYPE_EVENT);
-        public final Map<String, String> RESOURCE_ADHOC = Collections.unmodifiableMap(
-                AuthorizationUtil
-                        .resource(TYPE_ADHOC)
-        );
     }
 
     class OptionsPrompt extends CLIToolOptionsException {

--- a/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/cli/acl/AclTool.java
@@ -22,7 +22,7 @@ import com.dtolabs.rundeck.core.authentication.Username;
 import com.dtolabs.rundeck.core.authorization.*;
 import com.dtolabs.rundeck.core.authorization.providers.*;
 import com.dtolabs.rundeck.core.cli.*;
-import com.dtolabs.rundeck.core.common.AuthConstants;
+import org.rundeck.core.auth.AuthConstants;
 import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.common.FrameworkProject;
 import org.apache.commons.cli.*;

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/AuthConstants.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/AuthConstants.java
@@ -1,38 +1,12 @@
-/*
- * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
-* AuthConstants.java
-* 
-* User: Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
-* Created: 9/1/11 9:20 AM
-* 
-*/
-package com.dtolabs.rundeck.server.authorization;
+package com.dtolabs.rundeck.core.common;
 
 import com.dtolabs.rundeck.core.authorization.AuthorizationUtil;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Map;
 
-/**
- * AuthConstants is ...
- *
- * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
- */
 public class AuthConstants {
+
     public static final String ACTION_CREATE = "create";
     public static final String ACTION_READ = "read";
     public static final String ACTION_VIEW = "view";
@@ -41,13 +15,14 @@ public class AuthConstants {
     public static final String ACTION_RUN = "run";
     public static final String ACTION_KILL = "kill";
     public static final String ACTION_ADMIN = "admin";
+    public static final String ACTION_GENERATE_USER_TOKEN = "generate_user_token";
+    public static final String ACTION_GENERATE_SERVICE_TOKEN = "generate_service_token";
     public static final String ACTION_REFRESH = "refresh";
     public static final String ACTION_RUNAS = "runAs";
     public static final String ACTION_KILLAS = "killAs";
     public static final String ACTION_CONFIGURE = "configure";
     public static final String ACTION_IMPORT = "import";
     public static final String ACTION_EXPORT = "export";
-    public static final String ACTION_PROMOTE = "promote";
     public static final String ACTION_INSTALL = "install";
     public static final String ACTION_UNINSTALL = "uninstall";
     public static final String ACTION_DELETE_EXECUTION = "delete_execution";
@@ -55,13 +30,13 @@ public class AuthConstants {
     public static final String ACTION_DISABLE_EXECUTIONS = "disable_executions";
     public static final String ACTION_TOGGLE_SCHEDULE = "toggle_schedule";
     public static final String ACTION_TOGGLE_EXECUTION = "toggle_execution";
-    public static final String GENERATE_USER_TOKEN = "generate_user_token";
-    public static final String GENERATE_SERVICE_TOKEN="generate_service_token";
-    public static final String SCM_UPDATE="scm_update";
-    public static final String SCM_CREATE="scm_create";
-    public static final String SCM_DELETE="scm_delete";
-    public static final String SCM_IMPORT = "scm_import";
-    public static final String SCM_EXPORT = "scm_export";
+    public static final String ACTION_SCM_UPDATE="scm_update";
+    public static final String ACTION_SCM_CREATE="scm_create";
+    public static final String ACTION_SCM_DELETE="scm_delete";
+    public static final String ACTION_SCM_IMPORT = "scm_import";
+    public static final String ACTION_SCM_EXPORT = "scm_export";
+    public static final String ACTION_PROMOTE = "promote";
+
 
     public static final String TYPE_SYSTEM = "system";
     public static final String TYPE_SYSTEM_ACL = "system_acl";
@@ -71,10 +46,10 @@ public class AuthConstants {
     public static final String TYPE_ADHOC = "adhoc";
     public static final String TYPE_PROJECT = "project";
     public static final String TYPE_PROJECT_ACL = "project_acl";
+    public static final String TYPE_PLUGIN = "plugin";
     public static final String TYPE_EVENT = "event";
     public static final String TYPE_USER = "user";
     public static final String TYPE_STORAGE = "storage";
-    public static final String TYPE_PLUGIN = "plugin";
 
     private static Map<String, String> resType(String type) {
         return Collections.unmodifiableMap(AuthorizationUtil.resourceType(type));

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/AuthConstants.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/AuthConstants.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.dtolabs.rundeck.core.common;
 
 import com.dtolabs.rundeck.core.authorization.AuthorizationUtil;

--- a/core/src/main/java/org/rundeck/core/auth/AuthConstants.java
+++ b/core/src/main/java/org/rundeck/core/auth/AuthConstants.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.dtolabs.rundeck.core.common;
+package org.rundeck.core.auth;
 
 import com.dtolabs.rundeck.core.authorization.AuthorizationUtil;
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -20,7 +20,7 @@ import com.dtolabs.rundeck.app.api.tokens.ListTokens
 import com.dtolabs.rundeck.app.api.tokens.RemoveExpiredTokens
 import com.dtolabs.rundeck.app.api.tokens.Token
 import com.dtolabs.rundeck.core.authorization.AuthContext
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.extension.ApplicationExtension
 import grails.web.mapping.LinkGenerator
 import org.rundeck.util.Sizes

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.app.api.tokens.ListTokens
 import com.dtolabs.rundeck.app.api.tokens.RemoveExpiredTokens
 import com.dtolabs.rundeck.app.api.tokens.Token
 import com.dtolabs.rundeck.core.authorization.AuthContext
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.extension.ApplicationExtension
 import grails.web.mapping.LinkGenerator
 import org.rundeck.util.Sizes
@@ -28,7 +29,6 @@ import rundeck.AuthToken
 import javax.servlet.http.HttpServletResponse
 import java.lang.management.ManagementFactory
 
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import com.dtolabs.rundeck.app.api.ApiVersions
 
 /**

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -25,7 +25,7 @@ import com.dtolabs.rundeck.app.support.ExecutionQuery
 import com.dtolabs.rundeck.app.support.ExecutionQueryException
 import com.dtolabs.rundeck.app.support.ExecutionViewParams
 import com.dtolabs.rundeck.core.authorization.AuthContext
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.PluginDisabledException
 import com.dtolabs.rundeck.core.execution.workflow.state.StateUtils
 import com.dtolabs.rundeck.core.execution.workflow.state.StepIdentifier

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -25,6 +25,7 @@ import com.dtolabs.rundeck.app.support.ExecutionQuery
 import com.dtolabs.rundeck.app.support.ExecutionQueryException
 import com.dtolabs.rundeck.app.support.ExecutionViewParams
 import com.dtolabs.rundeck.core.authorization.AuthContext
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.PluginDisabledException
 import com.dtolabs.rundeck.core.execution.workflow.state.StateUtils
 import com.dtolabs.rundeck.core.execution.workflow.state.StepIdentifier
@@ -37,7 +38,6 @@ import com.dtolabs.rundeck.core.utils.OptsUtil
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
 import com.dtolabs.rundeck.plugins.logs.ContentConverterPlugin
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.converters.JSON
 import groovy.transform.PackageScope
 import org.quartz.JobExecutionContext

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -24,7 +24,7 @@ import com.dtolabs.rundeck.app.support.PluginConfigParams
 import com.dtolabs.rundeck.app.support.StoreFilterCommand
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.Validation
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.IProjectNodes
 import com.dtolabs.rundeck.core.common.IRundeckProject

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -16,17 +16,15 @@
 
 package rundeck.controllers
 
-import com.dtolabs.client.utils.Constants
-import com.dtolabs.rundeck.app.api.ApiVersions
+
 import com.dtolabs.rundeck.app.api.project.sources.Resources
 import com.dtolabs.rundeck.app.api.project.sources.Source
 import com.dtolabs.rundeck.app.api.project.sources.Sources
-import com.dtolabs.rundeck.app.support.BaseNodeFilters
-import com.dtolabs.rundeck.app.support.ExtNodeFilters
 import com.dtolabs.rundeck.app.support.PluginConfigParams
 import com.dtolabs.rundeck.app.support.StoreFilterCommand
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.Validation
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.IProjectNodes
 import com.dtolabs.rundeck.core.common.IRundeckProject
@@ -36,16 +34,10 @@ import com.dtolabs.rundeck.core.execution.service.ExecutionServiceException
 import com.dtolabs.rundeck.core.plugins.ExtPluginConfiguration
 import com.dtolabs.rundeck.core.plugins.SimplePluginConfiguration
 import com.dtolabs.rundeck.core.plugins.ValidatedPlugin
-import com.dtolabs.rundeck.core.execution.service.FileCopierService
-import com.dtolabs.rundeck.core.execution.service.NodeExecutorService
 import com.dtolabs.rundeck.core.resources.ResourceModelSourceException
-import com.dtolabs.rundeck.core.resources.format.ResourceFormatGeneratorException
 import com.dtolabs.rundeck.core.resources.format.ResourceFormatParser
-import com.dtolabs.rundeck.core.resources.format.UnsupportedFormatException
 import com.dtolabs.rundeck.core.utils.NodeSet
 import com.dtolabs.rundeck.core.utils.OptsUtil
-
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.converters.JSON
 import grails.converters.XML
 import grails.web.servlet.mvc.GrailsParameterMap
@@ -78,7 +70,6 @@ import com.dtolabs.rundeck.core.execution.service.NodeExecutorService
 import com.dtolabs.rundeck.core.execution.service.FileCopierService
 
 import com.dtolabs.client.utils.Constants
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import com.dtolabs.rundeck.core.common.NodeSetImpl
 import com.dtolabs.rundeck.core.common.FrameworkResource
 import com.dtolabs.rundeck.app.support.BaseNodeFilters

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -33,6 +33,7 @@ import com.dtolabs.rundeck.app.support.SysAclFile
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.AuthorizationUtil
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.IRundeckProject
@@ -56,7 +57,6 @@ import com.dtolabs.rundeck.plugins.step.RemoteScriptNodeStepPlugin
 import com.dtolabs.rundeck.plugins.step.StepPlugin
 import com.dtolabs.rundeck.plugins.storage.StorageConverterPlugin
 import com.dtolabs.rundeck.plugins.storage.StoragePlugin
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import com.dtolabs.rundeck.server.plugins.services.StorageConverterPluginProviderService
 import com.dtolabs.rundeck.server.plugins.services.StoragePluginProviderService
 import grails.converters.JSON
@@ -479,7 +479,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                                                  frameworkService.authResourceForProject(
                                                                          params.project
                                                                  ),
-                                                                 [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT, AuthConstants.SCM_EXPORT]
+                                                                 [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT, AuthConstants.ACTION_SCM_EXPORT]
             )) {
                 if(frameworkService.isClusterModeEnabled()){
                     if (!scmService.projectHasConfiguredExportPlugin(params.project)) {
@@ -513,7 +513,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                                                  frameworkService.authResourceForProject(
                                                                          params.project
                                                                  ),
-                                                                 [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT, AuthConstants.SCM_IMPORT]
+                                                                 [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT, AuthConstants.ACTION_SCM_IMPORT]
             )) {
                 if(frameworkService.isClusterModeEnabled()){
                     if (!scmService.projectHasConfiguredImportPlugin(params.project)) {
@@ -549,7 +549,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                             params.project
                     ),
                     [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT, AuthConstants.ACTION_IMPORT,
-                     AuthConstants.SCM_IMPORT, AuthConstants.SCM_EXPORT]
+                     AuthConstants.ACTION_SCM_IMPORT, AuthConstants.ACTION_SCM_EXPORT]
             )) {
                 if (minScm) {
                     def pluginData = [:]
@@ -3241,7 +3241,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     frameworkService.authResourceForProject(
                             params.project
                     ),
-                    [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT,  AuthConstants.SCM_EXPORT]
+                    [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT,  AuthConstants.ACTION_SCM_EXPORT]
             )) {
                 def pluginData = [:]
                 if (frameworkService.isClusterModeEnabled()) {
@@ -3267,7 +3267,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     frameworkService.authResourceForProject(
                             params.project
                     ),
-                    [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT, AuthConstants.SCM_IMPORT]
+                    [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT, AuthConstants.ACTION_SCM_IMPORT]
             )) {
                 if (frameworkService.isClusterModeEnabled()) {
                     //initialize if in another node

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -33,7 +33,6 @@ import com.dtolabs.rundeck.app.support.SysAclFile
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.AuthorizationUtil
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
-import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.IRundeckProject
@@ -63,6 +62,7 @@ import grails.converters.JSON
 import groovy.transform.PackageScope
 import groovy.xml.MarkupBuilder
 import org.grails.plugins.metricsweb.MetricService
+import org.rundeck.core.auth.AuthConstants
 import org.rundeck.util.Sizes
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
@@ -2,9 +2,9 @@ package rundeck.controllers
 
 import com.dtolabs.rundeck.app.support.PluginResourceReq
 import com.dtolabs.rundeck.core.authorization.AuthContext
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.plugins.PluginValidator
 import com.dtolabs.rundeck.core.plugins.configuration.PluginAdapterUtility
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import com.dtolabs.rundeck.server.plugins.services.UIPluginProviderService
 import grails.converters.JSON
 import groovy.transform.CompileStatic

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
@@ -2,7 +2,7 @@ package rundeck.controllers
 
 import com.dtolabs.rundeck.app.support.PluginResourceReq
 import com.dtolabs.rundeck.core.authorization.AuthContext
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.plugins.PluginValidator
 import com.dtolabs.rundeck.core.plugins.configuration.PluginAdapterUtility
 import com.dtolabs.rundeck.server.plugins.services.UIPluginProviderService

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
@@ -21,10 +21,10 @@ import com.dtolabs.rundeck.app.support.ProjectArchiveParams
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.authorization.Validation
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.FrameworkResource
 import com.dtolabs.rundeck.core.common.IRundeckProject
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import com.dtolabs.rundeck.app.api.ApiVersions
 import grails.converters.JSON
 import org.apache.commons.lang.StringUtils

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
@@ -21,13 +21,13 @@ import com.dtolabs.rundeck.app.support.ProjectArchiveParams
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.authorization.Validation
-import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.FrameworkResource
 import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.app.api.ApiVersions
 import grails.converters.JSON
 import org.apache.commons.lang.StringUtils
+import org.rundeck.core.auth.AuthConstants
 import rundeck.Project
 import rundeck.services.ApiService
 import rundeck.services.ArchiveOptions

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
@@ -21,8 +21,8 @@ import com.dtolabs.rundeck.app.support.ExecQueryFilterCommand
 import com.dtolabs.rundeck.app.support.StoreFilterCommand
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.AuthorizationUtil
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.converters.JSON
 import org.grails.plugins.metricsweb.MetricService
 import rundeck.Execution

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
@@ -21,7 +21,7 @@ import com.dtolabs.rundeck.app.support.ExecQueryFilterCommand
 import com.dtolabs.rundeck.app.support.StoreFilterCommand
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.AuthorizationUtil
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import grails.converters.JSON
 import org.grails.plugins.metricsweb.MetricService

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -27,13 +27,13 @@ import com.dtolabs.rundeck.app.support.RunJobCommand
 import com.dtolabs.rundeck.core.authentication.Group
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.INodeEntry
 import com.dtolabs.rundeck.core.common.NodeSetImpl
 import com.dtolabs.rundeck.core.utils.NodeSet
 import com.dtolabs.rundeck.core.utils.OptsUtil
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.converters.JSON
 import groovy.xml.MarkupBuilder
 import org.apache.commons.collections.list.TreeList
@@ -281,7 +281,7 @@ class ScheduledExecutionController  extends ControllerBase{
             if (frameworkService.authorizeApplicationResourceAny(authContext,
                                                                  frameworkService.authResourceForProject(params.project),
                                                                  [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT,
-                                                                  AuthConstants.SCM_EXPORT])) {
+                                                                  AuthConstants.ACTION_SCM_EXPORT])) {
                 if(scmService.projectHasConfiguredExportPlugin(params.project)) {
                     model.scmExportEnabled = true
                     model.scmExportStatus = scmService.exportStatusForJobs(authContext, [scheduledExecution])
@@ -291,7 +291,7 @@ class ScheduledExecutionController  extends ControllerBase{
             if (frameworkService.authorizeApplicationResourceAny(authContext,
                                                                  frameworkService.authResourceForProject(params.project),
                                                                  [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT,
-                                                                  AuthConstants.SCM_IMPORT])) {
+                                                                  AuthConstants.ACTION_SCM_IMPORT])) {
                 if(scmService.projectHasConfiguredPlugin('import',params.project)) {
                     model.scmImportEnabled = true
                     model.scmImportStatus = scmService.importStatusForJobs(authContext, [scheduledExecution])
@@ -491,7 +491,7 @@ class ScheduledExecutionController  extends ControllerBase{
         if (frameworkService.authorizeApplicationResourceAny(authContext,
                                                              projectResource,
                                                              [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT,
-                                                              AuthConstants.SCM_EXPORT])) {
+                                                              AuthConstants.ACTION_SCM_EXPORT])) {
             if(scmService.projectHasConfiguredExportPlugin(params.project)){
                 dataMap.scmExportEnabled = true
                 dataMap.scmExportStatus = scmService.exportStatusForJob(scheduledExecution)
@@ -501,7 +501,7 @@ class ScheduledExecutionController  extends ControllerBase{
         if (frameworkService.authorizeApplicationResourceAny(authContext,
                                                              projectResource,
                                                              [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT,
-                                                              AuthConstants.SCM_IMPORT])) {
+                                                              AuthConstants.ACTION_SCM_IMPORT])) {
             if(scmService.projectHasConfiguredPlugin('import',params.project)) {
                 dataMap.scmImportEnabled = true
                 dataMap.scmImportStatus = scmService.importStatusForJobs(authContext, [scheduledExecution])

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -27,7 +27,7 @@ import com.dtolabs.rundeck.app.support.RunJobCommand
 import com.dtolabs.rundeck.core.authentication.Group
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.INodeEntry
 import com.dtolabs.rundeck.core.common.NodeSetImpl

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -43,7 +43,7 @@ import com.dtolabs.rundeck.app.api.scm.ScmProjectStatus
 import com.dtolabs.rundeck.app.support.ScheduledExecutionQuery
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.plugins.configuration.Property
 import com.dtolabs.rundeck.core.plugins.views.Action
 import com.dtolabs.rundeck.core.plugins.views.BasicInputView

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -43,6 +43,7 @@ import com.dtolabs.rundeck.app.api.scm.ScmProjectStatus
 import com.dtolabs.rundeck.app.support.ScheduledExecutionQuery
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.plugins.configuration.Property
 import com.dtolabs.rundeck.core.plugins.views.Action
 import com.dtolabs.rundeck.core.plugins.views.BasicInputView
@@ -57,7 +58,6 @@ import com.dtolabs.rundeck.plugins.scm.ScmImportSynchState
 import com.dtolabs.rundeck.plugins.scm.ScmImportTrackedItem
 import com.dtolabs.rundeck.plugins.scm.ScmPluginException
 import com.dtolabs.rundeck.plugins.scm.SynchState
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
 import rundeck.ScheduledExecution
 import com.dtolabs.rundeck.app.api.ApiVersions
@@ -622,7 +622,7 @@ class ScmController extends ControllerBase {
 
         def isExport = scm.integration == 'export'
         def action = isExport ? AuthConstants.ACTION_EXPORT : AuthConstants.ACTION_IMPORT
-        def scmAction = isExport ? AuthConstants.SCM_EXPORT : AuthConstants.SCM_IMPORT
+        def scmAction = isExport ? AuthConstants.ACTION_SCM_EXPORT : AuthConstants.ACTION_SCM_IMPORT
 
         def authContext = apiAuthorize(scm.project, [action,scmAction], action)
         if (!authContext) {
@@ -738,7 +738,7 @@ class ScmController extends ControllerBase {
 
         def isExport = scm.integration == 'export'
         def action = isExport ? AuthConstants.ACTION_EXPORT : AuthConstants.ACTION_IMPORT
-        def scmAction = isExport ? AuthConstants.SCM_EXPORT : AuthConstants.SCM_IMPORT
+        def scmAction = isExport ? AuthConstants.ACTION_SCM_EXPORT : AuthConstants.ACTION_SCM_IMPORT
 
         def authContext = apiAuthorize(scm.project, [action,scmAction], action)
         if (!authContext) {
@@ -915,7 +915,7 @@ class ScmController extends ControllerBase {
     private BasicInputView validateView(String project, ActionRequest scm) {
         def isExport = scm.integration == 'export'
         def action = isExport ? AuthConstants.ACTION_EXPORT : AuthConstants.ACTION_IMPORT
-        def scmAction = isExport ? AuthConstants.SCM_EXPORT : AuthConstants.SCM_IMPORT
+        def scmAction = isExport ? AuthConstants.ACTION_SCM_EXPORT : AuthConstants.ACTION_SCM_IMPORT
 
         def authContext = apiAuthorize(project, [action,scmAction], action)
         if (!authContext) {
@@ -1114,7 +1114,7 @@ class ScmController extends ControllerBase {
 
 
         def requiredAction = integration == 'export' ? AuthConstants.ACTION_EXPORT : AuthConstants.ACTION_IMPORT
-        def requiredActionScm = integration == 'export' ? AuthConstants.SCM_EXPORT : AuthConstants.SCM_IMPORT
+        def requiredActionScm = integration == 'export' ? AuthConstants.ACTION_SCM_EXPORT : AuthConstants.ACTION_SCM_IMPORT
         if (unauthorizedResponse(
                 frameworkService.authorizeApplicationResourceAny(authContext,
                                                                  frameworkService.authResourceForProject(project),
@@ -1222,7 +1222,7 @@ class ScmController extends ControllerBase {
         )
         def requiredAction = integration == 'export' ? AuthConstants.ACTION_EXPORT :
                 AuthConstants.ACTION_IMPORT
-        def requiredActionScm = integration == 'export' ? AuthConstants.SCM_EXPORT : AuthConstants.SCM_IMPORT
+        def requiredActionScm = integration == 'export' ? AuthConstants.ACTION_SCM_EXPORT : AuthConstants.ACTION_SCM_IMPORT
         if (unauthorizedResponse(
                 frameworkService.authorizeApplicationResourceAny(authContext,
                                                                  frameworkService.authResourceForProject(project),
@@ -1397,7 +1397,7 @@ class ScmController extends ControllerBase {
 
         def isExport = scm.integration == 'export'
         def action = isExport ? AuthConstants.ACTION_EXPORT : AuthConstants.ACTION_IMPORT
-        def scmAction = isExport ? AuthConstants.SCM_EXPORT : AuthConstants.SCM_IMPORT
+        def scmAction = isExport ? AuthConstants.ACTION_SCM_EXPORT : AuthConstants.ACTION_SCM_IMPORT
 
         def authContext = apiAuthorize(scheduledExecution.project, [action,scmAction], action)
 
@@ -1510,7 +1510,7 @@ class ScmController extends ControllerBase {
 
         def isExport = scm.integration == 'export'
         def action = isExport ? AuthConstants.ACTION_EXPORT : AuthConstants.ACTION_IMPORT
-        def scmAction = isExport ? AuthConstants.SCM_EXPORT : AuthConstants.SCM_IMPORT
+        def scmAction = isExport ? AuthConstants.ACTION_SCM_EXPORT : AuthConstants.ACTION_SCM_IMPORT
 
         def authContext = apiAuthorize(job.project, [action,scmAction], action)
         if (!authContext) {
@@ -1613,7 +1613,7 @@ class ScmController extends ControllerBase {
 
         def isExport = scm.integration == 'export'
         def action = isExport ? AuthConstants.ACTION_EXPORT : AuthConstants.ACTION_IMPORT
-        def scmAction = isExport ? AuthConstants.SCM_EXPORT : AuthConstants.SCM_IMPORT
+        def scmAction = isExport ? AuthConstants.ACTION_SCM_EXPORT : AuthConstants.ACTION_SCM_IMPORT
 
         def authContext = apiAuthorize(scheduledExecution.project, [action,scmAction], action)
         if (!authContext) {
@@ -1644,7 +1644,7 @@ class ScmController extends ControllerBase {
 
         def isExport = scm.integration == 'export'
         def action = isExport ? AuthConstants.ACTION_EXPORT : AuthConstants.ACTION_IMPORT
-        def scmAction = isExport ? AuthConstants.SCM_EXPORT : AuthConstants.SCM_IMPORT
+        def scmAction = isExport ? AuthConstants.ACTION_SCM_EXPORT : AuthConstants.ACTION_SCM_IMPORT
 
         def authContext = apiAuthorize(scheduledExecution.project, [action,scmAction], action)
         if (!authContext) {
@@ -1701,7 +1701,7 @@ class ScmController extends ControllerBase {
 
         def isExport = integration == 'export'
         def diffAction = isExport ? AuthConstants.ACTION_EXPORT : AuthConstants.ACTION_IMPORT
-        def diffScmAction = integration == 'export' ? AuthConstants.SCM_EXPORT : AuthConstants.SCM_IMPORT
+        def diffScmAction = integration == 'export' ? AuthConstants.ACTION_SCM_EXPORT : AuthConstants.ACTION_SCM_IMPORT
         if (unauthorizedResponse(
                 frameworkService.authorizeApplicationResourceAny(authContext,
                                                                  frameworkService.authResourceForProject(project),

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -19,7 +19,7 @@ package rundeck.controllers
 import com.dtolabs.rundeck.core.authentication.tokens.AuthTokenType
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import grails.converters.JSON
 import grails.core.GrailsApplication
 import org.rundeck.util.Sizes

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -19,7 +19,7 @@ package rundeck.controllers
 import com.dtolabs.rundeck.core.authentication.tokens.AuthTokenType
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
-import com.dtolabs.rundeck.server.authorization.AuthConstants
+import com.dtolabs.rundeck.core.common.AuthConstants
 import grails.converters.JSON
 import grails.core.GrailsApplication
 import org.rundeck.util.Sizes

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/ProjectSelectInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/ProjectSelectInterceptor.groovy
@@ -17,8 +17,8 @@
 package rundeck.interceptors
 
 import com.dtolabs.rundeck.core.authorization.AuthContext
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.FrameworkResource
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 
 import javax.servlet.http.HttpServletResponse
 

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/ProjectSelectInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/ProjectSelectInterceptor.groovy
@@ -17,7 +17,7 @@
 package rundeck.interceptors
 
 import com.dtolabs.rundeck.core.authorization.AuthContext
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.FrameworkResource
 
 import javax.servlet.http.HttpServletResponse

--- a/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
@@ -20,7 +20,7 @@ import com.dtolabs.rundeck.core.authentication.tokens.AuthTokenType
 import com.dtolabs.rundeck.core.authorization.AuthorizationUtil
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.authorization.Validation
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import grails.converters.JSON
 import grails.transaction.Transactional
 import grails.web.JSONBuilder

--- a/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
@@ -20,7 +20,7 @@ import com.dtolabs.rundeck.core.authentication.tokens.AuthTokenType
 import com.dtolabs.rundeck.core.authorization.AuthorizationUtil
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.authorization.Validation
-import com.dtolabs.rundeck.server.authorization.AuthConstants
+import com.dtolabs.rundeck.core.common.AuthConstants
 import grails.converters.JSON
 import grails.transaction.Transactional
 import grails.web.JSONBuilder
@@ -255,11 +255,11 @@ class ApiService {
     }
 
     public boolean hasTokenUserGenerateAuth(UserAndRolesAuthContext authContext) {
-        authorizedForTokenAction(authContext, AuthConstants.GENERATE_USER_TOKEN)
+        authorizedForTokenAction(authContext, AuthConstants.ACTION_GENERATE_USER_TOKEN)
     }
 
     public boolean hasTokenServiceGenerateAuth(UserAndRolesAuthContext authContext) {
-        authorizedForTokenAction(authContext, AuthConstants.GENERATE_SERVICE_TOKEN)
+        authorizedForTokenAction(authContext, AuthConstants.ACTION_GENERATE_SERVICE_TOKEN)
     }
 
     private boolean authorizedForTokenAction(UserAndRolesAuthContext authContext, String action) {

--- a/rundeckapp/grails-app/services/rundeck/services/AuthedLogFileLoaderService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/AuthedLogFileLoaderService.groovy
@@ -2,12 +2,12 @@ package rundeck.services
 
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.execution.ExecutionNotFound
 import com.dtolabs.rundeck.core.execution.ExecutionReference
 import com.dtolabs.rundeck.core.execution.logstorage.AsyncExecutionFileLoaderService
 import com.dtolabs.rundeck.core.execution.logstorage.ExecutionFileLoader
 import com.dtolabs.rundeck.core.execution.logstorage.ExecutionFileLoaderService
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.gorm.transactions.Transactional
 import groovy.transform.CompileStatic
 import rundeck.Execution

--- a/rundeckapp/grails-app/services/rundeck/services/AuthedLogFileLoaderService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/AuthedLogFileLoaderService.groovy
@@ -2,12 +2,11 @@ package rundeck.services
 
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.execution.ExecutionNotFound
 import com.dtolabs.rundeck.core.execution.ExecutionReference
 import com.dtolabs.rundeck.core.execution.logstorage.AsyncExecutionFileLoaderService
 import com.dtolabs.rundeck.core.execution.logstorage.ExecutionFileLoader
-import com.dtolabs.rundeck.core.execution.logstorage.ExecutionFileLoaderService
 import grails.gorm.transactions.Transactional
 import groovy.transform.CompileStatic
 import rundeck.Execution

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -51,7 +51,6 @@ import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.jobs.JobPreExecutionEventImpl
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
 import com.dtolabs.rundeck.plugins.scm.JobChangeEvent
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.events.EventPublisher
 import grails.events.annotation.Subscriber
 import grails.gorm.transactions.NotTransactional

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -64,6 +64,7 @@ import org.grails.web.json.JSONObject
 import org.hibernate.StaleObjectStateException
 import org.hibernate.criterion.CriteriaSpecification
 import org.hibernate.type.StandardBasicTypes
+import org.rundeck.core.auth.AuthConstants
 import org.rundeck.storage.api.StorageException
 import org.rundeck.util.Sizes
 import org.springframework.context.ApplicationContext

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -42,6 +42,7 @@ import com.dtolabs.rundeck.server.plugins.services.StoragePluginProviderService
 import grails.core.GrailsApplication
 import org.apache.commons.lang.StringUtils
 import org.rundeck.app.spi.Services
+import org.rundeck.core.auth.AuthConstants
 import org.rundeck.core.projects.ProjectConfigurable
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -36,7 +36,6 @@ import com.dtolabs.rundeck.core.resources.ResourceModelSourceFactory
 import com.dtolabs.rundeck.core.schedule.JobScheduleManager
 import com.dtolabs.rundeck.core.storage.StorageTree
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
 import com.dtolabs.rundeck.server.plugins.loader.ApplicationContextPluginFileSource
 import com.dtolabs.rundeck.server.plugins.services.StoragePluginProviderService

--- a/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
@@ -20,8 +20,7 @@ import com.dtolabs.rundeck.app.support.BaseNodeFilters
 import com.dtolabs.rundeck.app.support.ExecutionQuery
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
-import com.dtolabs.rundeck.core.common.AuthConstants
-import com.dtolabs.rundeck.core.common.Framework
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.INodeSet
 import com.dtolabs.rundeck.core.common.NodeFilter

--- a/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.app.support.BaseNodeFilters
 import com.dtolabs.rundeck.app.support.ExecutionQuery
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.INodeSet
@@ -33,7 +34,6 @@ import com.dtolabs.rundeck.core.jobs.JobReference
 import com.dtolabs.rundeck.core.jobs.JobService
 import com.dtolabs.rundeck.core.jobs.JobState
 import com.dtolabs.rundeck.core.utils.NodeSet
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.transaction.Transactional
 import org.rundeck.util.Sizes
 import rundeck.Execution

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -20,7 +20,7 @@ import com.dtolabs.rundeck.app.support.ScheduledExecutionQuery
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRoles
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.INodeSet
 import com.dtolabs.rundeck.core.common.IRundeckProject
@@ -43,7 +43,6 @@ import com.dtolabs.rundeck.core.schedule.JobScheduleManager
 import com.dtolabs.rundeck.core.utils.NodeSet
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.jobs.ExecutionLifecyclePlugin
-import com.dtolabs.rundeck.plugins.jobs.JobOptionImpl
 import com.dtolabs.rundeck.plugins.jobs.JobPersistEventImpl
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
 import com.dtolabs.rundeck.plugins.scm.JobChangeEvent

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.app.support.ScheduledExecutionQuery
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRoles
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.INodeSet
 import com.dtolabs.rundeck.core.common.IRundeckProject
@@ -47,7 +48,6 @@ import com.dtolabs.rundeck.plugins.jobs.JobPersistEventImpl
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
 import com.dtolabs.rundeck.plugins.scm.JobChangeEvent
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import com.fasterxml.jackson.databind.ObjectMapper
 import grails.events.EventPublisher
 import grails.gorm.transactions.Transactional
@@ -1025,7 +1025,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
         def authActions = [AuthConstants.ACTION_DELETE]
         if (callingAction == 'scm-import') {
-            authActions << AuthConstants.SCM_DELETE
+            authActions << AuthConstants.ACTION_SCM_DELETE
         }
         if ((
             !frameworkService.authorizeProjectResourceAny(
@@ -1695,8 +1695,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         def updateAuthActions = [AuthConstants.ACTION_UPDATE]
         def createAuthActions = [AuthConstants.ACTION_CREATE]
         if (changeinfo?.method == 'scm-import') {
-            updateAuthActions += [AuthConstants.SCM_UPDATE]
-            createAuthActions += [AuthConstants.SCM_CREATE]
+            updateAuthActions += [AuthConstants.ACTION_SCM_UPDATE]
+            createAuthActions += [AuthConstants.ACTION_SCM_CREATE]
         }
         jobset.each { jobdata ->
             log.debug("saving job data: ${jobdata}")
@@ -3402,7 +3402,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
         def actions = [AuthConstants.ACTION_CREATE]
         if(changeinfo?.method == 'scm-import'){
-            actions += [AuthConstants.SCM_CREATE]
+            actions += [AuthConstants.ACTION_SCM_CREATE]
         }
         if (!frameworkService.authorizeProjectJobAny(authContext, scheduledExecution, actions, scheduledExecution.project)) {
             scheduledExecution.discard()

--- a/rundeckapp/grails-app/taglib/rundeck/AuthTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/AuthTagLib.groovy
@@ -20,7 +20,6 @@ import com.dtolabs.rundeck.core.authorization.Attribute;
 import com.dtolabs.rundeck.core.authorization.Authorization
 import com.dtolabs.rundeck.core.authorization.Decision
 import com.dtolabs.rundeck.core.authorization.providers.EnvironmentalContext
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import rundeck.services.FrameworkService;
 
 class AuthTagLib {

--- a/rundeckapp/grails-app/views/common/_mainbar.gsp
+++ b/rundeckapp/grails-app/views/common/_mainbar.gsp
@@ -1,4 +1,4 @@
-<%@ page import="com.opensymphony.module.sitemesh.RequestConstants; com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.opensymphony.module.sitemesh.RequestConstants; com.dtolabs.rundeck.core.common.AuthConstants" %>
   <g:set var="selectParams" value="${[:]}"/>
   <g:if test="${pageScope._metaTabPage && pageScope._metaTabPage != 'configure'&& pageScope._metaTabPage != 'projectconfigure'}">
     <g:set var="selectParams" value="${[page: _metaTabPage,project:params.project?:request.project]}"/>

--- a/rundeckapp/grails-app/views/common/_mainbar.gsp
+++ b/rundeckapp/grails-app/views/common/_mainbar.gsp
@@ -1,4 +1,4 @@
-<%@ page import="com.opensymphony.module.sitemesh.RequestConstants; com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="com.opensymphony.module.sitemesh.RequestConstants; org.rundeck.core.auth.AuthConstants" %>
   <g:set var="selectParams" value="${[:]}"/>
   <g:if test="${pageScope._metaTabPage && pageScope._metaTabPage != 'configure'&& pageScope._metaTabPage != 'projectconfigure'}">
     <g:set var="selectParams" value="${[page: _metaTabPage,project:params.project?:request.project]}"/>

--- a/rundeckapp/grails-app/views/common/_sidebar.gsp
+++ b/rundeckapp/grails-app/views/common/_sidebar.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.opensymphony.module.sitemesh.RequestConstants; com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.opensymphony.module.sitemesh.RequestConstants; com.dtolabs.rundeck.core.common.AuthConstants" %>
 <g:set var="selectParams" value="${[:]}"/>
 <g:set var="buildIdent" value="${servletContextAttribute(attribute: 'app.ident')}"/>
 <g:set var="appId" value="${g.appTitle()}"/>

--- a/rundeckapp/grails-app/views/common/_sidebar.gsp
+++ b/rundeckapp/grails-app/views/common/_sidebar.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.opensymphony.module.sitemesh.RequestConstants; com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="com.opensymphony.module.sitemesh.RequestConstants; org.rundeck.core.auth.AuthConstants" %>
 <g:set var="selectParams" value="${[:]}"/>
 <g:set var="buildIdent" value="${servletContextAttribute(attribute: 'app.ident')}"/>
 <g:set var="appId" value="${g.appTitle()}"/>

--- a/rundeckapp/grails-app/views/execution/_execDetails.gsp
+++ b/rundeckapp/grails-app/views/execution/_execDetails.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.app.support.ExecutionContext; com.dtolabs.rundeck.server.authorization.AuthConstants; com.dtolabs.rundeck.core.plugins.configuration.Description; rundeck.ScheduledExecution; rundeck.controllers.ScheduledExecutionController" %>
+<%@ page import="com.dtolabs.rundeck.app.support.ExecutionContext; com.dtolabs.rundeck.core.common.AuthConstants; com.dtolabs.rundeck.core.plugins.configuration.Description; rundeck.ScheduledExecution; rundeck.controllers.ScheduledExecutionController" %>
 <g:set var="rkey" value="${g.rkey()}"/>
 <div class="row">
 <div class="col-sm-12 table-responsive">

--- a/rundeckapp/grails-app/views/execution/_execDetails.gsp
+++ b/rundeckapp/grails-app/views/execution/_execDetails.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.app.support.ExecutionContext; com.dtolabs.rundeck.core.common.AuthConstants; com.dtolabs.rundeck.core.plugins.configuration.Description; rundeck.ScheduledExecution; rundeck.controllers.ScheduledExecutionController" %>
+<%@ page import="com.dtolabs.rundeck.app.support.ExecutionContext; org.rundeck.core.auth.AuthConstants; com.dtolabs.rundeck.core.plugins.configuration.Description; rundeck.ScheduledExecution; rundeck.controllers.ScheduledExecutionController" %>
 <g:set var="rkey" value="${g.rkey()}"/>
 <div class="row">
 <div class="col-sm-12 table-responsive">

--- a/rundeckapp/grails-app/views/execution/_showFragment.gsp
+++ b/rundeckapp/grails-app/views/execution/_showFragment.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 
 <g:if test="${!execution.dateCompleted}">
     <g:jsonToken id="exec_cancel_token" url="${request.forwardURI}"/>

--- a/rundeckapp/grails-app/views/execution/_showFragment.gsp
+++ b/rundeckapp/grails-app/views/execution/_showFragment.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 
 <g:if test="${!execution.dateCompleted}">
     <g:jsonToken id="exec_cancel_token" url="${request.forwardURI}"/>

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="grails.util.Environment; rundeck.Execution; com.dtolabs.rundeck.core.common.AuthConstants; rundeck.ScheduledExecution" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants; grails.util.Environment; rundeck.Execution; rundeck.ScheduledExecution" %>
 
 <html>
   <head>

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="grails.util.Environment; rundeck.Execution; com.dtolabs.rundeck.server.authorization.AuthConstants; rundeck.ScheduledExecution" %>
+<%@ page import="grails.util.Environment; rundeck.Execution; com.dtolabs.rundeck.core.common.AuthConstants; rundeck.ScheduledExecution" %>
 
 <html>
   <head>

--- a/rundeckapp/grails-app/views/execution/showFragment.gsp
+++ b/rundeckapp/grails-app/views/execution/showFragment.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
     <g:set var="followmode" value="${params.mode in ['browse','tail','node']?params.mode:null==execution?.dateCompleted?'tail':'browse'}"/>
 <g:set var="authKeys"
        value="${[AuthConstants.ACTION_KILL, AuthConstants.ACTION_READ, AuthConstants.ACTION_CREATE, AuthConstants.ACTION_RUN]}"/>

--- a/rundeckapp/grails-app/views/execution/showFragment.gsp
+++ b/rundeckapp/grails-app/views/execution/showFragment.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
     <g:set var="followmode" value="${params.mode in ['browse','tail','node']?params.mode:null==execution?.dateCompleted?'tail':'browse'}"/>
 <g:set var="authKeys"
        value="${[AuthConstants.ACTION_KILL, AuthConstants.ACTION_READ, AuthConstants.ACTION_CREATE, AuthConstants.ACTION_RUN]}"/>

--- a/rundeckapp/grails-app/views/framework/adhoc.gsp
+++ b/rundeckapp/grails-app/views/framework/adhoc.gsp
@@ -14,7 +14,7 @@
   limitations under the License.
   --}%
 
-<%@ page import="grails.util.Environment; rundeck.User; com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="grails.util.Environment; rundeck.User; com.dtolabs.rundeck.core.common.AuthConstants" %>
 <html>
 <head>
     <g:set var="ukey" value="${g.rkey()}" />

--- a/rundeckapp/grails-app/views/framework/adhoc.gsp
+++ b/rundeckapp/grails-app/views/framework/adhoc.gsp
@@ -14,7 +14,7 @@
   limitations under the License.
   --}%
 
-<%@ page import="grails.util.Environment; rundeck.User; com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="grails.util.Environment; rundeck.User; org.rundeck.core.auth.AuthConstants" %>
 <html>
 <head>
     <g:set var="ukey" value="${g.rkey()}" />

--- a/rundeckapp/grails-app/views/framework/editProjectFile.gsp
+++ b/rundeckapp/grails-app/views/framework/editProjectFile.gsp
@@ -16,7 +16,7 @@
 <%--
    Author: Greg Schueler <a href="mailto:greg@simplifyops.com">greg@simplifyops.com</a>
 --%>
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/framework/editProjectFile.gsp
+++ b/rundeckapp/grails-app/views/framework/editProjectFile.gsp
@@ -16,7 +16,7 @@
 <%--
    Author: Greg Schueler <a href="mailto:greg@simplifyops.com">greg@simplifyops.com</a>
 --%>
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/framework/editProjectNodeSourceFile.gsp
+++ b/rundeckapp/grails-app/views/framework/editProjectNodeSourceFile.gsp
@@ -21,7 +21,7 @@
   Time: 10:36 AM
 --%>
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/framework/editProjectNodeSourceFile.gsp
+++ b/rundeckapp/grails-app/views/framework/editProjectNodeSourceFile.gsp
@@ -21,7 +21,7 @@
   Time: 10:36 AM
 --%>
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/framework/nodes.gsp
+++ b/rundeckapp/grails-app/views/framework/nodes.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="grails.util.Environment; rundeck.User; com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="grails.util.Environment; rundeck.User; org.rundeck.core.auth.AuthConstants" %>
 <html>
 <head>
     <g:set var="ukey" value="${g.rkey()}" />

--- a/rundeckapp/grails-app/views/framework/nodes.gsp
+++ b/rundeckapp/grails-app/views/framework/nodes.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="grails.util.Environment; rundeck.User; com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="grails.util.Environment; rundeck.User; com.dtolabs.rundeck.core.common.AuthConstants" %>
 <html>
 <head>
     <g:set var="ukey" value="${g.rkey()}" />

--- a/rundeckapp/grails-app/views/menu/_configExecutionMode.gsp
+++ b/rundeckapp/grails-app/views/menu/_configExecutionMode.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
     <div class="form-group">
         <label class=" control-label"><g:message code="executionMode.label"/>:</label>
 

--- a/rundeckapp/grails-app/views/menu/_configExecutionMode.gsp
+++ b/rundeckapp/grails-app/views/menu/_configExecutionMode.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
     <div class="form-group">
         <label class=" control-label"><g:message code="executionMode.label"/>:</label>
 

--- a/rundeckapp/grails-app/views/menu/_jobslist.gsp
+++ b/rundeckapp/grails-app/views/menu/_jobslist.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="rundeck.ScheduledExecution; rundeck.Execution; com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="rundeck.ScheduledExecution; rundeck.Execution; com.dtolabs.rundeck.core.common.AuthConstants" %>
 
 <g:set var="ukey" value="${g.rkey()}"/>
         <div class="jobslist ${small?'small':''}">

--- a/rundeckapp/grails-app/views/menu/_jobslist.gsp
+++ b/rundeckapp/grails-app/views/menu/_jobslist.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="rundeck.ScheduledExecution; rundeck.Execution; com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="rundeck.ScheduledExecution; rundeck.Execution; org.rundeck.core.auth.AuthConstants" %>
 
 <g:set var="ukey" value="${g.rkey()}"/>
         <div class="jobslist ${small?'small':''}">

--- a/rundeckapp/grails-app/views/menu/_projectConfigNavMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_projectConfigNavMenu.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 
 <g:set var="authAdmin" value="${auth.resourceAllowedTest(
         action: AuthConstants.ACTION_ADMIN,

--- a/rundeckapp/grails-app/views/menu/_projectConfigNavMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_projectConfigNavMenu.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 
 <g:set var="authAdmin" value="${auth.resourceAllowedTest(
         action: AuthConstants.ACTION_ADMIN,

--- a/rundeckapp/grails-app/views/menu/_projectExportForm.gsp
+++ b/rundeckapp/grails-app/views/menu/_projectExportForm.gsp
@@ -15,7 +15,7 @@
   --}%
 
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 <script type="application/javascript">
     function select_all() {
         jQuery('.export_select_list input[type=checkbox]').prop('checked', true);

--- a/rundeckapp/grails-app/views/menu/_projectExportForm.gsp
+++ b/rundeckapp/grails-app/views/menu/_projectExportForm.gsp
@@ -15,7 +15,7 @@
   --}%
 
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 <script type="application/javascript">
     function select_all() {
         jQuery('.export_select_list input[type=checkbox]').prop('checked', true);

--- a/rundeckapp/grails-app/views/menu/_projectImportForm.gsp
+++ b/rundeckapp/grails-app/views/menu/_projectImportForm.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 
 
 <div class="col-xs-12">

--- a/rundeckapp/grails-app/views/menu/_projectImportForm.gsp
+++ b/rundeckapp/grails-app/views/menu/_projectImportForm.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 
 
 <div class="col-xs-12">

--- a/rundeckapp/grails-app/views/menu/_sidebarProjectMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_sidebarProjectMenu.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 <g:set var="authAdmin" value="${auth.resourceAllowedTest(
         action: AuthConstants.ACTION_ADMIN,
         type: AuthConstants.TYPE_PROJECT,

--- a/rundeckapp/grails-app/views/menu/_sidebarProjectMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_sidebarProjectMenu.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 <g:set var="authAdmin" value="${auth.resourceAllowedTest(
         action: AuthConstants.ACTION_ADMIN,
         type: AuthConstants.TYPE_PROJECT,

--- a/rundeckapp/grails-app/views/menu/_sysConfigExecutionModeNavMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_sysConfigExecutionModeNavMenu.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 
 <g:set var="authAction" value="${g.executionMode(active: true) ? AuthConstants.ACTION_DISABLE_EXECUTIONS :
         AuthConstants.ACTION_ENABLE_EXECUTIONS}"/>

--- a/rundeckapp/grails-app/views/menu/_sysConfigExecutionModeNavMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_sysConfigExecutionModeNavMenu.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 
 <g:set var="authAction" value="${g.executionMode(active: true) ? AuthConstants.ACTION_DISABLE_EXECUTIONS :
         AuthConstants.ACTION_ENABLE_EXECUTIONS}"/>

--- a/rundeckapp/grails-app/views/menu/_sysConfigNavMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_sysConfigNavMenu.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 
 <g:set var="authRead" value="${auth.resourceAllowedTest(
         type: 'resource',

--- a/rundeckapp/grails-app/views/menu/_sysConfigNavMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_sysConfigNavMenu.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 
 <g:set var="authRead" value="${auth.resourceAllowedTest(
         type: 'resource',

--- a/rundeckapp/grails-app/views/menu/_workflowsFull.gsp
+++ b/rundeckapp/grails-app/views/menu/_workflowsFull.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="rundeck.User; com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="rundeck.User; org.rundeck.core.auth.AuthConstants" %>
 <%--
  Copyright 2010 DTO Labs, Inc. (http://dtolabs.com)
 

--- a/rundeckapp/grails-app/views/menu/_workflowsFull.gsp
+++ b/rundeckapp/grails-app/views/menu/_workflowsFull.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="rundeck.User; com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="rundeck.User; com.dtolabs.rundeck.core.common.AuthConstants" %>
 <%--
  Copyright 2010 DTO Labs, Inc. (http://dtolabs.com)
 

--- a/rundeckapp/grails-app/views/menu/acls.gsp
+++ b/rundeckapp/grails-app/views/menu/acls.gsp
@@ -23,7 +23,7 @@
 --%>
 
 <%@ page contentType="text/html;charset=UTF-8" %>
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 <html>
 <g:set var="hasAdminAuth" value="${auth.resourceAllowedTest([
         any    : true,

--- a/rundeckapp/grails-app/views/menu/acls.gsp
+++ b/rundeckapp/grails-app/views/menu/acls.gsp
@@ -23,7 +23,7 @@
 --%>
 
 <%@ page contentType="text/html;charset=UTF-8" %>
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 <html>
 <g:set var="hasAdminAuth" value="${auth.resourceAllowedTest([
         any    : true,

--- a/rundeckapp/grails-app/views/menu/executionMode.gsp
+++ b/rundeckapp/grails-app/views/menu/executionMode.gsp
@@ -21,7 +21,7 @@
   Time: 11:50 AM
 --%>
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <title><g:message code="gui.menu.ExecutionMode" default="Execution Mode" /></title>

--- a/rundeckapp/grails-app/views/menu/executionMode.gsp
+++ b/rundeckapp/grails-app/views/menu/executionMode.gsp
@@ -21,7 +21,7 @@
   Time: 11:50 AM
 --%>
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <title><g:message code="gui.menu.ExecutionMode" default="Execution Mode" /></title>

--- a/rundeckapp/grails-app/views/menu/home.gsp
+++ b/rundeckapp/grails-app/views/menu/home.gsp
@@ -22,7 +22,7 @@
   To change this template use File | Settings | File Templates.
 --%>
 
-<%@ page import="grails.converters.JSON; com.dtolabs.rundeck.server.authorization.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="grails.converters.JSON; com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/menu/home.gsp
+++ b/rundeckapp/grails-app/views/menu/home.gsp
@@ -22,7 +22,7 @@
   To change this template use File | Settings | File Templates.
 --%>
 
-<%@ page import="grails.converters.JSON; com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="grails.converters.JSON; org.rundeck.core.auth.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants; rundeck.User; grails.util.Environment" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants;rundeck.User; grails.util.Environment" %>
 <html>
 <head>
     <g:set var="rkey" value="${g.rkey()}" />

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants; rundeck.User; grails.util.Environment" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants; rundeck.User; grails.util.Environment" %>
 <html>
 <head>
     <g:set var="rkey" value="${g.rkey()}" />

--- a/rundeckapp/grails-app/views/menu/plugins.gsp
+++ b/rundeckapp/grails-app/views/menu/plugins.gsp
@@ -22,7 +22,7 @@ Time: 3:13 PM
 To change this template use File | Settings | File Templates.
 --%>
 
-<%@ page import="java.util.regex.Pattern; com.dtolabs.rundeck.core.plugins.configuration.PropertyScope; com.dtolabs.rundeck.server.authorization.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="java.util.regex.Pattern; com.dtolabs.rundeck.core.plugins.configuration.PropertyScope; com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/menu/plugins.gsp
+++ b/rundeckapp/grails-app/views/menu/plugins.gsp
@@ -22,7 +22,7 @@ Time: 3:13 PM
 To change this template use File | Settings | File Templates.
 --%>
 
-<%@ page import="java.util.regex.Pattern; com.dtolabs.rundeck.core.plugins.configuration.PropertyScope; com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="java.util.regex.Pattern; com.dtolabs.rundeck.core.plugins.configuration.PropertyScope; org.rundeck.core.auth.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/menu/projectAcls.gsp
+++ b/rundeckapp/grails-app/views/menu/projectAcls.gsp
@@ -21,7 +21,7 @@
   Time: 9:01 AM
 --%>
 <%@ page contentType="text/html;charset=UTF-8" %>
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 <html>
 
 <g:set var="hasAdminAuth" value="${auth.resourceAllowedTest([

--- a/rundeckapp/grails-app/views/menu/projectAcls.gsp
+++ b/rundeckapp/grails-app/views/menu/projectAcls.gsp
@@ -21,7 +21,7 @@
   Time: 9:01 AM
 --%>
 <%@ page contentType="text/html;charset=UTF-8" %>
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 <html>
 
 <g:set var="hasAdminAuth" value="${auth.resourceAllowedTest([

--- a/rundeckapp/grails-app/views/menu/projectHome.gsp
+++ b/rundeckapp/grails-app/views/menu/projectHome.gsp
@@ -22,7 +22,7 @@
   To change this template use File | Settings | File Templates.
 --%>
 
-<%@ page import="grails.converters.JSON; com.dtolabs.rundeck.server.authorization.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="grails.converters.JSON; com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/menu/projectHome.gsp
+++ b/rundeckapp/grails-app/views/menu/projectHome.gsp
@@ -22,7 +22,7 @@
   To change this template use File | Settings | File Templates.
 --%>
 
-<%@ page import="grails.converters.JSON; com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="grails.converters.JSON; org.rundeck.core.auth.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/reports/_activityLinks.gsp
+++ b/rundeckapp/grails-app/views/reports/_activityLinks.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 
 <g:set var="projParams" value="${[project: project ?: params.project ?: request.project]}"/>
 <g:set var="linkParams" value="${filter?filter+projParams:projParams}"/>

--- a/rundeckapp/grails-app/views/reports/_activityLinks.gsp
+++ b/rundeckapp/grails-app/views/reports/_activityLinks.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 
 <g:set var="projParams" value="${[project: project ?: params.project ?: request.project]}"/>
 <g:set var="linkParams" value="${filter?filter+projParams:projParams}"/>

--- a/rundeckapp/grails-app/views/reports/_eventsFragment.gsp
+++ b/rundeckapp/grails-app/views/reports/_eventsFragment.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants; rundeck.User" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants; rundeck.User" %>
 <g:set var="rkey" value="${g.rkey()}" />
 
 <g:if test="${session.user && User.findByLogin(session.user)?.reportfilters}">

--- a/rundeckapp/grails-app/views/reports/_eventsFragment.gsp
+++ b/rundeckapp/grails-app/views/reports/_eventsFragment.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants; rundeck.User" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants; rundeck.User" %>
 <g:set var="rkey" value="${g.rkey()}" />
 
 <g:if test="${session.user && User.findByLogin(session.user)?.reportfilters}">

--- a/rundeckapp/grails-app/views/reports/index.gsp
+++ b/rundeckapp/grails-app/views/reports/index.gsp
@@ -21,7 +21,7 @@
   Time: 05:08
 --%>
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
 

--- a/rundeckapp/grails-app/views/reports/index.gsp
+++ b/rundeckapp/grails-app/views/reports/index.gsp
@@ -21,7 +21,7 @@
   Time: 05:08
 --%>
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
 

--- a/rundeckapp/grails-app/views/scheduledExecution/_createForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_createForm.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 
     <g:render template="/common/errorFragment"/>
     <g:render template="editLogFilterModal"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_createForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_createForm.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 
     <g:render template="/common/errorFragment"/>
     <g:render template="editLogFilterModal"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="rundeck.ScheduledExecution; rundeck.User; com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="rundeck.ScheduledExecution; rundeck.User; com.dtolabs.rundeck.core.common.AuthConstants" %>
 
 <g:jsonToken id="job_edit_tokens" url="${request.forwardURI}"/>
 

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="rundeck.ScheduledExecution; rundeck.User; com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="rundeck.ScheduledExecution; rundeck.User; org.rundeck.core.auth.AuthConstants" %>
 
 <g:jsonToken id="job_edit_tokens" url="${request.forwardURI}"/>
 

--- a/rundeckapp/grails-app/views/scheduledExecution/_editForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editForm.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 
 <g:render template="/common/errorFragment"/>
 <g:render template="editLogFilterModal"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_editForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editForm.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 
 <g:render template="/common/errorFragment"/>
 <g:render template="editLogFilterModal"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_jobActionButton.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_jobActionButton.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 %{--
 - Copyright 2014 SimplifyOps Inc, <http://simplifyops.com>
 -

--- a/rundeckapp/grails-app/views/scheduledExecution/_jobActionButton.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_jobActionButton.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 %{--
 - Copyright 2014 SimplifyOps Inc, <http://simplifyops.com>
 -

--- a/rundeckapp/grails-app/views/scheduledExecution/_jobActionButtonMenuContent.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_jobActionButtonMenuContent.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 <g:set var="authUpdate" value="${auth.jobAllowedTest(job: scheduledExecution, action: [AuthConstants.ACTION_UPDATE])}"/>
 <g:set var="authRead" value="${auth.jobAllowedTest(job: scheduledExecution, any: true, action: [AuthConstants.ACTION_READ])}"/>
 <g:set var="authDelete" value="${auth.jobAllowedTest(job: scheduledExecution, action: [AuthConstants.ACTION_DELETE])}"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_jobActionButtonMenuContent.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_jobActionButtonMenuContent.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 <g:set var="authUpdate" value="${auth.jobAllowedTest(job: scheduledExecution, action: [AuthConstants.ACTION_UPDATE])}"/>
 <g:set var="authRead" value="${auth.jobAllowedTest(job: scheduledExecution, any: true, action: [AuthConstants.ACTION_READ])}"/>
 <g:set var="authDelete" value="${auth.jobAllowedTest(job: scheduledExecution, action: [AuthConstants.ACTION_DELETE])}"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="rundeck.ScheduledExecution; com.dtolabs.rundeck.server.authorization.AuthConstants; rundeck.Execution" %>
+<%@ page import="rundeck.ScheduledExecution; com.dtolabs.rundeck.core.common.AuthConstants; rundeck.Execution" %>
 
 <g:set var="runAccess" value="${auth.jobAllowedTest(job: scheduledExecution, action: AuthConstants.ACTION_RUN)}"/>
 <g:set var="readAccess" value="${auth.jobAllowedTest(job: scheduledExecution, action: AuthConstants.ACTION_READ)}"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="rundeck.ScheduledExecution; com.dtolabs.rundeck.core.common.AuthConstants; rundeck.Execution" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants; rundeck.Execution" %>
 
 <g:set var="runAccess" value="${auth.jobAllowedTest(job: scheduledExecution, action: AuthConstants.ACTION_RUN)}"/>
 <g:set var="readAccess" value="${auth.jobAllowedTest(job: scheduledExecution, action: AuthConstants.ACTION_READ)}"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_showHead.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_showHead.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants; rundeck.ScheduledExecution" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants; rundeck.ScheduledExecution" %>
 
 <div class="jobInfoSection">
     <g:if test="${scheduledExecution.groupPath}">

--- a/rundeckapp/grails-app/views/scheduledExecution/_showHead.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_showHead.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants; rundeck.ScheduledExecution" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants; rundeck.ScheduledExecution" %>
 
 <div class="jobInfoSection">
     <g:if test="${scheduledExecution.groupPath}">

--- a/rundeckapp/grails-app/views/scheduledExecution/delete.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/delete.gsp
@@ -21,7 +21,7 @@
   Time: 4:16 PM
 --%>
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/delete.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/delete.gsp
@@ -21,7 +21,7 @@
   Time: 4:16 PM
 --%>
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/jobDetailFragment.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/jobDetailFragment.gsp
@@ -22,7 +22,7 @@
     Created: Jan 7, 2011 2:21:36 PM
  --%>
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 <!--Display job details-->
 <div >
 

--- a/rundeckapp/grails-app/views/scheduledExecution/jobDetailFragment.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/jobDetailFragment.gsp
@@ -22,7 +22,7 @@
     Created: Jan 7, 2011 2:21:36 PM
  --%>
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 <!--Display job details-->
 <div >
 

--- a/rundeckapp/grails-app/views/scheduledExecution/runbook.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/runbook.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants; rundeck.ScheduledExecution; grails.util.Environment" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants; rundeck.ScheduledExecution; grails.util.Environment" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/runbook.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/runbook.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants; rundeck.ScheduledExecution; grails.util.Environment" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants; rundeck.ScheduledExecution; grails.util.Environment" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
@@ -55,8 +55,7 @@
 </div>
 <g:set var="runAccess" value="${auth.jobAllowedTest(
         job: scheduledExecution,
-        action: com.dtolabs.rundeck.server.
-                authorization.AuthConstants.ACTION_RUN
+        action: AuthConstants.ACTION_RUN
 )}"/>
 <g:set var="runEnabled" value="${g.executionMode(is: 'active', project:params.project ?: request.project)}"/>
 <g:set var="canRunJob" value="${runAccess && runEnabled}"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/show.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants; grails.util.Environment" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants; grails.util.Environment" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/show.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants; grails.util.Environment" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants; grails.util.Environment" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/user/_user.gsp
+++ b/rundeckapp/grails-app/views/user/_user.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="rundeck.AuthToken; com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="rundeck.AuthToken; com.dtolabs.rundeck.core.common.AuthConstants" %>
 <%--
    _user.gsp
 

--- a/rundeckapp/grails-app/views/user/_user.gsp
+++ b/rundeckapp/grails-app/views/user/_user.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="rundeck.AuthToken; com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="rundeck.AuthToken; org.rundeck.core.auth.AuthConstants" %>
 <%--
    _user.gsp
 

--- a/rundeckapp/grails-app/views/user/_userListItem.gsp
+++ b/rundeckapp/grails-app/views/user/_userListItem.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 <%--
  Copyright 2010 DTO Labs, Inc. (http://dtolabs.com)
 

--- a/rundeckapp/grails-app/views/user/_userListItem.gsp
+++ b/rundeckapp/grails-app/views/user/_userListItem.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 <%--
  Copyright 2010 DTO Labs, Inc. (http://dtolabs.com)
 

--- a/rundeckapp/grails-app/views/user/list.gsp
+++ b/rundeckapp/grails-app/views/user/list.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
 e<html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/user/list.gsp
+++ b/rundeckapp/grails-app/views/user/list.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 e<html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/grails-app/views/user/profile.gsp
+++ b/rundeckapp/grails-app/views/user/profile.gsp
@@ -1,4 +1,4 @@
-<%@ page import="rundeck.AuthToken; com.dtolabs.rundeck.server.authorization.AuthConstants" %>
+<%@ page import="rundeck.AuthToken; com.dtolabs.rundeck.core.common.AuthConstants" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
@@ -21,12 +21,12 @@
 
     <g:set var="selfToken" value="${auth.resourceAllowedTest(
             kind: 'apitoken',
-            action: [AuthConstants.GENERATE_USER_TOKEN],
+            action: [AuthConstants.ACTION_GENERATE_USER_TOKEN],
             context: 'application'
     )}"/>
     <g:set var="serviceToken" value="${auth.resourceAllowedTest(
             kind: 'apitoken',
-            action: [AuthConstants.GENERATE_SERVICE_TOKEN],
+            action: [AuthConstants.ACTION_GENERATE_SERVICE_TOKEN],
             context: 'application'
     )}"/>
     <g:appTitle/> - <g:message code="userController.page.profile.title"/>: ${user.login}</title>

--- a/rundeckapp/grails-app/views/user/profile.gsp
+++ b/rundeckapp/grails-app/views/user/profile.gsp
@@ -1,4 +1,4 @@
-<%@ page import="rundeck.AuthToken; com.dtolabs.rundeck.core.common.AuthConstants" %>
+<%@ page import="rundeck.AuthToken; org.rundeck.core.auth.AuthConstants" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowNodeStateImpl.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowNodeStateImpl.groovy
@@ -16,9 +16,12 @@
 
 package com.dtolabs.rundeck.app.internal.workflow
 
-import com.dtolabs.rundeck.core.execution.workflow.state.ExecutionState
+
 import com.dtolabs.rundeck.core.execution.workflow.state.StepIdentifier
 import com.dtolabs.rundeck.core.execution.workflow.state.StepState
+import groovy.transform.CompileStatic
+
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * $INTERFACE is ...
@@ -26,6 +29,7 @@ import com.dtolabs.rundeck.core.execution.workflow.state.StepState
  * Date: 11/13/13
  * Time: 11:43 AM
  */
+@CompileStatic
 class MutableWorkflowNodeStateImpl implements MutableWorkflowNodeState {
     String nodeName
     MutableStepState mutableNodeState
@@ -35,7 +39,7 @@ class MutableWorkflowNodeStateImpl implements MutableWorkflowNodeState {
     MutableWorkflowNodeStateImpl(String nodeName) {
         this.nodeName = nodeName
         mutableNodeState=new MutableStepStateImpl()
-        mutableStepStateMap=new HashMap<StepIdentifier,MutableStepState>()
+        mutableStepStateMap = new ConcurrentHashMap<>()
     }
 
     public StepState getNodeState() {

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStepState.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStepState.groovy
@@ -18,6 +18,7 @@ package com.dtolabs.rundeck.app.internal.workflow
 
 import com.dtolabs.rundeck.core.execution.workflow.state.StepIdentifier
 import com.dtolabs.rundeck.core.execution.workflow.state.StepState
+import com.dtolabs.rundeck.core.execution.workflow.state.StepStateChange
 import com.dtolabs.rundeck.core.execution.workflow.state.WorkflowState
 import com.dtolabs.rundeck.core.execution.workflow.state.WorkflowStepState
 
@@ -44,12 +45,28 @@ public interface MutableWorkflowStepState extends WorkflowStepState{
     Map<String, MutableStepState> getMutableNodeStateMap();
 
     /**
+     * Get or create the mutable step state for a node
+     * @param node
+     * @return mutable state
+     */
+    MutableStepState getOrCreateMutableNodeState(String node);
+
+    /**
      * Return a parameterized step state
      * @param ident
      * @param params
      * @return
      */
     public MutableWorkflowStepState getParameterizedStepState(StepIdentifier ident,Map<String,String> params);
+
+    /**
+     * Update the timestamp and state for a sub step in the workflow
+     * @param identifier
+     * @param index
+     * @param stepStateChange
+     * @param timestamp
+     */
+    void touchStateForSubStep(StepIdentifier identifier, int index, StepStateChange stepStateChange, Date timestamp);
 
     /**
      * Return a map of node name to step states for the step
@@ -67,10 +84,10 @@ public interface MutableWorkflowStepState extends WorkflowStepState{
     MutableWorkflowStepState getOwnerStepState();
 
     /**
-     * Creates a mutable sub workflow state and enables it
+     * Creates a mutable sub workflow state and enables it, or returns existing
      * @return
      */
-    MutableWorkflowState createMutableSubWorkflowState(List<String> nodeSet, long count);
+    MutableWorkflowState getOrCreateMutableSubWorkflowState(List<String> nodeSet, long count);
 
     /**
      * Indicates that the step is a node step with the given targets

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/RundeckAuthContextEvaluator.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/RundeckAuthContextEvaluator.groovy
@@ -21,7 +21,7 @@ import com.dtolabs.rundeck.core.authorization.AuthContextEvaluator
 import com.dtolabs.rundeck.core.authorization.AuthorizationUtil
 import com.dtolabs.rundeck.core.authorization.Decision
 import com.dtolabs.rundeck.core.authorization.providers.EnvironmentalContext
-import com.dtolabs.rundeck.server.authorization.AuthConstants
+import com.dtolabs.rundeck.core.common.AuthConstants
 import groovy.transform.CompileStatic
 
 /**

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/RundeckAuthContextEvaluator.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/RundeckAuthContextEvaluator.groovy
@@ -21,7 +21,7 @@ import com.dtolabs.rundeck.core.authorization.AuthContextEvaluator
 import com.dtolabs.rundeck.core.authorization.AuthorizationUtil
 import com.dtolabs.rundeck.core.authorization.Decision
 import com.dtolabs.rundeck.core.authorization.providers.EnvironmentalContext
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import groovy.transform.CompileStatic
 
 /**

--- a/rundeckapp/src/main/groovy/rundeck/services/AuthorizingNodeExecutionService.groovy
+++ b/rundeckapp/src/main/groovy/rundeck/services/AuthorizingNodeExecutionService.groovy
@@ -18,6 +18,7 @@ package rundeck.services
 
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.INodeEntry
 import com.dtolabs.rundeck.core.common.NodeSetImpl
 import com.dtolabs.rundeck.core.execution.ExecArgList
@@ -27,7 +28,6 @@ import com.dtolabs.rundeck.core.execution.NodeExecutionService
 import com.dtolabs.rundeck.core.execution.UnauthorizedException
 import com.dtolabs.rundeck.core.execution.service.FileCopierException
 import com.dtolabs.rundeck.core.execution.service.NodeExecutorResult
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import groovy.transform.CompileStatic
 
 /**

--- a/rundeckapp/src/main/groovy/rundeck/services/AuthorizingNodeExecutionService.groovy
+++ b/rundeckapp/src/main/groovy/rundeck/services/AuthorizingNodeExecutionService.groovy
@@ -18,7 +18,7 @@ package rundeck.services
 
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.INodeEntry
 import com.dtolabs.rundeck.core.common.NodeSetImpl
 import com.dtolabs.rundeck.core.execution.ExecArgList

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -18,6 +18,7 @@
 import com.dtolabs.rundeck.app.support.QueueQuery
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import com.dtolabs.rundeck.core.common.NodeSetImpl
@@ -37,7 +38,6 @@ import com.dtolabs.rundeck.core.jobs.JobEventStatus
 import com.dtolabs.rundeck.core.storage.keys.KeyStorageTree
 import com.dtolabs.rundeck.execution.ExecutionItemFactory
 import com.dtolabs.rundeck.execution.JobRefCommand
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import grails.testing.spring.AutowiredTest

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -18,7 +18,7 @@
 import com.dtolabs.rundeck.app.support.QueueQuery
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import com.dtolabs.rundeck.core.common.NodeSetImpl

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStateImplSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStateImplSpec.groovy
@@ -17,8 +17,10 @@
 package com.dtolabs.rundeck.app.internal.workflow
 
 import com.dtolabs.rundeck.core.execution.workflow.state.ExecutionState
+import com.dtolabs.rundeck.core.execution.workflow.state.StateUtils
 import com.dtolabs.rundeck.core.execution.workflow.state.StepContextId
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static com.dtolabs.rundeck.core.execution.workflow.state.StateUtils.*
 
@@ -189,4 +191,24 @@ class MutableWorkflowStateImplSpec extends Specification {
 
     }
 
+
+    def "locateStepWithContext"() {
+        given:
+            def wf = new MutableWorkflowStateImpl([], 5)
+            wf.mutableStepStates[2].getParameterizedStepState(stepIdentifierFromString('3@node=anode'), [node: 'anode'])
+        when:
+            def result = wf.locateStepWithContext(stepIdentifierFromString(stepId), ndx, ignore)
+        then:
+            result.stepIdentifier.toString() == expect
+        where:
+            stepId                 | ndx | ignore | expect
+            '1'                    | 0   | false  | '1'
+            '1/2/3/4/5'            | 0   | false  | '1'
+            '1/2/3/4/5'            | 1   | false  | '2'
+            '1/2/3/4/5'            | 2   | false  | '3'
+            '1/2/3@node=anode/4/5' | 2   | false  | '3@node=anode'
+            '1/2/3@node=anode/4/5' | 2   | true   | '3'
+            '1/2/3/4/5'            | 3   | false  | '4'
+            '1/2/3/4/5'            | 4   | false  | '5'
+    }
 }

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStateImplTest.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStateImplTest.groovy
@@ -730,6 +730,7 @@ class MutableWorkflowStateImplTest  {
             try{
                 processStateChange(mutableWorkflowState,change)
             }catch (Throwable t){
+                t.printStackTrace(System.err)
                 fail("Error processing change: ${t}: ${ndx}: ${change}")
             }
         }

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStepStateImplTest.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStepStateImplTest.groovy
@@ -58,7 +58,7 @@ class MutableWorkflowStepStateImplTest {
         assertNotNull(resultState)
         assertEquals(test, resultState.ownerStepState)
         assertEquals(identifier, resultState.stepIdentifier)
-        assertEquals([], resultState.mutableSubWorkflowState.nodeSet)
+        assertEquals(['test1'], resultState.mutableSubWorkflowState.nodeSet)
         assertEquals(1, resultState.mutableSubWorkflowState.stepCount)
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -20,7 +20,7 @@ import asset.pipeline.grails.AssetMethodTagLib
 import asset.pipeline.grails.AssetProcessorService
 import com.dtolabs.rundeck.app.internal.logging.DefaultLogEvent
 import com.dtolabs.rundeck.app.support.ExecutionQuery
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.IRundeckProjectConfig
 import com.dtolabs.rundeck.core.common.ProjectManager

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -20,6 +20,7 @@ import asset.pipeline.grails.AssetMethodTagLib
 import asset.pipeline.grails.AssetProcessorService
 import com.dtolabs.rundeck.app.internal.logging.DefaultLogEvent
 import com.dtolabs.rundeck.app.support.ExecutionQuery
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.IRundeckProjectConfig
 import com.dtolabs.rundeck.core.common.ProjectManager
@@ -27,7 +28,6 @@ import com.dtolabs.rundeck.core.logging.LogEvent
 import com.dtolabs.rundeck.core.logging.LogLevel
 import com.dtolabs.rundeck.core.logging.LogUtil
 import com.dtolabs.rundeck.core.logging.StreamingLogReader
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import grails.test.mixin.TestMixin

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -46,7 +46,7 @@ import rundeck.services.feature.FeatureService
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import static com.dtolabs.rundeck.core.common.AuthConstants.*
+import static org.rundeck.core.auth.AuthConstants.*
 
 /**
  * Created by greg on 7/28/15.
@@ -79,7 +79,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceAny(null,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[action,ACTION_ADMIN])>>false
+            1 * authorizeApplicationResourceAny(null,RESOURCE_TYPE_SYSTEM_ACL,[action,ACTION_ADMIN])>>false
         }
         when:
         params.project='monkey'
@@ -116,7 +116,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceAny(null,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_READ,ACTION_ADMIN])>>true
+            1 * authorizeApplicationResourceAny(null,RESOURCE_TYPE_SYSTEM_ACL,[ACTION_READ,ACTION_ADMIN])>>true
         }
         when:
         params.path='elf'
@@ -134,7 +134,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceAny(_,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_READ,ACTION_ADMIN]) >> true
+            1 * authorizeApplicationResourceAny(_,RESOURCE_TYPE_SYSTEM_ACL,[ACTION_READ,ACTION_ADMIN]) >> true
         }
         controller.apiService=Mock(ApiService){
             1 * requireVersion(_,_,14) >> true
@@ -163,7 +163,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceAny(_,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_READ,ACTION_ADMIN]) >> true
+            1 * authorizeApplicationResourceAny(_,RESOURCE_TYPE_SYSTEM_ACL,[ACTION_READ,ACTION_ADMIN]) >> true
         }
         controller.apiService=Mock(ApiService){
             1 * requireVersion(_,_,14) >> true
@@ -191,7 +191,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceAny(_,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_READ,ACTION_ADMIN]) >> true
+            1 * authorizeApplicationResourceAny(_,RESOURCE_TYPE_SYSTEM_ACL,[ACTION_READ,ACTION_ADMIN]) >> true
         }
         controller.apiService=Mock(ApiService){
             1 * requireVersion(_,_,14) >> true
@@ -219,7 +219,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceAny(_,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_READ,ACTION_ADMIN]) >> true
+            1 * authorizeApplicationResourceAny(_,RESOURCE_TYPE_SYSTEM_ACL,[ACTION_READ,ACTION_ADMIN]) >> true
         }
         controller.apiService=Mock(ApiService){
             1 * requireVersion(_,_,14) >> true
@@ -252,7 +252,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceAny(_,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_READ,ACTION_ADMIN]) >> true
+            1 * authorizeApplicationResourceAny(_, RESOURCE_TYPE_SYSTEM_ACL,[ACTION_READ, ACTION_ADMIN]) >> true
             0*_(*_)
         }
         controller.apiService=Mock(ApiService){
@@ -284,7 +284,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-                         1 * authorizeApplicationResourceAny(_,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_READ,ACTION_ADMIN]) >> true
+                         1 * authorizeApplicationResourceAny(_,RESOURCE_TYPE_SYSTEM_ACL,[ACTION_READ,ACTION_ADMIN]) >> true
             0*_(*_)
         }
         controller.apiService=Mock(ApiService){
@@ -318,7 +318,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceAny(_,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_CREATE,ACTION_ADMIN]) >> true
+            1 * authorizeApplicationResourceAny(_,RESOURCE_TYPE_SYSTEM_ACL,[ACTION_CREATE,ACTION_ADMIN]) >> true
         }
         controller.apiService=Mock(ApiService){
             1 * requireVersion(_,_,14) >> true
@@ -354,7 +354,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceAny(_,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_CREATE,ACTION_ADMIN]) >> true
+            1 * authorizeApplicationResourceAny(_,RESOURCE_TYPE_SYSTEM_ACL,[ACTION_CREATE,ACTION_ADMIN]) >> true
         }
         controller.apiService=Mock(ApiService){
             1 * requireVersion(_,_,14) >> true
@@ -392,7 +392,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceAny(_,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_UPDATE,ACTION_ADMIN]) >> true
+            1 * authorizeApplicationResourceAny(_,RESOURCE_TYPE_SYSTEM_ACL,[ACTION_UPDATE,ACTION_ADMIN]) >> true
         }
         controller.apiService=Mock(ApiService){
             1 * requireVersion(_,_,14) >> true
@@ -436,7 +436,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceAny(_,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_UPDATE,ACTION_ADMIN]) >> true
+            1 * authorizeApplicationResourceAny(_,RESOURCE_TYPE_SYSTEM_ACL,[ACTION_UPDATE,ACTION_ADMIN]) >> true
         }
         controller.apiService=Mock(ApiService){
             1 * requireVersion(_,_,14) >> true
@@ -472,7 +472,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceAny(_,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_DELETE,ACTION_ADMIN]) >> true
+            1 * authorizeApplicationResourceAny(_,RESOURCE_TYPE_SYSTEM_ACL,[ACTION_DELETE,ACTION_ADMIN]) >> true
         }
         controller.apiService=Mock(ApiService){
             1 * requireVersion(_,_,14) >> true
@@ -500,7 +500,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceAny(_,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_DELETE,ACTION_ADMIN]) >> true
+            1 * authorizeApplicationResourceAny(_,RESOURCE_TYPE_SYSTEM_ACL,[ACTION_DELETE,ACTION_ADMIN]) >> true
         }
         controller.apiService=Mock(ApiService){
             1 * requireVersion(_,_,14) >> true
@@ -528,7 +528,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceAny(_,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_CREATE,ACTION_ADMIN]) >> true
+            1 * authorizeApplicationResourceAny(_,RESOURCE_TYPE_SYSTEM_ACL,[ACTION_CREATE,ACTION_ADMIN]) >> true
         }
         controller.apiService=Mock(ApiService){
             1 * requireVersion(_,_,14) >> true
@@ -571,7 +571,7 @@ class FrameworkControllerSpec extends Specification {
         }
         controller.frameworkService=Mock(FrameworkService){
             1 * getAuthContextForSubject(_) >> null
-                         1 * authorizeApplicationResourceAny(_,AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,[ACTION_CREATE,ACTION_ADMIN]) >> true
+                         1 * authorizeApplicationResourceAny(_,RESOURCE_TYPE_SYSTEM_ACL,[ACTION_CREATE,ACTION_ADMIN]) >> true
         }
         controller.apiService=Mock(ApiService){
             1 * requireVersion(_,_,14) >> true
@@ -1146,7 +1146,7 @@ class FrameworkControllerSpec extends Specification {
         controller.frameworkService=Mock(FrameworkService){
             getRundeckFramework() >> rdframework
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceTypeAll(null,'project',[AuthConstants.ACTION_CREATE])>>true
+            1 * authorizeApplicationResourceTypeAll(null,'project',[ACTION_CREATE])>>true
             1 * validateProjectConfigurableInput(_,_,_)>>[props:[:]]
             listDescriptions()>>[Mock(ResourceModelSourceService),Mock(NodeExecutorService),Mock(FileCopierService)]
         }
@@ -1197,7 +1197,7 @@ class FrameworkControllerSpec extends Specification {
         controller.frameworkService=Mock(FrameworkService){
             getRundeckFramework() >> rdframework
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceTypeAll(null,'project',[AuthConstants.ACTION_CREATE])>>true
+            1 * authorizeApplicationResourceTypeAll(null,'project',[ACTION_CREATE])>>true
             1 * validateProjectConfigurableInput(_,_,_)>>[props:[:]]
             listDescriptions()>>[Mock(ResourceModelSourceService),Mock(NodeExecutorService),Mock(FileCopierService)]
         }
@@ -1399,7 +1399,7 @@ class FrameworkControllerSpec extends Specification {
         controller.frameworkService=Mock(FrameworkService){
             getRundeckFramework() >> rdframework
             1 * getAuthContextForSubject(_) >> null
-            1 * authorizeApplicationResourceTypeAll(null,'project',[AuthConstants.ACTION_CREATE])>>true
+            1 * authorizeApplicationResourceTypeAll(null,'project',[ACTION_CREATE])>>true
             1 * validateProjectConfigurableInput(_,_,_)>>[props:[:]]
             1 * createFrameworkProject(_,_)>>[project, null]
             1 * refreshSessionProjects(_,_)>>null

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -29,7 +29,6 @@ import com.dtolabs.rundeck.core.resources.ResourceModelSourceService
 import com.dtolabs.rundeck.core.resources.format.ResourceFormatGeneratorService
 import com.dtolabs.rundeck.core.resources.format.ResourceXMLFormatGenerator
 import com.dtolabs.rundeck.core.resources.format.json.ResourceJsonFormatGenerator
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import grails.test.mixin.TestMixin
@@ -47,7 +46,7 @@ import rundeck.services.feature.FeatureService
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import static com.dtolabs.rundeck.server.authorization.AuthConstants.*
+import static com.dtolabs.rundeck.core.common.AuthConstants.*
 
 /**
  * Created by greg on 7/28/15.

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerTest.groovy
@@ -28,7 +28,7 @@ import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.core.plugins.configuration.Description
 import com.dtolabs.rundeck.core.plugins.configuration.Property
 import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import groovy.mock.interceptor.MockFor

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerTest.groovy
@@ -16,7 +16,7 @@
 
 package rundeck.controllers
 
-import groovy.mock.interceptor.MockFor
+
 import rundeck.services.PluginService
 import rundeck.services.feature.FeatureService
 
@@ -28,7 +28,7 @@ import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.core.plugins.configuration.Description
 import com.dtolabs.rundeck.core.plugins.configuration.Property
 import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants
-import com.dtolabs.rundeck.server.authorization.AuthConstants
+import com.dtolabs.rundeck.core.common.AuthConstants
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import groovy.mock.interceptor.MockFor

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -26,7 +26,7 @@ import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.authorization.ValidationSet
 import com.dtolabs.rundeck.core.authorization.providers.Policy
 import com.dtolabs.rundeck.core.authorization.providers.PolicyCollection
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.core.common.ProjectManager

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -26,10 +26,10 @@ import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.authorization.ValidationSet
 import com.dtolabs.rundeck.core.authorization.providers.Policy
 import com.dtolabs.rundeck.core.authorization.providers.PolicyCollection
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.core.common.ProjectManager
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
@@ -981,10 +981,10 @@ class MenuControllerSpec extends Specification {
                                                                         displayParams:[:]]
         1 * controller.frameworkService.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN,
                                                                                AuthConstants.ACTION_EXPORT,
-                                                                                AuthConstants.SCM_EXPORT]) >> true
+                                                                                AuthConstants.ACTION_SCM_EXPORT]) >> true
         1 * controller.frameworkService.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN,
                                                                                AuthConstants.ACTION_IMPORT,
-                                                                               AuthConstants.SCM_IMPORT]) >> true
+                                                                               AuthConstants.ACTION_SCM_IMPORT]) >> true
         1 * controller.scmService.projectHasConfiguredExportPlugin(project) >> true
         1 * controller.scmService.projectHasConfiguredImportPlugin(project) >> false
         1 * controller.scmService.loadScmConfig(project,'export') >> scmConfig
@@ -1022,10 +1022,10 @@ class MenuControllerSpec extends Specification {
                                                                         displayParams:[:]]
         1 * controller.frameworkService.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN,
                                                                                AuthConstants.ACTION_EXPORT,
-                                                                               AuthConstants.SCM_EXPORT]) >> true
+                                                                               AuthConstants.ACTION_SCM_EXPORT]) >> true
         1 * controller.frameworkService.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN,
                                                                                AuthConstants.ACTION_IMPORT,
-                                                                                AuthConstants.SCM_IMPORT]) >> true
+                                                                                AuthConstants.ACTION_SCM_IMPORT]) >> true
         1 * controller.scmService.projectHasConfiguredExportPlugin(project) >> true
         1 * controller.scmService.projectHasConfiguredImportPlugin(project) >> false
         1 * controller.scmService.loadScmConfig(project,'export') >> scmConfig

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerSpec.groovy
@@ -17,7 +17,6 @@
 package rundeck.controllers
 
 import com.dtolabs.rundeck.core.authentication.Group
-import com.dtolabs.rundeck.core.authorization.Validation
 import com.dtolabs.rundeck.core.common.IRundeckProject
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
@@ -37,12 +36,12 @@ import spock.lang.Unroll
 
 import javax.security.auth.Subject
 
-import static com.dtolabs.rundeck.core.common.AuthConstants.ACTION_ADMIN
-import static com.dtolabs.rundeck.core.common.AuthConstants.ACTION_CREATE
-import static com.dtolabs.rundeck.core.common.AuthConstants.ACTION_DELETE
-import static com.dtolabs.rundeck.core.common.AuthConstants.ACTION_IMPORT
-import static com.dtolabs.rundeck.core.common.AuthConstants.ACTION_READ
-import static com.dtolabs.rundeck.core.common.AuthConstants.ACTION_UPDATE
+import static org.rundeck.core.auth.AuthConstants.ACTION_ADMIN
+import static org.rundeck.core.auth.AuthConstants.ACTION_CREATE
+import static org.rundeck.core.auth.AuthConstants.ACTION_DELETE
+import static org.rundeck.core.auth.AuthConstants.ACTION_IMPORT
+import static org.rundeck.core.auth.AuthConstants.ACTION_READ
+import static org.rundeck.core.auth.AuthConstants.ACTION_UPDATE
 
 /**
  * Created by greg on 2/26/15.

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerSpec.groovy
@@ -37,12 +37,12 @@ import spock.lang.Unroll
 
 import javax.security.auth.Subject
 
-import static com.dtolabs.rundeck.server.authorization.AuthConstants.ACTION_ADMIN
-import static com.dtolabs.rundeck.server.authorization.AuthConstants.ACTION_CREATE
-import static com.dtolabs.rundeck.server.authorization.AuthConstants.ACTION_DELETE
-import static com.dtolabs.rundeck.server.authorization.AuthConstants.ACTION_IMPORT
-import static com.dtolabs.rundeck.server.authorization.AuthConstants.ACTION_READ
-import static com.dtolabs.rundeck.server.authorization.AuthConstants.ACTION_UPDATE
+import static com.dtolabs.rundeck.core.common.AuthConstants.ACTION_ADMIN
+import static com.dtolabs.rundeck.core.common.AuthConstants.ACTION_CREATE
+import static com.dtolabs.rundeck.core.common.AuthConstants.ACTION_DELETE
+import static com.dtolabs.rundeck.core.common.AuthConstants.ACTION_IMPORT
+import static com.dtolabs.rundeck.core.common.AuthConstants.ACTION_READ
+import static com.dtolabs.rundeck.core.common.AuthConstants.ACTION_UPDATE
 
 /**
  * Created by greg on 2/26/15.

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerTest.groovy
@@ -18,6 +18,7 @@
 package rundeck.controllers
 
 import com.dtolabs.rundeck.app.api.ApiVersions
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.server.projects.RundeckProject
 import groovy.mock.interceptor.StubFor
@@ -31,7 +32,6 @@ import com.dtolabs.rundeck.core.authentication.Username
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.FrameworkProject
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import groovy.mock.interceptor.MockFor

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerTest.groovy
@@ -18,9 +18,8 @@
 package rundeck.controllers
 
 import com.dtolabs.rundeck.app.api.ApiVersions
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.IRundeckProject
-import com.dtolabs.rundeck.server.projects.RundeckProject
 import groovy.mock.interceptor.StubFor
 
 import static org.junit.Assert.*

--- a/rundeckapp/src/test/groovy/rundeck/services/JobStateServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/JobStateServiceSpec.groovy
@@ -16,7 +16,7 @@
 
 package rundeck.services
 
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 
 import static org.junit.Assert.*
 

--- a/rundeckapp/src/test/groovy/rundeck/services/JobStateServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/JobStateServiceSpec.groovy
@@ -16,6 +16,8 @@
 
 package rundeck.services
 
+import com.dtolabs.rundeck.core.common.AuthConstants
+
 import static org.junit.Assert.*
 
 import com.dtolabs.rundeck.app.support.ExecutionQuery
@@ -24,7 +26,6 @@ import com.dtolabs.rundeck.core.authorization.SubjectAuthContext
 import com.dtolabs.rundeck.core.dispatcher.ExecutionState
 import com.dtolabs.rundeck.core.jobs.JobNotFound
 import com.dtolabs.rundeck.core.jobs.JobReference
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import rundeck.CommandExec
@@ -369,7 +370,7 @@ class JobStateServiceSpec extends Specification {
             ).save()
 
         service.frameworkService=Mock(FrameworkService){
-            1 * authorizeProjectJobAny(null,job,[AuthConstants.ACTION_READ,AuthConstants.ACTION_VIEW],projectName) >> false
+            1 * authorizeProjectJobAny(null,job,[AuthConstants.ACTION_READ, AuthConstants.ACTION_VIEW],projectName) >> false
             0 * _(*_)
         }
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -16,7 +16,7 @@
 
 package rundeck.services
 
-import com.dtolabs.rundeck.core.common.AuthConstants
+import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.plugins.PluginConfigSet
 import com.dtolabs.rundeck.core.plugins.SimplePluginConfiguration
 import com.dtolabs.rundeck.core.plugins.ValidatedPlugin

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -16,6 +16,7 @@
 
 package rundeck.services
 
+import com.dtolabs.rundeck.core.common.AuthConstants
 import com.dtolabs.rundeck.core.plugins.PluginConfigSet
 import com.dtolabs.rundeck.core.plugins.SimplePluginConfiguration
 import com.dtolabs.rundeck.core.plugins.ValidatedPlugin
@@ -39,7 +40,6 @@ import com.dtolabs.rundeck.core.plugins.configuration.Description
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolver
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
-import com.dtolabs.rundeck.server.authorization.AuthConstants
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
 import org.quartz.ListenerManager
@@ -3217,7 +3217,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         result.jobs.size() == 1
         result.jobs[0].properties.description == 'milk duds'
         1 * service.frameworkService.authorizeProjectJobAny(_,_,
-                [AuthConstants.ACTION_UPDATE, AuthConstants.SCM_UPDATE],_) >> true
+                [AuthConstants.ACTION_UPDATE, AuthConstants.ACTION_SCM_UPDATE],_) >> true
     }
 
     def "not check scm_update permission if isnt a scm-import"() {
@@ -3251,7 +3251,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         1 * service.frameworkService.authorizeProjectJobAny(_,_,
                 [AuthConstants.ACTION_UPDATE],_) >> true
         0 * service.frameworkService.authorizeProjectJobAny(_,_,
-                [AuthConstants.ACTION_UPDATE, AuthConstants.SCM_UPDATE],_) >> true
+                [AuthConstants.ACTION_UPDATE, AuthConstants.ACTION_SCM_UPDATE],_) >> true
     }
 
     @Unroll
@@ -3285,7 +3285,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         result.errjobs.size() == 1
         result.errjobs[0].errmsg.startsWith("Unauthorized: Update Job")
         1 * service.frameworkService.authorizeProjectJobAny(_,_,
-                [AuthConstants.ACTION_UPDATE, AuthConstants.SCM_UPDATE],_) >> false
+                [AuthConstants.ACTION_UPDATE, AuthConstants.ACTION_SCM_UPDATE],_) >> false
     }
 
 
@@ -3307,7 +3307,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         result
         result.success?.job
         1 * service.frameworkService.authorizeProjectJobAny(_,_,
-                [AuthConstants.ACTION_DELETE,AuthConstants.SCM_DELETE],_) >> true
+                [AuthConstants.ACTION_DELETE,AuthConstants.ACTION_SCM_DELETE],_) >> true
     }
 
     @Unroll
@@ -3329,7 +3329,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         !result.sucess
         result.error
         0 * service.frameworkService.authorizeProjectJobAll(_,_,
-                [AuthConstants.SCM_DELETE],_) >> true
+                [AuthConstants.ACTION_SCM_DELETE],_) >> true
     }
 
     @Unroll
@@ -3350,9 +3350,9 @@ class ScheduledExecutionServiceSpec extends Specification {
         then:
         result.jobs.size()==1
         1 * service.frameworkService.authorizeProjectResourceAny(_,AuthConstants.RESOURCE_TYPE_JOB,
-                [AuthConstants.ACTION_CREATE,AuthConstants.SCM_CREATE],'AProject') >> true
+                [AuthConstants.ACTION_CREATE,AuthConstants.ACTION_SCM_CREATE],'AProject') >> true
         1 * service.frameworkService.authorizeProjectJobAny(_,_,
-                [AuthConstants.ACTION_CREATE,AuthConstants.SCM_CREATE],_) >> true
+                [AuthConstants.ACTION_CREATE,AuthConstants.ACTION_SCM_CREATE],_) >> true
 
     }
 
@@ -3376,7 +3376,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         1 * service.frameworkService.authorizeProjectResourceAny(_,AuthConstants.RESOURCE_TYPE_JOB,
                 [AuthConstants.ACTION_CREATE],'AProject') >> true
         0 * service.frameworkService.authorizeProjectJobAny(_,_,
-                [AuthConstants.SCM_CREATE],_) >> false
+                [AuthConstants.ACTION_SCM_CREATE],_) >> false
         1 * service.frameworkService.authorizeProjectJobAny(_,_,
                 [AuthConstants.ACTION_CREATE],_) >> true
 


### PR DESCRIPTION
Move AuthConstants.java from grails app to core to be used on core classes like AclTool and exposed to other apps.

fix #5354