### PR TITLE
Fix regression in plugin service causing plugin names to return prefixed with type

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
@@ -546,9 +546,9 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
 
     @Override
     PluginMetadata getPluginMetadata(final String service, final String provider) throws ProviderLoaderException {
-        if (pluginRegistryMap[provider]) {
+        if (pluginRegistryMap["${service}:${provider}"] || pluginRegistryMap[provider]) {
             Class groovyPluginType = ServiceTypes.getPluginType(service)
-            String beanName=pluginRegistryMap[provider]
+            String beanName=pluginRegistryMap["${service}:${provider}"] ?: pluginRegistryMap[provider]
             try {
                 def bean = findBean(beanName)
                 if (bean instanceof PluginBuilder) {

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
@@ -478,12 +478,13 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
         def Map<String,DescribedPlugin<T>> list= [:]
         pluginRegistryMap.each { String k, String v ->
             try {
+                String pluginName = extractPluginName(k)
                 def bean = findBean(v)
                 if (bean instanceof PluginBuilder) {
                     bean = ((PluginBuilder) bean).buildPlugin()
                 }
                 if (bean != null && groovyPluginType.isAssignableFrom(bean.class)) {
-                    def file = new File(pluginDirectory, k + ".groovy")
+                    def file = new File(pluginDirectory, pluginName + ".groovy")
                     //try to check annotations
                     Description desc=null
                     if (bean instanceof Describable) {
@@ -491,7 +492,7 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
                     } else if (PluginAdapterUtility.canBuildDescription(bean)) {
                         desc = PluginAdapterUtility.buildDescription(bean, DescriptionBuilder.builder())
                     }
-                    list[k] = new DescribedPlugin(bean, desc, k, file)
+                    list[pluginName] = new DescribedPlugin(bean, desc, pluginName, file)
                 }
             } catch (NoSuchBeanDefinitionException e) {
                 log.error("No such bean: ${v}")
@@ -526,6 +527,15 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
         }
 
         list
+    }
+
+    private String extractPluginName(String key){
+        List k = key?.split(':')
+        if(k?.size() > 1) {
+            return k.get(1)
+        }
+
+        return key
     }
 
     @Override

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistrySpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistrySpec.groovy
@@ -8,11 +8,13 @@ import com.dtolabs.rundeck.core.common.PropertyRetriever
 import com.dtolabs.rundeck.core.execution.service.NodeExecutor
 import com.dtolabs.rundeck.core.plugins.PluggableProviderService
 import com.dtolabs.rundeck.core.plugins.Plugin
+import com.dtolabs.rundeck.core.plugins.PluginMetadata
 import com.dtolabs.rundeck.core.plugins.ServiceProviderLoader
 import com.dtolabs.rundeck.core.plugins.configuration.Configurable
 import com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException
 import com.dtolabs.rundeck.core.plugins.configuration.Describable
 import com.dtolabs.rundeck.core.plugins.configuration.Description
+import com.dtolabs.rundeck.plugins.ServiceTypes
 import com.dtolabs.rundeck.plugins.step.NodeStepPlugin
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder
@@ -244,6 +246,55 @@ class RundeckPluginRegistrySpec extends Specification implements GrailsUnitTest 
     }
 
     @Unroll
+    def "get plugin metadata"() {
+        given:
+        def description1 = DescriptionBuilder.builder()
+                .name('plugin1')
+                .property(PropertyBuilder.builder().string('prop1').build())
+                .property(PropertyBuilder.builder().string('prop2').build())
+                .build()
+
+        def testPlugin1 = new TestPluginMetaData()
+        testPlugin1.description = description1
+
+        def description2 = DescriptionBuilder.builder()
+                .name('plugin3')
+                .property(PropertyBuilder.builder().string('prop1').build())
+                .property(PropertyBuilder.builder().string('prop2').build())
+                .build()
+
+        def testPlugin2 = new TestPluginMetaData()
+        testPlugin2.description = description2
+
+        def beanBuilder1 = new TestBuilderMetadata2(instance: testPlugin1)
+        def beanBuilder2 = new TestBuilderMetadata2(instance: testPlugin2)
+
+        defineBeans {
+            testBeanBuilder(InstanceFactoryBean, beanBuilder1)
+            testBeanBuilder2(InstanceFactoryBean, beanBuilder2)
+        }
+        GroovyMock(ServiceTypes, global: true)
+        ServiceTypes.getPluginType(_) >> TestPluginMetaData
+        def sut = new RundeckPluginRegistry()
+        sut.pluginDirectory = File.createTempDir('test', 'dir')
+        sut.applicationContext = applicationContext
+        sut.pluginRegistryMap = ['plugin1': 'testBeanBuilder', 'otherservice:plugin2': 'testBeanBuilder2']
+        sut.rundeckServerServiceProviderLoader = Mock(ServiceProviderLoader)
+
+        when:
+        def result = sut.getPluginMetadata('otherservice',providerName)
+
+        then:
+        result
+        result instanceof TestBuilderMetadata2
+
+        where:
+        providerName            | instanceClass
+        'plugin1'               | TestBuilderMetadata2
+        'plugin2'               | TestBuilderMetadata2
+    }
+
+    @Unroll
     def "validate plugin by name with different property scopes"() {
         given:
             def description = DescriptionBuilder
@@ -339,6 +390,109 @@ class RundeckPluginRegistrySpec extends Specification implements GrailsUnitTest 
     }
 
     @Plugin(service = "otherservice", name = 'providername')
+    static class TestPluginMetaData implements PluginMetadata {
+        Description description
+
+        @Override
+        String getFilename() {
+            return null
+        }
+
+        @Override
+        File getFile() {
+            return null
+        }
+
+        @Override
+        String getPluginArtifactName() {
+            return null
+        }
+
+        @Override
+        String getPluginAuthor() {
+            return null
+        }
+
+        @Override
+        String getPluginFileVersion() {
+            return null
+        }
+
+        @Override
+        String getPluginVersion() {
+            return null
+        }
+
+        @Override
+        String getPluginUrl() {
+            return null
+        }
+
+        @Override
+        Date getPluginDate() {
+            return null
+        }
+
+        @Override
+        Date getDateLoaded() {
+            return null
+        }
+
+        @Override
+        String getPluginName() {
+            return null
+        }
+
+        @Override
+        String getPluginDescription() {
+            return null
+        }
+
+        @Override
+        String getPluginId() {
+            return null
+        }
+
+        @Override
+        String getRundeckCompatibilityVersion() {
+            return null
+        }
+
+        @Override
+        String getTargetHostCompatibility() {
+            return null
+        }
+
+        @Override
+        List<String> getTags() {
+            return null
+        }
+
+        @Override
+        String getPluginLicense() {
+            return null
+        }
+
+        @Override
+        String getPluginThirdPartyDependencies() {
+            return null
+        }
+
+        @Override
+        String getPluginSourceLink() {
+            return null
+        }
+
+        @Override
+        String getPluginDocsLink() {
+            return null
+        }
+
+        @Override
+        String getPluginType() {
+            return null
+        }
+    }
     static class TestPluginWithAnnotation2 implements Configurable, Describable {
         Properties configuration
         Description description
@@ -361,6 +515,121 @@ class RundeckPluginRegistrySpec extends Specification implements GrailsUnitTest 
         @Override
         Class<TestPluginWithAnnotation> getPluginClass() {
             TestPluginWithAnnotation
+        }
+    }
+
+    static class TestBuilderMetadata2 implements PluginBuilder<TestPluginMetaData>, PluginMetadata {
+        TestPluginMetaData instance
+
+        @Override
+        TestPluginMetaData buildPlugin() {
+            return instance
+        }
+
+
+        @Override
+        Class<TestPluginMetaData> getPluginClass() {
+            TestPluginMetaData
+        }
+
+        @Override
+        String getFilename() {
+            return null
+        }
+
+        @Override
+        File getFile() {
+            return null
+        }
+
+        @Override
+        String getPluginArtifactName() {
+            return null
+        }
+
+        @Override
+        String getPluginAuthor() {
+            return null
+        }
+
+        @Override
+        String getPluginFileVersion() {
+            return null
+        }
+
+        @Override
+        String getPluginVersion() {
+            return null
+        }
+
+        @Override
+        String getPluginUrl() {
+            return null
+        }
+
+        @Override
+        Date getPluginDate() {
+            return null
+        }
+
+        @Override
+        Date getDateLoaded() {
+            return null
+        }
+
+        @Override
+        String getPluginName() {
+            return null
+        }
+
+        @Override
+        String getPluginDescription() {
+            return null
+        }
+
+        @Override
+        String getPluginId() {
+            return null
+        }
+
+        @Override
+        String getRundeckCompatibilityVersion() {
+            return null
+        }
+
+        @Override
+        String getTargetHostCompatibility() {
+            return null
+        }
+
+        @Override
+        List<String> getTags() {
+            return null
+        }
+
+        @Override
+        String getPluginLicense() {
+            return null
+        }
+
+        @Override
+        String getPluginThirdPartyDependencies() {
+            return null
+        }
+
+        @Override
+        String getPluginSourceLink() {
+            return null
+        }
+
+        @Override
+        String getPluginDocsLink() {
+            return null
+        }
+
+        @Override
+        String getPluginType() {
+            return null
         }
     }
 


### PR DESCRIPTION
Fixes #5784 and fixes https://github.com/rundeckpro/rundeckpro/issues/882

**Is this a bugfix, or an enhancement? Please describe.**
This bug was inserted after changing the plugins registry map to use type of plugin as prefix of name on key. 

**Describe the solution you've implemented**
The type as prefix on key map should be used only on registry map. When listPlugins method is called, this method returns a list of a specific type, so it does not needed to use the type as prefix.
