### PR TITLE
Fix duplicate ACE editors being added on job edit page.

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -1250,9 +1250,6 @@ function getCurSEID(){
 <g:if test="${params.executionLifecyclePluginValidation}">
             jobeditor.addError('plugins');
 </g:if>
-            jQuery('.apply_ace').each(function () {
-                _setupAceTextareaEditor(this, confirm.setNeetsConfirm);
-            });
             initKoBind(null,{jobeditor:jobeditor})
         }
 


### PR DESCRIPTION
ACE editor setup call is already being done in the jobedit.js. This seems to have the effect of adding it twice.