### PR TITLE
Enhance stack traces for selenium webdriver errors

### DIFF
--- a/test/testdeck/src/util/Error.ts
+++ b/test/testdeck/src/util/Error.ts
@@ -1,0 +1,10 @@
+/** A custom Error class than can have extra error stacks appended */
+export class CustomError extends Error {
+    constructor(message: string) {
+        super(message)
+    }
+
+    addCause(cause: Error) {
+        this.stack = `${this.stack}\n\nCaused by: ${cause.stack}`
+    }
+}


### PR DESCRIPTION
Proxies calls to the Selenium driver methods and wraps them with extra error information.

In the case that a promise rejection was not handled(`await` was forgotten) the stack from the original call will be preserved in the resulting unhandled error.

In the case of `await` raising the error in the Jest test, Jest will still print the correct source lines.

Workaround for seleniumhq/selenium#7626

**Error raised in Jest test**
![image](https://user-images.githubusercontent.com/271965/89678302-92fd2d00-d8b4-11ea-89f9-92303f67544e.png)

**Unhandled Error**
![image](https://user-images.githubusercontent.com/271965/89678371-a9a38400-d8b4-11ea-8626-f8b43200e077.png)


