### PR TITLE
Use pessimistic locking on job stats update

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -1153,10 +1153,10 @@ class ScheduledExecution extends ExecutionContext implements EmbeddedJsonData {
         }
     }
 
-    ScheduledExecutionStats getStats() {
+    ScheduledExecutionStats getStats(lock = false) {
         def stats
         if(this.id) {
-            stats = ScheduledExecutionStats.findBySe(this)
+            stats = ScheduledExecutionStats.findBySe(this, [lock: lock])
             if (!stats) {
                 def content = [execCount   : this.execCount,
                                totalTime   : this.totalTime,

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecutionStats.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecutionStats.groovy
@@ -8,10 +8,14 @@ import org.hibernate.annotations.OptimisticLocking
 class ScheduledExecutionStats {
     String content
 
+    long _version = 0
+
     static belongsTo=[se:ScheduledExecution]
     static transients = ['contentMap']
 
     static mapping = {
+        version false
+        _version column: 'version'
         content type: 'text'
     }
 

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecutionStats.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecutionStats.groovy
@@ -11,6 +11,7 @@ class ScheduledExecutionStats {
     static transients = ['contentMap']
 
     static mapping = {
+        version false
         content type: 'text'
     }
 

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecutionStats.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecutionStats.groovy
@@ -2,16 +2,16 @@ package rundeck
 
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.hibernate.annotations.OptimisticLockType
+import org.hibernate.annotations.OptimisticLocking
 
 class ScheduledExecutionStats {
-
     String content
 
     static belongsTo=[se:ScheduledExecution]
     static transients = ['contentMap']
 
     static mapping = {
-        version false
         content type: 'text'
     }
 

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecutionStats.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecutionStats.groovy
@@ -2,8 +2,6 @@ package rundeck
 
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.hibernate.annotations.OptimisticLockType
-import org.hibernate.annotations.OptimisticLocking
 
 class ScheduledExecutionStats {
     String content

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -46,7 +46,7 @@ import java.util.function.Consumer
 class ExecutionJob implements InterruptableJob {
 
     public static final int DEFAULT_STATS_RETRY_MAX = 5
-    public static final long DEFAULT_STATS_RETRY_DELAY = 5000
+    public static final long DEFAULT_STATS_RETRY_DELAY = 1000
     public static final int DEFAULT_FINALIZE_RETRY_MAX = 10
     public static final long DEFAULT_FINALIZE_RETRY_DELAY = 5000
 

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2983,6 +2983,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      * @param execution
      * @return
      */
+    @NotTransactional
     def updateScheduledExecStatistics(Long schedId, eId, long time) {
         def success = false
         try {
@@ -3022,8 +3023,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     }
                     success = true
                 }
-
-
             }
         } catch (org.springframework.dao.ConcurrencyFailureException e) {
             log.warn("Caught ConcurrencyFailureException, will retry updateScheduledExecStatistics for ${eId}")

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2988,8 +2988,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         try {
             ScheduledExecutionStats.withTransaction {
                 def scheduledExecution = ScheduledExecution.get(schedId)
-                def seStats = scheduledExecution.getStats()
-
+                def seStats = scheduledExecution.getStats(true)
 
                 if (scheduledExecution.scheduled) {
                     scheduledExecution.nextExecution = scheduledExecutionService.nextExecutionTime(scheduledExecution)


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Fixes #5963

**Describe the solution you've implemented**
Disable optimistic concurrency control on the job stats domain object. This will allow a "last writer" wins scenario but should reduce/remove update contention. If we don't necessarily care about the update order this may be a viable solution.

**Describe alternatives you've considered**
Solutions outlined in #5963 

**Additional context**
https://gorm.grails.org/latest/hibernate/manual/#locking
https://gorm.grails.org/latest/hibernate/manual/#ormdsl
