### PR TITLE
adding some small changes to the edit project form for UI plugin

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -2305,6 +2305,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                 'extraConfig.',
                 fwkProject.projectProperties
         )
+        //sort the beans in order to control the way they are shown on the form
+        extraConfig = extraConfig.sort { it.key.toLowerCase() }
         [
             project: project,
             projectDescription:projectDescription?:fwkProject.getProjectProperties().get("project.description"),

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -113,14 +113,14 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 title 'Disable Execution'
                 required(false)
                 defaultValue null
-                renderingOption('booleanTrueDisplayValueClass', 'text-warning')
+                renderingOptions( ['booleanTrueDisplayValueClass': 'text-warning','groupName':'Enable/Disable Execution Now'])
             }.build(),
             PropertyBuilder.builder().with {
                 booleanType 'disableSchedule'
                 title 'Disable Schedule'
                 required(false)
                 defaultValue null
-                renderingOption('booleanTrueDisplayValueClass', 'text-warning')
+                renderingOptions( ['booleanTrueDisplayValueClass': 'text-warning','groupName':'Enable/Disable Execution Now'])
             }.build(),
     ]
 

--- a/rundeckapp/grails-app/views/framework/_projectConfigurableForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_projectConfigurableForm.gsp
@@ -37,7 +37,8 @@
                 origfieldnamePrefix: 'orig.' + pluginprefix,
                 allowedScope       : PropertyScope.Project,
                 messagePrefix       : categoryPrefix?:'',
-                messagesType       : 'project.configuration'
+                messagesType       : 'project.configuration',
+                groupTitleCss      : 'projectConfigurableTitle'
             ]}"/>
 
         </g:each>


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
<enhancement>
for grails-plugin Disable/Enable execution after X hours
https://github.com/robertopaez/execution-mode-later-plugin

The plugin add the option to enable/disable executions/schedule after X hours.

This PR add some small changes to the edit project form in order to inject the  `execution mode later` form with more control on css modifications.

**Describe the solution you've implemented**

**Describe alternatives you've considered**

**Additional context**

Without the PR
<img width="573" alt="Screenshot 2019-12-31 01 44 31" src="https://user-images.githubusercontent.com/13395122/71610377-1ca28a80-2b6f-11ea-9964-415841f6fbf5.png">


With the PR
<img width="673" alt="Screenshot 2019-12-31 01 41 57" src="https://user-images.githubusercontent.com/13395122/71610330-c46b8880-2b6e-11ea-8437-89807f4a0a0e.png">

