### PR TITLE
Output Viewer Safari style fixes

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/.storybook/main.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/.storybook/main.js
@@ -47,6 +47,7 @@ module.exports = {
             use: [
             'style-loader',
             {loader: 'css-loader', options: {sourceMap: true}},
+            {loader: 'postcss-loader', options: {sourceMap: true, plugins: [require('autoprefixer')]}},
             {loader: 'less-loader',
             options: {
                 sourceMap: true,
@@ -60,6 +61,7 @@ module.exports = {
             use: [
               {loader: 'vue-style-loader'},
               {loader: 'css-loader', options: {sourceMap: true}},
+              {loader: 'postcss-loader', options: {sourceMap: true, plugins: [require('autoprefixer')] }},
               {loader: 'sass-loader', options: {sourceMap: true}},
             ],
         });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/execution.stories.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/execution.stories.ts
@@ -40,7 +40,7 @@ export const darkTheme = () => (Vue.extend({
     template: '<LogViewer :useUserSettings="false" :config="settings" executionId="912" style="height: 100%;" />',
     mounted: function() {
         const el = this.$el as any
-        el.parentNode.style.height = '100%'
+        el.parentNode.style.height = '100vh'
     },
     props: {
         settings: {
@@ -60,7 +60,7 @@ export const darkTheme = () => (Vue.extend({
 //     template: '<LogViewer :useUserSettings="false" executionId="1" style="height: 100%;" />',
 //     mounted: function() {
 //         const el = this.$el as any
-//         el.parentNode.style.height = '100%'
+//         el.parentNode.style.height = '100vh'
 //     },
 //     props: {},
 //     provide: () => ({
@@ -104,7 +104,7 @@ export const basicOutput = () => (Vue.extend({
     mounted: async function() {
         console.log('Mounted!!!')
         const el = this.$el as any
-        el.parentNode.style.height = '100%'
+        el.parentNode.style.height = '100vh'
         
         fetchMock.reset()
         const cassette = await Cassette.Load('/fixtures/ExecBasicOutput.json')
@@ -144,7 +144,7 @@ export const htmlOutput = () => (Vue.extend({
     template: '<LogViewer :useUserSettings="false" executionId="907" style="height: 100%;" />',
     mounted: async function() {
         const el = this.$el as any
-        el.parentNode.style.height = '100%'
+        el.parentNode.style.height = '100vh'
     },
     props: {
         
@@ -161,7 +161,7 @@ export const ansiColorOutput = () => (Vue.extend({
     template: '<LogViewer :useUserSettings="false" executionId="912" style="height: 100%;" />',
     mounted: async function() {
         const el = this.$el as any
-        el.parentNode.style.height = '100%'
+        el.parentNode.style.height = '100vh'
     },
     props: {
         
@@ -178,7 +178,7 @@ export const largeOutput = () => (Vue.extend({
     template: '<LogViewer :useUserSettings="false" executionId="7" style="height: 100%;" />',
     mounted: async function() {
         const el = this.$el as any
-        el.parentNode.style.height = '100%'
+        el.parentNode.style.height = '100vh'
     },
     props: {
         
@@ -195,7 +195,7 @@ export const runningOutput = () => (Vue.extend({
     template: '<LogViewer :useUserSettings="false" executionId="900" style="height: 100%;" />',
     mounted: async function() {
         const el = this.$el as any
-        el.parentNode.style.height = '100%'
+        el.parentNode.style.height = '100vh'
     },
     props: {
         
@@ -212,7 +212,7 @@ export const failedOutput = () => (Vue.extend({
     template: '<LogViewer :useUserSettings="false" executionId="880" style="height: 100%;" />',
     mounted: async function() {
         const el = this.$el as any
-        el.parentNode.style.height = '100%'
+        el.parentNode.style.height = '100vh'
     },
     props: {
         
@@ -229,7 +229,7 @@ export const gutterOverflow = () => (Vue.extend({
     template: '<LogViewer :useUserSettings="false" :config="config" executionId="900" style="height: 100%;" />',
     mounted: async function() {
         const el = this.$el as any
-        el.parentNode.style.height = '100%'
+        el.parentNode.style.height = '100vh'
     },
     props: {
         config: { default: {
@@ -252,7 +252,7 @@ export const userSettings = () => (Vue.extend({
     template: '<LogViewer executionId="900" style="height: 100%;" />',
     mounted: async function() {
         const el = this.$el as any
-        el.parentNode.style.height = '100%'
+        el.parentNode.style.height = '100vh'
     },
     provide: () => ({
         rootStore: new RootStore(window._rundeck.rundeckClient),
@@ -273,7 +273,7 @@ export const filtered = () => (Vue.extend({
     mounted: async function() {
         console.log('Mounted!!!')
         const el = this.$el as any
-        el.parentNode.style.height = '100%'
+        el.parentNode.style.height = '100vh'
         
         fetchMock.reset()
         const cassette = await Cassette.Load('/fixtures/ExecFailedOutput.json')

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logEntryFlex.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logEntryFlex.vue
@@ -16,8 +16,8 @@
                 'execution-log__content--html': $options.entry.logHtml
             }]"
             ><span v-if="displayNodeBadge" class="execution-log__node-badge"><i class="fas fa-hdd"/> {{$options.entry.node}}</span
-            ><span v-if="$options.entry.logHtml" v-bind:class="{'execution-log__content-text--overflow': !lineWrap}" v-html="$options.entry.logHtml"
-            /><span v-if="!$options.entry.logHtml" v-bind:class="{'execution-log__content-text--overflow': !lineWrap}">{{$options.entry.log}}</span
+            ><span v-if="$options.entry.logHtml" class="execution-log__content-text" v-bind:class="{'execution-log__content-text--overflow': !lineWrap}" v-html="$options.entry.logHtml"
+            /><span v-if="!$options.entry.logHtml" class="execution-log__content-text" v-bind:class="{'execution-log__content-text--overflow': !lineWrap}">{{$options.entry.log}}</span
         ></div
     ></div>
 </template>
@@ -74,7 +74,6 @@ export default class Flex extends Vue {
   display: flex;
   width: 100%;
   font-family: monospace;
-  word-break: break-word;
 }
 
 .execution-log__gutter {
@@ -103,11 +102,16 @@ export default class Flex extends Vue {
     min-width: 0;
 }
 
+.execution-log__content-text {
+    word-break: break-word;
+}
+
 .execution-log__content-text--overflow {
     overflow: hidden;
     white-space: pre;
     text-overflow: ellipsis;
     display: block;
+    word-break: normal;
 }
 
 .execution-log__content--html {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logEntryFlex.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logEntryFlex.vue
@@ -6,18 +6,21 @@
             }"
         >
             <span class="gutter line-number">
-                {{timestamps ? $options.entry.time : ''}}
+                <span class="execution-log_gutter-entry" :pseudo-content="timestamps ? $options.entry.time : ''" />
+                <!-- {{timestamps ? $options.entry.time : ''}} -->
                 <i v-if="command" class="rdicon icon-small" v-bind:class="[$options.entry.stepType]"></i>
-                {{command ? $options.entry.stepLabel : ''}}
+                <span class="execution-log_gutter-entry" :pseudo-content="command ? $options.entry.stepLabel : ''" />
+                <!-- {{command ? $options.entry.stepLabel : ''}} -->
             </span>
-        </div
-        ><div class="execution-log__content" v-bind:class="[`execution-log__content--level-${$options.entry.level.toLowerCase()}`,
+        </div>
+        <div class="execution-log__content" v-bind:class="[`execution-log__content--level-${$options.entry.level.toLowerCase()}`,
             {
                 'execution-log__content--html': $options.entry.logHtml
             }]"
-            ><span v-if="displayNodeBadge" class="execution-log__node-badge"><i class="fas fa-hdd"/> {{$options.entry.node}}</span
-            ><span v-if="$options.entry.logHtml" class="execution-log__content-text" v-bind:class="{'execution-log__content-text--overflow': !lineWrap}" v-html="$options.entry.logHtml"
-            /><span v-if="!$options.entry.logHtml" class="execution-log__content-text" v-bind:class="{'execution-log__content-text--overflow': !lineWrap}">{{$options.entry.log}}</span
+        >
+            <span v-if="displayNodeBadge" class="execution-log__node-badge"><i class="fas fa-hdd"/><span :pseudo-content="$options.entry.node" /></span>
+            <span v-if="$options.entry.logHtml" class="execution-log__content-text" v-bind:class="{'execution-log__content-text--overflow': !lineWrap}" v-html="$options.entry.logHtml"/>
+            <span v-if="!$options.entry.logHtml" class="execution-log__content-text" v-bind:class="{'execution-log__content-text--overflow': !lineWrap}">{{$options.entry.log}}</span
         ></div
     ></div>
 </template>
@@ -84,6 +87,11 @@ export default class Flex extends Vue {
     display: flex;
     align-items: center;
     min-width: 0;
+
+    & i {
+        margin-left: 0.5em;
+        margin-right: 0.2em;
+    }
 }
 
 .execution-log__gutter--slim {
@@ -126,6 +134,14 @@ export default class Flex extends Vue {
 .execution-log__node-badge {
     float: right;
     user-select: none;
+    & i {
+        margin-left: 0.2em;
+        margin-right: 0.2em;
+    }
+}
+
+[pseudo-content]::before {
+    content: attr(pseudo-content);
 }
 
 </style>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logViewer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logViewer.vue
@@ -54,33 +54,35 @@
         </div>
       </form>
     </a-drawer>
-    <div ref="scroller" class="execution-log__scroller" v-bind:class="{
+    <div class="execution-log__scroller" v-bind:class="{
       'execution-log--no-transition': this.logLines > 1000,
       'ansicolor-on': this.settings.ansiColor
     }">
-      <div v-if="showSettings" class="execution-log__settings"  style="margin-left: 5px; margin-right: 5px;">
-        <a-button-group>
-          <a-button size="small" @click="(e) => {settingsVisible = !settingsVisible; e.target.blur();}">
-            <a-icon type="setting"/>Settings
-          </a-button>
+      <div ref="scroller">
+        <div v-if="showSettings" class="execution-log__settings"  style="margin-left: 5px; margin-right: 5px;">
+          <a-button-group>
+            <a-button size="small" @click="(e) => {settingsVisible = !settingsVisible; e.target.blur();}">
+              <a-icon type="setting"/>Settings
+            </a-button>
 
-          <a-button size="small" @click="(e) => {this.follow = !this.follow; e.target.blur();}">
-            <a-icon :type="followIcon"/>Follow
-          </a-button>
-        </a-button-group>
-        <transition name="fade">
-          <div class="execution-log__progress-bar" v-if="showProgress">
-            <progress-bar v-model="barProgress" :type="progressType" :label-text="progressText" label min-width striped active @click="() => {this.consumeLogs = !this.consumeLogs}"/>
-          </div>
-        </transition>
-      </div>
-      <div class="execution-log__warning" v-if="overSize">
-        <h3> 🐋 {{+(logSize / 1048576).toFixed(2)}}MiB is a whale of a log! 🐋 </h3>
-        <h4> Select a download option above to avoid sinking the ship. </h4>
-        <h5> Log content may be truncated </h5>
-      </div>
-      <div class="execution-log__warning" v-if="errorMessage">
-        <h4>{{errorMessage}}</h4>
+            <a-button size="small" @click="(e) => {this.follow = !this.follow; e.target.blur();}">
+              <a-icon :type="followIcon"/>Follow
+            </a-button>
+          </a-button-group>
+          <transition name="fade">
+            <div class="execution-log__progress-bar" v-if="showProgress">
+              <progress-bar v-model="barProgress" :type="progressType" :label-text="progressText" label min-width striped active @click="() => {this.consumeLogs = !this.consumeLogs}"/>
+            </div>
+          </transition>
+        </div>
+        <div class="execution-log__warning" v-if="overSize">
+          <h3> 🐋 {{+(logSize / 1048576).toFixed(2)}}MiB is a whale of a log! 🐋 </h3>
+          <h4> Select a download option above to avoid sinking the ship. </h4>
+          <h5> Log content may be truncated </h5>
+        </div>
+        <div class="execution-log__warning" v-if="errorMessage">
+          <h4>{{errorMessage}}</h4>
+        </div>
       </div>
     </div>
     <div class="stats" v-if="settings.stats">
@@ -628,11 +630,6 @@ export default class LogViewer extends Vue {
 
 .execution-log__stats {
   flex: 0 0 1em;
-}
-
-.execution-log__controls {
-    contain: layout;
-    display: flex;
 }
 
 .execution-log__scroller {


### PR DESCRIPTION
Resolves some Safari related issues with layout:

* Content area no longer overflows when option is deselected
* Gutter ellipsis overflow fixed
* Non-content items no longer copied to clipboard
* Fixed sticky controls : https://bugs.webkit.org/show_bug.cgi?id=175029