### PR TITLE
fix #6239 acls not imported during fs conversion upgrading from 3.2 to 3.3

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -877,15 +877,22 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
                 projectProps.putAll(other.getProjectProperties())
                 def newProj=createFrameworkProject(other.name,projectProps)
                 //import resources
-                ["readme.md","motd.md"].each{ fpath ->
-                    if(other.existsFileResource(fpath)){
-                        log.warn("Importing ${fpath} for project ${other.name}...")
+                List paths=other.listDirPaths('')
+                while(paths.size()>0) {
+                    String path = paths.remove(0)
+                    if(path=="/etc/project.properties"){
+                        continue
+                    }
+                    if(path.endsWith('/')){
+                        paths.addAll(other.listDirPaths(path))
+                    }else{
+                        log.warn("Importing ${path} for project ${other.name}...")
                         def baos=new ByteArrayOutputStream()
                         try {
-                            other.loadFileResource(fpath, baos)
-                            newProj.storeFileResource(fpath, new ByteArrayInputStream(baos.toByteArray()))
+                            other.loadFileResource(path, baos)
+                            newProj.storeFileResource(path, new ByteArrayInputStream(baos.toByteArray()))
                         }catch (IOException e){
-                            log.error("Failed importing ${fpath} for project ${other.name}: ${e.message}",e)
+                            log.error("Failed importing ${path} for project ${other.name}: ${e.message}",e)
                         }
                     }
                 }

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -826,38 +826,27 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
                     }
             );
 
-    /**
-     * Import any projects that do not exist from the source
-     * @param source
-     */
-    boolean testProjectWasImported(ProjectManager source, String projectName) {
-        return source.existsFrameworkProject(projectName) &&
-                source.getFrameworkProject(projectName).existsFileResource("etc/project.properties.imported")
-    }
 
     /**
-     * Import any projects that do not exist from the source
+     * Mark imported file
      * @param source
      */
-    void markProjectAsImported(ProjectManager source, String projectName){
+    void markProjectFileAsImported(IRundeckProject other, String path){
         //mark as imported
-        if(source.existsFrameworkProject(projectName)) {
-            IRundeckProject other = source.getFrameworkProject(projectName)
-            try {
-                def baos = new ByteArrayOutputStream()
-                other.loadFileResource("etc/project.properties", baos)
-                other.storeFileResource(
-                        "etc/project.properties.imported",
-                        new ByteArrayInputStream(baos.toByteArray())
-                )
-                other.deleteFileResource("etc/project.properties")
-                log.warn("Filesystem project ${other.name}, marked as imported. Rename etc/project.properties to etc/project.properties.imported")
-            } catch (IOException e) {
-                log.error(
-                        "Failed marking ${other.name} as imported (rename etc/project.properties to etc/project.properties.imported): ${e.message}",
-                        e
-                )
-            }
+       try {
+            def baos = new ByteArrayOutputStream()
+            other.loadFileResource(path, baos)
+            other.storeFileResource(
+                    "${path}.imported",
+                    new ByteArrayInputStream(baos.toByteArray())
+            )
+            other.deleteFileResource(path)
+            log.warn("Filesystem project ${other.name}, marked as imported. Rename $path to ${path}.imported")
+        } catch (IOException e) {
+            log.error(
+                    "Failed marking ${other.name} as imported (rename $path to ${path}.imported): ${e.message}",
+                    e
+            )
         }
     }
     /**
@@ -866,21 +855,35 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
      */
     public void importProjectsFromProjectManager(ProjectManager source){
         source.listFrameworkProjects().each{IRundeckProject other->
-            if(testProjectWasImported(source,other.name)){
+            if(other.existsFileResource("etc/project.properties.imported")){
                 //marked as imported, so skip re-import.
-                log.warn("Discovered filesystem project ${other.name}, was previously imported, skipping.")
+                log.warn("Discovered filesystem project ${other.name}, was previously imported.")
                 return
             }
+            boolean needsImport = configurationService?.getString('projectsStorageImportResources') == 'always'
             if(!existsFrameworkProject(other.name)){
                 log.warn("Discovered filesystem project ${other.name}, importing...")
                 def projectProps=new Properties()
                 projectProps.putAll(other.getProjectProperties())
-                def newProj=createFrameworkProject(other.name,projectProps)
+                def newProj = createFrameworkProject(other.name, projectProps)
+                needsImport=true
+            }else{
+                log.warn("Skipping creation for filesystem project ${other.name}, it already exists.")
+            }
+            //mark as imported
+            markProjectFileAsImported(other,"etc/project.properties")
+            if(needsImport){
+                log.warn("Importing resources for filesystem project: ${other.name} ...")
+                def newProj=getFrameworkProject(other.name)
                 //import resources
+                int count=0
                 List paths=other.listDirPaths('')
                 while(paths.size()>0) {
                     String path = paths.remove(0)
                     if(path=="/etc/project.properties"){
+                        continue
+                    }
+                    if(path.endsWith('.imported')){
                         continue
                     }
                     if(path.endsWith('/')){
@@ -890,17 +893,17 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
                         def baos=new ByteArrayOutputStream()
                         try {
                             other.loadFileResource(path, baos)
-                            newProj.storeFileResource(path, new ByteArrayInputStream(baos.toByteArray()))
+                            def data = baos.toByteArray()
+                            newProj.storeFileResource(path, new ByteArrayInputStream(data))
+                            other.storeFileResource("${path}.imported", new ByteArrayInputStream(data))
+                            other.deleteFileResource(path)
+                            count++
                         }catch (IOException e){
                             log.error("Failed importing ${path} for project ${other.name}: ${e.message}",e)
                         }
                     }
                 }
-                //mark as imported
-                markProjectAsImported(source,other.name)
-            }else{
-                log.warn("Skipping import for filesystem project ${other.name}, it already exists...")
-                markProjectAsImported(source,other.name)
+                log.warn("Imported ${count} resources for project: ${other.name}")
             }
         }
     }

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
@@ -1243,6 +1243,96 @@ class ProjectManagerServiceSpec extends HibernateSpec implements ServiceUnitTest
         1*service.projectCache.invalidate('abc')
         Project.findByName('abc')!=null
     }
+    void "import project from fs, not yet imported with readme"(){
+        given:
+        def projectProps = new Properties()
+        projectProps['test']='abc'
+        def pm1 = Mock(ProjectManager){
+            1*listFrameworkProjects()>>[
+                    Mock(IRundeckProject){
+                        getName()>>'abc'
+                        getProjectProperties()>>projectProps
+                        1 * existsFileResource('readme.md')>>true
+                        1* existsFileResource('motd.md')>>true
+                        1* loadFileResource('motd.md',_)>>{
+                            it[1].write('motddata'.bytes)
+                            1
+                        }
+                        1* loadFileResource('readme.md',_)>>{
+                            it[1].write('readmedata'.bytes)
+                            1
+                        }
+                    }
+            ]
+            2*existsFrameworkProject('abc')>>true
+            2*getFrameworkProject('abc') >> Mock(IRundeckProject){
+                1* existsFileResource('etc/project.properties.imported') >> false
+
+                //mark as imported
+                1* loadFileResource('etc/project.properties',_) >> {args->
+                    args[1].write('test=abc'.bytes)
+                    4
+                }
+                1*storeFileResource('etc/project.properties.imported',{
+                    def props=new Properties()
+                    props.load(it)
+                    props['test']=='abc'
+                }) >> 4
+
+                1*deleteFileResource('etc/project.properties') >> true
+
+            }
+        }
+        def modDate=new Date(123)
+        service.storage=Mock(StorageTree){
+            1 * hasResource("projects/abc/etc/project.properties") >> false
+            1 * createResource("projects/abc/etc/project.properties",{res->
+                def props=new Properties()
+                props.load(res.inputStream)
+                props['test']=='abc'
+            }) >> Stub(Resource){
+                getContents()>> Stub(ResourceMeta){
+                    getInputStream() >> new ByteArrayInputStream('abc=def'.bytes)
+                    getModificationTime() >> modDate
+                    getCreationTime() >> modDate
+                }
+            }
+            1 * createResource("projects/abc/motd.md",{res->
+                res.inputStream.text=='motddata'
+            }) >> Stub(Resource){
+                getContents()>> Stub(ResourceMeta){
+                    getInputStream() >> new ByteArrayInputStream('asdf'.bytes)
+                    getModificationTime() >> modDate
+                    getCreationTime() >> modDate
+                }
+            }
+            1 * createResource("projects/abc/readme.md",{res->
+                res.inputStream.text=='readmedata'
+            }) >> Stub(Resource){
+                getContents()>> Stub(ResourceMeta){
+                    getInputStream() >> new ByteArrayInputStream('asdf'.bytes)
+                    getModificationTime() >> modDate
+                    getCreationTime() >> modDate
+                }
+            }
+        }
+        def properties=new Properties()
+        service.frameworkService=Stub(FrameworkService){
+            getRundeckFramework() >> Stub(Framework){
+                getPropertyLookup() >> PropertyLookup.create(properties)
+            }
+        }
+        service.rundeckNodeService=Mock(NodeService)
+        service.projectCache=Mock(LoadingCache)
+        when:
+        service.importProjectsFromProjectManager(pm1)
+
+        then:
+        1*service.rundeckNodeService.refreshProjectNodes('abc')
+        0*service.rundeckNodeService.getNodes('abc')
+        1*service.projectCache.invalidate('abc')
+        Project.findByName('abc')!=null
+    }
 
     def "load project to cache"(){
         setup:

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
@@ -22,7 +22,6 @@ import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.core.common.ProjectManager
 import com.dtolabs.rundeck.core.storage.ResourceMeta
-import com.dtolabs.rundeck.core.storage.ResourceMetaBuilder
 import com.dtolabs.rundeck.core.storage.StorageTree
 import com.dtolabs.rundeck.core.storage.StorageUtil
 import com.dtolabs.rundeck.core.utils.PropertyLookup
@@ -1046,80 +1045,31 @@ class ProjectManagerServiceSpec extends HibernateSpec implements ServiceUnitTest
         rulea.sourceIdentity=='[project:test1]acls/file1.aclpolicy[1][type:resource][rule: 1]'
     }
 
-    void "mark existing other project as imported"(){
+    void "mark file as imported"() {
         given:
-        def pm1 = Mock(ProjectManager){
-            1*existsFrameworkProject('abc')>>true
-            1*getFrameworkProject('abc')>>Mock(IRundeckProject){
-                1* loadFileResource('etc/project.properties',_) >> {args->
-                    args[1].write('test'.bytes)
-                    4
-                }
-                1*storeFileResource('etc/project.properties.imported',{
-                    def baos=new ByteArrayOutputStream()
-                    Streams.copy(it,baos,true)
-                    new String(baos.toByteArray())=='test'
-                }) >> 4
-                1*deleteFileResource('etc/project.properties') >> true
+            def other = Mock(IRundeckProject)
+        when:
+            service.markProjectFileAsImported(other, path)
+
+        then:
+
+            1 * other.loadFileResource(path, _) >> { args ->
+                args[1].write('test'.bytes)
+                4
             }
-        }
-        when:
-        service.markProjectAsImported(pm1, 'abc')
-
-        then:
-        true
-    }
-
-    void "mark non-existing other project as imported"(){
-        given:
-        def pm1 = Mock(ProjectManager){
-            1*existsFrameworkProject('abc')>>false
-        }
-        when:
-        service.markProjectAsImported(pm1, "abc")
-
-        then:
-        true
-    }
-    void "Test project was imported, dne"(){
-        given:
-        def pm1 = Mock(ProjectManager){
-            1*existsFrameworkProject('abc')>>false
-        }
-        when:
-        def result=service.testProjectWasImported(pm1,'abc')
-
-        then:
-        !result
-    }
-    void "Test project was imported, exists, not imported"(){
-        given:
-        def pm1 = Mock(ProjectManager){
-            1*existsFrameworkProject('abc')>>true
-            1*getFrameworkProject('abc') >> Mock(IRundeckProject){
-                1* existsFileResource('etc/project.properties.imported') >> false
+            1 * other.storeFileResource(
+                path + '.imported', {
+                def baos = new ByteArrayOutputStream()
+                Streams.copy(it, baos, true)
+                new String(baos.toByteArray()) == 'test'
             }
-        }
-        when:
-        def result=service.testProjectWasImported(pm1,'abc')
+            ) >> 4
+            1 * other.deleteFileResource(path) >> true
 
-        then:
-        !result
+        where:
+            path << ['etc/project.properties', 'readme.md', 'acls/test.aclpolicy']
     }
-    void "Test project was imported, exists, was imported"(){
-        given:
-        def pm1 = Mock(ProjectManager){
-            1*existsFrameworkProject('abc')>>true
-            1*getFrameworkProject('abc') >> Mock(IRundeckProject){
-                1* existsFileResource('etc/project.properties.imported') >> true
-            }
-        }
-        when:
-        def result=service.testProjectWasImported(pm1,'abc')
 
-        then:
-        result
-    }
 
     void "import project from fs, no projects"(){
         given:
@@ -1135,26 +1085,23 @@ class ProjectManagerServiceSpec extends HibernateSpec implements ServiceUnitTest
     void "import project from fs, already present"(){
         given:
         def proj1 = new Project(name:'abc').save()
-        def pm1 = Mock(ProjectManager){
-            1*listFrameworkProjects()>>[
-                    Stub(IRundeckProject){
-                        getName()>>'abc'
+        def pm1 = Stub(ProjectManager){
+            listFrameworkProjects()>>[
+                    Mock(IRundeckProject){
+                        _ * getName() >> 'abc'
+                        //mark as imported
+                        1* loadFileResource('etc/project.properties',_) >> {args->
+                            args[1].write('test'.bytes)
+                            4
+                        }
+                        1*storeFileResource('etc/project.properties.imported',{
+                            def baos=new ByteArrayOutputStream()
+                            Streams.copy(it,baos,true)
+                            new String(baos.toByteArray())=='test'
+                        }) >> 4
+                        1*deleteFileResource('etc/project.properties') >> true
                     }
             ]
-            2*existsFrameworkProject('abc')>>true
-            2*getFrameworkProject('abc') >> Mock(IRundeckProject){
-                //mark as imported
-                1* loadFileResource('etc/project.properties',_) >> {args->
-                    args[1].write('test'.bytes)
-                    4
-                }
-                1*storeFileResource('etc/project.properties.imported',{
-                    def baos=new ByteArrayOutputStream()
-                    Streams.copy(it,baos,true)
-                    new String(baos.toByteArray())=='test'
-                }) >> 4
-                1*deleteFileResource('etc/project.properties') >> true
-            }
         }
         when:
         service.importProjectsFromProjectManager(pm1)
@@ -1166,15 +1113,11 @@ class ProjectManagerServiceSpec extends HibernateSpec implements ServiceUnitTest
         given:
         def pm1 = Mock(ProjectManager){
             1*listFrameworkProjects()>>[
-                    Stub(IRundeckProject){
-                        getName()>>'abc'
-                    }
+                Mock(IRundeckProject){
+                    _*getName()>>'abc'
+                    1* existsFileResource('etc/project.properties.imported') >> true
+                }
             ]
-            1*existsFrameworkProject('abc')>>true
-            1*getFrameworkProject('abc') >> Mock(IRundeckProject){
-                1* existsFileResource('etc/project.properties.imported') >> true
-
-            }
         }
         when:
         service.importProjectsFromProjectManager(pm1)
@@ -1188,28 +1131,27 @@ class ProjectManagerServiceSpec extends HibernateSpec implements ServiceUnitTest
         projectProps['test']='abc'
         def pm1 = Mock(ProjectManager){
             1*listFrameworkProjects()>>[
-                    Stub(IRundeckProject){
-                        getName()>>'abc'
-                        getProjectProperties()>>projectProps
+                Mock(IRundeckProject){
+                    _*getName()>>'abc'
+                    _*getProjectProperties()>>projectProps
+                    1* existsFileResource('etc/project.properties.imported') >> false
+
+                    1 * listDirPaths('')>>['/etc/']
+                    1 * listDirPaths('/etc/')>>['/etc/project.properties']
+                    //mark as imported
+                    1* loadFileResource('etc/project.properties',_) >> {args->
+                        args[1].write('test=abc'.bytes)
+                        4
                     }
-            ]
-            2*existsFrameworkProject('abc')>>true
-            2*getFrameworkProject('abc') >> Mock(IRundeckProject){
-                1* existsFileResource('etc/project.properties.imported') >> false
+                    1*storeFileResource('etc/project.properties.imported',{
+                        def props=new Properties()
+                        props.load(it)
+                        props['test']=='abc'
+                    }) >> 4
+                    1*deleteFileResource('etc/project.properties') >> true
 
-                //mark as imported
-                1* loadFileResource('etc/project.properties',_) >> {args->
-                    args[1].write('test=abc'.bytes)
-                    4
                 }
-                1*storeFileResource('etc/project.properties.imported',{
-                    def props=new Properties()
-                    props.load(it)
-                    props['test']=='abc'
-                }) >> 4
-                1*deleteFileResource('etc/project.properties') >> true
-
-            }
+            ]
         }
         def modDate=new Date(123)
         service.storage=Stub(StorageTree){
@@ -1233,60 +1175,73 @@ class ProjectManagerServiceSpec extends HibernateSpec implements ServiceUnitTest
             }
         }
         service.rundeckNodeService=Mock(NodeService)
-        service.projectCache=Mock(LoadingCache)
+        service.projectCache=Mock(LoadingCache){
+            1 * get('abc')>>{
+                 service.loadProject('abc')
+            }
+        }
         when:
         service.importProjectsFromProjectManager(pm1)
 
         then:
-        1*service.rundeckNodeService.refreshProjectNodes('abc')
+        2*service.rundeckNodeService.refreshProjectNodes('abc')
         0*service.rundeckNodeService.getNodes('abc')
         1*service.projectCache.invalidate('abc')
         Project.findByName('abc')!=null
     }
+    @Unroll
     void "import project from fs, not yet imported with readme"(){
         given:
         def projectProps = new Properties()
         projectProps['test']='abc'
-        def pm1 = Mock(ProjectManager){
-            1*listFrameworkProjects()>>[
-                    Mock(IRundeckProject){
-                        getName()>>'abc'
-                        getProjectProperties()>>projectProps
-                        1 * listDirPaths('')>>['/motd.md','/readme.md','/etc/']
-                        1 * listDirPaths('/etc/')>>['/etc/project.properties']
-                        1* loadFileResource('/motd.md',_)>>{
-                            it[1].write('motddata'.bytes)
-                            1
-                        }
-                        1* loadFileResource('/readme.md',_)>>{
-                            it[1].write('readmedata'.bytes)
-                            1
-                        }
-                    }
-            ]
-            2*existsFrameworkProject('abc')>>true
-            2*getFrameworkProject('abc') >> Mock(IRundeckProject){
-                1* existsFileResource('etc/project.properties.imported') >> false
-
-                //mark as imported
-                1* loadFileResource('etc/project.properties',_) >> {args->
-                    args[1].write('test=abc'.bytes)
-                    4
-                }
-                1*storeFileResource('etc/project.properties.imported',{
-                    def props=new Properties()
-                    props.load(it)
-                    props['test']=='abc'
-                }) >> 4
-
-                1*deleteFileResource('etc/project.properties') >> true
-
+        service.configurationService=Mock(ConfigurationService){
+            1 * getString('projectsStorageImportResources')>>{
+                configSet?'always':null
             }
+        }
+        if(projExists){
+            def proj1 = new Project(name:'abc').save()
+        }
+        def pm1 = Stub(ProjectManager){
+            listFrameworkProjects()>>[
+                Mock(IRundeckProject){
+                    getName()>>'abc'
+                    getProjectProperties()>>projectProps
+                    1 * listDirPaths('')>>['/motd.md','/readme.md','/etc/']
+                    1 * listDirPaths('/etc/')>>['/etc/project.properties']
+                    1* loadFileResource('/motd.md',_)>>{
+                        it[1].write('motddata'.bytes)
+                        1
+                    }
+                    1* loadFileResource('/readme.md',_)>>{
+                        it[1].write('readmedata'.bytes)
+                        1
+                    }
+
+                    1* existsFileResource('etc/project.properties.imported') >> false
+
+                    //mark as imported
+                    1* loadFileResource('etc/project.properties', _) >> { args->
+                        args[1].write('test=abc'.bytes)
+                        4
+                    }
+                    1* storeFileResource('etc/project.properties.imported', {
+                        def props=new Properties()
+                        props.load(it)
+                        props['test']=='abc'
+                    }) >> 4
+
+                    1* deleteFileResource('etc/project.properties') >> true
+                    1*deleteFileResource('/motd.md') >> true
+                    1*deleteFileResource('/readme.md') >> true
+                    0*deleteFileResource(_)
+                }
+            ]
         }
         def modDate=new Date(123)
         service.storage=Mock(StorageTree){
-            1 * hasResource("projects/abc/etc/project.properties") >> false
-            1 * createResource("projects/abc/etc/project.properties",{res->
+            (projExists ? 1 : 2) * hasResource("projects/abc/etc/project.properties") >> projExists
+            (projExists ? 0 : 1) * createResource("projects/abc/etc/project.properties", { res->
                 def props=new Properties()
                 props.load(res.inputStream)
                 props['test']=='abc'
@@ -1323,64 +1278,73 @@ class ProjectManagerServiceSpec extends HibernateSpec implements ServiceUnitTest
             }
         }
         service.rundeckNodeService=Mock(NodeService)
-        service.projectCache=Mock(LoadingCache)
+        service.projectCache=Mock(LoadingCache){
+            1 * get('abc')>>{
+                service.loadProject('abc')
+            }
+        }
         when:
         service.importProjectsFromProjectManager(pm1)
 
         then:
-        1*service.rundeckNodeService.refreshProjectNodes('abc')
+        _*service.rundeckNodeService.refreshProjectNodes('abc')
         0*service.rundeckNodeService.getNodes('abc')
-        1*service.projectCache.invalidate('abc')
+        _*service.projectCache.invalidate('abc')
         Project.findByName('abc')!=null
+        where:
+            projExists | configSet
+            false       | false
+            true        | true
     }
     void "import project from fs, not yet imported with acls"(){
         given:
         def projectProps = new Properties()
         projectProps['test']='abc'
-        def pm1 = Mock(ProjectManager){
-            1*listFrameworkProjects()>>[
-                    Mock(IRundeckProject){
-                        getName()>>'abc'
-                        getProjectProperties()>>projectProps
-                        1 * listDirPaths('')>>['/motd.md','/readme.md','/etc/','/acls/']
-                        1 * listDirPaths('/etc/')>>['/etc/project.properties']
-                        1 * listDirPaths('/acls/')>>['/acls/test1.aclpolicy']
-                        1* loadFileResource('/motd.md',_)>>{
-                            it[1].write('motddata'.bytes)
-                            1
-                        }
-                        1* loadFileResource('/readme.md',_)>>{
-                            it[1].write('readmedata'.bytes)
-                            1
-                        }
-                        1* loadFileResource('/acls/test1.aclpolicy',_)>>{
-                            it[1].write('acldata'.bytes)
-                            1
-                        }
+        def pm1 = Stub(ProjectManager){
+            listFrameworkProjects()>>[
+                Mock(IRundeckProject){
+                    getName()>>'abc'
+                    getProjectProperties()>>projectProps
+                    1 * listDirPaths('')>>['/motd.md','/readme.md','/etc/','/acls/']
+                    1 * listDirPaths('/etc/')>>['/etc/project.properties']
+                    1 * listDirPaths('/acls/')>>['/acls/test1.aclpolicy']
+                    1* loadFileResource('/motd.md',_)>>{
+                        it[1].write('motddata'.bytes)
+                        1
                     }
-            ]
-            2*existsFrameworkProject('abc')>>true
-            2*getFrameworkProject('abc') >> Mock(IRundeckProject){
-                1* existsFileResource('etc/project.properties.imported') >> false
+                    1* loadFileResource('/readme.md',_)>>{
+                        it[1].write('readmedata'.bytes)
+                        1
+                    }
+                    1* loadFileResource('/acls/test1.aclpolicy',_)>>{
+                        it[1].write('acldata'.bytes)
+                        1
+                    }
+                    1* existsFileResource('etc/project.properties.imported') >> false
 
-                //mark as imported
-                1* loadFileResource('etc/project.properties',_) >> {args->
-                    args[1].write('test=abc'.bytes)
-                    4
+                    //mark as imported
+                    1* loadFileResource('etc/project.properties',_) >> {args->
+                        args[1].write('test=abc'.bytes)
+                        4
+                    }
+                    1*storeFileResource('etc/project.properties.imported',{
+                        def props=new Properties()
+                        props.load(it)
+                        props['test']=='abc'
+                    }) >> 4
+
+                    1*deleteFileResource('etc/project.properties') >> true
+                    1*deleteFileResource('/motd.md') >> true
+                    1*deleteFileResource('/readme.md') >> true
+                    1*deleteFileResource('/acls/test1.aclpolicy') >> true
+                    0*deleteFileResource(_)
+
                 }
-                1*storeFileResource('etc/project.properties.imported',{
-                    def props=new Properties()
-                    props.load(it)
-                    props['test']=='abc'
-                }) >> 4
-
-                1*deleteFileResource('etc/project.properties') >> true
-
-            }
+            ]
         }
         def modDate=new Date(123)
         service.storage=Mock(StorageTree){
-            1 * hasResource("projects/abc/etc/project.properties") >> false
+            2 * hasResource("projects/abc/etc/project.properties") >> false
             1 * createResource("projects/abc/etc/project.properties",{res->
                 def props=new Properties()
                 props.load(res.inputStream)
@@ -1427,12 +1391,16 @@ class ProjectManagerServiceSpec extends HibernateSpec implements ServiceUnitTest
             }
         }
         service.rundeckNodeService=Mock(NodeService)
-        service.projectCache=Mock(LoadingCache)
+        service.projectCache=Mock(LoadingCache){
+            1 * get('abc')>>{
+                service.loadProject('abc')
+            }
+        }
         when:
         service.importProjectsFromProjectManager(pm1)
 
         then:
-        1*service.rundeckNodeService.refreshProjectNodes('abc')
+        2*service.rundeckNodeService.refreshProjectNodes('abc')
         0*service.rundeckNodeService.getNodes('abc')
         1*service.projectCache.invalidate('abc')
         Project.findByName('abc')!=null


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Fix #6239 

**Describe the solution you've implemented**

Converting from project storage type FS to DB now imports all config resources

**Additional context**

Using WAR deployment in rundeck 3.2 and earlier, the default for the `rundeck.projectsStorageType` was `file` not `db` based on internal app default, whereas other install types (deb,rpm,docker) use `db` by default.

On upgrade from 3.2.x to 3.3.0, a war install using the default config value would convert from file to db, however project level ACLs were not getting converted.

**mitigation**

If you upgrade to Rundeck 3.3.0 using a war install, and did not set `rundeck.projectsStorageType` explicitly in your config file, any filesystem-stored projects would be converted to DB storage, but ACLs would not be copied.  You will need to manually install the aclpolicy files from the filesystem by using the Rundeck UI or API to add them to the project.

If you upgrade to Rundeck 3.3.1(TBR) from 3.2.x, the ACLs will be imported.  

If you upgrade to Rundeck 3.3.1(TBR) from 3.3.0 you can reimport the missing files by adding this config: `rundeck.projectsStorageImportResources=always` and renaming any `project.properties.imported` back to `project.properties` before starting up 3.3.1.  This will reimport any files (acls, readme) from the filesystem to existing projects.  You can rename any file to end with ".imported" before startup to have it be skipped by this process.
