### PR TITLE
Docker - Process passwd update through /tmp for random uid

### DIFF
--- a/docker/official/lib/entry.sh
+++ b/docker/official/lib/entry.sh
@@ -51,9 +51,13 @@ fi
 
 # Support Arbitrary User IDs on OpenShift
 if ! whoami &> /dev/null; then
-  if [ -w /etc/passwd ]; then
-    sed -i "\#rundeck#c\rundeck:x:$(id -u):0:rundeck user:/home/rundeck:/bin/bash" /etc/passwd
-  fi
+    if [ -w /etc/passwd ]; then
+        TMP_PASSWD=$(mktemp)
+        cat /etc/passwd > "${TMP_PASSWD}"
+        sed -i "\#rundeck#c\rundeck:x:$(id -u):0:rundeck user:/home/rundeck:/bin/bash" "${TMP_PASSWD}"
+        cat "${TMP_PASSWD}" > /etc/passwd
+        rm "${TMP_PASSWD}"
+    fi
 fi
 
 exec java \


### PR DESCRIPTION
Fixes #6167

**Describe the solution you've implemented**
Move `passwd` to a temp file under `/tmp`, process it, and then overwrite the original with it.

Cleanup the temp file afterwards.

**Describe alternatives you've considered**
#6163 would work however in an effort to keep everything tidy and not have duplicate entries, this solution was based off the RedHat Jupyter notebooks blog: https://www.openshift.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id .

**Additional Context**
```
rundeck@a62ccb92d499:~$ cat /etc/passwd
...
rundeck:x:1234:0:rundeck user:/home/rundeck:/bin/bash
rundeck@a62ccb92d499:~$ whoami
rundeck
rundeck@a62ccb92d499:~$ echo $HOME
/home/rundeck
```