### PR TITLE
Fixes #5133 - Change duration jobs info displayed on activity view to show seconds time and not a text saying "a few seconds"

### DIFF
--- a/rundeckapp/grails-spa/src/components/activity/activityList.vue
+++ b/rundeckapp/grails-spa/src/components/activity/activityList.vue
@@ -279,7 +279,7 @@
                 <span v-else-if="rpt.node.succeeded>0">{{rpt.node.succeeded}} {{$t('ok')}}</span>
             </td>
             <td class="duration text-secondary">
-                <span class="duration">{{rpt.duration | duration('humanize',false)}}</span>
+                <span class="duration">{{formatDurationMomentHumanize(rpt.duration)}}</span>
             </td>
             <td class="  user text-right " style="white-space: nowrap;">
                 <em><i18n path="by" default="by"/></em>
@@ -589,6 +589,14 @@ export default Vue.extend({
     },
     reportStateCss(rpt:any){
       return this.executionStateCss(this.reportState(rpt))
+    },
+    formatDurationMomentHumanize(ms:any) {
+        moment.relativeTimeThreshold('ss', -1)
+        if (ms < 0) {
+            return '';
+        }
+        var duration = moment.duration(ms);
+        return duration.humanize();
     },
     executionState(status:string){
         if (status == 'scheduled') {


### PR DESCRIPTION
fixes #5133 

**Is this a bugfix, or an enhancement? Please describe.**
Customers requested to back old way to show duration time when jobs spend seconds to end. Today the activity view is displaying the words "a few seconds" but needs to be shown the amount of seconds

**Describe the solution you've implemented**
The activityList.vue was changed to set the relative time threshold so 'moment' lib will not change the seconds value to the text "a few seconds".

