### PR TITLE
Adds automagic copyright date

### DIFF
--- a/rundeckapp/grails-app/views/common/_footer.gsp
+++ b/rundeckapp/grails-app/views/common/_footer.gsp
@@ -1,5 +1,5 @@
 %{--
-  - Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+  - Copyright 2019 Rundeck, Inc. (http://rundeck.com)
   -
   - Licensed under the Apache License, Version 2.0 (the "License");
   - you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@
 <footer class="footer">
   <div class="container-fluid">
     <div class="copyright pull-left">
-        &copy; Copyright 2019 <a href="http://rundeck.com">Rundeck, Inc.</a>
+        &copy; Copyright ${java.time.LocalDate.now().getYear()} <a href="http://rundeck.com">Rundeck, Inc.</a>
 
         All rights reserved.
     </div>


### PR DESCRIPTION
So that we don't have to constantly update the copyright each time the year changes, setting the copyright year to use local Java getYear.
