### PR TITLE
Revert "Improve interactivity of page when loading execution log"

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/executionControl.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionControl.js
@@ -473,91 +473,9 @@ var FollowControl = function (eid, elem, params) {
         var rowcount= this.countTableRows(this.cmdoutputtbl);
         var compacted = data.compacted;
         var compactedAttr = data.compactedAttr;
-
-        /**Called after table update is finished for housekeeping and fetching next batch if necessary **/
-        var doFinishedLogUpdate = function() {
-
-            this.lineCount+=entries.length;
-
-            if (typeof(this.onAppend) == 'function') {
-                this.onAppend();
-            }
-            if (this.clusterExec && this.showClusterExecWarning) {
-                if (!this.runningcmd.completed) {
-                    //show cluster loading info
-                    jQuery('#' + generateId(this.parentElement) + '_clusterinfo').show()
-                } else {
-                    jQuery('#' + generateId(this.parentElement) + '_clusterinfo').hide()
-                }
-            }
-
-            if (this.runningcmd.completed && this.runningcmd.jobcompleted) {
-                //halt timer
-
-                if (null != data.totalSize) {
-                    if (jQuery('#' + this.outfileSizeId)) {
-                        setText('#' + this.outfileSizeId, data.totalSize + " bytes")
-                    }
-                }
-                this.finishDataOutput();
-                this.finishedExecution(this.runningcmd.jobstatus,this.runningcmd.statusString);
-                return;
-            } else {
-                var obj=this;
-                var time= (this.tailmode && this.taildelay > 0) ? this.taildelay * 1000 : 50;
-                if(this.runningcmd.pending != null){
-                    time= (this.tailmode && this.taildelay > 0) ? this.taildelay * 5000 : 5000
-                }
-                if (data.retryBackoff) {
-                    time = Math.max(data.retryBackoff,time);
-                }
-                if (!this.cancelload) {
-                    setTimeout(function () {
-                        obj.loadMoreOutput(obj.runningcmd.id, obj.runningcmd.offset)
-                    }, time)
-
-                }
-            }
-            if (this.runningcmd.jobcompleted && !this.runningcmd.completed) {
-                this.jobFinishStatus(this.runningcmd.jobstatus,this.runningcmd.statusString);
-                var message=null;
-                var percent=null;
-                if(this.runningcmd.percent!=null){
-                    percent= Math.ceil(this.runningcmd.percent);
-                    message= "Loading Output... ";
-                } else if (this.runningcmd.pending != null) {
-                    message = this.runningcmd.pending;
-                }
-                this.showLoading(message,percent);
-            }else if (!this.runningcmd.jobcompleted && !this.runningcmd.completed) {
-                //pending a remote load
-                if (this.runningcmd.pending != null) {
-                    this.showLoading(this.runningcmd.pending);
-                }else {
-                    this.hideLoading();
-                }
-            }
-            if (this.runningcmd.jobcompleted) {
-
-                if (null != data.totalSize) {
-                    if (jQuery('#' + this.outfileSizeId)) {
-                        setText('#' + this.outfileSizeId, data.totalSize + " bytes")
-                    }
-                }
-            }
-            if (this.cancelload) {
-                if (typeof (this._onStopCallback) == 'function') {
-                    var cb = this._onStopCallback
-                    this._onStopCallback = null
-                    cb()
-                }
-            }
-        }.bind(this)
-
         if (entries != null && entries.length > 0) {
             var tr;
             var self=this;
-
             var eachEntry = function (e) {
                 "use strict";
                 //this.runningcmd.entries.push(e);
@@ -565,47 +483,97 @@ var FollowControl = function (eid, elem, params) {
                 //if tail mode and count>last lines, remove 1 row from top
                 rowcount++;
             };
-
             if (compacted) {
-                var decompEntries = _decompactMapList(entries, compactedAttr, function(){});
+                _decompactMapList(entries, compactedAttr, eachEntry);
             } else {
-                var decompEntries = entries
+                for (var i = 0; i < entries.length; i++) {
+                    eachEntry(entries[i]);
+                }
             }
-
-            /** At around 20k(eyeballed) rows the table reflow takes a large amount of time so we add more rows at once **/
-            var batchSize = rowcount >= 20000 ? 500 : 50
-
-            self.processRowBatches(decompEntries, 0, batchSize, eachEntry, function() {
-                if (this.refresh && rowcount > this.lastlines && !data.lastlinesSupported && this.truncateToTail) {
-                    //remove extra lines
-                    this.removeTableRows(this.cmdoutputtbl, rowcount- this.lastlines);
-                }
-                if(needsScroll && !this.runningcmd.jobcompleted) {
-                    this.scrollToBottom();
-                }
-                doFinishedLogUpdate();
-            }.bind(this))
-        }
-    },
-    /** Process entries in batches of size to prevent blocking the renderer **/
-    processRowBatches: function(entries, index, size, procFunc, doneFunc) {
-        // console.log('Resume at ' + index, ' with size', size)
-
-        for (var i = index; i < entries.length; i++) {
-
-            procFunc(entries[i]);
-
-            if (i !== 0 && i % size === 0) {
-                var resumeIndex = i + 1
-
-                setTimeout(function() {
-                    this.processRowBatches(entries, resumeIndex, size, procFunc, doneFunc)}.bind(this), 0)
-                return
+            if (this.refresh && rowcount > this.lastlines && !data.lastlinesSupported && this.truncateToTail) {
+                //remove extra lines
+                this.removeTableRows(this.cmdoutputtbl, rowcount- this.lastlines);
+            }
+            if(needsScroll && !this.runningcmd.jobcompleted){
+                this.scrollToBottom();
             }
         }
-        doneFunc()
-    },
+        this.lineCount+=entries.length;
 
+        if (typeof(this.onAppend) == 'function') {
+            this.onAppend();
+        }
+        if (this.clusterExec && this.showClusterExecWarning) {
+            if (!this.runningcmd.completed) {
+                //show cluster loading info
+                jQuery('#' + generateId(this.parentElement) + '_clusterinfo').show()
+            } else {
+                jQuery('#' + generateId(this.parentElement) + '_clusterinfo').hide()
+            }
+        }
+
+        if (this.runningcmd.completed && this.runningcmd.jobcompleted) {
+            //halt timer
+
+            if (null != data.totalSize) {
+                if (jQuery('#' + this.outfileSizeId)) {
+                    setText('#' + this.outfileSizeId, data.totalSize + " bytes")
+                }
+            }
+            this.finishDataOutput();
+            this.finishedExecution(this.runningcmd.jobstatus,this.runningcmd.statusString);
+            return;
+        } else {
+            var obj=this;
+            var time= (this.tailmode && this.taildelay > 0) ? this.taildelay * 1000 : 50;
+            if(this.runningcmd.pending != null){
+                time= (this.tailmode && this.taildelay > 0) ? this.taildelay * 5000 : 5000
+            }
+            if (data.retryBackoff) {
+                time = Math.max(data.retryBackoff,time);
+            }
+            if (!this.cancelload) {
+                setTimeout(function () {
+                    obj.loadMoreOutput(obj.runningcmd.id, obj.runningcmd.offset)
+                }, time)
+
+            }
+        }
+        if (this.runningcmd.jobcompleted && !this.runningcmd.completed) {
+            this.jobFinishStatus(this.runningcmd.jobstatus,this.runningcmd.statusString);
+            var message=null;
+            var percent=null;
+            if(this.runningcmd.percent!=null){
+                percent= Math.ceil(this.runningcmd.percent);
+                message= "Loading Output... ";
+            } else if (this.runningcmd.pending != null) {
+                message = this.runningcmd.pending;
+            }
+            this.showLoading(message,percent);
+        }else if (!this.runningcmd.jobcompleted && !this.runningcmd.completed) {
+            //pending a remote load
+            if (this.runningcmd.pending != null) {
+                this.showLoading(this.runningcmd.pending);
+            }else {
+                this.hideLoading();
+            }
+        }
+        if (this.runningcmd.jobcompleted) {
+
+            if (null != data.totalSize) {
+                if (jQuery('#' + this.outfileSizeId)) {
+                    setText('#' + this.outfileSizeId, data.totalSize + " bytes")
+                }
+            }
+        }
+        if (this.cancelload) {
+            if (typeof (this._onStopCallback) == 'function') {
+                var cb = this._onStopCallback
+                this._onStopCallback = null
+                cb()
+            }
+        }
+    },
     finishDataOutput: function() {
 
         if (typeof(this.onLoadComplete) == 'function') {
@@ -1081,9 +1049,6 @@ var FollowControl = function (eid, elem, params) {
 
         }
         var tr = (this.lastTBody.insertRow(this.isAppendTop() ? 0 : -1))
-
-        // var tr = new HTMLTableRowElement()
-
         this.configureDataRow(tr, data, ctxid);
 
         this.runningcmd.count++;

--- a/rundeckapp/grails-app/assets/javascripts/util/compactMapList.js
+++ b/rundeckapp/grails-app/assets/javascripts/util/compactMapList.js
@@ -27,7 +27,6 @@
  * @private
  */
 function _decompactMapList(entries, compactedAttr, func) {
-    var decomp = []
     var odata = {};
     for (var i = 0; i < entries.length; i++) {
         var e = entries[i];
@@ -52,7 +51,5 @@ function _decompactMapList(entries, compactedAttr, func) {
         }
         odata = e;
         func(e);
-        decomp.push(e)
     }
-    return decomp
 }

--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -211,8 +211,7 @@ rundeck:
             tail:
                 lines:
                     default: 20
-                    max: 2000
-
+                    max: 500
         job:
             description:
                 disableHTML: false


### PR DESCRIPTION
Reverts #5254

This introduced a regression with the loading bar not going away after the execution has finished when viewing the log output.

After spending some time going through the code the exact cause wasn't presenting itself quick enough :) There is a much, much quicker log output viewer in the works that should make this change obsolete shortly so reverting is probably a better use of time.