### PR TITLE
Job query internal extension

### DIFF
--- a/core/src/main/java/org/rundeck/app/components/jobs/BaseQueryInput.java
+++ b/core/src/main/java/org/rundeck/app/components/jobs/BaseQueryInput.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.app.components.jobs;
+
+public interface BaseQueryInput {
+    Integer getMax();
+
+    Integer getOffset();
+
+    String getSortBy();
+
+    String getSortOrder();
+}

--- a/core/src/main/java/org/rundeck/app/components/jobs/JobQuery.java
+++ b/core/src/main/java/org/rundeck/app/components/jobs/JobQuery.java
@@ -16,6 +16,9 @@
 
 package org.rundeck.app.components.jobs;
 
+import com.dtolabs.rundeck.core.plugins.configuration.Property;
+
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -31,4 +34,6 @@ public interface JobQuery {
      * @param delegate criteria builder delegate
      */
     void extendCriteria(final JobQueryInput input, Map params, Object delegate);
+
+    List<Property> getQueryProperties();
 }

--- a/core/src/main/java/org/rundeck/app/components/jobs/JobQuery.java
+++ b/core/src/main/java/org/rundeck/app/components/jobs/JobQuery.java
@@ -35,5 +35,8 @@ public interface JobQuery {
      */
     void extendCriteria(final JobQueryInput input, Map params, Object delegate);
 
+    /**
+     * @return list of input properties for query, added to the Job Query form
+     */
     List<Property> getQueryProperties();
 }

--- a/core/src/main/java/org/rundeck/app/components/jobs/JobQuery.java
+++ b/core/src/main/java/org/rundeck/app/components/jobs/JobQuery.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.app.components.jobs;
+
+import java.util.Map;
+
+/**
+ * Defines query interface
+ */
+public interface JobQuery {
+
+    /**
+     * Extend criteria builder input
+     *
+     * @param input    query input object
+     * @param params   all request parameters
+     * @param delegate criteria builder delegate
+     */
+    void extendCriteria(final JobQueryInput input, Map params, Object delegate);
+}

--- a/core/src/main/java/org/rundeck/app/components/jobs/JobQueryInput.java
+++ b/core/src/main/java/org/rundeck/app/components/jobs/JobQueryInput.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.app.components.jobs;
+
+/**
+ * Base input for a jobs query
+ */
+public interface JobQueryInput extends BaseQueryInput {
+
+    String getJobFilter();
+
+    String getJobExactFilter();
+
+    String getProjFilter();
+
+    String getGroupPath();
+
+    String getGroupPathExact();
+
+    String getDescFilter();
+
+    String getLoglevelFilter();
+
+    String getIdlist();
+
+    Boolean getScheduledFilter();
+
+    Boolean getScheduleEnabledFilter();
+
+    Boolean getExecutionEnabledFilter();
+
+    String getServerNodeUUIDFilter();
+
+    Integer getDaysAhead();
+
+    Boolean getRunJobLaterFilter();
+}

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -334,9 +334,11 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         results.nextSchedListIds = results.nextScheduled?.collect {ScheduledExecution job->
             job.extid
         }
+        def jobQueryComponents = applicationContext.getBeansOfType(JobQuery)
+
         withFormat{
             html {
-                results
+                results + [jobQueryComponents:jobQueryComponents]
             }
             yaml{
                 final def encoded = JobsYAMLCodec.encode(results.nextScheduled as List)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -62,6 +62,8 @@ import grails.converters.JSON
 import groovy.transform.PackageScope
 import groovy.xml.MarkupBuilder
 import org.grails.plugins.metricsweb.MetricService
+import org.rundeck.app.components.jobs.JobQuery
+import org.rundeck.app.components.jobs.JobQueryInput
 import org.rundeck.core.auth.AuthConstants
 import org.rundeck.util.Sizes
 import org.springframework.context.ApplicationContext
@@ -655,7 +657,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         if(null!=query){
             query.configureFilter()
         }
-        def qres = scheduledExecutionService.listWorkflows(query)
+        def qres = scheduledExecutionService.listWorkflows(query, params)
         log.debug("service.listWorkflows: "+(System.currentTimeMillis()-start));
         long rest=System.currentTimeMillis()
         def schedlist=qres.schedlist

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -635,7 +635,7 @@ class ScmController extends ControllerBase {
             if(isExport){
                 def query=new ScheduledExecutionQuery()
                 query.projFilter = params.project
-                def jobs = scheduledExecutionService.listWorkflows(query)
+                def jobs = scheduledExecutionService.listWorkflows(query, params)
                 //relaod all jobs to get project status
                 scmService.exportStatusForJobs(authContext, jobs.schedlist)
             }

--- a/rundeckapp/grails-app/views/menu/_workflowsFull.gsp
+++ b/rundeckapp/grails-app/views/menu/_workflowsFull.gsp
@@ -140,7 +140,25 @@
                     </div>
                 </div>
                 </g:if>
+                <g:if test="${jobQueryComponents}">
+                <g:each in="${jobQueryComponents}" var="component">
+                    <g:if test="${component.value.queryProperties}">
+                        <g:each in="${component.value.queryProperties}" var="properties">
+                              <g:render template="/framework/pluginConfigPropertiesInputs" model="${[
+                                    properties         : properties,
+                                    report             : null,
+                                    prefix             : '',
+                                    values             : params,
+                                    fieldnamePrefix    : '',
+                                    origfieldnamePrefix: 'orig.' ,
+                                    messagePrefix       :'',
+                                    messagesType       : 'job.query'
+                                ]}"/>
+                        </g:each>
+                    </g:if>
+                </g:each>
 
+                </g:if>
 
 
         </div>

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/BaseQuery.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/BaseQuery.groovy
@@ -17,6 +17,7 @@
 package com.dtolabs.rundeck.app.support
 
 import grails.validation.Validateable
+import org.rundeck.app.components.jobs.BaseQueryInput
 
 
 /*
@@ -26,7 +27,7 @@ import grails.validation.Validateable
  * Created: Feb 13, 2008 4:18:48 PM
  * $Id$
  */
-class BaseQuery implements Validateable{
+class BaseQuery implements Validateable, BaseQueryInput{
     Integer max
     Integer offset
     String sortBy

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ScheduledExecutionQuery.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ScheduledExecutionQuery.groovy
@@ -17,6 +17,7 @@
 package com.dtolabs.rundeck.app.support
 
 import grails.validation.Validateable
+import org.rundeck.app.components.jobs.JobQueryInput
 
 /*
  * ScheduledExecutionQuery.java
@@ -25,7 +26,7 @@ import grails.validation.Validateable
  * Created: Feb 12, 2010 1:02:43 PM
  * $Id$
  */
-public class ScheduledExecutionQuery extends BaseQuery implements Validateable{
+public class ScheduledExecutionQuery extends BaseQuery implements JobQueryInput, Validateable{
 
     String jobFilter
     String jobExactFilter

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -255,7 +255,7 @@ class MenuControllerSpec extends Specification {
                                                                                    resource  : [group: job1.groupPath, name: job1.jobName]]]
         1 * controller.frameworkService.existsFrameworkProject('AProject') >> true
         1 * controller.apiService.requireExists(_, true, ['project', 'AProject']) >> true
-        1 * controller.scheduledExecutionService.listWorkflows(_) >> [schedlist: [job1]]
+        1 * controller.scheduledExecutionService.listWorkflows(_,_) >> [schedlist: [job1]]
         1 * controller.scheduledExecutionService.finishquery(_, _, _) >> [max           : 20,
                                                                           offset        : 0,
                                                                           paginateParams: [:],
@@ -297,7 +297,7 @@ class MenuControllerSpec extends Specification {
                                                                                    resource  :[group:job1.groupPath,name:job1.jobName]] ]
         1 * controller.frameworkService.existsFrameworkProject('AProject') >> true
         1 * controller.apiService.requireExists(_,true,['project','AProject']) >> true
-        1 * controller.scheduledExecutionService.listWorkflows(_) >> [schedlist : [job1]]
+        1 * controller.scheduledExecutionService.listWorkflows(_,_) >> [schedlist : [job1]]
         1 * controller.scheduledExecutionService.finishquery(_,_,_) >> [max: 20,
                                                                         offset:0,
                                                                         paginateParams:[:],
@@ -346,7 +346,7 @@ class MenuControllerSpec extends Specification {
                                     resource:[group:job1.groupPath,name:job1.jobName]] ]
         1 * controller.frameworkService.existsFrameworkProject('AProject') >> true
         1 * controller.apiService.requireExists(_,true,['project','AProject']) >> true
-        1 * controller.scheduledExecutionService.listWorkflows(_) >> [schedlist : [job1]]
+        1 * controller.scheduledExecutionService.listWorkflows(_,_) >> [schedlist : [job1]]
         1 * controller.scheduledExecutionService.finishquery(_,_,_) >> [max: 20,
                                                                         offset:0,
                                                                         paginateParams:[:],
@@ -392,7 +392,7 @@ class MenuControllerSpec extends Specification {
                                                                                    resource  : [group: job1.groupPath, name: job1.jobName]]]
         1 * controller.frameworkService.existsFrameworkProject('AProject') >> true
         1 * controller.apiService.requireExists(_, true, ['project', 'AProject']) >> true
-        1 * controller.scheduledExecutionService.listWorkflows(_) >> [schedlist: [job1]]
+        1 * controller.scheduledExecutionService.listWorkflows(_,_) >> [schedlist: [job1]]
         1 * controller.scheduledExecutionService.finishquery(_, _, _) >> [max           : 20,
                                                                           offset        : 0,
                                                                           paginateParams: [:],
@@ -976,7 +976,7 @@ class MenuControllerSpec extends Specification {
         controller.listExport()
         then:
 
-        1 * controller.scheduledExecutionService.listWorkflows(_) >> [schedlist : []]
+        1 * controller.scheduledExecutionService.listWorkflows(_,_) >> [schedlist : []]
         1 * controller.scheduledExecutionService.finishquery(_,_,_) >> [max: 20,
                                                                         offset:0,
                                                                         paginateParams:[:],
@@ -1017,7 +1017,7 @@ class MenuControllerSpec extends Specification {
         controller.listExport()
         then:
 
-        1 * controller.scheduledExecutionService.listWorkflows(_) >> [schedlist : []]
+        1 * controller.scheduledExecutionService.listWorkflows(_,_) >> [schedlist : []]
         1 * controller.scheduledExecutionService.finishquery(_,_,_) >> [max: 20,
                                                                         offset:0,
                                                                         paginateParams:[:],
@@ -1190,7 +1190,7 @@ class MenuControllerSpec extends Specification {
         1 * controller.frameworkService.authorizeProjectResources(_, _, _, _) >> [[authorized: true,
                                                                                    action    : AuthConstants.ACTION_READ,
                                                                                    resource  : [group: job1.groupPath, name: job1.jobName]]]
-        1 * controller.scheduledExecutionService.listWorkflows(_) >> [schedlist: [job1]]
+        1 * controller.scheduledExecutionService.listWorkflows(_,_) >> [schedlist: [job1]]
         1 * controller.scheduledExecutionService.finishquery(_, _, _) >> [max           : 20,
                                                                           offset        : 0,
                                                                           paginateParams: [:],
@@ -1227,7 +1227,7 @@ class MenuControllerSpec extends Specification {
         1 * controller.frameworkService.authorizeProjectResources(_, _, _, _) >> [[authorized: true,
                                                                                    action    : AuthConstants.ACTION_READ,
                                                                                    resource  : [group: job1.groupPath, name: job1.jobName]]]
-        1 * controller.scheduledExecutionService.listWorkflows(_) >> [schedlist: [job1]]
+        1 * controller.scheduledExecutionService.listWorkflows(_,_) >> [schedlist: [job1]]
         1 * controller.scheduledExecutionService.finishquery(_, _, _) >> [max           : 20,
                                                                           offset        : 0,
                                                                           paginateParams: [:],


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Add JobQuery type for extending job queries

**Describe the solution you've implemented**

Some refactoring of the job query methods to allow a spring bean to contribute to UI and query.

**usage**

1. define a bean that implements `JobQuery`
2. return a `List<Property>` from `getQueryProperties`
3. implement the `extendCriteria` method
    * This method will be called when the job query is invoked, the "params" contains the web query params
3. If the params contains an input property defined in the queryProperties, modify the query using the delegate (Criteria)
