### PR TITLE
Show project Readme only when Configuration > User Interface > Display the Project Readme > Project Home Page is checked

### DIFF
--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-dashboard/components/projectReadme.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-dashboard/components/projectReadme.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="row row-space" v-if="project.readme.readmeHTML">
+  <div class="row row-space" v-if="project.readme.readmeHTML && showReadme">
     <div class="col-sm-12">
       <div class="card">
         <div class="card-header">
@@ -22,7 +22,21 @@ export default {
     'project'
   ],
   data () {
-    return {}
+    return {
+      showReadme: false
+    }
+  },
+  methods: {
+    shouldShowReadme () {
+      const display = this.project.readmeDisplay
+      if (display.indexOf('projectHome')>=0) {
+        return true
+      }
+      return false
+    }
+  },
+  mounted () {
+    this.showReadme = this.shouldShowReadme()
   }
 }
 </script>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This fixes #6138 so that the project readme is no longer shown on the project home when **Configuration > User Interface > Display the Project Readme > Project Home Page** is unchecked.

**Describe the solution you've implemented**
Previously, the project readme was always shown if it existed. I added a check to rundeckapp/grails-spa/packages/ui/src/pages/project-dashboard/components/projectReadme.vue to determine if the box to show the project readme on the home page is checked.
