### PR TITLE
Display message when no log output is available

### DIFF
--- a/rundeckapp/grails-spa/README.md
+++ b/rundeckapp/grails-spa/README.md
@@ -16,7 +16,7 @@ nvm use
 
 * Start rundeck in Development mode
 * Run `nvm use`
-* Run `nvm run dev` to start building `packages/ui` in watch mode
+* Run `npm run dev` to start building `packages/ui` in watch mode
 
 
 ### Working with UI Trellis

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logViewer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logViewer.vue
@@ -85,6 +85,9 @@
         <div class="execution-log__warning" v-if="errorMessage">
           <h4>{{errorMessage}}</h4>
         </div>
+        <div class="execution-log__warning" v-if="completed && logLines == 0">
+          <h5>No output</h5>
+        </div>
       </div>
     </div>
     <div class="stats" v-if="settings.stats">

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/stores/ExecutionOutput.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/stores/ExecutionOutput.ts
@@ -1,5 +1,5 @@
 import {observable, action, IObservableArray} from 'mobx'
-import {ObservableGroupMap} from 'mobx-utils'
+import {ObservableGroupMap, actionAsync, task} from 'mobx-utils'
 
 import {RundeckClient} from '@rundeck/client'
 import { RootStore } from './RootStore'
@@ -113,11 +113,13 @@ export class ExecutionOutput {
     }
 
     @Serial
+    @actionAsync
     async getOutput(maxLines: number): Promise<ExecutionOutputEntry[]> {
-        const workflow = await this.getJobWorkflow()
-        await this.waitBackOff()
+        const workflow = await task(this.getJobWorkflow())
+        await task(this.waitBackOff())
 
-        const res = await this.client.executionOutputGet(this.id, {offset: this.offset.toString(), maxlines: maxLines})
+        const res = await task(this.client.executionOutputGet(this.id, {offset: this.offset.toString(), maxlines: maxLines}))
+
         this.offset = parseInt(res.offset)
         this.size = res.totalSize
         this.completed = res.completed && res.execCompleted

--- a/rundeckapp/grails-spa/packages/ui/src/pages/execution-show/nodeView.ts
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/execution-show/nodeView.ts
@@ -21,24 +21,6 @@ window._rundeck.eventBus.$on('ko-exec-show-output', (nodeStep: any) => {
     const elm = document.querySelector(query)!
     elm.appendChild(div)
 
-    /** Update the KO code when this views output starts showing up */
-    const execOutput = rootStore.executionOutputStore.createOrGet(execId)
-    autorun((reaction) => {
-        const entries = execOutput.getEntriesByNodeCtx(node, stepCtx)
-
-        if (!entries || entries.length == 0) {
-            if (execOutput.completed) {
-                reaction.dispose()
-                nodeStep.outputLineCount(1)
-            } else {
-                return
-            }
-        }
-
-        reaction.dispose()
-        nodeStep.outputLineCount(1)
-    })
-
     const template = `\
     <LogViewer
         class="wfnodestep"
@@ -68,5 +50,26 @@ window._rundeck.eventBus.$on('ko-exec-show-output', (nodeStep: any) => {
                 stats: false,
             })}
         },
+    })
+
+    /** Update the KO code when this views output starts showing up */
+    const execOutput = rootStore.executionOutputStore.createOrGet(execId)
+    autorun((reaction) => {
+        const entries = execOutput.getEntriesByNodeCtx(node, stepCtx)
+
+        if (!entries || entries.length == 0) {
+            /** There was no output so we update KO and remove the viewer */
+            if (execOutput.completed) {
+                reaction.dispose()
+                nodeStep.outputLineCount(0)
+                vue.$el.remove()
+                return
+            } else {
+                return
+            }
+        }
+
+        reaction.dispose()
+        nodeStep.outputLineCount(1)
     })
 })

--- a/rundeckapp/grails-spa/packages/ui/src/pages/execution-show/nodeView.ts
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/execution-show/nodeView.ts
@@ -26,8 +26,14 @@ window._rundeck.eventBus.$on('ko-exec-show-output', (nodeStep: any) => {
     autorun((reaction) => {
         const entries = execOutput.getEntriesByNodeCtx(node, stepCtx)
 
-        if (!entries || entries.length == 0)
-            return
+        if (!entries || entries.length == 0) {
+            if (execOutput.completed) {
+                reaction.dispose()
+                nodeStep.outputLineCount(1)
+            } else {
+                return
+            }
+        }
 
         reaction.dispose()
         nodeStep.outputLineCount(1)


### PR DESCRIPTION
Fixes rundeckpro/rundeckpro#1172

**Is this a bugfix, or an enhancement? Please describe.**
Resolves infinite loading spinner when viewing an execution output node's step if there is not output for it.

**Describe the solution you've implemented**
The KO code needs to be updated after all output has been consumed regardless if there was any output for the step. This updates the KO code and displays a message in the viewer if there was no output loaded.
