### PR TITLE
Fix #5943 - Avoiding creating temporary files when deleting executions

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
@@ -334,23 +334,20 @@ class ExecutionUtilService {
     }
 
     /**
-     * Write execution.xml file to a temp file and return
+     * Write execution.xml file and return
      * @param exec execution
-     * @param path path to store the file on filesystem. If null a temporary file will be created and deleted.
+     * @param file path to store the file on filesystem.
      * @return file containing execution.xml
      */
-    File getExecutionXmlFileForExecution(Execution execution, File executionXmlfile = null) {
-        if(!executionXmlfile){
-            executionXmlfile = File.createTempFile("execution-${execution.id}", ".xml")
-            executionXmlfile.deleteOnExit()
-        }
-        executionXmlfile.withWriter("UTF-8") { Writer writer ->
+    File getExecutionXmlFileForExecution(Execution execution, File executionXmlfile) {
+        executionXmlfile?.withWriter("UTF-8") { Writer writer ->
             exportExecutionXml(
                     execution,
                     writer,
                     "output-${execution.id}.rdlog"
             )
         }
+
         executionXmlfile
     }
 

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -165,7 +165,8 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
 
     @Override
     ExecutionFile produceStorageFileForExecution(final ExecutionReference e) {
-        File localfile = executionUtilService.getExecutionXmlFileForExecution(Execution.get(e.id))
+        File localfile = logFileStorageService.
+                getFileForExecutionFiletype(Execution.get(e.id), EXECUTION_XML_LOG_FILETYPE, false)
 
         new ProducedExecutionFile(localFile: localfile, fileDeletePolicy: ExecutionFile.DeletePolicy.ALWAYS)
     }


### PR DESCRIPTION
Fix #5943 

**Is this a bugfix, or an enhancement? Please describe.**
Temporary files are being created when deleting executions. This becomes an issue especially when the "Executions History Cleaner" feature is enabled and removes many files frequently.

**Describe the solution you've implemented**
The file path for the xml file created when execution finish should be determined from logFileStorageService.getFileForExecutionFiletype

**Additional context**
The creation of the file at the end of the execution was also updated to obtain the file path in the same way instead of being constructed
