### PR TITLE
Webhook validation fixes

### DIFF
--- a/rundeckapp/grails-spa/src/pages/webhooks/views/WebhooksView.vue
+++ b/rundeckapp/grails-spa/src/pages/webhooks/views/WebhooksView.vue
@@ -51,7 +51,7 @@
                     </div>
                     <div class="form-group"><label>{{ $t('message.webhookRolesLabel') }}</label><input v-model="curHook.roles" class="form-control"></div>
                     <div class="form-group"><label>{{ $t('message.webhookEventPluginLabel') }}</label><select v-model="curHook.eventPlugin"
-                                                                     @change="setSelectedPlugin()" class="form-control">
+                                                                     @change="setSelectedPlugin(false)" class="form-control">
                       <option v-for="plugin in webhookPlugins" :key="plugin.name" v-bind:value="plugin.name">{{plugin.title}}</option>
                     </select></div>
                     <div class="row">
@@ -71,6 +71,7 @@
                         :key="curHook.name"
                         :show-title="false"
                         :show-description="false"
+                        :validation="validation"
                         v-if="!customConfigComponent"
                       >
                       </plugin-config>
@@ -143,6 +144,7 @@ export default {
       webhookPlugins: [],
       curHook: null,
       errors: {},
+      validation:{valid:true,errors:{}},
       selectedPlugin: null,
       apiBasePostUrl: `${rdBase}api/${apiVersion}/webhook/`,
       customConfigComponent: null,
@@ -201,16 +203,20 @@ export default {
         this.webhooks = response.data.hooks
         if (this.curHook) {
           this.curHook = this.webhooks.find(hk => hk.id === this.curHook.id)
-          if(this.curHook) this.setSelectedPlugin()
+          if(this.curHook) this.setSelectedPlugin(true)
         }
       })
     },
     select(selected) {
       this.curHook = selected
-      this.setSelectedPlugin()
+      this.setSelectedPlugin(true)
     },
-    setSelectedPlugin() {
-      this.selectedPlugin = {type: this.curHook.eventPlugin, config: this.curHook.config}
+    setSelectedPlugin(preserve) {
+      this.selectedPlugin = {type: this.curHook.eventPlugin, config: preserve? this.curHook.config:{}}
+      if(!preserve){
+          this.validation = {valid:true,errors:{}}
+          this.errors={}
+      }
       getServiceProviderDescription("WebhookEvent", this.curHook.eventPlugin).then(data => {
         this.customConfigComponent = data.vueConfigComponent
         this.showPluginConfig = this.customConfigComponent || data.props.length > 0
@@ -226,15 +232,18 @@ export default {
         if (response.data.err) {
           this.setError("Failed to save! " + response.data.err)
           this.errors = response.data.errors
+          this.validation = {valid:false,errors:response.data.errors}
         } else {
           this.setMessage("Saved!")
           this.errors = {}
+          this.validation = {valid:true,errors:{}}
           this.getHooks()
         }
       }).catch(err => {
         if (err.response.data.err) {
           this.setError("Failed to save! " + err.response.data.err)
           this.errors = err.response.data.errors
+          this.validation = {valid:false,errors:err.response.data.errors}
         }
       })
     },

--- a/rundeckapp/grails-spa/src/pages/webhooks/views/WebhooksView.vue
+++ b/rundeckapp/grails-spa/src/pages/webhooks/views/WebhooksView.vue
@@ -207,8 +207,13 @@ export default {
         }
       })
     },
+    setValidation(valid,errors={}){
+      this.validation = {valid:valid, errors}
+      this.errors=errors
+    },
     select(selected) {
       this.curHook = selected
+      this.setValidation(true)
       this.setSelectedPlugin(true)
     },
     setSelectedPlugin(preserve) {

--- a/rundeckapp/grails-spa/src/pages/webhooks/views/WebhooksView.vue
+++ b/rundeckapp/grails-spa/src/pages/webhooks/views/WebhooksView.vue
@@ -219,8 +219,7 @@ export default {
     setSelectedPlugin(preserve) {
       this.selectedPlugin = {type: this.curHook.eventPlugin, config: preserve? this.curHook.config:{}}
       if(!preserve){
-          this.validation = {valid:true,errors:{}}
-          this.errors={}
+          this.setValidation(true)
       }
       getServiceProviderDescription("WebhookEvent", this.curHook.eventPlugin).then(data => {
         this.customConfigComponent = data.vueConfigComponent
@@ -236,19 +235,17 @@ export default {
       this.ajax("post", `${rdBase}webhook/admin/save`, this.curHook).then(response => {
         if (response.data.err) {
           this.setError("Failed to save! " + response.data.err)
-          this.errors = response.data.errors
-          this.validation = {valid:false,errors:response.data.errors}
+
+          this.setValidation(false, response.data.errors)
         } else {
           this.setMessage("Saved!")
-          this.errors = {}
-          this.validation = {valid:true,errors:{}}
+          this.setValidation(true)
           this.getHooks()
         }
       }).catch(err => {
         if (err.response.data.err) {
           this.setError("Failed to save! " + err.response.data.err)
-          this.errors = err.response.data.errors
-          this.validation = {valid:false,errors:err.response.data.errors}
+          this.setValidation(false, err.response.data.errors)
         }
       })
     },

--- a/rundeckapp/webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/rundeckapp/webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -131,7 +131,10 @@ class WebhookService {
         hook.name = hookData.name ?: hook.name
         hook.project = hookData.project ?: hook.project
         if(hookData.enabled != null) hook.enabled = hookData.enabled
-        if(hookData.eventPlugin && !pluginService.listPlugins(WebhookEventPlugin).any { it.key == hookData.eventPlugin}) return [err:"Plugin does not exist: " + hookData.eventPlugin]
+        if(hookData.eventPlugin && !pluginService.listPlugins(WebhookEventPlugin).any { it.key == hookData.eventPlugin}){
+            hook.discard()
+            return [err:"Plugin does not exist: " + hookData.eventPlugin]
+        }
         hook.eventPlugin = hookData.eventPlugin ?: hook.eventPlugin
 
         Map pluginConfig = [:]
@@ -142,6 +145,7 @@ class WebhookService {
             def errMsg = isCustom ?
                     "Validation errors" :
                     "Invalid plugin configuration: " + vPlugin.report.errors.collect { k, v -> "$k : $v" }.join("\n")
+            hook.discard()
 
             return [err: errMsg, errors: vPlugin.report.errors]
         }

--- a/rundeckapp/webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/rundeckapp/webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -125,8 +125,6 @@ class WebhookService {
             String checkUser = hookData.user ?: authContext.username
             if (!userService.validateUserExists(checkUser)) return [err: "Webhook user '${checkUser}' not found"]
             hook = new Webhook()
-            Set<String> roles = hookData.roles ? rundeckAuthTokenManagerService.parseAuthRoles(hookData.roles) : authContext.roles
-            hook.authToken = apiService.generateUserToken(authContext,null,checkUser,roles, false, true).token
         }
         hook.name = hookData.name ?: hook.name
         hook.project = hookData.project ?: hook.project
@@ -152,9 +150,26 @@ class WebhookService {
 
         hook.pluginConfigurationJson = mapper.writeValueAsString(pluginConfig)
 
+        if(!hook.id || !hook.authToken){
+            //create token
+            String checkUser = hookData.user ?: authContext.username
+            Set<String> roles = hookData.roles ? rundeckAuthTokenManagerService.parseAuthRoles(hookData.roles) : authContext.roles
+            try {
+                def at=apiService.generateUserToken(authContext, null, checkUser, roles, false, true)
+                hook.authToken = at.token
+            } catch (Exception e) {
+                hook.discard()
+                return [err: "Failed to create associated Auth Token: "+e.message]
+            }
+        }
+
         if(hook.save(true)) {
             return [msg: "Saved webhook"]
         } else {
+            if(!hook.id && hook.authToken){
+                //delete the created token
+                rundeckAuthTokenManagerService.deleteToken(hook.authToken)
+            }
             return [err: hook.errors.allErrors.collect { messageSource.getMessage(it,null) }.join(",")]
         }
     }

--- a/rundeckapp/webhooks/src/test/groovy/webhooks/WebhookServiceSpec.groovy
+++ b/rundeckapp/webhooks/src/test/groovy/webhooks/WebhookServiceSpec.groovy
@@ -168,7 +168,70 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
         0 * service.apiService.generateUserToken(_,_,_,_,_,_)
 
     }
+    def "save new webhook token creation fails"() {
+        given:
+        def mockUserAuth = Mock(UserAndRolesAuthContext) {
+            getUsername() >> { "webhookUser" }
+            getRoles() >> { ["webhook","test"] }
+        }
+        service.apiService = Mock(MockApiService){
+            generateUserToken(_,_,_,_,_,_)>>{
+                throw new Exception("token error")
+            }
+        }
+        service.rundeckAuthTokenManagerService = Mock(AuthTokenManager) {
+            parseAuthRoles(_) >> { ["webhook","test"] }
+        }
+        service.userService = Mock(MockUserService) {
+            validateUserExists(_) >> { true }
+        }
+        def report=new Validator.Report()
+        service.pluginService = Mock(MockPluginService) {
+            validatePluginConfig(_,_,_) >> { return new ValidatedPlugin(report: report,valid:true) }
+            getPlugin(_,_) >> { new TestWebhookEventPlugin() }
+            listPlugins(WebhookEventPlugin) >> { ["log-webhook-event":new TestWebhookEventPlugin()] }
+        }
 
+        when:
+        def result = service.saveHook(mockUserAuth,[name:"test",project:"Test",user:"webhookUser",roles:"webhook,test",eventPlugin:"log-webhook-event","config":["cfg1":"val1"]])
+        Webhook created = Webhook.findByName("test")
+
+        then:
+        result.err ==~ /^Failed to create associated Auth Token: token error$/
+        !created
+    }
+
+    def "save new webhook fails due to gorm validation, token should get deleted"() {
+        given:
+            def mockUserAuth = Mock(UserAndRolesAuthContext) {
+                getUsername() >> { "webhookUser" }
+                getRoles() >> { ["webhook","test"] }
+            }
+            service.apiService = Mock(MockApiService)
+            service.rundeckAuthTokenManagerService = Mock(AuthTokenManager) {
+                parseAuthRoles(_) >> { ["webhook","test"] }
+            }
+            service.userService = Mock(MockUserService) {
+                validateUserExists(_) >> { true }
+            }
+            service.pluginService = Mock(MockPluginService) {
+                validatePluginConfig(_,_,_) >> { return new ValidatedPlugin(report: new Validator.Report(),valid:true) }
+                getPlugin(_,_) >> { new TestWebhookEventPlugin() }
+                listPlugins(WebhookEventPlugin) >> { ["log-webhook-event":new TestWebhookEventPlugin()] }
+            }
+
+        when:
+            def result = service.saveHook(mockUserAuth,[project:"Test",user:"webhookUser",roles:"webhook,test",eventPlugin:"log-webhook-event","config":["cfg1":"val1"]])
+            Webhook created = Webhook.findByName("test")
+
+
+        then:
+            result.err
+            !created
+            1 * service.apiService.generateUserToken(_,_,_,_,_,_) >> { [token:"12345"] }
+            1 * service.rundeckAuthTokenManagerService.deleteToken('12345')
+
+    }
     def "webhook name must be unique in project"() {
         given:
         def mockUserAuth = Mock(UserAndRolesAuthContext) {
@@ -349,7 +412,7 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
     }
 
     interface MockApiService {
-        Map generateUserToken(UserAndRolesAuthContext ctx, Integer expiration, String user, Set<String> roles, boolean forceExpiration, boolean webhookToken)
+        Map generateUserToken(UserAndRolesAuthContext ctx, Integer expiration, String user, Set<String> roles, boolean forceExpiration, boolean webhookToken) throws Exception
     }
 
     interface MockStorageService {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix save and validation problems with webhooks
- [x] during "save", if validation error for a plugin, the changes still get saved
- [x] gui should show plugin validation problems
- [x] switching plugin types should clear any previous plugin config values
- [x] auth token should not be created if new webhook validation fails
- [x] auth token should be deleted if gorm save fails for new webhook
