### PR TITLE
fixing Option Value plugin is not using the name attribute

### DIFF
--- a/rundeckapp/grails-app/views/framework/_jobOptionsKO.gsp
+++ b/rundeckapp/grails-app/views/framework/_jobOptionsKO.gsp
@@ -61,7 +61,7 @@ used by _editOptions.gsp template
                                               dateFormat         : optionSelect.dateFormat,
                                               optionType         : optionSelect.optionType,
 //                                              config             : optionSelect.configMap,
-                                              values             : optionSelect.optionValuesPluginType ? optionSelect.valuesFromPlugin.collect { it.value } : optionSelect.optionValues,
+                                              values             : optionSelect.optionValues,
                                               defaultValue       : optionSelect.defaultValue,
                                               defaultStoragePath : optionSelect.defaultStoragePath,
                                               multivalued        : optionSelect.multivalued,
@@ -158,7 +158,7 @@ data for configuring remote option cascading/dependencies
           <div data-bind="foreach: {data: options(), as: 'option' }" class="text-primary">
               <div><span data-bind="text: option.name"></span>=<span data-bind="text: option.value"></span></div>
           </div>
-        </div>        
+        </div>
       </div>
     </g:if>
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
bugfix:
fixing Option Value plugin is not using the name attribute (issue https://github.com/rundeck/rundeck/issues/5539) 

**Describe the solution you've implemented**
it is not necessary to assign the `valuesFromPlugin` to the KO `values` attributes, because KO checks later if the valuesFromPlugin is set ( using `hasPluginValues` method)

**Describe alternatives you've considered**

**Additional context**

<img width="515" alt="Screenshot 2019-11-25 15 35 07" src="https://user-images.githubusercontent.com/6034968/69567888-36ade380-0f99-11ea-8d3d-ef3b06a6c5e6.png">

<img width="832" alt="Screenshot 2019-11-25 15 35 22" src="https://user-images.githubusercontent.com/6034968/69567897-42010f00-0f99-11ea-8245-66e7b6333162.png">
