### PR TITLE
Ensure alert is above other elements

### DIFF
--- a/rundeckapp/grails-app/assets/scss/paper/_alerts.scss
+++ b/rundeckapp/grails-app/assets/scss/paper/_alerts.scss
@@ -4,6 +4,7 @@
   color: #FFFFFF;
   padding: 10px 15px;
   font-size: 14px;
+  z-index: 1000;
 
   .container & {
     border-radius: 4px;


### PR DESCRIPTION
Fixes rundeckpro/rundeckpro#816

**Describe the solution you've implemented**
Added a `z-index` to the alert class in `app.css`.

![image](https://user-images.githubusercontent.com/271965/70747026-b3a4c100-1cec-11ea-9d86-b8a585b8dda6.png)
