### PR TITLE
Avoiding loading all plugins whenever a method needs to search for a plugin description

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/DescribableServiceUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/DescribableServiceUtil.java
@@ -63,6 +63,20 @@ public class DescribableServiceUtil {
         return list;
     }
 
+    public static <T> Description loadDescriptionForType(final ProviderService<T> service, String name,
+                                                         final boolean includeFieldProperties) {
+        try {
+            final T providerForType = service.providerOfType(name);
+            return descriptionForProvider(includeFieldProperties, providerForType);
+        } catch (MissingProviderException ignored) {
+
+        } catch (ExecutionServiceException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
     /**
      * Get or build the description of a plugin instance of a given type
      * @param includeFieldProperties true to include introspected field properties

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
@@ -29,6 +29,7 @@ import com.dtolabs.rundeck.core.plugins.PluginMetadata
 import com.dtolabs.rundeck.core.plugins.PluginRegistry
 import com.dtolabs.rundeck.core.plugins.PluginResourceLoader
 import com.dtolabs.rundeck.core.plugins.ValidatedPlugin
+import com.dtolabs.rundeck.core.plugins.configuration.DescribableServiceUtil
 import com.dtolabs.rundeck.core.plugins.configuration.PluginAdapterUtility
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolver
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolverFactory
@@ -367,7 +368,7 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
                 }
             }
             if (null != instance) {
-                def d = service.listDescriptions().find { it.name == name }
+                def d = loadPluginDescription(service, name)
                 return new CloseableDescribedPlugin<T>(instance, d, name)
             }
         }
@@ -404,11 +405,15 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
                 }
             }
             if (null != instance) {
-                def d = service.listDescriptions().find { it.name == name }
+                def d = loadPluginDescription(service, name)
                 return new DescribedPlugin<T>(instance, d, name)
             }
         }
         null
+    }
+
+    private Description loadPluginDescription(PluggableProviderService service, String name){
+        return DescribableServiceUtil.loadDescriptionForType(service, name, true)
     }
 
     private <T> DescribedPlugin<T> loadBeanDescriptor(String name, String type = null) {
@@ -520,7 +525,7 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
                     list[ident.providerName] = new DescribedPlugin<T>(instance, null, ident.providerName)
                 }
             }
-            service.listDescriptions().each { Description d ->
+            service.listDescriptions()?.each { Description d ->
                 if (!list[d.name]) {
                     list[d.name] = new DescribedPlugin<T>( null, null, d.name)
                 }

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistrySpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistrySpec.groovy
@@ -187,6 +187,40 @@ class RundeckPluginRegistrySpec extends Specification implements GrailsUnitTest 
     }
 
     @Unroll
+    def "load plugin by name should load description by type"() {
+        given:
+
+        def description2 = DescriptionBuilder.builder()
+                .name('plugin2')
+                .property(PropertyBuilder.builder().string('prop1').build())
+                .property(PropertyBuilder.builder().string('prop2').build())
+                .build()
+
+        def testPlugin2 = new TestPluginWithAnnotation()
+        testPlugin2.description = description2
+
+        def sut = new RundeckPluginRegistry()
+        sut.pluginDirectory = File.createTempDir('test', 'dir')
+        sut.applicationContext = applicationContext
+        sut.pluginRegistryMap = [:]
+        sut.rundeckServerServiceProviderLoader = Mock(ServiceProviderLoader)
+
+        def svc = Mock(PluggableProviderService) {
+            getName() >> "otherservicename"
+            providerOfType("plugin2") >> testPlugin2
+        }
+
+        when:
+        def result = sut.loadPluginDescription(svc, 'plugin2')
+
+        then:
+
+        result
+        result.name == 'plugin2'
+        result == description2
+    }
+
+    @Unroll
     def "list plugin by type"() {
         given:
         def description1 = DescriptionBuilder.builder()


### PR DESCRIPTION
Fix https://github.com/rundeckpro/rundeckpro/issues/924

**Is this a bugfix, or an enhancement? Please describe.**
The first time the Job edit screen is loaded, it takes a long time to load. In some environments, it took more than 1 minute to open

**Describe the solution you've implemented**
These changes allow you to find a description of the plugin without having to load all plugins of a given type. Before, all plugins were loaded for each search for a description

**Additional context**
I couldn't find the reason why this case is more critical in Windows environments
