### PR TITLE
Fix: "Null hostname value"

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/common/NodeEntryImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/NodeEntryImpl.java
@@ -16,7 +16,7 @@
 
 /*
 * NodeEntryImpl.java
-* 
+*
 * User: greg
 * Created: Mar 31, 2008 4:58:29 PM
 * $Id$

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/NodeEntryImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/NodeEntryImpl.java
@@ -201,7 +201,7 @@ public class NodeEntryImpl extends NodeBaseImpl implements INodeEntry, INodeDesc
      */
     public static boolean containsUserName(final String host) {
         if (null == host) {
-            throw new IllegalArgumentException("Null hostname value");
+            return false;
         }
         return host.matches(USER_AT_HOSTNAME_REGEX);
     }
@@ -297,7 +297,7 @@ public class NodeEntryImpl extends NodeBaseImpl implements INodeEntry, INodeDesc
      */
     public static boolean containsPort(final String host) {
         if (null == host) {
-            throw new IllegalArgumentException("Null hostname value");
+            return false;
         }
         return host.matches(PORT_REGEX);
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/SSHTaskBuilder.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/SSHTaskBuilder.java
@@ -16,7 +16,7 @@
 
 /*
 * SSHTaskFactory.java
-* 
+*
 * User: Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
 * Created: Jun 3, 2010 11:33:34 AM
 * $Id$
@@ -136,7 +136,7 @@ public class SSHTaskBuilder {
                 throw new JSchException("Unable to start ssh-agent: " + e);
             }
         }
-        
+
         if (null != base.getSshKeyData()) {
             base.getPluginLogger().log(Project.MSG_DEBUG, "Using stored private key data.");
             //XXX: reset password to null, which was non-null to bypass Ant's behavior
@@ -286,15 +286,15 @@ public class SSHTaskBuilder {
         public PluginLogger getPluginLogger();
 
         public void setPluginLogger(PluginLogger pluginLogger);
-    
+
         public void setEnableSSHAgent(Boolean enableSSHAgent);
-        
+
         public Boolean getEnableSSHAgent();
-        
+
         public SSHAgentProcess getSSHAgentProcess();
 
         public void setTtlSSHAgent(Integer ttlSSHAgent);
-        
+
         public Integer getTtlSSHAgent();
 
         public void setBindAddress(String bindAddress);
@@ -445,33 +445,33 @@ public class SSHTaskBuilder {
         public void setEnableSSHAgent(Boolean enableSSHAgent) {
             instance.setEnableSSHAgent(enableSSHAgent);
         }
-        
+
         @Override
         public Boolean getEnableSSHAgent() {
             return instance.getEnableSSHAgent();
         }
-        
+
         @Override
         public void setSSHAgentProcess(SSHAgentProcess sshAgentProcess) {
              instance.setSSHAgentProcess(sshAgentProcess);
         }
-        
+
         @Override
         public SSHAgentProcess getSSHAgentProcess() {
             return instance.getSSHAgentProcess();
         }
-        
-        
+
+
         @Override
         public void setTtlSSHAgent(Integer ttlSSHAgent) {
             instance.setTtlSSHAgent(ttlSSHAgent);
         }
-        
+
         @Override
         public Integer getTtlSSHAgent() {
             return instance.getTtlSSHAgent();
         }
-        
+
         @Override
         public String getKnownhosts() {
             return instance.getKnownhosts();
@@ -657,7 +657,7 @@ public class SSHTaskBuilder {
         }
         switch (authenticationType) {
             case privateKey:
-                /**
+                /*
                  * Configure keybased authentication
                  */
                 final String sshKeypath = sshConnectionInfo.getPrivateKeyfilePath();
@@ -1000,9 +1000,9 @@ public class SSHTaskBuilder {
         public long getConnectTimeout();
 
         public String getUsername();
-        
+
         public Boolean getLocalSSHAgent();
-        
+
         public Integer getTtlSSHAgent();
 
         public Map<String,String> getSshConfig();

--- a/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/SSHTaskBuilder.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/tasks/net/SSHTaskBuilder.java
@@ -628,7 +628,13 @@ public class SSHTaskBuilder {
         sshbase.setTrust(true); // set this true to avoid  "reject HostKey" errors
         sshbase.setProject(project);
         sshbase.setVerbose(loglevel >= Project.MSG_VERBOSE);
-        sshbase.setHost(nodeentry.extractHostname());
+        String hostname = nodeentry.extractHostname();
+        if (null == hostname || StringUtils.isBlank(hostname)) {
+            throw new BuilderException(
+                    "Hostname must be set to connect to remote node '" + nodeentry.getNodename() + "'"
+            );
+        }
+        sshbase.setHost(hostname);
         // If the node entry contains a non-default port, configure the connection to use it.
         if (nodeentry.containsPort()) {
             final int portNum;

--- a/core/src/test/java/com/dtolabs/rundeck/core/tasks/net/TestSSHTaskBuilder.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/tasks/net/TestSSHTaskBuilder.java
@@ -16,10 +16,10 @@
 
 /*
 * TestSSHTaskBuilder.java
-* 
+*
 * User: Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
 * Created: 11/15/11 3:43 PM
-* 
+*
 */
 package com.dtolabs.rundeck.core.tasks.net;
 
@@ -180,7 +180,7 @@ public class TestSSHTaskBuilder extends TestCase {
         public void setUserInfo(SSHUserInfo userInfo) {
             this.userInfo = userInfo;
         }
-        
+
         public SSHAgentProcess getSSHAgentProcess() {
             return sshAgentProcess;
         }
@@ -189,21 +189,21 @@ public class TestSSHTaskBuilder extends TestCase {
     		public void setEnableSSHAgent(Boolean enableSSHAgent) {
     			this.enableSSHAgent = enableSSHAgent;
     		}
-    
+
     		@Override
     		public Boolean getEnableSSHAgent() {
     			return null;
     		}
-    
+
     		@Override
     		public void setSSHAgentProcess(SSHAgentProcess sshAgentProcess) {
     			this.sshAgentProcess = sshAgentProcess;
     		}
-    		
+
     	  public void setTtlSSHAgent(Integer ttlSSHAgent){
     	    this.ttlSSHAgent = ttlSSHAgent;
     	  }
-    	  
+
         public Integer getTtlSSHAgent(){
           return this.ttlSSHAgent;
         }
@@ -340,11 +340,11 @@ public class TestSSHTaskBuilder extends TestCase {
         public String getPrivateKeyStoragePath() {
             return privateKeyResourcePath;
         }
-        
+
         public Boolean getLocalSSHAgent() {
             return localSSHAgent;
         }
-        
+
         public Integer getTtlSSHAgent() {
           return localTtlSSHAgent;
         }

--- a/core/src/test/java/com/dtolabs/rundeck/core/tasks/net/TestSSHTaskBuilder.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/tasks/net/TestSSHTaskBuilder.java
@@ -776,7 +776,7 @@ public class TestSSHTaskBuilder extends TestCase {
         try {
             runBuildSSH(state, test, testLogger);
             fail("Shouldn't succeed");
-        } catch (IllegalArgumentException e) {
+        } catch (SSHTaskBuilder.BuilderException e) {
             assertNotNull(e);
         }
     }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix "Null hostname value" when a node definition has no hostname defined, but is not used for remote connection.  Move hostname null checks to the SSH builder.  Removes requirement to set a hostname in a node definition, if the node does not represent a host.

