### PR TITLE
variable execution.succeededNodeList to observe real node execution on notification

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -70,6 +70,7 @@ public class NotificationService implements ApplicationContextAware{
     def LoggingService loggingService
     def apiService
     def executionService
+    def workflowService
     OrchestratorPluginService orchestratorPluginService
 
     def ValidatedPlugin validatePluginConfig(String project, String name, Map config) {
@@ -583,6 +584,7 @@ public class NotificationService implements ApplicationContextAware{
     }
 
     protected Map exportExecutionData(Execution e) {
+        def modifiedSuccessNodeList = getEffectiveSuccessNodeList(e)
         def emap = [
             id: e.id,
             href: grailsLinkGenerator.link(controller: 'execution', action: 'follow', id: e.id, absolute: true,
@@ -597,8 +599,8 @@ public class NotificationService implements ApplicationContextAware{
             project: e.project,
             failedNodeListString: e.failedNodeList,
             failedNodeList: e.failedNodeList?.split(",") as List,
-            succeededNodeListString: e.succeededNodeList,
-            succeededNodeList: e.succeededNodeList?.split(",") as List,
+            succeededNodeListString: modifiedSuccessNodeList.join(','),
+            succeededNodeList: modifiedSuccessNodeList,
             loglevel: ExecutionService.textLogLevels[e.loglevel] ?: e.loglevel
         ]
         if (null != e.dateCompleted) {
@@ -608,6 +610,22 @@ public class NotificationService implements ApplicationContextAware{
         }
         emap['abortedby'] = e.cancelled?e.abortedby:null
         emap
+    }
+
+    protected getEffectiveSuccessNodeList(Execution e){
+        def modifiedSuccessNodeList = []
+        if(e.succeededNodeList) {
+            List<String> successNodeList = e.succeededNodeList?.split(',')
+            def nodeSummary = workflowService.requestStateSummary(e, successNodeList)
+            if(nodeSummary) {
+                successNodeList.each { node ->
+                    if (nodeSummary.workflowState.nodeSummaries[node]?.summaryState == 'SUCCEEDED') {
+                        modifiedSuccessNodeList.add(node)
+                    }
+                }
+            }
+        }
+        modifiedSuccessNodeList
     }
 
     protected Map exportJobdata(ScheduledExecution scheduledExecution) {


### PR DESCRIPTION
Modified `${execution.succeededNodeList}`  on notifications based on real node list not on the target node list.
Uses the `workflowService` to obtain the list of nodes and add only the nodes that really run the job, in case the workflow executor execute only in a portion of the nodes, as example, the random subset Orchestrator.

Fix #5517 