### PR TITLE
Build - Add command for printing cluster logs

### DIFF
--- a/test/testdeck/src/ClusterManager.ts
+++ b/test/testdeck/src/ClusterManager.ts
@@ -10,6 +10,7 @@ export interface IClusterManager {
     stopNode: (node: RundeckInstance) => Promise<void>
     startNode: (node: RundeckInstance) => Promise<void>
     listNodes: () => Promise<Url.UrlWithStringQuery[]>
+    logs: () => Promise<void>
 }
 
 interface IConfig {
@@ -35,7 +36,7 @@ export class DockerClusterManager implements IClusterManager {
     }
 
     async stopCluster() {
-        await this.compose.down()
+        await this.compose.stop()
     }
 
     async stopNode(node: RundeckInstance) {
@@ -64,6 +65,10 @@ export class DockerClusterManager implements IClusterManager {
         const containers = await this.compose.containers()
 
         return containers.map(c => Url.parse(`docker://${c}`))
+    }
+
+    async logs() {
+        await this.compose.logs()
     }
 
 }

--- a/test/testdeck/src/DockerCompose.ts
+++ b/test/testdeck/src/DockerCompose.ts
@@ -61,10 +61,15 @@ export class DockerCompose {
         })
     }
 
-    async stop(service: string): Promise<void> {
+    async stop(service?: string): Promise<void> {
         const env = {...process.env, ...this.config.env || {}}
 
-        const cp = CP.spawn('docker-compose', ['stop', service], {cwd: this.workDir, stdio: 'ignore', env})
+        const args = ['stop']
+
+        if (service)
+            args.push(service)
+
+        const cp = CP.spawn('docker-compose', args, {cwd: this.workDir, stdio: 'inherit', env})
 
         await new Promise((res, rej) => {
             cp.on('exit', (code, sig) => {
@@ -80,6 +85,21 @@ export class DockerCompose {
         const env = {...process.env, ...this.config.env || {}}
 
         const cp = CP.spawn('docker-compose', ['--compatibility', 'start', service], {cwd: this.workDir, stdio: 'ignore', env})
+
+        await new Promise((res, rej) => {
+            cp.on('exit', (code, sig) => {
+                if (sig || code != 0)
+                    rej(code)
+                else
+                    res()
+            })
+        })
+    }
+
+    async logs(service?: string): Promise<void> {
+        const env = {...process.env, ...this.config.env || {}}
+
+        const cp = CP.spawn('docker-compose', ['--compatibility', 'logs'], {cwd: this.workDir, stdio: 'inherit', env})
 
         await new Promise((res, rej) => {
             cp.on('exit', (code, sig) => {

--- a/test/testdeck/src/commands/cluster_commands/LogsCommand.ts
+++ b/test/testdeck/src/commands/cluster_commands/LogsCommand.ts
@@ -1,0 +1,38 @@
+import {Argv} from 'yargs'
+
+import { ClusterFactory } from '../../ClusterManager'
+
+import {Config} from '../../Config'
+
+interface Opts {
+    config: string
+    image: string
+}
+
+class LogsCommand {
+    command = "logs"
+    describe = "Print cluster logs"
+
+    builder(yargs: Argv) {
+        return yargs
+            .option('config', {
+                describe: 'Cluster configuration location',
+                type: 'string'
+            })
+    }
+
+    async handler(opts: Opts) {
+        const config = await Config.Load('./config.yml')
+
+        const clusterConfig = {
+            image: opts.image || config.baseImage,
+            licenseFile: config.licenseFile
+        }
+
+        const cluster = await ClusterFactory.CreateCluster(opts.config || config.clusterConfig, clusterConfig)
+
+        await cluster.logs()
+    }
+}
+
+module.exports = new LogsCommand()


### PR DESCRIPTION
* Uses `stop` to shutdown the cluster after tests are run so logs are still available
* Adds a basic command to print the cluster logs