### PR TITLE
Ability to load framework properties from the app config sources.

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -19,6 +19,7 @@ import com.dtolabs.rundeck.app.api.ApiMarshallerRegistrar
 import com.dtolabs.rundeck.app.gui.GroupedJobListLinkHandler
 import com.dtolabs.rundeck.app.gui.JobListLinkHandlerRegistry
 import com.dtolabs.rundeck.app.gui.UserSummaryMenuItem
+import com.dtolabs.rundeck.app.internal.framework.ConfigFrameworkPropertyLookupFactory
 import com.dtolabs.rundeck.app.internal.framework.FrameworkPropertyLookupFactory
 import com.dtolabs.rundeck.app.internal.framework.RundeckFrameworkFactory
 import com.dtolabs.rundeck.core.Constants
@@ -148,8 +149,12 @@ beans={
 
     rundeckNodeService(EnhancedNodeService)
 
-    frameworkPropertyLookupFactory(FrameworkPropertyLookupFactory){
-        baseDir=rdeckBase
+    if(application.config.rundeck.loadFrameworkPropertiesFromRundeckConfig in ["true",true]) {
+        frameworkPropertyLookupFactory(ConfigFrameworkPropertyLookupFactory) { }
+    } else {
+        frameworkPropertyLookupFactory(FrameworkPropertyLookupFactory){
+            baseDir=rdeckBase
+        }
     }
 
     frameworkPropertyLookup(frameworkPropertyLookupFactory:'create'){

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/framework/ConfigFrameworkPropertyLookupFactory.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/framework/ConfigFrameworkPropertyLookupFactory.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dtolabs.rundeck.app.internal.framework
+
+import com.dtolabs.rundeck.core.utils.IPropertyLookup
+import com.dtolabs.rundeck.core.utils.PropertyLookup
+import grails.util.Holders
+
+class ConfigFrameworkPropertyLookupFactory {
+
+    IPropertyLookup create() {
+        def cfg = getFrameworkProperties()
+        PropertyLookup lkp = PropertyLookup.create(!cfg.isEmpty() ? cfg.toProperties() : new Properties())
+        lkp.expand()
+        return lkp
+    }
+
+    def getFrameworkProperties() {
+        return Holders.getConfig().fwk
+    }
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/framework/FrameworkPropertyLookupFactory.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/framework/FrameworkPropertyLookupFactory.groovy
@@ -37,6 +37,7 @@ class FrameworkPropertyLookupFactory {
 
         PropertyLookup lookup1 = PropertyLookup.createDeferred(propertyFile);
         lookup1.expand();
+        println lookup1.getPropertiesMap()
         return lookup1;
     }
 }

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/framework/ConfigFrameworkPropertyLookupFactorySpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/framework/ConfigFrameworkPropertyLookupFactorySpec.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dtolabs.rundeck.app.internal.framework
+
+import com.dtolabs.rundeck.core.utils.IPropertyLookup
+import org.grails.config.NavigableMap
+import org.grails.testing.GrailsUnitTest
+import spock.lang.Specification
+
+
+class ConfigFrameworkPropertyLookupFactorySpec extends Specification implements GrailsUnitTest {
+
+    def "create property lookup"() {
+        setup:
+        ConfigFrameworkPropertyLookupFactory.metaClass.getFrameworkProperties = {
+            NavigableMap m = new NavigableMap()
+            m.merge(fwkProps)
+            return m
+        }
+
+        when:
+        IPropertyLookup lkp =  new ConfigFrameworkPropertyLookupFactory().create()
+
+        then:
+        lkp.propertiesMap.keySet().size() == count
+
+        where:
+        count | fwkProps
+        0     | [:]
+        2     | ['fwk.framework.server.name':"test_server",'fwk.framework.server.port':4440]
+    }
+}


### PR DESCRIPTION
Add the setting `rundeck.loadFrameworkPropertiesFromRundeckConfig=true` to your rundeck-config.properties file.

Put your framework properties settings in rundeck-config.properties with a `fwk` prefix.

Ex. 

`fwk.framework.server.name=my-server`
`fwk.rundeck.server.uuid=a4a4af69-74d6-4319-bzb1-16eec8c742d3`
