### PR TITLE
Ignore the unsupported exception thrown when posix file permissions are set

### DIFF
--- a/rundeck-storage/rundeck-storage-filesys/src/main/java/org/rundeck/storage/data/file/FileTree.java
+++ b/rundeck-storage/rundeck-storage-filesys/src/main/java/org/rundeck/storage/data/file/FileTree.java
@@ -274,6 +274,8 @@ public class FileTree<T extends ContentMeta> extends LockingTree<T> implements T
                 Files.setPosixFilePermissions(datafile.toPath(), contentFilePermissions);
 
                 Set<PosixFilePermission> result =Files.getPosixFilePermissions(datafile.toPath());
+            } catch(UnsupportedOperationException uopex) {
+                  //the underlying OS doesn't support setting posix permissions
             } catch (IOException e) {
                 throw createException(path, "cannot set permissions of the file:" + path );
             }


### PR DESCRIPTION
Fixes #6214 startup error on Windows.
