### PR TITLE
Reduce workflow engine meta logging in log output by marking as wfmeta

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/EngineWorkflowExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/EngineWorkflowExecutor.java
@@ -325,7 +325,9 @@ public class EngineWorkflowExecutor extends BaseWorkflowExecutor {
         return (String message) -> {
             String logMessage = String.format("[wf:%s] %s", workflowId, message);
             logger.debug(logMessage);
-            executionListener.log(Constants.DEBUG_LEVEL, logMessage);
+            HashMap<String, String> map = new HashMap<>();
+            map.put("wfmeta", "true");
+            executionListener.log(Constants.DEBUG_LEVEL, logMessage, map);
         };
     }
 
@@ -337,7 +339,9 @@ public class EngineWorkflowExecutor extends BaseWorkflowExecutor {
         return (String message) -> {
             String logMessage = String.format("[wf:%s] %s", workflowId, message);
             logger.warn(logMessage);
-            executionListener.log(Constants.WARN_LEVEL, logMessage);
+            HashMap<String, String> map = new HashMap<>();
+            map.put("wfmeta", "true");
+            executionListener.log(Constants.WARN_LEVEL, logMessage, map);
         };
     }
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -1485,6 +1485,9 @@ setTimeout(function(){
             if (!stateoutput && data.eventType != LogUtil.EVENT_TYPE_LOG) {
                 return false
             }
+            if(data.metadata?.wfmeta=='true' && (params.wfmeta!='true'&&!request.getHeader('referer')?.contains('?wfmeta=true'))){
+                return false
+            }
             if (stateoutput && stateonly && data.eventType == LogUtil.EVENT_TYPE_LOG) {
                 return false
             }


### PR DESCRIPTION
* hide warn/debug in log view by default unless `?wfmeta=true` param is sent
* don't include workflowID in exec output log data

**Is this a bugfix, or an enhancement? Please describe.**

Reduces DEBUG/WARN log output when workflow engine details are not necessary.

Fixes #5290

