### PR TITLE
Support for loading plugin resources from addons

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
@@ -44,6 +44,7 @@ import com.dtolabs.rundeck.plugins.CorePluginProviderServices
 import com.dtolabs.rundeck.plugins.ServiceTypes
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import com.dtolabs.rundeck.server.plugins.services.PluginBuilder
+import groovy.transform.PackageScope
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.BeanNotOfRequiredTypeException
@@ -447,7 +448,8 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
      * @param beanName
      * @return
      */
-    private Object findBean(String beanName) {
+    @PackageScope
+    Object findBean(String beanName) {
         (subContexts[beanName]?:applicationContext).getBean(beanName)
     }
 


### PR DESCRIPTION
Adds support on RundeckPluginRegistry to specify a PluginResourceLoader for plugins registered as beans from add-ons, enabling support for embedding ui-plugins into a grails addon.

This way, a grails plugin can inject a regular plugin (including UI plugins using the java interface) using a FactoryBean, and additionaly provide an implementation for the PluginResourceLoader to use with that plugin.

Example of UI plugin adapter loading resources from standard jar resources:

```
package com.rundeck.plugins.jobtags

import com.dtolabs.rundeck.core.plugins.Plugin
import com.dtolabs.rundeck.core.plugins.PluginException
import com.dtolabs.rundeck.core.plugins.PluginResourceLoader
import com.dtolabs.rundeck.plugins.ServiceNameConstants
import com.dtolabs.rundeck.plugins.descriptions.PluginDescription
import com.dtolabs.rundeck.plugins.rundeck.UIPlugin
import groovy.transform.CompileStatic

/**
 * Job Tags UI Plugin adapter.
 */
@Plugin(name = JobTagsUIPlugin.PROVIDER_NAME, service = ServiceNameConstants.UI)
@PluginDescription(title = JobTagsUIPlugin.PLUGIN_TITLE, description = JobTagsUIPlugin.PLUGIN_DESC)
@CompileStatic
class JobTagsUIPlugin implements UIPlugin, PluginResourceLoader {

    static final String PROVIDER_NAME = 'job-tags-ui'
    static final String PLUGIN_TITLE = "Job Tags UI Plugin"
    static final String PLUGIN_DESC = "Job Tags UI Elements"

    /** JS scripts */
    private static final List<String> SCRIPTS = [
            "lib/jquery.jobtags.js",
            "js/init.js",
            "js/jobtags.js"
    ]

    /** css stylesheets */
    private static final List<String> STYLES = [
            "css/ui-job-tags-plugin-styles.css"
    ]

    /** Full Resource list */
    private static final List<String> ALL_RESOURCES = SCRIPTS + STYLES


    @Override
    boolean doesApply(String path) {
        // TODO use AntPathMatcher
        return true
    }

    @Override
    List<String> resourcesForPath(String path) {
        return ALL_RESOURCES
    }

    @Override
    List<String> scriptResourcesForPath(String path) {
        return SCRIPTS
    }

    @Override
    List<String> styleResourcesForPath(String path) {
        return STYLES
    }

    @Override
    List<String> requires(String path) {
        return ["ui-common-platform"]
    }

    @Override
    List<String> listResources() throws PluginException, IOException {
        return ALL_RESOURCES
    }

    /**
     * Gets a resource from the classpath resources bundled in the jar.
     */
    @Override
    InputStream openResourceStreamFor(String name) throws PluginException, IOException {
        return this.getClass().getResourceAsStream("/" + name)
    }
}
```

After building rundeckpro with this fix, and installing the add-on in `server/addons`, the UI components implemented by the ui plugin work correctly:

![Screen Shot 2020-04-10 at 12 21 58](https://user-images.githubusercontent.com/11545533/79005884-e1c4d100-7b25-11ea-93ec-858fe8fbade3.png)





