### PR TITLE
Fix ordering violation in Gradle scripts

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -150,9 +150,12 @@ def expandTemplate = {
 }
 
 
+compileJava.outputs.file "$projectDir/src/main/resources/META-INF/com/dtolabs/rundeck/core/application.properties"
+compileJava.inputs.file "$projectDir/src/main/meta/com/dtolabs/rundeck/core/application.properties"
 compileJava.doFirst {
         expandTemplate()
 }
+processResources.mustRunAfter compileJava
 
 test{
     systemProperties 'rdeck.base': "$projectDir/build/rdeck_base"


### PR DESCRIPTION
Hello

This pull request fixes an ordering issue appearing in Gradle script.
Specifically, the task `core:compileJava` creates the `src/main/resources/META-INF/com/dtolabs/rundeck/core/application.properties` file from this [template](https://github.com/rundeck/rundeck/blob/master/core/src/main/meta/com/dtolabs/rundeck/core/application.properties).

This generated file is treated as resource; thus, the task `processResources` must run after `compileJava` so that `application.properties` exists in the file system. When `processResources` runs before `compileJava`, the build process produces an in correct jar file, i.e., the directory `META-INF` does not contain `application.properties`.

That's the diff of the contents of the `core:jar` file

````
< META-INF/com/
< META-INF/com/dtolabs/
< META-INF/com/dtolabs/rundeck/
< META-INF/com/dtolabs/rundeck/core/
< META-INF/com/dtolabs/rundeck/core/application.properties
````