### PR TITLE
 Fix URI parse message on Windows for log4j2 config file

### DIFF
--- a/rundeckapp/grails-app/init/rundeckapp/init/RundeckInitializer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/RundeckInitializer.groovy
@@ -309,7 +309,7 @@ class RundeckInitializer {
         if(!System.getProperty("log4j.configurationFile")) {
             Path log4j2ConfPath = Paths.get(config.configDir+"/log4j2.properties")
             if(Files.exists(log4j2ConfPath)) {
-                System.setProperty("log4j.configurationFile",log4j2ConfPath.toString())
+                System.setProperty("log4j.configurationFile",log4j2ConfPath.toUri().toString())
                 LoggerContext.getContext(false).reconfigure()
             }
         }


### PR DESCRIPTION
Fixes #6227 by converting the file path to a URI before setting the log4j2 system property. This is required on a Windows OS.
