### PR TITLE
Fix #5938 error when logging in with empty credentials.

### DIFF
--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1736,6 +1736,7 @@ deleted.referenced.job=This job was referenced by another, deleting it could had
 user.login.username.label=Username
 user.login.password.label=Password
 user.login.login.button=Log In
+user.login.empty.username=Username cannot be empty
 scheduledExecution.action.menu.none-available=No actions available
 
 scheduledExecution.property.defaultTab.label=Default Tab

--- a/rundeckapp/grails-app/views/user/login.gsp
+++ b/rundeckapp/grails-app/views/user/login.gsp
@@ -92,7 +92,7 @@
               </div>
             </g:if>
             <div class="col-md-4 col-sm-6 col-md-offset-4 col-sm-offset-3">
-              <form action="${g.createLink(uri:"/j_security_check")}" method="post" class="form " role="form">
+              <form action="${g.createLink(uri:"/j_security_check")}" method="post" class="form " role="form" onsubmit="return onLoginClicked()">
                 <div class="card" data-background="color" data-color="blue">
                   <div class="card-header">
                     <h3 class="card-title">
@@ -154,6 +154,7 @@
                     </div>
                         <div class="card-footer text-center">
                             <button type="submit" id="btn-login" class="btn btn-fill btn-wd "><g:message code="user.login.login.button"/></button>
+                            <span id="login-spinner" style="display: none;"><i class="fas fa-spinner fa-pulse"></i></span>
                         </div>
                     </g:showLocalLogin>
                   </div>
@@ -190,6 +191,16 @@
 
       </div>
     </div>
+      <script type="text/javascript">
+          function onLoginClicked() {
+            let lbtn = jQuery("#btn-login")
+            if(jQuery('#login').val() === '') return false
+            let spinner = jQuery("#login-spinner")
+            lbtn.hide()
+            spinner.show()
+            return true
+          }
+      </script>
     <g:render template="/common/footer"/>
   </div>
 </div>

--- a/rundeckapp/grails-app/views/user/login.gsp
+++ b/rundeckapp/grails-app/views/user/login.gsp
@@ -164,6 +164,9 @@
                           <span><g:enc>${flash.loginerror}</g:enc></span>
                       </div>
                     </g:if>
+                  <div class="alert alert-danger" style="display:none;" id="empty-username-msg">
+                      <span><g:message code="user.login.empty.username"/></span>
+                  </div>
 
                     <g:set var="footermessagehtml" value="${grailsApplication.config.rundeck?.gui?.login?.footerMessageHtml ?: ''}"/>
                     <g:if test="${footermessagehtml}">
@@ -194,7 +197,13 @@
       <script type="text/javascript">
           function onLoginClicked() {
             let lbtn = jQuery("#btn-login")
-            if(jQuery('#login').val() === '') return false
+            let emptyUserNameMsg = jQuery("#empty-username-msg")
+            if(jQuery('#login').val() === '') {
+              emptyUserNameMsg.show()
+              return false
+            } else {
+              emptyUserNameMsg.hide()
+            }
             let spinner = jQuery("#login-spinner")
             lbtn.hide()
             spinner.show()

--- a/rundeckapp/src/main/groovy/rundeck/services/audit/AuditEventsService.groovy
+++ b/rundeckapp/src/main/groovy/rundeck/services/audit/AuditEventsService.groovy
@@ -8,6 +8,7 @@ import com.dtolabs.rundeck.core.plugins.configuration.Description
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.audit.AuditEventListener
 import com.dtolabs.rundeck.plugins.audit.AuditEventListenerPlugin
+import groovy.transform.PackageScope
 import org.apache.log4j.Logger
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.grails.web.util.WebUtils
@@ -280,11 +281,12 @@ class AuditEventsService
     /**
      * Extract the username from an authentication object.
      */
-    private static String extractUsername(Authentication authentication) {
-        if (!authentication) {
+    @PackageScope
+    static String extractUsername(Authentication authentication) {
+        if (!authentication || authentication.principal == "") {
             return null
         }
-        return authentication.name ?: authentication.principal.name ?: null
+        return authentication.name ?: authentication.principal?.name ?: null
     }
 
 

--- a/rundeckapp/src/main/groovy/rundeck/services/audit/AuditEventsService.groovy
+++ b/rundeckapp/src/main/groovy/rundeck/services/audit/AuditEventsService.groovy
@@ -283,10 +283,12 @@ class AuditEventsService
      */
     @PackageScope
     static String extractUsername(Authentication authentication) {
-        if (!authentication || authentication.principal == "") {
+        if (!authentication) {
             return null
         }
-        return authentication.name ?: authentication.principal?.name ?: null
+        if(authentication.name) return authentication.name
+        if(authentication.principal instanceof String) return authentication.principal
+        return authentication.principal?.name ?: null
     }
 
 

--- a/rundeckapp/src/test/groovy/rundeck/services/audit/AuditEventsServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/audit/AuditEventsServiceSpec.groovy
@@ -5,12 +5,27 @@ import com.dtolabs.rundeck.core.audit.AuditEvent
 import com.dtolabs.rundeck.core.audit.ResourceTypes
 import com.dtolabs.rundeck.plugins.audit.AuditEventListener
 import grails.testing.services.ServiceUnitTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import rundeck.services.FrameworkService
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class AuditEventsServiceSpec extends Specification implements ServiceUnitTest<AuditEventsService> {
 
-    def cleanup() {
+    @Unroll
+    def "test extract username"() {
+        when:
+        def result = AuditEventsService.extractUsername(auth)
+
+        then:
+        expect == result
+
+        where:
+        expect  | auth
+        null    | null
+        null    | new UsernamePasswordAuthenticationToken(null,null)
+        null    | new UsernamePasswordAuthenticationToken("",null)
+        "admin"    | new UsernamePasswordAuthenticationToken("admin",null)
     }
 
     def "Test event builder data cloning"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/audit/AuditEventsServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/audit/AuditEventsServiceSpec.groovy
@@ -10,6 +10,8 @@ import rundeck.services.FrameworkService
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.security.Principal
+
 class AuditEventsServiceSpec extends Specification implements ServiceUnitTest<AuditEventsService> {
 
     @Unroll
@@ -24,8 +26,14 @@ class AuditEventsServiceSpec extends Specification implements ServiceUnitTest<Au
         expect  | auth
         null    | null
         null    | new UsernamePasswordAuthenticationToken(null,null)
-        null    | new UsernamePasswordAuthenticationToken("",null)
-        "admin"    | new UsernamePasswordAuthenticationToken("admin",null)
+        ""      | new UsernamePasswordAuthenticationToken("",null)
+        "admin" | new UsernamePasswordAuthenticationToken("admin",null)
+        "admin" | new UsernamePasswordAuthenticationToken(new Principal() {
+            @Override
+            String getName() {
+                return "admin"
+            }
+        }, null)
     }
 
     def "Test event builder data cloning"() {


### PR DESCRIPTION
Disallows submitting the login form with an empty username.
Login toggles a spinner to replace the login button so multiple form submissions cannot be attempted.
