### PR TITLE
Support api versions in semver style format. Update to v35.1

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/api/ApiInfoService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/api/ApiInfoService.java
@@ -27,9 +27,14 @@ public interface ApiInfoService
     String getApiBaseURL();
 
     /**
-     * @return current API version
+     * @return current API major version
      */
     int getCurrentVersion();
+
+    /**
+     * @return current API version
+     */
+    String getCurrentVersionFull();
 
     /**
      * @return minimum API version supported

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -473,7 +473,7 @@ class ApiController extends ControllerBase{
                             buildGit(grailsApplication.metadata['build.core.git.description'])
                             node(nodeName)
                             base(servletContext.getAttribute("RDECK_BASE"))
-                            apiversion(ApiVersions.API_CURRENT_VERSION)
+                            apiversion(ApiVersions.API_CURRENT_VERSION_STR)
                             serverUUID(sUUID)
                         }
                         executions(active:executionModeActive,executionMode:executionModeActive?'active':'passive')
@@ -547,7 +547,7 @@ class ApiController extends ControllerBase{
                             buildGit=(grailsApplication.metadata['build.core.git.description'])
                             node=(nodeName)
                             base=(servletContext.getAttribute("RDECK_BASE"))
-                            apiversion=(ApiVersions.API_CURRENT_VERSION)
+                            apiversion=(ApiVersions.API_CURRENT_VERSION_STR)
                             serverUUID=(sUUID)
                         }
                         executions={

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -1915,7 +1915,7 @@ setTimeout(function(){
             }
             xml{
                 return render(contentType: "text/xml", encoding: "UTF-8") {
-                    result(success: "true", apiversion: ApiVersions.API_CURRENT_VERSION) {
+                    result(success: "true", apiversion: ApiVersions.API_CURRENT_VERSION_STR) {
                         executionState(id:params.id){
                             new BuilderUtil().mapToDom(convertXml(state), delegate)
                         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2014,7 +2014,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         def buildGit = grailsApplication.metadata['build.core.git.description']
         def base = servletContext.getAttribute("RDECK_BASE")
         boolean executionModeActive=configurationService.executionModeActive
-        String apiVersion = ApiVersions.API_CURRENT_VERSION
+        String apiVersion = ApiVersions.API_CURRENT_VERSION_STR
 
         def memmax = Runtime.getRuntime().maxMemory()
         def memfree = Runtime.getRuntime().freeMemory()

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -1828,7 +1828,7 @@ class ScheduledExecutionController  extends ControllerBase{
             !pluginControlService?.isDisabledPlugin(it.name,'WorkflowStep')
         }
         def strategyPlugins = scheduledExecutionService.getWorkflowStrategyPluginDescriptions()
-        
+
         def crontab = scheduledExecution.timeAndDateAsBooleanMap()
 
         def notificationPlugins = notificationService.listNotificationPlugins().findAll{k,v->
@@ -4392,7 +4392,7 @@ class ScheduledExecutionController  extends ControllerBase{
                     return apiService.renderSuccessJson(response) {
                         delegate.'message'=("No action performed, cluster mode is not enabled.")
                         success=true
-                        apiversion=ApiVersions.API_CURRENT_VERSION
+                        apiversion=ApiVersions.API_CURRENT_VERSION_STR
                         self=[server:[uuid:frameworkService.getServerUUID()]]
                     }
                 }
@@ -4521,7 +4521,7 @@ class ScheduledExecutionController  extends ControllerBase{
                 }
                 render(contentType: "application/json",text: [
                     success:true,
-                    apiversion:ApiVersions.API_CURRENT_VERSION,
+                    apiversion:ApiVersions.API_CURRENT_VERSION_STR,
                     message: successMessage,
                     self:[server:[uuid:frameworkService.getServerUUID()]],
                     takeoverSchedule:datamap+[

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/AuthorizationInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/AuthorizationInterceptor.groovy
@@ -22,13 +22,13 @@ class AuthorizationInterceptor {
                 if (response.format in ['json']) {
                     render(contentType: "application/json", encoding: "UTF-8") {
                         error true
-                        apiversion ApiVersions.API_CURRENT_VERSION
+                        apiversion ApiVersions.API_CURRENT_VERSION_STR
                         errorCode "unauthorized"
                         message ("${authid} is not authorized for: ${request.forwardURI}")
                     }
                 } else {
                     render(contentType: "text/xml", encoding: "UTF-8") {
-                        result(error: "true", apiversion: ApiVersions.API_CURRENT_VERSION) {
+                        result(error: "true", apiversion: ApiVersions.API_CURRENT_VERSION_STR) {
                             delegate.'error'(code: "unauthorized") {
                                 message("${authid} is not authorized for: ${request.forwardURI}")
                             }

--- a/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
@@ -345,7 +345,7 @@ class ApiService {
     def respondOutput(HttpServletResponse response, String contentType, String output) {
         response.setContentType(contentType)
         response.setCharacterEncoding('UTF-8')
-        response.setHeader("X-Rundeck-API-Version",ApiVersions.API_CURRENT_VERSION.toString())
+        response.setHeader("X-Rundeck-API-Version",ApiVersions.API_CURRENT_VERSION_STR)
         def out = response.outputStream
         out << output
         out.flush()
@@ -467,7 +467,7 @@ class ApiService {
      */
     def renderSuccessXml(Closure recall){
         return renderSuccessXmlUnwrapped {
-            result(success: "true", apiversion: ApiVersions.API_CURRENT_VERSION) {
+            result(success: "true", apiversion: ApiVersions.API_CURRENT_VERSION_STR) {
                 recall.delegate = delegate
                 recall.resolveStrategy=Closure.DELEGATE_FIRST
                 recall()
@@ -797,7 +797,7 @@ class ApiService {
     def renderErrorJson(messages, String code=null){
         def result=[
                 error: true,
-                apiversion: ApiVersions.API_CURRENT_VERSION,
+                apiversion: ApiVersions.API_CURRENT_VERSION_STR,
         ]
         result.errorCode = code ?: 'api.error.unknown'
         if (!messages) {
@@ -829,7 +829,7 @@ class ApiService {
             xml=builder
         }
         xml.with {
-            result(error: "true", apiversion: ApiVersions.API_CURRENT_VERSION) {
+            result(error: "true", apiversion: ApiVersions.API_CURRENT_VERSION_STR) {
                 // REVIEW: disabled by grails3 merge
 //                def errorprops = [:]
                 def errorprops = [code: code ?: 'api.error.unknown']

--- a/rundeckapp/grails-app/views/common/_js.gsp
+++ b/rundeckapp/grails-app/views/common/_js.gsp
@@ -19,7 +19,7 @@
     <g:set var="currentProject" value="${params.project?:request.project}"/>
     <g:set var="projParams" value="${currentProject?[project:currentProject]:[:]}"/>
     var appLinks = {
-        api_version: '${com.dtolabs.rundeck.app.api.ApiVersions.API_CURRENT_VERSION}',
+        api_version: '${com.dtolabs.rundeck.app.api.ApiVersions.API_CURRENT_VERSION_STR}',
         project_name: '${params.project ?: request.project}',
         disclosureIcon: '${resource(dir:"images",file:"icon-tiny-disclosure.png")}',
         disclosureIconOpen: '${resource(dir:"images",file:"icon-tiny-disclosure-open.png")}',

--- a/rundeckapp/grails-app/views/layouts/base.gsp
+++ b/rundeckapp/grails-app/views/layouts/base.gsp
@@ -127,7 +127,7 @@
       window._rundeck = Object.assign(window._rundeck || {}, {
         rdBase: '${g.createLink(uri:"/",absolute:true)}',
         context: '${grailsApplication.config.server.contextPath}',
-        apiVersion: '${com.dtolabs.rundeck.app.api.ApiVersions.API_CURRENT_VERSION}',
+        apiVersion: '${com.dtolabs.rundeck.app.api.ApiVersions.API_CURRENT_VERSION_STR}',
         language: '${response.locale?.language ?: request.locale?.language}',
         locale: '${response.locale?.toString() ?: request.locale?.toString()}',
         projectName: '${enc(js:project?:params.project)}',

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiMarshallerRegistrar.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiMarshallerRegistrar.groovy
@@ -64,7 +64,7 @@ class ApiMarshallerRegistrar {
         JSON.registerObjectMarshaller(new CustomJsonMarshaller(api, curVersion))
 
         //use custom configuration for specific API versions
-        (1..ApiVersions.API_CURRENT_VERSION).each { apivers ->
+        (ApiVersions.API_EARLIEST_VERSION..ApiVersions.API_CURRENT_VERSION).each { apivers ->
             XML.createNamedConfig("v${apivers}") { cfg ->
                 cfg.registerObjectMarshaller(new CustomXmlMarshaller(api, apivers))
             }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/api/ApiInfo.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/api/ApiInfo.groovy
@@ -33,8 +33,13 @@ class ApiInfo implements ApiInfoService {
     }
 
     @Override
+    String getCurrentVersionFull() {
+        return ApiVersions.API_CURRENT_VERSION_STR
+    }
+
+    @Override
     int getMinimumSupportedVersion() {
-        ApiVersions.API_MIN_VERSION
+        ApiVersions.API_EARLIEST_VERSION
     }
 
     @Override

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/api/ApiVersionsSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/api/ApiVersionsSpec.groovy
@@ -1,0 +1,50 @@
+package com.dtolabs.rundeck.app.api
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ApiVersionsSpec extends Specification {
+    def "parse versions"() {
+        expect:
+            ApiVersions.parseVersion("1").toString() == "1.0"
+            ApiVersions.parseVersion("2").toString() == "2.0"
+            ApiVersions.parseVersion("1.1").toString() == "1.1"
+            ApiVersions.parseVersion("1.1.4").toString() == "1.1.4"
+            ApiVersions.parseVersion("1.1.4.4") == null
+            ApiVersions.parseVersion("0") == null
+            ApiVersions.parseVersion("0123") == null
+    }
+
+    def "compare versions"() {
+        expect:
+            ApiVersions.parseVersion("1") < ApiVersions.parseVersion("2")
+            ApiVersions.parseVersion("2") < ApiVersions.parseVersion("3")
+            ApiVersions.parseVersion("1.1") < ApiVersions.parseVersion("2")
+            ApiVersions.parseVersion("2.1") > ApiVersions.parseVersion("2")
+            ApiVersions.parseVersion("2.1") == ApiVersions.parseVersion("2.1.0")
+            ApiVersions.parseVersion("2") == ApiVersions.parseVersion("2.0")
+            ApiVersions.parseVersion("2") == ApiVersions.parseVersion("2.0.0")
+
+    }
+
+    @Unroll
+    def "is supported #value"() {
+        given:
+            ApiVersions versions = new ApiVersions(early, cur)
+        expect:
+            versions.isSupported(value) == result
+        where:
+            value      | early | cur  | result
+            '1'        | '1'   | '12' | true
+            '11'       | '1'   | '12' | true
+            '12'       | '1'   | '12' | true
+            '12.0'     | '1'   | '12' | true
+            '12.0.0'   | '1'   | '12' | true
+            '11.1'     | '1'   | '12' | true
+            '11.99.99' | '1'   | '12' | true
+            '12.0.1'   | '1'   | '12' | false
+            '3'        | '1'   | '2'  | false
+            '3'        | '4'   | '8'  | false
+            '8.0.1'    | '4'   | '8'  | false
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerTest.groovy
@@ -416,7 +416,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         //XML result has wrapper
         assertEquals 'result', response.xml.name()
         assertEquals 'true', response.xml.'@success'.text()
-        assertEquals ApiVersions.API_CURRENT_VERSION.toString(), response.xml.'@apiversion'.text()
+        assertEquals ApiVersions.API_CURRENT_VERSION_STR, response.xml.'@apiversion'.text()
 
         assertEquals 1, response.xml.projects.size()
         assertEquals 0, response.xml.project.size()
@@ -481,7 +481,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         //XML result has wrapper
         assertEquals 'result', response.xml.name()
         assertEquals 'true', response.xml.'@success'.text()
-        assertEquals ApiVersions.API_CURRENT_VERSION.toString(), response.xml.'@apiversion'.text()
+        assertEquals ApiVersions.API_CURRENT_VERSION_STR, response.xml.'@apiversion'.text()
 
         assertEquals 1, response.xml.projects.size()
         assertEquals 0, response.xml.project.size()
@@ -1000,7 +1000,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
             }
         }
     }
-    
+
     void deleteProject_apiversion(){
         when:
         controller.apiService = new ApiService()
@@ -1013,7 +1013,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals "true",response.xml.'@error'.text()
         assertEquals "api.error.api-version.unsupported",response.xml.error.'@code'.text()
     }
-    
+
     void deleteProject_xml_missingparam(){
         when:
         controller.apiService = new ApiService()
@@ -1041,7 +1041,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals true, response.json.error
         assertEquals "api.error.parameter.required", response.json.errorCode
     }
-    
+
     void deleteProject_xml_notfound(){
         when:
         controller.apiService = new ApiService()
@@ -1058,7 +1058,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals "true", response.xml.'@error'.text()
         assertEquals "api.error.item.doesnotexist", response.xml.error.'@code'.text()
     }
-    
+
     void deleteProject_json_notfound(){
         controller.apiService = new ApiService()
         controller.apiService.messageSource = mockWith(MessageSource) { getMessage { code, args,defval, locale -> code } }
@@ -1073,7 +1073,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals true, response.json.error
         assertEquals "api.error.item.doesnotexist", response.json.errorCode
     }
-    
+
     void deleteProject_xml_unauthorized(){
         when:
         controller.apiService = new ApiService()
@@ -1090,7 +1090,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals "true", response.xml.'@error'.text()
         assertEquals "api.error.item.unauthorized", response.xml.error.'@code'.text()
     }
-    
+
     void deleteProject_json_unauthorized(){
         when:
         controller.apiService = new ApiService()
@@ -1107,7 +1107,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals true, response.json.error
         assertEquals "api.error.item.unauthorized", response.json.errorCode
     }
-    
+
     void deleteProject_xml_haserrors(){
         when:
         controller.apiService = new ApiService()
@@ -1127,7 +1127,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
     }
 
 
-    
+
     void deleteProject_json_haserrors(){
         when:
         controller.apiService = new ApiService()
@@ -1145,7 +1145,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals true, response.json.error
         assertEquals "deleteProjectFailed", response.json.message
     }
-    
+
     void deleteProject_xml_success(){
         when:
         controller.apiService = new ApiService()
@@ -1163,7 +1163,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
     }
 
 
-    
+
     void deleteProject_json_success(){
         when:
         controller.apiService = new ApiService()
@@ -1501,7 +1501,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
     }
 
 
-    
+
     void apiProjectConfigGet_apiversion(){
         when:
         controller.apiService = new ApiService()
@@ -1514,7 +1514,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals "true", response.xml.'@error'.text()
         assertEquals "api.error.api-version.unsupported", response.xml.error.message.text()
     }
-    
+
     void apiProjectConfigGet_xml_missingparam(){
         when:
         controller.apiService = new ApiService()
@@ -1532,7 +1532,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals code, response.xml.error.message.text()
     }
 
-    
+
     void apiProjectConfigGet_json_missingparam(){
         when:
         controller.apiService = new ApiService()
@@ -1547,7 +1547,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals true, response.json.error
         assertEquals "api.error.parameter.required", response.json.errorCode
     }
-    
+
     void apiProjectConfigGet_xml_notfound(){
         when:
         controller.apiService = new ApiService()
@@ -1561,7 +1561,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals "true", response.xml.'@error'.text()
         assertEquals "api.error.item.doesnotexist", response.xml.error.message.text()
     }
-    
+
     void apiProjectConfigGet_json_notfound(){
         when:
         controller.apiService = new ApiService()
@@ -1577,7 +1577,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals true, response.json.error
         assertEquals "api.error.item.doesnotexist", response.json.errorCode
     }
-    
+
     void apiProjectConfigGet_xml_unauthorized(){
         when:
         controller.apiService = new ApiService()
@@ -1591,7 +1591,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals "true", response.xml.'@error'.text()
         assertEquals "api.error.item.unauthorized", response.xml.error.message.text()
     }
-    
+
     void apiProjectConfigGet_json_unauthorized(){
         when:
         controller.apiService = new ApiService()
@@ -1607,7 +1607,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals true, response.json.error
         assertEquals "api.error.item.unauthorized", response.json.errorCode
     }
-    
+
     void apiProjectConfigGet_xml_success(){
         when:
         controller.apiService = new ApiService()
@@ -1625,7 +1625,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals 'prop2',response.xml.property[1].'@key'.text()
         assertEquals 'value2',response.xml.property[1].'@value'.text()
     }
-    
+
     void apiProjectConfigGet_json_success(){
         when:
         controller.apiService = new ApiService()
@@ -1641,7 +1641,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals "value1",response.json.prop1
         assertEquals "value2",response.json.prop2
     }
-    
+
     void apiProjectConfigGet_text_success(){
         when:
         controller.apiService = new ApiService()
@@ -1658,7 +1658,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertTrue response.text.startsWith("#\n#")
     }
 
-    
+
     void apiProjectConfigPut_xml_success(){
         when:
         //controller.apiService.messageSource = mockWith(MessageSource) { getMessage { code, args,defval, locale -> code } }
@@ -1679,7 +1679,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals 'prop2', response.xml.property[1].'@key'.text()
         assertEquals 'value2', response.xml.property[1].'@value'.text()
     }
-    
+
     void apiProjectConfigPut_json_success(){
         when:
         controller.apiService = new ApiService()
@@ -1699,7 +1699,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
     }
 
 
-    
+
     void apiProjectConfigKeyGet_xml_success() {
         when:
         controller.apiService = new ApiService()
@@ -1718,7 +1718,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals 'value1', response.xml.'@value'.text()
     }
 
-    
+
     void apiProjectConfigKeyGet_json_success() {
         when:
         controller.apiService = new ApiService()
@@ -1735,7 +1735,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals 'prop1', response.json.key
         assertEquals 'value1', response.json.value
     }
-    
+
     void apiProjectConfigKeyGet_text_success() {
         when:
         controller.apiService = new ApiService()
@@ -1752,7 +1752,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
     }
 
 
-    
+
     void apiProjectConfigKeyPut_xml_success() {
         when:
         controller.apiService = new ApiService()
@@ -1772,7 +1772,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals 'value1', response.xml.'@value'.text()
     }
 
-    
+
     void apiProjectConfigKeyPut_json_success() {
         when:
         controller.apiService = new ApiService()
@@ -1791,7 +1791,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals 'prop1', response.json.key
         assertEquals 'value1', response.json.value
     }
-    
+
     void apiProjectConfigKeyPut_text_success() {
         when:
         controller.apiService = new ApiService()
@@ -1811,7 +1811,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals 'value1', response.text
     }
 
-    
+
     void apiProjectConfigKeyDelete_success() {
         when:
         controller.apiService = new ApiService()
@@ -1827,7 +1827,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         then:
         assertEquals HttpServletResponse.SC_NO_CONTENT, response.status
     }
-    
+
     void apiProjectExport_success() {
         when:
         controller.apiService = new ApiService()
@@ -1849,7 +1849,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals 'some data', response.text
 
     }
-    
+
     void apiProjectExport_apiversion() {
         when:
         controller.apiService = new ApiService()
@@ -1867,7 +1867,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         then:
         assertXmlError(response, HttpServletResponse.SC_BAD_REQUEST,'api.error.api-version.unsupported')
     }
-    
+
     void apiProjectExport_notfound() {
         when:
         controller.apiService = new ApiService()
@@ -1885,7 +1885,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         then:
         assertXmlError(response, HttpServletResponse.SC_NOT_FOUND,'api.error.item.doesnotexist')
     }
-    
+
     void apiProjectExport_unauthorized() {
         when:
         controller.apiService = new ApiService()
@@ -1903,7 +1903,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         then:
         assertXmlError(response, HttpServletResponse.SC_FORBIDDEN,'api.error.item.unauthorized')
     }
-    
+
     void apiProjectImport_notfound() {
         when:
         controller.apiService = new ApiService()
@@ -1917,7 +1917,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         then:
         assertXmlError(response, HttpServletResponse.SC_NOT_FOUND, "api.error.item.doesnotexist")
     }
-    
+
     void apiProjectImport_unauthorized() {
         when:
         controller.apiService = new ApiService()
@@ -1931,7 +1931,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         then:
         assertXmlError(response, HttpServletResponse.SC_FORBIDDEN, "api.error.item.unauthorized")
     }
-    
+
     void apiProjectImport_invalidFormat() {
         when:
         controller.apiService = new ApiService()
@@ -1945,7 +1945,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         then:
         assertXmlError(response, HttpServletResponse.SC_BAD_REQUEST, "api.error.invalid.request")
     }
-    
+
     void apiProjectImport_xml_failure() {
         when:
         controller.apiService = new ApiService()
@@ -1954,8 +1954,8 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         controller.projectService=mockWith(ProjectService){
             importToProject{  project,  framework,
                              UserAndRolesAuthContext authContext,  InputStream stream, ProjectArchiveImportRequest options->
-                
-                
+
+
                 [success:false,joberrors:['error1','error2']]
             }
         }
@@ -1977,7 +1977,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals 'error1',response.xml.errors.error[0].text()
         assertEquals 'error2',response.xml.errors.error[1].text()
     }
-    
+
     void apiProjectImport_json_failure() {
         when:
         controller.apiService = new ApiService()
@@ -1986,8 +1986,8 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         controller.projectService=mockWith(ProjectService){
             importToProject{  project,  framework,
                              UserAndRolesAuthContext authContext,  InputStream stream, ProjectArchiveImportRequest options->
-                
-                
+
+
                 [success:false,joberrors:['error1','error2']]
             }
         }
@@ -2008,7 +2008,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals 'error1',response.json.errors[0]
         assertEquals 'error2',response.json.errors[1]
     }
-    
+
     void apiProjectImport_xml_success() {
         when:
         controller.apiService = new ApiService()
@@ -2017,8 +2017,8 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         controller.projectService=mockWith(ProjectService){
             importToProject{  project,  framework,
                              UserAndRolesAuthContext authContext,  InputStream stream, ProjectArchiveImportRequest options->
-                
-                
+
+
                 assertEquals(true, options.importExecutions)
                 assertEquals('preserve', options.jobUuidOption)
                 assertEquals(false, options.importConfig)
@@ -2041,7 +2041,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals 'successful',response.xml.'@status'.text()
         assertEquals 0,response.xml.errors.size()
     }
-    
+
     void apiProjectImport_importExecutionsFalse() {
         when:
         controller.apiService = new ApiService()
@@ -2050,8 +2050,8 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         controller.projectService=mockWith(ProjectService){
             importToProject{  project,  framework,
                              UserAndRolesAuthContext authContext,  InputStream stream, ProjectArchiveImportRequest options->
-                
-                
+
+
                 assertEquals(false, options.importExecutions)
                 assertEquals('preserve', options.jobUuidOption)
                 assertEquals(false, options.importConfig)
@@ -2072,7 +2072,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         then:
         assertEquals HttpServletResponse.SC_OK,response.status
     }
-    
+
     void apiProjectImport_importExecutionsTrue() {
         when:
         controller.apiService = new ApiService()
@@ -2081,8 +2081,8 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         controller.projectService=mockWith(ProjectService){
             importToProject{  project, framework,
                              UserAndRolesAuthContext authContext,  InputStream stream, ProjectArchiveImportRequest options->
-                
-                
+
+
                 assertEquals(true, options.importExecutions)
                 assertEquals('preserve', options.jobUuidOption)
                 assertEquals(false, options.importConfig)
@@ -2102,7 +2102,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         then:
         assertEquals HttpServletResponse.SC_OK,response.status
     }
-    
+
     void apiProjectImport_jobUuidOptionPreserve() {
         when:
         controller.apiService = new ApiService()
@@ -2111,8 +2111,8 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         controller.projectService=mockWith(ProjectService){
             importToProject{  project,  framework,
                              UserAndRolesAuthContext authContext,  InputStream stream, ProjectArchiveImportRequest options->
-                
-                
+
+
                 assertEquals(true, options.importExecutions)
                 assertEquals('preserve', options.jobUuidOption)
                 assertEquals(false, options.importConfig)
@@ -2132,7 +2132,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         then:
         assertEquals HttpServletResponse.SC_OK,response.status
     }
-    
+
     void apiProjectImport_jobUuidOptionRemove() {
         controller.apiService = new ApiService()
         controller.apiService.messageSource = mockWith(MessageSource) { getMessage { code, args,defval, locale -> code } }
@@ -2140,8 +2140,8 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         controller.projectService=mockWith(ProjectService){
             importToProject{  project,  framework,
                              UserAndRolesAuthContext authContext,  InputStream stream, ProjectArchiveImportRequest options->
-                
-                
+
+
                 assertEquals(true, options.importExecutions)
                 assertEquals('remove', options.jobUuidOption)
                 assertEquals(false, options.importConfig)
@@ -2160,7 +2160,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         controller.apiProjectImport()
         assertEquals ("expected 200, ${response.contentAsString}",HttpServletResponse.SC_OK,response.status)
     }
-    
+
     void apiProjectImport_jobUuidOption_invalidValue() {
         controller.apiService = new ApiService()
         controller.apiService.messageSource = mockWith(MessageSource) { getMessage { code, args, defval, locale -> code+';'+args.join(';') } }
@@ -2168,8 +2168,8 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         controller.projectService=mockWith(ProjectService){
             importToProject{  project,  framework,
                              UserAndRolesAuthContext authContext,  InputStream stream, ProjectArchiveImportRequest options->
-                
-                
+
+
                 assertEquals([importExecutions: true, jobUuidOption: 'remove',importConfig:false, importACL:false], options)
                 [success:true]
             }
@@ -2193,7 +2193,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
                 response.json
         )
     }
-    
+
     void apiProjectImport_json_success() {
         controller.apiService = new ApiService()
         controller.apiService.messageSource = mockWith(MessageSource) { getMessage { code, args,defval, locale -> code } }
@@ -2201,8 +2201,8 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         controller.projectService=mockWith(ProjectService){
             importToProject{  project,  framework,
                              UserAndRolesAuthContext authContext,  InputStream stream, ProjectArchiveImportRequest options->
-                
-                
+
+
                 [success:true]
             }
         }
@@ -2221,7 +2221,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
     }
 
 
-    
+
     void apiProjectImport_importAcl_unauthorized() {
         when:
         controller.apiService = new ApiService()
@@ -2230,8 +2230,8 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         controller.projectService=mockWith(ProjectService){
             importToProject{  project,  framework,
                               UserAndRolesAuthContext authContext,  InputStream stream, ProjectArchiveImportRequest options->
-                
-                
+
+
                 [success:true]
             }
         }
@@ -2251,14 +2251,14 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
                               message:"api.error.item.unauthorized;[create, ACL for Project, [name:test1]]",
                               error: true,
                               errorCode : "api.error.item.unauthorized",
-                              apiversion: ApiVersions.API_CURRENT_VERSION
+                              apiversion: ApiVersions.API_CURRENT_VERSION_STR
                       ],
                       response.json
         )
         assertEquals null,response.json.errors
     }
 
-    
+
     void apiProjectImport_importAcl_authorized() {
         when:
         controller.apiService = new ApiService()
@@ -2267,8 +2267,8 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         controller.projectService=mockWith(ProjectService){
             importToProject{  project,  framework,
                               UserAndRolesAuthContext authContext,  InputStream stream, ProjectArchiveImportRequest options->
-                
-                
+
+
                 assertTrue(options.importACL)
                 [success:true]
             }
@@ -2294,7 +2294,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals null,response.json.errors
     }
 
-    
+
     void apiProjectImport_importScm_unauthorized() {
         when:
         controller.apiService = new ApiService()
@@ -2324,14 +2324,14 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
                 message:"api.error.item.unauthorized;[configure, SCM for Project, [name:test1]]",
                 error: true,
                 errorCode : "api.error.item.unauthorized",
-                apiversion: ApiVersions.API_CURRENT_VERSION
+                apiversion: ApiVersions.API_CURRENT_VERSION_STR
         ],
                 response.json
         )
         assertEquals null,response.json.errors
     }
 
-    
+
     void apiProjectImport_importScm_authorized() {
         when:
         controller.apiService = new ApiService()
@@ -2368,7 +2368,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals null,response.json.errors
     }
 
-    
+
     void apiProjectExport_scm_old_api_v() {
         when:
         controller.apiService = new ApiService()
@@ -2390,7 +2390,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals 'application/zip', response.contentType
         assertEquals 'some data', response.text
     }
-    
+
     void apiProjectExport_scm_success_v28() {
         when:
         controller.apiService = new ApiService()
@@ -2414,7 +2414,7 @@ class ProjectControllerTest extends HibernateSpec implements ControllerUnitTest<
         assertEquals 'some data', response.text
 
     }
-    
+
     void apiProjectList_json_date_v33_creation_time(){
         when:
         def dbProjA = new Project(name: 'testproject')

--- a/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
@@ -639,8 +639,8 @@ class ApiServiceSpec extends HibernateSpec implements ControllerUnitTest<ApiCont
 
         then:
         println result
-        result == '{"error":true,"apiversion":' +
-                (ApiVersions.API_CURRENT_VERSION) +
+        result == '{"error":true,"apiversion":"' +
+                (ApiVersions.API_CURRENT_VERSION_STR) +'"'+
                         (expectCode ? ',"errorCode":"' + (expectCode) +'"' : '') +
                         (eMessage ? ',"message":"' + (eMessage) +'"' : '') +
                         (eMessages ? ',"messages":' + (eMessages) : '') +
@@ -668,7 +668,7 @@ class ApiServiceSpec extends HibernateSpec implements ControllerUnitTest<ApiCont
         when:
         def result = service.renderErrorXml(data, code)
         then:
-        result == """<result error='true' apiversion='${ApiVersions.API_CURRENT_VERSION}'>
+        result == """<result error='true' apiversion='${ApiVersions.API_CURRENT_VERSION_STR}'>
   <error code='${
             code
         }'>
@@ -703,7 +703,7 @@ class ApiServiceSpec extends HibernateSpec implements ControllerUnitTest<ApiCont
         then:
         response.contentType == "text/xml"
         response.characterEncoding == "UTF-8"
-        response.getHeader("X-Rundeck-API-Version") == ApiVersions.API_CURRENT_VERSION.toString()
+        response.getHeader("X-Rundeck-API-Version") == ApiVersions.API_CURRENT_VERSION_STR
         response.getHeader("X-Rundeck-API-XML-Response-Wrapper") == "true"
         rs.success.message.text() == "test.code.arg1.arg2"
     }
@@ -720,7 +720,7 @@ class ApiServiceSpec extends HibernateSpec implements ControllerUnitTest<ApiCont
         closureCalled
         response.contentType == "text/xml"
         response.characterEncoding == "UTF-8"
-        response.getHeader("X-Rundeck-API-Version") == ApiVersions.API_CURRENT_VERSION.toString()
+        response.getHeader("X-Rundeck-API-Version") == ApiVersions.API_CURRENT_VERSION_STR
         response.getHeader("X-Rundeck-API-XML-Response-Wrapper") == "true"
         assertXmlSuccessText(response.text)
     }
@@ -739,7 +739,7 @@ class ApiServiceSpec extends HibernateSpec implements ControllerUnitTest<ApiCont
         response.contentType == "text/xml"
         response.characterEncoding == "UTF-8"
         response.status == 400
-        response.getHeader("X-Rundeck-API-Version") == ApiVersions.API_CURRENT_VERSION.toString()
+        response.getHeader("X-Rundeck-API-Version") == ApiVersions.API_CURRENT_VERSION_STR
         result.error.message.text() == 'api.error.api-version.unsupported:1:/test/uri:Minimum supported version: 2'
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ApiServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ApiServiceTests.groovy
@@ -67,7 +67,7 @@ class ApiServiceTests implements ServiceUnitTest<ApiServiceTests> {
         def gpath = slurper.parseText(result)
         assertEquals('result', gpath.name())
         assertEquals('true', gpath['@success'].text())
-        assertEquals(ApiVersions.API_CURRENT_VERSION.toString(), gpath['@apiversion'].text())
+        assertEquals(ApiVersions.API_CURRENT_VERSION_STR, gpath['@apiversion'].text())
         gpath
     }
     private GPathResult assertXmlErrorText(String result) {
@@ -75,7 +75,7 @@ class ApiServiceTests implements ServiceUnitTest<ApiServiceTests> {
         def gpath = slurper.parseText(result)
         assertEquals('result', gpath.name())
         assertEquals('true', gpath['@error'].text())
-        assertEquals(ApiVersions.API_CURRENT_VERSION.toString(), gpath['@apiversion'].text())
+        assertEquals(ApiVersions.API_CURRENT_VERSION_STR, gpath['@apiversion'].text())
         gpath
     }
 }

--- a/test/api/include.sh
+++ b/test/api/include.sh
@@ -2,6 +2,7 @@
 
 # common header for test scripts
 API_CURRENT_VERSION=35
+API_CURRENT_VERSION_STR=35.1
 
 SRC_DIR=$(cd `dirname $0` && pwd)
 DIR=${TMP_DIR:-$SRC_DIR}

--- a/test/api/test-require-version.sh
+++ b/test/api/test-require-version.sh
@@ -16,7 +16,7 @@ path=$(getpath "$runurl")
 echo "TEST: Invalid API Version, $path..."
 
 # get listing
-$SHELL $SRC_DIR/api-expect-error.sh ${runurl} "${params}" "Unsupported API Version \"${WRONG_VERS}\". API Request: ${path}. Reason: Current version: ${API_CURRENT_VERSION}" || exit 2
+$SHELL $SRC_DIR/api-expect-error.sh ${runurl} "${params}" "Unsupported API Version \"${WRONG_VERS}\". API Request: ${path}. Reason: Current version: ${API_CURRENT_VERSION_STR}" || exit 2
 echo "OK"
 
 
@@ -27,7 +27,7 @@ path=$(getpath "$runurl")
 echo "TEST: Wrong API Version: ${WRONG_VERS}..."
 
 # get listing
-$SHELL $SRC_DIR/api-expect-error.sh ${runurl} "${params}" "Unsupported API Version \"${WRONG_VERS}\". API Request: ${path}. Reason: Current version: ${API_CURRENT_VERSION}" || exit 2
+$SHELL $SRC_DIR/api-expect-error.sh ${runurl} "${params}" "Unsupported API Version \"${WRONG_VERS}\". API Request: ${path}. Reason: Current version: ${API_CURRENT_VERSION_STR}" || exit 2
 echo "OK"
 
 
@@ -38,7 +38,7 @@ path=$(getpath "$runurl")
 echo "TEST: Wrong API Version: ${WRONG_VERS}..."
 
 # get listing
-$SHELL $SRC_DIR/api-expect-error.sh ${runurl} "${params}" "Unsupported API Version \"${WRONG_VERS}\". API Request: ${path}. Reason: Current version: ${API_CURRENT_VERSION}" || exit 2
+$SHELL $SRC_DIR/api-expect-error.sh ${runurl} "${params}" "Unsupported API Version \"${WRONG_VERS}\". API Request: ${path}. Reason: Current version: ${API_CURRENT_VERSION_STR}" || exit 2
 echo "OK"
 
 WRONG_VERS="000001"
@@ -48,7 +48,7 @@ path=$(getpath "$runurl")
 echo "TEST: Wrong API Version: ${WRONG_VERS}..."
 
 # get listing
-$SHELL $SRC_DIR/api-expect-error.sh ${runurl} "${params}" "Unsupported API Version \"${WRONG_VERS}\". API Request: ${path}. Reason: Current version: ${API_CURRENT_VERSION}" || exit 2
+$SHELL $SRC_DIR/api-expect-error.sh ${runurl} "${params}" "Unsupported API Version \"${WRONG_VERS}\". API Request: ${path}. Reason: Current version: ${API_CURRENT_VERSION_STR}" || exit 2
 echo "OK"
 
 rm $DIR/curl.out

--- a/test/api/test-system-info.sh
+++ b/test/api/test-system-info.sh
@@ -31,7 +31,7 @@ fi
 
 #Check projects list
 testapivers=$($XMLSTARLET sel -T -t -v "/system/rundeck/apiversion" $DIR/curl.out)
-assert "${API_VERSION}" "${testapivers}" "Expected latest api version"
+assert "${API_CURRENT_VERSION_STR}" "${testapivers}" "Expected latest api version"
 
 echo "OK"
 
@@ -51,7 +51,7 @@ fi
 
 #Check projects list
 testapivers=$($XMLSTARLET sel -T -t -v "/system/rundeck/apiversion" $DIR/curl.out)
-assert "${API_VERSION}" "${testapivers}" "Expected latest api version"
+assert "${API_CURRENT_VERSION_STR}" "${testapivers}" "Expected latest api version"
 
 echo "OK"
 
@@ -72,7 +72,7 @@ fi
 
 #Check projects list
 testapivers=$($XMLSTARLET sel -T -t -v "/system/rundeck/apiversion" $DIR/curl.out)
-assert "${API_VERSION}" "${testapivers}" "Expected latest api version"
+assert "${API_CURRENT_VERSION_STR}" "${testapivers}" "Expected latest api version"
 
 echo "OK"
 
@@ -89,7 +89,7 @@ if [ 0 != $? ] ; then
     exit 2
 fi
 
-assert_json_value "${API_VERSION}" ".system.rundeck.apiversion" $DIR/curl.out || exit 2
+assert_json_value "${API_CURRENT_VERSION_STR}" ".system.rundeck.apiversion" $DIR/curl.out || exit 2
 
 
 echo "OK"
@@ -107,7 +107,7 @@ if [ 0 != $? ] ; then
     exit 2
 fi
 
-assert_json_value "${API_VERSION}" ".system.rundeck.apiversion" $DIR/curl.out || exit 2
+assert_json_value "${API_CURRENT_VERSION_STR}" ".system.rundeck.apiversion" $DIR/curl.out || exit 2
 
 
 echo "OK"


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

* Enables API versioning using "Major.Minor(.Patch)" format.
* Sets version to 35.1
* API endpoint calls can still use just the major version e.g. `/api/35/xyz`


**Additional context**

Allows non-breaking minor version updates to API