### PR TITLE
Docker - Update to Ubuntu 18.04 and OpenJDK 11

### DIFF
--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -25,6 +25,11 @@ task ensureWar {
 task officialBuild {
     dependsOn ensureWar
 
+    inputs.dir "official/etc"
+    inputs.dir "official/lib"
+    inputs.dir "official/remco"
+    inputs.file "official/Dockerfile"
+
     def outputDir = "$buildDir/tags"
 
     outputs.dir outputDir

--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -1,4 +1,4 @@
-FROM rundeck/ubuntu-base@sha256:f22116b6acdad58f2e24f9f6516c6ada0903f18839d285f12e01c5e905f6148d
+FROM rundeck/ubuntu-base@sha256:e9f21a4252c80b145a18c2d0de55453073b551c5ca737d449df4d942f0d1a443
 
 COPY --chown=rundeck:root .build .
 RUN java -jar rundeck.war --installonly \

--- a/docker/official/README.md
+++ b/docker/official/README.md
@@ -97,11 +97,10 @@ See the [Docker Zoo Exhibit](https://github.com/rundeck/docker-zoo/tree/master/c
 
 Not all rundeck configuration listed in the official documentation is available for setup yet. Please take a look at the templates to see all available variables.
 
-### `JVM_MAX_RAM_FRACTION=1`
+### `JVM_MAX_RAM_PERCENTAGE=75`
 
-The JVM will use `1/x` of the max RAM for heap. For example, a setting of `2` will cause
-the JVM to utilize up to half the container limit for heap. This is replaced in
-openjdk 10 with a percentage setting that will offer finer control.
+The JVM will use `x%` of the max RAM for heap. For example, a setting of `50` will cause
+the JVM to utilize up to half the container limit for heap. The default is set to `75`.
 
 ### `RUNDECK_SERVER_UUID`
 

--- a/docker/official/lib/entry.sh
+++ b/docker/official/lib/entry.sh
@@ -58,8 +58,7 @@ fi
 
 exec java \
     -XX:+UnlockExperimentalVMOptions \
-    -XX:MaxRAMFraction="${JVM_MAX_RAM_FRACTION}" \
-    -XX:+UseCGroupMemoryLimitForHeap \
+    -XX:MaxRAMPercentage="${JVM_MAX_RAM_PERCENTAGE}" \
     -Dlog4j.configurationFile="/home/rundeck/server/config/log4j2.properties" \
     -Dlogging.config="file:/home/rundeck/server/config/log4j2.properties" \
     -Dloginmodule.conf.name=jaas-loginmodule.conf \

--- a/docker/official/lib/includes/100_defaults.sh
+++ b/docker/official/lib/includes/100_defaults.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 # Hard-coded default for OSS so scheduler is not confused; set manually for multi-node deployments
 RUNDECK_SERVER_UUID="${RUNDECK_SERVER_UUID:-a14bc3e6-75e8-4fe4-a90d-a16dcc976bf6}"
 
-JVM_MAX_RAM_FRACTION="${JVM_MAX_RAM_FRACTION:-1}"
+JVM_MAX_RAM_PERCENTAGE="${JVM_MAX_RAM_FRACTION:-75}"

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -9,7 +9,7 @@ RUN go install github.com/HeavyHorst/remco/cmd/remco
 
 # Build base container
 ######################
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV LANG C.UTF-8
@@ -28,7 +28,7 @@ RUN set -euxo pipefail \
         gnupg2 \
         ssh-client \
         sudo \
-        openjdk-8-jdk-headless \
+        openjdk-11-jdk-headless \
         uuid-runtime \
         wget \
     && rm -rf /var/lib/apt/lists/* \
@@ -44,6 +44,7 @@ RUN set -euxo pipefail \
 ENV TINI_VERSION v0.18.0
 RUN wget -O /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
     && wget -O /tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc \
+    && export GNUPGHOME="$(mktemp -d)" &&  echo "disable-ipv6" >> "${GNUPGHOME}/dirmngr.conf" \
     && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
     && gpg --batch --verify /tini.asc /tini \
     && chmod +x /tini


### PR DESCRIPTION
Closes #6032 

* Updates base image to use Ubuntu 18.04 LTS
* Upgrades to OpenJDK 11
* Replaces deprecated JVM RAM properties with `MaxRAMPercenatage` and defaults it to 75%