### PR TITLE
enable executionLifecyclePlugin by default

### DIFF
--- a/rundeckapp/grails-app/conf/application.groovy
+++ b/rundeckapp/grails-app/conf/application.groovy
@@ -25,6 +25,7 @@ environments {
         rundeck.feature.'enhanced-nodes'.enabled = true
         rundeck.feature.workflowDynamicStepSummaryGUI.enabled = true
         rundeck.feature.cleanExecutionsHistoryJob.enabled = true
+        rundeck.feature.executionLifecyclePlugin.enabled = true
         dataSource {
             dbCreate = "create-drop" // one of 'create', 'create-drop','update'
             url = "jdbc:h2:file:./db/devDb"
@@ -54,6 +55,7 @@ environments {
         //enable dynamic workflow step descriptions in GUI by default
         rundeck.feature.workflowDynamicStepSummaryGUI.enabled = true
         rundeck.feature.cleanExecutionsHistoryJob.enabled = true
+        rundeck.feature.executionLifecyclePlugin.enabled = true
         dataSource {
             dbCreate = "update"
             url = "jdbc:h2:file:/rundeck/grailsh2"


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**
Enables the `executionLifecyclePlugin` feature by default