### PR TITLE
Fix: disabled execution should not show job schedule time

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/JobSchedulesService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobSchedulesService.groovy
@@ -140,7 +140,7 @@ class LocalJobSchedulesManager implements SchedulesManager {
         if(!se.scheduled){
             return new Date(TWO_HUNDRED_YEARS)
         }
-        if(!require && (!se.scheduleEnabled ||
+        if(!require && (!se.scheduleEnabled ||!se.executionEnabled ||
                 !scheduledExecutionService.isProjectScheduledEnabled(se.project) ||
                 !scheduledExecutionService.isProjectExecutionEnabled(se.project))){
             return null

--- a/rundeckapp/src/test/groovy/rundeck/services/LocalJobSchedulesManagerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/LocalJobSchedulesManagerSpec.groovy
@@ -43,7 +43,7 @@ class LocalJobSchedulesManagerSpec extends Specification {
         service.quartzScheduler.getTrigger(_) >> null
         service.scheduledExecutionService = Mock(ScheduledExecutionService){
             isProjectScheduledEnabled(_) >> projectScheduleEnabled
-            isProjectExecutionEnabled(_) >> executionEnabled
+            isProjectExecutionEnabled(_) >> projectExecutionEnabled
             0 * registerOnQuartz(*_)
         }
 
@@ -70,13 +70,22 @@ class LocalJobSchedulesManagerSpec extends Specification {
 
 
         where:
-            scheduleEnabled | executionEnabled | hasSchedule | expectScheduled | projectScheduleEnabled | year
-            true            | true             | true        | true            | true                   | '*'
-            true            | true             | true        | false           | true                   | '1971'
-            false           | true             | true        | false           | true                   | '*'
-            true            | false            | true        | false           | true                   | '*'
-            false           | false            | true        | false           | true                   | '*'
-            false           | false            | true        | false           | false                  | '*'
+            scheduleEnabled | executionEnabled | hasSchedule | projectExecutionEnabled | projectScheduleEnabled | year  | expectScheduled
+            true            | true             | true        | true                    | true                   | '*'   | true
+            true            | true             | true        | true                    | true                   | '1971'| false
+            false           | true             | true        | true                    | true                   | '*'   | false
+            true            | false            | true        | true                    | true                   | '*'   | false
+//            true            | true             | false       | true                    | true                   | '*'   | false
+            true            | true             | true        | false                   | true                   | '*'   | false
+            true            | true             | true        | true                    | false                  | '*'   | false
+            false           | false            | true        | true                    | true                   | '*'   | false
+            false           | false            | true        | true                    | false                  | '*'   | false
+            true            | true             | true        | false                   | true                   | '*'   | false
+            true            | true             | true        | false                   | true                   | '1971'| false
+            false           | true             | true        | false                   | true                   | '*'   | false
+            true            | false            | true        | false                   | true                   | '*'   | false
+            false           | false            | true        | false                   | true                   | '*'   | false
+            false           | false            | true        | false                   | false                  | '*'   | false
     }
 
     def "nextExecutions"(){


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Fix issue: Job execution disabled still shows next execution time for scheduled job in Job List and Job Show pages.

**Describe the solution you've implemented**

Fix nextExecutionTime; it was not considering job execution enabled.
