### PR TITLE
Adds media query to backdrop

### DIFF
--- a/rundeckapp/grails-app/assets/scss/custom/modals.scss
+++ b/rundeckapp/grails-app/assets/scss/custom/modals.scss
@@ -1,23 +1,25 @@
-.modal-dialog{
+.modal-dialog {
   // TODO: Fix modal dialog z-index
   z-index: 1040; // overrides some weird stuff that's making the modal dialog live under the modal overlay, could be a positioning issue
-  .modal-footer{
+
+  .modal-footer {
     text-align: left;
   }
-  .modal-body{
-    .container{
+
+  .modal-body {
+    .container {
       width: auto;
     }
   }
 }
 
-body.modal-open{
-  // .modal-dialog{
-  //   margin-left: 300px;
-  // }
-  //
-  // &.sidebar-mini{
-  //   margin-left: auto;
-  // }
-}
+@media only screen and (max-width:992px) {
 
+  // An issue exists with how our modals are 
+  // created deeply inside content areas.
+  // As such, the backdrop can appear on top
+  // of the .modal-dialog
+  .modal-backdrop.in {
+    display: none;
+  }
+}


### PR DESCRIPTION
Adds a media query that sets the modal backdrop to `display:none` for viewports smaller than 992px.

Turns this: 

<img width="988" alt="Screen Shot 2020-03-26 at 10 51 50 AM" src="https://user-images.githubusercontent.com/265904/77660602-ed25d300-6f4f-11ea-9459-56c970162524.png">

Into this:

<img width="995" alt="Screen Shot 2020-03-26 at 10 51 40 AM" src="https://user-images.githubusercontent.com/265904/77660625-f44ce100-6f4f-11ea-9208-a21e147d63d3.png">
