### PR TITLE
Docker : Ubuntu version upgrade

### DIFF
--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -9,7 +9,7 @@ RUN go install github.com/HeavyHorst/remco/cmd/remco
 
 # Build base container
 ######################
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV LANG C.UTF-8


### PR DESCRIPTION
Hello,

Can you upgrade the ubuntu image to 18_04 or directly 20_04 (on April 23, 2020)?

This is the result of the trivy scan with 3.2.5 version of rundeck:

```shell
sudo docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/Library/Caches:/root/.cache/ aquasec/trivy rundeck/rundeck:SNAPSHOT
```

for 16_04 :

```shell
rundeck/rundeck:SNAPSHOT (ubuntu 16.04)
=======================================
Total: 376 (UNKNOWN: 0, LOW: 44, MEDIUM: 262, HIGH: 68, CRITICAL: 2)
```

for 18_04 :

```shell
rundeck_18 (ubuntu 18.04)
=========================
Total: 141 (UNKNOWN: 0, LOW: 31, MEDIUM: 88, HIGH: 22, CRITICAL: 0)
```
Thanks