### PR TITLE
Reduces text size

### DIFF
--- a/rundeckapp/grails-app/views/common/_footer.gsp
+++ b/rundeckapp/grails-app/views/common/_footer.gsp
@@ -47,7 +47,7 @@
     </div>
     <nav class="pull-right">
         <ul>
-            <li class="ui-common-platform enterprise-hide">
+            <li class="ui-common-platform enterprise-hide" style="font-size:.7em;">
               UNSUPPORTED SOFTWARE. NO WARRANTY.
             <li>
             <li>


### PR DESCRIPTION
Reduces the size of the "Unsupported Software" notice in the footer from 1EM to .7EM.