### PR TITLE
Fix: delete all executions checkbox doesn't work in job delete form from upload page

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/delete.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/delete.gsp
@@ -54,10 +54,10 @@
                               action="${[AuthConstants.ACTION_DELETE_EXECUTION, AuthConstants.ACTION_ADMIN]}"
                               any="true">
             <div class="form-group">
-                <div class="col-sm-10 col-sm-offset-2">
-                    <label class="checkbox">
-                        <input type="checkbox" name="deleteExecutions"
-                               value="true"/>
+                <div class="checkbox col-sm-10 col-sm-offset-2">
+
+                    <input type="checkbox" name="deleteExecutions" id="deleteExecutions" value="true"/>
+                    <label class="checkbox" for="deleteExecutions">
                         <g:message code="delete.all.executions.of.this.job"/>
                     </label>
                 </div>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Job Delete form "All executions" checkbox doesn't work.

1. Upload a job via the job upload form
2. Choose "delete job" from action menu for uploaded job while in the Upload page
3. The "Delete all executions" checkbox doesn't work

**Describe the solution you've implemented**

Fix input label.