### PR TITLE
Enable LDAP sync in Docker

### DIFF
--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -39,6 +39,9 @@ rundeck.security.authorization.preauthenticated.userRolesHeader={{ getv("/rundec
 rundeck.security.authorization.preauthenticated.redirectLogout={{ getv("/rundeck/preauth/redirect/logout", "false") }}
 rundeck.security.authorization.preauthenticated.redirectUrl={{ getv("/rundeck/preauth/redirect/url", "/oauth2/sign_in") }}
 
+# LDAP Sync
+rundeck.security.syncLdapUser={{ getv("/rundeck/ldap/sync", "false") }}
+
 {% if exists("/rundeck/security/syncldapuser") %}
 rundeck.security.syncLdapUser={{ getv("/rundeck/security/syncldapuser") }}
 {% endif %}


### PR DESCRIPTION
Allow enabling LDAP Sync using docker environment variables (`RUNDECK_LDAP_SYNC: "true"`)