### PR TITLE
fix #5988 - Handling tags with null values on parser of node resource files in json format

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/format/json/ResourceJsonFormatParser.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/format/json/ResourceJsonFormatParser.java
@@ -177,7 +177,9 @@ public class ResourceJsonFormatParser implements ResourceFormatParser, Describab
     private Set<String> stringSet(final Collection tags) {
         HashSet<String> strings = new HashSet<>();
         for (Object tag : tags) {
-            strings.add(tag.toString());
+            if(null != tag){
+                strings.add(tag.toString());
+            }
         }
         return strings;
     }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/resources/format/json/ResourceJsonFormatParserSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/resources/format/json/ResourceJsonFormatParserSpec.groovy
@@ -160,6 +160,40 @@ class ResourceJsonFormatParserSpec extends Specification {
 }
 '''
 
+    static def nullTagsArrayJson='''
+{
+  "test1": {
+    "tags": [ "aluminum", "beans", null ],
+    "osFamily": "unix",
+    "ssh-key-storage-path": "keys/testkey1.pem",
+    "username": "vagrant",
+    "osVersion": "10.10.3",
+    "osArch": "x86_64",
+    "description": "Rundeck server node",
+    "hostname": "192.168.33.12",
+    "nodename": "test1",
+    "osName": "Mac OS X",
+    "rank":"1",
+    "doodad":"false"
+  },
+  "test2": {
+    "tags": ["alphabet", "soup", null],
+    "osFamily": "unix",
+    "ssh-key-storage-path": "keys/testkey1.pem",
+    "username": "vagrant",
+    "osVersion": "10.10.3",
+    "osArch": "x86_64",
+    "description": "Rundeck server node",
+    "hostname": "192.168.33.12",
+    "nodename": "test2",
+    "osName": "Mac OS X",
+    "meddlesome": null,
+    "rank":"2",
+    "doodad":"true"
+  }
+}
+'''
+
 
     @Unroll
     def "parse basic"(String json, List nodenames){
@@ -213,6 +247,7 @@ class ResourceJsonFormatParserSpec extends Specification {
         basicJson          | ['test1', 'test2']
         basicArrayJson     | ['test1', 'test2']
         basicTagsArrayJson | ['test1', 'test2']
+        nullTagsArrayJson  | ['test1', 'test2']
         basicJsonScalars   | ['test1', 'test2']
 
     }


### PR DESCRIPTION
fix #5988 

**Is this a bugfix, or an enhancement? Please describe.**
Some resources files were being generated with 'null' values on tag list causing an error when this files was parsed

**Describe the solution you've implemented**
Now 'null' values on tag list is handled to avoid errors on parser

**Describe alternatives you've considered**
Originally it was thought that the error could be related to the file size.
