### PR TITLE
fix selectable run later executions on bulk delete 5373

### DIFF
--- a/rundeckapp/grails-spa/src/components/activity/activityList.vue
+++ b/rundeckapp/grails-spa/src/components/activity/activityList.vue
@@ -565,7 +565,7 @@ export default Vue.extend({
         }
       }else if(rpt.executionId){
         this.toggleSelectId(rpt.executionId)
-      }else if(rpt.id && rpt.status!=='running'){
+      }else if(rpt.id && rpt.status!=='running' && rpt.status!=='scheduled'){
         this.toggleSelectId(rpt.id)
       }
     },

--- a/rundeckapp/grails-spa/src/components/activity/activityList.vue
+++ b/rundeckapp/grails-spa/src/components/activity/activityList.vue
@@ -180,7 +180,7 @@
                 name="bulk_edit"
                 :value="exec.id"
                 v-model="bulkSelectedIds"
-                :disabled="exec.status==='running'"
+                :disabled="exec.status==='running' || exec.status==='scheduled'"
                 class="_defaultInput"/>
             </td>
                  <td class="eventicon " :title="executionState(exec.status)" >


### PR DESCRIPTION
Run later executions or `scheduled` shouldn't be selectable to `bulk delete`

![image](https://user-images.githubusercontent.com/2894508/66829388-a4daa180-ef29-11e9-93df-6b9aa231a4cd.png)
