### PR TITLE
Update API archive import error response

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
@@ -1810,6 +1810,11 @@ class ProjectController extends ControllerBase{
                     if(result.scmerrors){
                         scm_errors result.scmerrors
                     }
+                    if (request.api_version > ApiVersions.V34) {
+                        if (result.importerErrors) {
+                            other_errors result.importerErrors
+                        }
+                    }
                 }
                 break;
             case 'xml':
@@ -1841,6 +1846,15 @@ class ProjectController extends ControllerBase{
                             delegate.'scmErrors'(count: result.scmerrors.size()){
                                 result.scmerrors.each{
                                     delegate.'error'(it)
+                                }
+                            }
+                        }
+                        if(request.api_version> ApiVersions.V34) {
+                            if(result.importerErrors){
+                                delegate.'otherErrors'(count: result.importerErrors.size()){
+                                    result.importerErrors.each{
+                                        delegate.'error'(it)
+                                    }
                                 }
                             }
                         }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
@@ -35,16 +35,17 @@ class ApiVersions {
     public static final int V32 = 32
     public static final int V33 = 33
     public static final int V34 = 34
+    public static final int V35 = 35
     public static final Map VersionMap = [:]
     public static final List Versions = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15, V16, V17, V18,
-                                         V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32,V33,V34]
+                                         V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32,V33,V34,V35]
     static {
         Versions.each { VersionMap[it.toString()] = it }
     }
     public static final Set VersionStrings = new HashSet(VersionMap.values())
 
     public final static int API_EARLIEST_VERSION = V1
-    public final static int API_CURRENT_VERSION = V34
+    public final static int API_CURRENT_VERSION = V35
     public final static int API_MIN_VERSION = API_EARLIEST_VERSION
     public final static int API_MAX_VERSION = API_CURRENT_VERSION
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerSpec.groovy
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.core.authentication.Group
 import com.dtolabs.rundeck.core.common.IRundeckProject
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
+import groovy.xml.MarkupBuilder
 import org.grails.plugins.testing.GrailsMockMultipartFile
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 import rundeck.Project
@@ -1521,6 +1522,122 @@ class ProjectControllerSpec extends Specification{
         response.status==204
 
     }
+
+    def "api v35 import archive webhooks error has detail response json"(){
+        setup:
+            controller.frameworkService=Mock(FrameworkService){
+                1 * existsFrameworkProject('test') >> true
+                1 * getAuthContextForSubjectAndProject(_,'test') >> null
+                2 * getAuthContextForSubject(_) >> null
+                1 * authResourceForProject('test') >> null
+                1 * authorizeApplicationResourceAny(_,_,[ACTION_IMPORT,ACTION_ADMIN]) >> true
+                1 * getFrameworkProject('test') >> Mock(IRundeckProject)
+                1 * getRundeckFramework() >> null
+
+                0 * _(*_)
+            }
+            controller.projectService=Mock(ProjectService){
+                1*importToProject(_,_,_,_, {
+                    it.importWebhooks== true
+                }
+                ) >> [success: false, importerErrors: ['err1', 'err2']]
+
+                0 * _(*_)
+            }
+            controller.apiService=Mock(ApiService){
+                1 * requireApi(_, _) >> true
+                1 * requireVersion(_, _, 11) >> true
+                1 * requireRequestFormat(_, _, _) >> true
+                1 * extractResponseFormat(_, _, _, _) >> 'json'
+            }
+
+            params.project="test"
+            params.importWebhooks='true'
+            response.format='json'
+            request.method='PUT'
+
+            request.content='test'.bytes
+            request.api_version=35
+        when:
+
+            def result=controller.apiProjectImport()
+
+        then:
+            response.contentType.contains 'application/json'
+            response.status==200
+            response.json.import_status=='failed'
+            response.json.successful==false
+            response.json.other_errors==['err1','err2']
+    }
+
+    def "api v35 import archive webhooks error has detail response xml"(){
+        setup:
+            controller.frameworkService=Mock(FrameworkService){
+                1 * existsFrameworkProject('test') >> true
+                1 * getAuthContextForSubjectAndProject(_,'test') >> null
+                2 * getAuthContextForSubject(_) >> null
+                1 * authResourceForProject('test') >> null
+                1 * authorizeApplicationResourceAny(_,_,[ACTION_IMPORT,ACTION_ADMIN]) >> true
+                1 * getFrameworkProject('test') >> Mock(IRundeckProject)
+                1 * getRundeckFramework() >> null
+
+                0 * _(*_)
+            }
+            controller.projectService=Mock(ProjectService){
+                1*importToProject(_,_,_,_, {
+                    it.importWebhooks== true
+                }
+                ) >> [success: false, importerErrors: ['err1', 'err2'], joberrors:[]]
+
+                0 * _(*_)
+            }
+            controller.apiService=Mock(ApiService){
+                1 * requireApi(_, _) >> true
+                1 * requireVersion(_, _, 11) >> true
+                1 * requireRequestFormat(_, _, _) >> true
+                1 * extractResponseFormat(_, _, _, _) >> 'xml'
+                1 * renderSuccessXml(_, _, _) >> { args ->
+                    def writer = new StringWriter()
+                    def xml = new MarkupBuilder(writer)
+                    def response = args[1]
+                    def recall = args[2]
+                    xml.with {
+                        recall.delegate = delegate
+                        recall.resolveStrategy = Closure.DELEGATE_FIRST
+                        recall()
+                    }
+                    def xmlstr = writer.toString()
+                    response.setContentType('application/xml')
+                    response.setCharacterEncoding('UTF-8')
+                    def out = response.outputStream
+                    out << xmlstr
+                    out.flush()
+                }
+            }
+
+            params.project="test"
+            params.importWebhooks='true'
+            response.format='xml'
+            request.method='PUT'
+
+            request.content='test'.bytes
+            request.api_version=35
+        when:
+
+            def result=controller.apiProjectImport()
+
+        then:
+            response.status==200
+            response.contentType.contains 'application/xml'
+            response.xml.@status=='failed'
+            response.xml.@successful==false
+            response.xml.otherErrors.@count=='2'
+            response.xml.otherErrors.size()==1
+            response.xml.otherErrors[0].error.size()==2
+            response.xml.otherErrors[0].error[0].text()=='err1'
+            response.xml.otherErrors[0].error[1].text()=='err2'
+    }
+
 
     def "import archive importACL"(){
         setup:

--- a/test/api/include.sh
+++ b/test/api/include.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # common header for test scripts
-API_CURRENT_VERSION=34
+API_CURRENT_VERSION=35
 
 SRC_DIR=$(cd `dirname $0` && pwd)
 DIR=${TMP_DIR:-$SRC_DIR}


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

API response for Archive import was not including any errors produced by webhook import.

**Describe the solution you've implemented**

* Add error messages to API responses from project data importers failures, when API version is greater than 34
* Update API version to 35 
