### PR TITLE
Fix log viewer and adhoc command page in FireFox ESR(68)

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -1127,7 +1127,7 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
         }
     };
     self.showOutput= function (nodestep) {
-        if (!window._rundeck.feature?.legacyExecOutputViewer?.enabled) {
+        if (!window._rundeck.feature.legacyExecOutputViewer.enabled) {
             /** Kick the event out to Vue Land and let the new viewer handle display */
             if (nodestep.executionState() != 'NOT_STARTED')
                 window._rundeck.eventBus.$emit('ko-exec-show-output', nodestep)

--- a/rundeckapp/grails-app/assets/javascripts/framework/adhoc.js
+++ b/rundeckapp/grails-app/assets/javascripts/framework/adhoc.js
@@ -185,7 +185,7 @@ function continueRunFollow(data) {
         reloadInterval:1500
     });
     nodeflowvm.followFlowState(flowState);
-    if (window._rundeck.feature?.legacyExecOutputViewer?.enabled)
+    if (window._rundeck.feature.legacyExecOutputViewer.enabled)
         nodeflowvm.logoutput().beginFollowingOutput(data.id);
 
     flowState.beginFollowing();


### PR DESCRIPTION
The conditional chaining operator is not supported by FireFox ESR(68) and other older browser versions. This code is not down-leveled.

Fixes #6232
Fixes #6230