### PR TITLE
Forcing a new attempt when to execute script and the script file is busy because of chmod command executed just before

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/NewLocalNodeExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/NewLocalNodeExecutor.java
@@ -41,13 +41,6 @@ public class NewLocalNodeExecutor implements NodeExecutor {
             final ExecutionContext context, final String[] command, final INodeEntry node
     )
     {
-        return executeCommand(context, command, node, true, 500);
-    }
-
-    private NodeExecutorResult executeCommand(
-            final ExecutionContext context, final String[] command, final INodeEntry node, boolean retryAttempt, int timeToWait
-    )
-    {
 
         StringBuilder preview = new StringBuilder();
 
@@ -60,7 +53,7 @@ public class NewLocalNodeExecutor implements NodeExecutor {
         );
         Map<String, String> env = DataContextUtils.generateEnvVarsFromContext(context.getDataContext());
 
-        int result = 0;
+        final int result;
         try {
             result = ScriptExecUtil.runLocalCommand(command, env, null, System.out, System.err);
             if (result != 0) {

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtilsSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtilsSpec.groovy
@@ -21,6 +21,7 @@ import com.dtolabs.rundeck.core.common.FrameworkProject
 import com.dtolabs.rundeck.core.common.IFrameworkServices
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import com.dtolabs.rundeck.core.execution.ExecArgList
+import com.dtolabs.rundeck.core.execution.ExecutionLogger
 import com.dtolabs.rundeck.core.execution.ExecutionService
 import com.dtolabs.rundeck.core.execution.impl.common.FileCopierUtil
 import com.dtolabs.rundeck.core.execution.service.NodeExecutorResult
@@ -101,6 +102,88 @@ class DefaultScriptFileNodeStepUtilsSpec extends Specification {
         }, node
         ) >> Mock(NodeExecutorResult) {
             isSuccess() >> true
+        }
+
+        1 * executionService.executeCommand(context, {
+            (((ExecArgList) it).asFlatStringList()) == [testRemotePath, 'someargs']
+        }, node
+        ) >> Mock(NodeExecutorResult) {
+            isSuccess() >> true
+        }
+
+        1 * executionService.executeCommand(context, {
+            (((ExecArgList) it).asFlatStringList()) == ['rm', '-f', testRemotePath]
+        }, node
+        ) >> Mock(NodeExecutorResult) {
+            isSuccess() >> true
+        }
+    }
+
+    def "basic execute script file with retry if script file is busy"() {
+        given:
+        def utils = new DefaultScriptFileNodeStepUtils()
+        utils.fileCopierUtil = Mock(FileCopierUtil)
+
+        File scriptFile = File.createTempFile("test", ".script");
+        scriptFile.deleteOnExit()
+        ExecutionLogger executionLogger = Mock(ExecutionLogger)
+
+        StepExecutionContext context = Mock(StepExecutionContext) {
+            getFramework() >> framework
+            getFrameworkProject() >> PROJECT_NAME
+            getExecutionLogger() >> executionLogger
+        }
+        ExecutionService executionService = Mock(ExecutionService)
+        framework.frameworkServices = Mock(IFrameworkServices) {
+            getExecutionService() >> executionService
+        }
+        def node = new NodeEntryImpl('node')
+        node.setOsFamily('unix')
+        node.setAttribute('file-busy-err-retry', 'true')
+        String filepath = scriptFile.absolutePath
+        String[] args = ['someargs'].toArray()
+        String testRemotePath = '/tmp/some-path-to-script'
+        when:
+        def result = utils.executeScriptFile(
+                context,
+                node,
+                null,
+                filepath,
+                null,
+                null,
+                args,
+                null,
+                false,
+                executionService,
+                true
+        )
+        then:
+        result != null
+        1 * utils.fileCopierUtil.generateRemoteFilepathForNode(
+                node,
+                testProject,
+                framework,
+                scriptFile.getName(),
+                null,
+                null
+
+        ) >> testRemotePath
+
+        1 * executionService.fileCopyFile(context, _, node, testRemotePath) >> testRemotePath
+
+        1 * executionService.executeCommand(context, {
+            (((ExecArgList) it).asFlatStringList()) == ['chmod', '+x', testRemotePath]
+        }, node
+        ) >> Mock(NodeExecutorResult) {
+            isSuccess() >> true
+        }
+
+        1 * executionService.executeCommand(context, {
+            (((ExecArgList) it).asFlatStringList()) == [testRemotePath, 'someargs']
+        }, node
+        ) >> Mock(NodeExecutorResult) {
+            isSuccess() >> false
+            getFailureMessage() >> "Cannot run program \"/tmp/2048-42562-carlos-cgl-ho-dispatch-script.tmp.sh\": error=26, File busy error"
         }
 
         1 * executionService.executeCommand(context, {

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtilsSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtilsSpec.groovy
@@ -105,6 +105,84 @@ class DefaultScriptFileNodeStepUtilsSpec extends Specification {
         }
 
         1 * executionService.executeCommand(context, {
+            (((ExecArgList) it).asFlatStringList()) == ['sync', testRemotePath]
+        }, node
+        ) >> Mock(NodeExecutorResult) {
+            isSuccess() >> true
+        }
+
+        1 * executionService.executeCommand(context, {
+            (((ExecArgList) it).asFlatStringList()) == [testRemotePath, 'someargs']
+        }, node
+        ) >> Mock(NodeExecutorResult) {
+            isSuccess() >> true
+        }
+
+        1 * executionService.executeCommand(context, {
+            (((ExecArgList) it).asFlatStringList()) == ['rm', '-f', testRemotePath]
+        }, node
+        ) >> Mock(NodeExecutorResult) {
+            isSuccess() >> true
+        }
+    }
+
+    def "basic execute script file disabling sync command"() {
+        given:
+        def utils = new DefaultScriptFileNodeStepUtils()
+        utils.fileCopierUtil = Mock(FileCopierUtil)
+
+        File scriptFile = File.createTempFile("test", ".script");
+        scriptFile.deleteOnExit()
+        StepExecutionContext context = Mock(StepExecutionContext) {
+            getFramework() >> framework
+            getFrameworkProject() >> PROJECT_NAME
+        }
+        ExecutionService executionService = Mock(ExecutionService)
+        framework.frameworkServices = Mock(IFrameworkServices) {
+            getExecutionService() >> executionService
+        }
+        def node = new NodeEntryImpl('node')
+        node.setOsFamily('unix')
+        node.setAttribute('enable-sync', 'false')
+        String filepath = scriptFile.absolutePath
+        String[] args = ['someargs'].toArray()
+        String testRemotePath = '/tmp/some-path-to-script'
+        when:
+        def result = utils.executeScriptFile(
+                context,
+                node,
+                null,
+                filepath,
+                null,
+                null,
+                args,
+                null,
+                false,
+                executionService,
+                true
+        )
+        then:
+        result != null
+        1 * utils.fileCopierUtil.generateRemoteFilepathForNode(
+                node,
+                testProject,
+                framework,
+                scriptFile.getName(),
+                null,
+                null
+
+        ) >> testRemotePath
+
+        1 * executionService.fileCopyFile(context, _, node, testRemotePath) >> testRemotePath
+
+        1 * executionService.executeCommand(context, {
+            (((ExecArgList) it).asFlatStringList()) == ['chmod', '+x', testRemotePath]
+        }, node
+        ) >> Mock(NodeExecutorResult) {
+            isSuccess() >> true
+        }
+
+        1 * executionService.executeCommand(context, {
             (((ExecArgList) it).asFlatStringList()) == [testRemotePath, 'someargs']
         }, node
         ) >> Mock(NodeExecutorResult) {
@@ -173,6 +251,13 @@ class DefaultScriptFileNodeStepUtilsSpec extends Specification {
 
         1 * executionService.executeCommand(context, {
             (((ExecArgList) it).asFlatStringList()) == ['chmod', '+x', testRemotePath]
+        }, node
+        ) >> Mock(NodeExecutorResult) {
+            isSuccess() >> true
+        }
+
+        1 * executionService.executeCommand(context, {
+            (((ExecArgList) it).asFlatStringList()) == ['sync', testRemotePath]
         }, node
         ) >> Mock(NodeExecutorResult) {
             isSuccess() >> true
@@ -251,6 +336,13 @@ class DefaultScriptFileNodeStepUtilsSpec extends Specification {
 
         1 * executionService.executeCommand(context, {
             (((ExecArgList) it).asFlatStringList()) == ['chmod', '+x', testRemotePath]
+        }, node
+        ) >> Mock(NodeExecutorResult) {
+            isSuccess() >> true
+        }
+
+        1 * executionService.executeCommand(context, {
+            (((ExecArgList) it).asFlatStringList()) == ['sync', testRemotePath]
         }, node
         ) >> Mock(NodeExecutorResult) {
             isSuccess() >> true

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptFileNodeStepExecutor.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptFileNodeStepExecutor.java
@@ -202,6 +202,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult=nodeExecutorResults;
             testcopier.testResult="/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -217,7 +218,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(3, testexec.index);
+            assertEquals(4, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -228,15 +229,21 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
 
+            assertEquals(test1, testexec.testNode.get(0));
+            final String[] stringSync = testexec.testCommand.get(1);
+            assertEquals(2, stringSync.length);
+            assertEquals("sync", stringSync[0]);
+
+
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(1);
+            final String[] strings2 = testexec.testCommand.get(2);
             assertEquals(1, strings2.length);
             assertEquals(filepath, strings2[0]);
 //            assertEquals(context, testexec.testContext.get(1));
             assertEquals(test1, testexec.testNode.get(1));
 
             //second call is to exec the filepath
-            final String[] strings3 = testexec.testCommand.get(2);
+            final String[] strings3 = testexec.testCommand.get(3);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -287,6 +294,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult=nodeExecutorResults;
             testcopier.testResult="/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -302,7 +310,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(3, testexec.index);
+            assertEquals(4, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -313,15 +321,21 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
 
+            assertEquals(test1, testexec.testNode.get(0));
+            final String[] stringSync = testexec.testCommand.get(1);
+            assertEquals(2, stringSync.length);
+            assertEquals("sync", stringSync[0]);
+
+
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(1);
+            final String[] strings2 = testexec.testCommand.get(2);
             assertEquals(1, strings2.length);
             assertEquals(filepath, strings2[0]);
 //            assertEquals(context, testexec.testContext.get(1));
             assertEquals(test1, testexec.testNode.get(1));
 
             //second call is to exec the filepath
-            final String[] strings3 = testexec.testCommand.get(2);
+            final String[] strings3 = testexec.testCommand.get(3);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -369,6 +383,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult=nodeExecutorResults;
             testcopier.testResult="/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -384,7 +399,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(3, testexec.index);
+            assertEquals(4, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -395,15 +410,20 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
 
+            assertEquals(test1, testexec.testNode.get(0));
+            final String[] stringSync = testexec.testCommand.get(1);
+            assertEquals(2, stringSync.length);
+            assertEquals("sync", stringSync[0]);
+
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(1);
+            final String[] strings2 = testexec.testCommand.get(2);
             assertEquals(1, strings2.length);
             assertEquals(filepath, strings2[0]);
 //            assertEquals(context, testexec.testContext.get(1));
             assertEquals(test1, testexec.testNode.get(1));
 
             //second call is to exec the filepath
-            final String[] strings3 = testexec.testCommand.get(2);
+            final String[] strings3 = testexec.testCommand.get(3);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -460,6 +480,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -475,7 +496,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(3, testexec.index);
+            assertEquals(4, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -486,8 +507,13 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
 
+            assertEquals(test1, testexec.testNode.get(0));
+            final String[] stringSync = testexec.testCommand.get(1);
+            assertEquals(2, stringSync.length);
+            assertEquals("sync", stringSync[0]);
+
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(1);
+            final String[] strings2 = testexec.testCommand.get(2);
             assertEquals(3, strings2.length);
             assertEquals(filepath, strings2[0]);
             assertEquals("some", strings2[1]);
@@ -496,7 +522,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testexec.testNode.get(1));
 
             //second call is to exec the filepath
-            final String[] strings3 = testexec.testCommand.get(2);
+            final String[] strings3 = testexec.testCommand.get(3);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -689,6 +715,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -704,7 +731,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(3, testexec.index);
+            assertEquals(4, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -715,15 +742,20 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
 
+            assertEquals(test1, testexec.testNode.get(0));
+            final String[] stringSync = testexec.testCommand.get(1);
+            assertEquals(2, stringSync.length);
+            assertEquals("sync", stringSync[0]);
+
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(1);
+            final String[] strings2 = testexec.testCommand.get(2);
             assertEquals(1, strings2.length);
             assertEquals(strings2[0], filepath);
             assertEquals(filepath, strings2[0]);
 //            assertEquals(context, testexec.testContext.get(1));
             assertEquals(test1, testexec.testNode.get(1));
             //second call is to exec the filepath
-            final String[] strings3 = testexec.testCommand.get(2);
+            final String[] strings3 = testexec.testCommand.get(3);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -793,6 +825,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -810,7 +843,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(3, testexec.index);
+            assertEquals(4, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -821,14 +854,19 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
 
+            assertEquals(test1, testexec.testNode.get(0));
+            final String[] stringSync = testexec.testCommand.get(1);
+            assertEquals(2, stringSync.length);
+            assertEquals("sync", stringSync[0]);
+
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(1);
+            final String[] strings2 = testexec.testCommand.get(2);
             assertEquals(1, strings2.length);
             assertEquals(filepath, strings2[0]);
 //            assertEquals(context, testexec.testContext.get(1));
             assertEquals(test1, testexec.testNode.get(1));
             //second call is to exec the filepath
-            final String[] strings3 = testexec.testCommand.get(2);
+            final String[] strings3 = testexec.testCommand.get(3);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -1040,6 +1078,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -1055,7 +1094,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(3, testexec.index);
+            assertEquals(4, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             final String filepath=strings[2];
@@ -1074,11 +1113,16 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals("chmod", strings[0]);
             assertEquals("+x", strings[1]);
 
+
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
+            final String[] stringSync = testexec.testCommand.get(1);
+            final String filepath1=stringSync[1];
+            assertEquals(2, stringSync.length);
+            assertEquals("sync", stringSync[0]);
 
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(1);
+            final String[] strings2 = testexec.testCommand.get(2);
             //replace ${scriptfile} with actual filepath
             for (int i = 0; i < expectedCommand.length; i++) {
                 String s = expectedCommand[i];
@@ -1090,7 +1134,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testexec.testNode.get(1));
 
             //third call to remove script
-            final String[] strings3 = testexec.testCommand.get(2);
+            final String[] strings3 = testexec.testCommand.get(3);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -1146,6 +1190,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -1162,7 +1207,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(3, testexec.index);
+            assertEquals(4, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -1172,14 +1217,19 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertTrue(filepath.endsWith("."+UNIX_FILE_EXT));
             assertEquals(test1, testexec.testNode.get(0));
 
+            assertEquals(test1, testexec.testNode.get(0));
+            final String[] stringSync = testexec.testCommand.get(1);
+            assertEquals(2, stringSync.length);
+            assertEquals("sync", stringSync[0]);
+
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(1);
+            final String[] strings2 = testexec.testCommand.get(2);
             assertEquals(1, strings2.length);
             assertEquals(strings2[0], filepath);
             assertEquals(filepath, strings2[0]);
             assertEquals(test1, testexec.testNode.get(1));
             //first call is chmod +x filepath
-            final String[] strings3 = testexec.testCommand.get(2);
+            final String[] strings3 = testexec.testCommand.get(3);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -1241,6 +1291,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -1257,7 +1308,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(3, testexec.index);
+            assertEquals(4, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -1267,13 +1318,18 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertTrue(filepath.endsWith("." + UNIX_FILE_EXT));
             assertEquals(test1, testexec.testNode.get(0));
 
+            assertEquals(test1, testexec.testNode.get(0));
+            final String[] stringSync = testexec.testCommand.get(1);
+            assertEquals(2, stringSync.length);
+            assertEquals("sync", stringSync[0]);
+
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(1);
+            final String[] strings2 = testexec.testCommand.get(2);
             assertEquals(1, strings2.length);
             assertEquals(filepath, strings2[0]);
 //            assertEquals(context, testexec.testContext.get(1));
             assertEquals(test1, testexec.testNode.get(1));
-            final String[] strings3 = testexec.testCommand.get(2);
+            final String[] strings3 = testexec.testCommand.get(3);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -1318,6 +1374,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             final ArrayList<NodeExecutorResult> nodeExecutorResults = new ArrayList<NodeExecutorResult>();
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createFailure(null, "failed", test1));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
@@ -1335,7 +1392,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(3, testexec.index);
+            assertEquals(4, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -1346,14 +1403,20 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
 
+            assertEquals(test1, testexec.testNode.get(0));
+            final String[] stringSync = testexec.testCommand.get(1);
+            final String filepath1=stringSync[1];
+            assertEquals(2, stringSync.length);
+            assertEquals("sync", stringSync[0]);
+
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(1);
+            final String[] strings2 = testexec.testCommand.get(2);
             assertEquals(1, strings2.length);
             assertEquals(filepath, strings2[0]);
 //            assertEquals(context, testexec.testContext.get(1));
             assertEquals(test1, testexec.testNode.get(1));
             //first call is chmod +x filepath
-            final String[] strings3 = testexec.testCommand.get(2);
+            final String[] strings3 = testexec.testCommand.get(3);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptURLNodeStepExecutor.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptURLNodeStepExecutor.java
@@ -282,6 +282,7 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final test1 interaction = new TestScriptURLNodeStepExecutor.test1();
@@ -308,7 +309,7 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(3, testexec.index);
+            assertEquals(4, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -318,15 +319,21 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             assertTrue(filepath.endsWith(".sh"));
             assertEquals(test1, testexec.testNode.get(0));
 
+            final String[] stringsSync = testexec.testCommand.get(1);
+            assertEquals(2, stringsSync.length);
+            assertEquals("sync", stringsSync[0]);
+            assertEquals(stringsSync[1], filepath);
+            assertEquals(test1, testexec.testNode.get(1));
+
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(1);
+            final String[] strings2 = testexec.testCommand.get(2);
             assertEquals(1, strings2.length);
             assertEquals(strings2[0], filepath);
             assertEquals(filepath, strings2[0]);
             assertEquals(test1, testexec.testNode.get(1));
 
             //third call is to remove remote file
-            final String[] strings3 = testexec.testCommand.get(2);
+            final String[] strings3 = testexec.testCommand.get(3);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -397,6 +404,7 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final test1 interaction = new TestScriptURLNodeStepExecutor.test1();
@@ -423,7 +431,7 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(3, testexec.index);
+            assertEquals(4, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             final String filepath=strings[2];
@@ -433,15 +441,21 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             assertTrue("file extension not correct", filepath.endsWith("." + fileExtension));
             assertEquals(test1, testexec.testNode.get(0));
 
+            final String[] stringsSync = testexec.testCommand.get(1);
+            assertEquals(2, stringsSync.length);
+            assertEquals("sync", stringsSync[0]);
+            assertEquals(stringsSync[1], filepath);
+            assertEquals(test1, testexec.testNode.get(1));
+
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(1);
+            final String[] strings2 = testexec.testCommand.get(2);
             assertEquals(1, strings2.length);
             assertEquals(strings2[0], strings[2]);
             assertEquals(filepath, strings2[0]);
             assertEquals(test1, testexec.testNode.get(1));
 
             //third call is to remove remote file
-            final String[] strings3 = testexec.testCommand.get(2);
+            final String[] strings3 = testexec.testCommand.get(3);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -512,6 +526,7 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final test1 interaction = new TestScriptURLNodeStepExecutor.test1();
@@ -538,7 +553,7 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(3, testexec.index);
+            assertEquals(4, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             final String filepath=strings[2];
@@ -549,15 +564,21 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             assertTrue("file extension not correct", filepath.endsWith("." + UNIX_EXT));
             assertEquals(test1, testexec.testNode.get(0));
 
+            final String[] stringsSync = testexec.testCommand.get(1);
+            assertEquals(2, stringsSync.length);
+            assertEquals("sync", stringsSync[0]);
+            assertEquals(stringsSync[1], filepath);
+            assertEquals(test1, testexec.testNode.get(1));
+
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(1);
+            final String[] strings2 = testexec.testCommand.get(2);
             assertEquals(2, strings2.length);
             assertEquals("mycommand",strings2[0]);
             assertEquals(filepath, strings2[1]);
             assertEquals(test1, testexec.testNode.get(1));
 
             //third call is to remove remote file
-            final String[] strings3 = testexec.testCommand.get(2);
+            final String[] strings3 = testexec.testCommand.get(3);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);


### PR DESCRIPTION
Fix https://github.com/rundeckpro/rundeckpro/issues/1080

**Is this a bugfix, or an enhancement? Please describe.**
Sometimes, if there is a lot of scripts running in parallel and this scripts produce output and output erros, some lines should be printed on a single line (i.e. merging more than one line).

**Describe the solution you've implemented**
A newLocalExecutor had already been implemented and fixed part of the problem. However, the "chmod" command executed before the script was causing the file to be busy at the time it was called to execute. A change was made to try again after a short wait

**Describe alternatives you've considered**
Before was implemented a solution to capture the stdout and stderr in separate streams before this lines is printed and breaks this line to print them correctly. https://github.com/rundeck/rundeck/pull/6273

**Additional context**
This problem appears at random
