### PR TITLE
Fixes #5495 - This changes fix a wrong behavior when edit a job with a wrong value so the options was lost from the session and removed if edit operation is canceled.

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -195,7 +195,7 @@ class ScheduledExecutionController  extends ControllerBase{
             session.removeAttribute('undoWF');
             session.removeAttribute('redoWF');
         }
-        if(session.editWF ){
+        if(session.editOPTS ){
             session.removeAttribute('editOPTS');
             session.removeAttribute('undoOPTS');
             session.removeAttribute('redoOPTS');
@@ -1909,6 +1909,7 @@ class ScheduledExecutionController  extends ControllerBase{
             def globals = frameworkService.getProjectGlobals(scheduledExecution.project).keySet()
             return render(
                     view: 'edit', model: [scheduledExecution        : scheduledExecution,
+                                          sessionOpts               : params['_sessionEditOPTSObject']?.values(),
                                           nextExecutionTime         : scheduledExecutionService.nextExecutionTime(
                                                   scheduledExecution
                                           ),

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -2334,6 +2334,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
         def todiscard = []
         def wftodelete = []
+        def optsChangedOnSession = []
         def fprojects = frameworkService.projectNames(authContext)
 
         if (scheduledExecution.workflow && params['_sessionwf'] && params['_sessionEditWFObject']) {
@@ -2511,14 +2512,13 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
             }
             if (!optfailed) {
-                def todelete = []
+                optsChangedOnSession = []
                 if(scheduledExecution.options){
-                    todelete.addAll(scheduledExecution.options)
+                    optsChangedOnSession.addAll(scheduledExecution.options)
                 }
+                todiscard.addAll(scheduledExecution.options)
                 scheduledExecution.options = null
-                todelete.each {oldopt ->
-                    oldopt.delete()
-                }
+
                 optsmap.values().each {Option opt ->
                     opt.convertValuesList()
                     Option newopt = opt.createClone()
@@ -2657,6 +2657,11 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             }
         }
         if (resultFromExecutionLifecyclePlugin.success && !failed && scheduledExecution.save(true)) {
+            if(optsChangedOnSession){
+                optsChangedOnSession.each {oldopt ->
+                    oldopt.delete()
+                }
+            }
             if (scheduledExecution.shouldScheduleExecution() && shouldScheduleInThisProject(scheduledExecution.project)) {
                 def nextdate = null
                 def nextExecNode = null

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -201,8 +201,11 @@
 
                   <div  id="editoptssect" class="rounded">
                       <%
-                          def tmpse = ScheduledExecution.get(scheduledExecution.id)
-                          def options = tmpse?tmpse.options:scheduledExecution.options
+                          def options = sessionOpts
+                          if(!options){
+                              def tmpse = ScheduledExecution.get(scheduledExecution.id)
+                              options = tmpse?tmpse.options:scheduledExecution.options
+                          }
                       %>
                       <g:render template="/scheduledExecution/detailsOptions" model="${[options:options,edit:true]}"/>
                       <g:if test="${scheduledExecution && scheduledExecution.argString}">

--- a/rundeckapp/grails-app/views/scheduledExecution/_editForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editForm.gsp
@@ -56,7 +56,7 @@
 
     <div class="card-content">
         <tmpl:tabsEdit scheduledExecution="${scheduledExecution}" crontab="${crontab}" authorized="${authorized}"
-                       command="${command}"/>
+                       command="${command}" sessionOpts="${sessionOpts}"/>
     </div>
 
     <div class="card-footer" data-ko-bind="jobeditor">

--- a/rundeckapp/grails-app/views/scheduledExecution/_tabsEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_tabsEdit.gsp
@@ -73,5 +73,5 @@
 <div class="tab-content" id="page_job_edit">
 
     <g:render template="edit"
-              model="['scheduledExecution': scheduledExecution, 'crontab': crontab, authorized: authorized]"/>
+              model="['scheduledExecution': scheduledExecution, 'crontab': crontab, authorized: authorized, sessionOpts: sessionOpts]"/>
 </div>

--- a/rundeckapp/grails-app/views/scheduledExecution/edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/edit.gsp
@@ -42,6 +42,6 @@
 <body>
 
 
-    <tmpl:editForm model="[scheduledExecution:scheduledExecution,crontab:crontab,authorized:authorized, notificationPlugins: notificationPlugins]"/>
+    <tmpl:editForm model="[scheduledExecution:scheduledExecution,crontab:crontab,authorized:authorized, notificationPlugins: notificationPlugins, sessionOpts: sessionOpts]"/>
 </body>
 </html>


### PR DESCRIPTION
fixes #5495

**Is this a bugfix, or an enhancement? Please describe.**
If a invalid value is entered when edit a job, options is lost from the session and removed if edition is canceled

**Describe the solution you've implemented**
With this changes, the options will be kept on session if some one was changed and this changes will be discarded if the edition is canceled
