### PR TITLE
Allow a rundeck server to be set as primary. 

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -25,6 +25,7 @@ public class RundeckConfigBase {
 
     String executionMode;
     String projectsStorageType;
+    String primaryServerId;
 
     Map<String,Object> mail;  //mail is a very dynamic config
     Map<String,Object> storage;  //config for the storage tree

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -60,3 +60,7 @@ rundeck.execution.logs.fileStoragePlugin={{ getv("/rundeck/plugin/executionfiles
 {% if exists("/rundeck/applyfix/workflowconfigfix973") %}
 rundeck.applyFix.workflowConfigFix973={{ getv("/rundeck/applyfix/workflowconfigfix973") }}
 {% endif %}
+
+{% if exists("/rundeck/primaryserverid") %}
+rundeck.primaryServerId={{ getv("/rundeck/primaryserverid") }}
+{% endif %}


### PR DESCRIPTION
Only apply data fixes using primary server if set.

If the Rundeck server is not configured in a cluster the fixes will be applied.
If no server is set as primary, all servers will attempt to run the fixes.