### PR TITLE
Fix execution stats lockmode

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -1155,8 +1155,11 @@ class ScheduledExecution extends ExecutionContext implements EmbeddedJsonData {
 
     ScheduledExecutionStats getStats(lock = false) {
         def stats
+
         if(this.id) {
-            stats = ScheduledExecutionStats.findBySe(this, [lock: lock])
+            def queryArgs = lock ? [lock: true]  : [:]
+
+            stats = ScheduledExecutionStats.findBySe(this, queryArgs)
             if (!stats) {
                 def content = [execCount   : this.execCount,
                                totalTime   : this.totalTime,


### PR DESCRIPTION
Fixes #6023

Grails GORM appears to have a bug where `Query.lock(boolean lock)` ignore `false` values. Passing in true or false always results in the `PESSIMISTIC_WRITE` lock mode being set.

This resolves the issue by leaving the argmap key out completely if locking isn't requested. A bug has been filed with GORM:

https://github.com/grails/grails-data-mapping/issues/1345