### PR TITLE
replace ehcache2 with jcache/ehcache3

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -90,7 +90,10 @@ dependencies {
     // Defined by create-app
     compile "org.grails.plugins:hibernate5"
     compile "org.hibernate:hibernate-core:${hibernateVersion}"
-    compile "org.hibernate:hibernate-ehcache:${hibernateVersion}"
+
+    compile( "org.hibernate:hibernate-jcache:${hibernateVersion}")
+    compile('org.ehcache:ehcache:3.8.1')
+
     compile ('org.hibernate:hibernate-validator:6.0.19.Final'){
         because 'https://snyk.io/vuln/SNYK-JAVA-ORGHIBERNATE-568162'
     }
@@ -128,7 +131,9 @@ dependencies {
     compile "org.eclipse.jetty:jetty-jaas"
     compile "org.eclipse.jetty:jetty-util"
     compile "org.eclipse.jetty:jetty-security"
-    compile 'org.grails.plugins:spring-security-core:4.0.0'
+    compile ('org.grails.plugins:spring-security-core:4.0.0'){
+        exclude(group:'net.sf.ehcache',module:'ehcache')
+    }
     compile 'org.kohsuke:libpam4j:1.10'
     compile 'ca.juliusdavies:not-yet-commons-ssl:0.3.17'
     compile "javax.xml.bind:jaxb-api:2.3.1"
@@ -161,6 +166,7 @@ dependencies {
     testCompile "org.grails:grails-web-testing-support"
     testCompile "org.grails.plugins:geb"
     testCompile "org.grails:grails-test-mixins:3.3.0.RC1"
+    testCompile( "org.hibernate:hibernate-jcache:${hibernateVersion}")
 
     testRuntime "org.seleniumhq.selenium:selenium-chrome-driver"
     testRuntime "org.seleniumhq.selenium:selenium-firefox-driver"

--- a/rundeckapp/grails-app/conf/application.groovy
+++ b/rundeckapp/grails-app/conf/application.groovy
@@ -2,9 +2,13 @@ hibernate {
     cache.queries = true
     cache.use_second_level_cache = true
     cache.use_query_cache = true
-    cache.provider_class = "net.sf.ehcache.hibernate.EhCacheProvider"
-    cache.region.factory_class = "org.hibernate.cache.ehcache.EhCacheRegionFactory"
+    cache.region.factory_class = "jcache"
     cache.ehcache.missing_cache_strategy = "create"
+    javax{
+        cache{
+            provider='org.ehcache.jsr107.EhcacheCachingProvider'
+        }
+    }
 }
 dataSource {
     pooled = true


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Replace ehcacheV2 dependency by using hibernate-jcache+ehcache3.

Reason: ehcache 2.10.6 includes embedded jackson-databind 2.9.6

Note: spring-security-core declares dependency on ehcache 2.10.6, which I excluded here.  This might be a problem