### PR TITLE
Fix java 11 illegal reflective access warnings

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -341,6 +341,11 @@ bootWar {
     from("templates") {
         into("templates")
     }
+    manifest {
+        attributes(
+            ['Add-Opens':'java.management/com.sun.jmx.mbeanserver java.base/java.io java.base/java.lang java.base/java.lang.invoke java.base/java.lang.reflect java.base/java.math java.base/java.net java.base/java.nio.charset java.base/java.nio.file java.base/java.security java.base/java.text java.base/java.time java.base/java.util java.base/java.util.concurrent java.base/java.util.function java.base/java.util.regex java.base/javax.crypto java.base/sun.nio.cs']
+        )
+    }
 }
 
 artifacts {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fixes warning messages at startup from Java 11:

    WARNING: Illegal reflective access by org.codehaus.groovy.vmplugin.v7.Java7$1 (jar:file:/Users/greg/rdinstall/rdcore/rundeck-3.3.0-7501.war!/WEB-INF/lib/groovy-2.5.6.jar!/) to constructor java.lang.invoke.MethodHandles$Lookup(java.lang.Class,int)


**Describe the solution you've implemented**

Add `Add-Opens` manifest entry to open selected modules/packages which quells the illegal reflective access warnings when running as `java -jar`

**Describe alternatives you've considered**

Can also be added to JVM options: `--add-opens=java.managment/com.sun.jmx.mbeanserver=ALL-UNNAMED ...` if not using `java -jar` to run the war.

**Additional context**

Groovy 2.5 uses "illegal" reflective access which causes Java 11 to warn about them, see <https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-2F61F3A9-0979-46A4-8B49-325BA0EE8B66>