### PR TITLE
Fixes empty job activity list and webhook RunJob plugin

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
@@ -148,7 +148,7 @@ class ReportsController extends ControllerBase{
         }
         if(params.includeJobRef && params.jobIdFilter){
             ScheduledExecution.withTransaction {
-                ScheduledExecution sched = params.jobIdFilter.toString().length() == 36 ? ScheduledExecution.findByUuid(params.jobIdFilter) : ScheduledExecution.get(params.jobIdFilter)
+                ScheduledExecution sched = !params.jobIdFilter.toString().isNumber() ? ScheduledExecution.findByUuid(params.jobIdFilter) : ScheduledExecution.get(params.jobIdFilter)
                 def list = ReferencedExecution.findAllByScheduledExecution(sched)
                 def include = []
                 list.each {refex ->

--- a/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
@@ -419,8 +419,11 @@ class ReportService  {
                 execnode: 'execnode'
         ]
 
-        if(query?.jobIdFilter && query.jobIdFilter.toString().length() == 36) {
+        if(query?.jobIdFilter) {
             def found = ScheduledExecution.findByUuid(query.jobIdFilter)
+            if(!found && query.jobIdFilter.isNumber()) {
+                found = ScheduledExecution.get(query.jobIdFilter)
+            }
             if(found) {
                 query.jobIdFilter = found.id.toString()
             }

--- a/rundeckapp/webhooks/src/main/groovy/webhooks/plugins/JobRunWebhookEventPlugin.groovy
+++ b/rundeckapp/webhooks/src/main/groovy/webhooks/plugins/JobRunWebhookEventPlugin.groovy
@@ -15,7 +15,6 @@
  */
 package webhooks.plugins
 
-import com.dtolabs.rundeck.core.dispatcher.DataContextUtils
 import com.dtolabs.rundeck.core.execution.ExecutionReference
 import com.dtolabs.rundeck.core.execution.workflow.steps.FailureReason
 import com.dtolabs.rundeck.core.jobs.JobExecutionError
@@ -24,7 +23,6 @@ import com.dtolabs.rundeck.core.jobs.JobReference
 import com.dtolabs.rundeck.core.jobs.JobService
 import com.dtolabs.rundeck.core.plugins.Plugin
 import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants
-import com.dtolabs.rundeck.core.utils.MapData
 import com.dtolabs.rundeck.core.utils.OptsUtil
 import com.dtolabs.rundeck.core.webhook.WebhookEventException
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
@@ -33,13 +31,11 @@ import com.dtolabs.rundeck.plugins.descriptions.PluginProperty
 import com.dtolabs.rundeck.plugins.descriptions.RenderingOption
 import com.dtolabs.rundeck.plugins.descriptions.RenderingOptions
 import com.dtolabs.rundeck.plugins.webhook.WebhookData
-import com.dtolabs.rundeck.plugins.webhook.WebhookDataImpl
 import com.dtolabs.rundeck.plugins.webhook.WebhookEventContext
 import com.dtolabs.rundeck.plugins.webhook.WebhookEventPlugin
 import com.fasterxml.jackson.databind.ObjectMapper
 import groovy.text.SimpleTemplateEngine
 import org.apache.log4j.Logger
-import org.rundeck.utils.UUIDPropertyValidator
 
 @Plugin(name='webhook-run-job',service= ServiceNameConstants.WebhookEvent)
 @PluginDescription(title="Run Job",description="Run a job on webhook event. This plugin expects the incoming payload to be JSON")
@@ -49,7 +45,7 @@ class JobRunWebhookEventPlugin implements WebhookEventPlugin {
     static Logger log = Logger.getLogger(JobRunWebhookEventPlugin)
 
 
-    @PluginProperty(required = true, title = 'Job', description = 'Job to run.', validatorClass = UUIDPropertyValidator)
+    @PluginProperty(required = true, title = 'Job', description = 'Job to run.')
     @RenderingOptions(
             [
                     @RenderingOption(key = StringRenderingConstants.SELECTION_ACCESSOR_KEY, value = 'RUNDECK_JOB'),


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Fixes #5998 and ~#5999~ #5194

**Describe the solution you've implemented**
To allow a job with custom uuid on the WebhookJobPlugin, I have disabled the UUIDPropertyValidator.

To fix the job activity list, I've removed the 'length == 36' verification.

**Screenshots**

#### List fixed

![image](https://user-images.githubusercontent.com/457100/80243635-f59c2700-863d-11ea-8240-71c92d473bb6.png)

#### Webhook fixed

![image](https://user-images.githubusercontent.com/457100/80243717-16647c80-863e-11ea-974f-a02985c9b06e.png)
