### PR TITLE
cleanup: unnecessary domain model field changes removed

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -1997,7 +1997,6 @@ class ScheduledExecutionController  extends ControllerBase{
         newScheduledExecution.project=scheduledExecution.project
         newScheduledExecution.id=null
         newScheduledExecution.uuid=null
-        newScheduledExecution.nextExecution=null
         //set session new workflow
         WorkflowController.getSessionWorkflow(session,null,new Workflow(scheduledExecution.workflow))
         if(scheduledExecution.options){

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -57,6 +57,7 @@ class ScheduledExecution extends ExecutionContext implements EmbeddedJsonData {
 
     Workflow workflow
 
+    /** @deprecated unused */
     Date nextExecution
     boolean scheduled = false
     Boolean nodesSelectedByDefault = true

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3053,15 +3053,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 def scheduledExecution = ScheduledExecution.get(schedId)
                 def seStats = scheduledExecution.getStats(true)
 
-                if (scheduledExecution.scheduled) {
-                    scheduledExecution.nextExecution = scheduledExecutionService.nextExecutionTime(scheduledExecution)
-                    if (scheduledExecution.save(flush: true)) {
-                        log.info("updated scheduled Execution nextExecution")
-                    } else {
-                        scheduledExecution.errors.allErrors.each { log.warn(it.defaultMessage) }
-                        log.warn("failed saving scheduled Execution nextExecution")
-                    }
-                }
                 def statsMap = seStats.getContentMap()
                 if (null == statsMap.execCount || 0 == statsMap.execCount || null == statsMap.totalTime || 0 == statsMap.totalTime) {
                     statsMap.execCount = 1

--- a/rundeckapp/grails-app/services/rundeck/services/JobSchedulesService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobSchedulesService.groovy
@@ -131,8 +131,6 @@ class LocalJobSchedulesManager implements SchedulesManager {
         return dates
     }
 
-    public static final long TWO_HUNDRED_YEARS=1000l * 60l * 60l * 24l * 365l * 200l
-
     /**
      * Return the next scheduled or predicted execution time for the scheduled job, and if it is not scheduled
      * return a time in the future.  If the job is not scheduled on the current server (cluster mode), returns
@@ -142,7 +140,7 @@ class LocalJobSchedulesManager implements SchedulesManager {
      */
     Date nextExecutionTime(ScheduledExecution se, boolean require=false) {
         if(!se.scheduled){
-            return new Date(TWO_HUNDRED_YEARS)
+            return null
         }
         if(!require && (!se.scheduleEnabled ||!se.executionEnabled ||
                 !scheduledExecutionService.isProjectScheduledEnabled(se.project) ||

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1513,7 +1513,6 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         return map
     }
 
-    public static final long TWO_HUNDRED_YEARS=1000l * 60l * 60l * 24l * 365l * 200l
     /**
      * Return the next scheduled or predicted execution time for the scheduled job, and if it is not scheduled
      * return a time in the future.  If the job is not scheduled on the current server (cluster mode), returns
@@ -3190,11 +3189,6 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }else if (scheduledExecution.scheduled) {
             scheduledExecution.populateTimeDateFields(params)
         }
-//        if(!scheduledExecution.scheduled){
-            //set nextExecution of non-scheduled job to be far in the future so that query results can sort correctly
-            //XXX: unnecessary
-//            scheduledExecution.nextExecution = new Date(ScheduledExecutionService.TWO_HUNDRED_YEARS)
-//        }
     }
 
     /**


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Cleans up unnecessary modifications to domain object field ScheduledExecution.nextExecution, reduce possibility of optimistic locking failures when doing other modifications to jobs and when handling cluster reschedules.
