### PR TITLE
Enable dynamic property values in vue plugin UIs, fix Icon node enhancer plugin

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
@@ -1300,7 +1300,8 @@ class WorkflowController extends ControllerBase {
     ) {
 
         try {
-            return frameworkService.getDynamicProperties(
+            return pluginService.getDynamicProperties(
+                frameworkService.rundeckFramework,
                 isNodeStep ? ServiceNameConstants.WorkflowNodeStep : ServiceNameConstants.WorkflowStep,
                 newItemType,
                 project,

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -814,52 +814,6 @@ class FrameworkService implements ApplicationContextAware, AuthContextProcessor,
     }
 
     /**
-     * load the dynamic select values for properties from the plugin, or null
-     * @param serviceName
-     * @param type
-     * @param project
-     * @param services
-     * @return
-     */
-    def Map<String, Object> getDynamicProperties(
-        String serviceName,
-        String type,
-        String project,
-        Services services
-    ) {
-        final PropertyResolver resolver = PropertyResolverFactory.createPluginRuntimeResolver(
-            project,
-            rundeckFramework,
-            null,
-            serviceName,
-            type
-        );
-
-        def pluginServiceType
-
-        if(serviceName == ServiceNameConstants.WorkflowNodeStep){
-            pluginServiceType = rundeckFramework.getNodeStepExecutorService()
-        }else if(serviceName == ServiceNameConstants.WorkflowStep){
-            pluginServiceType = rundeckFramework.getStepExecutionService()
-        }else{
-            pluginServiceType = serviceName
-        }
-
-        def pluginDescriptor = pluginService.getPluginDescriptor(type, pluginServiceType)
-
-        final Map<String, Object> config = PluginAdapterUtility.mapDescribedProperties(
-            resolver,
-            pluginDescriptor.description,
-            PropertyScope.Project
-        );
-
-        def plugin = pluginDescriptor.instance
-        if(plugin instanceof DynamicProperties){
-            return plugin.dynamicProperties(config, services)
-        }
-        return null
-    }
-    /**
      * Return the list of NodeStepPlugin descriptions
      * @param framework
      * @return

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/PluginInfo.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/PluginInfo.vue
@@ -10,7 +10,7 @@
     </span>
     <span :class="titleCss" v-if="showTitle" style="margin-left: 5px;">{{title}}</span>
     <span :class="descriptionCss" v-if="showDescription" style="margin-left: 5px;">{{shortDescription}}</span>
-    <details class="more-info details-reset" :class="extendedCss" v-if="inputShowDescription && showExtended && extraDescription">
+    <details class="more-info details-reset" :class="extendedCss" v-if="showDescription && showExtended && extraDescription">
         <summary>
             More...
             <span class="more-indicator-verbiage more-info-icon"><i class="glyphicon glyphicon-chevron-right"/></span>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
@@ -238,6 +238,13 @@ export default Vue.extend({
       }
     },
     loadPluginData(data: any) {
+      if(data.dynamicProps) {
+        this.props.forEach((prop: any) => {
+          if (data.dynamicProps[prop.name]) {
+            prop.allowed = data.dynamicProps[prop.name]
+          }
+        })
+      }
       this.props = data.props
       this.detail = data
       this.prepareInputs()

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropEdit.vue
@@ -28,7 +28,7 @@
             value="true"
             v-model="currentValue"
           >
-            {{prop.options&&prop.options['booleanTrueDisplayValue']?prop.options['booleanTrueDisplayValue']:$t('true')}}
+            <plugin-prop-val :prop="prop" :value="'true'"/>
           </label>
           <label :for="`${rkey}prop_false_`+pindex" class="radio-inline">
           <input
@@ -38,7 +38,7 @@
             value="false"
             v-model="currentValue"
           >
-            {{prop.options&&prop.options['booleanFalseDisplayValue']?prop.options['booleanFalseDisplayValue']:$t('false')}}
+            <plugin-prop-val :prop="prop" :value="'false'"/>
           </label>
       </div>
     </template>
@@ -59,7 +59,7 @@
             v-for="opt in prop.allowed"
             v-bind:value="opt"
             v-bind:key="opt"
-          >{{prop.selectLabels && prop.selectLabels[opt] || opt}}</option>
+          ><plugin-prop-val :prop="prop" :value="opt"/></option>
         </select>
       </div>
       <template v-else-if="prop.type==='FreeSelect'">
@@ -76,10 +76,10 @@
         <div class="col-sm-5">
           <select class="form-control input-sm" v-model="currentValue">
             <option
-              v-for="opt in prop.allowed"
-              v-bind:value="opt"
-              v-bind:key="opt"
-            >{{prop.selectLabels && prop.selectLabels[opt] || opt}}</option>
+                v-for="opt in prop.allowed"
+                v-bind:value="opt"
+                v-bind:key="opt"
+            ><plugin-prop-val :prop="prop" :value="opt"/></option>
           </select>
         </div>
       </template>
@@ -100,7 +100,7 @@
               <label
                 class="grid-row optionvaluemulti"
                 :for="`${rkey}opt_`+pindex+'_'+oindex"
-              >{{prop.selectLabels && prop.selectLabels[opt] || opt}}</label>
+              ><plugin-prop-val :prop="prop" :value="opt"/></label>
             </div>
           </div>
         </div>
@@ -234,12 +234,14 @@ import MarkdownItVue from 'markdown-it-vue'
 
 import JobConfigPicker from './JobConfigPicker.vue'
 import AceEditor from '../utils/AceEditor.vue'
+import PluginPropVal from './pluginPropVal.vue'
 import { client } from '../../modules/rundeckClient'
 export default Vue.extend({
   components:{
     AceEditor,
     JobConfigPicker,
-    MarkdownItVue
+    MarkdownItVue,
+    PluginPropVal
   },
   props:{
     'prop':{

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropEdit.vue
@@ -85,7 +85,7 @@
       </template>
       <template v-else-if="prop.type==='Options'">
         <div class="col-sm-10">
-          <div class="grid">
+          <div :class="{longlist:prop.allowed && prop.allowed.length>20}">
             <div
               class="checkbox"
               v-for="(opt,oindex) in prop.allowed"
@@ -330,3 +330,9 @@ export default Vue.extend({
   }
 })
 </script>
+<style scoped lang="scss">
+.longlist{
+  max-height: 500px;
+  overflow-y: auto
+}
+</style>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropEdit.vue
@@ -125,12 +125,6 @@
           ></textarea>
         </template>
         <template v-else-if="prop.options && prop.options['displayType']==='CODE'">
-          <!-- <textarea :name="`${rkey}prop_`+pindex"
-                          v-model="currentValue"
-                          :id="`${rkey}prop_`+pindex"
-                          rows="10"
-                          cols="100"
-          class="form-control input-sm"></textarea>-->
           <ace-editor
             :name="`${rkey}prop_`+pindex"
             v-model="currentValue"

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropEdit.vue
@@ -87,7 +87,7 @@
         <div class="col-sm-10">
           <div class="grid">
             <div
-              class="optionvaluemulti checkbox"
+              class="checkbox"
               v-for="(opt,oindex) in prop.allowed"
               v-bind:key="opt"
             >
@@ -98,7 +98,6 @@
                 :id="`${rkey}opt_`+pindex+'_'+oindex"
               >
               <label
-                class="grid-row optionvaluemulti"
                 :for="`${rkey}opt_`+pindex+'_'+oindex"
               ><plugin-prop-val :prop="prop" :value="opt"/></label>
             </div>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropVal.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropVal.vue
@@ -1,0 +1,34 @@
+<template>
+  <span>
+
+    <template  v-if="prop.type==='Boolean'">
+        <template v-if="value==='true'||value===true">
+          {{prop.options&&prop.options['booleanTrueDisplayValue']?prop.options['booleanTrueDisplayValue']:$t('yes')}}
+        </template>
+        <template v-if="value==='false'||value===false">
+          {{prop.options&&prop.options['booleanFalseDisplayValue']?prop.options['booleanFalseDisplayValue']:$t('no')}}
+        </template>
+    </template>
+    <template v-else-if="['Options', 'Select','FreeSelect'].indexOf(prop.type)>=0">
+      {{ prop.selectLabels && prop.selectLabels[value] || value }}
+    </template>
+    <template v-else-if="prop.options && prop.options['displayType']==='PASSWORD'">&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;</template>
+    <template v-else>{{ value }}</template>
+  </span>
+</template>
+
+<script lang="ts">
+import Vue from "vue"
+export default Vue.extend({
+  props: {
+    'prop': {
+      type: Object,
+      required: true
+    },
+    'value': {
+      required: true,
+      default: ''
+    }
+  }
+})
+</script>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropVal.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropVal.vue
@@ -10,6 +10,11 @@
         </template>
     </template>
     <template v-else-if="['Options', 'Select','FreeSelect'].indexOf(prop.type)>=0">
+      <template v-if="prop.options && prop.options['valueDisplayType']==='icon'">
+        <i :class="'glyphicon '+value" v-if="typeof(value)==='string' && value.startsWith('glyphicon-')"></i>
+        <i :class="'fas '+value" v-else-if="typeof(value)==='string' && value.startsWith('fa-')"></i>
+        <i :class="'fab fa-'+(value.substring(4))" v-else-if="typeof(value)==='string' && value.startsWith('fab-')"></i>
+      </template>
       {{ prop.selectLabels && prop.selectLabels[value] || value }}
     </template>
     <template v-else-if="prop.options && prop.options['displayType']==='PASSWORD'">&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;</template>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropView.vue
@@ -4,10 +4,10 @@
         <template v-if="value==='true' ||value===true || prop.defaultValue==='true' && (value==='false'||value===false)">
           <span :title="prop.desc">{{prop.title}}: </span>
           <span :class="prop.options && prop.options['booleanTrueDisplayValueClass']||'text-success'" v-if="value==='true'||value===true">
-            {{prop.options&&prop.options['booleanTrueDisplayValue']?prop.options['booleanTrueDisplayValue']:$t('yes')}}
+            <plugin-prop-val :prop="prop" :value="value"/>
           </span>
           <span :class="prop.options && prop.options['booleanFalseDisplayValueClass']||'text-success'" v-if="value==='false'||value===false">
-            {{prop.options&&prop.options['booleanFalseDisplayValue']?prop.options['booleanFalseDisplayValue']:$t('no')}}
+            <plugin-prop-val :prop="prop" :value="value"/>
           </span>
         </template>
       </span>
@@ -18,19 +18,19 @@
       <span class="configpair" v-else-if="['Options', 'Select','FreeSelect'].indexOf(prop.type)>=0">
         <span :title="prop.desc">{{prop.title}}:</span>
         <template v-if="prop.type!=='Options'">
-          <span class="text-success">{{prop.selectLabels && prop.selectLabels[value] || value}}</span>
+          <span class="text-success"><plugin-prop-val :prop="prop" :value="value"/></span>
         </template>
         <template v-else>
           <span v-if="typeof value==='string'">
           <span v-for="optval in value.split(/, */)" :key="optval" class="text-success">
-            <i class="glyphicon glyphicon-ok-circle"></i>
-            {{prop.selectLabels && prop.selectLabels[optval] || optval}}
+            <i class="glyphicon glyphicon-ok-circle" v-if="!(prop.options && prop.options['valueDisplayType'])"></i>
+            <plugin-prop-val :prop="prop" :value="optval"/>
           </span>
           </span>
           <span v-else-if="value.length>0">
             <span v-for="optval in value" :key="optval" class="text-success">
-            <i class="glyphicon glyphicon-ok-circle"></i>
-            {{prop.selectLabels && prop.selectLabels[optval] || optval}}
+            <i class="glyphicon glyphicon-ok-circle" v-if="!(prop.options && prop.options['valueDisplayType'])"></i>
+            <plugin-prop-val :prop="prop" :value="optval"/>
           </span>
           </span>
         </template>
@@ -71,10 +71,12 @@
 import Vue from 'vue'
 import Expandable from '../utils/Expandable.vue'
 import AceEditor from '../utils/AceEditor.vue'
+import PluginPropVal from './pluginPropVal.vue'
 export default Vue.extend({
   components:{
     Expandable,
-    AceEditor
+    AceEditor,
+    PluginPropVal
   },
   props:{
     value:{

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/modules/pluginService.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/modules/pluginService.ts
@@ -24,7 +24,8 @@ const getParameters = () :Promise<{[key:string]:string}>=> {
     if (window._rundeck && window._rundeck.rdBase && window._rundeck.apiVersion) {
       resolve({
         apiBase: `${window._rundeck.rdBase}/api/${window._rundeck.apiVersion}`,
-        rdBase: window._rundeck.rdBase
+        rdBase: window._rundeck.rdBase,
+        project:window._rundeck.projectName
       })
     } else {
       reject(new Error('No rdBase found'))
@@ -65,12 +66,17 @@ export const getServiceProviderDescription = async (svcName:string, provider:str
     })
   }
   const params=await getParameters()
+  let qparams:any={}
+  if(params.project){
+    qparams.project=params.project
+  }
 
   const resp = await client.sendRequest({
     pathTemplate: `/plugin/detail/{svcName}/{provider}`,
     pathParameters: {svcName:svcName,provider:provider},
     baseUrl: params.rdBase,
-    method: 'GET'
+    method: 'GET',
+    queryParameters:qparams
   });
   if (!resp.parsedBody) {
     throw new Error(`Error getting service provider detail for ${svcName}/${provider}`);

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectPluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectPluginConfig.vue
@@ -69,7 +69,7 @@
                     <a
                       class="btn btn-info btn-xs"
                       @click="editFocus=index"
-                      :key="edit"
+                      :key="'edit'"
                     >{{$t('Edit')}}</a>
                   </span>
                   <span v-if="editFocus===index">

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectPluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectPluginConfig.vue
@@ -76,7 +76,7 @@
                     <a
                       class="btn btn-success btn-xs"
                       @click="savePlugin(plugin,index)"
-                      :key="save"
+                      :key="'save'"
                     >{{$t('Save')}}</a>
                     <a class="btn btn-warning btn-xs" @click="editFocus=-1">{{$t('Cancel')}}</a>
                   </span>

--- a/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
@@ -266,49 +266,6 @@ class FrameworkServiceSpec extends Specification implements ServiceUnitTest<Fram
         [disableExecution: 'true']  | [disableExecution:'true', disableSchedule:'false']|['project.disable.executions': 'true','project.disable.schedule': 'false']
     }
 
-    def "getDynamicProperties"() {
-        given:
-            String project = 'aproject'
-            String svcName = 'AService'
-            String type = 'AProvider'
-
-            def services = Mock(Services)
-
-            def manager = Mock(ProjectManager) {
-                getFrameworkProject(project) >> Mock(FrameworkProject) {
-                    getProperties() >> projProps
-                }
-            }
-
-            service.rundeckFramework = Mock(Framework) {
-                getFrameworkProjectMgr() >> manager
-                getPropertyRetriever() >> PropertyResolverFactory.instanceRetriever(fwkProps)
-            }
-            Description desc = DescriptionBuilder.builder()
-                                                 .name(type)
-                                                 .property(PropertyBuilder.builder().string('aprop').build())
-                                                 .property(PropertyBuilder.builder().string('xprop').build())
-                                                 .build()
-            def pluginInstance = Mock(DynamicProperties)
-            service.pluginService = Mock(PluginService) {
-                getPluginDescriptor(type, svcName) >> new DescribedPlugin<Object>(pluginInstance, desc, type)
-            }
-
-
-        when:
-            def result = service.getDynamicProperties(svcName, type, project, services)
-
-        then:
-            1 * pluginInstance.dynamicProperties(dynamicInput, services) >> [aprop: ['a', 'b']]
-            result == [aprop: ['a', 'b']]
-
-        where:
-            fwkProps                                              | projProps | dynamicInput
-            [:]                                                   | [:]       | [:]
-            ['framework.plugin.AService.AProvider.aprop': 'aval'] | [:]       | [aprop: 'aval']
-            ['framework.plugin.AService.AProvider.aprop': 'aval'] | ['project.plugin.AService.AProvider.aprop': 'bval']       | [aprop: 'bval']
-            ['framework.plugin.AService.AProvider.xprop': 'xval'] | ['project.plugin.AService.AProvider.aprop': 'bval']       | [aprop: 'bval',xprop:'xval']
-    }
 
     def "getServicePropertiesMapForType missing provider"() {
         given:
@@ -377,7 +334,7 @@ class FrameworkServiceSpec extends Specification implements ServiceUnitTest<Fram
         firstLoginMarker.absolutePath == tmpVar.absolutePath+File.separator + "var" + File.separator +FrameworkService.FIRST_LOGIN_FILE
 
     }
-  
+
     @Unroll
     def "discoverScopedConfiguration"() {
         given:


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Enables plugin property "dynamicValues" to be set for Rundeck Plugin config UIs using Vue.

ref: https://github.com/rundeck-plugins/attribute-match-node-enhancer/issues/6

**Describe the solution you've implemented**
- [x] Include dynamicValues from plugins in the plugin detail.
- [x] fix some Vue issues in plugin config components (unquoted strings)
- [x] allow option values which are icon names to be displayed as icons