### PR TITLE
Scheduler - Handle null trigger and do not store durably

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
@@ -156,7 +156,7 @@ class QuartzJobScheduleManagerService implements JobScheduleManager, Initializin
 
         String triggerGroup = pending ? TRIGGER_GROUP_PENDING : group
 
-        def jobDetail = JobBuilder.newJob(ExecutionJob).storeDurably()
+        def jobDetail = JobBuilder.newJob(ExecutionJob)
                                   .withIdentity(name, group)
                                   .usingJobData(new JobDataMap(data ?: [:])).build()
 
@@ -217,6 +217,10 @@ class QuartzJobScheduleManagerService implements JobScheduleManager, Initializin
         quartzScheduler.getTriggerKeys(matcher).each { triggerKey ->
             if (triggerKey.group == TRIGGER_GROUP_PENDING) {
                 Trigger trigger = quartzScheduler.getTrigger(triggerKey)
+                /** Trigger may have been rescheduled already under heavy activity */
+                if (trigger == null)
+                    return
+
                 Map data = trigger.jobDataMap
                 Instant created = data.get('meta.created') as Instant
 


### PR DESCRIPTION
The trigger could be gone already and is more likely under heavy activity. This would cause an `NPE` during the cleanup task.

`storeDurably()` is extraneous and shouldn't have made it in during the cluster fix. It could cause Jobs to stay in the scheduler after the triggers are removed if they are not otherwise explicitly removed.