### PR TITLE
Reduce console messages in standalone war launch

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -351,7 +351,7 @@ bootWar {
     }
     manifest {
         attributes(
-            ['Add-Opens':'java.management/com.sun.jmx.mbeanserver java.base/java.io java.base/java.lang java.base/java.lang.invoke java.base/java.lang.reflect java.base/java.math java.base/java.net java.base/java.nio.charset java.base/java.nio.file java.base/java.nio.file.attribute java.base/java.security java.base/java.text java.base/java.time java.base/java.util java.base/java.util.zip java.base/java.util.concurrent java.base/java.util.concurrent.atomic java.base/java.util.stream java.base/java.util.function java.base/java.util.regex java.base/javax.crypto java.base/sun.nio.cs java.base/sun.nio.fs java.base/sun.net.www.protocol.jar java.xml/org.xml.sax java.xml/com.sun.org.apache.xerces.internal.impl java.xml/com.sun.org.apache.xerces.internal.dom']
+            ['Add-Opens':'java.management/com.sun.jmx.mbeanserver java.base/java.io java.base/java.lang java.base/java.lang.invoke java.base/java.lang.reflect java.management/java.lang.management java.management/sun.management java.base/java.math java.base/java.net java.base/java.nio.charset java.base/java.nio.file java.base/java.nio.file.attribute java.base/java.security java.base/java.text java.base/java.time java.base/java.time.chrono java.base/java.util java.base/java.util.zip java.base/java.util.concurrent java.base/java.util.concurrent.atomic java.base/java.util.stream java.base/java.util.function java.base/java.util.regex java.base/javax.crypto java.base/javax.security.auth java.base/sun.nio.cs java.base/sun.nio.fs java.base/sun.security.util java.base/sun.net.www.protocol.jar java.xml/org.xml.sax java.xml/com.sun.org.apache.xerces.internal.impl java.xml/com.sun.org.apache.xerces.internal.dom java.sql/java.sql']
         )
     }
 }

--- a/rundeckapp/templates/config/log4j2.properties.template
+++ b/rundeckapp/templates/config/log4j2.properties.template
@@ -148,7 +148,7 @@ rootLogger.appenderRef.stdout.ref = STDOUT
 rootLogger.appenderRef.rundeck.ref = rundeck
 
 logger.interceptors.name = rundeck.interceptors
-logger.interceptors.level = debug
+logger.interceptors.level = warn
 logger.interceptors.additivity = false
 logger.interceptors.appenderRef.stdout.ref = STDOUT
 
@@ -166,6 +166,11 @@ logger.grails.name = grails
 logger.grails.level = warn
 logger.grails.additivity = false
 logger.grails.appenderRef.stdout.ref = STDOUT
+
+logger.grails_env.name = grails.util.Environment
+logger.grails_env.level = error
+logger.grails_env.additivity = false
+logger.grails_env.appenderRef.stdout.ref = STDOUT
 
 logger.prjmanager.name = grails.app.services.rundeck.services.ProjectManagerService
 logger.prjmanager.level = info


### PR DESCRIPTION
Set logging of interceptors to info.
Set logging of grails.util.Environment to error to avoid unhelpful warning messages.
Add more module opens for JDK 11.
