### PR TITLE
Fix Grails plugins in development mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,8 @@ jobs:
           name: Upload artifacts
           command: |
             source .circleci/travis-shim.sh
-            copy_artifacts && sync_to_s3
+            copy_artifacts
+            sync_to_s3
             seal_artifacts
       - save-gradle-cache
 

--- a/grails-persistlocale/build.gradle
+++ b/grails-persistlocale/build.gradle
@@ -14,7 +14,6 @@ group "org.rundeck.grails.plugins.persistlocale"
 apply plugin:"eclipse"
 apply plugin:"idea"
 apply plugin:"org.grails.grails-plugin"
-apply plugin:"org.grails.grails-plugin-publish"
 apply plugin:"asset-pipeline"
 apply plugin:"org.grails.grails-gsp"
 
@@ -62,7 +61,6 @@ bootRun {
 }
 // enable if you wish to package this plugin as a standalone application
 bootRepackage.enabled = false
-
 
 assets {
     packagePlugin = true

--- a/grails-persistlocale/gradle.properties
+++ b/grails-persistlocale/gradle.properties
@@ -1,3 +1,4 @@
 grailsVersion=3.3.8
 gormVersion=6.1.10.RELEASE
 gradleWrapperVersion=3.5
+exploded=false

--- a/grails-securityheaders/build.gradle
+++ b/grails-securityheaders/build.gradle
@@ -14,7 +14,6 @@ group "org.rundeck.grails.plugins.securityheaders"
 apply plugin:"eclipse"
 apply plugin:"idea"
 apply plugin:"org.grails.grails-plugin"
-apply plugin:"org.grails.grails-plugin-publish"
 apply plugin:"asset-pipeline"
 apply plugin:"org.grails.grails-gsp"
 

--- a/grails-securityheaders/gradle.properties
+++ b/grails-securityheaders/gradle.properties
@@ -1,3 +1,4 @@
 grailsVersion=3.3.8
 gormVersion=6.1.10.RELEASE
 gradleWrapperVersion=3.5
+exploded=false

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -155,7 +155,6 @@ dependencies {
     testRuntime "org.seleniumhq.selenium:selenium-remote-driver"
     testRuntime "org.seleniumhq.selenium:selenium-api"
 
-
     // transitive dependencies constraints.
     constraints {
         compile("com.mchange:c3p0:0.9.5.4") {
@@ -184,8 +183,12 @@ grails{
         compile project(':rundeckapp:repository')
         compile project(':rundeckapp:webhooks')
 
-        project.findProperty('bundledGrailsPlugins')?.forEach {
-            compile it
+        /** It's important that the configuration addition follow the form 'compile project("")'
+         * so the Gradle magic happens. Other forms(ie 'compile proj' or 'compile project(proj)'
+         * can produce broken plugins in development mode. */
+        for(proj in project.findProperty('bundledGrailsPlugins')) {
+            logger.info("Injecting Grails plugin ${proj}")
+            compile project("$proj")
         }
     }
 }
@@ -308,7 +311,7 @@ task copySpa(type: Copy) {
     into "$projectDir/grails-app/assets"
     outputs.dir "$projectDir/grails-app/assets/provided"
 }
-compileGroovy.dependsOn copySpa
+assetPluginPackage.dependsOn copySpa
 assetCompile.dependsOn copySpa
 
 war {

--- a/rundeckapp/metricsweb/build.gradle
+++ b/rundeckapp/metricsweb/build.gradle
@@ -16,7 +16,6 @@ group "metricsweb"
 apply plugin: "eclipse"
 apply plugin: "idea"
 apply plugin: "org.grails.grails-plugin"
-apply plugin: "org.grails.grails-plugin-publish"
 apply plugin: "asset-pipeline"
 apply plugin: "org.grails.grails-gsp"
 
@@ -67,19 +66,6 @@ bootRun {
 }
 // enable if you wish to package this plugin as a standalone application
 bootRepackage.enabled = false
-grailsPublish {
-    // TODO: Provide values here
-    user = 'user'
-    key = 'key'
-    githubSlug = 'foo/bar'
-    license {
-        name = 'Apache-2.0'
-    }
-    title = "My Plugin"
-    desc = "Full plugin description"
-    developers = [johndoe: "John Doe"]
-}
-
 
 assets {
     packagePlugin = true

--- a/rundeckapp/metricsweb/gradle.properties
+++ b/rundeckapp/metricsweb/gradle.properties
@@ -1,0 +1,1 @@
+exploded=false

--- a/rundeckapp/repository/build.gradle
+++ b/rundeckapp/repository/build.gradle
@@ -15,7 +15,6 @@ group "repository"
 apply plugin:"eclipse"
 apply plugin:"idea"
 apply plugin:"org.grails.grails-plugin"
-apply plugin:"org.grails.grails-plugin-publish"
 apply plugin:"asset-pipeline"
 apply plugin:"org.grails.grails-gsp"
 
@@ -77,19 +76,6 @@ bootRun {
 }
 // enable if you wish to package this plugin as a standalone application
 bootRepackage.enabled = false
-grailsPublish {
-    // TODO: Provide values here
-    user = 'user'
-    key = 'key'
-    githubSlug = 'foo/bar'
-    license {
-        name = 'Apache-2.0'
-    }
-    title = "My Plugin"
-    desc = "Full plugin description"
-    developers = [johndoe:"John Doe"]
-}
-
 
 assets {
     packagePlugin = true

--- a/rundeckapp/repository/gradle.properties
+++ b/rundeckapp/repository/gradle.properties
@@ -3,3 +3,4 @@ grailsVersion=3.3.8
 grailsWrapperVersion=1.0.0
 gormVersion=6.1.10.RELEASE
 gradleWrapperVersion=3.5
+exploded=false

--- a/rundeckapp/webhooks/build.gradle
+++ b/rundeckapp/webhooks/build.gradle
@@ -15,7 +15,6 @@ group "webhooks"
 apply plugin:"eclipse"
 apply plugin:"idea"
 apply plugin:"org.grails.grails-plugin"
-apply plugin:"org.grails.grails-plugin-publish"
 apply plugin:"asset-pipeline"
 apply plugin:"org.grails.grails-gsp"
 
@@ -64,20 +63,6 @@ bootRun {
 }
 // enable if you wish to package this plugin as a standalone application
 bootRepackage.enabled = false
-
-grailsPublish {
-    // TODO: Provide values here
-    user = 'user'
-    key = 'key'
-    githubSlug = 'foo/bar'
-    license {
-        name = 'Apache-2.0'
-    }
-    title = "My Plugin"
-    desc = "Full plugin description"
-    developers = [johndoe:"John Doe"]
-}
-
 
 assets {
     packagePlugin = true

--- a/scripts/travis-helpers.sh
+++ b/scripts/travis-helpers.sh
@@ -132,7 +132,7 @@ copy_artifacts() {
         cp -r --parents rundeckapp/**/build/poms artifacts/
         cp -r --parents rundeck-storage/**/build/libs artifacts/
         cp -r --parents rundeck-storage/**/build/poms artifacts/
-        tar -czf artifacts/m2.tgz -C ~/.m2/repository/ org/rundeck metricsweb
+        tar -czf artifacts/m2.tgz -C ~/.m2/repository/ org/rundeck
     )
 }
 


### PR DESCRIPTION
Switches dynamic addition of plugins into the build to a form that works correctly during development. Without this the plugins would randomly, but more often than not, be "broken" during development causing errors resolving `gsp` view names..

This _magic incantation_ could have something to do with the Gradle AST transformations, or the way the closures are constructed in the Grails plugin. I did not end up locating the specific issue in the source code.