### PR TITLE
Fix #5945 - Shared data context was not considering the base map with options attributes

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -540,7 +540,7 @@ public class NotificationService implements ApplicationContextAware{
             userData['user.lastName'] = user.lastName
         }
         //pass data context
-        def dcontext = content.context?.getSharedDataContext()?.getData(ContextView.global())?.getData() ?: [:] //usage of modified global context
+        def dcontext = content.context?.getSharedDataContext()?.consolidate()?.getData(ContextView.global())?.getData() ?: [:] //usage of modified global context
         def mailcontext = DataContextUtils.addContext("job", userData, null)
         def context = DataContextUtils.merge(dcontext, mailcontext)
         context


### PR DESCRIPTION
Fix #5945

**Is this a bugfix, or an enhancement? Please describe.**
Options variables on subject of an email notifications was not replaced by values passed by parent job.

**Describe the solution you've implemented**
The shared data context was not getting the base map with some context like options and global variables causing the option attributes not to be replaced in the subject of the email notification