### PR TITLE
Fix #5933 wf strategy change saved without changing workflow contents

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3138,6 +3138,18 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             }
         } else if (params.workflow && params.workflow instanceof Workflow) {
             scheduledExecution.workflow = new Workflow(params.workflow)
+        }else if (params.workflow && params.workflow instanceof Map){
+            if (!scheduledExecution.workflow) {
+                scheduledExecution.workflow = new Workflow(params.workflow)
+            }
+            if (params.workflow.strategy) {
+                scheduledExecution.workflow.strategy = params.workflow.strategy
+            } else if (!scheduledExecution.workflow.strategy) {
+                scheduledExecution.workflow.strategy = 'sequential'
+            }
+            if (null != params.workflow.keepgoing) {
+                scheduledExecution.workflow.keepgoing = params.workflow.keepgoing == 'true'
+            }
         }
         if(!scheduledExecution.workflow){
             scheduledExecution.workflow = new Workflow()

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -4285,6 +4285,40 @@ class ScheduledExecutionServiceSpec extends Specification {
             job.workflow.toMap() == params.workflow.toMap()
 
     }
+    def "job definition workflow from map params"() {
+        given: "existing job workflow"
+            def job = new ScheduledExecution(workflow: new Workflow(commands: [new CommandExec(adhocRemoteString: 'test')]))
+            def params = [workflow: [strategy:'parallel',keepgoing: 'true']]
+            def auth = Mock(UserAndRolesAuthContext)
+        when: "workflow attributes modified"
+            service.jobDefinitionWorkflow(job, null, params, auth)
+        then: "workflow is modified"
+            job.workflow != null
+            job.workflow.toMap().keepgoing == true
+            job.workflow.toMap().strategy == 'parallel'
+            job.workflow.toMap().commands == [[exec: 'test']]
+
+    }
+    def "job definition workflow strategy config from map params"() {
+        given: "existing job workflow"
+            def job = new ScheduledExecution(workflow: new Workflow(strategy:'aplugin', commands: [new CommandExec(adhocRemoteString: 'test')]))
+            def params = [workflow: [
+                strategy:'aplugin',
+                strategyPlugin:[
+                    aplugin:[
+                        config:[a:'b']
+                    ]
+                ]
+            ]]
+            def auth = Mock(UserAndRolesAuthContext)
+        when: "workflow strategy config input"
+            service.jobDefinitionWFStrategy(job, null, params, auth)
+        then: "workflow strategy plugin config is modified"
+            job.workflow != null
+            job.workflow.toMap().strategy == 'aplugin'
+            job.workflow.toMap().pluginConfig == [WorkflowStrategy:[aplugin:[a:'b']]]
+
+    }
 
     def "job definition workflow from session params"() {
         given: "new job"


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Fix #5933 

**Describe the solution you've implemented**

handle input param values for workflow details when there is not a workflow object in session