### PR TITLE
OWASP dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,10 @@ apply plugin: 'org.owasp.dependencycheck'
 dependencyCheck {
     suppressionFile='cve-suppress.xml'
     formats=['HTML','JUNIT']
-    outputDirectory='build/owasp-reports/junit'
+    outputDirectory="build/owasp-reports/junit"
     failBuildOnCVSS=8
+    skipConfigurations=['agent']
+    scanSet=[]
 }
 
 /*

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -81,8 +81,8 @@ dependencies {
         'com.jcraft:jsch.agentproxy.core:0.0.9',
         "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}",
         "org.yaml:snakeyaml:${snakeyamlVersion}",
-        'com.squareup.retrofit2:retrofit:2.6.1',
-        'com.squareup.retrofit2:converter-jackson:2.6.1',
+        'com.squareup.retrofit2:retrofit:2.7.2',
+        'com.squareup.retrofit2:converter-jackson:2.7.2',
         'javax.servlet:javax.servlet-api:4.0.1'
 
 
@@ -96,7 +96,7 @@ dependencies {
 
     testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
     testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
-    testCompile "com.squareup.retrofit2:retrofit-mock:2.6.1"
+    testCompile "com.squareup.retrofit2:retrofit-mock:2.7.2"
     testCompile "cglib:cglib-nodep:2.2.2"
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,6 +31,7 @@ snakeyamlVersion=1.26
 # available properties at:
 # https://github.com/spring-projects/spring-boot/blob/1.5.x/spring-boot-dependencies/pom.xml
 #
+spring-security.version=5.1.11.RELEASE
 log4j2.version=2.13.2
 jackson.version=2.10.1
 assetPluginVersion=3.1.0

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -130,7 +130,7 @@ dependencies {
     compile "org.eclipse.jetty:jetty-jaas"
     compile "org.eclipse.jetty:jetty-util"
     compile "org.eclipse.jetty:jetty-security"
-    compile ('org.grails.plugins:spring-security-core:4.0.0'){
+    compile ('org.grails.plugins:spring-security-core:4.0.2'){
         exclude(group:'net.sf.ehcache',module:'ehcache')
     }
     compile 'org.kohsuke:libpam4j:1.11'


### PR DESCRIPTION
Update okhttp, and spring security dependencies with CVEs reported by OWASP.
Prevent OWASP from scanning npm files to avoid redundant security reports.
