### PR TITLE
Enable h2 console in dev mode

### DIFF
--- a/rundeckapp/grails-app/conf/application.groovy
+++ b/rundeckapp/grails-app/conf/application.groovy
@@ -32,6 +32,7 @@ environments {
             dbCreate = "create-drop" // one of 'create', 'create-drop','update'
             url = "jdbc:h2:file:./db/devDb"
         }
+        spring.h2.console.enabled=true
 
     }
     test {


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Enables the `/h2-console` in development mode
