### PR TITLE
Bugfix: close logread in tailExecutionOutput

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -1504,6 +1504,7 @@ setTimeout(function(){
             //don't change last modified unless new data has been read
             lastmodl = reqlastmod
         }
+        logread.close()
 
 //        if("true" == servletContext.getAttribute("output.ansicolor.enabled") || params.ansicolor=='true'){
             entry.each {


### PR DESCRIPTION
When the browser is polling for logging updates on an active job,
tailExecutionOutput can be called many times in succession. Each
call leaks a file descriptor until the garbage collector cleans up
the underlying FileInputStream.

This can be easily verified by writing a long running noisy job,
trying to watch the logs in the browser, then monitoring the list
of open files using something like lsof or, on linux,
/proc/$rundeckPid/fd/.
