### PR TITLE
Remove tabulation and line break from the content of text area

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsTriggerForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsTriggerForm.gsp
@@ -127,9 +127,8 @@ implied. - See the License for the specific language governing permissions and -
 
                 <g:set var="notifurlcontent" value="${params[triggerUrlFieldName] ?: defUrl?.content}"/>
                 <g:if test="${notifurlcontent && notifurlcontent.size() > 100}">
-                  <textarea name="${enc(attr:triggerUrlFieldName)}" style="vertical-align:top;" placeholder="http://" rows="6" cols="40" class="form-control context_var_autocomplete">
-                    <g:enc>${notifurlcontent}</g:enc>
-                  </textarea>
+                  <textarea name="${enc(attr:triggerUrlFieldName)}" style="vertical-align:top;" placeholder="http://" rows="6" cols="40"
+                            class="form-control context_var_autocomplete"><g:enc>${notifurlcontent}</g:enc></textarea>
 
                   <span class=" text-primary">
                     <g:message code="notification.webhook.field.description"/>

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerSpec.groovy
@@ -1621,7 +1621,7 @@ class ProjectControllerSpec extends Specification{
             }
             controller.projectService=Mock(ProjectService){
                 1*importToProject(_,_,_,_, {
-                    it.importWebhooks== true
+                    it.importComponents == [(WebhooksProjectComponent.COMPONENT_NAME): true]
                 }
                 ) >> [success: false, importerErrors: ['err1', 'err2']]
 
@@ -1668,7 +1668,7 @@ class ProjectControllerSpec extends Specification{
             }
             controller.projectService=Mock(ProjectService){
                 1*importToProject(_,_,_,_, {
-                    it.importWebhooks== true
+                    it.importComponents == [(WebhooksProjectComponent.COMPONENT_NAME): true]
                 }
                 ) >> [success: false, importerErrors: ['err1', 'err2'], joberrors:[]]
 


### PR DESCRIPTION
fix #5911
This was caused by the line break and tabulation inside the `<textarea>` tag
This happens only on notifications that has a length of more than 100 characters.
In that case, the input type in the GUI changes to a text area and adds empty spaces and line break characters.  If the job is saved without removing the empty spaces is saved with the new characters every time.


Fix validated by @runwaldo see original issue: rundeckpro/rundeckpro#931