### PR TITLE
Docker - Set uid in passwd for OpenShift support

### DIFF
--- a/docker/official/lib/entry.sh
+++ b/docker/official/lib/entry.sh
@@ -52,7 +52,7 @@ fi
 # Support Arbitrary User IDs on OpenShift
 if ! whoami &> /dev/null; then
   if [ -w /etc/passwd ]; then
-    echo "rundeck:x:$(id -u):0:rundeck user:/home/server:/sbin/nologin" >> /etc/passwd
+    echo "rundeck:x:$(id -u):0:rundeck user:/home/rundeck:/bin/bash" >> /etc/passwd
   fi
 fi
 

--- a/docker/official/lib/entry.sh
+++ b/docker/official/lib/entry.sh
@@ -49,6 +49,13 @@ if [[ ! -z "${RUNDECK_ENVARS_UNSETS:-}" ]] ; then
     unset RUNDECK_ENVARS_UNSETS
 fi
 
+# Support Arbitrary User IDs on OpenShift
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "rundeck:x:$(id -u):0:rundeck user:/home/server:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+
 exec java \
     -XX:+UnlockExperimentalVMOptions \
     -XX:MaxRAMFraction="${JVM_MAX_RAM_FRACTION}" \

--- a/docker/official/lib/entry.sh
+++ b/docker/official/lib/entry.sh
@@ -52,7 +52,7 @@ fi
 # Support Arbitrary User IDs on OpenShift
 if ! whoami &> /dev/null; then
   if [ -w /etc/passwd ]; then
-    sed -i "/rundeck/c\rundeck:x:$(id -u):0:rundeck user:\/home\/rundeck:\/bin\/bash" /etc/passwd
+    sed -i "\#rundeck#c\rundeck:x:$(id -u):0:rundeck user:/home/rundeck:/bin/bash" /etc/passwd
   fi
 fi
 

--- a/docker/official/lib/entry.sh
+++ b/docker/official/lib/entry.sh
@@ -52,7 +52,7 @@ fi
 # Support Arbitrary User IDs on OpenShift
 if ! whoami &> /dev/null; then
   if [ -w /etc/passwd ]; then
-    echo "rundeck:x:$(id -u):0:rundeck user:/home/rundeck:/bin/bash" >> /etc/passwd
+    sed -i "/rundeck/c\rundeck:x:$(id -u):0:rundeck user:\/home\/rundeck:\/bin\/bash" /etc/passwd
   fi
 fi
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
It is both :) 
OpenShift Container Platform runs containers using an arbitrarily assigned user ID, this means the rundeck process will be started with an UID not equal to the rundeck user defined in the passwd. This leads to problems, for example using ssh.
![rundeck](https://user-images.githubusercontent.com/38468371/67960155-22750180-fbfa-11e9-864b-ff6b5ff27651.png)

**Describe the solution you've implemented**
Simple add a new rundeck passwd entry with the correct UID during the start of the container. 
Of course the /etc/passwd needs write permissions for the group (->'RUN chmod g=u /etc/passwd' has to be added to the Dockerfile as well)

**Additional context**
Morge background information:
https://docs.openshift.com/container-platform/3.3/creating_images/guidelines.html#openshift-container-platform-specific-guidelines
