### PR TITLE
Defining a default value for crontabString prop when field is empty. 

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -929,7 +929,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                     frameworkService.scheduleCleanerExecutions(project, cleanerHistoryEnabled, cleanerHistoryEnabled && params.cleanperiod ? Integer.parseInt(params.cleanperiod) : -1,
                             params.minimumtokeep ? Integer.parseInt(params.minimumtokeep) : 0,
                             params.maximumdeletionsize ? Integer.parseInt(params.maximumdeletionsize) : 500,
-                            params.crontabString)
+                            params.crontabString ?: SCHEDULE_DEFAULT)
                 }
                 frameworkService.refreshSessionProjects(authContext, session)
                 flash.message = message(code: "project.0.was.created.flash.message", args: [proj.name])


### PR DESCRIPTION
Fixes #5679

**Is this a bugfix, or an enhancement? Please describe.**
Creating a new Project and enabling Execution History Clean leaving 'cron expression' field empty to use default values causes an on-screen error

**Describe the solution you've implemented**
All properties uses a default value when fields on UI is empty. This was not just for the 'Cron' field but now it was fixed
