### PR TITLE
Fix: schedule takeover results in 0 jobs when it should match

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/schedule/SchedulesManager.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/schedule/SchedulesManager.java
@@ -100,6 +100,15 @@ public interface SchedulesManager {
     List getSchedulesJobToClaim(String toServerUUID, String fromServerUUID, boolean selectAll, String projectFilter, List<String> jobids);
 
     /**
+     * Gets a list of scheduled jobs with adhoc scheduled executions
+     * @param toServerUUID
+     * @param fromServerUUID
+     * @param selectAll
+     * @param projectFilter
+     * @return
+     */
+    List getJobsWithAdhocScheduledExecutionsToClaim(String toServerUUID, String fromServerUUID, boolean selectAll, String projectFilter);
+    /**
      * Returns a list of dates in a time lapse between now and the to Date.
      * @param jobUuid
      * @param to Date in the future

--- a/rundeckapp/grails-app/services/rundeck/services/JobSchedulesService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobSchedulesService.groovy
@@ -55,6 +55,17 @@ class JobSchedulesService implements SchedulesManager {
     }
 
     @Override
+    List getJobsWithAdhocScheduledExecutionsToClaim(
+        final String toServerUUID,
+        final String fromServerUUID,
+        final boolean selectAll,
+        final String projectFilter
+    ) {
+        return rundeckJobSchedulesManager.
+            getJobsWithAdhocScheduledExecutionsToClaim(toServerUUID, fromServerUUID, selectAll, projectFilter)
+    }
+
+    @Override
     List<Date> nextExecutions(String jobUuid, Date to, boolean past) {
         return rundeckJobSchedulesManager.nextExecutions(jobUuid, to, past)
     }
@@ -111,6 +122,11 @@ class LocalJobSchedulesManager implements SchedulesManager {
     @Override
     List getSchedulesJobToClaim(String toServerUUID, String fromServerUUID, boolean selectAll, String projectFilter, List<String> jobids) {
         return scheduledExecutionService.getSchedulesJobToClaim(toServerUUID, fromServerUUID, selectAll, projectFilter, jobids)
+    }
+
+    @Override
+    List getJobsWithAdhocScheduledExecutionsToClaim(String toServerUUID, String fromServerUUID, boolean selectAll, String projectFilter){
+        return scheduledExecutionService.getJobsWithAdhocScheduledExecutionsToClaim(toServerUUID, fromServerUUID, selectAll, projectFilter)
     }
 
     @Override


### PR DESCRIPTION
* query was not correctly selecting jobs


**Is this a bugfix, or an enhancement? Please describe.**

Fix: schedule takeover results in 0 jobs when it should match
