### PR TITLE
Fix #5721 by setting the form name to the correct value for the avg duration url.

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsForm.gsp
@@ -140,7 +140,7 @@
                   triggerEmailCheckboxName: ScheduledExecutionController.NOTIFY_OVERAVGDURATION_EMAIL,
                   triggerEmailRecipientsName: ScheduledExecutionController.NOTIFY_OVERAVGDURATION_RECIPIENTS,
                   triggerEmailSubjectName: ScheduledExecutionController.NOTIFY_OVERAVGDURATION_SUBJECT,
-                  triggerUrlCheckboxName: ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL,
+                  triggerUrlCheckboxName: ScheduledExecutionController.NOTIFY_ONOVERAVGDURATION_URL,
                   triggerUrlFieldName: ScheduledExecutionController.NOTIFY_OVERAVGDURATION_URL,
                   isEmail: isAvg,
                   isUrl: isAvgUrl,


### PR DESCRIPTION
Fix #5721 by setting the form name to the correct value for the avg duration url.