### PR TITLE
Clean up duplicate LogFileStorageRequest entries at startup

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
@@ -112,7 +112,7 @@ class ReportsController extends ControllerBase{
                     query2.setPagination(query)
                     query=query2
                     def props=query.properties
-                    params.putAll(props) 
+                    params.putAll(props)
                     usedFilter=params.filterName
                 }
             }
@@ -224,7 +224,7 @@ class ReportsController extends ControllerBase{
             return render(view: '/common/error', model: [beanErrors: query.errors])
         }
         def User u = userService.findOrCreateUser(session.user)
-        
+
         if(params.filterName){
             //load a named filter and create a query from it
             if(u){
@@ -370,14 +370,14 @@ class ReportsController extends ControllerBase{
                     map.jobGroup=job?.groupPath
                 }catch(Exception e){
                 }
-                if(map.execution.argString){
+                if(map.execution?.argString){
                     map.execution.jobArguments=FrameworkService.parseOptsFromString(map.execution.argString)
                 }
             }
             map.user= map.remove('author')
             map.executionString= map.remove('title')
-            return map
-        }
+            return map.execution?map:null
+        }.findAll{it}
 //        results.params=params
         results.query=null
 
@@ -581,7 +581,7 @@ class ReportsController extends ControllerBase{
             )
         }
     }
-   
+
 
     /**
      * API actions

--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -465,6 +465,7 @@ class BootStrap {
                  }
              }
 
+             logFileStorageService.cleanupDuplicates()
              def resumeMode = configurationService.getString("logFileStorageService.startup.resumeMode", "")
              if ('sync' == resumeMode) {
                  timer("logFileStorageService.resumeIncompleteLogStorage") {
@@ -512,7 +513,7 @@ class BootStrap {
      def destroy = {
          log.info("Rundeck Shutdown detected")
      }
-} 
+}
 
 
 

--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -834,8 +834,8 @@ class LogFileStorageService
 
         dupes.each{
             def execid=it[0]
-            def list = LogFileStorageRequest.executeQuery('select id,completed from LogFileStorageRequest where execution_id=?',[execid])
-            log.warn("Found duplicate LogFileStorageRequests for execution $execid: ${list}")
+            def list = LogFileStorageRequest.executeQuery('select id,completed from LogFileStorageRequest where execution_id=:eid',[eid:execid])
+            log.warn("Found duplicate LogFileStorageRequests for execution $execid: ${list*.getAt(0)}")
             //find first incomplete request to preserve
             def keep = list.find{!it[1]}
             if(!keep){
@@ -843,8 +843,8 @@ class LogFileStorageService
             }
             list.each{entry->
                 if (entry != keep) {
-                    LogFileStorageRequest.executeUpdate('delete from LogFileStorageRequest where id=?',[entry[0]])
-                    log.error("deleted LogFileStorageRequest id=${entry[0]}")
+                    LogFileStorageRequest.executeUpdate('delete from LogFileStorageRequest where id=:lid',[lid:entry[0]])
+                    log.warn("Deleted LogFileStorageRequest id=${entry[0]} for execution_id=${execid}")
                 }
             }
         }

--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -40,6 +40,8 @@ import com.dtolabs.rundeck.server.plugins.services.ExecutionFileStoragePluginPro
 import com.google.common.util.concurrent.Futures
 import grails.events.EventPublisher
 import org.hibernate.sql.JoinType
+import org.hibernate.type.IntegerType
+import org.hibernate.type.LongType
 import org.springframework.beans.factory.InitializingBean
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
@@ -815,6 +817,35 @@ class LogFileStorageService
                 failedRequests.remove(request.id)
                 failures.remove(request.id)
 
+            }
+        }
+    }
+    /**
+     * remove log file storage requests that are duplicates for an execution, retains 1 entry for an execution, either the
+     * first incomplete request found, or the first complete request found if no incomplete requests exist for an execution.
+     */
+    void cleanupDuplicates(){
+        def dupes = LogFileStorageRequest.createCriteria().list {
+            projections{
+                sqlGroupProjection 'execution_id, count(id) as dupecount', 'execution_id having count(execution_id) > 1', ['execution_id', 'dupecount'], [
+                    LongType.INSTANCE, IntegerType.INSTANCE]
+            }
+        }
+
+        dupes.each{
+            def execid=it[0]
+            def list = LogFileStorageRequest.executeQuery('select id,completed from LogFileStorageRequest where execution_id=?',[execid])
+            log.warn("Found duplicate LogFileStorageRequests for execution $execid: ${list}")
+            //find first incomplete request to preserve
+            def keep = list.find{!it[1]}
+            if(!keep){
+                keep=list.first()//keep 1
+            }
+            list.each{entry->
+                if (entry != keep) {
+                    LogFileStorageRequest.executeUpdate('delete from LogFileStorageRequest where id=?',[entry[0]])
+                    log.error("deleted LogFileStorageRequest id=${entry[0]}")
+                }
             }
         }
     }


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**

removes duplicate LogFileStorageRequest entries at bootstrap time

ref https://github.com/rundeck/rundeck/issues/5081

**Describe the solution you've implemented**

Find and remove any duplicate entries at startup.  Rundeck 3.2.5 and earlier had no unique constraint preventing duplicate LogFileStorageRequest entries from being created, which can occur in some conditions. Rundeck 3.2.6 added a constraint, which should prevent further duplicates from being created. However existing duplicates can still be a problem in a DB without manual removal.

This introduces a cleanup process at startup which can remove duplicates.

