### PR TITLE
Add bom char to destination file of the script #4291

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/data/SharedDataContextUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/data/SharedDataContextUtils.java
@@ -224,7 +224,8 @@ public class SharedDataContextUtils {
             final MultiDataContext<ContextView, DataContext> dataContext,
             final ScriptfileUtils.LineEndingStyle style,
             final File destination,
-            final String nodeName
+            final String nodeName,
+            final boolean addBom
     )
             throws IOException
     {
@@ -232,7 +233,8 @@ public class SharedDataContextUtils {
                 script,
                 dataContext,
                 style,
-                destination, nodeName, true
+                destination, nodeName, true,
+                addBom
         );
     }
 
@@ -253,7 +255,8 @@ public class SharedDataContextUtils {
             final ScriptfileUtils.LineEndingStyle style,
             final File destination,
             final String nodeName,
-            final boolean blankIfMissing
+            final boolean blankIfMissing,
+            final boolean addBom
     )
             throws IOException
     {
@@ -264,7 +267,8 @@ public class SharedDataContextUtils {
                 new StringReader(script),
                 dataContext,
                 style,
-                destination, nodeName,blankIfMissing
+                destination, nodeName,blankIfMissing,
+                addBom
         );
     }
 
@@ -286,7 +290,8 @@ public class SharedDataContextUtils {
             final MultiDataContext<ContextView, DataContext> dataContext,
             final ScriptfileUtils.LineEndingStyle style,
             final File destination,
-            final String nodeName
+            final String nodeName,
+            final boolean addBom
     )
             throws IOException
     {
@@ -297,7 +302,7 @@ public class SharedDataContextUtils {
                 new InputStreamReader(stream),
                 dataContext,
                 style,
-                destination, nodeName
+                destination, nodeName, true, addBom
         );
     }
 
@@ -321,7 +326,7 @@ public class SharedDataContextUtils {
     )
             throws IOException
     {
-        replaceTokensInReader(reader,dataContext,style,destination,nodeName,true);
+        replaceTokensInReader(reader,dataContext,style,destination,nodeName,true, false);
     }
     /**
      * Copies the source stream to a temp file or specific destination, replacing the @key.X@ tokens
@@ -340,7 +345,8 @@ public class SharedDataContextUtils {
             final ScriptfileUtils.LineEndingStyle style,
             final File destination,
             final String nodeName,
-            final boolean blankIfMissing
+            final boolean blankIfMissing,
+            final boolean addBom
     )
             throws IOException
     {
@@ -359,7 +365,7 @@ public class SharedDataContextUtils {
                 '@',
                 '@'
         );
-        ScriptfileUtils.writeScriptFile(null, null, replaceTokens, style, destination);
+        ScriptfileUtils.writeScriptFile(null, null, replaceTokens, style, destination, addBom);
     }
 
     /**

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/common/DefaultFileCopierUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/common/DefaultFileCopierUtil.java
@@ -125,7 +125,10 @@ public class DefaultFileCopierUtil implements FileCopierUtil {
 
         final File tempfile;
         ScriptfileUtils.LineEndingStyle style = ScriptfileUtils.lineEndingStyleForNode(node);
-
+        boolean addBom = false;
+        if(style == ScriptfileUtils.LineEndingStyle.WINDOWS){
+            addBom = ScriptfileUtils.shouldAddBomForNode(node);
+        }
         try {
             if (null == destination) {
                 tempfile = ScriptfileUtils.createTempFile(framework);
@@ -146,10 +149,11 @@ public class DefaultFileCopierUtil implements FileCopierUtil {
                             sharedContext,
                             style,
                             tempfile,
-                            node.getNodename()
+                            node.getNodename(),
+                            addBom
                     );
                 } else {
-                    ScriptfileUtils.writeScriptFile(null, script, null, style, tempfile);
+                    ScriptfileUtils.writeScriptFile(null, script, null, style, tempfile, addBom);
                 }
             } else if (null != input) {
                 if (expandTokens) {
@@ -158,10 +162,11 @@ public class DefaultFileCopierUtil implements FileCopierUtil {
                             sharedContext,
                             style,
                             tempfile,
-                            node.getNodename()
+                            node.getNodename(),
+                            addBom
                     );
                 } else {
-                    ScriptfileUtils.writeScriptFile(input, null, null, style, tempfile);
+                    ScriptfileUtils.writeScriptFile(input, null, null, style, tempfile, addBom);
                 }
             } else {
                 return null;

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/script/ScriptfileUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/script/ScriptfileUtils.java
@@ -166,7 +166,8 @@ public class ScriptfileUtils {
                         LineEndingStyle.LOCAL.getLineSeparator() :
                         style.getLineSeparator();
 
-        if(addBom && StandardCharsets.UTF_8.equals(writer.getEncoding()) && style == LineEndingStyle.WINDOWS) {
+        if(addBom && StandardCharsets.UTF_8.aliases().contains(writer.getEncoding())
+                && style == LineEndingStyle.WINDOWS) {
             writer.write('\ufeff');
         }
         while ((inData = inbuff.readLine()) != null) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/script/ScriptfileUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/script/ScriptfileUtils.java
@@ -32,7 +32,7 @@ import java.util.Set;
 public class ScriptfileUtils {
 
 
-    private static final String SHOULD_ADD_BOM = "file-add-bom";
+    public static final String SHOULD_ADD_BOM = "file-copier-add-utf8-bom";
 
     /**
      * @return the line ending style for the node, based on the osFamily, or use LOCAL if

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/script/ScriptfileUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/script/ScriptfileUtils.java
@@ -20,6 +20,8 @@ import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.common.INodeEntry;
 
 import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -28,6 +30,10 @@ import java.util.Set;
  * Utility methods for writing temp files for scripts and setting file permissions.
  */
 public class ScriptfileUtils {
+
+
+    private static final String SHOULD_ADD_BOM = "file-add-bom";
+
     /**
      * @return the line ending style for the node, based on the osFamily, or use LOCAL if
      * undetermined
@@ -37,6 +43,14 @@ public class ScriptfileUtils {
      */
     public static LineEndingStyle lineEndingStyleForNode(final INodeEntry node) {
         return LineEndingStyle.forOsFamily(node.getOsFamily());
+    }
+
+    public static boolean shouldAddBomForNode(final INodeEntry node){
+        if (null != node.getAttributes() && null != node.getAttributes().get(SHOULD_ADD_BOM)) {
+            String s = node.getAttributes().get(SHOULD_ADD_BOM);
+            return "true".equals(s);
+        }
+        return false;
     }
 
     /**
@@ -99,7 +113,7 @@ public class ScriptfileUtils {
     private static void writeStream(final InputStream input, final FileWriter writer)
             throws IOException
     {
-        writeStream(input, writer, LineEndingStyle.LOCAL);
+        writeStream(input, writer, LineEndingStyle.LOCAL, false);
     }
 
     /**
@@ -111,11 +125,12 @@ public class ScriptfileUtils {
     private static void writeStream(
             final InputStream input,
             final FileWriter writer,
-            final LineEndingStyle style
+            final LineEndingStyle style,
+            final boolean addBom
     ) throws IOException
     {
         try (InputStreamReader inStream = new InputStreamReader(input)) {
-            writeReader(inStream, writer, style);
+            writeReader(inStream, writer, style, addBom);
         }
     }
 
@@ -126,7 +141,7 @@ public class ScriptfileUtils {
      * @throws IOException if an error occurs
      */
     private static void writeReader(final Reader reader, final FileWriter writer) throws IOException {
-        writeReader(reader, writer, LineEndingStyle.LOCAL);
+        writeReader(reader, writer, LineEndingStyle.LOCAL, false);
     }
 
     /**
@@ -140,7 +155,8 @@ public class ScriptfileUtils {
     private static void writeReader(
             final Reader reader,
             final FileWriter writer,
-            final LineEndingStyle style
+            final LineEndingStyle style,
+            final boolean addBom
     ) throws IOException
     {
         final BufferedReader inbuff = new BufferedReader(reader);
@@ -149,6 +165,10 @@ public class ScriptfileUtils {
                 null == style ?
                         LineEndingStyle.LOCAL.getLineSeparator() :
                         style.getLineSeparator();
+
+        if(addBom && StandardCharsets.UTF_8.equals(writer.getEncoding()) && style == LineEndingStyle.WINDOWS) {
+            writer.write('\ufeff');
+        }
         while ((inData = inbuff.readLine()) != null) {
             writer.write(inData);
             writer.write(linesep);
@@ -225,21 +245,43 @@ public class ScriptfileUtils {
             String scriptString,
             Reader reader,
             LineEndingStyle style,
-            File scriptfile
+            File scriptfile,
+            boolean addBom
     ) throws IOException
     {
-
         try (FileWriter writer = new FileWriter(scriptfile)) {
             if (null != scriptString) {
-                ScriptfileUtils.writeReader(new StringReader(scriptString), writer, style);
+                ScriptfileUtils.writeReader(new StringReader(scriptString), writer, style, addBom);
             } else if (null != reader) {
-                ScriptfileUtils.writeReader(reader, writer, style);
+                ScriptfileUtils.writeReader(reader, writer, style, addBom);
             } else if (null != stream) {
-                ScriptfileUtils.writeStream(stream, writer, style);
+                ScriptfileUtils.writeStream(stream, writer, style, addBom);
             } else {
                 throw new IllegalArgumentException("no script source argument");
             }
         }
+    }
+
+    /**
+     * Write script content to a destination file from one of the sources
+     *
+     * @param stream       stream source
+     * @param scriptString script content
+     * @param reader       reader source
+     * @param style        line ending style
+     * @param scriptfile   destination file
+     *
+     * @throws IOException on io error
+     */
+    public static void writeScriptFile(
+            InputStream stream,
+            String scriptString,
+            Reader reader,
+            LineEndingStyle style,
+            File scriptfile
+    ) throws IOException
+    {
+        writeScriptFile(stream, scriptString, reader, style, scriptfile, false);
     }
 
     /**

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/dispatcher/SharedDataContextUtilsSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/dispatcher/SharedDataContextUtilsSpec.groovy
@@ -275,7 +275,8 @@ class SharedDataContextUtilsSpec extends Specification {
                 sharedContext,
                 ScriptfileUtils.LineEndingStyle.UNIX,
                 dest,
-                node
+                node,
+                false
         )
 
 
@@ -312,7 +313,8 @@ class SharedDataContextUtilsSpec extends Specification {
                 sharedContext,
                 ScriptfileUtils.LineEndingStyle.UNIX,
                 dest,
-                node
+                node,
+                false
         )
 
 
@@ -343,7 +345,8 @@ class SharedDataContextUtilsSpec extends Specification {
                 sharedContext,
                 ScriptfileUtils.LineEndingStyle.UNIX,
                 dest,
-                node
+                node,
+                false
         )
 
 

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptFileNodeStepExecutor.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptFileNodeStepExecutor.java
@@ -38,6 +38,7 @@ import com.dtolabs.rundeck.core.utils.FileUtils;
 import com.dtolabs.utils.Streams;
 
 import java.io.*;
+import java.nio.charset.Charset;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1412,6 +1413,82 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
                 assertEquals("copyFile test", e.getCause().getMessage());
             }
         }
+    }
+
+    /**
+     * Windows target node will copy using file copier and read the addBom property  from node, then execute the
+     * filepath
+     */
+    public void testInterpretCommandScriptContentLocalWindowsUsingBom() throws Exception {
+        final Framework frameworkInstance = getFrameworkInstance();
+        ScriptFileNodeStepExecutor interpret = new ScriptFileNodeStepExecutor(frameworkInstance);
+
+        //setup nodeexecutor for local node
+        multiTestNodeExecutor testexec = new multiTestNodeExecutor();
+        NodeExecutorService service = NodeExecutorService.getInstanceForFramework(getFrameworkInstance());
+        service.registerInstance("local", testexec);
+
+        testFileCopier testcopier = new testFileCopier();
+        FileCopierService copyservice = FileCopierService.getInstanceForFramework(getFrameworkInstance());
+        copyservice.registerInstance("local", testcopier);
+
+        //execute command interpreter on local node
+        final NodeEntryImpl test1 = new NodeEntryImpl("testhost1", "test1");
+        test1.setOsFamily("windows");
+        test1.getAttributes().put("file-add-bom", "true");
+
+        final StepExecutionContext context = ExecutionContextImpl.builder()
+                .frameworkProject(PROJ_NAME)
+                .framework(frameworkInstance)
+                .user("blah")
+                .build();
+        final String testScript = "a script\n";
+        String expectScript = "a script\r\n";
+        if("UTF-8".equals(Charset.defaultCharset())){
+            expectScript = "\ufeffa script\r\n";
+        }
+
+        ScriptFileCommand command = new ScriptFileCommandBase() {
+            public String getScript() {
+                return testScript;
+            }
+
+        };
+        final ArrayList<NodeExecutorResult> nodeExecutorResults = new ArrayList<NodeExecutorResult>();
+        nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+        nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+        testexec.testResult=nodeExecutorResults;
+        testcopier.testResult = "/test/file/path";
+        final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
+
+        assertNotNull(interpreterResult);
+        assertTrue(interpreterResult.isSuccess());
+        assertEquals(interpreterResult, nodeExecutorResults.get(0));
+
+        assertEquals(context, testcopier.testContext);
+        assertNotNull(testcopier.testFile);
+        assertEquals(expectScript, testcopier.testFileContents);
+        assertFalse(testcopier.testFile.exists());
+        assertEquals(test1, testcopier.testNode);
+
+        //test nodeexecutor was called twice
+        assertEquals(2, testexec.index);
+
+        //second call is to exec the filepath
+        final String[] strings2 = testexec.testCommand.get(0);
+        assertEquals(1, strings2.length);
+        String filepath = strings2[0];
+        assertNotNull(filepath);
+        assertTrue(filepath.endsWith("." + WINDOWS_FILE_EXT));
+//            assertEquals(context, testexec.testContext.get(0));
+        assertEquals(test1, testexec.testNode.get(0));
+
+        //second call is to exec the filepath
+        final String[] strings3 = testexec.testCommand.get(1);
+        assertEquals(2, strings3.length);
+        assertEquals("del", strings3[0]);
+        assertEquals(filepath, strings3[1]);
+        assertEquals(test1, testexec.testNode.get(1));
     }
 
 }

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptFileNodeStepExecutor.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptFileNodeStepExecutor.java
@@ -1445,7 +1445,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
                 .build();
         final String testScript = "a script\n";
         String expectScript = "a script\r\n";
-        if("UTF-8".equals(Charset.defaultCharset())){
+        if("UTF-8".equals(Charset.defaultCharset().name())){
             expectScript = "\ufeffa script\r\n";
         }
 

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptFileNodeStepExecutor.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptFileNodeStepExecutor.java
@@ -27,6 +27,7 @@ import com.dtolabs.rundeck.core.common.*;
 import com.dtolabs.rundeck.core.dispatcher.DataContextUtils;
 import com.dtolabs.rundeck.core.execution.ExecutionContext;
 import com.dtolabs.rundeck.core.execution.ExecutionContextImpl;
+import com.dtolabs.rundeck.core.execution.script.ScriptfileUtils;
 import com.dtolabs.rundeck.core.execution.service.*;
 import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext;
 import com.dtolabs.rundeck.core.execution.workflow.steps.FailureReason;
@@ -1435,7 +1436,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
         //execute command interpreter on local node
         final NodeEntryImpl test1 = new NodeEntryImpl("testhost1", "test1");
         test1.setOsFamily("windows");
-        test1.getAttributes().put("file-add-bom", "true");
+        test1.getAttributes().put(ScriptfileUtils.SHOULD_ADD_BOM, "true");
 
         final StepExecutionContext context = ExecutionContextImpl.builder()
                 .frameworkProject(PROJ_NAME)


### PR DESCRIPTION
Add bom char to destination file if all of these conditions are true:
* the target node is `windows`
* the encryption is `utf-8` 
* the special property `file-add-bom` is present on the target node.

fix #4291
Pending documentation PR