### PR TITLE
call refresh-nodes when the project settings are refresh

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -735,6 +735,8 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
         )
         rdproject.nodesFactory = rundeckNodeService
         log.info("Loaded project ${project} in ${System.currentTimeMillis()-start}ms")
+
+        rundeckNodeService.refreshProjectNodes(project)
         return rdproject
     }
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Bug fix:
On cluster mode, if a cluster member modifies any node enhancer plugin, the other cluster members cannot refresh the plugin list defined on the EnhancedNodeService.

 
for issue https://github.com/rundeckpro/rundeckpro/issues/823

**Describe the solution you've implemented**
The workaround is to call the `refreshProjectNodes` when a change on the project settings is detected on ProjectManagerService

**Describe alternatives you've considered**
add a guava cache on EnhancedNodeService

