### PR TITLE
Fixing a n+1 issue removing a code that accessed the list of executions and was making a query for each one. 

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -95,6 +95,7 @@ import rundeck.services.authorization.PoliciesValidation
 
 import javax.servlet.http.HttpServletResponse
 import java.lang.management.ManagementFactory
+import java.sql.Timestamp
 import java.util.concurrent.TimeUnit
 
 class MenuController extends ControllerBase implements ApplicationContextAware{
@@ -417,11 +418,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                         ]
                     }
 
-                    Date now = new Date()
-                    se?.executions?.findAll {Execution e ->
-                        return e.dateStarted > now && e.dateCompleted == null
-                    }?.each {Execution execution ->
-                        results.nextExecutions[se.id] = new Date(execution.dateStarted?.getTime())
+                    scheduledExecutionService.listDateStartOneTimeScheduledExecutions(se)?.each {Timestamp dateStarted ->
+                        results.nextExecutions[se.id] = new Date(dateStarted?.getTime())
                     }
 
                     if(results.nextExecutions?.get(se.id)){

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -21,7 +21,6 @@ import com.dtolabs.rundeck.app.api.jobs.info.JobInfo
 import com.dtolabs.rundeck.app.api.jobs.info.JobInfoList
 import com.dtolabs.rundeck.app.support.AclFile
 import com.dtolabs.rundeck.app.support.BaseQuery
-import com.dtolabs.rundeck.app.support.ExecutionQuery
 import com.dtolabs.rundeck.app.support.ProjAclFile
 import com.dtolabs.rundeck.app.support.QueueQuery
 import com.dtolabs.rundeck.app.support.SaveProjAclFile
@@ -34,28 +33,9 @@ import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.AuthorizationUtil
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.Framework
-import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.IRundeckProject
-import com.dtolabs.rundeck.core.execution.service.FileCopier
-import com.dtolabs.rundeck.core.execution.service.NodeExecutor
-import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutor
-import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepExecutor
 import com.dtolabs.rundeck.core.extension.ApplicationExtension
-import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
-import com.dtolabs.rundeck.core.resources.ResourceModelSourceFactory
-import com.dtolabs.rundeck.core.resources.format.ResourceFormatGenerator
-import com.dtolabs.rundeck.core.resources.format.ResourceFormatParser
-import com.dtolabs.rundeck.plugins.file.FileUploadPlugin
-import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
-import com.dtolabs.rundeck.plugins.logs.ContentConverterPlugin
-import com.dtolabs.rundeck.plugins.orchestrator.OrchestratorPlugin
-import com.dtolabs.rundeck.plugins.option.OptionValuesPlugin
 import com.dtolabs.rundeck.plugins.scm.ScmPluginException
-import com.dtolabs.rundeck.plugins.step.NodeStepPlugin
-import com.dtolabs.rundeck.plugins.step.RemoteScriptNodeStepPlugin
-import com.dtolabs.rundeck.plugins.step.StepPlugin
-import com.dtolabs.rundeck.plugins.storage.StorageConverterPlugin
-import com.dtolabs.rundeck.plugins.storage.StoragePlugin
 import com.dtolabs.rundeck.server.plugins.services.StorageConverterPluginProviderService
 import com.dtolabs.rundeck.server.plugins.services.StoragePluginProviderService
 import grails.converters.JSON
@@ -63,13 +43,11 @@ import groovy.transform.PackageScope
 import groovy.xml.MarkupBuilder
 import org.grails.plugins.metricsweb.MetricService
 import org.rundeck.app.components.jobs.JobQuery
-import org.rundeck.app.components.jobs.JobQueryInput
 import org.rundeck.core.auth.AuthConstants
 import org.rundeck.util.Sizes
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
 import org.springframework.web.multipart.MultipartHttpServletRequest
-import rundeck.AuthToken
 import rundeck.Execution
 import rundeck.LogFileStorageRequest
 import rundeck.Project
@@ -95,7 +73,6 @@ import rundeck.services.authorization.PoliciesValidation
 
 import javax.servlet.http.HttpServletResponse
 import java.lang.management.ManagementFactory
-import java.sql.Timestamp
 import java.util.concurrent.TimeUnit
 
 class MenuController extends ControllerBase implements ApplicationContextAware{
@@ -418,14 +395,24 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                         ]
                     }
 
-                    scheduledExecutionService.listDateStartOneTimeScheduledExecutions(se)?.each {Timestamp dateStarted ->
-                        results.nextExecutions[se.id] = new Date(dateStarted?.getTime())
-                    }
-
-                    if(results.nextExecutions?.get(se.id)){
+                    if(results.nextExecutions?.get(se.id) || results.nextOneTimeScheduledExecutions?.get(se.id)){
                         data.nextScheduledExecution=results.nextExecutions?.get(se.id)
+                        data.nextOneTimeScheduledExecutions=results.nextOneTimeScheduledExecutions?.get(se.id)
+
+                        if(!data.nextScheduledExecution ||
+                                (data.nextScheduledExecution &&
+                                        data.nextOneTimeScheduledExecutions &&
+                                        data.nextScheduledExecution > data.nextOneTimeScheduledExecutions)){
+                            data.nextScheduledExecution = data.nextOneTimeScheduledExecutions
+                        }
+
                         if (futureDate) {
-                            data.futureScheduledExecutions = scheduledExecutionService.nextExecutions(se,futureDate)
+                            data.futureScheduledExecutions = []
+                            if(data.nextOneTimeScheduledExecutions){
+                                data.futureScheduledExecutions += data.nextOneTimeScheduledExecutions
+                            }
+                            data.futureScheduledExecutions += scheduledExecutionService.nextExecutions(se,futureDate)
+
                             if (maxFutures
                                 && data.futureScheduledExecutions
                                 && data.futureScheduledExecutions.size() > maxFutures) {
@@ -668,6 +655,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
 
         def allScheduled = schedlist.findAll { it.scheduled }
         def nextExecutions=scheduledExecutionService.nextExecutionTimes(allScheduled)
+        def nextOneTimeScheduledExecutions = scheduledExecutionService.nextOneTimeScheduledExecutions(schedlist)
+
         def clusterMap=scheduledExecutionService.clusterScheduledJobs(allScheduled)
         log.debug("listWorkflows(nextSched): "+(System.currentTimeMillis()-rest));
         long preeval=System.currentTimeMillis()
@@ -758,6 +747,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         return [
         nextScheduled:schedlist,
         nextExecutions: nextExecutions,
+        nextOneTimeScheduledExecutions: nextOneTimeScheduledExecutions,
                 clusterMap: clusterMap,
         jobauthorizations:jobauthorizations,
         authMap:authorizemap,

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -655,7 +655,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
 
         def allScheduled = schedlist.findAll { it.scheduled }
         def nextExecutions=scheduledExecutionService.nextExecutionTimes(allScheduled)
-        def nextOneTimeScheduledExecutions = scheduledExecutionService.nextOneTimeScheduledExecutions(schedlist)
+        def nextOneTimeScheduledExecutions = query.runJobLaterFilter ? scheduledExecutionService.nextOneTimeScheduledExecutions(schedlist) : null
 
         def clusterMap=scheduledExecutionService.clusterScheduledJobs(allScheduled)
         log.debug("listWorkflows(nextSched): "+(System.currentTimeMillis()-rest));

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -4374,9 +4374,9 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     /**
      * Return a map with date start (timestamp) of one time scheduled executions (Job Run Later)
      * @param se
-     * @return Map with timestamp scheduled of a ScheduledExecutions
+     * @return Map<Long, Date> with timestamp scheduled of a ScheduledExecutions
      */
-    Map nextOneTimeScheduledExecutions(List<ScheduledExecution> se) {
+    Map<Long, Date> nextOneTimeScheduledExecutions(List<ScheduledExecution> se) {
         Date now = new Date()
         Map item = [:]
         Execution.createCriteria().list() {

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -356,7 +356,9 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
 
                 add(Restrictions.disjunction().add(Subqueries.exists(subquery)).add(restr))
-            } else if(boolfilters.any {key, val -> null!=query["${key}Filter"]}){ add(restr) }
+            } else if(restr.conditions().size() > 0){
+                add(restr)
+            }
 
             if('*'==query["groupPath"] || (('-'==query.groupPath)||!query.groupPath) && !query.groupPathExact){
                 //don't filter out any grouppath

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -356,7 +356,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
 
                 add(Restrictions.disjunction().add(Subqueries.exists(subquery)).add(restr))
-            }
+            } else if(boolfilters.any {key, val -> null!=query["${key}Filter"]}){ add(restr) }
 
             if('*'==query["groupPath"] || (('-'==query.groupPath)||!query.groupPath) && !query.groupPathExact){
                 //don't filter out any grouppath

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -85,6 +85,7 @@ import org.rundeck.core.projects.ProjectConfigurable
 import rundeck.utils.OptionsUtil
 
 import javax.servlet.http.HttpSession
+import java.sql.Timestamp
 import java.text.MessageFormat
 import java.text.SimpleDateFormat
 import java.util.concurrent.TimeUnit
@@ -4365,6 +4366,27 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             return TriggerUtils.computeFireTimesBetween(trigger, cal, to,new Date())
         }else {
             return TriggerUtils.computeFireTimesBetween(trigger, cal, new Date(), to)
+        }
+    }
+
+    /**
+     * Retunr a list of date start (timestamp)  of one time scheduled executions (Job Run Later)
+     * @param se
+     * @return list of timestamp scheduled to start executions
+     */
+    List<Timestamp> listDateStartOneTimeScheduledExecutions(ScheduledExecution se) {
+        Date now = new Date()
+        return Execution.createCriteria().list() {
+            projections {
+                property('dateStarted')
+            }
+            and {
+                "scheduledExecution"{
+                    eq('id', se.id)
+                }
+                gt("dateStarted", now)
+                isNull("dateCompleted")
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #5735 
Fixes rundeckpro/rundeckpro#873

**Is this a bugfix, or an enhancement? Please describe.**
Mistakenly, was inserted a code which made a query for each execution of a job. It caused a n+1 issue and that strongly impacted performance

**Describe the solution you've implemented**
Was changed the code so instead of a query for each execution, now should run only one query for the executions.