### PR TITLE
Fix an issue that caused job execution to get stuck inside a loop when an exception was thrown from a log event call

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessor.java
@@ -304,22 +304,25 @@ class WorkflowEngineOperationsProcessor<DAT, RES extends WorkflowSystem.Operatio
         @Override
         public void onFailure(final Throwable t) {
             WorkflowSystem.OperationResult<DAT, RES, OP> result = result(t, operation);
-            eventHandler.event(
-                    WorkflowSystemEventType.OperationFailed,
-                    String.format("operation failed: %s", t),
-                    StateWorkflowSystem.operationCompleteEvent(
-                            operation.getIdentity(),
-                            workflowEngine.getState(),
-                            sharedData,
-                            result
-                    )
-            );
-            resultConsumer.accept(result);
-            StateObj newFailureState = operation.getFailureState(t);
-            if (null == newFailureState) {
-                newFailureState = new DataState();
+            try{
+                eventHandler.event(
+                        WorkflowSystemEventType.OperationFailed,
+                        String.format("operation failed: %s", t),
+                        StateWorkflowSystem.operationCompleteEvent(
+                                operation.getIdentity(),
+                                workflowEngine.getState(),
+                                sharedData,
+                                result
+                        )
+                );
+            } finally {
+                resultConsumer.accept(result);
+                StateObj newFailureState = operation.getFailureState(t);
+                if (null == newFailureState) {
+                    newFailureState = new DataState();
+                }
+                finishedOperation(WorkflowEngine.<DAT>dummyResult(newFailureState, operation.getIdentity(), false), operation);
             }
-            finishedOperation(WorkflowEngine.<DAT>dummyResult(newFailureState, operation.getIdentity(), false), operation);
         }
     }
 


### PR DESCRIPTION
Fix https://github.com/rundeckpro/rundeckpro/issues/980

**Is this a bugfix, or an enhancement? Please describe.**
When a node with an incorrect configuration was loaded during a job execution, an exception was thrown and the execution was stuck in a loop

**Describe the solution you've implemented**
A "finally" clause has been added to ensure that execution will continue even if an exception is thrown in a log event call
