### PR TITLE
Docker - Add version and commit labels to docker image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ plugins {
     id 'com.gradle.build-scan' version '3.2.1'
     id "org.dvaske.gradle.git-build-info" version "0.8"
     id "com.dorongold.task-tree" version "1.5"
+    id "org.ajoberstar.grgit" version "2.2.1"
 }
 
 apply plugin: 'java'
@@ -107,6 +108,9 @@ if (ext.environment == 'release') {
 } else {
     project.ext.resolvedVersion = "${vNum}-SNAPSHOT".toString()
 }
+
+project.ext.branch = grgit.branch.current().name
+project.ext.commit = grgit.head().id
 
 logger.lifecycle("Building version {}", project.resolvedVersion)
 

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -52,6 +52,8 @@ task officialBuild {
         def args = [
             "docker",
             "build",
+            "--label=com.rundeck.version=$resolvedVersion",
+            "--label=com.rundeck.commit=$commit"
         ]
 
         for (tag in dockerTags)


### PR DESCRIPTION
Adds the following labels to the built docker image:
* `com.rundeck.version` => The Rundeck version the image was built against
* `com.rundeck.commit` => The project commit the image was built from