### PR TITLE
saving the correct list of Succeeded Node

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -597,7 +597,7 @@ public class NotificationService implements ApplicationContextAware{
     }
 
     protected Map exportExecutionData(Execution e) {
-        def modifiedSuccessNodeList = getEffectiveSuccessNodeList(e)
+        def modifiedSuccessNodeList = executionService.getEffectiveSuccessNodeList(e)
         def emap = [
             id: e.id,
             href: grailsLinkGenerator.link(controller: 'execution', action: 'follow', id: e.id, absolute: true,

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -132,6 +132,9 @@ class NotificationServiceSpec extends Specification {
         }
         service.orchestratorPluginService = Mock(OrchestratorPluginService)
         service.pluginService = Mock(PluginService)
+        service.executionService = Mock(ExecutionService){
+            getEffectiveSuccessNodeList(_)>>[]
+        }
         def mailbuilder = Mock(MailMessageBuilder)
 
         when:
@@ -190,6 +193,9 @@ class NotificationServiceSpec extends Specification {
         service.grailsLinkGenerator = Mock(LinkGenerator) {
             _ * link(*_) >> 'alink'
         }
+        service.executionService = Mock(ExecutionService){
+            getEffectiveSuccessNodeList(_)>>[]
+        }
 
 
         when:
@@ -231,6 +237,9 @@ class NotificationServiceSpec extends Specification {
             _ * link(*_) >> 'alink'
         }
         service.pluginService = Mock(PluginService)
+        service.executionService = Mock(ExecutionService){
+            getEffectiveSuccessNodeList(_)>>[]
+        }
 
 
         def config = [method:null, url:null]
@@ -248,7 +257,7 @@ class NotificationServiceSpec extends Specification {
         def (job, execution) = createTestJob()
         def content = [
                 execution: execution,
-                context  : Mock(ExecutionContext) 
+                context  : Mock(ExecutionContext)
         ]
 
         job.notifications = [
@@ -270,6 +279,9 @@ class NotificationServiceSpec extends Specification {
             _ * link(*_) >> 'alink'
         }
         service.pluginService = Mock(PluginService)
+        service.executionService = Mock(ExecutionService){
+            getEffectiveSuccessNodeList(_)>>[]
+        }
 
         when:
         service.triggerJobNotification('start', job, content)
@@ -311,6 +323,9 @@ class NotificationServiceSpec extends Specification {
             _ * link(*_) >> 'alink'
         }
         service.pluginService = Mock(PluginService)
+        service.executionService = Mock(ExecutionService){
+            getEffectiveSuccessNodeList(_)>>[]
+        }
 
         def mockPlugin = Mock(NotificationPlugin){
         }
@@ -365,6 +380,9 @@ class NotificationServiceSpec extends Specification {
         service.mailService = Mock(MailService)
         service.grailsLinkGenerator = Mock(LinkGenerator) {
             _ * link(*_) >> 'alink'
+        }
+        service.executionService = Mock(ExecutionService){
+            getEffectiveSuccessNodeList(_)>>[]
         }
 
         def reader = new ExecutionLogReader(state: ExecutionFileState.AVAILABLE)
@@ -422,6 +440,9 @@ class NotificationServiceSpec extends Specification {
         service.mailService = Mock(MailService)
         service.grailsLinkGenerator = Mock(LinkGenerator) {
             _ * link(*_) >> 'alink'
+        }
+        service.executionService = Mock(ExecutionService){
+            getEffectiveSuccessNodeList(_)>>[]
         }
 
         def reader = new ExecutionLogReader(state: ExecutionFileState.AVAILABLE)
@@ -492,8 +513,8 @@ class NotificationServiceSpec extends Specification {
         def mockPlugin = Mock(NotificationPlugin){
         }
 
-        service.workflowService = Mock(WorkflowService){
-
+        service.executionService = Mock(ExecutionService){
+            getEffectiveSuccessNodeList(_)>>['a']
         }
 
         def config = [method:null, url:null]
@@ -561,8 +582,8 @@ class NotificationServiceSpec extends Specification {
         def mockPlugin = Mock(NotificationPlugin){
         }
 
-        service.workflowService = Mock(WorkflowService){
-
+        service.executionService = Mock(ExecutionService){
+            getEffectiveSuccessNodeList(_)>>['f']
         }
 
 

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -534,7 +534,6 @@ class NotificationServiceSpec extends Specification {
             }
             return false
         }
-        1 * service.workflowService.requestStateSummary(_,['a','b','c']) >> new WorkflowStateFileLoader(workflowState: [nodeSummaries: [a: [summaryState:'SUCCEEDED']], nodeSteps: [a: 'steps']])
         ret
 
     }
@@ -599,7 +598,6 @@ class NotificationServiceSpec extends Specification {
         1 * mockPlugin.postNotification(_, _, _)>>{ trigger, data, allConfig ->
             return true
         }
-        1 * service.workflowService.requestStateSummary(_,['f','g']) >> new WorkflowStateFileLoader(workflowState: [nodeSummaries: [f: [summaryState:'SUCCEEDED']], nodeSteps: [f: 'steps']])
 
         ret
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
bugfix: for issue https://github.com/rundeck/rundeck/issues/5725

When an Execution is saved (that is dispatched to nodes), the Succeeded Node List is not saved as expected, in the case that exists an incomplete node list.

**Describe the solution you've implemented**
Using the `requestStateSummary` method from `workflowService` that returns the correct status of the nodes after the execution finished. Then, with this status, we can get the correct list of succeeded nodes and saved on the execution table.

**Describe alternatives you've considered**
change the implementation of FailedNodesListener, but that just can get the partial status of a node execution.

**Additional context**
