### PR TITLE
Fix: run job with extra metadata doesn't work

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
@@ -288,7 +288,7 @@ class JobStateService implements AuthorizingJobService {
         optionData.each { k, v ->
             inputOpts['option.' + k] = v
         }
-        return doRunJob(jobFilter, inputOpts, jobReference, auth, asUser)
+        return doRunJob(jobFilter, inputOpts, jobReference, auth, asUser, meta)
     }
 
     ExecutionReference doRunJob(

--- a/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
@@ -345,13 +345,12 @@ class JobStateService implements AuthorizingJobService {
                         dateStarted: result.execution?.dateStarted
                 )
             }
-        } else {
-            throw new JobExecutionError(
-                result?.message ?: result?.error ?: "Unknown: ${result}",
-                jobReference.id,
-                jobReference.project
-            )
         }
+        throw new JobExecutionError(
+            result?.message ?: result?.error ?: "Unknown: ${result}",
+            jobReference.id,
+            jobReference.project
+        )
     }
 
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

fix: run job via JobService passing extra execution metadata doesn't correctly store the metadata to the execution

**Additional context**

Job resume feature not working
