### PR TITLE
Docker - Add / on rundeck/jaas/file/required

### DIFF
--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -62,7 +62,7 @@
 {% endmacro %}
 
 {% macro PropertyFileLoginModule() %}
-    org.eclipse.jetty.jaas.spi.PropertyFileLoginModule {{ getv("rundeck/jaas/file/required", "required") }}
+    org.eclipse.jetty.jaas.spi.PropertyFileLoginModule {{ getv("/rundeck/jaas/file/required", "required") }}
         debug="true"
         file="{{ rundeckHome }}/server/config/realm.properties";
 {% endmacro %}


### PR DESCRIPTION
Add / at the begining of rundeck/jaas/file/required. Without "/", the env variable is not taken in consideration