### PR TITLE
Build - Use npm install for development

### DIFF
--- a/rundeckapp/grails-spa/build.gradle
+++ b/rundeckapp/grails-spa/build.gradle
@@ -43,7 +43,11 @@ task runNpmBuild(type: NpmTask, group: 'build') {
     outputs.dir(file("$spaBuildDir"))
     outputs.cacheIf { true }
 
-    args = ['run', 'build:ci']
+    def npmCommand = System.env.CI ?
+      'ci:build' :
+      'dev:build'
+
+    args = ['run', npmCommand]
 
     execOverrides {
       it.workingDir = './packages/ui'

--- a/rundeckapp/grails-spa/packages/ui-trellis/build.gradle
+++ b/rundeckapp/grails-spa/packages/ui-trellis/build.gradle
@@ -23,7 +23,11 @@ task runNpmBuild(type: NpmTask, group: 'build') {
     outputs.dir(file("$buildDir"))
     outputs.cacheIf { true }
 
-    args = ['run', 'build:ci']
+    def npmCommand = System.env.CI ?
+      'ci:bulid' :
+      'dev:build'
+
+    args = ['run', npmCommand]
 }
 
 assemble.dependsOn runNpmBuild

--- a/rundeckapp/grails-spa/packages/ui-trellis/build.gradle
+++ b/rundeckapp/grails-spa/packages/ui-trellis/build.gradle
@@ -24,7 +24,7 @@ task runNpmBuild(type: NpmTask, group: 'build') {
     outputs.cacheIf { true }
 
     def npmCommand = System.env.CI ?
-      'ci:bulid' :
+      'ci:build' :
       'dev:build'
 
     args = ['run', npmCommand]

--- a/rundeckapp/grails-spa/packages/ui-trellis/package.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package.json
@@ -5,7 +5,8 @@
   "main": "./lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build:ci": "npm ci && npm run build",
+    "dev:build": "npm install && npm run build",
+    "ci:build": "npm ci && npm run build",
     "dev": "concurrently -n vue,tsc \"vue-cli-service build --mode development --watch\" \"tsc -W -p ./tsconfig.build.json\"",
     "build": "run-script-os",
     "build:darwin:linux": "vue-cli-service build --mode production && tsc -p ./tsconfig.build.json",

--- a/rundeckapp/grails-spa/packages/ui/package-lock.json
+++ b/rundeckapp/grails-spa/packages/ui/package-lock.json
@@ -35,9 +35,17 @@
         "axios": "^0.18.0",
         "form-data": "^2.3.2",
         "tough-cookie": "^2.4.3",
+        "tslib": "^1.9.2",
         "tunnel": "0.0.6",
         "uuid": "^3.2.1",
         "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
       }
     },
     "@babel/code-frame": {
@@ -1121,7 +1129,15 @@
         "@esfx/disposable": "^1.0.0-pre.13",
         "@esfx/internal-deprecate": "^1.0.0-pre.13",
         "@esfx/internal-guards": "^1.0.0-pre.11",
-        "@esfx/internal-tag": "^1.0.0-pre.6"
+        "@esfx/internal-tag": "^1.0.0-pre.6",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
       }
     },
     "@esfx/disposable": {
@@ -1131,20 +1147,46 @@
       "requires": {
         "@esfx/internal-deprecate": "^1.0.0-pre.13",
         "@esfx/internal-guards": "^1.0.0-pre.11",
-        "@esfx/internal-tag": "^1.0.0-pre.6"
+        "@esfx/internal-tag": "^1.0.0-pre.6",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
       }
     },
     "@esfx/internal-deprecate": {
       "version": "1.0.0-pre.13",
       "resolved": "https://registry.npmjs.org/@esfx/internal-deprecate/-/internal-deprecate-1.0.0-pre.13.tgz",
-      "integrity": "sha512-uF4EhrILmUJdcDkSQNsr+33XEKaMj92/8804VIHswytdbwaQjQ85dbj1bSB9TFsXG2zkZtJo09NKNQ9p7NvTPQ=="
+      "integrity": "sha512-uF4EhrILmUJdcDkSQNsr+33XEKaMj92/8804VIHswytdbwaQjQ85dbj1bSB9TFsXG2zkZtJo09NKNQ9p7NvTPQ==",
+      "requires": {
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
     },
     "@esfx/internal-guards": {
       "version": "1.0.0-pre.11",
       "resolved": "https://registry.npmjs.org/@esfx/internal-guards/-/internal-guards-1.0.0-pre.11.tgz",
       "integrity": "sha512-DnRXkwwSrqIaml+sAm/zzpfDOCBnZkzflmGB833AqVYbgopO7xPBobngxqGBhYjutgTmVuXV3GKP0g08h4mQEw==",
       "requires": {
-        "@esfx/type-model": "^1.0.0-pre.11"
+        "@esfx/type-model": "^1.0.0-pre.11",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
       }
     },
     "@esfx/internal-tag": {
@@ -1155,7 +1197,17 @@
     "@esfx/type-model": {
       "version": "1.0.0-pre.11",
       "resolved": "https://registry.npmjs.org/@esfx/type-model/-/type-model-1.0.0-pre.11.tgz",
-      "integrity": "sha512-ImM8fj0HFE2GRPRq+q1xnW3kNaIbZscpJfWjGyeo9KdMxKoI75bJebsA3XK6AH9zbEWba+521V+m6NDvDhcnSw=="
+      "integrity": "sha512-ImM8fj0HFE2GRPRq+q1xnW3kNaIbZscpJfWjGyeo9KdMxKoI75bJebsA3XK6AH9zbEWba+521V+m6NDvDhcnSw==",
+      "requires": {
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+        }
+      }
     },
     "@evocateur/libnpmaccess": {
       "version": "3.1.2",

--- a/rundeckapp/grails-spa/packages/ui/package.json
+++ b/rundeckapp/grails-spa/packages/ui/package.json
@@ -9,10 +9,13 @@
     "start": "npm run dev",
     "lint": "eslint --ext .js,.vue src",
     "test": "jest",
-    "build:ci": "npm ci && npm run build",
     "build": "run-script-os",
     "build:darwin:linux": "./node_modules/.bin/vue-cli-service build --mode production",
-    "build:win32": "node_modules/.bin/vue-cli-service.js build --mode production"
+    "build:win32": "node_modules/.bin/vue-cli-service.js build --mode production",
+    "dev:build": "npm install && npm run build",
+    "ci:build": "npm ci && npm run build",
+    "dev:test": "npm install && npm run test",
+    "ci:test": "npm ci && npm run test"
   },
   "dependencies": {
     "ant-design-vue": "^1.5.4",


### PR DESCRIPTION
Newer versions of NPM do not stomp on the `package-lock.json` file unless there is a version range conflict between it and `package.json`. Using npm install will re-use the `node_modules` directory along with the webpack cache loader dir `node_modules/.cache` for faster re-builds.