### PR TITLE
Job detail: show plugins

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -27,6 +27,7 @@ import com.dtolabs.rundeck.app.support.RunJobCommand
 import com.dtolabs.rundeck.core.authentication.Group
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.INodeEntry
@@ -467,6 +468,11 @@ class ScheduledExecutionController  extends ControllerBase{
         def parentList = ReferencedExecution.parentList(scheduledExecution,10)
         def isReferenced = parentList?.size()>0
 
+        def pluginDescriptions=[:]
+        if(featureService.featurePresent('executionLifecyclePlugin')) {
+            pluginDescriptions[ServiceNameConstants.ExecutionLifecycle] = pluginService.
+                    listPluginDescriptions(ServiceNameConstants.ExecutionLifecycle)
+        }
         def dataMap= [
                 scheduledExecution: scheduledExecution,
                 isReferenced: isReferenced,
@@ -482,6 +488,7 @@ class ScheduledExecutionController  extends ControllerBase{
 				orchestratorPlugins: orchestratorPluginService.getOrchestratorPlugins(),
                 strategyPlugins: scheduledExecutionService.getWorkflowStrategyPluginDescriptions(),
                 logFilterPlugins: pluginService.listPlugins(LogFilterPlugin),
+                pluginDescriptions: pluginDescriptions,
                 max: params.int('max') ?: 10,
                 offset: params.int('offset') ?: 0] + _prepareExecute(scheduledExecution, framework,authContext)
         if (params.opt && (params.opt instanceof Map)) {

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1826,3 +1826,4 @@ start=Start
 end=End
 job.editor.workflow.unsavedchanges.warning=Some changes to the workflow have not been completed.
 scheduledExecution.property.executionLifecyclePluginConfig.help.text=Selected Plugins will be enabled for this Job.
+scheduledExecution.plugins.title=Plugins

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1740,3 +1740,4 @@ job.editor.workflow.unsavedchanges.warning=Some changes to the workflow have not
 scheduledExecution.property.executionLifecyclePluginConfig.help.text=Selected Plugins will be enabled for this Job.
 project.configuration.extra.category.jobLifecyclePlugin.title=Job Lifecycle Plugins
 project.configuration.extra.category.jobLifecyclePlugin.description=Configuracion de Job Life Cycle plugins a nivel de proyecto.
+scheduledExecution.plugins.title=Plugins

--- a/rundeckapp/grails-app/i18n/messages_fr_FR.properties
+++ b/rundeckapp/grails-app/i18n/messages_fr_FR.properties
@@ -1730,3 +1730,4 @@ start=Start
 end=End
 job.editor.workflow.unsavedchanges.warning=Some changes to the workflow have not been completed.
 scheduledExecution.property.executionLifecyclePluginConfig.help.text=Selected Plugins will be enabled for this Job.
+scheduledExecution.plugins.title=Plugins

--- a/rundeckapp/grails-app/i18n/messages_ja.properties
+++ b/rundeckapp/grails-app/i18n/messages_ja.properties
@@ -1358,3 +1358,4 @@ start=Start
 end=End
 job.editor.workflow.unsavedchanges.warning=Some changes to the workflow have not been completed.
 scheduledExecution.property.executionLifecyclePluginConfig.help.text=Selected Plugins will be enabled for this Job.
+scheduledExecution.plugins.title=Plugins

--- a/rundeckapp/grails-app/i18n/messages_pt_BR.properties
+++ b/rundeckapp/grails-app/i18n/messages_pt_BR.properties
@@ -1754,3 +1754,4 @@ start=Start
 end=End
 job.editor.workflow.unsavedchanges.warning=Some changes to the workflow have not been completed.
 scheduledExecution.property.executionLifecyclePluginConfig.help.text=Selected Plugins will be enabled for this Job.
+scheduledExecution.plugins.title=Plugins

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -1728,3 +1728,4 @@ start=Start
 end=End
 job.editor.workflow.unsavedchanges.warning=Some changes to the workflow have not been completed.
 scheduledExecution.property.executionLifecyclePluginConfig.help.text=Selected Plugins will be enabled for this Job.
+scheduledExecution.plugins.title=Plugins

--- a/rundeckapp/grails-app/views/execution/_execDetails.gsp
+++ b/rundeckapp/grails-app/views/execution/_execDetails.gsp
@@ -121,6 +121,32 @@
                 </td>
             </tr>
         </g:if>
+        <g:if test="${execdata instanceof ScheduledExecution &&  execdata.pluginConfigMap }">
+            <tr>
+                <td>
+                    <g:message code="scheduledExecution.plugins.title" />
+                </td>
+                <td >
+                    <g:each in="${execdata.pluginConfigMap.keySet()}"  var="service">
+                            <g:each in="${execdata.pluginConfigMap[service]}" var="pluginConfig">
+                                <g:render template="/framework/renderPluginConfig"
+                                          model="[showPluginIcon: true,
+                                                  serviceName   : service,
+                                                  type          : pluginConfig.key,
+                                                  values        : pluginConfig.value,
+                                                  description   : pluginDescriptions[service].find{it.name==pluginConfig.key},
+                                                  hideDescription: true
+                                          ]"/>
+                                <g:if test="${!pluginDescriptions[service].find{it.name==pluginConfig.key}}">
+                                    <span class="text-danger">
+                                        <g:message code="plugin.not.found.0" args="[service+': '+pluginConfig.key]"/>
+                                    </span>
+                                </g:if>
+                            </g:each>
+                    </g:each>
+                </td>
+            </tr>
+        </g:if>
     </g:if>
 <g:if test="${execdata?.loglevel=='DEBUG'}">
     <tr>

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -33,6 +33,7 @@ import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 import rundeck.*
 import rundeck.codecs.URIComponentCodec
 import rundeck.services.*
+import rundeck.services.feature.FeatureService
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -479,6 +480,7 @@ class ScheduledExecutionControllerSpec extends Specification {
         controller.notificationService=Mock(NotificationService)
         controller.orchestratorPluginService=Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
+        controller.featureService = Mock(FeatureService)
         when:
         request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
 
@@ -547,6 +549,7 @@ class ScheduledExecutionControllerSpec extends Specification {
         controller.notificationService = Mock(NotificationService)
         controller.orchestratorPluginService = Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
+            controller.featureService = Mock(FeatureService)
         when:
         request.parameters = [id: se.id.toString(), project: 'project1']
         response.format = format
@@ -1085,6 +1088,7 @@ class ScheduledExecutionControllerSpec extends Specification {
             1 * getOrchestratorPlugins()
         }
         controller.pluginService = Mock(PluginService)
+            controller.featureService = Mock(FeatureService)
         when:
         params.project = 'testProject'
         request.method = 'POST'
@@ -1295,6 +1299,7 @@ class ScheduledExecutionControllerSpec extends Specification {
             1 * getOrchestratorPlugins()
         }
         controller.pluginService = Mock(PluginService)
+            controller.featureService = Mock(FeatureService)
         when:
         params.project = 'testProject'
         request.method = 'POST'
@@ -1373,6 +1378,7 @@ class ScheduledExecutionControllerSpec extends Specification {
         controller.notificationService=Mock(NotificationService)
         controller.orchestratorPluginService=Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
+            controller.featureService = Mock(FeatureService)
         when:
         request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
 
@@ -1463,6 +1469,7 @@ class ScheduledExecutionControllerSpec extends Specification {
         controller.notificationService=Mock(NotificationService)
         controller.orchestratorPluginService=Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
+            controller.featureService = Mock(FeatureService)
         when:
         request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
 
@@ -1558,6 +1565,7 @@ class ScheduledExecutionControllerSpec extends Specification {
         controller.notificationService=Mock(NotificationService)
         controller.orchestratorPluginService=Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
+            controller.featureService = Mock(FeatureService)
         when:
         request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
 
@@ -1786,6 +1794,7 @@ class ScheduledExecutionControllerSpec extends Specification {
         controller.notificationService=Mock(NotificationService)
         controller.orchestratorPluginService=Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
+            controller.featureService = Mock(FeatureService)
         when:
         request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
 
@@ -1854,6 +1863,7 @@ class ScheduledExecutionControllerSpec extends Specification {
         controller.notificationService=Mock(NotificationService)
         controller.orchestratorPluginService=Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
+            controller.featureService = Mock(FeatureService)
         when:
         request.parameters = [id: se.id.toString(),project:'project1']
 
@@ -1925,6 +1935,7 @@ class ScheduledExecutionControllerSpec extends Specification {
         controller.notificationService=Mock(NotificationService)
         controller.orchestratorPluginService=Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
+            controller.featureService = Mock(FeatureService)
         when:
         request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
 
@@ -2001,6 +2012,7 @@ class ScheduledExecutionControllerSpec extends Specification {
         controller.notificationService = Mock(NotificationService)
         controller.orchestratorPluginService = Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
+            controller.featureService = Mock(FeatureService)
         when:
         request.parameters = [id: se.id.toString(), project: 'project1', retryFailedExecId: exec.id.toString()]
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerTests.groovy
@@ -19,6 +19,7 @@ package rundeck.controllers
 import com.dtolabs.rundeck.core.common.PluginControlService
 import groovy.mock.interceptor.MockFor
 import rundeck.services.ExecutionLifecyclePluginService
+import rundeck.services.feature.FeatureService
 import rundeck.services.optionvalues.OptionValuesService
 import rundeck.ScheduledExecutionStats
 
@@ -2085,6 +2086,9 @@ class ScheduledExecutionControllerTests  {
         sec.pluginService = mockWith(PluginService) {
             listPlugins(){[]}
         }
+        sec.featureService=mockWith(FeatureService){
+            featurePresent(){name->false}
+        }
         def params = [id: se.id.toString(),project:'project1']
         sec.params.putAll(params)
         def model = sec.show()
@@ -2175,6 +2179,9 @@ class ScheduledExecutionControllerTests  {
         }
         sec.pluginService = mockWith(PluginService) {
             listPlugins(){[]}
+        }
+        sec.featureService=mockWith(FeatureService){
+            featurePresent(){name->false}
         }
         def params = [id: se.id.toString(),project:'project1']
         sec.params.putAll(params)
@@ -2280,6 +2287,9 @@ class ScheduledExecutionControllerTests  {
         sec.pluginService = mockWith(PluginService) {
             listPlugins(){[]}
         }
+        sec.featureService=mockWith(FeatureService){
+            featurePresent(){name->false}
+        }
 
         def params = [id: se.id.toString(),project:'project1']
         sec.params.putAll(params)
@@ -2381,6 +2391,9 @@ class ScheduledExecutionControllerTests  {
         }
         sec.pluginService = mockWith(PluginService) {
             listPlugins(){[]}
+        }
+        sec.featureService=mockWith(FeatureService){
+            featurePresent(){name->false}
         }
 
         def params = [id: se.id.toString(),project:'project1']
@@ -2484,6 +2497,9 @@ class ScheduledExecutionControllerTests  {
         sec.pluginService = mockWith(PluginService) {
             listPlugins(){[]}
         }
+        sec.featureService=mockWith(FeatureService){
+            featurePresent(){name->false}
+        }
 
         def params = [id: se.id.toString(),project:'project1']
         sec.params.putAll(params)
@@ -2584,6 +2600,9 @@ class ScheduledExecutionControllerTests  {
         }
         sec.pluginService = mockWith(PluginService) {
             listPlugins(){[]}
+        }
+        sec.featureService=mockWith(FeatureService){
+            featurePresent(){name->false}
         }
 
         def params = [id: se.id.toString(),project:'project1']
@@ -2713,6 +2732,9 @@ class ScheduledExecutionControllerTests  {
             listPlugins(){[]}
         }
 
+        sec.featureService=mockWith(FeatureService){
+            featurePresent(){name->false}
+        }
         def params = [id: se.id.toString(),project:'project1',retryExecId:exec.id.toString()]
         sec.params.putAll(params)
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

List plugins for the Job in the job detail, such as ExecutionLifecycle plugins
