### PR TITLE
Enhance/logged users options

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -477,15 +477,6 @@ class UserController extends ControllerBase{
 
         boolean loggedOnly = params.getBoolean('loggedOnly', false)
         boolean includeExec = params.getBoolean('includeExec', false)
-        boolean showLoginStatus = grailsApplication.config.getProperty(
-                "rundeck.gui.user.summary.show.login.status",
-                Boolean.class,
-                false
-        )
-
-        if(!showLoginStatus){
-            loggedOnly = false
-        }
 
         def filters = [:]
         if (params.loginFilter && !params.loginFilter.trim().isEmpty()) {
@@ -507,7 +498,7 @@ class UserController extends ControllerBase{
                 DEFAULT_USER_PAGE_SIZE
         )
 
-        def result = userService.findWithFilters(loggedOnly, filters, offset, max, showLoginStatus)
+        def result = userService.findWithFilters(loggedOnly, filters, offset, max)
 
         def userList = []
         result.users.each {
@@ -532,7 +523,7 @@ class UserController extends ControllerBase{
                 obj.lastSessionId = it.lastSessionId
             }
             obj.loggedInTime = it.lastLogin
-            if (showLoginStatus && loggedOnly && obj.loggedStatus.equals(UserService.LogginStatus.LOGGEDIN.value)) {
+            if (result.showLoginStatus && loggedOnly && obj.loggedStatus.equals(UserService.LogginStatus.LOGGEDIN.value)) {
                 userList.add(obj)
             } else {
                 userList.add(obj)
@@ -547,7 +538,7 @@ class UserController extends ControllerBase{
                                 offset          : offset,
                                 maxRows         : max,
                                 sessionIdEnabled: userService.isSessionIdRegisterEnabled(),
-                                showLoginStatus : showLoginStatus
+                                showLoginStatus : result.showLoginStatus
                         ]
                 ) as JSON
         )
@@ -564,22 +555,13 @@ class UserController extends ControllerBase{
         )) {
             return
         }
-        boolean loggedOnly = grailsApplication.config.getProperty(
-                "rundeck.gui.user.summary.show.logged.users.default",
-                Boolean.class,
-                true
-        )
-        boolean showLoginStatus = grailsApplication.config.getProperty(
-                "rundeck.gui.user.summary.show.login.status",
-                Boolean.class,
-                false
-        )
+        def result = userService.getSummaryPageConfig()
         render(
                 contentType: 'application/json', text:
                 (
                         [
-                                loggedOnly      : loggedOnly,
-                                showLoginStatus : showLoginStatus
+                                loggedOnly      : result.loggedOnly,
+                                showLoginStatus : result.showLoginStatus
                         ]
                 ) as JSON
         )

--- a/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
@@ -212,14 +212,14 @@ class UserService {
         status
     }
 
-    def findWithFilters(boolean loggedInOnly, def filters, offset, max){
+    def findWithFilters(boolean loggedInOnly, def filters, offset, max, showLoginStatus){
 
         int timeOutMinutes = configurationService.getInteger(SESSION_ABANDONDED_MINUTES, DEFAULT_TIMEOUT)
         Calendar calendar = Calendar.getInstance()
         calendar.add(Calendar.MINUTE, -timeOutMinutes)
 
         def totalRecords = User.createCriteria().count(){
-            if(loggedInOnly){
+            if(showLoginStatus && loggedInOnly){
                 or{
                     and{
                         isNotNull("lastLogin")
@@ -244,7 +244,7 @@ class UserService {
         def users = []
         if(totalRecords > 0){
             users = User.createCriteria().list(max:max, offset:offset){
-                if(loggedInOnly){
+                if(showLoginStatus && loggedInOnly){
                     or{
                         and{
                             isNotNull("lastLogin")

--- a/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
@@ -31,6 +31,8 @@ class UserService {
     public static final String SESSION_ID_ENABLED = 'userService.login.track.sessionId.enabled'
     public static final String SESSION_ID_METHOD = 'userService.login.track.sessionId.method'
     public static final String SESSION_ABANDONDED_MINUTES = 'userService.login.track.sessionAbandoned'
+    public static final String SHOW_LOGIN_STATUS = 'gui.userSummaryShowLoginStatus'
+    public static final String SHOW_LOGGED_USERS_DEFAULT = 'gui.userSummaryShowLoggedUsersDefault'
 
     static enum LogginStatus{
         LOGGEDIN('LOGGED IN'),LOGGEDOUT('LOGGED OUT'),ABANDONED('ABANDONED'),NOTLOGGED('NOT LOGGED')
@@ -212,9 +214,10 @@ class UserService {
         status
     }
 
-    def findWithFilters(boolean loggedInOnly, def filters, offset, max, showLoginStatus){
+    def findWithFilters(boolean loggedInOnly, def filters, offset, max){
 
         int timeOutMinutes = configurationService.getInteger(SESSION_ABANDONDED_MINUTES, DEFAULT_TIMEOUT)
+        boolean showLoginStatus = configurationService.getBoolean(SHOW_LOGIN_STATUS, false)
         Calendar calendar = Calendar.getInstance()
         calendar.add(Calendar.MINUTE, -timeOutMinutes)
 
@@ -269,8 +272,9 @@ class UserService {
             }
         }
         [
-            totalRecords:totalRecords,
-            users       :users
+            totalRecords    : totalRecords,
+            users           : users,
+            showLoginStatus : showLoginStatus
         ]
     }
 
@@ -292,5 +296,16 @@ class UserService {
 
     boolean validateUserExists(String username) {
         User.findByLogin(username) != null
+    }
+
+    /**
+     * It looks for property to choose whether to show users logged status or not
+     * @return Map
+     */
+    def getSummaryPageConfig(){
+        [
+                loggedOnly      :configurationService.getBoolean(SHOW_LOGGED_USERS_DEFAULT, false),
+                showLoginStatus :configurationService.getBoolean(SHOW_LOGIN_STATUS, false)
+        ]
     }
 }

--- a/rundeckapp/grails-spa/src/pages/menu/components/LoginStatus.vue
+++ b/rundeckapp/grails-spa/src/pages/menu/components/LoginStatus.vue
@@ -15,7 +15,7 @@
   -->
 
 <template>
-    <span>
+    <span v-if="showLoginStatus">
         <b v-if="status === 'LOGGED IN'" class="text-success fas fa-dot-circle"></b>
         <b v-if="status === 'LOGGED OUT'" class="logged-out fas fa-dot-circle"></b>
         <b v-if="status === 'NOT LOGGED'" class="text-muted fas fa-minus-circle"></b>
@@ -31,7 +31,8 @@ export default {
     name: 'LoginStatus',
     props: [
         'status',
-        'label'
+        'label',
+        'showLoginStatus'
     ]
 }
 </script>

--- a/rundeckapp/src/test/groovy/rundeck/controllers/UserControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/UserControllerSpec.groovy
@@ -704,6 +704,13 @@ class UserControllerSpec extends Specification implements ControllerUnitTest<Use
             1 * authorizeApplicationResourceType(_, _, _) >> true
         }
 
+        controller.userService = Mock(UserService) {
+            1 * getSummaryPageConfig() >> [
+                    loggedOnly      :false,
+                    showLoginStatus :false
+            ]
+        }
+
         when:
         def config = controller.getSummaryPageConfig()
 
@@ -719,8 +726,12 @@ class UserControllerSpec extends Specification implements ControllerUnitTest<Use
             1 * getAuthContextForSubject(_) >> auth
             1 * authorizeApplicationResourceType(_, _, _) >> true
         }
-        grailsApplication.config.rundeck.gui.user.summary.show.login.status = true
-        grailsApplication.config.rundeck.gui.user.summary.show.logged.users.default = true
+        controller.userService = Mock(UserService) {
+            1 * getSummaryPageConfig() >> [
+                    loggedOnly      :true,
+                    showLoginStatus :true
+            ]
+        }
         when:
         def config = controller.getSummaryPageConfig()
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/UserControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/UserControllerSpec.groovy
@@ -695,4 +695,38 @@ class UserControllerSpec extends Specification implements ControllerUnitTest<Use
         }
         tk.save()
     }
+
+    def "getSummaryPageConfig with no rundeck config values"() {
+        given:
+        UserAndRolesAuthContext auth = Mock(UserAndRolesAuthContext)
+        controller.frameworkService = Mock(FrameworkService) {
+            1 * getAuthContextForSubject(_) >> auth
+            1 * authorizeApplicationResourceType(_, _, _) >> true
+        }
+
+        when:
+        def config = controller.getSummaryPageConfig()
+
+        then:
+        response.json.loggedOnly == false
+        response.json.showLoginStatus == false
+    }
+
+    def "getSummaryPageConfig with rundeck config values"() {
+        given:
+        UserAndRolesAuthContext auth = Mock(UserAndRolesAuthContext)
+        controller.frameworkService = Mock(FrameworkService) {
+            1 * getAuthContextForSubject(_) >> auth
+            1 * authorizeApplicationResourceType(_, _, _) >> true
+        }
+        grailsApplication.config.rundeck.gui.user.summary.show.login.status = true
+        grailsApplication.config.rundeck.gui.user.summary.show.logged.users.default = true
+        when:
+        def config = controller.getSummaryPageConfig()
+
+        then:
+        response.json.loggedOnly == true
+        response.json.showLoginStatus == true
+    }
+
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/UserServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/UserServiceSpec.groovy
@@ -163,7 +163,7 @@ class UserServiceSpec extends Specification implements ServiceUnitTest<UserServi
                 getInteger(_, _) >> { it[1] }
             }
         when:
-            def result = service.findWithFilters(false, [login: userToSearch], 0, 100, false)
+            def result = service.findWithFilters(false, [login: userToSearch], 0, 100)
 
         then:
             result.users
@@ -298,9 +298,11 @@ class UserServiceSpec extends Specification implements ServiceUnitTest<UserServi
 
         service.configurationService = Mock(ConfigurationService) {
             getInteger(_, _) >> { it[1] }
+            getBoolean(UserService.SHOW_LOGIN_STATUS, false) >> true
         }
+
         when:
-        def result = service.findWithFilters(true, [login: userToSearch], 0, 100, true)
+        def result = service.findWithFilters(true, [login: userToSearch], 0, 100)
 
         then:
         result.totalRecords == 0
@@ -321,7 +323,7 @@ class UserServiceSpec extends Specification implements ServiceUnitTest<UserServi
             getInteger(_, _) >> { it[1] }
         }
         when:
-        def result = service.findWithFilters(true, [], 0, 100, true)
+        def result = service.findWithFilters(true, [], 0, 100)
 
         then:
         result.totalRecords == 1
@@ -342,10 +344,23 @@ class UserServiceSpec extends Specification implements ServiceUnitTest<UserServi
             getInteger(_, _) >> { it[1] }
         }
         when:
-        def result = service.findWithFilters(true, [], 0, 100, false)
+        def result = service.findWithFilters(true, [], 0, 100)
 
         then:
         result.totalRecords == 2
         result.users.size() == 2
+    }
+
+    def "getSummaryPageConfig with default values"() {
+        given:
+        service.configurationService = Mock(ConfigurationService) {
+
+        }
+        when:
+        def result = service.getSummaryPageConfig()
+
+        then:
+        result.loggedOnly == false
+        result.showLoginStatus == false
     }
 }

--- a/rundeckapp/templates/config/rundeck-config.properties.template
+++ b/rundeckapp/templates/config/rundeck-config.properties.template
@@ -24,3 +24,7 @@ rundeck.security.authorization.preauthenticated.redirectUrl=/oauth2/sign_in
 rundeck.log4j.config.file=${rundeck.server.configDir}/log4j.properties
 
 rundeck.feature.repository.enabled=true
+# Enables loggin status in user summary page
+rundeck.gui.user.summary.show.login.status=false
+# Sets the default value for users logged status to show on summary page (it will only work with rundeck.gui.user.summary.show.login.status=true)
+rundeck.gui.user.summary.show.logged.users.default=false

--- a/rundeckapp/templates/config/rundeck-config.properties.template
+++ b/rundeckapp/templates/config/rundeck-config.properties.template
@@ -24,7 +24,3 @@ rundeck.security.authorization.preauthenticated.redirectUrl=/oauth2/sign_in
 rundeck.log4j.config.file=${rundeck.server.configDir}/log4j.properties
 
 rundeck.feature.repository.enabled=true
-# Enables loggin status in user summary page
-rundeck.gui.user.summary.show.login.status=false
-# Sets the default value for users logged status to show on summary page (it will only work with rundeck.gui.user.summary.show.login.status=true)
-rundeck.gui.user.summary.show.logged.users.default=false


### PR DESCRIPTION
Enhancement for user summary page:
1.-New option to choose  if logged status is going to be show in the page
rundeck.gui.userSummaryShowLoginStatus=true/false
2.-New option to choose the default users to show (all or logged in only), in order to make this option to work "rundeck.gui.userSummaryShowLoginStatus" needs to be true
rundeck.gui.userSummaryShowLoggedUsersDefault=true/false

Both options are false by default and are not included in the rundeck-config.properties-template