### PR TITLE
Set webpack public path dynamically

### DIFF
--- a/rundeckapp/grails-spa/packages/ui/src/components/tour/main.js
+++ b/rundeckapp/grails-spa/packages/ui/src/components/tour/main.js
@@ -1,3 +1,4 @@
+__webpack_public_path__ = (new URL(window._rundeck.rdBase)).pathname + 'assets/static/'
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 import Vue from 'vue'

--- a/rundeckapp/grails-spa/packages/ui/vue.config.js
+++ b/rundeckapp/grails-spa/packages/ui/vue.config.js
@@ -21,12 +21,14 @@ module.exports = {
   },
 
   outputDir: process.env.VUE_APP_OUTPUT_DIR,
-  publicPath: '/assets/',
+  publicPath: '/assets/static/',
   filenameHashing: false,
   parallel: true,
   css: {
     sourceMap: true,
-    /** Workaround for Vue CLI accounting for nested page paths */
+    /** Workaround for Vue CLI accounting for nested page paths
+     * https://github.com/vuejs/vue-cli/issues/4378
+    */
     extract: {
       filename: '/css/[name].css',
       chunkFilename: '/css/[name].css',


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Fixes rundeckpro/rundeckpro#1200

**Describe the solution you've implemented**
The public path was not set correctly to load assets referenced from source files. This also needs to be set dynamically in the entry in order to account for non-bare base url paths(ie running in tomcat under `/rundeck`).

**Describe alternatives you've considered**
It may be cleaner to have a single webpack runtime file loaded and then set the public path once in `central/main`. This is a big runtime change to be made so close to release though.
