### PR TITLE
Update AWS plugins

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 rundeck:
   plugins: # Extra plugins to bundle
   - "com.github.Batix:rundeck-ansible-plugin:3.1.0"
-  - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.3"
+  - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.4"
   - "com.github.rundeck-plugins:py-winrm-plugin:2.0.5"
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.0"
   - "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.0.0"


### PR DESCRIPTION
Updates AWS plugins to latest which include `aws-java-sdk-sts`. This should hopefully allow the default credential provider chain to resolve web identity roles(IAM for service accounts).