### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/docker/debinstall/Dockerfile
+++ b/docker/debinstall/Dockerfile
@@ -2,7 +2,7 @@ FROM rdubuntu16.04-util:latest
 
 ## General package configuration
 RUN apt-get -y update && \
-    apt-get -y install \
+    apt-get --no-install-recommends -y install \
         sudo \
         software-properties-common \
         debconf-utils \
@@ -14,7 +14,7 @@ RUN apt-get -y update && \
 
 ## Install Oracle JVM
 RUN apt-get update && \
-  apt-get install -y openjdk-8-jdk-headless
+  apt-get --no-install-recommends -y install openjdk-8-jdk-headless
 
 ## DEBUG ENV VARS AT THIS POINT
 #RUN echo "**** ENV VARS START ****" && printenv > /env_at_build_time && cat /env_at_build_time && echo "**** ENV VARS END ****"

--- a/test/docker/dockers/hostnode/Dockerfile
+++ b/test/docker/dockers/hostnode/Dockerfile
@@ -5,7 +5,7 @@ VOLUME /var/lib/docker
 
 ## General package configuration
 RUN apt-get -y update && \
-    apt-get -y install \
+    apt-get --no-install-recommends -y install \
         sudo \
         unzip \
         curl \

--- a/test/docker/dockers/rundeck/Dockerfile
+++ b/test/docker/dockers/rundeck/Dockerfile
@@ -33,7 +33,7 @@ ARG RUNDECK_NODE=rundeck1
 RUN echo "download rundeck launcher: ${LAUNCHER_URL}" \
     && { test -f $HOME/rundeck-launcher.war || curl -sS -f -L ${LAUNCHER_URL} > $HOME/rundeck-launcher.war; } \
     && { test -f $HOME/data/rd.deb && dpkg -i $HOME/data/rd.deb || true; } \
-    && { test -f $HOME/data/rd.deb || apt-get -y update && apt-get -y install rundeck-cli=$CLI_VERS; } \
+    && { test -f $HOME/data/rd.deb || apt-get -y update && apt-get --no-install-recommends -y install rundeck-cli=$CLI_VERS; } \
     && java \
         -Dserver.http.port=4440 \
         -Dserver.hostname=$RUNDECK_NODE \
@@ -41,7 +41,7 @@ RUN echo "download rundeck launcher: ${LAUNCHER_URL}" \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get -y update
-RUN apt-get -y install dos2unix
+RUN apt-get --no-install-recommends -y install dos2unix
 USER rundeck
 
 

--- a/test/docker/dockers/rundeckansible/Dockerfile
+++ b/test/docker/dockers/rundeckansible/Dockerfile
@@ -1,10 +1,10 @@
 FROM rdtest:latest
 
 RUN sudo apt-get update
-RUN sudo apt-get install -y software-properties-common
+RUN sudo apt-get --no-install-recommends -y install software-properties-common
 RUN sudo apt-add-repository ppa:ansible/ansible
 RUN sudo apt-get update
-RUN sudo apt-get install -y ansible
+RUN sudo apt-get --no-install-recommends -y install ansible
 
 RUN mkdir -p $HOME/atest
 COPY config $HOME/atest

--- a/test/docker/dockers/testnode/Dockerfile
+++ b/test/docker/dockers/testnode/Dockerfile
@@ -4,7 +4,7 @@ VOLUME /var/lib/docker
 
 ## General package configuration
 RUN apt-get -y update && \
-    apt-get -y install \
+    apt-get --no-install-recommends -y install \
         sudo \
         unzip \
         curl \

--- a/test/docker/dockers/tomcat/Dockerfile
+++ b/test/docker/dockers/tomcat/Dockerfile
@@ -3,7 +3,7 @@ ARG TOMCAT_TAG
 FROM tomcat:${TOMCAT_TAG:-8}
 
 RUN apt-get update && \
-    apt-get -y install coreutils file jq netcat xmlstarlet
+    apt-get --no-install-recommends -y install coreutils file jq netcat xmlstarlet
 
 RUN mkdir -p /usr/local/tomcat/webapps/rundeck/rundeck/server/config \
     && mkdir -p /usr/local/tomcat/webapps/rundeck/rundeck/var/log

--- a/test/docker/dockers/ubuntudeb/Dockerfile
+++ b/test/docker/dockers/ubuntudeb/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 ## General package configuration
 RUN apt-get -y update && \
-    apt-get -y install \
+    apt-get --no-install-recommends -y install \
         sudo \
         debconf-utils \
         apt-utils \
@@ -16,7 +16,7 @@ RUN wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=bintra
 RUN sudo apt-get -y update 
 
 ## install openjdk 8
-RUN sudo apt-get install -y openjdk-8-jdk
+RUN sudo apt-get --no-install-recommends -y install openjdk-8-jdk
 
 ## DEBUG ENV VARS AT THIS POINT
 #RUN echo "**** ENV VARS START ****" && printenv > /env_at_build_time && cat /env_at_build_time && echo "**** ENV VARS END ****"
@@ -44,7 +44,7 @@ WORKDIR $HOME
 USER rundeck
 
 #download debian package
-RUN  sudo apt-get install -y rundeck
+RUN  sudo apt-get --no-install-recommends -y install rundeck
 
 # RUNDECK - install
 


### PR DESCRIPTION
Pull for issue #6315 

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>  