### PR TITLE
Quell a common grails/spring bean warning

### DIFF
--- a/docker/official/remco/templates/log4j2.properties
+++ b/docker/official/remco/templates/log4j2.properties
@@ -99,6 +99,12 @@ logger.spring-core.level = warn
 logger.spring-core.additivity = false
 logger.spring-core.appenderRef.stdout.ref = STDOUT
 
+#Quell a noisy WARN from this class
+logger.springBeanPropertyDescriptor.name = org.springframework.beans.GenericTypeAwarePropertyDescriptor
+logger.springBeanPropertyDescriptor.level = error
+logger.springBeanPropertyDescriptor.additivity = false
+logger.springBeanPropertyDescriptor.appenderRef.stdout.ref = STDOUT
+
 # This logger covers all of Grails' internals
 # Enable to see whats going on underneath.
 logger.internals.name = org.codehaus.groovy.grails

--- a/rundeckapp/templates/config/log4j2.properties.template
+++ b/rundeckapp/templates/config/log4j2.properties.template
@@ -251,3 +251,8 @@ logger.jaas.name = org.rundeck.jaas
 logger.jaas.level = debug
 logger.jaas.additivity = false
 logger.jaas.appenderRef.stdout.ref = STDOUT
+
+logger.springBeanPropertyDescriptor.name = org.springframework.beans.GenericTypeAwarePropertyDescriptor
+logger.springBeanPropertyDescriptor.level = error
+logger.springBeanPropertyDescriptor.additivity = false
+logger.springBeanPropertyDescriptor.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
Quell a spring bean warning log message that is common for grails applications on startup. The grails guys don't appear to be in a hurry to fix it, so this log4j entry bumps the threshold to error for that particular class.