### PR TITLE
fix: incorrect height for sidebar wrapper

### DIFF
--- a/rundeckapp/grails-app/assets/scss/paper/_sidebar-and-main-panel.scss
+++ b/rundeckapp/grails-app/assets/scss/paper/_sidebar-and-main-panel.scss
@@ -92,9 +92,7 @@
 
   .sidebar-wrapper {
     position: relative;
-    height: calc(100% - 75px);
-    // max-height: none;
-    // min-height: 100%;
+    height: calc(100% - 60px);
     z-index: 4;
     box-shadow: inset -1px 0px 0px 0px $medium-gray;
     width: 260px;


### PR DESCRIPTION
* seems logo height was previously explicitly 75px, but is now 60px due to 5px padding + 50px a link

**Is this a bugfix, or an enhancement? Please describe.**

incorrect height on sidebar-wrapper shows as a 15px bar in Safari, although I don't see it in Chrome or Firefox

![Screen Shot 2020-05-15 at 3 09 52 PM](https://user-images.githubusercontent.com/55603/82100904-dbdf8400-96bf-11ea-9211-9dba7b8a14f6.png)
