### PR TITLE
Fixes webhook config for plugins with a custom config component.

### DIFF
--- a/rundeckapp/grails-spa/src/pages/webhooks/views/WebhooksView.vue
+++ b/rundeckapp/grails-spa/src/pages/webhooks/views/WebhooksView.vue
@@ -217,7 +217,8 @@ export default {
       this.setSelectedPlugin(true)
     },
     setSelectedPlugin(preserve) {
-      this.selectedPlugin = {type: this.curHook.eventPlugin, config: preserve? this.curHook.config:{}}
+      if(!preserve) this.curHook.config = {}
+      this.selectedPlugin = {type: this.curHook.eventPlugin, config: this.curHook.config}
       if(!preserve){
           this.setValidation(true)
       }


### PR DESCRIPTION
When switching between event plugin types on the config page, the selected plugin object was not maintaining a reference to the same object, so the config wasn't always being saved properly in the cases of custom config components.