### PR TITLE
Enhance YAML multiline export functionality

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -333,7 +333,9 @@ beans={
 
     rundeckJobDefinitionManager(RundeckJobDefinitionManager)
     rundeckJobXmlFormat(JobXMLFormat)
-    rundeckJobYamlFormat(JobYAMLFormat)
+    rundeckJobYamlFormat(JobYAMLFormat) {
+        trimSpacesFromLines = application.config.getProperty('rundeck.job.export.yaml.trimSpaces', Boolean)
+    }
 
     scmExportPluginProviderService(ScmExportPluginProviderService) {
         rundeckServerServiceProviderLoader = ref('rundeckServerServiceProviderLoader')

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/BuilderUtil.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/BuilderUtil.groovy
@@ -230,6 +230,17 @@ class BuilderUtil {
     }
 
     /**
+     * Trim all empty space from each line in the input string and
+     * replace all line endings with the given string
+     * @param os input string
+     * @param lineEnding line ending string to use
+     * @return new string
+     */
+    static String trimAllLinesAndReplaceLineEndings(String os, String lineEnding) {
+        os.readLines().collect { it.trim() }.join(lineEnding)
+    }
+
+    /**
      * Add entry to the map for the given key, converting the key into an
      * attribute key identifier
      */

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/BuilderUtil.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/BuilderUtil.groovy
@@ -16,6 +16,7 @@
 
 package com.dtolabs.rundeck.app.support
 
+import org.apache.commons.lang3.StringUtils
 import org.rundeck.app.components.jobs.JobXMLUtil
 
 import java.util.regex.Pattern
@@ -237,7 +238,7 @@ class BuilderUtil {
      * @return new string
      */
     static String trimAllLinesAndReplaceLineEndings(String os, String lineEnding) {
-        os.readLines().collect { it.trim() }.join(lineEnding)
+        os.readLines().collect { StringUtils.stripEnd(it,null) }.join(lineEnding)
     }
 
     /**

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/support/BuilderUtilSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/support/BuilderUtilSpec.groovy
@@ -226,8 +226,8 @@ class BuilderUtilSpec extends Specification {
 
         where:
         ending  | input             | expected
-        '\n'    | 'test \n trim '   | 'test\ntrim'
-        '\r\n'  | 'test \n trim '   | 'test\r\ntrim'
+        '\n'    | 'test \n trim '   | 'test\n trim'
+        '\r\n'  | 'test \n trim '   | 'test\r\n trim'
 
     }
 }

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/support/BuilderUtilSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/support/BuilderUtilSpec.groovy
@@ -215,4 +215,19 @@ class BuilderUtilSpec extends Specification {
         '\r\n' | 'abc\r\ndef\r\nghi' | 'abc\r\ndef\r\nghi'
 
     }
+
+    def "trimSpacesAndReplaceLineEndings"() {
+
+        when:
+        def result = BuilderUtil.trimAllLinesAndReplaceLineEndings(input,ending)
+
+        then:
+        result == expected
+
+        where:
+        ending  | input             | expected
+        '\n'    | 'test \n trim '   | 'test\ntrim'
+        '\r\n'  | 'test \n trim '   | 'test\r\ntrim'
+
+    }
 }

--- a/rundeckapp/src/test/groovy/org/rundeck/app/components/JobYAMLFormatSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/components/JobYAMLFormatSpec.groovy
@@ -122,7 +122,7 @@ class JobYAMLFormatSpec extends Specification {
     @Unroll
     def "encoding multiline line endings are unix"() {
         given:
-            def sut = new JobYAMLFormat()
+            def sut = new JobYAMLFormat(trimSpacesFromLines: trimSpaces)
             def writer = new StringWriter()
             def data = [[a: text]]
             def options = JobFormat.options(false, null, (String) null)
@@ -131,10 +131,15 @@ class JobYAMLFormatSpec extends Specification {
         then:
             writer.toString() == expected
         where:
-            text      | expected
-            'ab\nc'   | '- a: |-\n    ab\n    c\n'
-            'ab\r\nc' | '- a: |-\n    ab\n    c\n'
-            'ab\rc'   | '- a: |-\n    ab\n    c\n'
+            text            | trimSpaces    | expected
+            'ab\nc'         | false         | '- a: |-\n    ab\n    c\n'
+            'ab\r\nc'       | false         | '- a: |-\n    ab\n    c\n'
+            'ab\rc'         | false         | '- a: |-\n    ab\n    c\n'
+            'ab \rc'        | false         | '- a: "ab \\nc"\n'
+            'ab \rc'        | true          | '- a: |-\n    ab\n    c\n'
+            'ab\n \nc'      | false         | '- a: "ab\\n \\nc"\n'
+            'ab\n \nc'      | true          | '- a: |-\n    ab\n\n    c\n'
+            'ab\n \nc \n '  | true          | '- a: |\n    ab\n\n    c\n'
     }
     @Unroll
     def "encoding comma strings are quoted"() {

--- a/rundeckapp/src/test/groovy/org/rundeck/app/components/JobYAMLFormatSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/components/JobYAMLFormatSpec.groovy
@@ -140,6 +140,7 @@ class JobYAMLFormatSpec extends Specification {
             'ab\n \nc'      | false         | '- a: "ab\\n \\nc"\n'
             'ab\n \nc'      | true          | '- a: |-\n    ab\n\n    c\n'
             'ab\n \nc \n '  | true          | '- a: |\n    ab\n\n    c\n'
+            'ab\n \n c \n ' | true          | '- a: |\n    ab\n\n     c\n'
     }
     @Unroll
     def "encoding comma strings are quoted"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/audit/AuditEventsServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/audit/AuditEventsServiceSpec.groovy
@@ -102,7 +102,7 @@ class AuditEventsServiceSpec extends Specification implements ServiceUnitTest<Au
                 .setResourceName(user)
                 .publish()
         // Wait for async process to finish
-        Thread.sleep(100)
+        Thread.sleep(300)
 
         then:
         invocations == 1


### PR DESCRIPTION
Allows a user to direct the yaml exporter to trim lines before exporting in order to get a nice literal text dump of their code blocks.

The user who reported their job exporting in an unexpected format #5723 was apparently depending on the older snakeyaml lib behavior which was more lax about string space representation. The newer snakeyaml lib tries to be more accurate in its string spacing representation and defaults to the YAML double quote representation which provides the most accurate rendering of complex multiline output.

Stripping all trailing spaces on all lines seems to allow the YAML exporter to use the literal representation more deterministically.

Default for the trim spaces is off.

New Rundeck config:
`rundeck.job.export.yaml.trimSpaces=true` 