### PR TITLE
Add API endpoint for getting job workflow tree

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -311,16 +311,9 @@ function JobWorkflowsCache(url,data){
      * @returns {*}
      */
     self.load=function(id){
-        return jQuery.ajax({
-            url:_genUrl(self.url,{id:id}),
-            method:'GET',
-            contentType:'json',
-            success:function(data){
-                // setTimeout(function(){
-                    self.add(id,data.workflow);
-                // },2000);
-            }
-        });
+        window._rundeck.rundeckClient.jobWorkflowGet(id).then(function(resp) {
+            self.add(id, resp.workflow);
+        })
     };
     /**
      * add job ID data

--- a/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
+++ b/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
@@ -87,6 +87,8 @@ class UrlMappings {
         "/api/$api_version/job/$id/scm/$integration/action/$actionId/input"(controller: 'scm', action: 'apiJobActionInput')
         "/api/$api_version/job/$id/scm/$integration/action/$actionId"(controller: 'scm', action: 'apiJobActionPerform')
 
+        "/api/$api_version/job/$id/workflow"(controller: 'scheduledExecution', action: 'apiJobWorkflow')
+
         "/api/$api_version/jobs/delete"(controller: 'scheduledExecution', action: 'apiJobDeleteBulk')
         "/api/$api_version/jobs/schedule/enable"(controller: 'scheduledExecution',action: 'apiFlipScheduleEnabledBulk') {
             status = true

--- a/rundeckapp/grails-spa/package.json
+++ b/rundeckapp/grails-spa/package.json
@@ -16,7 +16,7 @@
     "axios": "^0.18.0",
     "brace": "^0.11.1",
     "fuse.js": "^3.4.4",
-    "ts-rundeck": "0.0.18",
+    "ts-rundeck": "0.1.5",
     "uiv": "^0.27.0",
     "vue": "2.5.17",
     "vue-cookies": "^1.5.6",
@@ -32,7 +32,7 @@
     "snyk": "^1.165.2"
   },
   "devDependencies": {
-    "@rundeck/ui-trellis": "git+https://github.com/rundeck/ui-trellis.git#fd12bd83de08538d664e301610e2883a69446f91",
+    "@rundeck/ui-trellis": "git+https://github.com/rundeck/ui-trellis.git#0ac79c7181cad4f16cdd9d35103d5820b9ebc2ef",
     "@types/lodash": "^4.14.117",
     "autoprefixer": "^7.1.2",
     "babel-core": "^6.22.1",

--- a/rundeckapp/grails-spa/package.json
+++ b/rundeckapp/grails-spa/package.json
@@ -32,7 +32,7 @@
     "snyk": "^1.165.2"
   },
   "devDependencies": {
-    "@rundeck/ui-trellis": "git+https://github.com/rundeck/ui-trellis.git#0ac79c7181cad4f16cdd9d35103d5820b9ebc2ef",
+    "@rundeck/ui-trellis": "git+https://github.com/rundeck/ui-trellis.git#1c9bda785db0a4a209fb3232b2032f826653de75",
     "@types/lodash": "^4.14.117",
     "autoprefixer": "^7.1.2",
     "babel-core": "^6.22.1",

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
@@ -34,16 +34,17 @@ class ApiVersions {
     public static final int V31 = 31
     public static final int V32 = 32
     public static final int V33 = 33
+    public static final int V34 = 34
     public static final Map VersionMap = [:]
     public static final List Versions = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18,
-                                         V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32,V33]
+                                         V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32,V33,V34]
     static {
         Versions.each { VersionMap[it.toString()] = it }
     }
     public static final Set VersionStrings = new HashSet(VersionMap.values())
 
     public final static int API_EARLIEST_VERSION = V1
-    public final static int API_CURRENT_VERSION = V33
+    public final static int API_CURRENT_VERSION = V34
     public final static int API_MIN_VERSION = API_EARLIEST_VERSION
     public final static int API_MAX_VERSION = API_CURRENT_VERSION
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -67,14 +67,19 @@ class ScheduledExecutionControllerSpec extends Specification {
     def "workflow json"() {
         given:
         ScheduledExecution job = new ScheduledExecution(createJobParams())
+        controller.apiService = Mock(ApiService)
         controller.frameworkService = Mock(FrameworkService)
         controller.scheduledExecutionService = Mock(ScheduledExecutionService)
 
         when:
+        request.api_version = 34
+        request.method = 'GET'
         params.id = job.extid
-        def result = controller.workflowJson()
+        def result = controller.apiJobWorkflow()
 
         then:
+        1 * controller.apiService.requireApi(_,_)>>true
+        1 * controller.apiService.requireVersion(_,_,34) >> true
         1 * controller.frameworkService.authorizeProjectJobAny(_, job, ['read', 'view'], 'AProject') >> true
         1 * controller.frameworkService.authorizeProjectJobAny(_, job, ['read'], 'AProject') >> readauth
         1 * controller.scheduledExecutionService.getByIDorUUID(_) >> job

--- a/test/api/include.sh
+++ b/test/api/include.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # common header for test scripts
-API_CURRENT_VERSION=33
+API_CURRENT_VERSION=34
 
 SRC_DIR=$(cd `dirname $0` && pwd)
 DIR=${TMP_DIR:-$SRC_DIR}


### PR DESCRIPTION
* Adds `job/[ID]/workflow` endpoint to public API for retrieving a job's workflow tree

This is preparatory work for moving more functionality out into components in the `grails-spa` project. Specifically it is being utilized by the new execution output viewer component.

**Docs PR**
rundeck/docs#338