### PR TITLE
Fix issue 1020 - Error handler on failed steps should be executed only in failed nodes

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContextImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContextImpl.java
@@ -35,6 +35,7 @@ import com.dtolabs.rundeck.core.jobs.JobService;
 import com.dtolabs.rundeck.core.logging.LoggingManager;
 import com.dtolabs.rundeck.core.nodes.ProjectNodeService;
 import com.dtolabs.rundeck.core.storage.StorageTree;
+import com.dtolabs.rundeck.core.common.NodeFilter;
 import lombok.Getter;
 
 import java.util.*;
@@ -663,6 +664,11 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
 
     public INodeSet getNodes() {
         return nodes;
+    }
+
+    @Override
+    public INodeSet filteredNodes() {
+        return null != nodeSet ? NodeFilter.filterNodes(nodeSet, nodes) : nodes;
     }
 
     public int getLoglevel() {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/OrchestratorNodeDispatcher.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/OrchestratorNodeDispatcher.java
@@ -103,9 +103,9 @@ public class OrchestratorNodeDispatcher implements NodeDispatcher {
                 ServiceNameConstants.Orchestrator,
                 config.getType()
         );
-        PluginAdapterUtility.configureProperties(resolver, description, plugin, PropertyScope.InstanceOnly);        
-        
-        INodeSet nodes = context.getNodes();
+        PluginAdapterUtility.configureProperties(resolver, description, plugin, PropertyScope.InstanceOnly);
+
+        INodeSet nodes = context.filteredNodes();
         boolean keepgoing = context.isKeepgoing();
 
         final HashSet<String> nodeNames = new HashSet<>();

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/ParallelNodeDispatcher.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/ParallelNodeDispatcher.java
@@ -82,7 +82,7 @@ public class ParallelNodeDispatcher implements NodeDispatcher {
     public DispatcherResult dispatch(final StepExecutionContext context,
                                      final NodeStepExecutionItem item, final Dispatchable toDispatch) throws
         DispatcherException {
-        INodeSet nodes = context.getNodes();
+        INodeSet nodes = context.filteredNodes();
         boolean keepgoing = context.isKeepgoing();
 
         final HashSet<String> nodeNames = new HashSet<>();

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/SequentialNodeDispatcher.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/dispatch/SequentialNodeDispatcher.java
@@ -71,7 +71,7 @@ public class SequentialNodeDispatcher implements NodeDispatcher {
                                      final NodeStepExecutionItem item, final Dispatchable toDispatch) throws
                                                                                                       DispatcherException {
 
-        INodeSet nodes = context.getNodes();
+        INodeSet nodes = context.filteredNodes();
         if (nodes.getNodes().size() < 1) {
             throw new DispatcherException("No nodes matched");
         }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/StepExecutionContext.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/StepExecutionContext.java
@@ -23,6 +23,7 @@
 */
 package com.dtolabs.rundeck.core.execution.workflow;
 
+import com.dtolabs.rundeck.core.common.INodeSet;
 import com.dtolabs.rundeck.core.execution.ExecutionContext;
 
 import java.util.List;
@@ -48,5 +49,11 @@ public interface StepExecutionContext extends ExecutionContext {
      * @return object to control workflow
      */
     public FlowControl getFlowControl();
+
+    /**
+     *
+     * @return filtered node set
+     */
+    public INodeSet filteredNodes();
 
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/dispatch/OrchestratorNodeDispatcherSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/dispatch/OrchestratorNodeDispatcherSpec.groovy
@@ -96,6 +96,7 @@ class OrchestratorNodeDispatcherSpec extends Specification {
         StepExecutionContext context = Mock(StepExecutionContext) {
             getOrchestrator() >> oconfig
             getNodes() >> nodeSet
+            filteredNodes() >> nodeSet
             getExecutionListener() >> Mock(ExecutionListener)
             getThreadCount() >> 1
             getDataContext() >> DataContextUtils.context(dataContext)
@@ -141,6 +142,7 @@ class OrchestratorNodeDispatcherSpec extends Specification {
         StepExecutionContext context = Mock(StepExecutionContext) {
             getOrchestrator() >> oconfig
             getNodes() >> nodeSet
+            filteredNodes() >> nodeSet
             getExecutionListener() >> Mock(ExecutionListener)
             getThreadCount() >> 1
             getDataContext() >> DataContextUtils.context(dataContext)

--- a/core/src/test/java/com/dtolabs/rundeck/core/tools/AbstractBaseTest.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/tools/AbstractBaseTest.java
@@ -72,6 +72,9 @@ public abstract class AbstractBaseTest extends TestCase {
     }
 
     public static void generateProjectResourcesFile(final File source, final IRundeckProject frameworkProject){
+        generateProjectResourcesFile(source, frameworkProject, false);
+    }
+    public static void generateProjectResourcesFile(final File source, final IRundeckProject frameworkProject, boolean localExecutor){
         //copy test nodes to resources file
         File resourcesfile = null;
         try {
@@ -86,6 +89,10 @@ public abstract class AbstractBaseTest extends TestCase {
         properties.put("resources.source.1.config.file", resourcesfile.getAbsolutePath());
         properties.put("resources.source.1.config.generateFileAutomatically", "false");
         properties.put("resources.source.1.config.includeServerNode", "true");
+        if(localExecutor) {
+            properties.put("resources.source.2.type", "local");
+            properties.put("service.NodeExecutor.default.provider", "local");
+        }
 
         Set<String> prefixes=new HashSet<String>();
         prefixes.add("resources.source");
@@ -106,6 +113,8 @@ public abstract class AbstractBaseTest extends TestCase {
         properties.put("resources.source.1.config.file", resourcesfile.getAbsolutePath());
         properties.put("resources.source.1.config.generateFileAutomatically", "false");
         properties.put("resources.source.1.config.includeServerNode", "true");
+        properties.put("resources.source.2.type", "local");
+        properties.put("service.NodeExecutor.default.provider", "local");
         return properties;
     }
     protected String getExistingFilePath(String filename, String type)

--- a/core/src/test/resources/com/dtolabs/rundeck/core/common/test-nodes5.xml
+++ b/core/src/test/resources/com/dtolabs/rundeck/core/common/test-nodes5.xml
@@ -1,0 +1,39 @@
+<!--
+  ~ Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project>
+  <node name="testnode1" type="SubNode" description="this is the test1 node" tags="boring,priority1"
+        hostname="host1.local"
+        osArch="i386"
+        osFamily="unix"
+        osName="Mac OS X"
+        osVersion="10.5.1"
+        username="username1"
+      >
+
+  </node>
+    <node name="testnode2" type="Node" description="registered Node asdf" tags="boring"
+          hostname="host2.local"
+          osArch="i386"
+          osFamily="unix"
+          osName="Mac OS X"
+          osVersion="10.5.1"
+          username="username2"
+    >
+
+    </node>
+
+</project>


### PR DESCRIPTION
Fix https://github.com/rundeckpro/rundeckpro/issues/1020

**Is this a bugfix, or an enhancement? Please describe.**
When a step fail, the node where this step failed is stored in a list but, when the error handler is executed, it's executed on all nodes

**Describe the solution you've implemented**
the execution should consider the filtered node by selector so that error handler will be executed only on node where the step failed
