### PR TITLE
Fix #5494 by returning 405 for disallowed webhook request methods.

### DIFF
--- a/rundeckapp/webhooks/grails-app/controllers/webhooks/WebhookInterceptor.groovy
+++ b/rundeckapp/webhooks/grails-app/controllers/webhooks/WebhookInterceptor.groovy
@@ -1,0 +1,23 @@
+package webhooks
+
+
+class WebhookInterceptor {
+
+    int order = HIGHEST_PRECEDENCE + 20
+
+    boolean before() {
+        //A webhook must be a post, null action here indicates an unmatched HTTP method used
+        if(!actionName) {
+            response.setHeader("Allow","POST")
+            response.status = 405
+            return false
+        }
+        return true
+    }
+
+    boolean after() { true }
+
+    void afterView() {
+        // no-op
+    }
+}

--- a/rundeckapp/webhooks/src/test/groovy/webhooks/WebhookInterceptorSpec.groovy
+++ b/rundeckapp/webhooks/src/test/groovy/webhooks/WebhookInterceptorSpec.groovy
@@ -1,0 +1,33 @@
+package webhooks
+
+import grails.testing.web.interceptor.InterceptorUnitTest
+import org.grails.web.util.GrailsApplicationAttributes
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class WebhookInterceptorSpec extends Specification implements InterceptorUnitTest<WebhookInterceptor> {
+
+    def setup() {
+    }
+
+    def cleanup() {
+
+    }
+
+    @Unroll
+    void "Webhook allowed methods"() {
+        when:
+        request.setAttribute(GrailsApplicationAttributes.ACTION_NAME_ATTRIBUTE, action)
+        withRequest(controller:"webhook")
+
+        then:
+        interceptor.doesMatch()
+        expected == interceptor.before()
+        response.status == code
+
+        where:
+        action | code | expected
+        'post' | 200  | true
+        null   | 405  | false
+    }
+}


### PR DESCRIPTION
Return 405 for non POST http methods to the webhook endpoint.