### PR TITLE
Use spring loaded instead of dev tools

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -30,6 +30,7 @@ apply plugin:"asset-pipeline"
 apply plugin:"org.grails.grails-gsp"
 
 configurations {
+    agent
     war{}
     bootWar{}
     pluginFiles {
@@ -51,7 +52,7 @@ repositories {
 }
 
 dependencies {
-    developmentOnly("org.springframework.boot:spring-boot-devtools")
+    agent "org.springframework:springloaded:1.2.8.RELEASE"
     //Rundeck plugin dependencies
     pluginFiles project.findProperty('bundledPlugins')?:[]
 
@@ -214,7 +215,7 @@ bootRun {
             '-Dspring.output.ansi.enabled=always',
             '-noverify',
             '-XX:TieredStopAtLevel=1',
-            '-Xmx1024m')
+            '-Xmx2048m')
     systemProperties(System.properties)
     String springProfilesActive = 'spring.profiles.active'
     systemProperty springProfilesActive, System.getProperty(springProfilesActive)


### PR DESCRIPTION
Removes the spring boot session storage default change by dev-tools causing jetty to complain about being unable to serialize/store sessions.

Spring loaded is reportedly still the fastest reload option: https://github.com/grails/grails-core/pull/11441 .

Also increase the `bootRun` max heap. This seems to improve devmode perf particularly on first page loads and first asset access.