### PR TITLE
Lifecycle plugin updates

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContext.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContext.java
@@ -150,6 +150,11 @@ public interface ExecutionContext {
     public Map<String, Map<String, String>> getDataContext();
     public DataContext getDataContextObject();
 
+    /**
+     * @param type
+     * @param <T>
+     * @return collection of components of specified type
+     */
     <T> Collection<T> componentsForType(Class<T> type);
 
     /**
@@ -177,6 +182,13 @@ public interface ExecutionContext {
      */
     <T> boolean useSingleComponentOfType(Class<T> type, Consumer<Optional<T>> consumer);
 
+    /**
+     * apply the consumer to a single component of the given type, and remove the component if it is "useOnce"
+     *
+     * @param type
+     * @param <T>
+     * @return optional component object
+     */
     <T> Optional<T> useSingleComponentOfType(Class<T> type);
 
     /**

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContextImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContextImpl.java
@@ -135,7 +135,11 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
     @Override
     public <T> Optional<T> useSingleComponentOfType(final Class<T> type) {
         Optional<ContextComponent<?>> found = componentStream(type).findFirst();
-        found.ifPresent(contextComponent -> componentList.remove(contextComponent));
+        found.ifPresent(contextComponent -> {
+            if (contextComponent.isUseOnce()) {
+                componentList.remove(contextComponent);
+            }
+        });
         return found.map((opt) -> type.cast(opt.getObject()));
     }
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/ExecutionLifecycleStatusImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/ExecutionLifecycleStatusImpl.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.core.jobs;
+
+import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext;
+import lombok.Builder;
+import lombok.Data;
+
+
+@Data
+@Builder
+public class ExecutionLifecycleStatusImpl
+        implements ExecutionLifecycleStatus
+{
+    private final boolean successful;
+    private final String errorMessage;
+    private final boolean useNewValues;
+    private final StepExecutionContext executionContext;
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/StringRenderingConstants.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/StringRenderingConstants.java
@@ -39,6 +39,7 @@ public class StringRenderingConstants {
     public static final String GROUP_NAME = "groupName";
     public static final String CODE_SYNTAX_MODE = "codeSyntaxMode";
     public static final String CODE_SYNTAX_SELECTABLE = "codeSyntaxSelectable";
+    public static final String CODE_SYNTAX_MODES_ALLOWED = "codeSyntaxModesAllowed";
 
     /**
      * Values that can be specified for a key of {@link #DISPLAY_TYPE_KEY}

--- a/rundeckapp/grails-app/assets/javascripts/application.js
+++ b/rundeckapp/grails-app/assets/javascripts/application.js
@@ -416,6 +416,7 @@ function _setupAceTextareaEditor(textarea, callback, autoCompleter) {
   //add syntax dropdown
   var addSyntaxSelect = data.aceControlSyntax ? data.aceControlSyntax : false;
   if (addSyntaxSelect) {
+    var allowSyntaxModes = data.aceAllowedSyntaxModes ? data.aceAllowedSyntaxModes.split(',') : [];
     var sel = jQuery('<select/>')
       .addClass('form-control')
       .on('change', function (e) {
@@ -424,6 +425,9 @@ function _setupAceTextareaEditor(textarea, callback, autoCompleter) {
     sel.append(jQuery('<option/>').attr('value', '-').text('-None-'));
     for (var i = 0; i < _ace_modes.length; i++) {
       var mode = _ace_modes[i];
+      if(allowSyntaxModes.length>0 && allowSyntaxModes.indexOf(mode)<0){
+        continue
+      }
       var option = jQuery('<option/>').attr('value', mode).text(mode);
       sel.append(option);
       if (mode == data.aceSessionMode) {

--- a/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
+++ b/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
@@ -195,9 +195,11 @@
     <g:elseif test="${prop.renderingOptions?.(StringRenderingConstants.DISPLAY_TYPE_KEY) in [StringRenderingConstants.DisplayType.CODE, 'CODE']}">
         <g:set var="syntax" value="${prop.renderingOptions?.(StringRenderingConstants.CODE_SYNTAX_MODE)}"/>
         <g:set var="syntaxSelectable" value="${prop.renderingOptions?.(StringRenderingConstants.CODE_SYNTAX_SELECTABLE)}"/>
+        <g:set var="syntaxModes" value="${prop.renderingOptions?.(StringRenderingConstants.CODE_SYNTAX_MODES_ALLOWED)}"/>
         <g:textArea name="${fieldname}" value="${valueText}"
             data-ace-session-mode="${syntax}"
             data-ace-control-syntax="${syntaxSelectable?true:false}"
+            data-ace-allowed-syntax-modes="${syntaxModes?:''}"
             data-ace-height="100px"
             data-ace-resize-auto="true"
             data-ace-resize-max="20"

--- a/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
+++ b/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
@@ -198,6 +198,9 @@
         <g:textArea name="${fieldname}" value="${valueText}"
             data-ace-session-mode="${syntax}"
             data-ace-control-syntax="${syntaxSelectable?true:false}"
+            data-ace-height="100px"
+            data-ace-resize-auto="true"
+            data-ace-resize-max="20"
                     id="${fieldid}" rows="10" cols="100" class="${formControlCodeType} ${extraInputCss}"/>
     </g:elseif>
     <g:elseif test="${prop.renderingOptions?.(StringRenderingConstants.DISPLAY_TYPE_KEY) in [StringRenderingConstants.DisplayType.PASSWORD, 'PASSWORD']}">

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -1250,6 +1250,9 @@ function getCurSEID(){
 <g:if test="${params.executionLifecyclePluginValidation}">
             jobeditor.addError('plugins');
 </g:if>
+            jQuery('.apply_ace').each(function () {
+                _setupAceTextareaEditor(this, confirm.setNeetsConfirm);
+            });
             initKoBind(null,{jobeditor:jobeditor})
         }
 


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**

Some fixes for lifecycle plugins:

* UI: CODE rendering option in job edit page not loading for exec lifecycle plugins
* Add utility implementation of expected return type for execution lifecycle plugins
* fix: `useSingleComponentOfType` method not working correctly
