### PR TITLE
Table word wrap issue, fixes #5384

### DIFF
--- a/rundeckapp/grails-app/views/user/_token.gsp
+++ b/rundeckapp/grails-app/views/user/_token.gsp
@@ -59,8 +59,8 @@
                 (${token.creator})
             </g:if>
         </td>
-        <td width="30%" class="ellipsis" title="${token.authRoles}">
-            <span>${token.authRoles}</span>
+        <td width="30%" title="${token.authRoles}">
+            <span style="word-break: break-all;">${token.authRoles}</span>
         </td>
         <td width="10%">
           <a style="padding-left:14px; padding-right: 14px; ${wdgt.styleVisible(if: token.token && !(params.showConfirm && params.token==token.token))}"


### PR DESCRIPTION
User token table, when a user has many roles, does not wrap the text therein, obsecuring the delete button off the viewport. This fix adds an inline "word-break" to the containing span and removes "ellipsis" class that is both unnecessary and incorrect.

<img width="542" alt="Screen Shot 2019-11-06 at 11 27 42 AM" src="https://user-images.githubusercontent.com/265904/68317226-c3473f00-0088-11ea-8c86-101423562efa.png">
