### PR TITLE
Docker - Optional bindPassword variable for jass-loginmodule

### DIFF
--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -6,7 +6,7 @@
         contextFactory="{{ getv("/rundeck/jaas/ldap/contextfactory", "com.sun.jndi.ldap.LdapCtxFactory") }}"
         providerUrl="{{ getv("/rundeck/jaas/ldap/providerurl") }}"
         bindDn="{{ getv("/rundeck/jaas/ldap/binddn") }}"
-        {% if exists("/rundeck/jaas/ldap/bindpassword") -%}
+    {% if exists("/rundeck/jaas/ldap/bindpassword") -%}
         bindPassword="{{ getv("/rundeck/jaas/ldap/bindpassword") }}"
         {% endif %}
         authenticationMethod="{{ getv("/rundeck/jaas/ldap/authenticationmode", "simple") }}"

--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -6,7 +6,9 @@
         contextFactory="{{ getv("/rundeck/jaas/ldap/contextfactory", "com.sun.jndi.ldap.LdapCtxFactory") }}"
         providerUrl="{{ getv("/rundeck/jaas/ldap/providerurl") }}"
         bindDn="{{ getv("/rundeck/jaas/ldap/binddn") }}"
+        {% if exists("/rundeck/jaas/ldap/bindpassword") -%}
         bindPassword="{{ getv("/rundeck/jaas/ldap/bindpassword") }}"
+        {% endif %}
         authenticationMethod="{{ getv("/rundeck/jaas/ldap/authenticationmode", "simple") }}"
         forceBindingLogin="{{ getv("/rundeck/jaas/ldap/forcebindinglogin", "true") }}"
         forceBindingLoginUseRootContextForRoles="{{ getv("/rundeck/jaas/ldap/forcebindingloginuserootcontextforroles", "true") }}"

--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -8,7 +8,7 @@
         bindDn="{{ getv("/rundeck/jaas/ldap/binddn") }}"
     {% if exists("/rundeck/jaas/ldap/bindpassword") -%}
         bindPassword="{{ getv("/rundeck/jaas/ldap/bindpassword") }}"
-        {% endif %}
+    {% endif %}
         authenticationMethod="{{ getv("/rundeck/jaas/ldap/authenticationmode", "simple") }}"
         forceBindingLogin="{{ getv("/rundeck/jaas/ldap/forcebindinglogin", "true") }}"
         forceBindingLoginUseRootContextForRoles="{{ getv("/rundeck/jaas/ldap/forcebindingloginuserootcontextforroles", "true") }}"


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
optional bindPassword environment variable for jass-loginmodule.

If you try to use the enterprise password encryption this value must be empty.
https://docs.rundeck.com/docs/administration/configuration/encryptable-properties.html#rundeck-enterprise-config-property-encryption

**Describe the solution you've implemented**
Enable the attribute  if the variable is set

**Describe alternatives you've considered**

**Additional context**
