### PR TITLE
Bug/3922/jobs incorrect cursors

### DIFF
--- a/rundeckapp/grails-app/assets/scss/custom/jobs.scss
+++ b/rundeckapp/grails-app/assets/scss/custom/jobs.scss
@@ -77,6 +77,7 @@
 .job_list_row,
 .job_list_group_header {
   clear: both;
+  cursor: pointer;
 }
 
 .job_list_group_header {
@@ -106,7 +107,6 @@
   border-style: solid;
   border-width: 0 0 3px 0;
   border-color: transparent;
-  cursor: pointer;
 
   &:hover {
     background: #F8f8f8;

--- a/rundeckapp/grails-app/assets/scss/custom/jobs.scss
+++ b/rundeckapp/grails-app/assets/scss/custom/jobs.scss
@@ -106,6 +106,7 @@
   border-style: solid;
   border-width: 0 0 3px 0;
   border-color: transparent;
+  cursor: pointer;
 
   &:hover {
     background: #F8f8f8;
@@ -125,7 +126,8 @@
   white-space: nowrap;
 }
 
-.exec-args-section.argstring-scrollable  .optkey , .exec-args-section.argstring-scrollable  .optvalue{
+.exec-args-section.argstring-scrollable .optkey,
+.exec-args-section.argstring-scrollable .optvalue {
   display: block;
 }
 


### PR DESCRIPTION
Fixes #3922 

Cursor was "text selection" instead of "pointer" for list items. Corrects cursor CSS in the following UIs:

<img width="1066" alt="Screen Shot 2020-01-14 at 5 07 37 PM" src="https://user-images.githubusercontent.com/265904/72387043-99497300-36f0-11ea-9d13-91508ef45627.png">
<img width="1060" alt="Screen Shot 2020-01-14 at 5 08 09 PM" src="https://user-images.githubusercontent.com/265904/72387044-99497300-36f0-11ea-94ce-3213db24c821.png">
