### PR TITLE
expanding execution variables on notification plugin config

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -493,7 +493,20 @@ public class NotificationService implements ApplicationContextAware{
                     execMap.context=context
                     Map config= n.configuration
                     if (context && config) {
-                        config = DataContextUtils.replaceDataReferences(config, context)
+                        //adding the execution variables in order to apply a replacement of config data (for example replace things like ${execution.xxx} on config)
+
+                        //clone the original execMap to exclude java list and numeric values
+                        def newExecMap = execMap.clone()
+                        newExecMap.remove("id") // replace ID for String id
+                        newExecMap.remove("failedNodeList") // remove java list, use failedNodeListString instead
+                        newExecMap.remove("succeededNodeList") // remove java list, use succeededNodeListString instead
+                        newExecMap["id"]=exec.id.toString()
+
+                        //merging the execution variables with the existing context
+                        def execContext = DataContextUtils.addContext("execution", newExecMap, null)
+                        def newContext = DataContextUtils.merge(context, execContext)
+
+                        config = DataContextUtils.replaceDataReferences(config, newContext)
                     }
 
                     config = config?.each {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
bugfix:
fix for issue https://github.com/rundeck/rundeck/issues/5674
Replacing execution context variables (like `${execution.id}`) doesn't work on notification plugin config attributes. Job, options and globals variables can be replaced.

**Describe the solution you've implemented**
add execution context variables to the process that performs the replacement

**Describe alternatives you've considered**

**Additional context**
<img width="842" alt="Screenshot 2020-01-09 12 29 51" src="https://user-images.githubusercontent.com/6034968/72082146-711bd780-32de-11ea-856e-65a0aba18402.png">

<img width="1178" alt="Screenshot 2020-01-09 12 29 59" src="https://user-images.githubusercontent.com/6034968/72082145-711bd780-32de-11ea-8b13-c33627a5eb05.png">
