### PR TITLE
Prevent attempt to schedule jobs on a quartz scheduler that is shutdown.

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
@@ -214,6 +214,7 @@ class QuartzJobScheduleManagerService implements JobScheduleManager, Initializin
      */
     private void cleanupTriggers() {
         GroupMatcher<TriggerKey> matcher = GroupMatcher.groupEquals(TRIGGER_GROUP_PENDING)
+        if(quartzScheduler.isShutdown()) return
         quartzScheduler.getTriggerKeys(matcher).each { triggerKey ->
             if (triggerKey.group == TRIGGER_GROUP_PENDING) {
                 Trigger trigger = quartzScheduler.getTrigger(triggerKey)


### PR DESCRIPTION
This generally happens in dev mode when a misconfiguration causes the startup to fail after bootstrap. Jobs with a schedule were trying to be scheduled on a quart scheduler that was shutdown which causes massive stacktrace dumps.