### PR TITLE
Remove the @Transactional from JobEventsService

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/JobEventsService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobEventsService.groovy
@@ -25,7 +25,6 @@ import org.rundeck.app.components.RundeckJobDefinitionManager
 import rundeck.ScheduledExecution
 import rundeck.services.scm.ProjectJobChangeListener
 
-@Transactional
 class JobEventsService {
     def configurationService
     def List<JobChangeListener> listeners = []


### PR DESCRIPTION
Removes the @Transactional from JobEventsService to avoid triggering "Active Connection is required" error when withNewSession is used on a @Transactional method

Might be hitting this bug: https://github.com/grails/grails-data-mapping/issues/1234

Fixes #6310
