### PR TITLE
Fix missing import 5375

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="org.rundeck.core.auth.AuthConstants; rundeck.Execution" %>
+<%@ page import="rundeck.ScheduledExecution; org.rundeck.core.auth.AuthConstants; rundeck.Execution" %>
 
 <g:set var="runAccess" value="${auth.jobAllowedTest(job: scheduledExecution, action: AuthConstants.ACTION_RUN)}"/>
 <g:set var="readAccess" value="${auth.jobAllowedTest(job: scheduledExecution, action: AuthConstants.ACTION_READ)}"/>


### PR DESCRIPTION
Fix missing import from #5362 on `rundeckapp/grails-app/views/scheduledExecution/_show.gsp`