### PR TITLE
Webhook save must flush the session

### DIFF
--- a/rundeckapp/webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/rundeckapp/webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -181,7 +181,8 @@ class WebhookService {
             hook.authToken = hookData.authToken
         }
 
-        if(hook.save(true)) {
+        if(hook.validate()) {
+            hook.save(failOnError:true, flush:true)
             return [msg: "Saved webhook"]
         } else {
             if(!hook.id && hook.authToken){


### PR DESCRIPTION
Rundeck running on postgres requires the webhook save to flush in order to save the webhook.
