### PR TITLE
Fix for log4j2 template 

### DIFF
--- a/rundeckapp/templates/config/log4j2.properties.template
+++ b/rundeckapp/templates/config/log4j2.properties.template
@@ -4,7 +4,7 @@ name = Rundeck Logging Configuration
 property.baseDir = ${sys:rundeck.server.logDir:-./server/logs}
 property.classLength = 2
 property.noConsoleNoAnsi = true
-property.prefix = [%style{%d{ISO8601}}{dim, noConsoleNoAnsi=${noConsoleNoAnsi}}] %highlight{%-5p}{noConsoleNoAnsi=${noConsoleNoAnsi}} %style{%c${classLength}}{cyan,noConsoleNoAnsi=${noConsoleNoAnsi}}
+property.prefix = [%style{%d{ISO8601}}{dim, noConsoleNoAnsi=${noConsoleNoAnsi}}] %highlight{%-5p}{noConsoleNoAnsi=${noConsoleNoAnsi}} %style{%c{${classLength}}}{cyan,noConsoleNoAnsi=${noConsoleNoAnsi}}
 
 appender.console.type = Console
 appender.console.name = STDOUT


### PR DESCRIPTION
Fix for log4j2 template where the classLength number was literally added to the message rather than limiting the class precision.
