### PR TITLE
Accept Environment variables optional for jsch executor

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutor.java
@@ -165,6 +165,10 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
     public static final String FWK_SSH_CONFIG_PREFIX = FWK_PROP_PREFIX + SSH_CONFIG_PREFIX;
     public static final String PROJ_SSH_CONFIG_PREFIX = PROJ_PROP_PREFIX + SSH_CONFIG_PREFIX;
 
+    public static final String NODE_ATTR_PASS_ENV = "ssh-accept-env";
+    public static final String FWK_PROP_PASS_ENV = FWK_PROP_PREFIX + NODE_ATTR_PASS_ENV;
+    public static final String PROJ_PROP_PASS_ENV = PROJ_PROP_PREFIX + NODE_ATTR_PASS_ENV;
+
     private Framework framework;
 
     public JschNodeExecutor(final Framework framework) {
@@ -181,6 +185,7 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
     public static final String CONFIG_CON_TIMEOUT = "ssh-connection-timeout";
     public static final String CONFIG_COMMAND_TIMEOUT = "ssh-command-timeout";
     public static final String CONFIG_BIND_ADDRESS = "ssh-bind-address";
+    public static final String CONFIG_PASS_ENV = "ssh-accept-env";
 
     static final Description DESC ;
 
@@ -254,6 +259,15 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
             null
     );
 
+    public static final Property PASS_ENV_VAR = PropertyUtil.bool(CONFIG_PASS_ENV, "Pass RD_* Variables",
+            "Pass environment variables to server. Requires the AcceptEnv directive." +
+                    "\n" +
+                    "It is required to properly configure the SSH server on the remote end. " +
+                    "See the AcceptEnv directive in the `\"sshd_config(5)\"` manual page for instructions.\n" +
+                    "\n" +
+                    "See [rundeck documentation for more info about passing environment variables through remote command](https://docs.rundeck.com/docs/administration/projects/node-execution/ssh.html#passing-environment-variables-through-remote-command)",
+            false, "false");
+
     static {
         DescriptionBuilder builder = DescriptionBuilder.builder();
         builder.name(SERVICE_PROVIDER_TYPE)
@@ -270,6 +284,7 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
         builder.property(PROP_CON_TIMEOUT);
         builder.property(PROP_COMMAND_TIMEOUT);
         builder.property(PROP_BIND_ADDRESS);
+        builder.property(PASS_ENV_VAR);
 
         builder.mapping(CONFIG_KEYPATH, PROJ_PROP_SSH_KEYPATH);
         builder.frameworkMapping(CONFIG_KEYPATH, FWK_PROP_SSH_KEYPATH);
@@ -294,6 +309,9 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
         builder.mapping(CONFIG_BIND_ADDRESS, PROJ_PROP_BRIND_ADDRESS);
         builder.frameworkMapping(CONFIG_BIND_ADDRESS, FWK_PROP_BRIND_ADDRESS);
 
+        builder.mapping(CONFIG_PASS_ENV, PROJ_PROP_PASS_ENV);
+        builder.frameworkMapping(CONFIG_PASS_ENV, FWK_PROP_PASS_ENV);
+
         DESC=builder.build();
     }
 
@@ -316,6 +334,10 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
             );
         }
         boolean forceNewPty = ResolverUtil.resolveBooleanProperty(CONFIG_SET_PTY,false,
+                node,context.getFramework().getFrameworkProjectMgr().getFrameworkProject(context.getFrameworkProject()),
+                context.getFramework());
+
+        boolean passEnvVar = ResolverUtil.resolveBooleanProperty(CONFIG_PASS_ENV,false,
                 node,context.getFramework().getFrameworkProjectMgr().getFrameworkProject(context.getFrameworkProject()),
                 context.getFramework());
 
@@ -466,6 +488,9 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
         try {
             if(forceNewPty) {
                 sshexec.setAllocatePty(true);
+            }
+            if(passEnvVar) {
+                sshexec.passEnvVar(true);
             }
             sshexec.execute();
             success = true;

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutorSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutorSpec.groovy
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.FrameworkProject
 import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
+import com.dtolabs.rundeck.core.common.ProjectManager
 import com.dtolabs.rundeck.core.execution.ExecutionContext
 import com.dtolabs.rundeck.core.tools.AbstractBaseTest
 import spock.lang.Specification
@@ -64,5 +65,59 @@ class JschNodeExecutorSpec extends Specification {
         hostval | _
         null    | _
         ""      | _
+    }
+
+    def "ssh-accept-env from project configuration"() {
+        given:
+        def exec = new JschNodeExecutor(framework)
+        def frameworkProject = Mock(IRundeckProject)
+        def context = Mock(ExecutionContext) {
+            getFrameworkProject() >> PROJECT_NAME
+            getFramework() >> Mock(Framework){
+                getFrameworkProjectMgr()>> Mock(ProjectManager){
+                    getFrameworkProject(PROJECT_NAME) >> frameworkProject
+                }
+            }
+        }
+        def command = ['echo', 'hi'].toArray(new String[2])
+        def node = new NodeEntryImpl('anode')
+        node.setHostname("testhost")
+
+        when:
+        exec.executeCommand(context, command, node)
+
+
+        then:
+        1 * frameworkProject.hasProperty(JschNodeExecutor.PROJ_PROP_PREFIX + JschNodeExecutor.CONFIG_PASS_ENV) >> true
+        2 * frameworkProject.getProperty(JschNodeExecutor.PROJ_PROP_PREFIX + JschNodeExecutor.CONFIG_PASS_ENV) >> 'true'
+
+    }
+
+    def "ssh-accept-env from framework configuration"() {
+        given:
+        def exec = new JschNodeExecutor(framework)
+        def frameworkProject = Mock(IRundeckProject)
+        def framework = Mock(Framework){
+            getFrameworkProjectMgr()>> Mock(ProjectManager){
+                getFrameworkProject(PROJECT_NAME) >> frameworkProject
+            }
+        }
+        def context = Mock(ExecutionContext) {
+            getFrameworkProject() >> PROJECT_NAME
+            getFramework() >> framework
+        }
+        def command = ['echo', 'hi'].toArray(new String[2])
+        def node = new NodeEntryImpl('anode')
+        node.setHostname("testhost")
+
+        when:
+        exec.executeCommand(context, command, node)
+
+
+        then:
+        1 * frameworkProject.hasProperty(JschNodeExecutor.PROJ_PROP_PREFIX + JschNodeExecutor.CONFIG_PASS_ENV) >> false
+        1 * framework.hasProperty(JschNodeExecutor.FWK_PROP_PREFIX + JschNodeExecutor.CONFIG_PASS_ENV) >> true
+        1 * framework.getProperty(JschNodeExecutor.FWK_PROP_PREFIX + JschNodeExecutor.CONFIG_PASS_ENV) >> 'true'
+
     }
 }


### PR DESCRIPTION
fix #4137

Jsch library has a problem with infinite timeout on channel connection, it has a hardcoded retry of 20000ms.

The solution is to use a number different to 0 on the timeout, but that has the collateral impact to throw an error previously ignored from Jsch: If the remote server is not configured to accept environment variables throws an exception.

The solution proposed is to make Environment variables optional, so you enable only if you are sure you already configured that on the server:
https://docs.rundeck.com/docs/administration/projects/node-execution/ssh.html#passing-environment-variables-through-remote-command

Another collateral effect of this change is connections with high latency that doesn't pass the variable environment has a better time on the execution of the step since it doesn't waste time passing multiple environment variables and waiting for the response.

The current configuration of jsch executor will have accept-env-var on false and need to be enabled manually
 
![image](https://user-images.githubusercontent.com/2894508/83906439-939d0a00-a731-11ea-87be-faa6ca4ae03e.png)


Solution tested in an environment with very high latency by @g3nsvrv and @cwaltherf