### PR TITLE
Fix: flaky test race condition in LogFileStorageServiceSpec

### DIFF
--- a/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
@@ -31,6 +31,7 @@ import grails.test.mixin.TestFor
 import grails.testing.services.ServiceUnitTest
 import org.rundeck.app.services.ExecutionFile
 import org.rundeck.app.services.ExecutionFileProducer
+import org.springframework.core.task.AsyncListenableTaskExecutor
 import org.springframework.core.task.SimpleAsyncTaskExecutor
 import org.springframework.scheduling.TaskScheduler
 import rundeck.Execution
@@ -1118,7 +1119,7 @@ class LogFileStorageServiceSpec extends HibernateSpec implements ServiceUnitTest
                         PropertyScope.Instance
                 ) >> new ConfiguredPlugin<ExecutionFileStoragePlugin>(plugin, [:])
             }
-            service.logFileTaskExecutor = new SimpleAsyncTaskExecutor()
+            service.logFileTaskExecutor = Mock(AsyncListenableTaskExecutor)
 
 
         when:


### PR DESCRIPTION
replace real executor with mock to prevent race condition for test result


**Is this a bugfix, or an enhancement? Please describe.**

fix a flaky test