### PR TITLE
Verirfying list of listeners to avoid an exception thrown before handle result

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -186,7 +186,7 @@ class LogFileStorageService
      * @return
      */
     def runRetrievalRequestTask(Map task){
-        def listener = logFileRetrievalListeners.remove(task.ruuid)
+        def listener = !logFileRetrievalListeners?.isEmpty() && logFileRetrievalListeners[task.ruuid] ? logFileRetrievalListeners.remove(task.ruuid) : null
         def future = runRetrievalRequest(task)
         future.handle(
                 { result, throwable ->

--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -186,7 +186,7 @@ class LogFileStorageService
      * @return
      */
     def runRetrievalRequestTask(Map task){
-        def listener = !logFileRetrievalListeners?.isEmpty() && logFileRetrievalListeners[task.ruuid] ? logFileRetrievalListeners.remove(task.ruuid) : null
+        def listener = task.ruuid?logFileRetrievalListeners.remove(task.ruuid):null
         def future = runRetrievalRequest(task)
         future.handle(
                 { result, throwable ->

--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -186,7 +186,7 @@ class LogFileStorageService
      * @return
      */
     def runRetrievalRequestTask(Map task){
-        def listener = task.ruuid?logFileRetrievalListeners.remove(task.ruuid):null
+        def listener = task.ruuid ? logFileRetrievalListeners.remove(task.ruuid) : null
         def future = runRetrievalRequest(task)
         future.handle(
                 { result, throwable ->


### PR DESCRIPTION
Fix #5901 and https://github.com/rundeckpro/rundeckpro/issues/886
**Is this a bugfix, or an enhancement? Please describe.**
the "live log" between the cluster members was not refreshed; it can be seen when the job is finished.

**Describe the solution you've implemented**
at some point, the list of listeners is empty and an exception is thrown and log processing is interrupted. This changes is to avoid the process to be interrupted.
