### PR TITLE
Fix #6158 should not set incorrect project.name

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProjectConfig.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkProjectConfig.java
@@ -172,7 +172,6 @@ public class FrameworkProjectConfig implements IRundeckProjectConfig, IRundeckPr
             return;
         }
         final Properties newProps = new Properties();
-        newProps.setProperty("project.name", name);
 
         //TODO: improve default configuration generation
         if (addDefaultProps) {
@@ -233,6 +232,7 @@ public class FrameworkProjectConfig implements IRundeckProjectConfig, IRundeckPr
         if (null != properties) {
             newProps.putAll(properties);
         }
+        newProps.setProperty("project.name", name);
 
         try {
             if(!destfile.getParentFile().exists()){

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/common/FrameworkProjectConfigSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/common/FrameworkProjectConfigSpec.groovy
@@ -1,0 +1,44 @@
+package com.dtolabs.rundeck.core.common
+
+import spock.lang.Specification
+
+import java.nio.file.Files
+
+class FrameworkProjectConfigSpec extends Specification {
+    def "generateProjectPropertiesFile doesn't overwrite project.name"() {
+        given:
+            String projectName = 'project1'
+            File destfile = Files.createTempFile('temp', '.properties').toFile()
+            destfile.deleteOnExit()
+
+            Properties orig = new Properties()
+            orig.setProperty('project.name', 'project1')
+            destfile.withWriter { Writer os ->
+                orig.store(os, 'test')
+            }
+
+            Properties props = new Properties()
+            props.setProperty('project.name', 'XXX')
+            boolean merge = true
+        when:
+            FrameworkProjectConfig.
+                generateProjectPropertiesFile(
+                    projectName,
+                    destfile,
+                    true,
+                    props,
+                    merge,
+                    new HashSet<String>(),
+                    false
+                )
+
+            Properties result = new Properties()
+            destfile.withReader {
+                result.load(it)
+            }
+        then:
+            result.getProperty('project.name') == projectName
+        cleanup:
+            destfile.delete()
+    }
+}


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Fix #6158 

**Describe the solution you've implemented**

fix storage method to set project.name after merging properties
