### PR TITLE
job query enhancement

### DIFF
--- a/core/src/main/java/org/rundeck/app/components/jobs/JobQuery.java
+++ b/core/src/main/java/org/rundeck/app/components/jobs/JobQuery.java
@@ -32,8 +32,9 @@ public interface JobQuery {
      * @param input    query input object
      * @param params   all request parameters
      * @param delegate criteria builder delegate
+     * @return map with filtered values to show in jobs list page
      */
-    void extendCriteria(final JobQueryInput input, Map params, Object delegate);
+    Map extendCriteria(final JobQueryInput input, Map params, Object delegate);
 
     /**
      * @return list of input properties for query, added to the Job Query form

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -260,6 +260,15 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }else{
             params.groupPath=null
         }
+        if(model.customFilters && !model.customFilters.isEmpty()){
+            def totalCustomFilters = [:]
+            model.customFilters.each{
+                totalCustomFilters.putAll(it)
+            }
+            if(totalCustomFilters && !totalCustomFilters.isEmpty()){
+                paginateParams.customFilters = totalCustomFilters
+            }
+        }
 
 
         def tmod=[max: query?.max?query.max:getConfiguredMaxPerPage(10),
@@ -283,6 +292,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         def boolfilters=ScheduledExecutionQuery.BOOL_FILTERS
         def filters = ScheduledExecutionQuery.ALL_FILTERS
         def xfilters = ScheduledExecutionQuery.X_FILTERS
+        def totalCustomFilters = []
         Integer queryMax=query.max
         Integer queryOffset=query.offset
 
@@ -384,7 +394,10 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
             def critDelegate=delegate
             jobQueryComponents?.each { name, jobQuery ->
-                jobQuery.extendCriteria(query, params, critDelegate)
+                def customFilters = jobQuery.extendCriteria(query, params, critDelegate)
+                if(customFilters && !customFilters.isEmpty()){
+                    totalCustomFilters.add(customFilters)
+                }
             }
 
             if(query && query.sortBy && xfilters[query.sortBy]){
@@ -453,7 +466,10 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
                 def critDelegate=delegate
                 jobQueryComponents?.each { name, jobQuery ->
-                    jobQuery.extendCriteria(query, params, critDelegate)
+                    def customFilters = jobQuery.extendCriteria(query, params, critDelegate)
+                    if(customFilters && !customFilters.isEmpty()){
+                        totalCustomFilters.add(customFilters)
+                    }
                 }
             }
         }
@@ -463,7 +479,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             query:query,
             schedlist:schedlist,
             total: total,
-            _filters:filters
+            _filters:filters,
+            customFilters: totalCustomFilters
             ]
 
     }

--- a/rundeckapp/grails-app/services/rundeck/services/jobs/JobQueryService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/jobs/JobQueryService.groovy
@@ -10,7 +10,7 @@ class JobQueryService implements JobQuery {
     def localJobQueryService
 
     @Override
-    void extendCriteria(JobQueryInput input, Map params, Object delegate) {
+    Map extendCriteria(JobQueryInput input, Map params, Object delegate) {
         localJobQueryService.extendCriteria(input, params, delegate)
     }
 
@@ -22,12 +22,15 @@ class JobQueryService implements JobQuery {
 
 class LocalJobQueryService {
 
-    void extendCriteria(JobQueryInput input, Map params, Object delegate) {
+    Map extendCriteria(JobQueryInput input, Map params, Object delegate) {
         ScheduledExecutionQuery.IS_SCHEDULED_FILTER.each { key, val ->
             if(null!=input["${key}Filter"]){
                 delegate.eq(val,input["${key}Filter"])
             }
         }
+        //this returns an empty map since schedules is already considered as part of the attributes to show as part of the search
+        //ergo, no need to add new values
+        return [:]
     }
 
     List<Property> getQueryProperties() {

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -407,7 +407,6 @@ search
      <a href="#">
 
         <g:if test="${wasfiltered}">
-            ${filterName}
             <g:if test="${filterName}">
                 <i class="glyphicon glyphicon-filter"></i>
                 <g:enc>${filterName}</g:enc>

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -383,7 +383,7 @@ search
     }
 })
       </g:javascript>
-    <g:set var="wasfiltered" value="${paginateParams?.keySet().grep(~/(?!proj).*Filter|groupPath|idlist$/)}"/>
+    <g:set var="wasfiltered" value="${paginateParams?.keySet().grep(~/(?!proj).*Filter|groupPath|customFilters|idlist$/)}"/>
     <g:embedJSON data="${paginateParams?.subMap(wasfiltered)?:[:]}" id="filterParams"/>
       <asset:javascript src="static/pages/project-activity.js" defer="defer"/>
 </head>
@@ -407,6 +407,7 @@ search
      <a href="#">
 
         <g:if test="${wasfiltered}">
+            ${filterName}
             <g:if test="${filterName}">
                 <i class="glyphicon glyphicon-filter"></i>
                 <g:enc>${filterName}</g:enc>
@@ -418,12 +419,20 @@ search
                                     <span class="query-section">
                 <g:each in="${wasfiltered.sort()}" var="qparam">
                       <g:if test="${qparam!='groupPath'}">
-
-                        <span class="text-secondary"><g:message code="jobquery.title.${qparam}"/>:</span>
+                        <g:if test="${paginateParams[qparam] instanceof Map}">
+                            <g:each in="${paginateParams[qparam]}" var="customParam">
+                                <span class="text-secondary">${customParam.key}:</span>
+                                <span class="text-info">${customParam.value}</span>
+                            </g:each>
+                        </g:if>
+                        <g:else>
+                          <span class="text-secondary"><g:message code="jobquery.title.${qparam}"/>:</span>
 
                           <span class="text-info">
                               ${g.message(code:'jobquery.title.'+qparam+'.label.'+paginateParams[qparam].toString(),default:enc(html:paginateParams[qparam].toString()).toString())}
                           </span>
+                        </g:else>
+
                       </g:if>
                   </g:each>
                   </span>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Enhancement: job query components can now show the search parameters in jobs list


**Additional context**
Currently: When an implementation of job query is used, the aditional parameters used by the implentation are not shown in the jobs list page.
Proposed: extendCriteria method can now return a map with the values to be shown in the jobs list page

![imagen](https://user-images.githubusercontent.com/50217398/76982180-4a030700-691a-11ea-8d37-87e40d71725e.png)

![imagen](https://user-images.githubusercontent.com/50217398/76982242-5c7d4080-691a-11ea-81d7-f5de724be60b.png)
