### PR TITLE
Add default result for git-import pull action

### DIFF
--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/imp/actions/PullAction.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/imp/actions/PullAction.groovy
@@ -110,7 +110,11 @@ Pulling from remote branch: `${plugin.branch}`"""
         } else if (status.branchTrackingStatus?.behindCount > 0) {
             gitPull(context, plugin)
         } else {
-            //no action
+            def result = new ScmExportResultImpl()
+            result.success = true
+            result.message = "Git Pull succeeded"
+            result.extendedMessage = "Git Pull not needed"
+            result
         }
 
     }

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitImportPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitImportPluginSpec.groovy
@@ -17,6 +17,7 @@
 package org.rundeck.plugin.scm.git
 
 import com.dtolabs.rundeck.plugins.scm.ImportSynchState
+import com.dtolabs.rundeck.plugins.scm.JobImporter
 import com.dtolabs.rundeck.plugins.scm.JobScmReference
 import com.dtolabs.rundeck.plugins.scm.ScmOperationContext
 import org.eclipse.jgit.api.Git
@@ -205,4 +206,42 @@ class GitImportPluginSpec extends Specification {
         'import-all'  | _
         'import-jobs' | _
     }
+
+    def "perform pull on clean state withouth npe"() {
+        given:
+        def projectName = 'GitImportPluginSpec'
+        def gitdir = new File(tempdir, 'scm')
+        def origindir = new File(tempdir, 'origin')
+        Import config = createTestConfig(gitdir, origindir)
+
+        Git git = GitExportPluginSpec.createGit(origindir)
+
+
+        git.close()
+        ScmOperationContext context = Mock(ScmOperationContext) {
+            getFrameworkProject() >> projectName
+        }
+
+        JobImporter importer = Mock(JobImporter)
+        List<String> selectedPaths = []
+        Map<String, String> input = [:]
+
+        def plugin = new GitImportPlugin(config, [])
+        plugin.initialize(context)
+
+        when:
+        def ret = plugin.scmImport(context, actionId,
+         importer,
+        selectedPaths,
+        input)
+
+        then:
+        ret != null
+        ret.success
+
+        where:
+        actionId      | _
+        'remote-pull' | _
+    }
+
 }


### PR DESCRIPTION
fix #6078

Add default result when no pull action is needed in `git-import` plugin.

This is targeted to 3.2.9 and 3.3.0 leaving as draft meanwhile 3.2.8 is on testing phase.