### PR TITLE
Docker - Environment Variable $HOME not set

### DIFF
--- a/docker/official/lib/entry.sh
+++ b/docker/official/lib/entry.sh
@@ -10,6 +10,7 @@ done
 export HOSTNAME=$(hostname)
 
 export RUNDECK_HOME=/home/rundeck
+export HOME=$RUNDECK_HOME
 
 export REMCO_HOME=/etc/remco
 export REMCO_RESOURCE_DIR=${REMCO_HOME}/resources.d


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
BUG: When starting the container with a different UID as 1000 (e.g. in OpenShift), the HOME environment variable is set to /.
This can lead to problems, e.g. Ansible is using ~/.ansible/tmp as local temorary directory.

**Describe the solution you've implemented**
simply declare it
