### PR TITLE
fix asUser on retry job

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -3632,7 +3632,7 @@ class ScheduledExecutionController  extends ControllerBase{
 
         if (request.format == 'json') {
             failedOnly = request.JSON.failedNodes?:'true'
-            request.JSON.asUser = request.JSON.asUser?:e.user
+            request.JSON.asUser = request.JSON.asUser?:null
             request.JSON.loglevel = request.JSON.loglevel?:e.loglevel
             if(request.JSON.options){
                 def map = FrameworkService.parseOptsFromString(e.argString)
@@ -3646,7 +3646,7 @@ class ScheduledExecutionController  extends ControllerBase{
             }
         }else{
             failedOnly = params.failedNodes?:'true'
-            params.asUser=params.asUser?:e.user
+            params.asUser=params.asUser?:null
             params.loglevel=params.loglevel?:e.loglevel
             if(params.option){
                 def map = FrameworkService.parseOptsFromString(e.argString)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -32,6 +32,7 @@ import org.grails.plugins.codecs.URLCodec
 import org.grails.plugins.testing.GrailsMockMultipartFile
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 import org.rundeck.app.components.RundeckJobDefinitionManager
+import org.rundeck.core.auth.AuthConstants
 import org.springframework.web.multipart.commons.CommonsMultipartFile
 import rundeck.*
 import rundeck.codecs.URIComponentCodec
@@ -2186,5 +2187,74 @@ class ScheduledExecutionControllerSpec extends Specification {
             ) >> [success: true]
             0 * controller.executionService.respondExecutionsXml(_, _, _)
             0 * controller.executionService._(*_)
+    }
+
+    def "api retry job option jobAsUser not set"() {
+        given:
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService)
+        controller.apiService = Mock(ApiService)
+        controller.executionService = Mock(ExecutionService)
+        controller.frameworkService = Mock(FrameworkService)
+        def se = new ScheduledExecution(
+                uuid: 'testUUID',
+                jobName: 'test1',
+                project: 'project1',
+                groupPath: 'testgroup',
+                doNodedispatch: true,
+                filter:'name: ${option.nodes}',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [
+                                new CommandExec([
+                                        adhocRemoteString: 'test buddy',
+                                        argString: '-delay 12 -monkey cheese -particle'
+                                ])
+                        ]
+                )
+        ).save()
+        def exec = new Execution(
+                user: "testuser",
+                project: "project1",
+                loglevel: 'WARN',
+                status: 'FAILED',
+                doNodedispatch: true,
+                filter:'name: nodea',
+                succeededNodeList:'fwnode',
+                failedNodeList: 'nodec xyz,nodea',
+                workflow: new Workflow(commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]).save(),
+                scheduledExecution: se
+        ).save()
+
+        when:
+        request.api_version = 24
+        request.method = 'POST'
+        params.executionId = exec.id.toString()
+        params.id = se.extid.toString()
+        request.json = [
+                options: [abc: 'tyz', def: 'xyz']
+        ]
+        def result = controller.apiJobRetry()
+
+        then:
+        0 * controller.apiService.requireVersion(_,_,5)
+        0 * controller.frameworkService.authorizeProjectJobAll(_, _, [AuthConstants.ACTION_RUNAS], 'project1')
+        1 * controller.apiService.requireVersion(_,_,24)>>true
+        1 * controller.apiService.requireApi(_, _) >> true
+        1 * controller.scheduledExecutionService.getByIDorUUID(se.extid.toString()) >> se
+        2 * controller.frameworkService.getAuthContextForSubjectAndProject(_, 'project1')
+        1 * controller.frameworkService.authorizeProjectExecutionAny(_, _, ['read', 'view']) >> true
+        1 * controller.frameworkService.authorizeProjectJobAll(_, _, ['run'], _) >> true
+        1 * controller.apiService.requireAuthorized(_, _, _) >> true
+        3 * controller.apiService.requireExists(_, _, _) >> true
+        1 * controller.executionService.executeJob(
+                _,
+                _,
+                _,
+                { it['option.abc'] == 'tyz' && it['option.def'] == 'xyz' }
+        ) >> [success: true]
+        1 * controller.executionService.respondExecutionsXml(_, _, _)
+        0 * controller.executionService._(*_)
+
+
     }
 }


### PR DESCRIPTION
fix #5670

Leave `asUser` empty if not set on retry job from API.