### PR TITLE
Fixing the job import process where the ruleset strategy was not saved correctly

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Workflow.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Workflow.groovy
@@ -1,6 +1,7 @@
 package rundeck
 
 import com.dtolabs.rundeck.app.support.DomainIndexHelper
+import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.ObjectMapper
 
@@ -136,6 +137,18 @@ public class Workflow {
             pluginConfig = null
         }
     }
+
+    public boolean validatePluginConfigMap(){
+        Map configMap = getPluginConfigMap()
+        Map workflowStrategyConfig = configMap ? configMap[ServiceNameConstants.WorkflowStrategy] : null
+        if(workflowStrategyConfig && workflowStrategyConfig[this.strategy] instanceof Map){
+            return workflowStrategyConfig[this.strategy]?.size() != 1 ||
+                    !(workflowStrategyConfig[this.strategy].any {it.key == this.strategy})
+        }
+
+        return true
+    }
+
     public String toString() {
         return "Workflow:(threadcount:${threadcount}){ ${commands} }"
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ConfigStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ConfigStorageService.groovy
@@ -51,6 +51,14 @@ class ConfigStorageService implements StorageManager {
         listeners.remove(listener)
     }
 
+    boolean hasFixIndicator(String name) {
+        existsFileResource(getSystemFixIndicatorPath(name))
+    }
+
+    public String getSystemFixIndicatorPath(String name) {
+        "sys/fix/$name"
+    }
+
     boolean existsFileResource(String path) {
         def storagePath = (path.startsWith("/") ? path : "/${path}")
         return getStorage().hasResource(storagePath)

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3110,10 +3110,17 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     public void jobDefinitionWFStrategy(ScheduledExecution scheduledExecution, ScheduledExecution input,Map params, UserAndRoles userAndRoles) {
         //workflow strategy plugin config and validation
         if(input){
+            Map configmap = input.workflow.getPluginConfigData(ServiceNameConstants.WorkflowStrategy)
+            def configStrategyPluginData = null
+
+            if(configmap instanceof Map){
+                configStrategyPluginData = configmap[input.workflow.strategy] ? configmap[input.workflow.strategy] : configmap
+            }
+
             scheduledExecution.workflow.setPluginConfigData(
                     ServiceNameConstants.WorkflowStrategy,
                     input.workflow.strategy,
-                    input.workflow.getPluginConfigData(ServiceNameConstants.WorkflowStrategy)
+                    configStrategyPluginData ?: configmap
             )
         }else if (params.workflow instanceof Map) {
             Map configmap = params.workflow?.strategyPlugin?.get(scheduledExecution.workflow.strategy)?.config

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3131,6 +3131,10 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             scheduledExecution.workflow.pluginConfigMap = params.workflow.pluginConfigMap
 
         }
+
+        if(!scheduledExecution.workflow.validatePluginConfigMap()){
+            throw new RuntimeException("Invalid workflow plugin config: " + scheduledExecution.workflow.pluginConfig )
+        }
     }
 
     public void jobDefinitionWorkflow(ScheduledExecution scheduledExecution, ScheduledExecution input,Map params, UserAndRoles userAndRoles) {

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3110,13 +3110,13 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     public void jobDefinitionWFStrategy(ScheduledExecution scheduledExecution, ScheduledExecution input,Map params, UserAndRoles userAndRoles) {
         //workflow strategy plugin config and validation
         if(input){
-            Map configStrategyPluginData =
-                input.workflow.getPluginConfigData(ServiceNameConstants.WorkflowStrategy, input.workflow.strategy)
-
             scheduledExecution.workflow.setPluginConfigData(
                     ServiceNameConstants.WorkflowStrategy,
                     input.workflow.strategy,
-                    configStrategyPluginData
+                    input.workflow.getPluginConfigData(
+                        ServiceNameConstants.WorkflowStrategy,
+                        input.workflow.strategy
+                    )
             )
         }else if (params.workflow instanceof Map) {
             Map configmap = params.workflow?.strategyPlugin?.get(scheduledExecution.workflow.strategy)?.config

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3110,17 +3110,13 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     public void jobDefinitionWFStrategy(ScheduledExecution scheduledExecution, ScheduledExecution input,Map params, UserAndRoles userAndRoles) {
         //workflow strategy plugin config and validation
         if(input){
-            Map configmap = input.workflow.getPluginConfigData(ServiceNameConstants.WorkflowStrategy)
-            def configStrategyPluginData = null
-
-            if(configmap instanceof Map){
-                configStrategyPluginData = configmap[input.workflow.strategy] ? configmap[input.workflow.strategy] : configmap
-            }
+            Map configStrategyPluginData =
+                input.workflow.getPluginConfigData(ServiceNameConstants.WorkflowStrategy, input.workflow.strategy)
 
             scheduledExecution.workflow.setPluginConfigData(
                     ServiceNameConstants.WorkflowStrategy,
                     input.workflow.strategy,
-                    configStrategyPluginData ?: configmap
+                    configStrategyPluginData
             )
         }else if (params.workflow instanceof Map) {
             Map configmap = params.workflow?.strategyPlugin?.get(scheduledExecution.workflow.strategy)?.config

--- a/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
@@ -411,9 +411,9 @@ class WorkflowService implements ApplicationContextAware,ExecutionFileProducer{
     }
 
     private List scanWorkflowsWithRulesetError(){
-        List strategies = Workflow.createCriteria().listDistinct {
-            projections{
-                property('strategy')
+        List strategies = Workflow.createCriteria().list {
+            projections {
+                distinct('strategy')
             }
         }
 

--- a/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
@@ -462,7 +462,7 @@ class WorkflowService implements ApplicationContextAware,ExecutionFileProducer{
             }
 
             if(!w.save()){
-                log.info("Ruleset fixed and saved with success")
+                log.error("Error saving ruleset fix for workflow ${w.id}")
                 success = false
             }
         }

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -4336,6 +4336,22 @@ class ScheduledExecutionServiceSpec extends Specification {
             job.workflow.toMap().pluginConfig == [WorkflowStrategy:[ruleset:[rules:'[*] run-in-sequence\r\n[5] if:option.env==QA\r\n[6] unless:option.env==PRODUCTION']]]
 
     }
+    def "job definition workflow strategy config from input unmatched strategy"() {
+        given: "existing job workflow"
+            def job = new ScheduledExecution(workflow: new Workflow(strategy:'other', commands: [new CommandExec(adhocRemoteString: 'test')]))
+            def jobInput = new ScheduledExecution(workflow: new Workflow(strategy:'other',
+                    pluginConfig: "{\"WorkflowStrategy\":{\"ruleset\":{\"rules\":\"[*] run-in-sequence\\r\\n[5] if:option.env==QA\\r\\n[6] unless:option.env==PRODUCTION\"}}}",
+                    commands: [new CommandExec(adhocRemoteString: 'test')]))
+
+            def auth = Mock(UserAndRolesAuthContext)
+        when: "workflow strategy config input"
+            service.jobDefinitionWFStrategy(job, jobInput, null, auth)
+        then: "workflow strategy plugin config is modified"
+            job.workflow != null
+            job.workflow.toMap().strategy == 'other'
+            job.workflow.toMap().pluginConfig == null
+
+    }
 
     def "job definition workflow from session params"() {
         given: "new job"

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -4320,6 +4320,23 @@ class ScheduledExecutionServiceSpec extends Specification {
 
     }
 
+    def "job definition workflow strategy config from input"() {
+        given: "existing job workflow"
+            def job = new ScheduledExecution(workflow: new Workflow(strategy:'ruleset', commands: [new CommandExec(adhocRemoteString: 'test')]))
+            def jobInput = new ScheduledExecution(workflow: new Workflow(strategy:'ruleset',
+                    pluginConfig: "{\"WorkflowStrategy\":{\"ruleset\":{\"rules\":\"[*] run-in-sequence\\r\\n[5] if:option.env==QA\\r\\n[6] unless:option.env==PRODUCTION\"}}}",
+                    commands: [new CommandExec(adhocRemoteString: 'test')]))
+
+            def auth = Mock(UserAndRolesAuthContext)
+        when: "workflow strategy config input"
+            service.jobDefinitionWFStrategy(job, jobInput, null, auth)
+        then: "workflow strategy plugin config is modified"
+            job.workflow != null
+            job.workflow.toMap().strategy == 'ruleset'
+            job.workflow.toMap().pluginConfig == [WorkflowStrategy:[ruleset:[rules:'[*] run-in-sequence\r\n[5] if:option.env==QA\r\n[6] unless:option.env==PRODUCTION']]]
+
+    }
+
     def "job definition workflow from session params"() {
         given: "new job"
             def job = new ScheduledExecution()

--- a/rundeckapp/src/test/groovy/rundeck/services/WorkflowServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/WorkflowServiceSpec.groovy
@@ -65,6 +65,17 @@ class WorkflowServiceSpec extends Specification{
                 commands: [new CommandExec(adhocRemoteString: 'test')])
 
         workflow.save()
+
+        Workflow workflowWithNoError1 = new Workflow(strategy:'aplugin', commands: [new CommandExec(adhocRemoteString: 'test')])
+
+        workflowWithNoError1.save()
+
+        Workflow workflowWithNoError2 = new Workflow(strategy:'ruleset',
+                pluginConfig: "{\"WorkflowStrategy\":{\"ruleset\":{\"rules\":\"ruleset description\"}}}",
+                commands: [new CommandExec(adhocRemoteString: 'test')])
+
+        workflowWithNoError2.save()
+        
         when:
         def resp = service.fixRulesetError()
 
@@ -72,6 +83,8 @@ class WorkflowServiceSpec extends Specification{
         resp
         workflow.pluginConfig == "{\"WorkflowStrategy\":{\"ruleset\":{\"rules\":\"[*] run-in-sequence\\r\\n[5] if:option.env==QA\\r\\n[6] unless:option.env==PRODUCTION\"}}}"
         workflow.validatePluginConfigMap()
+        workflowWithNoError1.pluginConfig == null
+        workflowWithNoError2.pluginConfig == "{\"WorkflowStrategy\":{\"ruleset\":{\"rules\":\"ruleset description\"}}}"
     }
 
     def "validate plugin config"(){

--- a/rundeckapp/src/test/groovy/rundeck/services/WorkflowServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/WorkflowServiceSpec.groovy
@@ -75,12 +75,17 @@ class WorkflowServiceSpec extends Specification{
                 commands: [new CommandExec(adhocRemoteString: 'test')])
 
         workflowWithNoError2.save()
-        
+
         when:
         def resp = service.fixRulesetError()
 
         then:
         resp
+        resp.success
+        resp.rulesetWithErros == 1
+        resp.changesetList.size() == 1
+        resp.changesetList[0].before == "{\"WorkflowStrategy\":{\"ruleset\":{\"ruleset\":{\"rules\":\"[*] run-in-sequence\\r\\n[5] if:option.env==QA\\r\\n[6] unless:option.env==PRODUCTION\"}}}}"
+        resp.changesetList[0].after == "{\"WorkflowStrategy\":{\"ruleset\":{\"rules\":\"[*] run-in-sequence\\r\\n[5] if:option.env==QA\\r\\n[6] unless:option.env==PRODUCTION\"}}}"
         workflow.pluginConfig == "{\"WorkflowStrategy\":{\"ruleset\":{\"rules\":\"[*] run-in-sequence\\r\\n[5] if:option.env==QA\\r\\n[6] unless:option.env==PRODUCTION\"}}}"
         workflow.validatePluginConfigMap()
         workflowWithNoError1.pluginConfig == null

--- a/rundeckapp/src/test/groovy/rundeck/services/WorkflowServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/WorkflowServiceSpec.groovy
@@ -77,12 +77,12 @@ class WorkflowServiceSpec extends Specification{
         workflowWithNoError2.save()
 
         when:
-        def resp = service.fixRulesetError()
+        def resp = service.applyWorkflowConfigFix973()
 
         then:
         resp
         resp.success
-        resp.rulesetWithErros == 1
+        resp.invalidCount == 1
         resp.changesetList.size() == 1
         resp.changesetList[0].before == "{\"WorkflowStrategy\":{\"ruleset\":{\"ruleset\":{\"rules\":\"[*] run-in-sequence\\r\\n[5] if:option.env==QA\\r\\n[6] unless:option.env==PRODUCTION\"}}}}"
         resp.changesetList[0].after == "{\"WorkflowStrategy\":{\"ruleset\":{\"rules\":\"[*] run-in-sequence\\r\\n[5] if:option.env==QA\\r\\n[6] unless:option.env==PRODUCTION\"}}}"


### PR DESCRIPTION
fix https://github.com/rundeckpro/rundeckpro/issues/973

**Is this a bugfix, or an enhancement? Please describe.**
When importing a job definition, the ruleset description was lost

**Describe the solution you've implemented**
When handling the data map of the strategy plugin an error caused the map to become inconsistent and thus it was not possible to interpret it when loading the job.
