### PR TITLE
Fix #5488. Wrong boolean check for execution lifecycle feature

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionLifecyclePluginService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionLifecyclePluginService.groovy
@@ -50,8 +50,8 @@ class ExecutionLifecyclePluginService implements IExecutionLifecyclePluginServic
      * @return Map containing all of the ExecutionLifecyclePlugin implementations
      */
     Map listExecutionLifecyclePlugins(){
-        if(!featureService?.featurePresent('executionLifecyclePlugin', false)){
-            return pluginService?.listPlugins(ExecutionLifecyclePlugin, executionLifecyclePluginProviderService)
+        if(featureService?.featurePresent('executionLifecyclePlugin', false)){
+            return pluginService?.listPlugins(ExecutionLifecyclePlugin)
         }
         return null
     }


### PR DESCRIPTION
Inverted boolean check caused the plugin listing to be bypassed when feature is enabled.
