### PR TITLE
Fix node view output not rendering

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logBuilder.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logBuilder.ts
@@ -48,15 +48,9 @@ export class LogBuilder {
 
     const {node, stepCtx} = this.opts
 
-    if (node && !stepCtx) {
-      const query = `${this.opts.node}`
+    if (node) {
       this.observeFiltered(() => {
-        return executionOutput.entriesByNode.get(query)
-      })
-    } else if (node && stepCtx) {
-      const query = `${node} ${stepCtx}`
-      this.observeFiltered(() => {
-        return executionOutput.entriesbyNodeCtx.get(query)
+        return executionOutput.getEntriesByNodeCtx(node, stepCtx)
       })
     } else {
       output = executionOutput.entries

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/stores/ExecutionOutput.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/stores/ExecutionOutput.ts
@@ -63,7 +63,9 @@ export class ExecutionOutput {
 
     constructor(id: string, client: RundeckClient) {
         Object.assign(this, { id, client })
-        this.entriesbyNodeCtx = new ObservableGroupMap(this.entries, (e) => `${e.node} ${e.stepctx}`)
+        this.entriesbyNodeCtx = new ObservableGroupMap(this.entries, (e) => {
+            return `${e.node}:${e.stepctx ? JobWorkflow.cleanContextId(e.stepctx) : ''}`
+        })
         this.entriesByNode = new ObservableGroupMap(this.entries, (e) => `${e.node}`)
     }
 
@@ -77,7 +79,7 @@ export class ExecutionOutput {
     /** Get an observable list of entries grouped by node or node and step */
     getEntriesByNodeCtx(node: string, stepCtx?: string) {
         if (stepCtx)
-            return this.entriesbyNodeCtx.get(`${node} ${stepCtx}`)
+            return this.entriesbyNodeCtx.get(`${node}:${JobWorkflow.cleanContextId(stepCtx)}`)
         else
             return this.entriesByNode.get(node)
     }


### PR DESCRIPTION
Fixes #6292
Fixes rundeckpro/rundeckpro#1150

**Is this a bugfix, or an enhancement? Please describe.**
This fixes execution output not rendering in the "node view". More likely to occur with job reference steps.

**Describe the solution you've implemented**
The KO code uses a _cleaned_(stripped of parameters like node) step context when creating an `RDNodeStep`. The execution output store was grouping on the raw `stepctx` causing a lookup failure if it contained encoded parameters.

This change groups the output entries by the cleaned `stepctx` so the lookups will always be successful.

**Describe alternatives you've considered**
N/A
