### PR TITLE
Fix unexpected behavior when killing a job that includes Job Reference of workflow type. 5478

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3697,15 +3697,19 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             )
 
             thread.start()
+            if(exec.abortedby){
+                thread.abort()
+                Thread.yield()
+            }else {
+                if (!jitem.ignoreNotifications) {
+                    ScheduledExecution.withTransaction {
+                        // Get a new object attached to the new session
+                        def scheduledExecution = ScheduledExecution.get(id)
+                        notificationService.triggerJobNotification('start', scheduledExecution,
+                                [execution: exec, context: newContext, jobref: jitem.jobIdentifier])
+                    }
 
-            if(!jitem.ignoreNotifications) {
-                ScheduledExecution.withTransaction {
-                    // Get a new object attached to the new session
-                    def scheduledExecution = ScheduledExecution.get(id)
-                    notificationService.triggerJobNotification('start', scheduledExecution,
-                            [execution: exec, context: newContext, jobref: jitem.jobIdentifier])
                 }
-
             }
             return executionUtilService.runRefJobWithTimer(thread, startTime, shouldCheckTimeout, timeoutms)
 

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3696,11 +3696,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     executionLifecyclePluginExecHandler
             )
 
-            thread.start()
-            if(exec.abortedby){
-                thread.abort()
-                Thread.yield()
-            }else {
+
+            if(!exec.abortedby){
+                thread.start()
                 if (!jitem.ignoreNotifications) {
                     ScheduledExecution.withTransaction {
                         // Get a new object attached to the new session

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -5111,4 +5111,118 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         'keys/${job.username}/password' | true
 
     }
+
+
+
+    def "abort  run on aborted execution"(){
+        given:
+        def jobname = 'abc'
+        def group = 'path'
+        def project = 'AProject'
+        ScheduledExecution job = new ScheduledExecution(
+                jobName: jobname,
+                project: project,
+                groupPath: group,
+                description: 'a job',
+                argString: '-args b -args2 d',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec(
+                                [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
+                        )]
+                ),
+                retry: '1'
+        )
+        job.save()
+        Execution e1 = new Execution(
+                project: project,
+                user: 'bob',
+                dateStarted: new Date(),
+                dateEnded: new Date(),
+                abortedby: 'admin'
+        )
+        e1.save() != null
+
+        def datacontext = [job:[execid:e1.id]]
+
+
+        def nodeSet = new NodeSetImpl()
+        def node1 = new NodeEntryImpl('node1')
+        nodeSet.putNode(node1)
+
+        service.fileUploadService = Mock(FileUploadService)
+        service.executionUtilService = Mock(ExecutionUtilService)
+        service.storageService = Mock(StorageService)
+        service.jobStateService = Mock(JobStateService)
+        service.frameworkService = Mock(FrameworkService) {
+            authorizeProjectJobAll(*_) >> true
+            filterAuthorizedNodes(_, _, _, _) >> { args ->
+                nodeSet
+            }
+        }
+        service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+
+
+        def origContext = Mock(StepExecutionContext){
+            getDataContext()>>datacontext
+            getStepNumber()>>1
+            getStepContext()>>[]
+            getNodes()>> nodeSet
+            getFramework() >> Mock(Framework)
+
+        }
+        JobRefCommand item = ExecutionItemFactory.createJobRef(
+                group+'/'+jobname,
+                ['args', 'args2'] as String[],
+                false,
+                null,
+                true,
+                '.*',
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                project,
+                false,
+                false,
+                null,
+                false,
+                false
+        )
+
+
+        service.notificationService = Mock(NotificationService)
+        def dispatcherResult = Mock(DispatcherResult)
+        def wresult = Mock(WorkflowExecutionResult){
+            isSuccess()>>success
+        }
+
+
+        service.metricService = Mock(MetricService){
+            withTimer(_,_,_)>>{classname, name,  closure ->
+                closure()
+                [result:wresult]
+            }
+        }
+
+        def createFailure = { FailureReason reason, String msg ->
+            return new StepExecutionResultImpl(null, reason, msg)
+        }
+        def createSuccess = {
+            return new StepExecutionResultImpl()
+        }
+        when:
+        service.runJobRefExecutionItem(origContext,item,createFailure,createSuccess)
+        then:
+        0 * service.notificationService.triggerJobNotification('start', _, _)
+        1 * service.notificationService.triggerJobNotification(trigger, _, _)
+        where:
+        success      | trigger
+        true         | 'success'
+        false        | 'failure'
+    }
+
+
 }


### PR DESCRIPTION
Abort referenced execution before it has time to start if the execution has been aborted. 

Now the aborted job reference step works in job references that run as a workflow step.
![image](https://user-images.githubusercontent.com/2894508/69827229-36118900-11f5-11ea-8561-42b7e90134b0.png)
