### PR TITLE
fix Nullpointer exception on api call

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1853,7 +1853,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                     }
                 }
             }
-            if (origid && origid != scheduledExecution.extid) {
+            if ( scheduledExecution && origid && origid != scheduledExecution.extid) {
                 remappedIds[scheduledExecution.extid] = origid
             }
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -3727,4 +3727,28 @@ class ScheduledExecutionServiceSpec extends Specification {
 
     }
 
+
+    @Unroll
+    def "scm create jobs using scm_create without permission"(){
+        given:
+        setupDoUpdate()
+        //scm create setup
+
+        def  uuid=UUID.randomUUID().toString()
+        def upload = new ScheduledExecution(
+                createJobParams(jobName:'job1',groupPath:'path1',project:'AProject', uuid: uuid)
+        )
+
+        when:
+        def result = service.loadJobs([upload], 'create','remove', [method: 'scm-import'],  mockAuth())
+
+        then:
+        result.jobs.size()==0
+        1 * service.frameworkService.authorizeProjectResourceAny(_,AuthConstants.RESOURCE_TYPE_JOB,
+                [AuthConstants.ACTION_CREATE,AuthConstants.ACTION_SCM_CREATE],'AProject') >> false
+        0 * service.frameworkService.authorizeProjectJobAny(_,_,
+                [AuthConstants.ACTION_CREATE,AuthConstants.ACTION_SCM_CREATE],_)
+
+    }
+
 }


### PR DESCRIPTION
fix #5794 

if the user has no `create` or `scm_crete` permission the `scheduledExecution` is null so it is added to the validation.