### PR TITLE
Docker - Make /etc/passwd group writable

### DIFF
--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -38,7 +38,8 @@ RUN set -euxo pipefail \
     && passwd -d rundeck \
     && addgroup rundeck sudo \
     && echo | sudo -u rundeck ssh-keygen -N '' \
-    && echo 'PATH=$PATH:$HOME/tools/bin' >> /home/rundeck/.bashrc
+    && echo 'PATH=$PATH:$HOME/tools/bin' >> /home/rundeck/.bashrc \
+    && chmod g+w /etc/passwd
 
 # Add Tini
 ENV TINI_VERSION v0.18.0


### PR DESCRIPTION
Make /etc/passwd groupwriteable thus that at starttime of the container the Rundeck user entry can be adjusted. 
That is important for the arbitrary user ID support on OpenShift (see #5440 )