### PR TITLE
Allow build output to be consume from other projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ buildscript {
         classpath 'com.adaptc.gradle:nexus-workflow:0.6'
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        classpath group: 'org.yaml', name: 'snakeyaml', version: '1.26'
     }
 }
 
@@ -123,8 +124,11 @@ subprojects {
     eclipse.project.name = "${project.getParent().eclipse.project.name}:${name}"
 }
 
+def buildConf  = new org.yaml.snakeyaml.Yaml().load( file('./build.yaml').newDataInputStream() )
 project(':rundeckapp') {
-    it.ext.bundledPlugins = [
+    it.ext.bundledPlugins = buildConf.rundeck.plugins
+
+    it.ext.bundledPlugins += [
         project(':plugins:script-plugin'),
         project(':plugins:stub-plugin'),
         project(':plugins:localexec-plugin'),
@@ -136,13 +140,7 @@ project(':rundeckapp') {
         project(':plugins:orchestrator-plugin'),
         project(':plugins:git-plugin'),
         project(':plugins:source-refresh-plugin'),
-        project(':plugins:upvar-plugin'),
-        "com.github.Batix:rundeck-ansible-plugin:3.1.0",
-        "com.github.rundeck-plugins:aws-s3-model-source:v1.0.2",
-        "com.github.rundeck-plugins:py-winrm-plugin:2.0.5",
-        "com.github.rundeck-plugins:openssh-node-execution:2.0.0",
-        "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.0.0",
-        "com.github.rundeck-plugins:attribute-match-node-enhancer:v0.1.5"
+        project(':plugins:upvar-plugin')
     ]
 }
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,9 @@
+---
+rundeck:
+  plugins: # Extra plugins to bundle
+  - "com.github.Batix:rundeck-ansible-plugin:3.1.0"
+  - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.2"
+  - "com.github.rundeck-plugins:py-winrm-plugin:2.0.5"
+  - "com.github.rundeck-plugins:openssh-node-execution:2.0.0"
+  - "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.0.0"
+  - "com.github.rundeck-plugins:attribute-match-node-enhancer:v0.1.5"

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -29,9 +29,9 @@ apply plugin:"com.energizedwork.idea-project-components"
 apply plugin:"asset-pipeline"
 apply plugin:"org.grails.grails-gsp"
 
-
 configurations {
     war{}
+    bootWar{}
     pluginFiles {
         transitive = false
     }
@@ -223,11 +223,6 @@ assets {
     excludes = ['gulpfile.js','**/*~','*.json','bootstrap/**/*.less']
 }
 
-
-artifacts {
-    war war
-}
-
 buildProperties.doLast {
     File grailsBuildInfoFile = it.outputs.files.files.find { it.name == 'grails.build.info' }
     if (!grailsBuildInfoFile) return
@@ -341,6 +336,12 @@ sourceJar {
 // produce a jar file for our javadoc
 javadocJar {
     baseName='rundeck'
+}
+
+
+artifacts {
+    war war
+    bootWar file: war.archivePath, builtBy: bootRepackage
 }
 
 //spring boot 1.5.x bootRepackage is not a good gradle citizen


### PR DESCRIPTION
Exports the output of `bootWar` through a custom configuration.
