### PR TITLE
Allow all plugin properties to use groupName and grouping rendering options.

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtility.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtility.java
@@ -249,15 +249,9 @@ public class PluginAdapterUtility {
 
             ReplaceDataVariablesWithBlanks blankReplaceAnnotation = field.getAnnotation(ReplaceDataVariablesWithBlanks.class);
             if(blankReplaceAnnotation != null) pbuild.blankIfUnexpandable(blankReplaceAnnotation.value());
-
-            for (RenderingOption renderingOption : field.getAnnotationsByType(RenderingOption.class)) {
-                pbuild.renderingOption(renderingOption.key(), renderingOption.value());
-            }
-        } else {
-            for (RenderingOption renderingOption : field.getAnnotationsByType(RenderingOption.class)) {
-                if(renderingOption.key().equals(StringRenderingConstants.GROUP_NAME) || renderingOption.key().equals(StringRenderingConstants.GROUPING))
-                pbuild.renderingOption(renderingOption.key(), renderingOption.value());
-            }
+        }
+        for (RenderingOption renderingOption : field.getAnnotationsByType(RenderingOption.class)) {
+            pbuild.renderingOption(renderingOption.key(), renderingOption.value());
         }
 
         String name = annotation.name();

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtility.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtility.java
@@ -253,6 +253,11 @@ public class PluginAdapterUtility {
             for (RenderingOption renderingOption : field.getAnnotationsByType(RenderingOption.class)) {
                 pbuild.renderingOption(renderingOption.key(), renderingOption.value());
             }
+        } else {
+            for (RenderingOption renderingOption : field.getAnnotationsByType(RenderingOption.class)) {
+                if(renderingOption.key().equals(StringRenderingConstants.GROUP_NAME) || renderingOption.key().equals(StringRenderingConstants.GROUPING))
+                pbuild.renderingOption(renderingOption.key(), renderingOption.value());
+            }
         }
 
         String name = annotation.name();

--- a/core/src/test/java/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtilityTest.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtilityTest.java
@@ -214,6 +214,19 @@ public class PluginAdapterUtilityTest extends TestCase {
         @PluginProperty
         @RenderingOption(key = "def", value = "cookie")
         private String testSingle;
+
+        @PluginProperty
+        @RenderingOption(key = StringRenderingConstants.GROUP_NAME, value = "grp1")
+        private Boolean testBoolRO;
+
+        @PluginProperty
+        @RenderingOptions(
+                {
+                        @RenderingOption(key = "abc", value = "monkey"),
+                        @RenderingOption(key = "xyz", value = "donkey")
+                }
+        )
+        private Integer testInvalidRO;
     }
     /**
      * rendering option values
@@ -226,6 +239,10 @@ public class PluginAdapterUtilityTest extends TestCase {
         Property p1 = map.get("testSingle");
         assertEquals(Property.Type.String, p1.getType());
         assertEquals("cookie", p1.getRenderingOptions().get("def"));
+
+        Property p2 = map.get("testBoolRO");
+        assertEquals(Property.Type.Boolean, p2.getType());
+        assertEquals("grp1", p2.getRenderingOptions().get(StringRenderingConstants.GROUP_NAME));
     }
     /**
      * rendering option values
@@ -239,6 +256,10 @@ public class PluginAdapterUtilityTest extends TestCase {
         assertEquals(Property.Type.String, p1.getType());
         assertEquals("monkey", p1.getRenderingOptions().get("abc"));
         assertEquals("donkey", p1.getRenderingOptions().get("xyz"));
+
+        Property p2 = map.get("testInvalidRO");
+        assertEquals(Property.Type.Integer, p2.getType());
+        assertEquals(true, p2.getRenderingOptions().isEmpty());
     }
     /**
      * Default annotation values

--- a/core/src/test/java/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtilityTest.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtilityTest.java
@@ -222,11 +222,11 @@ public class PluginAdapterUtilityTest extends TestCase {
         @PluginProperty
         @RenderingOptions(
                 {
-                        @RenderingOption(key = "abc", value = "monkey"),
-                        @RenderingOption(key = "xyz", value = "donkey")
+                        @RenderingOption(key = "aaa", value = "duck"),
+                        @RenderingOption(key = "zzz", value = "goose")
                 }
         )
-        private Integer testInvalidRO;
+        private Integer testRenderingOpt;
     }
     /**
      * rendering option values
@@ -257,9 +257,10 @@ public class PluginAdapterUtilityTest extends TestCase {
         assertEquals("monkey", p1.getRenderingOptions().get("abc"));
         assertEquals("donkey", p1.getRenderingOptions().get("xyz"));
 
-        Property p2 = map.get("testInvalidRO");
+        Property p2 = map.get("testRenderingOpt");
         assertEquals(Property.Type.Integer, p2.getType());
-        assertEquals(true, p2.getRenderingOptions().isEmpty());
+        assertEquals("duck", p2.getRenderingOptions().get("aaa"));
+        assertEquals("goose", p2.getRenderingOptions().get("zzz"));
     }
     /**
      * Default annotation values

--- a/rundeckapp/src/integration-test/groovy/rundeck/services/PluginApiServiceIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/services/PluginApiServiceIntegrationSpec.groovy
@@ -56,7 +56,7 @@ class PluginApiServiceIntegrationSpec extends Specification {
                             ServiceNameConstants.UserGroupSource,
                             ServiceNameConstants.UI,
                             ServiceNameConstants.WebhookEvent,
-                            ServiceNameConstants.PasswordUtilityEncryptor,
+                            ServiceNameConstants.PasswordUtilityEncrypter,
                     ]
             )
         pluginList.descriptions.size() == 26


### PR DESCRIPTION
Allow all plugin properties to use groupName and grouping rendering options.
Also fixes the name of a service in the Plugin api integration test.
