### PR TITLE
Performance enhancement for job takeover process

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -546,7 +546,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
                     if (jobSchedulesService.isScheduled(scheduledExecution.uuid)) {
                         scheduledExecution.serverNodeUUID = serverUUID
-                        if (scheduledExecution.save(flush: true)) {
+                        if (scheduledExecution.save()) {
                             log.info("claimScheduledJob: schedule claimed for ${schedId} on node ${serverUUID}")
                         } else {
                             log.debug("claimScheduledJob: failed for ${schedId} on node ${serverUUID}")
@@ -559,7 +559,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                             claimDate
                     ).each {
                         it.serverNodeUUID = serverUUID
-                        it.save(flush:true)
+                        it.save()
                         log.info("claimed adhoc execution ${it.id}")
                         claimedExecs << it
                     }
@@ -596,7 +596,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         Map claimed = [:]
         def queryFromServerUUID = fromServerUUID
         def queryProject = projectFilter
-        ScheduledExecution.withTransaction {
+        ScheduledExecution.withSession { session ->
             def scheduledExecutions = jobSchedulesService.getSchedulesJobToClaim(toServerUUID, queryFromServerUUID, selectAll, queryProject, jobids)
             scheduledExecutions.each { ScheduledExecution se ->
                 def orig = se.serverNodeUUID
@@ -610,6 +610,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                     ]
                 }
             }
+            session.flush()
         }
         claimed
     }


### PR DESCRIPTION
Significant performance enhancement for job takeover with large job/execution sets.

The current code is doing a session flush inside a loop for every job and execution that is being taken over. This session flush can take up to 2s per domain object being saved. For takeovers that deal with 100s of jobs, the takeover time can be very long. 

This change flushes the session once after all of the jobs and executions have been claimed. The session flush is necessary because a subsequent query in the reschedule code needs up to date job/execution information to schedule jobs correctly.