### PR TITLE
Set project storage to use db by default

### DIFF
--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -235,7 +235,7 @@ rundeck:
     logFileStorageService:
         startup:
             resumeMode: async
-    projectsStorageType: filesystem
+    projectsStorageType: db
     ajax:
         compression: gzip
         executionState:


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

sets default project storage to use DB which is consistent with the default configuration templates.