### PR TITLE
Fix build parallel bug and improve build cacheability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,31 @@ commands:
       - store_artifacts:
           path: ~/test-results/junit
 
+  restore-gradle-cache:
+    description: Restore Gradle cache
+    steps:
+      - restore_cache:
+          keys:
+            - v2-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - restore_cache:
+          keys:
+            - v2-gradle-cache-{{ .Branch }}-<<pipeline.number>>
+            - v2-gradle-cache-{{ .Branch }}-
+            - v2-gradle-cache-
+
+  save-gradle-cache:
+    description: Save Gradle cache
+    steps:
+      - save_cache:
+          paths:
+            - ~/.gradle/wrapper
+          key: v2-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - save_cache:
+          paths:
+            - ~/.gradle/caches
+          key: v2-gradle-cache-{{ .Branch }}-<<pipeline.number>>
+
+
 jobs:
   build:
     <<: *defaults
@@ -59,17 +84,14 @@ jobs:
 
     executor:
       name: gradle-docker
-      RUNDECK_GRADLE_OPTS: --no-daemon --max-workers 7 -x check install --stacktrace --info
+      RUNDECK_GRADLE_OPTS: --no-daemon --max-workers 7 -x check install --stacktrace --info --parallel --build-cache
       resourceClass: xlarge
       
     steps:
       - checkout
       # - node/install-node:
       #     version: '8.13.0'
-      - restore_cache:
-          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-      - restore_cache:
-          key: v1-gradle-cache-{{ checksum "build.gradle" }}
+      - restore-gradle-cache
       - run:
           name: Build
           command: |
@@ -88,14 +110,7 @@ jobs:
             source .circleci/travis-shim.sh
             copy_artifacts && sync_to_s3
             seal_artifacts
-      - save_cache:
-          paths:
-            - ~/.gradle/wrapper
-          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ .BuildNum }}
-      - save_cache:
-          paths:
-            - ~/.gradle/caches
-          key: v1-gradle-cache-{{ checksum "build.gradle" }}-{{ .BuildNum }}
+      - save-gradle-cache
 
   test-gradle:
     <<: *defaults
@@ -104,15 +119,8 @@ jobs:
       - checkout
       - node/install-node:
           version: '8.13.0'
-      - restore_cache:
-          keys:
-            - v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-{{ .BuildNum }}
-            - v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}-
-      - restore_cache:
-          keys:
-            - v1-gradle-cache-{{ checksum "build.gradle" }}-{{ .BuildNum }}
-            - v1-gradle-cache-{{ checksum "build.gradle" }}-
-      - run: ./gradlew --no-daemon test --stacktrace --info
+      - restore-gradle-cache
+      - run: ./gradlew --no-daemon test --stacktrace --info --parallel
       - collect-gradle-tests
       
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - node/install-node:
           version: '8.13.0'
       - restore-gradle-cache
-      - run: ./gradlew --no-daemon test --stacktrace --info --parallel
+      - run: ./gradlew --no-daemon test --stacktrace --info --parallel --build-cache
       - collect-gradle-tests
       
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ buildscript {
 plugins {
     id 'com.gradle.build-scan' version '1.13'
     id "org.dvaske.gradle.git-build-info" version "0.8"
+    id "com.dorongold.task-tree" version "1.5"
 }
 
 apply plugin: 'java'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -139,21 +139,22 @@ jar.doFirst {
     }
 }
 
-def expandTemplate = {
-    ant.delete(file:"$projectDir/src/main/resources/META-INF/com/dtolabs/rundeck/core/application.properties")
-    def datestring = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").format(new Date())
-    println("Building: $version-$buildNum ($datestring)")
-    copy{
-        expand('version':version,'version_build':buildNum,'version_ident':version+'-'+buildNum,date:datestring)
-        from "$projectDir/src/main/meta/com/dtolabs/rundeck/core/application.properties"
-        into "$projectDir/src/main/resources/META-INF/com/dtolabs/rundeck/core/"
+task expandTemplate {
+    inputs.file "$projectDir/src/main/meta/com/dtolabs/rundeck/core/application.properties"
+    outputs.file "$projectDir/src/main/resources/META-INF/com/dtolabs/rundeck/core/application.properties"
+
+    doLast {
+        ant.delete(file: "$projectDir/src/main/resources/META-INF/com/dtolabs/rundeck/core/application.properties")
+        def datestring = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").format(new Date())
+        println("Building: $version-$buildNum ($datestring)")
+        copy {
+            expand('version': version, 'version_build': buildNum, 'version_ident': version + '-' + buildNum, date: datestring)
+            from "$projectDir/src/main/meta/com/dtolabs/rundeck/core/application.properties"
+            into "$projectDir/src/main/resources/META-INF/com/dtolabs/rundeck/core/"
+        }
     }
 }
-
-
-compileJava.doFirst {
-        expandTemplate()
-}
+processResources.dependsOn tasks.expandTemplate
 
 test{
     systemProperties 'rdeck.base': "$projectDir/build/rdeck_base"

--- a/rundeckapp/grails-spa/build.gradle
+++ b/rundeckapp/grails-spa/build.gradle
@@ -3,6 +3,8 @@ plugins {
   id 'base'
 }
 
+ext.spaBuildDir = "${buildDir}/spa"
+
 configurations{
   spa
 }
@@ -13,6 +15,8 @@ node{
 }
 
 task npmCI(type: NpmTask, group: 'Node') {
+  dependsOn 'npmCISwitch'
+  enabled false
   args = ['ci']
 
   inputs.file(file("${projectDir}/package.json"))
@@ -21,19 +25,39 @@ task npmCI(type: NpmTask, group: 'Node') {
   outputs.dir(file("${projectDir}/node_modules"))
 }
 
+task npmCISwitch {
+  inputs.file(file("${projectDir}/package.json"))
+  inputs.file(file("${projectDir}/package-lock.json"))
+  inputs.dir "src"
+  inputs.dir "build"
+  inputs.dir "config"
+
+  outputs.file "${buildDir}/switch"
+
+  outputs.cacheIf {true}
+  doLast {
+    tasks.npmCI.enabled = true
+  }
+}
+
 task runNpmBuild(type: NpmTask, group: 'build') {
-    dependsOn npmCI
+    dependsOn 'npmCISwitch', 'npmCI'
 
-    workingDir = file("${project.projectDir}")
+    inputs.file 'package.json'
+    inputs.file 'package-lock.json'
+    inputs.dir "src"
+    inputs.dir "build"
+    inputs.dir "config"
 
-    inputs.dir 'packages'
+    outputs.dir(file("$spaBuildDir"))
+    outputs.cacheIf {true}
 
-    outputs.dir(buildDir)
     args = ['run', 'build']
 }
 
 assemble.dependsOn runNpmBuild
 
 artifacts {
-  spa(file: buildDir, name: "${project.name}", type: 'directory', builtBy: runNpmBuild)
+  spa(file: file(spaBuildDir), name: "${project.name}", type: 'directory', builtBy: runNpmBuild)
 }
+

--- a/rundeckapp/grails-spa/config/index.js
+++ b/rundeckapp/grails-spa/config/index.js
@@ -33,7 +33,7 @@ module.exports = {
     // index: path.resolve(__dirname, '../dist/index.html'),
 
     // Paths
-    assetsRoot: path.resolve(__dirname, '../gradle-build/provided'),
+    assetsRoot: path.resolve(__dirname, '../gradle-build/spa/provided'),
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',
 


### PR DESCRIPTION
* Solve dependency issue when using parallel Gradle builds
* Restores build caching in CircleCI builds
* Improves chances `grails-spa` will be pulled from cache