### PR TITLE
Fix artifact id and publishing path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,12 @@ exportedProjects.each {
             existing
         }
 
-        def archiveName=project.name.startsWith('rundeckapp')?project.name.replace("rundeckapp","rundeck"): "rundeck-${project.name}"
+        def archiveName = project.name
+        
+        if (! archiveName.startsWith('rundeck'))
+            archiveName = "rundeck-${project.name}"
+        else if (archiveName.startsWith('rundeckapp'))
+            archiveName = project.name.replace('rundeckapp', 'rundeck')
 
         /* Modify auto-gen POM which gets picked up by Bintray */
         install {
@@ -163,7 +168,7 @@ exportedProjects.each {
                     inceptionYear '2014'
                     packaging 'jar'
                     version version
-                    name "Rundeck library ${project.name}"
+                    name "Rundeck library ${archiveName}"
                     description project.description?:'Rundeck'
                     url 'http://rundeck.org'
                     licenses {
@@ -215,7 +220,7 @@ exportedProjects.each {
                 inceptionYear '2014'
                 packaging 'jar'
                 version version
-                name "Rundeck library ${project.name}"
+                name "Rundeck library ${archiveName}"
                 description project.description?:'Rundeck'
                 url 'http://rundeck.org'
                 licenses {

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -374,7 +374,7 @@ bintray {
         filesSpec {
             from "$artifactDir/rundeckapp/build/libs"
             from "$artifactDir/rundeckapp/build/poms"
-            into "${project.group}.${project.name}".replace('.', '/') + "/$version"
+            into "${project.group}.rundeck".replace('.', '/') + "/$version"
             exclude '*.original'
             rename { file ->
                 if (file =~ /^pom/)


### PR DESCRIPTION
This change updates the artifact IDs and publishing paths of published projects to take into account the `rundeckapp` project name change.