### PR TITLE
Accept Environment variables optional for jsch executor. fix #4137

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutor.java
@@ -266,7 +266,7 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
                     "See the AcceptEnv directive in the `\"sshd_config(5)\"` manual page for instructions.\n" +
                     "\n" +
                     "See [rundeck documentation for more info about passing environment variables through remote command](https://docs.rundeck.com/docs/administration/projects/node-execution/ssh.html#passing-environment-variables-through-remote-command)",
-            false, "true");
+            false, null);
 
     static {
         DescriptionBuilder builder = DescriptionBuilder.builder();
@@ -337,7 +337,7 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
                 node,context.getFramework().getFrameworkProjectMgr().getFrameworkProject(context.getFrameworkProject()),
                 context.getFramework());
 
-        boolean passEnvVar = ResolverUtil.resolveBooleanProperty(CONFIG_PASS_ENV,true,
+        boolean passEnvVar = ResolverUtil.resolveBooleanProperty(CONFIG_PASS_ENV,false,
                 node,context.getFramework().getFrameworkProjectMgr().getFrameworkProject(context.getFrameworkProject()),
                 context.getFramework());
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutor.java
@@ -165,7 +165,7 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
     public static final String FWK_SSH_CONFIG_PREFIX = FWK_PROP_PREFIX + SSH_CONFIG_PREFIX;
     public static final String PROJ_SSH_CONFIG_PREFIX = PROJ_PROP_PREFIX + SSH_CONFIG_PREFIX;
 
-    public static final String NODE_ATTR_PASS_ENV = "ssh-accept-env";
+    public static final String NODE_ATTR_PASS_ENV = "ssh-send-env";
     public static final String FWK_PROP_PASS_ENV = FWK_PROP_PREFIX + NODE_ATTR_PASS_ENV;
     public static final String PROJ_PROP_PASS_ENV = PROJ_PROP_PREFIX + NODE_ATTR_PASS_ENV;
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/jsch/JschNodeExecutor.java
@@ -185,7 +185,7 @@ public class JschNodeExecutor implements NodeExecutor, Describable {
     public static final String CONFIG_CON_TIMEOUT = "ssh-connection-timeout";
     public static final String CONFIG_COMMAND_TIMEOUT = "ssh-command-timeout";
     public static final String CONFIG_BIND_ADDRESS = "ssh-bind-address";
-    public static final String CONFIG_PASS_ENV = "ssh-accept-env";
+    public static final String CONFIG_PASS_ENV = NODE_ATTR_PASS_ENV;
 
     static final Description DESC ;
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/ExtSSHExec.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/ExtSSHExec.java
@@ -195,7 +195,8 @@ public class ExtSSHExec extends SSHBase implements SSHTaskBuilder.SSHExecInterfa
     }
 
     private boolean allocatePty = false;
-    
+    private boolean passEnvVar = false;
+
     /**
      * Allocate a Pseudo-Terminal.
      * If set true, the SSH connection will be setup to run over an allocated pty.
@@ -203,6 +204,13 @@ public class ExtSSHExec extends SSHBase implements SSHTaskBuilder.SSHExecInterfa
      */
     public void setAllocatePty(boolean b) {
         allocatePty = b;
+    }
+
+    /**
+     * Pass ENV_ rundeck variables.
+     */
+    public void passEnvVar(boolean b) {
+        passEnvVar = b;
     }
 
     private int exitStatus =-1;
@@ -451,13 +459,15 @@ public class ExtSSHExec extends SSHBase implements SSHTaskBuilder.SSHExecInterfa
             channel.setPty(allocatePty);
 
             /* set env vars if any are embedded */
-            if(null!=envVars && envVars.size()>0){
+            if(null!=envVars && envVars.size()>0 && passEnvVar){
                 for(final Environment.Variable env:envVars) {
                     channel.setEnv(env.getKey(), env.getValue());
                 }
             }
-            
-            channel.connect();
+            //since jsch doesnt accept infinite in connection timeout we use a week of timeout instead of 0
+            int jschConTimeout = sshConTimeout>0?(int)sshConTimeout:604800000;
+
+            channel.connect(jschConTimeout);
             // wait for it to finish
             thread =
                 new Thread() {

--- a/test/docker/dockers/hostnode/Dockerfile
+++ b/test/docker/dockers/hostnode/Dockerfile
@@ -31,7 +31,7 @@ ARG RUNDECK_NODE
 #RUN ssh-keygen
 VOLUME $HOME/resources
 RUN mkdir -p $HOME/resources
-RUN $HOME/scripts/createnode.sh $RUNDECK_NODE "username=\"$USERNAME\"" 'tags="remote"' "ssh-keypath=\"$HOME/resources/$RUNDECK_NODE.rsa\"" > $HOME/$RUNDECK_NODE.xml
+RUN $HOME/scripts/createnode.sh $RUNDECK_NODE "username=\"$USERNAME\"" 'tags="remote"' 'ssh-send-env="true"' "ssh-keypath=\"$HOME/resources/$RUNDECK_NODE.rsa\"" > $HOME/$RUNDECK_NODE.xml
 
 RUN chown -R $USERNAME:$USERNAME $HOME 
 

--- a/test/docker/dockers/hostnode/scripts/createnode.sh
+++ b/test/docker/dockers/hostnode/scripts/createnode.sh
@@ -10,6 +10,7 @@ $REST
 <node name="${NAME}-stored"
  description="remote node using stored ssh key" 
  ssh-key-storage-path="/keys/id_rsa.pem"
+ ssh-send-env="true"
   hostname="${NAME}" 
    osFamily="unix" 
    osName="Linux"


### PR DESCRIPTION
fix #4137

Jsch library has a problem with infinite timeout on channel connection, it has a hardcoded retry of 20000ms.

The solution is to use a number different to 0 on the timeout, but that has the collateral impact to throw an error previously ignored from Jsch: If the remote server is not configured to accept environment variables throws an exception.

The solution proposed is to make Environment variables optional, so you enable only if you are sure you already configured that on the server:
https://docs.rundeck.com/docs/administration/projects/node-execution/ssh.html#passing-environment-variables-through-remote-command

Another collateral effect of this change is connections with high latency that doesn't pass the variable environment has a better time on the execution of the step since it doesn't waste time passing multiple environment variables and waiting for the response.

The current configuration of JSCH executor will have `accept-env-var` on true and need to be disabled manually (changed from original PR since it looks like most rundeck users use `RD_` variables).

Solution tested in an environment with very high latency by @g3nsvrv and @cwaltherf