### PR TITLE
ssh export rd variables

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionService.java
@@ -51,7 +51,7 @@ import java.util.List;
 public interface ExecutionService
         extends FrameworkSupportService, NodeExecutionService
 {
-    public static final String SERVICE_NAME = "ExecutionService";
+    static final String SERVICE_NAME = "ExecutionService";
 
     /**
      * Execute a workflow step item for the given context and return the result.

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionServiceImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionServiceImpl.java
@@ -413,7 +413,13 @@ class ExecutionServiceImpl implements ExecutionService {
         );
 
         NodeExecutorResult result = null;
+
         String[] commandArray = commandList.toArray(new String[commandList.size()]);
+
+        if(nodeExecutor.supportVariableInjection()){
+            commandArray = NodeExecutorUtils.getExportedVariablesForNode(node, nodeContext, commandList);
+        }
+
         try {
             result = nodeExecutor.executeCommand(nodeContext, commandArray, node);
         } finally {
@@ -427,6 +433,5 @@ class ExecutionServiceImpl implements ExecutionService {
     public String getName() {
         return SERVICE_NAME;
     }
-
 
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/NodeExecutorUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/NodeExecutorUtils.java
@@ -1,0 +1,58 @@
+package com.dtolabs.rundeck.core.execution;
+
+import com.dtolabs.rundeck.core.common.INodeEntry;
+import com.dtolabs.rundeck.core.dispatcher.DataContextUtils;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class NodeExecutorUtils {
+
+    static final String RD_VARIABLE_PATTERN = "ssh-variable-export-pattern";
+    static final String RD_VARIABLE_PATTERN_SEPARATOR = "ssh-variable-export-separator";
+    static final String RD_VARIABLE_PATTERN_EXCLUDE_NODES = "ssh-variable-export-exclude-nodes";
+    static final String RD_VARIABLE_PATTERN_EXCLUDE_NODES_PATTERN = "RD_NODE";
+    static final String RD_VARIABLE_PATTERN_DEFAULT_SEPARATOR = ";";
+
+    /**
+     * It checkf if the node allows RD variable inyection, if so, it will be added as part of the execution command
+     * @param node
+     * @param nodeContext
+     * @param commandList current command list to execute
+     * @return String[] commands with exported variables
+     */
+    public static String[] getExportedVariablesForNode(final INodeEntry node,
+                                                final ExecutionContext nodeContext,
+                                                final List commandList){
+        String exportedVariables = "";
+        List<String> commandsList = new ArrayList<>();
+        if(node.getAttributes().get(RD_VARIABLE_PATTERN) != null){
+            List<String> envArgs = new ArrayList<>();
+            String replacementPattern = node.getAttributes().get(RD_VARIABLE_PATTERN);
+            final Map<String, String> envVars = DataContextUtils.generateEnvVarsFromContext(nodeContext.getDataContext());
+            envVars.forEach((k,v)->{
+                if(node.getAttributes().get(RD_VARIABLE_PATTERN_EXCLUDE_NODES) != null
+                        && Boolean.TRUE.equals(Boolean.valueOf(node.getAttributes().get(RD_VARIABLE_PATTERN_EXCLUDE_NODES)))){
+                    if(!k.startsWith(RD_VARIABLE_PATTERN_EXCLUDE_NODES_PATTERN)){
+                        envArgs.add(replacementPattern.replace("{key}", k).replace("{value}", v));
+                    }
+                }else{
+                    envArgs.add(replacementPattern.replace("{key}", k).replace("{value}", v));
+                }
+            });
+            if(!envArgs.isEmpty()){
+                String variablePatternSeparator = RD_VARIABLE_PATTERN_DEFAULT_SEPARATOR;
+                if(node.getAttributes().get(RD_VARIABLE_PATTERN_SEPARATOR) != null){
+                    variablePatternSeparator = node.getAttributes().get(RD_VARIABLE_PATTERN_SEPARATOR);
+                }
+                exportedVariables = StringUtils.join(envArgs, StringEscapeUtils.unescapeJava(variablePatternSeparator)) + StringEscapeUtils.unescapeJava(variablePatternSeparator);
+                commandsList.add(exportedVariables);
+            }
+        }
+        commandsList.addAll(commandList);
+        return commandsList.toArray(new String[commandsList.size()]);
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutor.java
@@ -296,6 +296,10 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
         DESC=builder.build();
     }
 
+    @Override
+    public boolean supportVariableInjection() {
+        return true;
+    }
 
     public Description getDescription() {
         return DESC;
@@ -686,7 +690,5 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
         public FailureReason getReason() {
             return reason;
         }
-
-
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeExecutor.java
@@ -43,4 +43,11 @@ public interface NodeExecutor {
      * @return a result
      */
     public NodeExecutorResult executeCommand(ExecutionContext context, String[] command, INodeEntry node);
+
+    /**
+     * To indicate if the command execution suppports rd_variable injection
+     * @return boolean
+     */
+    default boolean supportVariableInjection(){return false;}
+
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/SSHTaskBuilder.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/SSHTaskBuilder.java
@@ -593,6 +593,7 @@ public class SSHTaskBuilder {
         configureSSHBase(nodeentry, project, sshConnectionInfo, sshexecTask, loglevel, logger);
 
         //nb: args are already quoted as necessary
+
         final String commandString = StringUtils.join(args, " ");
         sshexecTask.setCommand(commandString);
         sshexecTask.setTimeout(sshConnectionInfo.getTimeout());

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/NodeExecutorUtilsSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/NodeExecutorUtilsSpec.groovy
@@ -1,0 +1,76 @@
+package com.dtolabs.rundeck.core.execution
+
+import com.dtolabs.rundeck.core.common.NodeEntryImpl
+import com.dtolabs.rundeck.core.dispatcher.DataContextUtils
+import spock.lang.Specification
+
+class NodeExecutorUtilsSpec extends Specification {
+
+    def "getExportedVariablesForNode without exclude"() {
+        given:
+        def nodea = new NodeEntryImpl("nodea.host", "nodea")
+        nodea.setAttribute(NodeExecutorUtils.RD_VARIABLE_PATTERN, "export {key} = '{value}'")
+        nodea.setAttribute(NodeExecutorUtils.RD_VARIABLE_PATTERN_SEPARATOR, ";")
+
+        def orig = ExecutionContextImpl.builder()
+                .stepContext([1, 2])
+                .stepNumber(3)
+                .dataContext(DataContextUtils.context('b', [c: 'd']))
+                .build()
+        orig.getDataContext()
+        def commandList = ["ls"]
+        when:
+        def result = NodeExecutorUtils.getExportedVariablesForNode(nodea, orig, commandList)
+
+        then:
+        result.size() == 2
+        result[0] == 'export RD_B_C = \'d\';'
+        result[1] == 'ls'
+    }
+
+    def "getExportedVariablesForNode with exclude node attributes"() {
+        given:
+        def nodea = new NodeEntryImpl("nodea.host", "nodea")
+        nodea.setAttribute(NodeExecutorUtils.RD_VARIABLE_PATTERN, "export {key} = '{value}'")
+        nodea.setAttribute(NodeExecutorUtils.RD_VARIABLE_PATTERN_SEPARATOR, ";")
+        nodea.setAttribute(NodeExecutorUtils.RD_VARIABLE_PATTERN_EXCLUDE_NODES, "true")
+
+        def orig = ExecutionContextImpl.builder()
+                .stepContext([1, 2])
+                .stepNumber(3)
+                .dataContext(DataContextUtils.context('node', [c: 'd']))
+                .build()
+        orig.getDataContext()
+        def commandList = ["ls"]
+        when:
+        def result = NodeExecutorUtils.getExportedVariablesForNode(nodea, orig, commandList)
+
+        then:
+        result.size() == 1
+        result[0] == 'ls'
+    }
+
+    def "getExportedVariablesForNode with exclude node attributes and addional attributes added"() {
+        given:
+        def nodea = new NodeEntryImpl("nodea.host", "nodea")
+        nodea.setAttribute(NodeExecutorUtils.RD_VARIABLE_PATTERN, "export {key} = '{value}'")
+        nodea.setAttribute(NodeExecutorUtils.RD_VARIABLE_PATTERN_SEPARATOR, ";")
+        nodea.setAttribute(NodeExecutorUtils.RD_VARIABLE_PATTERN_EXCLUDE_NODES, "true")
+        def attributes = ['node':[c:'d']]
+        attributes << ['job':[e:'f']]
+        def orig = ExecutionContextImpl.builder()
+                .stepContext([1, 2])
+                .stepNumber(3)
+                .dataContext(DataContextUtils.context(attributes))
+                .build()
+        orig.getDataContext()
+        def commandList = ["ls"]
+        when:
+        def result = NodeExecutorUtils.getExportedVariablesForNode(nodea, orig, commandList)
+
+        then:
+        result.size() == 2
+        result[0] == 'export RD_JOB_E = \'f\';'
+        result[1] == 'ls'
+    }
+}

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/tasks/net/SSHTaskBuilderSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/tasks/net/SSHTaskBuilderSpec.groovy
@@ -346,6 +346,7 @@ class SSHTaskBuilderSpec extends Specification {
         given:
         def node = Mock(INodeEntry) {
             extractHostname() >> 'ahostname'
+            getAttributes() >> [:]
         }
         def project = new Project()
 
@@ -381,5 +382,4 @@ class SSHTaskBuilderSpec extends Specification {
         built.getBindAddress() == "192.168.0.120"
 
     }
-
 }


### PR DESCRIPTION
Enhancement:
You can now inyect RD_ variables as part of the ssh commands, so no modification to the ssh configuration on the client side is needed

- This can be enabled/setup at node level making it able to run with different sintaxis depending on the node config.

EG:
1.-Linux node
ssh-variable-export-pattern="export {key}='{value}'"
2.-Windows node
ssh-variable-export-pattern="set {key}='{value}'"

- Custom separator can also be set with the following node attribute:

ssh-variable-export-separator

EG:
1.-ssh-variable-export-separator=";"
2.-ssh-variable-export-separator="\n"

- Node attributes can now be excluded from the export, using the following node attribute:

ssh-variable-export-exclude-nodes="true"

- Example job to print the environment variables

[simpleCommand.zip](https://github.com/rundeck/rundeck/files/4010135/simpleCommand.zip)


