### PR TITLE
Task/5504/add support type

### DIFF
--- a/rundeckapp/grails-app/assets/scss/custom/sidebar.scss
+++ b/rundeckapp/grails-app/assets/scss/custom/sidebar.scss
@@ -1,11 +1,3 @@
-// .sidebar,
-// .main-panel{
-//   max-height: initial;
-//   height:
-//   // max-height: 100%;
-//   // height: 100%;
-// }
-
 .sidebar {
   .logo {
     background-color: #000000;
@@ -25,12 +17,6 @@
       display: block;
       background-position-y: 15px;
       background-position-x: 65px;
-      // .appTitle{
-      //   padding-left:8px;
-      //   opacity: 1;
-      //   -webkit-transition: opacity 700ms, visibility 700ms;
-      //   transition: opacity 700ms, visibility 700ms;
-      // }
     }
 
     .navbar-minimize {
@@ -48,10 +34,6 @@
         top: -7px;
       }
 
-      // .btn:focus{
-      //   background-color: black;
-      //   color: #66615B;
-      // }
       // sidebar open
       i.fas.fa-ellipsis-v,
       i.fas.fa-sign-out-alt,
@@ -100,25 +82,16 @@
     margin-bottom: 40px;
   }
 
-  // .nav > li.snapshot-version{
-  //   position: absolute;
-  //   width: 100%;
-  //   bottom: 0;
-  //   a{
-  //     background: rgba(255, 255, 255, 0.14);
-  //     opacity: 1;
-  //     color: #FFFFFF;
-  //   }
-  // }
   #sidebar-bottom {
     padding: 0 0 10px 0;
-    // border-top:1px solid #fa2501;
     text-align: center;
     position: fixed;
     bottom: 0;
     left: 0;
+    width: 100%;
     max-width: 258px;
     background: #000;
+    // transition: width .2s;
 
     .sidebar-footer-line-item {
       text-align: left;
@@ -131,7 +104,6 @@
       padding-top: .5em;
 
       a {
-        // background: rgba(255, 255, 255, 0.14);
         opacity: 1;
         color: #FFFFFF;
       }
@@ -174,6 +146,11 @@ body.modal-open {
 
 .sidebar {
   .sidebar-mini:not(.nav-open) & {
+    #sidebar-bottom {
+      width: 80px;
+      transition: width .2s;
+    }
+
     a.home {
       background-image: none;
     }

--- a/rundeckapp/grails-app/assets/scss/pages/login.scss
+++ b/rundeckapp/grails-app/assets/scss/pages/login.scss
@@ -4,6 +4,7 @@
 
   .logo {
     text-align: center;
+
     // background-color: #000000;
     a {
       font-family: 'Futura';
@@ -20,17 +21,18 @@
   .alert.alert-danger {
     background-color: #ff666f;
     color: #ffffff;
-    border:0;
+    border: 0;
   }
 
   .footer,
   .footer .copyright {
-    color: #d5d5d5!important;
+    color: #d5d5d5 !important;
 
     & a:not(.btn) {
       text-decoration: underline;
     }
   }
+
   $rdlogo-color: rgba(255, 0, 0, 1);
   // $bgcolor1: #9CF6E4;
   // $bgcolor2: #999999;
@@ -46,4 +48,7 @@
   //   background-size: contain;
   //   z-index: 4;
   // }
+  .ui-common-platform.enterprise-hide {
+    display: none;
+  }
 }

--- a/rundeckapp/grails-app/views/common/_footer.gsp
+++ b/rundeckapp/grails-app/views/common/_footer.gsp
@@ -47,7 +47,9 @@
     </div>
     <nav class="pull-right">
         <ul>
-
+            <li>
+              UNSUPPORTED SOFTWARE. NO WARRANTY.
+            <li>
             <li>
                 <g:link controller="menu" action="licenses"><g:message code="licenses"/></g:link>
             </li>

--- a/rundeckapp/grails-app/views/common/_footer.gsp
+++ b/rundeckapp/grails-app/views/common/_footer.gsp
@@ -47,7 +47,7 @@
     </div>
     <nav class="pull-right">
         <ul>
-            <li>
+            <li class="ui-common-platform enterprise-hide">
               UNSUPPORTED SOFTWARE. NO WARRANTY.
             <li>
             <li>

--- a/rundeckapp/grails-app/views/common/_sidebar.gsp
+++ b/rundeckapp/grails-app/views/common/_sidebar.gsp
@@ -230,6 +230,7 @@
         <g:appTitle/> ${buildIdent}
     </g:link>
   </div>
+  <div style="margin-top:.5em;">UNSUPPORTED SOFTWARE.<br/>NO WARRANTY.</div>
 </div>
 
 <g:javascript>

--- a/rundeckapp/grails-app/views/common/_sidebar.gsp
+++ b/rundeckapp/grails-app/views/common/_sidebar.gsp
@@ -220,12 +220,14 @@
     </div>
   </div>
   <div id="version-notification-vue"></div>
-  <div id="snapshot-version" class="snapshot-version">
-    <span class="rundeck-version-identity"
+  <div id="snapshot-version" class="snapshot-version" data-toggle="sidebartooltip" data-placement="top" title="${enc(attr: buildIdent)} / ${enc(attr: servletContextAttribute(attribute: 'version.date_short'))}">
+    <!--
+      <span class="rundeck-version-identity"
           data-version-string="${enc(attr: buildIdent)}"
           data-version-date="${enc(attr: servletContextAttribute(attribute: 'version.date_short'))}"
           data-app-id="${enc(attr: appId)}"
           style="display:block;"></span>
+    -->
     <g:link controller="menu" action="welcome" class="version link-bare">
         <g:appTitle/> ${buildIdent}
     </g:link>
@@ -237,6 +239,8 @@
 
 
   jQuery(function(){
+    // inits the tooltips
+    jQuery('[data-toggle="sidebartooltip"]').tooltip()
     // Sets user preference on opening/closing the sidebar
     jQuery('.navbar-minimize a').click(function(){
 

--- a/rundeckapp/grails-app/views/common/_sidebar.gsp
+++ b/rundeckapp/grails-app/views/common/_sidebar.gsp
@@ -230,7 +230,7 @@
         <g:appTitle/> ${buildIdent}
     </g:link>
   </div>
-  <div style="margin-top:.5em;">UNSUPPORTED SOFTWARE.<br/>NO WARRANTY.</div>
+  <div class="ui-common-platform enterprise-hide" style="margin-top:.5em;">UNSUPPORTED SOFTWARE.<br/>NO WARRANTY.</div>
 </div>
 
 <g:javascript>

--- a/rundeckapp/grails-app/views/menu/welcome.gsp
+++ b/rundeckapp/grails-app/views/menu/welcome.gsp
@@ -47,6 +47,9 @@ Time: 12:54 PM
             </h2>
           </div>
           <div class="card-content">
+            <div class="ui-common-platform enterprise-hide" style="margin:0 0 2em;">
+              <h3 >UNSUPPORTED SOFTWARE. NO WARRANTY.</h3>
+            </div>
             <g:markdown><g:autoLink>${message(code: "app.firstRun.md")}</g:autoLink></g:markdown>
             <div style="margin-top:2em;">
               <g:link controller="menu" action="index" class="btn btn-lg btn-success">


### PR DESCRIPTION
Implements a support type notification that the OSS version of Rundeck is unsupported and provides no warranty.

To better make use of the space provided in the sidebar and allow for the placement of another instance of the support type indicator; the build date has been moved into a tooltip that is visible on hover of the version number.

<img width="1067" alt="Screen Shot 2019-11-21 at 6 20 39 PM" src="https://user-images.githubusercontent.com/265904/69384897-a8311d80-0c8b-11ea-896e-8ba095e273d8.png">

<img width="259" alt="Screen Shot 2019-11-21 at 6 21 19 PM" src="https://user-images.githubusercontent.com/265904/69384931-c3039200-0c8b-11ea-9a4f-4d2fbcbac7df.png">

