### PR TITLE
Fixes when to execute a job using "Remote URL options" #6275

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2523,7 +2523,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      */
     private HashMap validateJobInputOptions(Map props, ScheduledExecution scheduledExec, UserAndRolesAuthContext authContext, Map securedOpts, Map securedExposedOpts) {
         HashMap optparams
-        optparams = parseJobOptionInput(props, scheduledExec)
+        optparams = parseJobOptionInput(props, scheduledExec, authContext)
         def result = checkBeforeJobExecution(scheduledExec, optparams, props, authContext)
         if(result?.isUseNewValues()){
             optparams = result.optionsValues

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -5378,4 +5378,25 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         "node1,node2,node3"     | 0     | []                                                                                    |  null                          | false
         ""                      | 1     | [node1: [summaryState:'SUCCEEDED'], node2: [summaryState:'SUCCEEDED'], node3: [summaryState:'SUCCEEDED']]   | ["node2","node3","node1"] | true
     }
+
+    def "opt enforced allowed values from Remote Url with sending the username"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution()
+        Option opt = new Option(name: null, enforced: true, defaultValue: null, optionValues: null)
+        se.addToOptions(opt)
+
+        UserAndRolesAuthContext Admin = Mock(UserAndRolesAuthContext) {
+            getUsername() >> 'Admin'
+            getRoles() >> new HashSet<String>(['Admin'])
+        }
+
+        service.scheduledExecutionService = Mock(ScheduledExecutionService)
+
+        when:
+        HashMap optparams = service.parseJobOptionInput([:], se, Admin)
+
+        then:
+            1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,'Admin') >> [:]
+    }
+
 }

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -5385,7 +5385,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         Option opt = new Option(name: null, enforced: true, defaultValue: null, optionValues: null)
         se.addToOptions(opt)
 
-        UserAndRolesAuthContext Admin = Mock(UserAndRolesAuthContext) {
+        UserAndRolesAuthContext admin = Mock(UserAndRolesAuthContext) {
             getUsername() >> 'Admin'
             getRoles() >> new HashSet<String>(['Admin'])
         }
@@ -5393,10 +5393,11 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         service.scheduledExecutionService = Mock(ScheduledExecutionService)
 
         when:
-        HashMap optparams = service.parseJobOptionInput([:], se, Admin)
+        HashMap optparams = service.parseJobOptionInput([:], se, admin)
 
         then:
             1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,'Admin') >> [:]
+            0 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_, null) >> [:]
     }
 
 }


### PR DESCRIPTION
fixes: https://github.com/rundeck/rundeck/issues/6275

Fix a problem when to execute a job using "Remote URL options" and "Enforcing from allowed values". 

**solution implemented**
Send the "authContext" in the "ExecutionService.addRemoteOptionSelected" method as a parameter because the OptionsUtil.expandUrl method requires the variable usename of the job 
 and thus don't incorrectly call the OptionsUtil.getHttpSessionInstance () method.
