### PR TITLE
scm git plugin: close repo and delete using recursive flag on cleanup

### DIFF
--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/BaseGitPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/BaseGitPlugin.groovy
@@ -510,7 +510,11 @@ class BaseGitPlugin {
 
     private void removeWorkdir(File base) {
         //remove the dir
-        FileUtils.delete(base, FileUtils.RECURSIVE)
+        try {
+            FileUtils.delete(base, FileUtils.RECURSIVE)
+        } catch(IOException e){
+            logger.error("Failed to delete repo folder")
+        }
     }
 
     protected void cloneOrCreate(final ScmOperationContext context, File base, String url) throws ScmPluginException {

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
@@ -30,6 +30,7 @@ import org.eclipse.jgit.api.errors.JGitInternalException
 import org.eclipse.jgit.lib.BranchTrackingStatus
 import org.eclipse.jgit.lib.Ref
 import org.eclipse.jgit.revwalk.RevCommit
+import org.eclipse.jgit.util.FileUtils
 import org.rundeck.plugin.scm.git.config.Export
 import org.rundeck.plugin.scm.git.exp.actions.CommitJobsAction
 import org.rundeck.plugin.scm.git.exp.actions.FetchAction
@@ -143,12 +144,18 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
     @Override
     void cleanup() {
         git?.close()
+        git?.getRepository()?.close()
     }
 
     @Override
     void totalClean(){
+        git?.getRepository()?.close()
         File base = new File(config.dir)
-        base?.deleteDir()
+        try {
+            FileUtils.delete(base, FileUtils.RECURSIVE)
+        } catch(IOException e){
+            logger.error("Failed to delete repo folder")
+        }
     }
 
 

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
@@ -30,6 +30,7 @@ import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.treewalk.TreeWalk
 import org.eclipse.jgit.treewalk.filter.PathFilterGroup
+import org.eclipse.jgit.util.FileUtils
 import org.rundeck.plugin.scm.git.config.Import
 import org.rundeck.plugin.scm.git.imp.actions.FetchAction
 import org.rundeck.plugin.scm.git.imp.actions.ImportJobs
@@ -171,13 +172,18 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
 
     @Override
     void cleanup() {
-        git.close()
+        git?.getRepository()?.close()
     }
 
     @Override
     void totalClean(){
+        git?.getRepository()?.close()
         File base = new File(config.dir)
-        base?.deleteDir()
+        try {
+            FileUtils.delete(base, FileUtils.RECURSIVE)
+        } catch(IOException e){
+            logger.error("Failed to delete repo folder")
+        }
     }
 
 


### PR DESCRIPTION
fix #5675 

Fix a random condition on git SCM plugin on windows, `.pack` files aren't released until the garbage collector runs and those files cant be deleted immediately.

If the error is just ignored and logged that file is released later and causes no problem with the configuration.
