### PR TITLE
Docker - Allow Remco templates to target different rundeck base dirs

### DIFF
--- a/docker/official/remco/templates/framework.properties
+++ b/docker/official/remco/templates/framework.properties
@@ -1,3 +1,5 @@
+{% set rundeckHome = getenv("RUNDECK_HOME", "/home/rundeck") %}
+
 # framework.properties -
 #
 
@@ -14,14 +16,14 @@ framework.server.url = {{ getv("/rundeck/grails/url", "http://127.0.0.1:4440") }
 # Installation locations
 # ----------------------------------------------------------------
 
-rdeck.base=/home/rundeck
+rdeck.base={{ getenv("RUNDECK_HOME", "ubuntu") }}
 
-framework.projects.dir=/home/rundeck/projects
-framework.etc.dir=/home/rundeck/etc
-framework.var.dir=/home/rundeck/var
-framework.tmp.dir=/home/rundeck/var/tmp
-framework.logs.dir=/home/rundeck/var/logs
-framework.libext.dir=/home/rundeck/libext
+framework.projects.dir={{ rundeckHome }}/projects
+framework.etc.dir={{ rundeckHome }}/etc
+framework.var.dir={{ rundeckHome }}/var
+framework.tmp.dir={{ rundeckHome }}/var/tmp
+framework.logs.dir={{ rundeckHome }}/var/logs
+framework.libext.dir={{ rundeckHome }}/libext
 
 {% if exists("/rundeck/tokens/file") %}
 rundeck.tokens.file={{ getv("/rundeck/tokens/file") }}
@@ -31,7 +33,7 @@ rundeck.tokens.file={{ getv("/rundeck/tokens/file") }}
 # SSH defaults for node executor and file copier
 # ----------------------------------------------------------------
 
-framework.ssh.keypath = /home/rundeck/.ssh/id_rsa
+framework.ssh.keypath = {{ rundeckHome }}/.ssh/id_rsa
 framework.ssh.user = rundeck
 
 # ssh connection timeout after a specified number of milliseconds.

--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -1,4 +1,4 @@
-
+{% set rundeckHome = getenv("RUNDECK_HOME", "/home/rundeck") %}
 
 {% macro JettyCachingLdapLoginModule(module) %}
     com.dtolabs.rundeck.jetty.jaas.{{module}} {{ getv("/rundeck/jaas/ldap/flag", "required") }}
@@ -64,7 +64,7 @@
 {% macro PropertyFileLoginModule() %}
     org.eclipse.jetty.jaas.spi.PropertyFileLoginModule {{ getv("rundeck/jaas/file/required", "required") }}
         debug="true"
-        file="/home/rundeck/server/config/realm.properties";
+        file="{{ rundeckHome }}/server/config/realm.properties";
 {% endmacro %}
 
 

--- a/docker/official/remco/templates/log4j2.properties
+++ b/docker/official/remco/templates/log4j2.properties
@@ -1,10 +1,11 @@
+{% set rundeckHome = getenv("RUNDECK_HOME", "/home/rundeck") %}
 {% set strategy = getv("/rundeck/logging/strategy", "CONSOLE") %}
 {% set ansiConsole = getv("/rundeck/logging/ansi/noconsolenoansi", "true") %}
 {% set classLength = printf("{%s}", getv("/rundeck/logging/classlength", "2")) %}
 {% set appender = "Console" %}
 
 name = Rundeck Logging Configuration
-property.baseDir = /home/rundeck/server/logs
+property.baseDir = {{ rundeckHome }}/server/logs
 property.ansiConsole = {{ansiConsole}}
 property.classLength = {{classLength}}
 property.prefix = {% verbatim %}[%style{%d{ISO8601}}{dim, noConsoleNoAnsi=${ansiConsole}}] %highlight{%-5p}{noConsoleNoAnsi=${ansiConsole}} %style{%c${classLength}}{cyan,noConsoleNoAnsi=${ansiConsole}}{% endverbatim %}

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -1,6 +1,8 @@
+{% set rundeckHome = getenv("RUNDECK_HOME", "/home/rundeck") %}
+
 #loglevel.default is the default log level for jobs: ERROR,WARN,INFO,VERBOSE,DEBUG
 loglevel.default=INFO
-rdeck.base=/home/rundeck
+rdeck.base={{ rundeckHome }}
 
 #rss.enabled if set to true enables RSS feeds that are public (non-authenticated)
 rss.enabled=false
@@ -13,7 +15,7 @@ grails.serverURL={{ getv("/rundeck/grails/url", "http://127.0.0.1:4440") }}
 server.servlet.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
 
 dataSource.dbCreate = {{ getv("/rundeck/database/create", "update") }}
-dataSource.url = {{ getv("/rundeck/database/url", "jdbc:h2:file:/home/rundeck/server/data/grailsdb;MVCC=true") }}
+dataSource.url = {{ getv("/rundeck/database/url", printf("jdbc:h2:file:%s/server/data/grailsdb;MVCC=true", rundeckHome)) }}
 dataSource.username = {{ getv("/rundeck/database/username", "") }}
 dataSource.password = {{ getv("/rundeck/database/password", "") }}
 {% if exists("/rundeck/database/driver") %}
@@ -45,7 +47,7 @@ rundeck.security.syncLdapUser={{ getv("/rundeck/security/syncldapuser") }}
 
 rundeck.api.tokens.duration.max={{ getv("/rundeck/api/tokens/duration/max", "30d") }}
 
-rundeck.log4j.config.file=/home/rundeck/server/config/log4j.properties
+rundeck.log4j.config.file={{ rundeckHome }}/server/config/log4j.properties
 
 rundeck.gui.startpage=projectHome
 


### PR DESCRIPTION
These changes make it easier to reuse the configuration templating and entry in different contexts(ie Tomcat).