### PR TITLE
Fix typo in remco template (nestedGroups)

### DIFF
--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -50,7 +50,7 @@
         userEmailAttribute={{ getv("/rundeck/jaas/ldap/useremailattribute") }}
     {% endif %}
     {% if exists("/rundeck/jaas/ldap/nestedgroups") -%}
-        nestedGroups={{ getv("/rundeck/jaas/ldap/nestedGroups") }}
+        nestedGroups={{ getv("/rundeck/jaas/ldap/nestedgroups") }}
     {% endif %}
 
     ;


### PR DESCRIPTION
When nestedgroups are setup in Docker using environment variables, a single character case typo will produce invalid configuration file preventing Rundeck to start.

With this fix, Remco will set the right value in the configuration file and Rundeck will start normally.

Fixes https://github.com/rundeck/rundeck/issues/5474