### PR TITLE
Allow to run jobs using variables with keystorage and required yes

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1220,6 +1220,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      * @return
      */
     boolean canReadStoragePassword(AuthContext authContext, String storagePath, boolean failIfMissing){
+        if(storagePath?.contains('${')){
+            return true;//bypass validation if uses an execution variable
+        }
         def keystore = storageService.storageTreeWithContext(authContext)
         try {
             return keystore.hasPassword(storagePath)

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -5092,4 +5092,23 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         e2.user == 'testuser'
     }
 
+    def "can read storage password using variables"() {
+        given:
+        AuthContext context = Mock(AuthContext)
+        service.storageService = Mock(StorageService)
+
+        when:
+        def result = service.canReadStoragePassword(context, path, false)
+
+        then:
+        service.storageService.storageTreeWithContext(context) >> Mock(KeyStorageTree) {
+            0 * hasPassword(path)
+        }
+        result == canread
+
+        where:
+        path                            | canread
+        'keys/${job.username}/password' | true
+
+    }
 }


### PR DESCRIPTION
Skip the previous validation only if the default field contains a variable (`${`).

If the default value is invalid, the job fails with the correct message:
![image](https://user-images.githubusercontent.com/2894508/69159402-9d795b80-0ac6-11ea-9be1-7f55f4155b73.png)

Fix #5397