### PR TITLE
Cleanup test dir in NodeServiceSpec test

### DIFF
--- a/rundeckapp/src/test/groovy/rundeck/services/NodeServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NodeServiceSpec.groovy
@@ -38,6 +38,7 @@ import spock.lang.Unroll
  */
 @TestFor(NodeService)
 class NodeServiceSpec extends Specification {
+    private static final String RESOURCE_TMP_DIR = '/tmp/rundeckNodeServiceSpec'
     def "get nodes project DNE"() {
         given:
         service.frameworkService = Mock(FrameworkService)
@@ -65,6 +66,7 @@ class NodeServiceSpec extends Specification {
         nodeSet.putNode(new NodeEntryImpl('anode'))
         def properties = [
 
+                'framework.var.dir'                                  : RESOURCE_TMP_DIR,
                 'resources.source.1.type'                            : 'file',
                 'resources.source.1.config.file'                     : '/tmp/test.xml',
                 'resources.source.1.config.generateFileAutomatically': 'false',
@@ -136,6 +138,7 @@ class NodeServiceSpec extends Specification {
         INodeSet nodeSet = new NodeSetImpl()
         nodeSet.putNode(new NodeEntryImpl('anode'))
         def properties = [
+                'framework.var.dir'                                  : RESOURCE_TMP_DIR,
                 'resources.source.1.type'                            : 'file',
                 'resources.source.1.config.file'                     : '/tmp/test.xml',
                 'resources.source.1.config.generateFileAutomatically': 'false',
@@ -211,6 +214,7 @@ class NodeServiceSpec extends Specification {
         preloadedNodes.putNode(new NodeEntryImpl('bnode'))
 
         def properties = [
+                'framework.var.dir'                                  : RESOURCE_TMP_DIR,
                 'resources.source.1.type'                            : 'file',
                 'resources.source.1.config.file'                     : '/tmp/test.xml',
                 'resources.source.1.config.generateFileAutomatically': 'false',
@@ -286,6 +290,7 @@ class NodeServiceSpec extends Specification {
         sourceNodes.putNode(new NodeEntryImpl("bnode"))
 
         def properties = [
+            'framework.var.dir'                                  : RESOURCE_TMP_DIR,
             'resources.source.1.type'                            : 'file',
             'resources.source.1.config.file'                     : '/tmp/test.xml',
             'resources.source.1.config.generateFileAutomatically': 'false',
@@ -372,7 +377,7 @@ class NodeServiceSpec extends Specification {
         modelNodes.putNode(new NodeEntryImpl('anode'))
 
         def properties = [
-
+                'framework.var.dir'                                  : RESOURCE_TMP_DIR,
                 'resources.source.1.type'                            : 'file',
                 'resources.source.1.config.file'                     : '/tmp/test.xml',
                 'resources.source.1.config.generateFileAutomatically': 'false',
@@ -445,7 +450,7 @@ class NodeServiceSpec extends Specification {
         modelNodes.putNode(new NodeEntryImpl('anode'))
 
         def properties = [
-
+                'framework.var.dir'                                  : RESOURCE_TMP_DIR,
                 'resources.source.1.type'                            : 'file',
                 'resources.source.1.config.file'                     : '/tmp/test.xml',
                 'resources.source.1.config.generateFileAutomatically': 'false',


### PR DESCRIPTION
Adds a framework.var.dir to the test so the temp dir that is generated is not in the rundeckapp dir.
