### PR TITLE
Fix #5753 - An error message needs to be shown on GUI when deleting the project returns an error

### DIFF
--- a/rundeckapp/grails-app/views/menu/_projectDeleteForm.gsp
+++ b/rundeckapp/grails-app/views/menu/_projectDeleteForm.gsp
@@ -21,6 +21,11 @@
         <h3 class="card-title"><g:message code="delete.project" /></h3>
       </div>
       <div class="card-content" style="padding: 2em 1em;">
+        <g:if test="${flash.error}">
+          <div class="alert alert-warning">
+            <g:enc>${flash.error}</g:enc>
+          </div>
+        </g:if>
         <a class="btn btn-danger btn-lg" data-toggle="modal" href="#deleteProjectModal">
           <g:message code="delete.this.project.button" />
           <i class="glyphicon glyphicon-remove"></i>


### PR DESCRIPTION
Fix #5753 and https://github.com/rundeckpro/rundeckpro/issues/872

**Is this a bugfix, or an enhancement? Please describe.**
No message is displayed on GUI when deleting a project returns an error

**Describe the solution you've implemented**
Was added a div to show an error alert if any error message exists
