### PR TITLE
Attempt to fix spurious testing errors in git plugin in some test cleanup phases

### DIFF
--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/BaseGitPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/BaseGitPluginSpec.groovy
@@ -64,7 +64,7 @@ class BaseGitPluginSpec extends Specification {
 
     def cleanup() {
         if (tempdir.exists()) {
-            FileUtils.delete(tempdir, FileUtils.RECURSIVE)
+            FileUtils.delete(tempdir, FileUtils.RECURSIVE | FileUtils.IGNORE_ERRORS)
         }
     }
     def "getSshConfig"() {

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginFactorySpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginFactorySpec.groovy
@@ -36,7 +36,7 @@ class GitExportPluginFactorySpec extends Specification {
 
     def cleanup() {
         if (tempdir.exists()) {
-            FileUtils.delete(tempdir, FileUtils.RECURSIVE)
+            FileUtils.delete(tempdir, FileUtils.RECURSIVE | FileUtils.IGNORE_ERRORS)
         }
     }
 

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
@@ -57,7 +57,7 @@ class GitExportPluginSpec extends Specification {
 
     def cleanup() {
         if (tempdir.exists()) {
-            FileUtils.delete(tempdir, FileUtils.RECURSIVE)
+            FileUtils.delete(tempdir, FileUtils.RECURSIVE | FileUtils.IGNORE_ERRORS)
         }
     }
 
@@ -545,7 +545,7 @@ class GitExportPluginSpec extends Specification {
         plugin.initialize(Mock(ScmOperationContext))
 
         //delete origin contents, will cause fetch to fail
-        FileUtils.delete(origindir, FileUtils.RECURSIVE)
+        FileUtils.delete(origindir, FileUtils.RECURSIVE | FileUtils.IGNORE_ERRORS)
 
         when:
         def status = plugin.getStatus(Mock(ScmOperationContext))
@@ -710,7 +710,7 @@ class GitExportPluginSpec extends Specification {
         when:
         def result = plugin.scmStateForStatus(status, revCommit, path)
         if (ltemp.exists()) {
-            FileUtils.delete(ltemp, FileUtils.RECURSIVE)
+            FileUtils.delete(ltemp, FileUtils.RECURSIVE | FileUtils.IGNORE_ERRORS)
         }
 
         then:

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitImportPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitImportPluginSpec.groovy
@@ -41,7 +41,7 @@ class GitImportPluginSpec extends Specification {
 
     def cleanup() {
         if (tempdir.exists()) {
-            FileUtils.delete(tempdir, FileUtils.RECURSIVE)
+            FileUtils.delete(tempdir, FileUtils.RECURSIVE | FileUtils.IGNORE_ERRORS)
         }
     }
 

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitUtilSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitUtilSpec.groovy
@@ -36,7 +36,7 @@ class GitUtilSpec extends Specification {
 
     def cleanup() {
         if (tempdir.exists()) {
-            FileUtils.delete(tempdir, FileUtils.RECURSIVE)
+            FileUtils.delete(tempdir, FileUtils.RECURSIVE | FileUtils.IGNORE_ERRORS)
         }
     }
     def "getcommit found"() {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

some spurious CI test errors seem to be due to race conditions around cleaning up temp dirs for git tests, this attempts to ignore those errors