### PR TITLE
Fix job scheduling transaction errors

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/schedule/JobScheduleManager.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/schedule/JobScheduleManager.java
@@ -43,10 +43,11 @@ public interface JobScheduleManager {
      * @param group  group
      * @param data   data
      * @param atTime time to run
+     * @param pending if job should be in a pending state
      *
      * @return time to run
      */
-    Date scheduleJob(String name, String group, Map data, Date atTime) throws JobScheduleFailure;
+    Date scheduleJob(String name, String group, Map data, Date atTime, Boolean pending) throws JobScheduleFailure;
 
     /**
      * Schedule a job to run now
@@ -54,10 +55,19 @@ public interface JobScheduleManager {
      * @param name  name
      * @param group group
      * @param data  data
-     *
+     * @param pending if job should be scheduled in a pending state
      * @return true if successful
      */
-    boolean scheduleJobNow(String name, String group, Map data) throws JobScheduleFailure;
+    boolean scheduleJobNow(String name, String group, Map data, Boolean pending) throws JobScheduleFailure;
+
+    /**
+     * Schedule a job that was previously scheduled as pending
+     * @param name job name
+     * @param group job group
+     *
+     * @return time to run
+     */
+    Date reschedulePendingJob(String name, String group) throws JobScheduleFailure;
 
     /**
      * In cluster mode, return true if the scheduleOWner should change to current node.

--- a/core/src/main/java/com/dtolabs/rundeck/core/schedule/JobScheduleManager.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/schedule/JobScheduleManager.java
@@ -47,7 +47,7 @@ public interface JobScheduleManager {
      *
      * @return time to run
      */
-    Date scheduleJob(String name, String group, Map data, Date atTime, Boolean pending) throws JobScheduleFailure;
+    Date scheduleJob(String name, String group, Map data, Date atTime, boolean pending) throws JobScheduleFailure;
 
     /**
      * Schedule a job to run now
@@ -58,7 +58,7 @@ public interface JobScheduleManager {
      * @param pending if job should be scheduled in a pending state
      * @return true if successful
      */
-    boolean scheduleJobNow(String name, String group, Map data, Boolean pending) throws JobScheduleFailure;
+    boolean scheduleJobNow(String name, String group, Map data, boolean pending) throws JobScheduleFailure;
 
     /**
      * Schedule a job that was previously scheduled as pending

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -46,6 +46,7 @@ import com.dtolabs.rundeck.server.plugins.storage.DbStoragePlugin
 import com.dtolabs.rundeck.server.plugins.storage.DbStoragePluginFactory
 import grails.plugin.springsecurity.SpringSecurityUtils
 import groovy.io.FileType
+import org.grails.orm.hibernate.HibernateEventListeners
 import org.rundeck.app.api.ApiInfo
 import org.rundeck.app.authorization.RundeckAuthContextEvaluator
 import org.rundeck.app.authorization.RundeckAuthorizedServicesProvider
@@ -79,7 +80,7 @@ import org.springframework.security.web.session.ConcurrentSessionFilter
 import rundeck.services.DirectNodeExecutionService
 import rundeck.services.LocalJobSchedulesManager
 import rundeck.services.PasswordFieldsService
-import rundeck.services.QuartzJobScheduleManager
+import rundeck.services.QuartzJobScheduleManagerService
 import rundeck.services.audit.AuditEventsService
 import rundeck.services.jobs.JobQueryService
 import rundeck.services.jobs.LocalJobQueryService
@@ -204,7 +205,7 @@ beans={
         bean.factoryMethod='createFromDirectory'
     }
 
-    rundeckJobScheduleManager(QuartzJobScheduleManager){
+    rundeckJobScheduleManager(QuartzJobScheduleManagerService){
         quartzScheduler=ref('quartzScheduler')
     }
 

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -54,8 +54,10 @@ class Execution extends ExecutionContext implements EmbeddedJsonData {
     Long retryPrevId
     String extraMetadata
 
+    boolean serverNodeUUIDChanged = false
+
     static hasOne = [logFileStorageRequest: LogFileStorageRequest]
-    static transients = ['executionState', 'customStatusString', 'userRoles', 'extraMetadataMap']
+    static transients = ['executionState', 'customStatusString', 'userRoles', 'extraMetadataMap', 'serverNodeUUIDChanged']
     static constraints = {
         project(matches: FrameworkResource.VALID_RESOURCE_NAME_REGEX, validator:{val,Execution obj->
             if(obj.scheduledExecution && obj.scheduledExecution.project!=val){
@@ -478,6 +480,10 @@ class Execution extends ExecutionContext implements EmbeddedJsonData {
                 targetNodes: targetNodes,
                 metadata: extraMetadataMap
         )
+    }
+
+    void beforeUpdate() {
+        serverNodeUUIDChanged = this.isDirty('serverNodeUUID')
     }
 }
 

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2190,7 +2190,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     e,
                     secureOpts,
                     secureOptsExposed,
-                    startTime
+                    startTime,
+                    true
             )
             if (nextRun != null) {
                 return [success: true, id: e.id, executionId: e.id,

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -52,7 +52,9 @@ import com.dtolabs.rundeck.plugins.jobs.JobPreExecutionEventImpl
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
 import com.dtolabs.rundeck.plugins.scm.JobChangeEvent
 import grails.events.EventPublisher
+import grails.events.annotation.Publisher
 import grails.events.annotation.Subscriber
+import grails.gorm.services.Service
 import grails.gorm.transactions.NotTransactional
 import grails.gorm.transactions.Transactional
 import grails.web.mapping.LinkGenerator
@@ -2246,7 +2248,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      * @param secureExposedOpts
      * @return execution
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     Execution int_createExecution(
             ScheduledExecution se,
             UserAndRolesAuthContext authContext,
@@ -2424,6 +2425,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      * @return
      * @throws ExecutionServiceException
      */
+    @Publisher
     def Execution createExecution(
             ScheduledExecution se,
             UserAndRolesAuthContext authContext,

--- a/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
@@ -214,6 +214,10 @@ class QuartzJobScheduleManagerService implements JobScheduleManager, Initializin
         false
     }
 
+    /**
+     * Removes PENDING triggers if their job detail indicates they are over 2 minutes old.
+     * This allows for some unexpected delays in committing due to lock timeouts and etc.
+     */
     private void cleanupTriggers() {
         GroupMatcher<TriggerKey> matcher = GroupMatcher.groupEquals(TRIGGER_GROUP_PENDING)
         quartzScheduler.getTriggerKeys(matcher).each { triggerKey ->
@@ -228,6 +232,9 @@ class QuartzJobScheduleManagerService implements JobScheduleManager, Initializin
         }
     }
 
+    /**
+     * If an execution has been re-assigned to the local node we reschedule the PENDING job
+     */
     @Subscriber
     void afterUpdate(PostUpdateEvent event) {
         if(!(event.entityObject instanceof Execution))
@@ -241,6 +248,9 @@ class QuartzJobScheduleManagerService implements JobScheduleManager, Initializin
         }
     }
 
+    /**
+     * For newly created local executions, if they are user created or scheduled, we reschedule the PENDING job
+     */
     @Subscriber
     void afterInsert(PostInsertEvent event) {
         if(!(event.entityObject instanceof Execution))

--- a/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
@@ -174,8 +174,10 @@ class QuartzJobScheduleManagerService implements JobScheduleManager, Initializin
         try {
             Trigger trigger = quartzScheduler.getTrigger(TriggerKey.triggerKey(name, TRIGGER_GROUP_PENDING))
 
-            if (trigger == null)
-                throw new JobScheduleFailure("Error retrieving pending trigger for: $name")
+            if (trigger == null) {
+                log.debug("Error retrieving pending trigger for: $name")
+                return null
+            }
 
             if (trigger) {
                 Trigger newTrigger = trigger.getTriggerBuilder().withIdentity(name, group).build()

--- a/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
@@ -248,7 +248,7 @@ class QuartzJobScheduleManagerService implements JobScheduleManager, Initializin
 
         Execution execution = event.entityObject as Execution
 
-        if (isExecutionLocal(execution))
+        if (isExecutionLocal(execution) && (isExecutionTypeUser(execution) || isExecutionStatusScheduled(execution)))
             reschedulePendingExecution(execution)
         else
             log.debug("Not rescheduling execution with node UUI $execution.serverNodeUUID on $frameworkService.serverUUID")
@@ -263,5 +263,21 @@ class QuartzJobScheduleManagerService implements JobScheduleManager, Initializin
 
     private boolean isExecutionLocal(Execution execution) {
         return (execution.serverNodeUUID == frameworkService.serverUUID)
+    }
+
+    /**
+     * @param execution
+     * @return true if executionType is 'user', indicates a "run job now" invocation
+     */
+    boolean isExecutionTypeUser(Execution execution) {
+        execution.executionType == 'user'
+    }
+
+    /**
+     * @param execution
+     * @return true if status is 'scheduled', indicates a "run job later" invocation
+     */
+    boolean isExecutionStatusScheduled(Execution execution) {
+        execution.status == 'scheduled'
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1221,7 +1221,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
 
         try {
-            return jobSchedulerService.scheduleJob(identity.jobname, identity.groupname, jobDetail, startTime)
+            return jobSchedulerService.scheduleJob(identity.jobname, identity.groupname, jobDetail, startTime, true)
         } catch (JobScheduleFailure exc) {
             throw new ExecutionServiceException("Could not schedule job: " + exc.message, exc)
         }
@@ -1365,15 +1365,15 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         try {
             if (retryAttempt > 0 && e.retryDelay) {
                 long retryTime = Sizes.parseTimeDuration(e.retryDelay, TimeUnit.MILLISECONDS)
-                Date now = new Date()
+                Date atTime = new Date().getTime() + retryTime
                 jobSchedulerService.scheduleJob(
                         ident.jobname,
                         ident.groupname,
                         jobDetail,
-                        new Date(now.getTime() + retryTime)
-                )
+                        atTime,
+                        true)
             } else {
-                jobSchedulerService.scheduleJobNow(ident.jobname, ident.groupname, jobDetail)
+                jobSchedulerService.scheduleJobNow(ident.jobname, ident.groupname, jobDetail, true)
             }
         } catch (JobScheduleFailure exc) {
             throw new ExecutionServiceException("Could not schedule job: " + exc.message, exc)

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1313,8 +1313,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         return didCancel
     }
 
-    def Map getJobIdent(ScheduledExecution se, Execution e){
-        def ident = []
+    Map<String, String> getJobIdent(ScheduledExecution se, Execution e){
+        Map<String, String> ident
 
         if (!se) {
             ident = [jobname:"TEMP:"+e.user +":"+e.id, groupname:e.user+":run"]

--- a/rundeckapp/src/test/groovy/rundeck/services/JobSchedulerServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/JobSchedulerServiceSpec.groovy
@@ -30,10 +30,10 @@ class JobSchedulerServiceSpec extends Specification {
         given:
         service.rundeckJobScheduleManager = Mock(JobScheduleManager)
         when:
-        service.scheduleJobNow('a', 'b', [:])
+        service.scheduleJobNow('a', 'b', [:], true)
 
         then:
-        1 * service.rundeckJobScheduleManager.scheduleJobNow('a', 'b', [:])
+        1 * service.rundeckJobScheduleManager.scheduleJobNow('a', 'b', [:], true)
     }
 
     void "schedule job at date delegates via bean"() {
@@ -41,9 +41,9 @@ class JobSchedulerServiceSpec extends Specification {
         service.rundeckJobScheduleManager = Mock(JobScheduleManager)
         Date date = new Date()
         when:
-        service.scheduleJob('a', 'b', [:], date)
+        service.scheduleJob('a', 'b', [:], date, true)
 
         then:
-        1 * service.rundeckJobScheduleManager.scheduleJob('a', 'b', [:], date)
+        1 * service.rundeckJobScheduleManager.scheduleJob('a', 'b', [:], date, true)
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -2884,7 +2884,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         1 * service.frameworkService.getAuthContextForUserAndRolesAndProject('bob', ['a', 'b'],job1.project) >> Mock(UserAndRolesAuthContext)
         1 * service.executionServiceBean.getExecutionsAreActive() >> true
         1 * service.frameworkService.getRundeckBase() >> ''
-        1 * service.jobSchedulerService.scheduleJob(_, _, _, exec1.dateStarted) >> exec1.dateStarted
+        1 * service.jobSchedulerService.scheduleJob(_, _, _, exec1.dateStarted, false) >> exec1.dateStarted
     }
 
 
@@ -2925,7 +2925,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         1 * service.frameworkService.getAuthContextForUserAndRolesAndProject('bob', ['a', 'b'],job1.project) >> Mock(UserAndRolesAuthContext)
         1 * service.executionServiceBean.getExecutionsAreActive() >> true
         1 * service.frameworkService.getRundeckBase() >> ''
-        1 * service.jobSchedulerService.scheduleJob(_, _, _, exec1.dateStarted) >> exec1.dateStarted
+        1 * service.jobSchedulerService.scheduleJob(_, _, _, exec1.dateStarted, false) >> exec1.dateStarted
     }
 
     def "reschedule adhoc execution getAuthContext error"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -278,7 +278,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         ).save()
 
         when:
-        service.scheduleAdHocJob(job, "user", null, Mock(Execution), [:], [:], null)
+        service.scheduleAdHocJob(job, "user", null, Mock(Execution), [:], [:], null, false)
 
         then:
         1 * service.executionServiceBean.getExecutionsAreActive() >> executionsAreActive
@@ -325,7 +325,7 @@ class ScheduledExecutionServiceSpec extends Specification {
         startTime.set(year: 1999, month: 1, dayOfMonth: 1, hourOfDay: 1, minute: 2, seconds: 42)
 
         when:
-        service.scheduleAdHocJob(job, "user", null, Mock(Execution), [:], [:], startTime)
+        service.scheduleAdHocJob(job, "user", null, Mock(Execution), [:], [:], startTime, false)
 
         then:
         1 * service.executionServiceBean.getExecutionsAreActive() >> executionsAreActive


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Bug fix. The use of `REQUIRES_NEW` to create executions has impacted existing code paths that were in the same unit of work. This has caused a number of scheduling issues to pop up related to transaction handling.

**Describe the solution you've implemented**
Jobs added to the Quartz scheduler through the existing code-path have their triggers placed into a `PENDING` trigger group, which is _paused_.

The `QuartzScheduleManager` subscribes to Grails GORM events in order to "activate" the job in the Quartz schedule after the transaction creating the `Execution` commits. This happens by rescheduling the job with a trigger set to the appropriate 

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
First introduced in #4498