### PR TITLE
Fix #5894 prevent double click on run job button

### DIFF
--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -156,7 +156,7 @@ search
                     }
                     clicked = true;
                     jQuery('#execOptFormRunButtons').hide()
-                    jQuery('#execOptFormRunJobSpinner').show()
+                    jQuery('#execOptFormRunJobSpinner').css('display', 'flex')
                     execSubmit('execDivContent', appLinks.scheduledExecutionRunJobInline);
                     return false;
                 });

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -148,10 +148,16 @@ search
                 jQuery('#execFormCancelButton').attr('name', "_x");
             }
             if (jQuery('#execFormRunButton').length) {
+                let clicked=false
                 jQuery('#execFormRunButton').on('click', function(evt) {
                     stopEvent(evt);
+                    if (clicked) {
+                        return false;
+                    }
+                    clicked = true;
+                    jQuery('#execOptFormRunButtons').hide()
+                    jQuery('#execOptFormRunJobSpinner').show()
                     execSubmit('execDivContent', appLinks.scheduledExecutionRunJobInline);
-                    // jQuery('#formbuttons').loading(message('job.starting.execution'));
                     return false;
                 });
             }

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsFormButtons.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsFormButtons.gsp
@@ -91,7 +91,12 @@
 
 
                 <input type="hidden" id="followoutputcheck" name="follow" value="true" data-bind="value: follow"/>
-                <div class="btn-group pull-right">
+
+                <div id="execOptFormRunJobSpinner" class="spinner text-secondary pull-right" style="display:none;">
+                    <i class="fas fa-spinner fa-pulse"></i>
+                    <g:message code="job.starting.execution"/>
+                </div>
+                <div class="btn-group pull-right" id="execOptFormRunButtons">
                     <button type="submit"
                             name="_action_runJobNow"
                             id="execFormRunButton"

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsFormButtons.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsFormButtons.gsp
@@ -92,7 +92,7 @@
 
                 <input type="hidden" id="followoutputcheck" name="follow" value="true" data-bind="value: follow"/>
 
-                <div id="execOptFormRunJobSpinner" class="spinner text-secondary pull-right" style="display:none;">
+                <div id="execOptFormRunJobSpinner" class="spinner text-secondary pull-right" style="display:none;width:172px;height:32px;align-items:center;justify-content:space-evenly">
                     <i class="fas fa-spinner fa-pulse"></i>
                     <g:message code="job.starting.execution"/>
                 </div>

--- a/rundeckapp/grails-app/views/scheduledExecution/show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/show.gsp
@@ -99,6 +99,18 @@ search
                 jQuery('#jobid').val(el.data('jobId'));
                 jQuery('#selectProject').modal();
             });
+            if (jQuery('#execFormRunButton').length) {
+                let clicked=false
+                jQuery('#execFormRunButton').on('click', function(evt) {
+                    if (clicked) {
+                        return false;
+                    }
+                    clicked = true
+                    jQuery('#execOptFormRunButtons').hide()
+                    jQuery('#execOptFormRunJobSpinner').show()
+                    return true
+                });
+            }
 
             initKoBind(null,
                 {

--- a/rundeckapp/grails-app/views/scheduledExecution/show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/show.gsp
@@ -107,7 +107,7 @@ search
                     }
                     clicked = true
                     jQuery('#execOptFormRunButtons').hide()
-                    jQuery('#execOptFormRunJobSpinner').show()
+                    jQuery('#execOptFormRunJobSpinner').css('display', 'flex')
                     return true
                 });
             }


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**

Fix #5894 

* show spinner to indicate execution is starting
* hide buttons, and prevent double click with state variable

