### PR TITLE
Fix #5553 duration more than 1 month should show correctly

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/momentutil.js
+++ b/rundeckapp/grails-app/assets/javascripts/momentutil.js
@@ -98,6 +98,12 @@
         }
         var duration = moment.duration(ms);
         var valarr = [];
+        if (duration.years() > 0) {
+            valarr.push(duration.years() + 'y');
+        }
+        if (duration.months() > 0) {
+            valarr.push(duration.months() + 'M');
+        }
         if (duration.days() > 0) {
             valarr.push(duration.days() + 'd');
         }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix #5553 

**Describe the solution you've implemented**

Relative duration formatting was skipping Month and Year 

**Describe alternatives you've considered**

Moment.js has a relative duration format function, but needs either custom locale data or separate utility library such as https://github.com/jsmreese/moment-duration-format to use a custom format.

the Moment.js duration formatting could be used as-is, but is more verbose " 22 days" vs "22d". 

I opted to correct the internal code instead of alter the formatting completely or adding a new dependency.