### PR TITLE
Plugin resource loader: remove unnecessary WARN log

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
@@ -551,7 +551,6 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
                 if (bean instanceof PluginResourceLoader) {
                     return bean
                 }
-                log.warn("No resource loader for bean plugin: ${provider}. Provided bean: ${beanName}")
             } catch (NoSuchBeanDefinitionException e) {
                 log.error("No such bean: ${beanName}")
             }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Remove unnecessary warning log output in plugin loader checking