### PR TITLE
Fix #4085 empty log file causes NaN in percentLoaded value

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -1591,7 +1591,7 @@ setTimeout(function(){
             entry=newe
         }
         long marktime=System.currentTimeMillis()
-        def percent=100.0 * (((float)storeoffset)/((float)totsize))
+        def percent=100.0 * (totsize>0? (((float)storeoffset)/((float)totsize)) : 0)
         log.debug("percent: ${percent}, store: ${storeoffset}, total: ${totsize} lastmod : ${lastmodl}")
 
         def resultData= [

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -466,6 +466,44 @@ class ExecutionControllerSpec extends HibernateSpec implements ControllerUnitTes
             '-1'     | 3
             'asdf'   | 3
     }
+    def "tail exec output 0 totsize should have 0 percentLoaded"() {
+        given:
+            def assetTaglib = mockTagLib(AssetMethodTagLib)
+            assetTaglib.assetProcessorService = Mock(AssetProcessorService) {
+                assetBaseUrl(*_) >> ''
+                getAssetPath(*_) >> ''
+            }
+
+            Execution e1 = new Execution(
+                project: 'test1',
+                user: 'bob',
+                dateStarted: new Date(),
+                dateEnded: new Date(),
+                status: 'successful'
+
+            )
+            e1.save() != null
+            controller.loggingService = Mock(LoggingService)
+            controller.configurationService = Mock(ConfigurationService)
+            controller.apiService = Mock(ApiService)
+            controller.frameworkService = Mock(FrameworkService)
+            def reader = new ExecutionLogReader(state: ExecutionFileState.AVAILABLE)
+            reader.reader = new TestReader(logs: [])
+        when:
+            params.id = e1.id.toString()
+            params.maxlines = '500'
+            request.addHeader('accept', 'text/json')
+            controller.tailExecutionOutput()
+        then:
+            def result = response.json
+            result.percentLoaded==0.0
+
+            1 * controller.apiService.requireExists(_, e1, _) >> true
+            1 * controller.frameworkService.getAuthContextForSubjectAndProject(_, _)
+            1 * controller.frameworkService.authorizeProjectExecutionAny(*_) >> true
+            1 * controller.loggingService.getLogReader(e1) >> reader
+
+    }
 
     /**
      * compacted=true, the log entries returned will include only the changed


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Fix #4085 

When log file is empty (e.g. race condition where API client reads output before any is produced), the `percentLoaded` value could return `NaN`
