### PR TITLE
upgrade py-winrm-plugin to 2.0.7

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ rundeck:
   plugins: # Extra plugins to bundle
   - "com.github.Batix:rundeck-ansible-plugin:3.1.0"
   - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.4"
-  - "com.github.rundeck-plugins:py-winrm-plugin:2.0.6"
+  - "com.github.rundeck-plugins:py-winrm-plugin:2.0.7"
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.0"
   - "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.0.0"
   - "com.github.rundeck-plugins:attribute-match-node-enhancer:v0.1.5"


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Enhancement:

upgrade py-winrm-plugin to 2.0.7
- passing env variables from rundeck to windows
- fix kerberos requirement warning message


**Describe the solution you've implemented**

**Describe alternatives you've considered**

**Additional context**
