### PR TITLE
Prune Webhook token output from unexpected places

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -19,6 +19,7 @@ package rundeck.controllers
 import com.dtolabs.rundeck.app.api.tokens.ListTokens
 import com.dtolabs.rundeck.app.api.tokens.RemoveExpiredTokens
 import com.dtolabs.rundeck.app.api.tokens.Token
+import com.dtolabs.rundeck.core.authentication.tokens.AuthTokenType
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.extension.ApplicationExtension
@@ -259,7 +260,7 @@ class ApiController extends ControllerBase{
             tokenlist = AuthToken.list()
         }
         def apiv19 = request.api_version >= ApiVersions.V19
-        def data = new ListTokens(params.user, !params.user, tokenlist.collect { new Token(it, apiv19) })
+        def data = new ListTokens(params.user, !params.user, tokenlist.findAll { it.type != AuthTokenType.WEBHOOK }.collect { new Token(it, apiv19) })
 
         respond(data, [formats: ['xml', 'json']])
     }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -514,7 +514,7 @@ class UserController extends ControllerBase{
                     obj.lastJob = lastExec
                 }
             }
-            def tokenCount = AuthToken.countByUser(it)
+            def tokenCount = countUserApiTokens(it)
             obj.tokens = tokenCount
             obj.loggedStatus = userService.getLoginStatus(it)
             obj.lastHostName = it.lastLoggedHostName
@@ -540,6 +540,19 @@ class UserController extends ControllerBase{
                         ]
                 ) as JSON
         )
+    }
+
+    protected Integer countUserApiTokens(User user) {
+        return AuthToken.createCriteria().list {
+            projections {
+                count()
+            }
+            eq("user",user)
+            or {
+                eq("type", AuthTokenType.USER)
+                isNull("type")
+            }
+        }[0]
     }
     public def update (User user) {
         withForm{

--- a/rundeckapp/src/test/groovy/rundeck/controllers/UserControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/UserControllerSpec.groovy
@@ -671,6 +671,21 @@ class UserControllerSpec extends Specification implements ControllerUnitTest<Use
 
     }
 
+    def "countUserApiTokens does not include webhook tokens"() {
+        given:
+        User bob = new User(login:"bob")
+        bob.save()
+        new AuthToken(user:bob,type:AuthTokenType.USER,authRoles: "admin",token:Math.random().toString()).save()
+        new AuthToken(user:bob,authRoles: "admin",token:Math.random().toString()).save()
+        new AuthToken(user:bob,type:AuthTokenType.WEBHOOK,authRoles: "admin",token:Math.random().toString()).save()
+
+        when:
+        def tokenCount = controller.countUserApiTokens(bob)
+
+        then:
+        tokenCount == 2
+    }
+
     private void createAuthToken(params) {
         AuthToken tk = new AuthToken()
         tk.authRoles = "admin"


### PR DESCRIPTION
Fixes two places that were outputting webhook tokens with user type API tokens.
