### PR TITLE
Fix issue 1080 where sometimes the log output is merging the stdout and stderr causing log filters to not work well

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/CustomExecTask.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/CustomExecTask.java
@@ -1,0 +1,89 @@
+package com.dtolabs.rundeck.core.execution.impl.local;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.taskdefs.ExecTask;
+import org.apache.tools.ant.taskdefs.ExecuteStreamHandler;
+import org.apache.tools.ant.taskdefs.PumpStreamHandler;
+import org.apache.tools.ant.taskdefs.Redirector;
+import org.apache.tools.ant.util.LineOrientedOutputStreamRedirector;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class CustomExecTask extends ExecTask {
+    ExecuteStreamHandler executeStreamHandler;
+
+    protected ExecuteStreamHandler createHandler() throws BuildException {
+        redirector.createHandler();
+        this.executeStreamHandler = new CustomPumpStreamHandler(redirector);
+        return this.executeStreamHandler;
+    }
+
+    public void log(String msg, int msgLevel) {
+        if(this.executeStreamHandler != null) {
+            CustomExecTask.CustomPumpStreamHandler p = (CustomExecTask.CustomPumpStreamHandler) this.executeStreamHandler;
+            CustomExecTask.CustomLineOrientedOutputStream outputStream = (CustomExecTask.CustomLineOrientedOutputStream) p.getOutputStream();
+            CustomExecTask.CustomLineOrientedOutputStream errorStream = (CustomExecTask.CustomLineOrientedOutputStream) p.getErrorStream();
+
+            int outputStreamLength = outputStream != null ? outputStream.baos.size() : 0;
+            int errorStreamLength = errorStream != null ? errorStream.baos.size() : 0;
+            byte[] a = msg.getBytes();
+
+            if (outputStreamLength > 0 &&
+                    errorStreamLength > 0 &&
+                    a.length == outputStreamLength + errorStreamLength) {
+
+                String out = outputStream.baos.toString();
+                String err = errorStream.baos.toString();
+
+                if (msg.startsWith(out) && msg.endsWith(err)) {
+                    super.log(out, msgLevel);
+                    super.log(err, msgLevel);
+                    return;
+                } else if (msg.startsWith(err) && msg.endsWith(out)) {
+                    super.log(err, msgLevel);
+                    super.log(out, msgLevel);
+                    return;
+                }
+            }
+        }
+
+        super.log(msg, msgLevel);
+    }
+
+    public static final class CustomPumpStreamHandler extends PumpStreamHandler{
+        public CustomPumpStreamHandler(Redirector redirector) {
+            super(new CustomLineOrientedOutputStream(redirector.getOutputStream()),
+                    new CustomLineOrientedOutputStream(redirector.getErrorStream()),
+                    redirector.getInputStream(), true);
+        }
+
+        protected OutputStream getOutputStream(){
+            return this.getOut();
+        }
+
+        protected OutputStream getErrorStream(){
+            return this.getErr();
+        }
+    }
+
+    public static final class CustomLineOrientedOutputStream extends LineOrientedOutputStreamRedirector {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        public CustomLineOrientedOutputStream(OutputStream stream) {
+            super(stream);
+        }
+
+        @Override
+        protected void processLine(byte[] b) throws IOException {
+            baos = new ByteArrayOutputStream();
+            baos.write(b);
+            this.doProcessLine(b);
+        }
+
+        private void doProcessLine(byte[] b) throws IOException {
+            super.processLine(b);
+        }
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/LocalNodeExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/LocalNodeExecutor.java
@@ -81,7 +81,7 @@ public class LocalNodeExecutor implements NodeExecutor {
                                      parameterGenerator.generate(node, true, null, command),
                                      context.getDataContext(),
                                      context.getCharsetEncoding(),
-                                     new ExecTask()
+                                     new CustomExecTask()
             );
         } catch (ExecutionException e) {
             return NodeExecutorResultImpl.createFailure(StepFailureReason.ConfigurationFailure,
@@ -118,13 +118,13 @@ public class LocalNodeExecutor implements NodeExecutor {
         }
     }
 
-    public static ExecTask buildExecTask(
+    public static CustomExecTask buildExecTask(
             Project project, ExecTaskParameters taskParameters,
             Map<String, Map<String, String>> dataContext,
             final String charset,
-            final ExecTask task
+            final CustomExecTask task
     ) {
-        final ExecTask execTask = task;
+        final CustomExecTask execTask = task;
         execTask.setTaskType("exec");
         execTask.setFailonerror(false);
         execTask.setProject(project);

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/impl/local/LocalNodeExecutorSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/impl/local/LocalNodeExecutorSpec.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
  * Created by greg on 7/7/16.
  */
 class LocalNodeExecutorSpec extends Specification {
-    class TExecTask extends ExecTask {
+    class TExecTask extends CustomExecTask {
         RedirectorElement getTestRedirectorElement() {
             return this.redirectorElement
         }


### PR DESCRIPTION
Fix https://github.com/rundeckpro/rundeckpro/issues/1080

**Is this a bugfix, or an enhancement? Please describe.**
Sometimes, if there is a lot of scripts running in parallel and this scripts produce output and output erros, some lines should be printed on a single line (i.e. merging more than one line).

**Describe the solution you've implemented**
This solution capture the stdout and stderr in separate streams before this lines is printed and breaks this line to print them correctly.

**Describe alternatives you've considered**
There is a new `LocalNodeExecutor` that has a new implementation for a local executor and it has a different way to handling the output streams and it would solve that issue.