### PR TITLE
project storage SPI

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/BaseFileResourceModelSource.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/BaseFileResourceModelSource.java
@@ -49,7 +49,7 @@ import java.nio.file.Files;
  * <ul>
  * <li>{@link #getResourceFormat()}</li>
  * <li>{@link #getDocumentFileExtension()}</li>
- * <li>{@link #writeFileData(InputStream)}</li>
+ * <li>{@link #writeFileData(long, InputStream)}</li>
  * <li>{@link #openFileDataInputStream()}</li>
  * </ul>
  *
@@ -124,7 +124,7 @@ public abstract class BaseFileResourceModelSource implements ResourceModelSource
 
     /**
      * Writes the data to a temp file, and attempts to parser it, then if successful it will
-     * call {@link #writeFileData(InputStream)} to invoke the sub class
+     * call {@link #writeFileData(long, InputStream)} to invoke the sub class
      *
      * @param data data
      *
@@ -156,7 +156,7 @@ public abstract class BaseFileResourceModelSource implements ResourceModelSource
                 throw new ResourceModelSourceException(e);
             }
             try (FileInputStream tempStream = new FileInputStream(temp)) {
-                return writeFileData(tempStream);
+                return writeFileData(temp.length(), tempStream);
             }
         } finally {
             temp.delete();
@@ -167,12 +167,23 @@ public abstract class BaseFileResourceModelSource implements ResourceModelSource
      * Write the file data from the inputstream to the backing store
      *
      * @param tempStream input stream
-     *
      * @return bytes writen
-     *
      * @throws IOException
      */
     public abstract long writeFileData(final InputStream tempStream) throws IOException;
+
+    /**
+     * Write the file data from the inputstream to the backing store, this implementation calls {@link
+     * #writeFileData(InputStream)} but can be overridden
+     *
+     * @param length     data length
+     * @param tempStream input stream
+     * @return bytes writen
+     * @throws IOException
+     */
+    protected long writeFileData(final long length, final InputStream tempStream) throws IOException {
+        return writeFileData(tempStream);
+    }
 
     /**
      * @return an input stream that reads the data from the backing store

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/FileResourceModelSource.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/FileResourceModelSource.java
@@ -16,10 +16,10 @@
 
 /*
 * FileResourceModelSource.java
-* 
+*
 * User: Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
 * Created: 7/19/11 11:28 AM
-* 
+*
 */
 package com.dtolabs.rundeck.core.resources;
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/ResourceModelSourceFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/ResourceModelSourceFactory.java
@@ -24,6 +24,7 @@
 package com.dtolabs.rundeck.core.resources;
 
 import com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException;
+import org.rundeck.app.spi.Services;
 
 import java.util.Properties;
 
@@ -34,9 +35,24 @@ import java.util.Properties;
  */
 public interface ResourceModelSourceFactory {
     /**
-     * @return a resource model source for the given configuration
      * @param configuration configuration data
+     * @return a resource model source for the given configuration
      * @throws ConfigurationException on configuration error
      */
     public ResourceModelSource createResourceModelSource(Properties configuration) throws ConfigurationException;
+
+    /**
+     * Create a ResourceModelSource, the default implementation calls {@link #createResourceModelSource(Properties)}
+     *
+     * @param services      available services
+     * @param configuration configuration
+     * @return ResourceModelSource
+     * @throws ConfigurationException on error
+     */
+    default public ResourceModelSource createResourceModelSource(Services services, Properties configuration)
+            throws ConfigurationException
+    {
+        return createResourceModelSource(configuration);
+    }
+
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/format/ResourceFormats.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/format/ResourceFormats.java
@@ -1,0 +1,24 @@
+package com.dtolabs.rundeck.core.resources.format;
+
+import org.rundeck.app.spi.AppService;
+
+/**
+ * Provides service level access to Rundeck Resource Formats
+ */
+public interface ResourceFormats
+        extends AppService
+{
+    /**
+     * @param format format name
+     * @return parser for resource format
+     * @throws UnsupportedFormatException if format is not supported
+     */
+    ResourceFormatParser getResourceFormatParser(String format) throws UnsupportedFormatException;
+
+    /**
+     * @param format format name
+     * @return generator for resource format
+     * @throws UnsupportedFormatException if format is not supported
+     */
+    ResourceFormatGenerator getResourceFormatGenerator(String format) throws UnsupportedFormatException;
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/storage/StorageTreeFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/storage/StorageTreeFactory.java
@@ -82,6 +82,16 @@ public class StorageTreeFactory {
         return StorageUtil.asStorageTree(buildTree(configuration));
     }
 
+    /**
+     * Create a tree mapped to a subtree of the given storage tree
+     * @param storageTree storage tree
+     * @param subpath subpath
+     * @return StorageTree view onto the subpath
+     */
+    public static StorageTree subTree(StorageTree storageTree, String subpath){
+        return StorageUtil.asStorageTree(TreeBuilder.subPathTree(storageTree, PathUtil.asPath(subpath)));
+    }
+
     private Tree<ResourceMeta> buildTree(Map<String,String> config) {
         if(null==config) {
             config = new HashMap<String, String>();

--- a/core/src/main/java/com/dtolabs/rundeck/core/storage/StorageUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/storage/StorageUtil.java
@@ -163,9 +163,11 @@ public class StorageUtil {
     }
 
     static Date parseDate(String s, Date defval) {
-        try {
-            return w3cDateFormat.get().parse(s);
-        } catch (ParseException ignored) {
+        if(null!=s){
+            try {
+                return w3cDateFormat.get().parse(s);
+            } catch (ParseException ignored) {
+            }
         }
         return defval;
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/storage/projects/ProjectStorageTree.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/storage/projects/ProjectStorageTree.java
@@ -1,0 +1,17 @@
+package com.dtolabs.rundeck.core.storage.projects;
+
+import com.dtolabs.rundeck.core.storage.StorageTree;
+import org.rundeck.app.spi.AppService;
+
+/**
+ * Access to the StorageTree associated with a Project, may be a subtree view of the Project's full tree
+ */
+public interface ProjectStorageTree
+        extends StorageTree, AppService
+{
+    String getProject();
+
+    static ProjectStorageTree withTree(StorageTree tree, String project) {
+        return new ProjectStorageTreeImpl(tree, project);
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/storage/projects/ProjectStorageTreeImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/storage/projects/ProjectStorageTreeImpl.java
@@ -1,0 +1,23 @@
+package com.dtolabs.rundeck.core.storage.projects;
+
+import com.dtolabs.rundeck.core.storage.ResourceMeta;
+import com.dtolabs.rundeck.core.storage.StorageTreeImpl;
+import lombok.Getter;
+import org.rundeck.storage.api.Tree;
+
+public class ProjectStorageTreeImpl
+        extends StorageTreeImpl
+        implements ProjectStorageTree
+{
+
+    @Getter private final String project;
+
+    public ProjectStorageTreeImpl(
+            final Tree<ResourceMeta> delegate,
+            final String project
+    )
+    {
+        super(delegate);
+        this.project = project;
+    }
+}

--- a/core/src/main/java/org/rundeck/app/spi/Services.java
+++ b/core/src/main/java/org/rundeck/app/spi/Services.java
@@ -37,4 +37,31 @@ public interface Services {
     default <T extends AppService> T getService(Class<T> type) {
         throw new IllegalStateException("Required service " + type.getName() + " was not available");
     }
+
+    /**
+     * @return combined services
+     */
+    default Services combine(Services other) {
+        return Services.combine(this, other);
+    }
+
+    /**
+     * @return Combined Services
+     */
+    static Services combine(Services a, Services b) {
+        return new Services() {
+            @Override
+            public boolean hasService(final Class<? extends AppService> type) {
+                return a.hasService(type) || b.hasService(type);
+            }
+
+            @Override
+            public <T extends AppService> T getService(final Class<T> type) {
+                if (a.hasService(type)) {
+                    return a.getService(type);
+                }
+                return b.getService(type);
+            }
+        };
+    }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/common/ProjectNodeSupportSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/common/ProjectNodeSupportSpec.groovy
@@ -105,8 +105,8 @@ class ProjectNodeSupportSpec extends Specification {
         def generatorService = new ResourceFormatGeneratorService(framework)
         def sourceService = new ResourceModelSourceService(framework)
 
-        def factory = { String type, Properties props ->
-            sourceService.getCloseableSourceForConfiguration(type, props)
+        def factory = { ProjectNodeSupport.SourceDefinition defe ->
+            sourceService.getCloseableSourceForConfiguration(defe.type, defe.properties)
         }
         def support = new ProjectNodeSupport(config, generatorService, sourceService, factory)
 

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/storage/StorageUtilSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/storage/StorageUtilSpec.groovy
@@ -1,0 +1,35 @@
+package com.dtolabs.rundeck.core.storage
+
+import spock.lang.Specification
+
+class StorageUtilSpec extends Specification {
+    def "parse date null value should return null"() {
+        given:
+            def content = StorageUtil.withStream(new ByteArrayInputStream(''.bytes), [:])
+        expect:
+            content.modificationTime == null
+            content.creationTime == null
+    }
+
+    def "parse date result"() {
+        given:
+            Date date = new Date(39393939000)
+            Date date2 = new Date(12312312000)
+            def content = StorageUtil.withStream(
+                new ByteArrayInputStream(''.bytes), [
+                (StorageUtil.RES_META_RUNDECK_CONTENT_MODIFY_TIME)  : StorageUtil.formatDate(date),
+                (StorageUtil.RES_META_RUNDECK_CONTENT_CREATION_TIME): StorageUtil.formatDate(date2),
+            ]
+            )
+        expect:
+            content.modificationTime == date
+            content.creationTime == date2
+    }
+
+    def "content length null value should return null"() {
+        given:
+            def content = StorageUtil.withStream(new ByteArrayInputStream(''.bytes), [:])
+        expect:
+            content.contentLength == -1
+    }
+}

--- a/core/src/test/java/com/dtolabs/rundeck/core/resources/TestFileResourceModelSource.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/resources/TestFileResourceModelSource.java
@@ -16,10 +16,10 @@
 
 /*
 * TestFileNodesProvider.java
-* 
+*
 * User: Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
 * Created: 7/21/11 9:08 AM
-* 
+*
 */
 package com.dtolabs.rundeck.core.resources;
 
@@ -65,7 +65,7 @@ public class TestFileResourceModelSource extends AbstractBaseTest {
         File projectdir = new File(getFrameworkProjectsBase(), PROJ_NAME);
         FileUtils.deleteDir(projectdir);
     }
-/*
+
     public void testConfigureProperties() throws Exception {
         final FileResourceModelSource fileNodesProvider = new FileResourceModelSource(getFrameworkInstance());
         try {
@@ -127,7 +127,7 @@ public class TestFileResourceModelSource extends AbstractBaseTest {
             fail("unexpected failure");
         }
 
-        
+
         props.setProperty("format", "resourcexml");
         config = new FileResourceModelSource.Configuration(props);
         //validation should succeed
@@ -531,7 +531,7 @@ public class TestFileResourceModelSource extends AbstractBaseTest {
         } catch (ResourceModelSourceException e) {
             assertTrue(e.getMessage().contains("File does not exist: " + dneFile.getAbsolutePath()));
         }
-    }*/
+    }
 
     public void testGetNodesWritableEmpty() throws Exception {
         Properties props = new Properties();

--- a/rundeck-storage/rundeck-storage-conf/src/main/java/org/rundeck/storage/conf/PrefixPathTree.java
+++ b/rundeck-storage/rundeck-storage-conf/src/main/java/org/rundeck/storage/conf/PrefixPathTree.java
@@ -1,0 +1,50 @@
+package org.rundeck.storage.conf;
+
+import org.rundeck.storage.api.ContentMeta;
+import org.rundeck.storage.api.Path;
+import org.rundeck.storage.api.PathUtil;
+import org.rundeck.storage.api.Tree;
+
+/**
+ * SelectiveTree that Maps resources into a delegate, that appends a path prefix to requests.
+ *
+ * This provides a root tree mapped to a subpath in the delegate.
+ *
+ * <ul>
+ *     <li>Input Path: <pre>a/b</pre></li>
+ *     <li>Path used for delegate: <pre>${pathPrefix}/a/b</pre></li>
+ * </ul>
+ * @param <T>
+ */
+public class PrefixPathTree<T extends ContentMeta>
+        extends SubPathTree<T>
+        implements SelectiveTree<T>
+{
+
+    public PrefixPathTree(final Tree<T> delegate, final String pathPrefix) {
+        super(delegate, pathPrefix, false);
+    }
+
+    public PrefixPathTree(
+            final Tree<T> delegate,
+            final Path rootPath
+    )
+    {
+        super(delegate, rootPath, false);
+    }
+
+    @Override
+    protected boolean isLocalRoot(final Path path) {
+        return PathUtil.isRoot(path);
+    }
+
+    @Override
+    protected String translatePathInternal(final String extpath) {
+        return PathUtil.appendPath(rootPath.getPath(), extpath);
+    }
+
+    @Override
+    protected String translatePathExternal(final String intpath) {
+        return PathUtil.removePrefix(rootPath.getPath(), intpath);
+    }
+}

--- a/rundeck-storage/rundeck-storage-conf/src/main/java/org/rundeck/storage/conf/SubPathTree.java
+++ b/rundeck-storage/rundeck-storage-conf/src/main/java/org/rundeck/storage/conf/SubPathTree.java
@@ -28,6 +28,13 @@ import java.util.Set;
 
 /**
  * SelectiveTree that Maps resources into a delegate, and can optionally remove the path prefix before transfering
+ *
+ * This provides a sub path mapped to the root of the delegate.
+ *
+ * <ul>
+ *     <li>Input Path: <pre>${rootPath}/a/b</pre></li>
+ *     <li>Path used for delegate: <pre>a/b</pre></li>
+ * </ul>
  */
 public class SubPathTree<T extends ContentMeta> extends DelegateTree<T> implements SelectiveTree<T> {
     Path rootPath;
@@ -58,7 +65,12 @@ public class SubPathTree<T extends ContentMeta> extends DelegateTree<T> implemen
         return PathUtil.asPath(translatePathInternal(extpath.getPath()));
     }
 
-    private String translatePathInternal(String extpath) {
+    /**
+     * Translate external path into internal path for the delegate
+     * @param extpath externally requested path
+     * @return internal path
+     */
+    protected String translatePathInternal(String extpath) {
         if (fullPath) {
             return extpath;
         } else {
@@ -66,8 +78,8 @@ public class SubPathTree<T extends ContentMeta> extends DelegateTree<T> implemen
         }
     }
 
-    private Path translatePathExternal(Path extpath) {
-        return PathUtil.asPath(translatePathExternal(extpath.getPath()));
+    private Path translatePathExternal(Path intpath) {
+        return PathUtil.asPath(translatePathExternal(intpath.getPath()));
     }
 
     /**
@@ -77,7 +89,7 @@ public class SubPathTree<T extends ContentMeta> extends DelegateTree<T> implemen
      *
      * @return
      */
-    private String translatePathExternal(String intpath) {
+    protected String translatePathExternal(String intpath) {
         if (fullPath) {
             return intpath;
         } else {
@@ -100,7 +112,7 @@ public class SubPathTree<T extends ContentMeta> extends DelegateTree<T> implemen
         return isLocalRoot(path) || super.hasDirectory(translatePathInternal(path));
     }
 
-    private boolean isLocalRoot(Path path) {
+    protected boolean isLocalRoot(Path path) {
         return PathUtil.isRoot(PathUtil.removePrefix(rootPath.getPath(), path.getPath()));
     }
 

--- a/rundeck-storage/rundeck-storage-conf/src/main/java/org/rundeck/storage/conf/TreeBuilder.java
+++ b/rundeck-storage/rundeck-storage-conf/src/main/java/org/rundeck/storage/conf/TreeBuilder.java
@@ -59,6 +59,19 @@ public class TreeBuilder<T extends ContentMeta> {
     }
 
     /**
+     * Return a new tree which accesses the base tree at the given subpath, as a root tree.
+     *
+     * @param base base tree
+     * @param <T>  content type
+     * @param subpath path
+     *
+     * @return root view of the subpath
+     */
+    public static <T extends ContentMeta> Tree<T> subPathTree(Tree<T> base, Path subpath) {
+        return new PrefixPathTree<T>(base, subpath);
+    }
+
+    /**
      * Set the base tree to be extended
      *
      * @param base base tree

--- a/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/PrefixPathTreeSpec.groovy
+++ b/rundeck-storage/rundeck-storage-conf/src/test/groovy/org/rundeck/storage/conf/PrefixPathTreeSpec.groovy
@@ -1,0 +1,228 @@
+package org.rundeck.storage.conf
+
+import org.rundeck.storage.api.Resource
+import org.rundeck.storage.data.MemoryTree
+import spock.lang.Specification
+
+import static org.rundeck.storage.data.DataUtil.dataWithText
+
+class PrefixPathTreeSpec extends Specification {
+
+    def "createResource then path prefix is added in underlying storage"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+        when:
+            def res=sub.createResource("abc/def", dataWithText('test data'))
+            def res2=mem.createResource("test/path/abc/def2", dataWithText('test data2'))
+        then:
+            res.path.path=='abc/def'
+            res2.path.path == 'test/path/abc/def2'
+            mem.hasResource("test/path/abc/def")
+            !mem.hasResource("abc/def")
+            sub.hasResource("abc/def")
+
+            mem.hasResource("test/path/abc/def2")
+            !mem.hasResource("abc/def2")
+            sub.hasResource("abc/def2")
+    }
+
+    def "hasDirectory then path prefix is removed"() {
+        given:
+            def mem = new MemoryTree()
+            def sup = new PrefixPathTree(mem, "test/path")
+        when:
+            def res = sup.createResource("abc/def", dataWithText( 'test data'))
+            def res2 = mem.createResource("abc2/def", dataWithText( 'test data2'))
+            def res3 = mem.createResource("test/path/abc3/def", dataWithText('test data2'))
+        then:
+
+            sup.hasDirectory("abc")
+            !sup.hasDirectory("abc2")
+            sup.hasDirectory("abc3")
+            !sup.hasDirectory("test/path")
+
+            !mem.hasDirectory("abc")
+            mem.hasDirectory("test/path/abc")
+            mem.hasDirectory("abc2")
+            !mem.hasDirectory("abc3")
+            mem.hasDirectory("test/path")
+    }
+
+    def "getResource then path prefix is added"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+        when:
+            def res2 = sub.createResource("abc2/def", dataWithText('test data2'))
+            def res3 = mem.createResource("test/path/abc3/def", dataWithText( 'test data3'))
+        then:
+            null!=sub.getResource("abc2/def")
+            null!=sub.getResource("abc3/def")
+    }
+    def "hasPath root and backing tree is empty"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+        when:
+            def res2 = sub.hasPath("/")
+        then:
+            res2
+    }
+    def "hasPath root and backing tree has resource"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+            def memres = mem.createResource("test/path", dataWithText( 'test data2'))
+        when:
+            def res2 = sub.hasPath("/")
+        then:
+            res2
+    }
+    def "hasResource root is false and backing tree is empty"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+        when:
+            def res2 = sub.hasResource("/")
+        then:
+            !res2
+    }
+    def "hasResource root is false and backing tree has resource"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+            def memres = mem.createResource("test/path", dataWithText( 'test data2'))
+        when:
+            def res2 = sub.hasResource("/")
+        then:
+            !res2
+    }
+    def "hasDirectory root is true and backing tree is empty"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+        when:
+            def res2 = sub.hasDirectory("/")
+        then:
+            res2
+    }
+    def "hasDirectory root is true and backing tree has resource"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+            def memres = mem.createResource("test/path", dataWithText( 'test data2'))
+        when:
+            def res2 = sub.hasDirectory("/")
+        then:
+            res2
+    }
+    def "getResource root and backing tree is empty is illegal argument"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+        when:
+            def res2 = sub.getResource("/")
+        then:
+            IllegalArgumentException e = thrown()
+            e!=null
+    }
+    def "getResource root and backing tree has resource is illegal argument"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+            def memres = mem.createResource("test/path", dataWithText( 'test data2'))
+        when:
+            def res2 = sub.getResource("test/path")
+        then:
+            IllegalArgumentException e = thrown()
+            e!=null
+    }
+    def "getPath root and backing tree is empty is a directory"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+        when:
+            def res2 = sub.getPath("/")
+        then:
+            res2!=null
+            res2.isDirectory()
+    }
+    def "getPath root and backing tree has resource is a directory"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+            def memres = mem.createResource("test/path", dataWithText( 'test data2'))
+        when:
+            def res2 = sub.getPath("/")
+        then:
+            res2!=null
+            res2.isDirectory()
+    }
+    def "listDirectory root and backing tree is empty is empty list"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+        when:
+            def res2 = sub.listDirectory("/")
+        then:
+            res2!=null
+            res2.size()==0
+    }
+    def "listDirectory root and backing tree has resource is empty list"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+            def memres = mem.createResource("test/path", dataWithText( 'test data2'))
+        when:
+            def res2 = sub.listDirectory("/")
+        then:
+            res2!=null
+            res2.size()==0
+    }
+
+    def "listResourceDirectory then path prefix is removed"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+        when:
+            def res2 = sub.createResource("abc2/def", dataWithText('test data2'))
+            def res3 = mem.createResource("test/path/abc2/def2", dataWithText('test data3'))
+            def res4 = mem.createResource("abc2/def3", dataWithText( 'test data3'))
+            Set<Resource> list = sub.listDirectoryResources("abc2")
+            Set<String> names = list.path*.name
+            Set<String> paths = list.path*.path
+        then:
+            list.size() == 2
+            'def' in names
+            'def2' in names
+            'abc2/def' in paths
+            'abc2/def2' in paths
+    }
+
+    def "deleteResource then path prefix is removed"() {
+        given:
+            def mem = new MemoryTree()
+            def sub = new PrefixPathTree(mem, "test/path")
+            def res2 = sub.createResource("abc2/def", dataWithText('test data2'))
+            def res4 = mem.createResource("test/path/abc2/def2", dataWithText('test data3'))
+            def res5 = mem.createResource("abc2/def3", dataWithText('test data3'))
+        when:
+            boolean deleted = sub.deleteResource("abc2/def")
+            boolean deleted2 = sub.deleteResource("abc2/def2")
+            boolean deleted3 = sub.deleteResource("abc2/def3")
+        then:
+            deleted
+            deleted2
+            !deleted3
+            !sub.hasPath("abc2/def")
+            !sub.hasPath("abc2/def2")
+            !sub.hasPath("abc2/def3")
+            !mem.hasPath("test/path/abc2/def")
+            !mem.hasPath("abc2/def")
+            !mem.hasPath("test/path/abc2/def2")
+            !mem.hasPath("abc2/def2")
+            !mem.hasPath("test/path/abc2/def3")
+            mem.hasPath("abc2/def3")
+    }
+}

--- a/rundeck-storage/rundeck-storage-data/src/main/java/org/rundeck/storage/data/DataUtil.java
+++ b/rundeck-storage/rundeck-storage-data/src/main/java/org/rundeck/storage/data/DataUtil.java
@@ -22,6 +22,7 @@ import org.rundeck.storage.api.HasInputStream;
 import org.rundeck.storage.api.PathUtil;
 
 import java.io.*;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -78,7 +79,7 @@ public class DataUtil {
     }
 
     public static <T extends ContentMeta> T withStream(InputStream source, ContentFactory<T> factory) {
-        return withStream(source, null, factory);
+        return withStream(source, new HashMap<>(), factory);
     }
 
     /**

--- a/rundeck-storage/rundeck-storage-data/src/test/groovy/org/rundeck/storage/data/DataUtilSpec.groovy
+++ b/rundeck-storage/rundeck-storage-data/src/test/groovy/org/rundeck/storage/data/DataUtilSpec.groovy
@@ -1,0 +1,14 @@
+package org.rundeck.storage.data
+
+import spock.lang.Specification
+
+class DataUtilSpec extends Specification {
+    def "with stream should have not-null metadata"() {
+        given:
+            def input = new ByteArrayInputStream('test'.bytes)
+        when:
+            def result = DataUtil.<DataContent> withStream(input, DataUtil.contentFactory())
+        then:
+            result.meta != null
+    }
+}

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -30,6 +30,7 @@ import com.dtolabs.rundeck.core.plugins.FilePluginCache
 import com.dtolabs.rundeck.core.plugins.JarPluginScanner
 import com.dtolabs.rundeck.core.plugins.PluginManagerService
 import com.dtolabs.rundeck.core.plugins.ScriptPluginScanner
+import com.dtolabs.rundeck.core.resources.format.ResourceFormats
 import com.dtolabs.rundeck.core.storage.AuthRundeckStorageTree
 import com.dtolabs.rundeck.core.storage.StorageTreeFactory
 import com.dtolabs.rundeck.core.utils.GrailsServiceInjectorJobListener
@@ -187,9 +188,10 @@ beans={
 
     rundeckSpiBaseServicesProvider(RundeckSpiBaseServicesProvider) {
         services = [
-                (ClusterInfoService)         : ref('clusterInfoService'),
-                (ApiInfo)                    : ref('rundeckApiInfoService'),
-                (ExecutionFileManagerService): ref('logFileStorageService')
+            (ClusterInfoService)         : ref('clusterInfoService'),
+            (ApiInfo)                    : ref('rundeckApiInfoService'),
+            (ExecutionFileManagerService): ref('logFileStorageService'),
+            (ResourceFormats)            : ref('pluginService')
         ]
     }
 

--- a/rundeckapp/grails-app/services/rundeck/services/ConfigStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ConfigStorageService.groovy
@@ -18,7 +18,9 @@ package rundeck.services
 
 import com.dtolabs.rundeck.core.storage.ResourceMeta
 import com.dtolabs.rundeck.core.storage.StorageTree
+import com.dtolabs.rundeck.core.storage.StorageTreeFactory
 import com.dtolabs.rundeck.core.storage.StorageUtil
+import com.dtolabs.rundeck.core.storage.projects.ProjectStorageTree
 import grails.transaction.Transactional
 import org.apache.commons.fileupload.util.Streams
 import org.rundeck.storage.api.PathUtil
@@ -165,5 +167,17 @@ class ConfigStorageService implements StorageManager {
     boolean deleteAllFileResources(String root) {
         def storagePath = root
         return StorageUtil.deletePathRecursive(getStorage(), PathUtil.asPath(storagePath))
+    }
+
+    /**
+     * Provides non-authorizing subtree for the given subpath
+     * @param subpath
+     * @return
+     */
+    public StorageTree storageTreeSubpath(String subpath) {
+        StorageTreeFactory.subTree(
+            rundeckConfigStorageTree,
+            subpath
+        )
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
@@ -60,6 +60,7 @@ class NodeService implements InitializingBean, ProjectConfigurable, IProjectNode
     def metricService
     def frameworkService
     def configurationService
+    def projectManagerService
     def pluginService
     def AsyncListenableTaskExecutor nodeTaskExecutor
 
@@ -224,15 +225,17 @@ class NodeService implements InitializingBean, ProjectConfigurable, IProjectNode
             rdprojectconfig,
             framework.getResourceFormatGeneratorService(),
             resourceModelSourceService,
-            { String type, Properties config ->
+            { ProjectNodeSupport.SourceDefinition definition ->
                 //load via pluginService to enable app-level plugins
                 def retained = pluginService.retainPlugin(
-                        type,
+                        definition.type,
                         resourceModelSourceService
                 )
                 if (null != retained) {
+                    //load services
+                    def services=projectManagerService.getNonAuthorizingProjectServices(project,"nodes/${definition.type}")
                     return retained.convert(
-                            ResourceModelSourceService.factoryConverter(config)
+                            ResourceModelSourceService.factoryConverter(services, definition.properties)
                     )
                 } else {
                     return null

--- a/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
@@ -27,6 +27,7 @@ import com.dtolabs.rundeck.core.nodes.ProjectNodeService
 import com.dtolabs.rundeck.core.plugins.CloseableProvider
 import com.dtolabs.rundeck.core.plugins.Closeables
 import com.dtolabs.rundeck.core.plugins.configuration.Property
+import com.dtolabs.rundeck.core.resources.ResourceModelSource
 import com.dtolabs.rundeck.core.resources.ResourceModelSourceFactory
 import com.dtolabs.rundeck.core.resources.ResourceModelSourceService
 import com.dtolabs.rundeck.core.resources.SourceFactory
@@ -231,7 +232,11 @@ class NodeService implements InitializingBean, ProjectConfigurable, IProjectNode
                 )
                 if (null != retained) {
                     //load services
-                    def services=projectManagerService.getNonAuthorizingProjectServices(project,"nodes/${definition.type}")
+                    def services = projectManagerService.getNonAuthorizingProjectServicesForPlugin(
+                        project,
+                        ServiceNameConstants.ResourceModelSource,
+                        definition.type
+                    )
                     return retained.convert(
                             ResourceModelSourceService.factoryConverter(services, definition.properties)
                     )

--- a/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
@@ -41,6 +41,7 @@ import com.google.common.cache.RemovalNotification
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.ListenableFutureTask
+import org.rundeck.app.spi.Services
 import org.rundeck.core.projects.ProjectConfigurable
 import org.rundeck.core.projects.ProjectPluginListConfigurable
 import org.springframework.beans.factory.InitializingBean
@@ -64,6 +65,7 @@ class NodeService implements InitializingBean, ProjectConfigurable, IProjectNode
     def projectManagerService
     def pluginService
     def AsyncListenableTaskExecutor nodeTaskExecutor
+    def Services rundeckSpiBaseServicesProvider
 
     @Override
     Map<String, String> getCategories() {
@@ -238,7 +240,10 @@ class NodeService implements InitializingBean, ProjectConfigurable, IProjectNode
                         definition.type
                     )
                     return retained.convert(
-                            ResourceModelSourceService.factoryConverter(services, definition.properties)
+                        ResourceModelSourceService.factoryConverter(
+                            rundeckSpiBaseServicesProvider.combine(services),
+                            definition.properties
+                        )
                     )
                 } else {
                     return null

--- a/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
@@ -64,8 +64,6 @@ class NodeService implements InitializingBean, ProjectConfigurable, IProjectNode
     def pluginService
     def AsyncListenableTaskExecutor nodeTaskExecutor
 
-    String category='resourceModelSource'
-
     @Override
     Map<String, String> getCategories() {
         [enabled: 'resourceModelSource', delay: 'resourceModelSource', firstLoadSynch: 'resourceModelSource']

--- a/rundeckapp/grails-app/services/rundeck/services/PluginService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/PluginService.groovy
@@ -29,6 +29,10 @@ import com.dtolabs.rundeck.core.plugins.configuration.Validator
 import com.dtolabs.rundeck.core.plugins.ConfiguredPlugin
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
 import com.dtolabs.rundeck.core.plugins.PluginRegistry
+import com.dtolabs.rundeck.core.resources.format.ResourceFormatGenerator
+import com.dtolabs.rundeck.core.resources.format.ResourceFormatParser
+import com.dtolabs.rundeck.core.resources.format.ResourceFormats
+import com.dtolabs.rundeck.core.resources.format.UnsupportedFormatException
 import com.dtolabs.rundeck.plugins.ServiceTypes
 import com.dtolabs.rundeck.plugins.storage.StoragePlugin
 import com.dtolabs.rundeck.server.plugins.RenamedDescription
@@ -36,7 +40,7 @@ import com.dtolabs.rundeck.core.plugins.ValidatedPlugin
 import groovy.transform.CompileStatic
 
 @CompileStatic
-class PluginService {
+class PluginService implements ResourceFormats {
 
     def PluginRegistry rundeckPluginRegistry
     def FrameworkService frameworkService
@@ -458,4 +462,21 @@ class PluginService {
 
         plugins
     }
+
+    ResourceFormatParser getResourceFormatParser(String format) {
+        def parser = getPlugin(format, ResourceFormatParser)
+        if (!parser) {
+            throw new UnsupportedFormatException("Unsupported format: " + format)
+        }
+        parser
+    }
+
+    ResourceFormatGenerator getResourceFormatGenerator(String format) {
+        def generator = getPlugin(format, ResourceFormatGenerator)
+        if (!generator) {
+            throw new UnsupportedFormatException("Unsupported format: " + format)
+        }
+        generator
+    }
+
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -116,6 +116,20 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
         )
     }
 
+    String getProjectPluginStorageSubpath(String service, String provider){
+        "plugins/${service}/${provider}"
+    }
+
+    /**
+     * Create a services provider for the config storage tree for the given project, accessing only the given path
+     * @param project project name
+     * @param subpath subpath
+     * @return
+     */
+    Services getNonAuthorizingProjectServicesForPlugin(String project, String service, String provider) {
+        getNonAuthorizingProjectServices(project,getProjectPluginStorageSubpath(service, provider))
+    }
+
     /**
      * Create a services provider for the config storage tree for the given project, accessing only the given path
      * @param project project name

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -50,6 +50,7 @@ import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.ListenableFutureTask
 import grails.gorm.transactions.Transactional
 import org.apache.commons.fileupload.util.Streams
+import org.rundeck.app.spi.RundeckSpiBaseServicesProvider
 import org.rundeck.app.spi.Services
 import org.rundeck.storage.api.PathUtil
 import org.rundeck.storage.api.Resource

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -299,7 +299,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
 
 
     boolean existsProjectFileResource(String projectName, String path) {
-        def storagePath = "projects/" + projectName + (path.startsWith("/")?path:"/${path}")
+        def storagePath = projectStorageSubpath(projectName, path)
         return getStorage().hasResource(storagePath)
     }
     boolean existsProjectDirResource(String projectName, String path) {
@@ -312,14 +312,14 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
     }
 
     Resource<ResourceMeta> getProjectFileResource(String projectName, String path) {
-        def storagePath = "projects/" + projectName + (path.startsWith("/")?path:"/${path}")
+        def storagePath = projectStorageSubpath(projectName, path)
         if (!getStorage().hasResource(storagePath)) {
             return null
         }
         getStorage().getResource(storagePath)
     }
     long readProjectFileResource(String projectName, String path, OutputStream output) {
-        def storagePath = "projects/" + projectName + (path.startsWith("/")?path:"/${path}")
+        def storagePath = projectStorageSubpath(projectName, path)
         def resource = getStorage().getResource(storagePath)
         Streams.copy(resource.contents.inputStream,output,false)
     }
@@ -373,7 +373,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
      * @return resource
      */
     Resource<ResourceMeta> updateProjectFileResource(String projectName, String path, InputStream input, Map<String,String> meta) {
-        def storagePath = "projects/" + projectName + (path.startsWith("/")?path:"/${path}")
+        def storagePath = projectStorageSubpath(projectName, path)
         def res=getStorage().
                 updateResource(storagePath, DataUtil.withStream(input, meta, StorageUtil.factory()))
         sourceCache.invalidate(ProjectFile.of(projectName, path))
@@ -388,7 +388,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
      * @return resource
      */
     Resource<ResourceMeta> createProjectFileResource(String projectName, String path, InputStream input, Map<String,String> meta) {
-        def storagePath = "projects/" + projectName + (path.startsWith("/")?path:"/${path}")
+        def storagePath = projectStorageSubpath(projectName, path)
 
         def res=getStorage().
                 createResource(storagePath, DataUtil.withStream(input, meta, StorageUtil.factory()))
@@ -404,7 +404,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
      * @return resource
      */
     Resource<ResourceMeta> writeProjectFileResource(String projectName, String path, InputStream input, Map<String,String> meta) {
-        def storagePath = "projects/" + projectName + (path.startsWith("/")?path:"/${path}")
+        def storagePath = projectStorageSubpath(projectName, path)
         fileCache.invalidate(ProjectFile.of(projectName, path))
         if (!getStorage().hasResource(storagePath)) {
             createProjectFileResource(projectName, path, input, meta)
@@ -419,7 +419,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
      * @return true if file was deleted or does not exist
      */
     boolean deleteProjectFileResource(String projectName, String path) {
-        def storagePath = "projects/" + projectName + (path.startsWith("/")?path:"/${path}")
+        def storagePath = projectStorageSubpath(projectName, path)
         sourceCache.invalidate(ProjectFile.of(projectName, path))
         fileCache.invalidate(ProjectFile.of(projectName, path))
         if (!getStorage().hasResource(storagePath)) {

--- a/rundeckapp/src/test/groovy/org/rundeck/app/authorization/RundeckAuthorizedServicesProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/authorization/RundeckAuthorizedServicesProviderSpec.groovy
@@ -17,8 +17,12 @@
 package org.rundeck.app.authorization
 
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import com.dtolabs.rundeck.core.execution.NodeExecutionService
+import com.dtolabs.rundeck.core.execution.logstorage.AsyncExecutionFileLoaderService
+import com.dtolabs.rundeck.core.execution.logstorage.ExecutionFileLoaderService
 import com.dtolabs.rundeck.core.jobs.JobService
 import com.dtolabs.rundeck.core.storage.keys.KeyStorageTree
+import org.rundeck.app.spi.AppService
 import org.rundeck.app.spi.Services
 import org.rundeck.app.spi.ServicesProvider
 import rundeck.services.JobStateService
@@ -27,6 +31,9 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class RundeckAuthorizedServicesProviderSpec extends Specification {
+    static interface OtherService extends AppService{
+
+    }
     def "get services with auth context"() {
         given:
             def sut = new RundeckAuthorizedServicesProvider()
@@ -47,7 +54,9 @@ class RundeckAuthorizedServicesProviderSpec extends Specification {
         given:
             def sut = new RundeckAuthorizedServicesProvider()
             sut.baseServices = Mock(ServicesProvider) {
-                getServices() >> Mock(Services)
+                getServices() >> Mock(Services){
+                    _ * hasService(OtherService)>>true
+                }
             }
             sut.jobStateService = Mock(JobStateService)
             sut.storageService = Mock(StorageService)
@@ -61,6 +70,7 @@ class RundeckAuthorizedServicesProviderSpec extends Specification {
             service        | _
             KeyStorageTree | _
             JobService     | _
+            OtherService   | _
     }
 
     @Unroll
@@ -76,7 +86,9 @@ class RundeckAuthorizedServicesProviderSpec extends Specification {
 
             def sut = new RundeckAuthorizedServicesProvider()
             sut.baseServices = Mock(ServicesProvider) {
-                getServices() >> Mock(Services)
+                getServices() >> Stub(Services){
+                    getService(OtherService)>>Stub(OtherService)
+                }
             }
             sut.jobStateService = Mock(JobStateService) {
                 jobServiceWithAuthContext(auth) >> jobServiceMock

--- a/rundeckapp/src/test/groovy/rundeck/services/NodeServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NodeServiceSpec.groovy
@@ -29,6 +29,7 @@ import com.dtolabs.rundeck.core.resources.ResourceModelSourceService
 import com.dtolabs.rundeck.core.resources.format.ResourceFormatGenerator
 import com.dtolabs.rundeck.core.resources.format.ResourceFormatGeneratorService
 import grails.test.mixin.TestFor
+import org.rundeck.app.spi.Services
 import org.springframework.core.task.AsyncListenableTaskExecutor
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -83,6 +84,8 @@ class NodeServiceSpec extends Specification {
         def modelSourceFactory = Mock(ResourceModelSourceFactory)
         def modelSource = Mock(ResourceModelSource)
         service.pluginService = Mock(PluginService)
+        service.projectManagerService=Mock(ProjectManagerService)
+        service.rundeckSpiBaseServicesProvider = Mock(Services)
         when:
         def result = service.getNodes('test1')
         def nodes1 = result.getNodeSet()
@@ -98,8 +101,9 @@ class NodeServiceSpec extends Specification {
                 0 * getCloseableSourceForConfiguration('file', _) >> Closeables.closeableProvider(modelSource)
             }
         }
+        1 * service.projectManagerService.getNonAuthorizingProjectServicesForPlugin('test1','ResourceModelSource','file')
         1 * service.pluginService.retainPlugin('file', _) >> Closeables.closeableProvider(modelSourceFactory)
-        1 * modelSourceFactory.createResourceModelSource(_) >> modelSource
+        1 * modelSourceFactory.createResourceModelSource(_,_) >> modelSource
         _ * modelSource.getNodes() >> nodeSet
         null != nodes1.getNode('anode')
         nodes1.nodeNames as List == ['anode']
@@ -176,9 +180,12 @@ class NodeServiceSpec extends Specification {
         def modelSourceFactory = Mock(ResourceModelSourceFactory)
         service.pluginService = Mock(PluginService)
         1 * service.pluginService.retainPlugin('file', _) >> Closeables.closeableProvider(modelSourceFactory)
-        1 * modelSourceFactory.createResourceModelSource({args->
+        1 * modelSourceFactory.createResourceModelSource(_,{args->
             args['file']=='/tmp/test.xml'
         }) >> modelSource
+
+        service.projectManagerService=Mock(ProjectManagerService)
+        service.rundeckSpiBaseServicesProvider = Mock(Services)
         when:
         def result1 = service.getNodes('test1')
         def nodes1 = result1.getNodeSet()
@@ -414,9 +421,12 @@ class NodeServiceSpec extends Specification {
         }
         service.pluginService = Mock(PluginService)
         1 * service.pluginService.retainPlugin('file', _) >> Closeables.closeableProvider(modelSourceFactory)
-        1 * modelSourceFactory.createResourceModelSource({args->
+        1 * modelSourceFactory.createResourceModelSource(_,{args->
             args['file']=='/tmp/test.xml'
         }) >> modelSource
+
+        service.projectManagerService=Mock(ProjectManagerService)
+        service.rundeckSpiBaseServicesProvider = Mock(Services)
         when:
         def result1 = service.getNodes('test1')
         def nodes1 = result1.getNodeSet()


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

* Adds SPI interfaces: ProjectStorageTree, and ResourceFormats
   * ResourceFormats added to base services
* extends ResourceModelSourceFactory with a new default method `createResourceModelSource(Services,Properties)` allowing factory to receive Services instance
* Node service creates model sources with appropriate ProjectStorageTree spi instance and passes in Services 
