### PR TITLE
Fixes API call using asterisk #6069

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3165,40 +3165,70 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     /**
      * API: /executions/running, version 1
      */
-    def apiExecutionsRunning (){
-        if(!apiAuthorizedForEvent(params.project,[AuthConstants.ACTION_READ])){
+    def apiExecutionsRunning () {
+
+        //allow project='*' to indicate all projects
+        def allProjects = request.api_version >= ApiVersions.V9 && params.project == '*'
+
+        if (!allProjects && !apiAuthorizedForEvent(params.project, [AuthConstants.ACTION_READ])) {
             return
         }
         if (!apiService.requireApi(request, response)) {
             return
         }
-        if(!params.project){
+        if (!params.project) {
             return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_BAD_REQUEST,
-                    code: 'api.error.parameter.required', args: ['project']])
+                                                           code  : 'api.error.parameter.required', args: ['project']])
         }
         //test valid project
-
-        //allow project='*' to indicate all projects
-        def allProjects = request.api_version >= ApiVersions.V9 && params.project == '*'
-        if(!allProjects){
-            if(!apiService.requireExists(response,frameworkService.existsFrameworkProject(params.project),['project',params.project])){
+        if (!allProjects) {
+            if (!apiService.requireExists(response, frameworkService.existsFrameworkProject(params.project), ['project', params.project])) {
                 return
             }
         }
-        if (request.api_version < ApiVersions.V14 && !(response.format in ['all','xml'])) {
-            return apiService.renderErrorXml(response,[
-                    status:HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE,
-                    code: 'api.error.item.unsupported-format',
-                    args: [response.format]
+        if (request.api_version < ApiVersions.V14 && !(response.format in ['all', 'xml'])) {
+            return apiService.renderErrorXml(response, [
+                    status: HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE,
+                    code  : 'api.error.item.unsupported-format',
+                    args  : [response.format]
             ])
         }
 
-        QueueQuery query = new QueueQuery(runningFilter:'running',projFilter:params.project)
-        if(params.max){
-            query.max=params.int('max')
+        def projectNameAuthorized = "";
+
+        if (allProjects){
+            def authContext = frameworkService.getAuthContextForSubject(session.subject)
+            def projectNames = frameworkService.projectNames(authContext)
+
+            if (!projectNames || projectNames.isEmpty()) {
+                return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_UNAUTHORIZED,
+                                                               code  : 'api.error.execution.project.notfound', args: [params.project]])
+            }
+
+            for (names in projectNames) {
+                if (apiAuthorizedForEvent(names, [AuthConstants.ACTION_READ])) {
+                    if (projectNameAuthorized.isEmpty()) {
+                        projectNameAuthorized = names;
+                    } else {
+                        projectNameAuthorized = projectNameAuthorized + "," + names;
+                    }
+                }
+            }
+
+            if (!projectNameAuthorized || projectNameAuthorized.isEmpty()) {
+                return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_UNAUTHORIZED,
+                                                               code  : 'api.error.execution.project.notfound', args: [params.project]])
+            }
+        } else {
+            projectNameAuthorized = params.project
         }
-        if(params.offset){
-            query.offset=params.int('offset')
+
+        QueueQuery query = new QueueQuery(runningFilter: 'running', projFilter: projectNameAuthorized)
+        if (params.max) {
+            query.max = params.int('max')
+        }
+        if (params.offset) {
+            query.offset = params.int('offset')
         }
 
         if (request.api_version >= ApiVersions.V31 && params.jobIdFilter) {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -52,6 +52,7 @@ import rundeck.Workflow
 import rundeck.services.ApiService
 import rundeck.services.AuthorizationService
 import rundeck.services.ConfigurationService
+import rundeck.services.ExecutionService
 import rundeck.services.FrameworkService
 import rundeck.services.JobSchedulesService
 import rundeck.services.ScheduledExecutionService
@@ -1645,4 +1646,214 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         "test"                 | true           | null
         "test"                 | false          | "grouped"
     }
+
+    def "test list all projects with a valid project"() {
+        given:
+        controller.apiService = Mock(ApiService){
+            1 * requireApi(_,_) >> true
+        }
+
+        controller.userService = Mock(UserService){}
+
+        UserAndRolesAuthContext test = Mock(UserAndRolesAuthContext) {
+            getUsername() >> 'test'
+            getRoles() >> new HashSet<String>(['test'])
+        }
+
+        def projectMock = Mock(IRundeckProject) {
+            getProperties() >> [:]
+            getName() >> 'aProject'
+        }
+
+        def executionService = Mock(ExecutionService){
+            finishQueueQuery(_,_,_) >> [:]
+        }
+
+        controller.executionService = executionService
+
+        controller.frameworkService = Mock(FrameworkService){
+            getRundeckBase() >> ''
+            getFrameworkProject(_) >> projectMock
+            getServerUUID() >> 'uuid'
+            authorizeProjectResourceAll(_, AuthorizationUtil.resourceType('event'),['read'], 'aProject') >> true
+            1 * getAuthContextForSubject(_) >> test
+
+        }
+
+        params.project = '*'
+        request.api_version = 35
+        def action = 'read'
+
+        when:
+        def result = controller.apiExecutionsRunning()
+
+        then:
+        0 * controller.frameworkService.getAuthContextForSubjectAndProject(_, '*')
+        1 * controller.frameworkService.projectNames(_) >> ['aProject']
+        0 * controller.apiService.renderErrorFormat(_,_)
+        1 * controller.executionService.queryQueue(_) >> {
+            assert it[0].projFilter == 'aProject'
+
+        }
+    }
+
+    def "test list all projects with an invalid project"() {
+        given:
+        controller.apiService = Mock(ApiService){
+            1 * requireApi(_,_) >> true
+        }
+
+        controller.userService = Mock(UserService){}
+
+        UserAndRolesAuthContext test = Mock(UserAndRolesAuthContext) {
+            getUsername() >> 'test'
+            getRoles() >> new HashSet<String>(['test'])
+        }
+
+        def projectMock = Mock(IRundeckProject) {
+            getProperties() >> [:]
+            getName() >> 'aProject'
+        }
+
+        def executionService = Mock(ExecutionService){
+            finishQueueQuery(_,_,_) >> [:]
+        }
+
+        controller.executionService = executionService
+
+        controller.frameworkService = Mock(FrameworkService){
+            getRundeckBase() >> ''
+            getFrameworkProject(_) >> projectMock
+            getServerUUID() >> 'uuid'
+            authorizeProjectResourceAll(_, AuthorizationUtil.resourceType('event'),['read'], 'aProject') >> false
+            1 * getAuthContextForSubject(_) >> test
+
+        }
+
+        params.project = '*'
+        request.api_version = 35
+        def action = 'read'
+
+        when:
+        def result = controller.apiExecutionsRunning()
+
+        then:
+        0 * controller.frameworkService.getAuthContextForSubjectAndProject(_, '*')
+        1 * controller.frameworkService.projectNames(_) >> ['aProject']
+        1 * controller.apiService.renderErrorFormat(_,{map->
+            map.status==401 && map.code=='api.error.execution.project.notfound'
+        })
+        0 * controller.executionService.queryQueue(_) >> {
+            assert it[0].projFilter == 'aProject'
+
+        }
+
+    }
+
+    def "test list all projects with an invalid and a valid project"() {
+        given:
+        controller.apiService = Mock(ApiService){
+            1 * requireApi(_,_) >> true
+        }
+
+        controller.userService = Mock(UserService){}
+
+        UserAndRolesAuthContext test = Mock(UserAndRolesAuthContext) {
+            getUsername() >> 'test'
+            getRoles() >> new HashSet<String>(['test'])
+        }
+
+        def projectMock = Mock(IRundeckProject) {
+            getProperties() >> [:]
+            getName() >> ['aProject', 'bProject']
+        }
+
+        def executionService = Mock(ExecutionService){
+            finishQueueQuery(_,_,_) >> [:]
+        }
+
+        controller.executionService = executionService
+
+        controller.frameworkService = Mock(FrameworkService){
+            getRundeckBase() >> ''
+            getFrameworkProject(_) >> projectMock
+            getServerUUID() >> 'uuid'
+            authorizeProjectResourceAll(_, AuthorizationUtil.resourceType('event'),['read'], 'aProject') >> true
+            1 * getAuthContextForSubject(_) >> test
+
+        }
+
+        params.project = '*'
+        request.api_version = 35
+        def action = 'read'
+
+        when:
+        def result = controller.apiExecutionsRunning()
+
+        then:
+        0 * controller.frameworkService.getAuthContextForSubjectAndProject(_, '*')
+        1 * controller.frameworkService.projectNames(_) >> ['aProject', 'bProject']
+        0 * controller.apiService.renderErrorFormat(_,{map->
+            map.status==401 && map.code=='api.error.execution.project.notfound'
+        })
+        1 * controller.executionService.queryQueue(_) >> {
+            assert it[0].projFilter == 'aProject'
+
+        }
+
+    }
+
+    def "test list all projects with multiple valid projects"() {
+        given:
+        controller.apiService = Mock(ApiService){
+            1 * requireApi(_,_) >> true
+        }
+
+        controller.userService = Mock(UserService){}
+
+        UserAndRolesAuthContext test = Mock(UserAndRolesAuthContext) {
+            getUsername() >> 'test'
+            getRoles() >> new HashSet<String>(['test'])
+        }
+
+        def projectMock = Mock(IRundeckProject) {
+            getProperties() >> [:]
+            getName() >>  ['aProject', 'bProject', 'cProject']
+        }
+
+        def executionService = Mock(ExecutionService){
+            finishQueueQuery(_,_,_) >> [:]
+        }
+
+        controller.executionService = executionService
+
+        controller.frameworkService = Mock(FrameworkService){
+            getRundeckBase() >> ''
+            getFrameworkProject(_) >> projectMock
+            getServerUUID() >> 'uuid'
+            authorizeProjectResourceAll(_, AuthorizationUtil.resourceType('event'),['read'], _) >> {
+                it[3] == 'aProject' ||  it[3] == 'bProject'||  it[3] == 'cProject'
+            }
+
+            1 * getAuthContextForSubject(_) >> test
+
+        }
+
+        params.project = '*'
+        request.api_version = 35
+        def action = 'read'
+
+        when:
+        def result = controller.apiExecutionsRunning()
+
+        then:
+        0 * controller.frameworkService.getAuthContextForSubjectAndProject(_, '*')
+        1 * controller.frameworkService.projectNames(_) >> ['aProject', 'bProject', 'cProject' ]
+        0 * controller.apiService.renderErrorFormat(_,_)
+        1 * controller.executionService.queryQueue(_) >> {
+            assert it[0].projFilter == 'aProject,bProject,cProject'
+
+        }
+    }
+
 }


### PR DESCRIPTION
fixes #6069

Fix a problem in API call

```
GET /api/14/project/[PROJECT]/executions/running
```
Entering asterisk instead of the project name generates an 500 error.

**solution implemented**
When the asterisk comes as a parameter the list of projects will be searched and those without permission will be filtered.