### PR TITLE
Fix #5081 log file storage request should be unique for execution

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/LogFileStorageRequest.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/LogFileStorageRequest.groovy
@@ -28,7 +28,7 @@ class LogFileStorageRequest {
     static belongsTo = Execution
 
     static constraints = {
-        execution nullable: false
+        execution nullable: false, unique: true
         pluginName maxSize: 255
         filetype nullable: true
     }

--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -636,6 +636,11 @@ class LogFileStorageService
             return
         }
         //multi storage available
+        //avoid multiple storage requests for the same Execution
+        def orig = LogFileStorageRequest.findByExecution(e)
+        if(orig){
+            return
+        }
         LogFileStorageRequest request = createStorageRequest(e, '*')
         request.discard()
         def reqid = request.execution.id.toString() + ":" + request.filetype

--- a/rundeckapp/src/integration-test/groovy/rundeck/ExecutionIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/ExecutionIntegrationSpec.groovy
@@ -1,0 +1,49 @@
+package rundeck
+
+import grails.gorm.transactions.Rollback
+import grails.testing.mixin.integration.Integration
+import grails.validation.ValidationException
+import spock.lang.Specification
+
+@Integration
+@Rollback
+class ExecutionIntegrationSpec extends Specification{
+
+    def "unique log file storage request"() {
+        given:
+            def uuid1 = UUID.randomUUID().toString()
+            def e1 = new Execution(
+                serverNodeUUID: uuid1,
+                dateStarted: new Date(),
+                dateCompleted: new Date(),
+                failedNodeList: null,
+                succeededNodeList: null,
+                project: "test",
+                user: "user",
+                status: 'true'
+            ).save(flush: true,
+                   failOnError: true)
+            def lfsr1 = new LogFileStorageRequest(
+                execution: e1,
+                pluginName: 'aplugin',
+                completed: false,
+                filetype: 'test'
+            ).save(flush:true,
+                   failOnError: true)
+        when:
+            def lfsr2 = new LogFileStorageRequest(
+                execution: e1,
+                pluginName: 'aplugin',
+                completed: true,
+                filetype: 'xyz'
+            ).save(flush:true,
+                   failOnError: true)
+
+        then:
+            ValidationException e = thrown()
+
+            e.errors.hasFieldErrors('execution')
+            e.errors.getFieldError('execution').code=='unique'
+
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
@@ -1251,4 +1251,35 @@ class LogFileStorageServiceSpec extends Specification {
             result['test1'] == file1
             !result['test2']
     }
+    def "submit for storage duplicate"(){
+        given:
+            def exec = new Execution(
+                dateStarted: new Date(),
+                dateCompleted: null,
+                user: 'user2',
+                project: 'test',
+                serverNodeUUID: 'D0CA0A6D-3F85-4F53-A714-313EB57A4D1F',
+                outputfilepath: '/tmp/file'
+            ).save()
+            service.frameworkService = Mock(FrameworkService){
+                2 * getFrameworkPropertyResolver(_)
+            }
+            service.configurationService=Mock(ConfigurationService){
+                _ * getString('execution.logs.fileStoragePlugin',null)>>'test1'
+            }
+            def instance = Mock(ExecutionFileStoragePlugin)
+            service.pluginService=Mock(PluginService){
+                2 * configurePlugin('test1', _, _, PropertyScope.Instance)>>new ConfiguredPlugin<ExecutionFileStoragePlugin>(
+                    instance,
+                    [:]
+                )
+            }
+            service.grailsLinkGenerator=Stub(grails.web.mapping.LinkGenerator)
+            service.submitForStorage(exec)
+        when:
+            service.submitForStorage(exec)
+        then:
+            service.storageRequests.size()==1
+
+    }
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Fix #5081 

**Describe the solution you've implemented**

Add unique constraint for LogFileStorageService.execution

