### PR TITLE
Remove remaining SCM calls prior to job list on GUI

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/menu/jobs.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/jobs.js
@@ -33,6 +33,7 @@
 //= require ko/binding-css2
 //= require scheduledExecution/jobRunFormOptionsKO
 //= require koBind
+//= require ko/binding-url-path-param
 
 /*
  Manifest for "menu/jobs.gsp" page
@@ -169,6 +170,7 @@ function BulkEditor(data){
     self.scmExportActions = ko.observable(null);
     self.scmImportActions = ko.observable(null);
     self.scmExportRenamed = ko.observable(null);
+    self.scmDone = ko.observable(null);
     self.isExportEnabled=ko.pureComputed(function(){
         return self.scmExportEnabled();
     });
@@ -412,5 +414,8 @@ function BulkEditor(data){
         return (self.displayExport() || self.displayImport());
     };
 
+    self.isLoadingSCMActions = function(){
+        return (!self.scmDone());
+    }
 }
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -488,14 +488,12 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                                                  ),
                                                                  [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT, AuthConstants.ACTION_SCM_EXPORT]
             )) {
-                if(frameworkService.isClusterModeEnabled()){
+                if((!minScm) && frameworkService.isClusterModeEnabled()){
                     if (!scmService.projectHasConfiguredExportPlugin(params.project)) {
                         //initialize if in another node
                         scmService.initProject(params.project, 'export')
                     }
-                    if(minScm){
-                        scmService.fixExportStatus(authContext, params.project, results.nextScheduled)
-                    }
+                    scmService.fixExportStatus(authContext, params.project, results.nextScheduled)
                 }
                 def pluginData = [:]
                 try {
@@ -507,8 +505,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                 pluginData.scmStatus = scmService.exportStatusForJobs(authContext, results.nextScheduled)
                                 pluginData.scmExportStatus = scmService.exportPluginStatus(authContext, params.project)
                                 pluginData.scmExportRenamed = scmService.getRenamedJobPathsForProject(params.project)
+                                pluginData.scmExportActions = scmService.exportPluginActions(authContext, params.project)
                             }
-                            pluginData.scmExportActions = scmService.exportPluginActions(authContext, params.project)
                         }
                         results.putAll(pluginData)
                     }
@@ -522,15 +520,13 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                                                  ),
                                                                  [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT, AuthConstants.ACTION_SCM_IMPORT]
             )) {
-                if(frameworkService.isClusterModeEnabled()){
+                if((!minScm) && frameworkService.isClusterModeEnabled()){
                     if (!scmService.projectHasConfiguredImportPlugin(params.project)) {
                         //initialize if in another node
                         scmService.initProject(params.project, 'import')
                     }
-                    if(minScm){
-                        scmService.fixImportStatus(authContext, params.project, results.nextScheduled)
-                        scmService.importPluginStatus(authContext, params.project)
-                    }
+                    scmService.fixImportStatus(authContext, params.project, results.nextScheduled)
+                    scmService.importPluginStatus(authContext, params.project)
                 }
                 def pluginData = [:]
                 try {
@@ -541,8 +537,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                             if(!minScm){
                                 pluginData.scmImportJobStatus = scmService.importStatusForJobs(authContext, results.nextScheduled)
                                 pluginData.scmImportStatus = scmService.importPluginStatus(authContext, params.project)
+                                pluginData.scmImportActions = scmService.importPluginActions(authContext, params.project)
                             }
-                            pluginData.scmImportActions = scmService.importPluginActions(authContext, params.project)
                         }
                         results.putAll(pluginData)
                     }
@@ -3261,6 +3257,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 if (frameworkService.isClusterModeEnabled()) {
                     //initialize if in another node
                     scmService.initProject(params.project, 'export')
+                    scmService.fixExportStatus(authContext, params.project, result.nextScheduled)
                 }
                 try {
                     if (scmService.projectHasConfiguredExportPlugin(params.project)) {
@@ -3286,6 +3283,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 if (frameworkService.isClusterModeEnabled()) {
                     //initialize if in another node
                     scmService.initProject(params.project, 'import')
+                    scmService.fixImportStatus(authContext, params.project, result.nextScheduled)
+                    scmService.importPluginStatus(authContext, params.project)
                 }
                 def pluginData = [:]
                 try {

--- a/rundeckapp/grails-app/views/menu/_jobslist.gsp
+++ b/rundeckapp/grails-app/views/menu/_jobslist.gsp
@@ -97,20 +97,6 @@
                                         </g:else>
                                     </span>
 
-                                <g:set var="exportstatus" value="${scmExportEnabled ? scmStatus?.get(scheduledExecution.extid):null}"/>
-                                <g:set var="importStatus" value="${scmImportEnabled ? scmImportJobStatus?.get(scheduledExecution.extid): null}"/>
-                                <g:if test="${exportstatus || importStatus}">
-
-                                    <g:render template="/scm/statusBadge"
-                                              model="[exportStatus: exportstatus?.synchState?.toString(),
-                                                      importStatus: importStatus?.synchState?.toString(),
-                                                      text  : '',
-                                                      notext: true,
-                                                      exportCommit  : exportstatus?.commit,
-                                                      importCommit  : importStatus?.commit,
-                                              ]"/>
-                                </g:if>
-
                                 <!-- ko if: displayBadge('${scheduledExecution.extid}') -->
                                 <span data-bind="attr: {'title': jobText('${scheduledExecution.extid}') }" class="has_tooltip">
                                     <span data-bind="css: jobClass('${scheduledExecution.extid}')">

--- a/rundeckapp/grails-app/views/menu/_workflowsFull.gsp
+++ b/rundeckapp/grails-app/views/menu/_workflowsFull.gsp
@@ -253,40 +253,34 @@
                       <g:message code="job.bulk.activate.menu.label" />
                     </a>
                   </li>
-                  <g:if test="${(scmExportEnabled && scmExportActions) || (scmImportEnabled && scmImportActions)}">
-                    <g:if test="${scmExportEnabled && scmExportActions}">
-                      <li class="divider"></li>
-                      <li role="presentation" class="dropdown-header">
+                  <g:if test="${(scmExportEnabled) || (scmImportEnabled)}">
+                  <li data-bind="visible: isLoadingSCMActions()" id="scm_export_actions_loading" role="presentation" class="dropdown-header">
+                      <g:message code="loading" /></li>
+                    <g:if test="${scmExportEnabled}">
+                      <li data-bind="visible: scmExportActions()" class="divider"></li>
+                      <li data-bind="visible: scmExportActions()" role="presentation" class="dropdown-header">
                         <g:icon name="circle-arrow-right"/>
                         <g:message code="scm.export.actions.title" />
-                      </li>
-                      <g:each in="${scmExportActions}" var="action">
-                        <g:if test="${action.id == '-'}">
-                          <li class="divider"></li>
-                        </g:if>
-                        <g:else>
+                        </li>
+                        <!-- ko foreach: scmExportActions() -->
                           <li>
-                            <g:render template="/scm/actionLink" model="[action:action,integration:'export',project:params.project]"/>
+                          <a href="${g.createLink(action:'performAction',controller:'scm',params:[project:params.project, integration:'export', actionId:'<$>'])}"
+                            data-bind="urlPathParam: $data.id, text: $data.title, attr: { title: $data.description}"></a>
                           </li>
-                        </g:else>
-                      </g:each>
+                        <!-- /ko -->
                     </g:if>
-                    <g:if test="${scmImportEnabled && scmImportActions}">
-                      <li class="divider"></li>
-                      <li role="presentation" class="dropdown-header">
+                    <g:if test="${scmImportEnabled}">
+                      <li data-bind="visible: scmImportActions()" class="divider"></li>
+                      <li data-bind="visible: scmImportActions()" role="presentation" class="dropdown-header">
                         <g:icon name="circle-arrow-left"/>
                         <g:message code="scm.import.actions.title" />
                       </li>
-                      <g:each in="${scmImportActions}" var="action">
-                        <g:if test="${action.id == '-'}">
-                          <li class="divider"></li>
-                        </g:if>
-                        <g:else>
+                        <!-- ko foreach: scmImportActions() -->
                           <li>
-                            <g:render template="/scm/actionLink" model="[action:action,integration:'import',project:params.project]"/>
+                          <a href="${g.createLink(action:'performAction',controller:'scm',params:[project:params.project, integration:'import', actionId:'<$>'])}"
+                            data-bind="urlPathParam: $data.id, text: $data.title, attr: { title: $data.description}"></a>
                           </li>
-                        </g:else>
-                      </g:each>
+                        <!-- /ko -->
                     </g:if>
                   </g:if>
                   <g:if test="${authProjectSCMAdmin && hasConfiguredPlugins}">

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -318,6 +318,8 @@ search
                     bulkeditor.scmImportJobStatus(data.scmImportJobStatus);
                     bulkeditor.scmImportStatus(data.scmImportStatus);
                     bulkeditor.scmImportActions(data.scmImportActions);
+
+                    bulkeditor.scmDone(true);
                 }
             });
             const filtersData=loadJsonData('jobFiltersJson')


### PR DESCRIPTION
Enhancement to improve the load time of the job list page using SCM.

`scmExportActions` and `scmImportActions` are no longer used on` jobsFragment` method if is called from the GUI (parameter `_gui_min_scm=true`).

Now on the job page the actions section looks like this:
![SharedScreenshot01](https://user-images.githubusercontent.com/2894508/79359201-48743100-7f10-11ea-8aff-e41f5d66a081.jpg)


Until the ajax call of scm return with the info (that info was already on that call, we were just using the one from the method to load that menu as son as the page load):
![SharedScreenshot02](https://user-images.githubusercontent.com/2894508/79359218-4f9b3f00-7f10-11ea-8f67-d190d5b46c42.jpg)


As usual this only affect if the SCM plugin is enabled.

fix #5967