### PR TITLE
Fix #6001 - useName property of referenced jobs should be true when it is null and there is name but there is not uuid on map

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
@@ -282,7 +282,7 @@ public class JobExec extends WorkflowStep implements IWorkflowJobItem{
                 }
             }
         }
-        if(map.jobref.useName in ['true',true]){
+        if(map.jobref.useName in ['true',true] || (map.jobref.useName == null && map.jobref.name && !map.jobref.uuid)){
             exec.useName=true
         }else{
             exec.useName=false

--- a/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
@@ -136,7 +136,7 @@ class JobExecSpec extends Specification {
 
     }
 
-    def "from map use name without nodeName property"() {
+    def "from map use name without useName property"() {
         given:
         def map = [
                 jobref     : [

--- a/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
@@ -135,6 +135,32 @@ class JobExecSpec extends Specification {
         false         | _
 
     }
+
+    def "from map use name without nodeName property"() {
+        given:
+        def map = [
+                jobref     : [
+                        group      : 'group',
+                        name       : 'name',
+                        uuid       : uuid,
+                        useName    : useName
+                        ],
+                description: 'a monkey'
+        ]
+        when:
+        def result = JobExec.jobExecFromMap(map)
+
+        then:
+        result.useName == useNameResult
+        where:
+        uuid   | useName | useNameResult
+        null   | null    | true
+        'uuid' | null    | false
+        null   | false   | false
+        null   | true    | true
+        'uuid' | true    | true
+
+    }
     def "from map with jobref.project"() {
         given:
         def map = [


### PR DESCRIPTION
fix #6001 

**Is this a bugfix, or an enhancement? Please describe.**
When a job with referenced jobs is exported on Rundeck 2.x and imported on Rundeck 3.2.x, the option "Search job by" have the value 'uuid' marked instead of 'name'. The file exported have only the name of referenced jobs

**Describe the solution you've implemented**
If there is a name of referenced job and there is not uuid, the property useName should  be true even the useName property is null

