### PR TITLE
fixing wrong job scheduled status message

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1602,7 +1602,10 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         if(!se.scheduled){
             return new Date(TWO_HUNDRED_YEARS)
         }
-        if(!require && (!se.scheduleEnabled || !se.executionEnabled)){
+        if(!require && (!se.scheduleEnabled ||
+                !se.executionEnabled ||
+                !isProjectScheduledEnabled(se.project) ||
+                !isProjectExecutionEnabled(se.project))){
             return null
         }
         if(frameworkService.isClusterModeEnabled()) {

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -3056,8 +3056,8 @@ class ScheduledExecutionServiceSpec extends Specification {
         }
 
         def projectMock = Mock(IRundeckProject) {
-            getProjectProperties() >> ['project.disable.schedule':projectScheduledEnabled,
-                                       'project.disable.executions': projectExecutionsEnabled]
+            getProjectProperties() >> ['project.disable.schedule':projectScheduledDisabled,
+                                       'project.disable.executions': projectExecutionsDisabled]
         }
 
         service.frameworkService = Mock(FrameworkService) {
@@ -3085,7 +3085,7 @@ class ScheduledExecutionServiceSpec extends Specification {
 
 
         where:
-        projectScheduledEnabled   | projectExecutionsEnabled    | expectScheduled
+        projectScheduledDisabled  | projectExecutionsDisabled   | expectScheduled
         "false"                   | "false"                     | true
         "true"                    | "false"                     | false
         "false"                   | "true"                      | false


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**
Bug Fix:
On Jobs Page, when you disable the project scheduled and you have the cluster mode enabled, the job status scheduled message is wrong (it is shown the next time instead show the scheduled is disabled)

https://github.com/rundeck/rundeck/issues/5763

**Describe the solution you've implemented**
if the project scheduled or project executions are disabled, return null to the nextExecutionTime (in order to show the correct status on job page)

**Describe alternatives you've considered**

**Additional context**
