### PR TITLE
Fixes #5320 - adds a wordbreak to the contents of a table column

### DIFF
--- a/rundeckapp/grails-app/assets/scss/custom/execution-output-table.scss
+++ b/rundeckapp/grails-app/assets/scss/custom/execution-output-table.scss
@@ -1,4 +1,5 @@
 $table-border-color: #eeeeee;
+
 //////////////////////////
 // execution output table view
 table.execoutput {
@@ -48,8 +49,9 @@ table.execoutput {
     color: #eee;
   }
 
-  tr.node-new > td {
+  tr.node-new>td {
     border-top: 1px solid #dddddd;
+    word-break: break-all;
   }
 
   td.node {}


### PR DESCRIPTION
Fixes a wordbreak bug in the log output of a job. Fixes #5320

Please test with the included job definition - renamed as .txt, change to .dtd

<img width="1440" alt="Screen Shot 2019-10-17 at 2 19 34 PM" src="https://user-images.githubusercontent.com/265904/67036204-2dec0700-f0e9-11e9-96d4-faa85da136d0.png">
[very_long_line copy.txt](https://github.com/rundeck/rundeck/files/3740733/very_long_line.copy.txt)
