### PR TITLE
Fix #6349: failure to serialize jobs for git due to mkdirs

### DIFF
--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/BaseGitPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/BaseGitPlugin.groovy
@@ -155,10 +155,16 @@ class BaseGitPlugin {
                 //only bother writing the file if this rev of Job if it is newer than previously serialized rev
 
                 if (!outfile.parentFile.isDirectory()) {
-                    if (!outfile.parentFile.mkdirs()) {
-                        throw new ScmPluginException(
-                                "Cannot create necessary dirs to serialize file to path: ${outfile.absolutePath}"
-                        )
+                    File parentFile = outfile.parentFile
+                    AtomicLong parentCounter = fileCounterFor(parentFile)
+                    synchronized (parentCounter) {
+                        if (!parentFile.isDirectory()) {
+                            if (!parentFile.mkdirs()) {
+                                throw new ScmPluginException(
+                                    "Cannot create necessary dirs to serialize file to path: ${outfile.absolutePath}"
+                                )
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Fix: #6349 
when serializing multiple jobs in the same dir at the same time a race
condition around the parent dir creation can cause a failure

**Describe the solution you've implemented**

this synchronizes creation of parent dirs
