### PR TITLE
Fixes #5809 by not executing a criteria query when the "in" criteria will be an empty list.

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -4380,6 +4380,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
      * @return Map<Long, Date> with timestamp scheduled of a ScheduledExecutions
      */
     Map<Long, Date> nextOneTimeScheduledExecutions(List<ScheduledExecution> se) {
+        if(se.isEmpty()) return [:]
         Date now = new Date()
         Map item = [:]
         Execution.createCriteria().list() {


### PR DESCRIPTION
Fixes #5809 by not executing a criteria query when the "in" criteria will be an empty list.
