### PR TITLE
Suppress NPE generated by Jetty JAAS logout module

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/security/RundeckJaasAuthenticationProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/RundeckJaasAuthenticationProvider.groovy
@@ -26,7 +26,7 @@ import javax.security.auth.login.LoginException
 
 
 class RundeckJaasAuthenticationProvider extends DefaultJaasAuthenticationProvider {
-    static final String IGNORE_THIS_ERROR = "java.lang.NullPointerException\n\tat org.eclipse.jetty.jaas.spi.AbstractLoginModule.logout(AbstractLoginModule.java:298)"
+    static final String IGNORE_THIS_ERROR = "java.lang.NullPointerException\n\tat org.eclipse.jetty.jaas.spi.AbstractLoginModule.logout(AbstractLoginModule.java"
 
     @Override
     protected void handleLogout(final SessionDestroyedEvent event) {


### PR DESCRIPTION
Update to the text checked for suppression when the Jetty Jaas module generates a spurious NPE on logout.
