### PR TITLE
Remove legacy node config UI

### DIFF
--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1832,3 +1832,4 @@ scheduledExecution.plugins.title=Plugins
 false=False
 archive.import.component.false.title.0=Do Not Import {0}
 archive.import.component.true.title.0=Import {0}
+no.modifiable.sources.found=No modifiable sources found

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -1744,3 +1744,4 @@ scheduledExecution.plugins.title=Plugins
 false=False
 archive.import.component.false.title.0=Do Not Import {0}
 archive.import.component.true.title.0=Import {0}
+no.modifiable.sources.found=No modifiable sources found

--- a/rundeckapp/grails-app/i18n/messages_fr_FR.properties
+++ b/rundeckapp/grails-app/i18n/messages_fr_FR.properties
@@ -1734,3 +1734,4 @@ scheduledExecution.plugins.title=Plugins
 false=False
 archive.import.component.false.title.0=Do Not Import {0}
 archive.import.component.true.title.0=Import {0}
+no.modifiable.sources.found=No modifiable sources found

--- a/rundeckapp/grails-app/i18n/messages_ja.properties
+++ b/rundeckapp/grails-app/i18n/messages_ja.properties
@@ -1362,3 +1362,4 @@ scheduledExecution.plugins.title=Plugins
 false=False
 archive.import.component.false.title.0=Do Not Import {0}
 archive.import.component.true.title.0=Import {0}
+no.modifiable.sources.found=No modifiable sources found

--- a/rundeckapp/grails-app/i18n/messages_pt_BR.properties
+++ b/rundeckapp/grails-app/i18n/messages_pt_BR.properties
@@ -1758,3 +1758,4 @@ scheduledExecution.plugins.title=Plugins
 false=False
 archive.import.component.false.title.0=Do Not Import {0}
 archive.import.component.true.title.0=Import {0}
+no.modifiable.sources.found=No modifiable sources found

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -1732,3 +1732,4 @@ scheduledExecution.plugins.title=Plugins
 false=False
 archive.import.component.false.title.0=Do Not Import {0}
 archive.import.component.true.title.0=Import {0}
+no.modifiable.sources.found=No modifiable sources found

--- a/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
+++ b/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
@@ -66,7 +66,7 @@
                 <div class="nav-tabs-wrapper">
                   <ul class="nav nav-tabs" id="node_config_tabs">
 
-                    <g:if test="${!legacyProjectNodesUi && feature.isDisabled(name: 'legacyProjectNodesUi')}">
+
 
                       <li class="${writeableSources ? 'active' : ''}" id="tab_link_sources_writeable">
                         <a href="#node_sources_writeable" data-toggle="tab">
@@ -81,7 +81,6 @@
                           <g:message code="project.node.sources.title.short" />
                         </a>
                       </li>
-                    </g:if>
 
                     <feature:enabled name="enhanced-nodes">
 
@@ -94,8 +93,7 @@
 
                     </feature:enabled>
 
-                    <li id="tab_link_settings"
-                      class="${legacyProjectNodesUi || feature.isEnabled(name: 'legacyProjectNodesUi') ? 'active':''}">
+                    <li id="tab_link_settings">
                       <a href="#node_settings" data-toggle="tab">
                         <i class="fas fa-cog"></i>
                         <g:message code="configuration" />
@@ -132,39 +130,9 @@
                 </div>
               </page-confirm>
               <div class="tab-content">
-                      <div class="tab-pane ${legacyProjectNodesUi || feature.isEnabled(name: 'legacyProjectNodesUi') ? 'active':''}" id="node_settings">
+                      <div class="tab-pane" id="node_settings">
 
-                        <g:if test="${resourceModelConfigDescriptions && (legacyProjectNodesUi || feature.isEnabled(name: 'legacyProjectNodesUi'))}">
-                        %{--NOTE: Legacy UI--}%
-
-                              <div class="panel panel-default">
-                                <div class="panel-heading">
-                                  <g:link controller="framework" action="editProjectNodeSources"
-                                          params="[project: params.project ?: request.project]"
-                                          class=" btn btn-info btn-sm">
-                                    <g:icon name="pencil"/>
-                                    <g:message code="edit.configuration"/>
-                                  </g:link>
-                                </div>
-
-                                <div class="panel-body">
-                                  <g:render template="/menu/projectConfigurableView"
-                                            model="${[extraConfigSet: extraConfig?.values(),
-                                                      category      : 'resourceModelSource',
-                                                      titleCode     : 'project.configuration.extra.category.resourceModelSource.title',
-                                                      helpCode      : 'project.configuration.extra.category.resourceModelSource.description'
-                                            ]}"/>
-                                  </div>
-                              </div>
-
-                              <g:render template="legacyNodeSourcesList"/>
-
-
-                        %{--END: Legacy UI--}%
-                        </g:if>
-                        <g:else>
-                        %{--updated UI--}%
-
+                          %{--updated UI--}%
                           <g:form action="saveProjectNodeSources" method="post" useToken="true" class="form">
 
 
@@ -186,11 +154,10 @@
                                 <g:submitButton name="save" value="${g.message(code: 'button.action.Save', default: 'Save')}" class="btn btn-primary reset_page_confirm"/>
                               </div>
                           </g:form>
-                        </g:else>
 
                       </div>
 
-                      <g:if test="${!legacyProjectNodesUi && feature.isDisabled(name: 'legacyProjectNodesUi')}">
+
 
                         <div class="tab-pane ${writeableSources ? 'active' : ''} project-plugin-config-vue"
                             id="node_sources_writeable">
@@ -241,7 +208,7 @@
                                                           :event-bus="EventBus">
                               </project-node-sources-config>
                         </div>
-                      </g:if>
+
 
                       <feature:enabled name="enhanced-nodes">
                         <div class="tab-pane" id="node_plugins">

--- a/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
+++ b/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
@@ -162,36 +162,25 @@
                         <div class="tab-pane ${writeableSources ? 'active' : ''} project-plugin-config-vue"
                             id="node_sources_writeable">
 
-                          <writeable-project-node-sources item-css="card"
-                                                          item-content-css="card-content"
-                                                          :event-bus="EventBus">
-                            <div slot="empty" class="card">
+                          <div class="help-block">
+                            <g:message code="modifiable.node.sources.will.appear.here" />
+                          </div>
 
-
-                              <div class="card-content">
-                                <span class="text-info"><i class="glyphicon glyphicon-info-sign"></i> No modifiable sources found</span>
-                              </div>
-
-
+                          <writeable-project-node-sources :event-bus="EventBus" class="list-group" item-css="list-group-item">
+                            <div slot="empty" class="list-group-item">
+                              <span class="text-info"><i class="glyphicon glyphicon-info-sign"></i> No modifiable sources found</span>
                             </div>
                           </writeable-project-node-sources>
 
-                          <div class="card">
-                            <div class="card-header">
-                              <span class="help-block"><g:message code="modifiable.node.sources.will.appear.here" /></span>
-                            </div>
-
-                            <div class="card-footer">
-                              <div class="well well-sm">
-                                <g:message code="use.the.node.sources.tab.1" />
-                                <a href="#node_sources" onclick="jQuery('#tab_link_sources').tab('show')">
-                                  <i class="fas fa-hdd fa-edit"></i>
-                                  <g:message code="project.node.sources.title.short"/>
-                                </a>
-                                <g:message code="use.the.node.sources.tab.2" />
-                              </div>
-                            </div>
+                          <div class="well well-sm">
+                            <g:message code="use.the.node.sources.tab.1" />
+                            <a href="#node_sources" onclick="jQuery('#tab_link_sources').tab('show')">
+                              <i class="fas fa-hdd fa-edit"></i>
+                              <g:message code="project.node.sources.title.short"/>
+                            </a>
+                            <g:message code="use.the.node.sources.tab.2" />
                           </div>
+
                         </div>
 
 

--- a/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
+++ b/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
@@ -168,7 +168,7 @@
 
                           <writeable-project-node-sources :event-bus="EventBus" class="list-group" item-css="list-group-item">
                             <div slot="empty" class="list-group-item">
-                              <span class="text-info"><i class="glyphicon glyphicon-info-sign"></i> No modifiable sources found</span>
+                              <span class="text-info"><i class="glyphicon glyphicon-info-sign"></i> <g:message code="no.modifiable.sources.found" /></span>
                             </div>
                           </writeable-project-node-sources>
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

* Removes "legacy" Node Config UI, which was disabled by default and only remained as a hedge against issues in the current (vue) UI.
* update current UI to clean up some styles

**Additional context**

Style fix: current incorrect nested `card` style:

![Screen Shot 2020-04-17 at 10 27 31 AM](https://user-images.githubusercontent.com/55603/79596943-40de9480-8096-11ea-9262-36dc3ef5c04e.png)

Cleaned up:

![Screen Shot 2020-04-17 at 10 27 02 AM](https://user-images.githubusercontent.com/55603/79596986-518f0a80-8096-11ea-9830-a4f54a52d0f6.png)
![Screen Shot 2020-04-17 at 10 26 10 AM](https://user-images.githubusercontent.com/55603/79596991-5227a100-8096-11ea-8c96-e5e6c10a8fa3.png)
