### PR TITLE
Job rescheduling issue

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -2290,7 +2290,6 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             scheduledExecution.nextExecution = new Date(ScheduledExecutionService.TWO_HUNDRED_YEARS)
         }
 
-        boolean shouldreSchedule = false
         def boolean renamed = oldjobname != scheduledExecution.generateJobScheduledName() || oldjobgroup != scheduledExecution.generateJobGroupName()
 
         if(frameworkService.isClusterModeEnabled()){
@@ -2312,15 +2311,11 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 )
                 if (modify) {
                     scheduledExecution.serverNodeUUID = frameworkService.serverUUID
-                    //schedule meesage want sent , it should be ran locally
-                    shouldreSchedule = true
                 }
             }
             if (!scheduledExecution.serverNodeUUID) {
                 scheduledExecution.serverNodeUUID = frameworkService.serverUUID
             }
-        }else{
-            shouldreSchedule = true
         }
 
         if (renamed) {
@@ -2662,7 +2657,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             }
         }
         if (resultFromExecutionLifecyclePlugin.success && !failed && scheduledExecution.save(true)) {
-            if (scheduledExecution.shouldScheduleExecution() && shouldScheduleInThisProject(scheduledExecution.project) && shouldreSchedule) {
+            if (scheduledExecution.shouldScheduleExecution() && shouldScheduleInThisProject(scheduledExecution.project)) {
                 def nextdate = null
                 def nextExecNode = null
                 try {


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Bug
for issue https://github.com/rundeck/rundeck/issues/5481
rebuilding PR https://github.com/rundeck/rundeck/pull/5145 that was overwritten

If a scheduled job (with cluster mode enabled) is modified without changing the scheduled or the name/group, the deleteJob method (that removes the job from the quartz) shouldn't be called.

**Describe the solution you've implemented**
described on PR  https://github.com/rundeck/rundeck/issues/5481

**Describe alternatives you've considered**

**Additional context**
