### PR TITLE
Handle webhook post with auth token containing hash

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
@@ -176,7 +176,8 @@ class SetUserInterceptor {
 
         AuthToken tokenobj = null
         if(webhookType) {
-            tokenobj = AuthToken.findByTokenAndType(authtoken,AuthTokenType.WEBHOOK)
+            String cleanedToken = cleanAuthToken(authtoken)
+            tokenobj = AuthToken.findByTokenAndType(cleanedToken,AuthTokenType.WEBHOOK)
         } else {
             tokenobj = AuthToken.createCriteria().get {
                 eq("token",authtoken)
@@ -228,5 +229,11 @@ class SetUserInterceptor {
             return roles
         }
         null
+    }
+
+    @PackageScope
+    String cleanAuthToken(String authtoken) {
+        if(authtoken.contains("#")) return authtoken.substring(0,authtoken.indexOf("#"))
+        return authtoken
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
@@ -134,4 +134,18 @@ class SetUserInterceptorSpec extends Specification implements InterceptorUnitTes
         "789"|true|"whk"
         "789"|false|null
     }
+
+    def "cleanup webtoken"() {
+
+        when:
+        String ctoken = interceptor.cleanAuthToken(token)
+
+        then:
+        ctoken == expected
+
+        where:
+        token                   | expected
+        "123456789"             | "123456789"
+        "123456789#Meta_Info"   | "123456789"
+    }
 }


### PR DESCRIPTION
When a webhook post is received the authtoken can contain a hash + webhook name. This commit cleans the token in that scenario.
