### PR TITLE
Enhancement: step search improvement

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/filterStepPluginsKOTest.js
+++ b/rundeckapp/grails-app/assets/javascripts/filterStepPluginsKOTest.js
@@ -37,6 +37,7 @@ var StepFiltersTest = function () {
             {
                 title: 'Plugin Example 1',
                 name: 'plugin1',
+                description: 'Randomness potato',
                 properties: [{
                     title: 'Preperty Example 1',
                     name: 'propEx1'
@@ -45,6 +46,7 @@ var StepFiltersTest = function () {
             {
                 title: 'Plugin Example 2',
                 name: 'plugin2',
+                description: 'Randomness zucchini',
                 properties: [{
                     title: 'Preperty Example 2',
                     name: 'propEx2'
@@ -53,6 +55,7 @@ var StepFiltersTest = function () {
             {
                 title: 'Other Example',
                 name: 'other',
+                description: 'interesting party',
                 properties: [{
                     title: 'Other Preperty',
                     name: 'otherProp'
@@ -60,11 +63,18 @@ var StepFiltersTest = function () {
             },
             {
                 title: 'Default Step Plugin',
-                name: 'default'
+                name: 'default',
+                description: 'other clever bagel',
             },
             {
                 title: 'Other Default Step Plugin',
-                name: 'otherDefault'
+                name: 'otherDefault',
+                description: 'aluminum zester',
+            },
+            {
+                title: 'XYZ Plugin',
+                name: 'randomPlugin',
+                description: 'hoo boy',
             }
         ]
     }
@@ -96,6 +106,45 @@ var StepFiltersTest = function () {
         assert(pref+'Default Step Plugin should not be visible',false,sf.isDefaultStepsVisible(stepDescriptionsList[3].title));
         assert(pref+'Other Default Step Plugin should not be visible',false,sf.isDefaultStepsVisible(stepDescriptionsList[4].title));
     };
+    self.basicFilterDescriptionTest = function (pref) {
+        var stepDescriptionsList = createPluginDescritptions()
+        var sf = createStepFilterObj({stepDescriptions: stepDescriptionsList})
+        sf.stepFilterValue("random")
+        sf.filterStepDescriptions()
+        assert(pref + 'Plugin Example 1 should  be visible', true, sf.isVisible(stepDescriptionsList[0].name))
+        assert(pref + 'Plugin Example 2 should  be visible', true, sf.isVisible(stepDescriptionsList[1].name))
+        assert(pref + 'Other Example should not be visible', false, sf.isVisible(stepDescriptionsList[2].name))
+        assert(pref + 'Default Step Plugin should not be visible (description)', false, sf.isVisible(stepDescriptionsList[3].name))
+        assert(pref + 'Other Default Step Plugin should not be visible', false, sf.isVisible(stepDescriptionsList[4].name))
+        assert(pref + 'Other Default Step Plugin should  be visible', true, sf.isVisible(stepDescriptionsList[5].name))
+    }
+    
+    self.basicFilterNameTest = function (pref) {
+        var stepDescriptionsList = createPluginDescritptions()
+        var sf = createStepFilterObj({stepDescriptions: stepDescriptionsList})
+        sf.stepFilterValue("plugin2")
+        sf.filterStepDescriptions()
+        assert(pref + 'Plugin Example 1 should not be visible', false, sf.isVisible(stepDescriptionsList[0].name))
+        assert(pref + 'Plugin Example 2 should be visible', true, sf.isVisible(stepDescriptionsList[1].name))
+        assert(pref + 'Other Example should not be visible', false, sf.isVisible(stepDescriptionsList[2].name))
+        assert(pref + 'Default Step Plugin should not be visible', false, sf.isVisible(stepDescriptionsList[3].name))
+        assert(pref + 'Other Default Step Plugin should not be visible', false, sf.isVisible(stepDescriptionsList[4].name))
+        assert(pref + 'Other Default Step Plugin should not be visible', false, sf.isVisible(stepDescriptionsList[5].name))
+    }
+
+    self.basicAllFieldsFilterTest = function (pref) {
+        var stepDescriptionsList = createPluginDescritptions()
+        var sf = createStepFilterObj({stepDescriptions: stepDescriptionsList})
+        sf.stepFilterValue("other")
+        sf.filterStepDescriptions()
+        assert(pref + 'currentPropertyFilter', 'title', sf.currentPropertyFilter())
+        assert(pref + 'currentFilter', "other", sf.currentFilter())
+        assert(pref + 'Plugin Example 1 should not be visible', false, sf.isVisible(stepDescriptionsList[0].name))
+        assert(pref + 'Plugin Example 2 should not be visible', false, sf.isVisible(stepDescriptionsList[1].name))
+        assert(pref + 'Other Example should be visible', true, sf.isVisible(stepDescriptionsList[2].name))
+        assert(pref + 'Default Step Plugin should be visible (description)', true, sf.isVisible(stepDescriptionsList[3].name))
+        assert(pref + 'Other Default Step Plugin should not be visible', true, sf.isVisible(stepDescriptionsList[4].name))
+    }
 
     self.ignoreCaseFilterTest=function(pref){
         var stepDescriptionsList = createPluginDescritptions();
@@ -196,7 +245,7 @@ var StepFiltersTest = function () {
     };
 
     self.testAll = function () {
-        jQuery(document.body).append(jQuery('<div id="step-filters-tests" class="test-elem"></div>'));
+        jQuery('#main-panel').append(jQuery('<div id="step-filters-tests" class="test-elem"></div>'))
         assert("Start: filterStepKOTest.js", 1, 1);
         for (var i in self) {
             if (i.endsWith('Test')) {
@@ -208,7 +257,7 @@ var StepFiltersTest = function () {
             }
         }
         if(failed>0){
-            jQuery(document.body).prepend(jQuery('<div></div>').append(jQuery('<span class="text-danger"></span>').text("FAIL: " + failed+"/"+total+" assertions failed")));
+            jQuery('#main-panel').prepend(jQuery('<div></div>').append(jQuery('<span class="text-danger"></span>').text("FAIL: " + failed + "/" + total + " assertions failed")))
         }
     };
 };

--- a/rundeckapp/grails-app/views/common/_stepPluginsfilterStringHelp.gsp
+++ b/rundeckapp/grails-app/views/common/_stepPluginsfilterStringHelp.gsp
@@ -14,16 +14,16 @@
   limitations under the License.
   --}%
 
-<strong>Select step by title:</strong>
+<strong>Basic search:</strong>
 <p>
     <code>mystep1</code>
 </p>
 <p>
-    This will show step that contains "mystep1" on title.
+    This will show steps that contains "mystep1" in the title, description, or name.
 </p>
 
-<strong>For step plugins:</strong>
-<p>Filter step by attribute value:</p>
+<strong>Filter by matching a specific field:</strong>
+
 <ul>
     <li>description: <code>description=value</code></li>
 
@@ -32,7 +32,7 @@
     <li>title: <code>title=value</code></li>
 </ul>
 
-<p>Filter step by property value:</p>
+<p>Filter by matching an input property value:</p>
 <ul>
     <li>property description: <code>property:description=value</code></li>
 

--- a/rundeckapp/grails-app/views/execution/_wfAddStep.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfAddStep.gsp
@@ -78,25 +78,25 @@
                         <g:message code="framework.service.WorkflowNodeStep.description" />
                     </span>
                 </div>
-                    <a data-bind="visible: isDefaultStepsVisible('${message(code:'step.type.exec.title')}')"
+                    <a data-bind="visible: isDefaultStepsVisible('${message(code:'step.type.exec.title')}','${message(code:'step.type.exec.description')}')"
                        class="list-group-item  add_node_step_type" data-node-step-type="command" href="#">
                         <i class="rdicon icon-small shell"></i>
                         <g:message code="step.type.exec.title"/>
                         <span class="text-info">- <g:message code="step.type.exec.description"/></span>
                     </a>
-                    <a data-bind="visible: isDefaultStepsVisible('${message(code:'step.type.script.title')}')"
+                    <a data-bind="visible: isDefaultStepsVisible('${message(code:'step.type.script.title')}','${message(code:'step.type.script.description')}')"
                        class="list-group-item textbtn  add_node_step_type" href="#" data-node-step-type="script">
                         <i class="rdicon icon-small script"></i>
                         <g:message code="step.type.script.title"/>
                         <span class="text-info">- <g:message code="step.type.script.description"/></span>
                     </a>
-                    <a data-bind="visible: isDefaultStepsVisible('${message(code:'step.type.scriptfile.title')}')"
+                    <a data-bind="visible: isDefaultStepsVisible('${message(code:'step.type.scriptfile.title')}','${message(code:'step.type.scriptfile.description')}')"
                        class="list-group-item textbtn  add_node_step_type" href="#" data-node-step-type="scriptfile">
                         <i class="rdicon icon-small scriptfile"></i>
                         <g:message code="step.type.scriptfile.title"/>
                         <span class="text-info">- <g:message code="step.type.scriptfile.description"/></span>
                     </a>
-                    <a data-bind="visible: isDefaultStepsVisible('${message(code:'step.type.jobreference.title')}')"
+                    <a data-bind="visible: isDefaultStepsVisible('${message(code:'step.type.jobreference.title')}','${message(code:'step.type.jobreference.nodestep.description')}')"
                        class="list-group-item textbtn add_node_step_type" data-node-step-type="job" href="#">
                         <i class="glyphicon glyphicon-book"></i>
                         <g:message code="step.type.jobreference.title"/>
@@ -145,7 +145,7 @@
                     </span>
                 </div>
 
-                <a data-bind="visible: isDefaultStepsVisible('${message(code:'step.type.jobreference.title')}')"
+                <a data-bind="visible: isDefaultStepsVisible('${message(code:'step.type.jobreference.title')}','${message(code:'step.type.jobreference.description')}')"
                    class="list-group-item textbtn add_step_type" data-step-type="job" href="#">
                     <i class="glyphicon glyphicon-book"></i>
                     <g:message code="step.type.jobreference.title" /> <span class="text-info">- <g:message code="step.type.jobreference.description" /></span>

--- a/rundeckapp/grails-app/views/framework/_stepPluginFilterInputGroup.gsp
+++ b/rundeckapp/grails-app/views/framework/_stepPluginFilterInputGroup.gsp
@@ -17,16 +17,19 @@
 <input type='search' name="${filterFieldName?enc(attr:filterFieldName):'filter'}" class="schedJobStepFilter form-control"
        data-bind="textInput: stepFilterValue,  executeOnEnter: filterStepDescriptions"
        placeholder="${queryFieldPlaceholderText?:g.message(code:'enter.a.node.filter')}"
-       data-toggle='popover'
-       data-popover-content-ref="#${queryFieldHelpId?enc(attr:queryFieldHelpId):'queryFilterHelp'}"
-       data-placement="bottom"
-       data-trigger="manual"
-       data-container="body"
        value="${enc(attr:filtvalue)}" id="${filterFieldId ? enc(attr: filterFieldId) : 'schedJobStepFilter'}"/>
 
 
 <span class="input-group-btn">
-    <a class="btn btn-default" data-toggle='popover-for' data-target="#${filterFieldId ? enc(attr: filterFieldId) : 'schedJobStepFilter'}" onclick="jQuery('#${filterFieldId ? enc(attr: filterFieldId) : 'schedJobStepFilter'}').popover('toggle')">
+    <a class="btn btn-default"
+       tabindex="0"
+       role="button"
+       data-toggle='popover'
+       data-popover-content-ref="#${queryFieldHelpId?enc(attr:queryFieldHelpId):'queryFilterHelp'}"
+       data-placement="bottom"
+       data-trigger="click"
+       data-popover-template-class="popover-wide"
+       data-container="body">
         <i class="glyphicon glyphicon-question-sign"></i>
     </a>
     <a class="btn btn-default" data-bind="click: filterStepDescriptions" href="#">


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**
Update search behavior for step plugin selector in Job Edit page.

**Describe the solution you've implemented**

Previous behavior only searched the Title, and required syntax like `description=query` to search the description or plugin name (identifier).

This change makes the field search the title, name, and description by default.

**Additional context**

Old behavior: (1 result for `inline`)

![Screen Shot 2019-10-15 at 3 29 30 PM](https://user-images.githubusercontent.com/55603/66875213-5dbcd280-ef62-11e9-9c5f-0bff937a1f3a.png)

New behavior: (3 results for `inline`)

![Screen Shot 2019-10-15 at 3 29 02 PM](https://user-images.githubusercontent.com/55603/66875225-6a412b00-ef62-11e9-84e4-abedb3a25e05.png)


**Future enhancements**

* The `description` that is searched is currently the default value from the plugin itself, and does not correctly use any i18n in the user's locale.
