### PR TITLE
BUG: with #5440 Rundeck does not start anymore on OpenShift

### DIFF
--- a/docker/official/lib/entry.sh
+++ b/docker/official/lib/entry.sh
@@ -52,7 +52,7 @@ fi
 # Support Arbitrary User IDs on OpenShift
 if ! whoami &> /dev/null; then
   if [ -w /etc/passwd ]; then
-    sed -i "\#rundeck#c\rundeck:x:$(id -u):0:rundeck user:/home/rundeck:/bin/bash" /etc/passwd
+    echo "rundeck:x:$(id -u):0:rundeck user:/home/rundeck:/bin/bash" >> /etc/passwd
   fi
 fi
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
BUG: With #5440 Rundeck does not start anymore in OpenShift because the entry script failed with:
sed: couldn't open temporary file /etc/sedF47F9T: Permission denied

I guess sed will generate this as temporary file, but there are no write permissions in /etc.

**Describe the solution you've implemented**
Solution would be to use the echo statement (it does not matter if there is the Rundeck user entry twice)

**Describe alternatives you've considered**
another possibility would be to make the /etc directory group writable. But from security perspective I like the other way more.

**Additional context**
In a first version of #5440 there was also this echo statement instead of the sed. After short discussion with @ProTip I changed it to sed statement. Sorry, I hadn't considered this behavior.
