### PR TITLE
Allow valid unicode characters in user first and last name fields

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/User.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/User.groovy
@@ -41,8 +41,8 @@ class User {
     static hasMany = [reportfilters:ReportFilter,jobfilters:ScheduledExecutionFilter,nodefilters:NodeFilter]
     static constraints={
         login(matches: '^[a-zA-Z0-9\\.,@\\(\\)\\s_\\\\/-]+$')
-        firstName(nullable:true, matches: '^[a-zA-Z0-9À-ÖØ-öø-ÿ\\s\\.,\\(\\)-]+$')
-        lastName(nullable:true, matches: '^[a-zA-Z0-9À-ÖØ-öø-ÿ\\s\\.,\\(\\)-]+$')
+        firstName(nullable:true, matches: '^[a-zA-Z0-9\\p{L}\\p{M}\\s\\.,\\(\\)-]+$')
+        lastName(nullable:true, matches: '^[a-zA-Z0-9\\p{L}\\p{M}\\s\\.,\\(\\)-]+$')
         email(nullable:true,validator: { val ->
             (!val || new AnyDomainEmailValidator().isValid(val)) ? null : 'email.invalid'
         })

--- a/rundeckapp/src/test/groovy/rundeck/UserTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/UserTests.groovy
@@ -63,7 +63,7 @@ class UserTests {
         assertFalse(user.errors.allErrors.collect { it.toString() }.join("; "),user.hasErrors())
     }
     void testValidationFirstnameWithAccentedChars() {
-        def user = new User(login: 'firstname',firstName: 'áéíóúÁÉÍÓÚÃ')
+        def user = new User(login: 'firstname',firstName: 'áéíóúÁÉÍÓÚÃšçž',lastName: 'áéíóúÁÉÍÓÚÃšçž')
         user.validate()
         assertFalse(user.errors.allErrors.collect { it.toString() }.join("; "),user.hasErrors())
     }


### PR DESCRIPTION
Fix #5188 and #5684 by allowing valid unicode characters in first and last name fields.
