### PR TITLE
Fix issue/1019 where running jobs is aways zero even if there are jobs running.

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -428,7 +428,10 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                             isNull('dateCompleted')
                             if(!query.considerPostponedRunsAsRunningFilter){
                                 le('dateStarted', now)
-                                ne('status', EXECUTION_SCHEDULED)
+                                or {
+                                    ne('status', EXECUTION_SCHEDULED)
+                                    isNull('status')
+                                }
                             }
                         }
                     } else {

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -428,10 +428,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                             isNull('dateCompleted')
                             if(!query.considerPostponedRunsAsRunningFilter){
                                 le('dateStarted', now)
-                                or {
-                                    ne('status', EXECUTION_SCHEDULED)
-                                    isNull('status')
-                                }
                             }
                         }
                     } else {

--- a/rundeckapp/grails-app/services/rundeck/services/jobs/JobQueryService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/jobs/JobQueryService.groovy
@@ -2,8 +2,13 @@ package rundeck.services.jobs
 
 import com.dtolabs.rundeck.app.support.ScheduledExecutionQuery
 import com.dtolabs.rundeck.core.plugins.configuration.Property
+import org.hibernate.criterion.DetachedCriteria
+import org.hibernate.criterion.Projections
+import org.hibernate.criterion.Restrictions
+import org.hibernate.criterion.Subqueries
 import org.rundeck.app.components.jobs.JobQuery
 import org.rundeck.app.components.jobs.JobQueryInput
+import rundeck.Execution
 
 class JobQueryService implements JobQuery {
 
@@ -23,10 +28,23 @@ class JobQueryService implements JobQuery {
 class LocalJobQueryService {
 
     Map extendCriteria(JobQueryInput input, Map params, Object delegate) {
+        def restr = Restrictions.conjunction()
         ScheduledExecutionQuery.IS_SCHEDULED_FILTER.each { key, val ->
             if(null!=input["${key}Filter"]){
-                delegate.eq(val,input["${key}Filter"])
+                restr.add(Restrictions.eq(val,input["${key}Filter"]))
             }
+        }
+        if(params.runJobLaterFilter){
+            Date now = new Date()
+            DetachedCriteria subquery = DetachedCriteria.forClass(Execution.class, "e").with{
+                setProjection Projections.property('e.id')
+                add(Restrictions.gt('e.dateStarted', now))
+                add Restrictions.conjunction().
+                        add(Restrictions.eqProperty('e.scheduledExecution.id', 'this.id'))
+            }
+            delegate.criteria.add(Restrictions.disjunction().add(Subqueries.exists(subquery)).add(restr))
+        } else if(restr.conditions().size() > 0){
+            delegate.criteria.add(restr)
         }
         //this returns an empty map since schedules is already considered as part of the attributes to show as part of the search
         //ergo, no need to add new values

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -2131,7 +2131,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         }
         query.projFilter = 'AProject'
         query.runningFilter = 'running'
-        query.considerPostponedRunsAsRunningFilter = false
+        query.considerPostponedRunsAsRunningFilter = considerPostponedRunsAsRunningFilter
         def exec = new Execution(
                 dateStarted: now,
                 dateCompleted: null,
@@ -2150,8 +2150,12 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
         then:
         2 == result.total
-        1 == result.nowrunning.size()
+        nowrunning == result.nowrunning.size()
 
+        where:
+        considerPostponedRunsAsRunningFilter | nowrunning
+        true                                 | 2
+        false                                | 1
     }
 
     def "list now running for project includes scheduled"() {

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -2136,7 +2136,8 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
                 dateStarted: now,
                 dateCompleted: null,
                 user: 'userB',
-                project: 'AProject'
+                project: 'AProject',
+                status: status
         ).save()
         def exec2 = new Execution(
                 dateStarted: future,
@@ -2153,9 +2154,11 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         nowrunning == result.nowrunning.size()
 
         where:
-        considerPostponedRunsAsRunningFilter | nowrunning
-        true                                 | 2
-        false                                | 1
+        considerPostponedRunsAsRunningFilter | nowrunning | status
+        true                                 | 2          | null
+        true                                 | 2          | 'scheduled'
+        false                                | 1          | null
+        false                                | 1          | 'scheduled'
     }
 
     def "list now running for project includes scheduled"() {


### PR DESCRIPTION
Fix https://github.com/rundeckpro/rundeckpro/issues/1019

**Is this a bugfix, or an enhancement? Please describe.**
Some changes affected the query that returns info to Dashboard page where the running jobs counter was showing zero jobs even if there are jobs running and, in addition, the schedules that was created by run job later option is not showing too.

**Describe the solution you've implemented**
The criteria to query jobs was fixed to get jobs running even the status of the execution is null and fixed `JobQueryService` to consider jobs executed with `run job later` option as scheduled job.

**Additional context**
If the addon enterprise-schedules is enabled the jobs scheduled by `run job later` will not be shown on dashboard: https://github.com/rundeckpro/rundeckpro/issues/1036
