### PR TITLE
[2.11 backport] ImportOptions to jobref in job definition

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -274,7 +274,7 @@ class ScheduledExecutionController  extends ControllerBase{
                                                                  [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT])) {
                 if(scmService.projectHasConfiguredExportPlugin(params.project)) {
                     model.scmExportEnabled = true
-                    model.scmExportStatus = scmService.exportStatusForJobs(authContext [scheduledExecution])
+                    model.scmExportStatus = scmService.exportStatusForJobs(authContext, [scheduledExecution])
                     model.scmExportRenamedPath=scmService.getRenamedJobPathsForProject(params.project)?.get(scheduledExecution.extid)
                 }
             }

--- a/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
@@ -134,7 +134,7 @@ public class JobExec extends WorkflowStep implements IWorkflowJobItem{
             map.failOnDisable = failOnDisable
         }
         if(importOptions){
-            map.importOptions = importOptions
+            map.jobref.importOptions = importOptions
         }
         if(nodeFilter){
             map.jobref.nodefilters=[filter:nodeFilter]

--- a/rundeckapp/test/unit/rundeck/JobExecSpec.groovy
+++ b/rundeckapp/test/unit/rundeck/JobExecSpec.groovy
@@ -167,4 +167,83 @@ class JobExecSpec extends Specification {
         result.jobProject == 'projectB'
 
     }
+
+    def "to map with importOptions"() {
+    	given:
+    	def expected = [:]
+        if(importOption) {
+            expected = [
+                    jobref     : [
+                            group        : 'group',
+                            name         : 'name',
+                            importOptions: true,
+                            nodefilters  : [
+                                    filter  : 'abc def',
+                                    dispatch: [
+                                            threadcount: 2
+                                    ]
+                            ]
+                    ],
+                    description: 'a monkey'
+            ]
+        }else{
+            expected = [
+                    jobref     : [
+                            group        : 'group',
+                            name         : 'name',
+                            nodefilters  : [
+                                    filter  : 'abc def',
+                                    dispatch: [
+                                            threadcount: 2
+                                    ]
+                            ]
+                    ],
+                    description: 'a monkey'
+            ]
+        }
+        when:
+        Map map = new JobExec(
+                jobGroup: 'group',
+                jobName: 'name',
+                description: 'a monkey',
+                nodeFilter: 'abc def',
+                importOptions: importOption,
+                nodeThreadcount: 2,
+        ).toMap()
+
+        then:
+        
+        map==expected
+
+        where:
+        importOption    | _
+        true            | _
+        false           | _
+        null            | _
+    }
+
+    def "from map with importOptions"() {
+        given:
+        def map = [
+                jobref     : [
+                        group      : 'group',
+                        name       : 'name'
+                ],
+                description: 'a monkey'
+        ]
+        if(importOption != null) {
+            map.jobref.importOptions = importOption
+        }
+        when:
+        def result = JobExec.jobExecFromMap(map)
+
+        then:
+        result.importOptions == (importOption?.equals('true')?:null)
+        where:
+        importOption    | _
+        'true'          | _
+        'false'         | _
+        null            | _
+
+    }
 }


### PR DESCRIPTION
Back port of #3442 

Not urgent, just nice to have in a future 2.11.x release.
Had to make this back port by hand instead of cherry picking commits because the test has changed between 3.0.0 and 2.11.x

Also found a missing comma inside a SCM method call from a previous back port. Its inside an Ajax call so it doesn't stop the flow of the SCM actions.