### PR TITLE
fix #4842 default selected validation fails if the object is not a map

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2560,7 +2560,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 if(null==optparams[opt.name] && opt.enforced && !opt.optionValues){
                     Map remoteOptions = scheduledExecutionService.loadOptionsRemoteValues(scheduledExecution, [option: opt.name, extra: [option: optparams]], authContext?.username)
                     if(!remoteOptions.err && remoteOptions.values){
-                        Map selectedOption = remoteOptions.values.find {Map value -> [true, 'true'].contains(value.selected)}
+                        Map selectedOption = remoteOptions.values.find {it instanceof Map && [true, 'true'].contains(it.selected)}
                         if(selectedOption){
                             defaultoptions[opt.name]=selectedOption.value
                         }

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -1608,6 +1608,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         defaultValue | optValue                                       | remoteValues
         "B"          | "B"                                            | [new JSONObject(name: "a", value:"A", selected: true), new JSONObject(name:"b", value:"B"), new JSONObject(name:"c", value:"C")]
         null         | "A"                                            | [new JSONObject(name: "a", value:"A", selected: true), new JSONObject(name:"b", value:"B"), new JSONObject(name:"c", value:"C")]
+        null         | null                                           | ['A','B','C']
 
     }
 


### PR DESCRIPTION
fix #4842

In this particular case: https://github.com/rundeck/rundeck/issues/4842#issuecomment-535131898

If the option is not mandatory and  the remote list is only values not complex json objects, the clause throws a `groovy.lang.MissingMethodException`.
