### PR TITLE
project component ordering changes

### DIFF
--- a/core/src/main/java/org/rundeck/app/components/project/BuiltinExportComponents.java
+++ b/core/src/main/java/org/rundeck/app/components/project/BuiltinExportComponents.java
@@ -1,0 +1,18 @@
+package org.rundeck.app.components.project;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Names of builtin pseudo components used for project export
+ */
+public enum BuiltinExportComponents {
+    jobs,
+    executions,
+    config;
+
+    public static List<String> names() {
+        return Arrays.stream(BuiltinExportComponents.values()).map(Enum::name).collect(Collectors.toList());
+    }
+}

--- a/core/src/main/java/org/rundeck/app/components/project/BuiltinImportComponents.java
+++ b/core/src/main/java/org/rundeck/app/components/project/BuiltinImportComponents.java
@@ -1,0 +1,21 @@
+package org.rundeck.app.components.project;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Names of builtin pseudo components used for project import
+ */
+public enum BuiltinImportComponents {
+    jobs,
+    executions,
+    config,
+    readme,
+    acl,
+    scm;
+
+    public static List<String> names() {
+        return Arrays.stream(BuiltinImportComponents.values()).map(Enum::name).collect(Collectors.toList());
+    }
+}

--- a/core/src/main/java/org/rundeck/core/projects/ProjectDataExporter.java
+++ b/core/src/main/java/org/rundeck/core/projects/ProjectDataExporter.java
@@ -68,4 +68,18 @@ public interface ProjectDataExporter {
     default List<Property> getExportProperties() {
         return null;
     }
+
+    /**
+     * @return list of component names to run before
+     */
+    default List<String> getExportMustRunBefore() {
+        return null;
+    }
+
+    /**
+     * @return list of component names to run after
+     */
+    default List<String> getExportMustRunAfter() {
+        return null;
+    }
 }

--- a/core/src/main/java/org/rundeck/core/projects/ProjectDataImporter.java
+++ b/core/src/main/java/org/rundeck/core/projects/ProjectDataImporter.java
@@ -68,4 +68,17 @@ public interface ProjectDataImporter {
         return null;
     }
 
+    /**
+     * @return list of component names to run before
+     */
+    default List<String> getImportMustRunBefore() {
+        return null;
+    }
+
+    /**
+     * @return list of component names to run after
+     */
+    default List<String> getImportMustRunAfter() {
+        return null;
+    }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -1015,7 +1015,7 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
             project.name
         )
         def baseRunBefore = [jobs: ['executions']]
-        def sortOrder=['jobs', 'executions', 'config', 'acl', 'scm'] +( projectImporters?.keySet()?.toSorted() ?: [])
+        def sortOrder=['jobs', 'executions', 'config','readme', 'acl', 'scm'] +( projectImporters?.keySet()?.toSorted() ?: [])
 
         def sortResult=Toposort.toposort(sortOrder, { String name->
             if(baseRunBefore[name]){
@@ -1224,19 +1224,13 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
                 importReportsToProject(reportxml, jobsByOldId, reportxmlnames, execidmap, projectName, execerrors)
                 importFileRecordsToProject(jfrecords, jobIdMap, jfrecordnames, execidmap, execerrors)
 
-            } else if (sortKey == 'config' && importConfig) {
-                if (configtemp) {
-
-                    importProjectConfig(configtemp, project, framework)
-                    log.debug("${project.name}: Loaded project configuration from archive")
-                }
-                if (mdfilestemp) {
-                    importProjectMdFiles(mdfilestemp, project)
-                }
-
+            } else if (sortKey == 'config' && importConfig && configtemp) {
+                importProjectConfig(configtemp, project, framework)
+                log.debug("${project.name}: Loaded project configuration from archive")
+            } else if (sortKey == 'readme' && importConfig && mdfilestemp) {
+                importProjectMdFiles(mdfilestemp, project)
             } else if (sortKey == 'acl' && importACL && aclfilestemp) {
                 aclerrors = importProjectACLPolicies(aclfilestemp, project)
-
             } else if (sortKey == 'scm' && importScm) {
 
                 if (scmimporttemp) {

--- a/rundeckapp/src/test/groovy/org/rundeck/util/ToposortSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/util/ToposortSpec.groovy
@@ -1,0 +1,43 @@
+package org.rundeck.util
+
+import spock.lang.Specification
+
+class ToposortSpec extends Specification {
+    def "topo sort map"() {
+        expect:
+            result == Toposort.toposort(nodes, edges, reverseEdges).result
+        where:
+            nodes           | edges                | reverseEdges         | result
+            ['a', 'b', 'c'] | [:]                  | [:]                  | ['a', 'b', 'c']
+            ['a', 'b', 'c'] | [b: ['a']]           | [:]                  | ['b', 'a', 'c']
+            ['a', 'b', 'c'] | [:]                  | [a: ['b']]           | ['b', 'a', 'c']
+            ['a', 'b', 'c'] | [b: ['a'], c: ['b']] | [:]                  | ['c', 'b', 'a']
+            ['a', 'b', 'c'] | [:]                  | [a: ['b'], b: ['c']] | ['c', 'b', 'a']
+    }
+
+    def "topo sort functional"() {
+        expect:
+            result == Toposort.toposort(nodes, edges, reverseEdges).result
+        where:
+            nodes           | edges                            | reverseEdges                     | result
+            ['a', 'b', 'c'] | { [] }                           | { [] }                           | ['a', 'b', 'c']
+            ['a', 'b', 'c'] | { [b: ['a']].get(it) }           | { [] }                           | ['b', 'a', 'c']
+            ['a', 'b', 'c'] | { [] }                           | { [a: ['b']].get(it) }           | ['b', 'a', 'c']
+            ['a', 'b', 'c'] | { [b: ['a'], c: ['b']].get(it) } | { [] }                           | ['c', 'b', 'a']
+            ['a', 'b', 'c'] | { [] }                           | { [a: ['b'], b: ['c']].get(it) } | ['c', 'b', 'a']
+    }
+
+    def "topo sort cyclical"() {
+
+        expect:
+            def sorted = Toposort.toposort(nodes, edges, reverseEdges)
+            !sorted.result
+            sorted.cycle
+        where:
+            nodes           | edges                          | reverseEdges
+            ['a', 'b', 'c'] | [b: ['a'], a: ['b']]           | [:]
+            ['a', 'b', 'c'] | [:]                            | [b: ['a'], a: ['b']]
+            ['a', 'b', 'c'] | [b: ['a'], a: ['c'], c: ['b']] | [:]
+            ['a', 'b', 'c'] | [:]                            | [b: ['a'], a: ['c'], c: ['b']]
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
@@ -31,6 +31,8 @@ import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import grails.testing.web.GrailsWebUnitTest
 import org.rundeck.app.authorization.RundeckAuthContextEvaluator
+import org.rundeck.app.components.project.BuiltinExportComponents
+import org.rundeck.app.components.project.BuiltinImportComponents
 import org.rundeck.app.components.project.ProjectComponent
 import org.rundeck.app.components.RundeckJobDefinitionManager
 import rundeck.BaseReport
@@ -699,9 +701,9 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
             'webhooks'  | 'test2' | null       | ['test2']   | null           | null         || ['webhooks', 'test2']
             'webhooks'  | 'test2' | null       | null        | ['webhooks']   | null         || ['webhooks', 'test2']
             'webhooks'  | 'test2' | null       | null        | null           | ['webhooks'] || ['test2', 'webhooks']
-            'webhooks'  | 'test2' | ['jobs']   | null        | null           | ['jobs']     || ['test2', 'webhooks']
-            'webhooks'  | 'test2' | null       | ['jobs']    | ['jobs']       | null         || ['webhooks', 'test2']
-            'webhooks'  | 'test2' | null       | ['jobs']    | ['executions'] | null         || ['webhooks', 'test2']
+            'webhooks'  | 'test2' | [BuiltinImportComponents.jobs.name()] | null | null | [BuiltinImportComponents.jobs.name()] || ['test2', 'webhooks']
+            'webhooks'  | 'test2' | null       | [BuiltinImportComponents.jobs.name()]    | [BuiltinImportComponents.jobs.name()]       | null         || ['webhooks', 'test2']
+            'webhooks'  | 'test2' | null       | [BuiltinImportComponents.jobs.name()]    | [BuiltinImportComponents.executions.name()] | null         || ['webhooks', 'test2']
     }
     def "import project archive with importComponent option false"() {
         setup:
@@ -1006,9 +1008,9 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
             'test1' | 'test2' | null       | ['test2']   | null           | null        || ['test1', 'test2']
             'test1' | 'test2' | null       | null        | ['test1']      | null        || ['test1', 'test2']
             'test1' | 'test2' | null       | null        | null           | ['test1']   || ['test2', 'test1']
-            'test1' | 'test2' | ['jobs']   | null        | null           | ['jobs']    || ['test2', 'test1']
-            'test1' | 'test2' | null       | ['jobs']    | ['jobs']       | null        || ['test1', 'test2']
-            'test1' | 'test2' | null       | ['jobs']    | ['executions'] | null        || ['test1', 'test2']
+            'test1' | 'test2' | [BuiltinExportComponents.jobs.name()] | null | null | [BuiltinExportComponents.jobs.name()] || ['test2', 'test1']
+            'test1' | 'test2' | null       | [BuiltinExportComponents.jobs.name()]    | [BuiltinExportComponents.jobs.name()]       | null        || ['test1', 'test2']
+            'test1' | 'test2' | null       | [BuiltinExportComponents.jobs.name()]    | [BuiltinExportComponents.executions.name()] | null        || ['test1', 'test2']
     }
     @Unroll
     def "export project with components ordered cyclic"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
@@ -640,8 +640,8 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
                 getImportConfig() >> true
                 getImportACL() >> true
                 getImportScm() >> true
-                getImportComponents() >> [webhooks: true, test2: true]
-                getImportOpts() >> [webhooks: [some: 'thing']]
+                getImportComponents() >> [(name1): true, (name2): true]
+                getImportOpts() >> [(name1): [some: 'thing']]
             }
 
             def tempfile2 = File.createTempFile("test-archive", ".jar")
@@ -658,9 +658,9 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
             }
             jarStream.close()
             component.getImportFilePatterns() >> ['webhooks.yaml']
-            component.getName() >> 'webhooks'
+            component.getName() >> name1
             component2.getImportFilePatterns() >> ['test2.yaml']
-            component2.getName() >> 'test2'
+            component2.getName() >> name2
 
             def orderTest=[]
         given: "components with import ordering"
@@ -679,12 +679,12 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
             orderTest == expectOrder
 
             1 * component.doImport(_, _, { it.containsKey('webhooks.yaml') }, [some: 'thing']) >>{
-                orderTest<<'webhooks'
+                orderTest<<name1
 
                 []
             }
             1 * component2.doImport(_, _, { it.containsKey('test2.yaml') }, _) >> {
-                orderTest<<'test2'
+                orderTest<<name2
                 []
             }
 
@@ -692,15 +692,16 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
             tempfile2.delete()
 
         where:
-            comp1After | comp1Before | comp2After     | comp2Before  || expectOrder
-            null       | null        | null           | null         || ['test2', 'webhooks']
-            ['test2']  | null        | null           | null         || ['test2', 'webhooks']
-            null       | ['test2']   | null           | null         || ['webhooks', 'test2']
-            null       | null        | ['webhooks']   | null         || ['webhooks', 'test2']
-            null       | null        | null           | ['webhooks'] || ['test2', 'webhooks']
-            ['jobs']   | null        | null           | ['jobs']     || ['test2', 'webhooks']
-            null       | ['jobs']    | ['jobs']       | null         || ['webhooks', 'test2']
-            null       | ['jobs']    | ['executions'] | null         || ['webhooks', 'test2']
+            name1       | name2   | comp1After | comp1Before | comp2After     | comp2Before  || expectOrder
+            'webhooks'  | 'test2' | null       | null        | null           | null         || ['test2', 'webhooks']
+            'Awebhooks' | 'test2' | null       | null        | null           | null         || ['Awebhooks', 'test2']
+            'webhooks'  | 'test2' | ['test2']  | null        | null           | null         || ['test2', 'webhooks']
+            'webhooks'  | 'test2' | null       | ['test2']   | null           | null         || ['webhooks', 'test2']
+            'webhooks'  | 'test2' | null       | null        | ['webhooks']   | null         || ['webhooks', 'test2']
+            'webhooks'  | 'test2' | null       | null        | null           | ['webhooks'] || ['test2', 'webhooks']
+            'webhooks'  | 'test2' | ['jobs']   | null        | null           | ['jobs']     || ['test2', 'webhooks']
+            'webhooks'  | 'test2' | null       | ['jobs']    | ['jobs']       | null         || ['webhooks', 'test2']
+            'webhooks'  | 'test2' | null       | ['jobs']    | ['executions'] | null         || ['webhooks', 'test2']
     }
     def "import project archive with importComponent option false"() {
         setup:


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Updates ProjectComponent to allow ordering declarations

* ProjectDataExporter
    * `exportMustRunBefore` list of component or builtin names to run before
    * `importMustRunAfter` list of component or builtin names to run after
    * builtin names: `jobs`,`executions`,`config` (readmes, acls and scm config are combined within `config`)
* ProjectDataImporter
    * `importMustRunBefore` list of component or builtin names to run before
    * `importMustRunAfter` list of component or builtin names to run after
    * builtin names:  `jobs`, `executions`, `config`,`readme`, `acl`, `scm`

**Describe the solution you've implemented**

Apply topological sort on before/after dependencies for components.  In case of cyclic dependency, revert to original (component names sorted, builtins ordered manually)
