### PR TITLE
Fixes #5121. Bump repository version.

### DIFF
--- a/rundeckapp/repository/build.gradle
+++ b/rundeckapp/repository/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     compile "org.grails.plugins:gsp"
 
     compile project(":core")
-    compile('com.github.rundeck.repository:repository-client:0.11.0') {
+    compile('com.github.rundeck.repository:repository-client:0.12.0') {
         exclude(group:"org.rundeck", module:"rundeck-core")
         exclude(group:"org.rundeck", module:"rundeck-storage-api")
         exclude(group:"org.rundeck", module:"rundeck-storage-data")


### PR DESCRIPTION
Bump repository version to update dependencies and fix an issue when accessing the official repo manifest fails.
