### PR TITLE
Fix for rundeckpro/969 job list paging

### DIFF
--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -648,7 +648,7 @@ search
            <div class="gsp-pager">
             <g:paginate next="Next" prev="Previous" max="${paginateJobsPerPage}"
             controller="menu" maxsteps="10"
-            action="jobs" total="${total}" params="${[max:params.max,offset:params.offset,project:params.project]}" />
+            action="jobs" total="${total}" params="${[max:params.max,offset:params.offset,project:params.project,jobListType:params.jobListType]}" />
             </div>
             </g:if>
         </div>


### PR DESCRIPTION
Fixes issue when using enterprise paged job list then reverting back to grouped job list and trying to advance a page.
