### PR TITLE
Fix potential webhook authtoken issue

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
@@ -12,6 +12,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import rundeck.AuthToken
 import rundeck.User
 import rundeck.services.UserService
+import webhooks.Webhook
 
 import javax.security.auth.Subject
 import javax.servlet.ServletContext
@@ -62,7 +63,7 @@ class SetUserInterceptor {
             request.subject = session.subject
         } else if (request.api_version && !session.user ) {
             //allow authentication token to be used
-            def authtoken = params.authtoken? params.authtoken : request.getHeader('X-RunDeck-Auth-Token')
+            def authtoken = params.authtoken? Webhook.cleanAuthToken(params.authtoken) : request.getHeader('X-RunDeck-Auth-Token')
             boolean webhookType = controllerName == "webhook" && actionName == "post"
             String user = lookupToken(authtoken, servletContext, webhookType)
             List<String> roles = lookupTokenRoles(authtoken, servletContext)
@@ -176,8 +177,7 @@ class SetUserInterceptor {
 
         AuthToken tokenobj = null
         if(webhookType) {
-            String cleanedToken = cleanAuthToken(authtoken)
-            tokenobj = AuthToken.findByTokenAndType(cleanedToken,AuthTokenType.WEBHOOK)
+            tokenobj = AuthToken.findByTokenAndType(authtoken,AuthTokenType.WEBHOOK)
         } else {
             tokenobj = AuthToken.createCriteria().get {
                 eq("token",authtoken)
@@ -231,9 +231,4 @@ class SetUserInterceptor {
         null
     }
 
-    @PackageScope
-    String cleanAuthToken(String authtoken) {
-        if(authtoken.contains("#")) return authtoken.substring(0,authtoken.indexOf("#"))
-        return authtoken
-    }
 }

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
@@ -135,17 +135,4 @@ class SetUserInterceptorSpec extends Specification implements InterceptorUnitTes
         "789"|false|null
     }
 
-    def "cleanup webtoken"() {
-
-        when:
-        String ctoken = interceptor.cleanAuthToken(token)
-
-        then:
-        ctoken == expected
-
-        where:
-        token                   | expected
-        "123456789"             | "123456789"
-        "123456789#Meta_Info"   | "123456789"
-    }
 }

--- a/rundeckapp/webhooks/grails-app/controllers/webhooks/WebhookController.groovy
+++ b/rundeckapp/webhooks/grails-app/controllers/webhooks/WebhookController.groovy
@@ -111,7 +111,7 @@ class WebhookController {
     }
 
     def post() {
-        Webhook hook = webhookService.getWebhookByToken(params.authtoken)
+        Webhook hook = webhookService.getWebhookByToken(Webhook.cleanAuthToken(params.authtoken))
 
         if(!hook) {
             sendJsonError("Webhook not found")

--- a/rundeckapp/webhooks/src/test/groovy/webhooks/WebhookControllerSpec.groovy
+++ b/rundeckapp/webhooks/src/test/groovy/webhooks/WebhookControllerSpec.groovy
@@ -42,7 +42,12 @@ class WebhookControllerSpec extends Specification implements ControllerUnitTest<
         1 * controller.frameworkService.getAuthContextForSubject(_) >> { new SubjectAuthContext(null, null) }
         1 * controller.frameworkService.authorizeProjectResourceAny(_,_,_,_) >> { return true }
         1 * controller.webhookService.processWebhook(_,_,_,_,_) >> { }
-        response.text == '{"msg":"ok"}'
+        response.text == expectedMsg
+
+        where:
+        authtoken   | expectedMsg
+        "1234"      | '{"msg":"ok"}'
+        "1234#test" | '{"msg":"ok"}'
     }
 
     def "post fail when not authorized"() {

--- a/rundeckapp/webhooks/src/test/groovy/webhooks/WebhookSpec.groovy
+++ b/rundeckapp/webhooks/src/test/groovy/webhooks/WebhookSpec.groovy
@@ -15,30 +15,21 @@
  */
 package webhooks
 
-class Webhook {
+import spock.lang.Specification
 
-    String uuid
-    String name
-    String project
-    String authToken
-    String eventPlugin
-    String pluginConfigurationJson = '{}'
-    boolean enabled = true
 
-    static constraints = {
-        uuid(nullable: true)
-        name(nullable: false)
-        project(nullable: false)
-        authToken(nullable: false)
-        eventPlugin(nullable: false)
-    }
+class WebhookSpec extends Specification {
+    def "cleanup webtoken"() {
 
-    static mapping = {
-        pluginConfigurationJson type: 'text'
-    }
+        when:
+        String ctoken = Webhook.cleanAuthToken(token)
 
-    static String cleanAuthToken(String authtoken) {
-        if(authtoken.contains("#")) return authtoken.substring(0,authtoken.indexOf("#"))
-        return authtoken
+        then:
+        ctoken == expected
+
+        where:
+        token                   | expected
+        "123456789"             | "123456789"
+        "123456789#Meta_Info"   | "123456789"
     }
 }


### PR DESCRIPTION
Fix possible issue with posting to a webhook endpoint with the hash and webhook name appended to the auth token used by the webhook.

This PR moves the auth token cleaning code and does an additional cleanup step in the post method of the webhook controller.