### PR TITLE
Fix #5001 - Adapting query so dashboard can show one time scheduled job (run job later) as scheduled and not as running job

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -412,6 +412,14 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                 serverOwner   : se.serverNodeUUID == serverNodeUUID
                         ]
                     }
+
+                    Date now = new Date()
+                    se?.executions?.findAll {Execution e ->
+                        return e.dateStarted > now && e.dateCompleted == null
+                    }?.each {Execution execution ->
+                        results.nextExecutions[se.id] = new Date(execution.dateStarted?.getTime())
+                    }
+
                     if(results.nextExecutions?.get(se.id)){
                         data.nextScheduledExecution=results.nextExecutions?.get(se.id)
                         if (futureDate) {

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -415,10 +415,17 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
                 //running status filter.
                 if (query.runningFilter) {
-                    if (EXECUTION_SCHEDULED == query.runningFilter) {
+                    Date now = new Date()
+                    if (EXECUTION_SCHEDULED == query.runningFilter ) {
                         eq('status', EXECUTION_SCHEDULED)
                     } else if ('running' == query.runningFilter) {
-                        isNull('dateCompleted')
+                        and{
+                            isNull('dateCompleted')
+                            if(!query.considerPostponedRunsAsRunningFilter){
+                                le('dateStarted', now)
+                                ne('status', EXECUTION_SCHEDULED)
+                            }
+                        }
                     } else {
                         and {
                             eq('status', 'completed' == query.runningFilter ? 'true' : 'false')

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -21,6 +21,9 @@ import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRoles
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException
+import org.hibernate.criterion.DetachedCriteria
+import org.hibernate.criterion.Projections
+import org.hibernate.criterion.Subqueries
 import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.INodeSet
@@ -57,6 +60,7 @@ import org.apache.log4j.MDC
 import org.grails.web.json.JSONObject
 import org.hibernate.StaleObjectStateException
 import org.hibernate.criterion.CriteriaSpecification
+import org.hibernate.criterion.Restrictions
 import org.quartz.*
 import org.quartz.impl.calendar.BaseCalendar
 import org.rundeck.util.Sizes
@@ -323,12 +327,25 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                     eq(val,query["${key}Filter"])
                 }
             }
+
+            def restr = Restrictions.conjunction()
             boolfilters.each{ key,val ->
                 if(null!=query["${key}Filter"]){
-                    eq(val,query["${key}Filter"])
+                    restr.add(Restrictions.eq(val, query["${key}Filter"]))
                 }
             }
 
+            if(query.runJobLaterFilter){
+                Date now = new Date()
+                DetachedCriteria subquery = DetachedCriteria.forClass(Execution.class, "e").with{
+                    setProjection Projections.property('e.id')
+                    add(Restrictions.gt('e.dateStarted', now))
+                    add Restrictions.conjunction().
+                            add(Restrictions.eqProperty('e.scheduledExecution.id', 'this.id'))
+                }
+
+                add(Restrictions.disjunction().add(Subqueries.exists(subquery)).add(restr))
+            }
 
             if('*'==query["groupPath"]){
                 //don't filter out any grouppath

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/QueueQuery.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/QueueQuery.groovy
@@ -27,8 +27,10 @@ import grails.validation.Validateable
  */
 public class QueueQuery extends ExecQuery implements Validateable{
     String runningFilter
+    Boolean considerPostponedRunsAsRunningFilter = true
 
     static constraints = {
         runningFilter(nullable:true,inList:["scheduled","running","completed","killed","cancelled" /*,"pattern"*/])
+        considerPostponedRunsAsRunningFilter(nullable:true, defaultValue: true)
     }
 }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ScheduledExecutionQuery.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ScheduledExecutionQuery.groovy
@@ -42,6 +42,7 @@ public class ScheduledExecutionQuery extends BaseQuery implements Validateable{
     String serverNodeUUIDFilter
 
     Integer daysAhead
+    Boolean runJobLaterFilter
 
     /**
      * text filters
@@ -106,6 +107,7 @@ public class ScheduledExecutionQuery extends BaseQuery implements Validateable{
             }
         })
         daysAhead(nullable: true)
+        runJobLaterFilter(nullable: true)
     }
 
 

--- a/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/ExecutionServiceSpec.groovy
@@ -18,6 +18,7 @@
 import com.dtolabs.rundeck.app.support.QueueQuery
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import groovy.time.TimeCategory
 import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
@@ -2140,6 +2141,40 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
         then:
         1 == result.total
+        1 == result.nowrunning.size()
+
+    }
+
+    def "list should not consider postponed runs as running filter"() {
+        given:
+        def query = new QueueQuery()
+        Date now = new Date()
+        Date future = now
+        use(TimeCategory) {
+            future = future + 1.days
+            now = now - 1.hours
+        }
+        query.projFilter = 'AProject'
+        query.runningFilter = 'running'
+        query.considerPostponedRunsAsRunningFilter = false
+        def exec = new Execution(
+                dateStarted: now,
+                dateCompleted: null,
+                user: 'userB',
+                project: 'AProject'
+        ).save()
+        def exec2 = new Execution(
+                dateStarted: future,
+                dateCompleted: null,
+                user: 'user',
+                project: 'AProject',
+                status: 'scheduled'
+        ).save()
+        when:
+        def result = service.queryQueue(query)
+
+        then:
+        2 == result.total
         1 == result.nowrunning.size()
 
     }


### PR DESCRIPTION
Fix #5001 
**Is this a bugfix, or an enhancement? Please describe.**
A customer requested to change dashboard behaviour so jobs that will run later should be shown as scheduled and not as running

**Describe the solution you've implemented**
The query was adapted to filter jobs with date start setted to a date future