### PR TITLE
Fix orchestrator issue

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2274,13 +2274,15 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 'workflow',
                 'argString',
                 'timeout',
-                'orchestrator',
                 'retry',
                 'retryDelay',
                 'excludeFilterUncheck'
         ]
         propset.each{k->
             props.put(k,se[k])
+        }
+        if(se.orchestrator) {
+            props["orchestrator"] = new Orchestrator(se.orchestrator.toMap())
         }
         props.user = authContext.username
         def roles = authContext.roles

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -2960,13 +2960,17 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             orchestrator = parseParamOrchestrator(params)
         }
         if(scheduledExecution.id && scheduledExecution.orchestrator){
-            scheduledExecution.orchestrator.delete()
+            if(!hasExecutionsLinkedToOrchestrator(scheduledExecution.orchestrator)) scheduledExecution.orchestrator.delete() //cannot deleted this orchestrator if linked to executions
             scheduledExecution.orchestrator=null
         }
         if (orchestrator) {
             scheduledExecution.orchestrator = orchestrator
             scheduledExecution.orchestrator.save()
         }
+    }
+
+    boolean hasExecutionsLinkedToOrchestrator(Orchestrator orchestrator) {
+        Execution.countByOrchestrator(orchestrator) > 0
     }
 
     public void jobDefinitionOptions(ScheduledExecution scheduledExecution, ScheduledExecution input,Map params, UserAndRoles userAndRoles) {


### PR DESCRIPTION
Do not try to delete Orchestrator if Executions are linked to it.
Copy Orchestrator when job is executed so that correct historical data is maintained.