### PR TITLE
Rundeck initialization refactoring

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,8 @@ mavenCentralUrl=https://repo1.maven.org/maven2/
 grailsCentralUrl=https://grails.org/plugins
 jacksonDatabindVersion=2.10.1
 snakeyamlVersion=1.26
+gsonVersion=2.8.6
+httpClientVersion=4.5.12
 #
 # Override of spring-boot dependencies versions.
 # available properties at:

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -145,6 +145,7 @@ dependencies {
     profile "org.grails.profiles:web"
 //    runtime "org.springframework:spring-test:5.0.3.RELEASE"
     runtime "com.h2database:h2:1.4.199"
+    runtime 'org.apache.logging.log4j:log4j-web:2.13.3'
 
     // Database drivers
     runtime 'mysql:mysql-connector-java:8.0.21'

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -123,7 +123,7 @@ dependencies {
     compile "org.grails.plugins:events"
     compile "org.grails.plugins:gsp"
     compileOnly "io.micronaut:micronaut-inject-groovy"
-    compile "com.google.code.gson:gson:2.8.2"
+    compile "com.google.code.gson:gson:${gsonVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
     compile "com.fasterxml.jackson.core:jackson-core"
     compile "com.fasterxml.jackson.core:jackson-annotations"
@@ -141,7 +141,7 @@ dependencies {
     console ("org.grails:grails-console") {
         exclude(group:"org.yaml",module:"snakeyaml")
     }
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.12'
+    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: "${httpClientVersion}"
     profile "org.grails.profiles:web"
 //    runtime "org.springframework:spring-test:5.0.3.RELEASE"
     runtime "com.h2database:h2:1.4.199"

--- a/rundeckapp/grails-app/conf/application.groovy
+++ b/rundeckapp/grails-app/conf/application.groovy
@@ -1,3 +1,5 @@
+import rundeckapp.init.prebootstrap.InitializeRundeckPreboostrap
+
 hibernate {
     cache.queries = true
     cache.use_second_level_cache = true
@@ -42,13 +44,16 @@ environments {
 
     }
     test {
+        def rdeckbasedir = File.createTempDir()
+        rdeckbasedir.deleteOnExit()
+        System.setProperty("rdeck.base",rdeckbasedir.absolutePath)
+        new InitializeRundeckPreboostrap().run()
         grails.profiler.disable=true
         rundeck.feature.executionLifecyclePlugin.enabled = true
         dataSource {
             dbCreate = "create-drop"
             url = "jdbc:h2:file:./db/testDb"
         }
-        System.setProperty("rdeck.base",File.createTempDir().absolutePath)
     }
     production {
 //        grails.serverURL = "http://www.changeme.com"
@@ -96,12 +101,6 @@ environments {
 grails.config.locations = [
         "classpath:QuartzConfig.groovy"
 ]
-
-if(environment=="development"){
-    grails.config.locations << "file:${userHome}/.grails/${appName}-config.properties"
-}
-
-grails.config.locations << "classpath:${appName}-config.properties"
 
 grails.plugin.springsecurity.securityConfigType = "InterceptUrlMap"
 

--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -49,7 +49,6 @@ management:
         enabled-by-default: false
         jmx:
             unique-names: true
-
 ---
 
 grails:
@@ -145,9 +144,6 @@ grails:
             twitter-bootstrap:
                 excludes: ["**/*.less"]
                 includes: ["bootstrap.less"]
-endpoints:
-    refresh:
-        enabled: true
 ---
 
 rdeck:

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -53,7 +53,9 @@ import com.dtolabs.rundeck.server.plugins.storage.DbStoragePlugin
 import com.dtolabs.rundeck.server.plugins.storage.DbStoragePluginFactory
 import com.dtolabs.rundeck.server.AuthContextEvaluatorCacheManager
 import grails.plugin.springsecurity.SpringSecurityUtils
+import grails.util.Environment
 import groovy.io.FileType
+import org.rundeck.app.AppRestarter
 import org.rundeck.app.api.ApiInfo
 import org.rundeck.app.authorization.RundeckAuthContextEvaluator
 import org.rundeck.app.authorization.RundeckAuthorizedServicesProvider
@@ -601,4 +603,7 @@ beans={
         }
     }
     rundeckConfig(RundeckConfig)
+    if(!Environment.isWarDeployed()) {
+        appRestarter(AppRestarter)
+    }
 }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/HealthController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/HealthController.groovy
@@ -1,0 +1,8 @@
+package rundeck.controllers
+
+class HealthController {
+
+    def index() {
+        render text:"ok"
+    }
+}

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/InterceptorHelper.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/InterceptorHelper.groovy
@@ -19,7 +19,7 @@ import javax.servlet.http.HttpServletRequest
  */
 
 class InterceptorHelper {
-    public static final List<String> STATIC_ASSETS = Collections.unmodifiableList(["static", "assets", "feed", "user-assets"])
+    public static final List<String> STATIC_ASSETS = Collections.unmodifiableList(["static", "assets", "feed", "user-assets", "health"])
     public static final List<String> SERVLET_PATH_ALLOWED = Collections.unmodifiableList(['/error', '/favicon.ico', '/health'])
 
     static matchesStaticAssets(String controllerName, HttpServletRequest request) {

--- a/rundeckapp/grails-app/init/rundeckapp/Application.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/Application.groovy
@@ -4,8 +4,10 @@ import com.dtolabs.rundeck.core.properties.CoreConfigurationPropertiesLoader
 import grails.boot.GrailsApp
 import grails.boot.config.GrailsAutoConfiguration
 import org.rundeck.app.bootstrap.PreBootstrap
+import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration
+import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.EnvironmentAware
 import org.springframework.core.env.Environment
 import org.springframework.core.env.MapPropertySource
@@ -22,26 +24,25 @@ import java.nio.file.Paths
 class Application extends GrailsAutoConfiguration implements EnvironmentAware {
     static final String SYS_PROP_RUNDECK_CONFIG_INITTED = "rundeck.config.initted"
     static RundeckInitConfig rundeckConfig = null
+    static ConfigurableApplicationContext ctx;
     static void main(String[] args) {
-        rundeckConfig = new RundeckInitConfig()
-        CommandLineSetup cliSetup = new CommandLineSetup()
-        rundeckConfig.cliOptions = cliSetup.runSetup(args)
         runPreboostrap()
-        GrailsApp.run(Application, args)
+        ctx = GrailsApp.run(Application, args)
+    }
+
+    static void restartServer() {
+        ApplicationArguments args = ctx.getBean(ApplicationArguments.class);
+        Thread thread = new Thread({
+            ctx.getBean("quartzScheduler").shutdown(true)
+            ctx.close()
+            ctx = GrailsApp.run(Application, args.getSourceArgs())
+        })
+        thread.setDaemon(false)
+        thread.start()
     }
 
     @Override
     void setEnvironment(final Environment environment) {
-        //initialization goes here
-        if(rundeckConfig == null) {
-            rundeckConfig = new RundeckInitConfig()
-            rundeckConfig.cliOptions = new CommandLineSetup().runSetup()
-        }
-        rundeckConfig.appVersion = environment.getProperty("info.app.version")
-
-        initialize()
-        loadAddons()
-        loadJdbcDrivers()
         Properties rundeckConfigs = loadRundeckPropertyFile()
 
         rundeckConfigs.setProperty("rundeck.useJaas", rundeckConfig.useJaas.toString())
@@ -74,10 +75,6 @@ class Application extends GrailsAutoConfiguration implements EnvironmentAware {
         }
     }
 
-    void initialize() {
-        new RundeckInitializer(rundeckConfig).initialize()
-    }
-
     def loadRundeckPropertyFile() {
         if (!System.getProperty(SYS_PROP_RUNDECK_CONFIG_INITTED) && !System.getProperty(RundeckInitConfig.SYS_PROP_RUNDECK_CONFIG_LOCATION).endsWith(".groovy")) {
             CoreConfigurationPropertiesLoader rundeckConfigPropertyFileLoader = new DefaultRundeckConfigPropertyLoader()
@@ -90,26 +87,6 @@ class Application extends GrailsAutoConfiguration implements EnvironmentAware {
             return rundeckConfigPropertyFileLoader.loadProperties()
         }
         return new Properties()
-    }
-
-    def loadAddons() {
-        File addonDir = new File(rundeckConfig.serverBaseDir, "addons")
-        if (addonDir.exists()) {
-            addonDir.eachFile { file ->
-                Thread.currentThread().contextClassLoader.addURL(file.toURI().toURL())
-            }
-        }
-    }
-
-    def loadJdbcDrivers() {
-        File serverLib = new File(rundeckConfig.serverBaseDir, "lib")
-        if (serverLib.exists()) {
-            serverLib.eachFile { file ->
-                if (!file.name.startsWith("rundeck-core") && file.name.endsWith(".jar")) {
-                    Thread.currentThread().contextClassLoader.addURL(file.toURI().toURL())
-                }
-            }
-        }
     }
 
     void loadGroovyRundeckConfigIfExists(final Environment environment) {

--- a/rundeckapp/grails-app/init/rundeckapp/Application.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/Application.groovy
@@ -25,7 +25,9 @@ class Application extends GrailsAutoConfiguration implements EnvironmentAware {
     static final String SYS_PROP_RUNDECK_CONFIG_INITTED = "rundeck.config.initted"
     static RundeckInitConfig rundeckConfig = null
     static ConfigurableApplicationContext ctx;
+    static String[] startArgs = []
     static void main(String[] args) {
+        Application.startArgs = args
         runPreboostrap()
         ctx = GrailsApp.run(Application, args)
     }

--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -1,5 +1,6 @@
 package rundeckapp
 
+import com.codahale.metrics.MetricFilter
 import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.health.HealthCheck
 import com.codahale.metrics.health.HealthCheckRegistry
@@ -254,7 +255,6 @@ class BootStrap {
                 }
             }
         }
-        frameworkService.initialize()
         executionService.initialize()
 
         //initialize manually to avoid circular reference problem with spring
@@ -560,6 +560,7 @@ class BootStrap {
     }
 
      def destroy = {
+         metricRegistry.removeMatching(MetricFilter.ALL)
          log.info("Rundeck Shutdown detected")
      }
 }

--- a/rundeckapp/grails-app/init/rundeckapp/cli/CommandLineSetup.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/cli/CommandLineSetup.groovy
@@ -179,6 +179,9 @@ class CommandLineSetup {
         if(!System.getProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_LOG_DIR) && cliOptions.logDir) {
             System.setProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_LOG_DIR, cliOptions.logDir)
         }
+        if(!System.getProperty("logging.config")) {
+            System.setProperty("logging.config",System.getProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_CONFIG_DIR)+"/log4j2.properties")
+        }
         return cliOptions
 
     }

--- a/rundeckapp/grails-app/init/rundeckapp/init/RundeckWebAppInitializer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/RundeckWebAppInitializer.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rundeckapp.init
+
+import org.springframework.core.annotation.Order
+import org.springframework.web.WebApplicationInitializer
+import rundeckapp.Application
+
+import javax.servlet.ServletContext
+import javax.servlet.ServletException
+
+/**
+ * This class only runs when Rundeck is inside a container.
+ * The preboot routine runs before any of the Spring web application initialization occurs so
+ * that all of the directories and system properties are setup properly
+ */
+@Order(-1)
+class RundeckWebAppInitializer implements WebApplicationInitializer {
+    @Override
+    void onStartup(final ServletContext servletContext) throws ServletException {
+        Application.runPreboostrap()
+    }
+}

--- a/rundeckapp/grails-app/init/rundeckapp/init/prebootstrap/AddonClasspathInjectorPrebootstrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/prebootstrap/AddonClasspathInjectorPrebootstrap.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rundeckapp.init.prebootstrap
+
+import org.rundeck.app.bootstrap.PreBootstrap
+import rundeckapp.Application
+
+
+class AddonClasspathInjectorPrebootstrap implements PreBootstrap {
+    @Override
+    void run() {
+        File addonDir = new File(Application.rundeckConfig.serverBaseDir, "addons")
+        if (addonDir.exists()) {
+            addonDir.eachFile { file ->
+                Thread.currentThread().contextClassLoader.addURL(file.toURI().toURL())
+            }
+        }
+    }
+
+    @Override
+    float getOrder() {
+        return 1
+    }
+}

--- a/rundeckapp/grails-app/init/rundeckapp/init/prebootstrap/InitializeRundeckPreboostrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/prebootstrap/InitializeRundeckPreboostrap.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rundeckapp.init.prebootstrap
+
+import org.rundeck.app.bootstrap.PreBootstrap
+import rundeckapp.Application
+import rundeckapp.cli.CommandLineSetup
+import rundeckapp.init.RundeckInitConfig
+import rundeckapp.init.RundeckInitializer
+
+
+class InitializeRundeckPreboostrap implements PreBootstrap {
+    @Override
+    void run() {
+        Application.rundeckConfig = new RundeckInitConfig()
+        Application.rundeckConfig.cliOptions = new CommandLineSetup().runSetup()
+        new RundeckInitializer(Application.rundeckConfig).initialize()
+    }
+
+    @Override
+    float getOrder() {
+        return 0
+    }
+
+}

--- a/rundeckapp/grails-app/init/rundeckapp/init/prebootstrap/InitializeRundeckPreboostrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/prebootstrap/InitializeRundeckPreboostrap.groovy
@@ -26,7 +26,7 @@ class InitializeRundeckPreboostrap implements PreBootstrap {
     @Override
     void run() {
         Application.rundeckConfig = new RundeckInitConfig()
-        Application.rundeckConfig.cliOptions = new CommandLineSetup().runSetup()
+        Application.rundeckConfig.cliOptions = new CommandLineSetup().runSetup(Application.startArgs)
         new RundeckInitializer(Application.rundeckConfig).initialize()
     }
 

--- a/rundeckapp/grails-app/init/rundeckapp/init/prebootstrap/ServerLibInjectorPreBoostrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/prebootstrap/ServerLibInjectorPreBoostrap.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rundeckapp.init.prebootstrap
+
+import org.rundeck.app.bootstrap.PreBootstrap
+import rundeckapp.Application
+
+
+class ServerLibInjectorPreBoostrap implements PreBootstrap {
+    @Override
+    void run() {
+        File serverLib = new File(Application.rundeckConfig.serverBaseDir, "lib")
+        if (serverLib.exists()) {
+            serverLib.eachFile { file ->
+                if (!file.name.startsWith("rundeck-core") && file.name.endsWith(".jar")) {
+                    Thread.currentThread().contextClassLoader.addURL(file.toURI().toURL())
+                }
+            }
+        }
+    }
+
+    @Override
+    float getOrder() {
+        return 2
+    }
+}

--- a/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
@@ -17,6 +17,7 @@
 package rundeck
 
 import com.dtolabs.rundeck.core.plugins.configuration.Property
+import grails.util.Holders
 import org.rundeck.app.components.RundeckJobDefinitionManager
 import org.rundeck.app.components.jobs.JobDefinitionComponent
 import org.rundeck.app.gui.AuthMenuItem
@@ -28,8 +29,10 @@ import grails.util.Environment
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 import org.rundeck.web.infosec.HMacSynchronizerTokensHolder
 import org.rundeck.web.infosec.HMacSynchronizerTokensManager
+import org.springframework.context.ConfigurableApplicationContext
 import rundeck.interceptors.FormTokenInterceptor
 import rundeck.services.FrameworkService
+import rundeckapp.Application
 
 import java.text.MessageFormat
 import java.text.SimpleDateFormat
@@ -1071,13 +1074,19 @@ class UtilityTagLib{
 
 
     def generateToken(long duration) {
+        if(!appIsActive()) return [TOKEN:"invalid",TIMESTAMP:-1]
         SynchronizerTokensHolder tokensHolder = tokensHolder()
         long timestamp = System.currentTimeMillis() + duration
         return [TOKEN:tokensHolder.generateToken(timestamp),TIMESTAMP:timestamp]
     }
     def generateToken(String url) {
+        if(!appIsActive()) return [TOKEN:"invalid", TIMESTAMP:-1]
         SynchronizerTokensHolder tokensHolder = tokensHolder()
         return tokensHolder.generateToken(url)
+    }
+
+    boolean appIsActive() {
+        return Holders.findApplicationContext()?.isActive()
     }
 
     protected SynchronizerTokensHolder tokensHolder() {

--- a/rundeckapp/src/integration-test/groovy/rundeck/init/RundeckInitializerTest.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/init/RundeckInitializerTest.groovy
@@ -49,57 +49,6 @@ class RundeckInitializerTest extends Specification {
         assert filecount == sourceFileCount
     }
 
-    def "copy to destination and expand templates log4j file war mode"() {
-        given:
-        File sourceTemplates = new File(System.getProperty("user.dir"),"templates")
-        File destination = new File(File.createTempFile("test-et","zzz").parentFile,"expandTest-"+UUID.randomUUID().toString().substring(0,8))
-        File warWebAppDir = new File(File.createTempFile("webappWar","zzz").parentFile,"expandTest-"+UUID.randomUUID().toString().substring(0,8))
-
-        destination.mkdir()
-        warWebAppDir.mkdir()
-
-        Properties testTemplateProperties = new Properties()
-
-        RundeckInitConfig cfg = new RundeckInitConfig()
-        cfg.runtimeConfiguration = testTemplateProperties
-        RundeckInitializer initializer = new RundeckInitializer(cfg)
-        initializer.thisJar = warWebAppDir
-        File log4Jfile = new File(sourceTemplates,"config/log4j2.properties.template")
-        Environment.metaClass.static.isWarDeployed = { return true }
-
-        when:
-        initializer.copyToDestinationAndExpandProperties(destination,sourceTemplates.toPath(),log4Jfile,testTemplateProperties,false)
-
-        then:
-        warWebAppDir.exists()
-        int filecount
-        warWebAppDir.traverse(type: groovy.io.FileType.FILES) { filecount++ }
-        filecount == 1
-    }
-
-    def "ensure rundeck config has log4j path commented war mode"() {
-        given:
-        File sourceTemplates = new File(System.getProperty("user.dir"),"templates")
-        File destination = new File(File.createTempFile("test-et","zzz").parentFile,"expandTest-"+UUID.randomUUID().toString().substring(0,8))
-
-        destination.mkdir()
-
-        Properties testTemplateProperties = new Properties()
-
-        RundeckInitConfig cfg = new RundeckInitConfig()
-        cfg.runtimeConfiguration = testTemplateProperties
-        RundeckInitializer initializer = new RundeckInitializer(cfg)
-        
-        File rcprops = new File(sourceTemplates,"config/rundeck-config.properties.template")
-        Environment.metaClass.static.isWarDeployed = { return true }
-
-        when:
-        initializer.copyToDestinationAndExpandProperties(destination,sourceTemplates.toPath(),rcprops,testTemplateProperties,false)
-        List<String> rcpropsContents = new File(destination,"config/rundeck-config.properties").readLines()
-        then:
-        rcpropsContents.findAll { it.startsWith("#rundeck.log4j.config.file")}
-    }
-
     @Unroll
     def "translate legacy system property #origProp to grails 3 compatible settings"() {
         given:

--- a/rundeckapp/src/main/groovy/org/rundeck/app/AppRestarter.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/AppRestarter.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.rundeck.app
+
+import grails.util.Environment
+import rundeckapp.Application
+
+
+class AppRestarter {
+
+    void restart() {
+        if(Environment.isWarDeployed()) return //we cannot restart in war mode
+        Thread thread = new Thread({
+            Thread.sleep(1500)
+            Application.restartServer()
+        })
+        thread.setDaemon(false)
+        thread.start()
+    }
+}

--- a/rundeckapp/src/main/resources/META-INF/services/org.rundeck.app.bootstrap.PreBootstrap
+++ b/rundeckapp/src/main/resources/META-INF/services/org.rundeck.app.bootstrap.PreBootstrap
@@ -1,0 +1,3 @@
+rundeckapp.init.prebootstrap.InitializeRundeckPreboostrap
+rundeckapp.init.prebootstrap.AddonClasspathInjectorPrebootstrap
+rundeckapp.init.prebootstrap.ServerLibInjectorPreBoostrap

--- a/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
@@ -291,7 +291,6 @@ class FrameworkServiceSpec extends Specification implements ServiceUnitTest<Fram
             def config = [:]
             def remove = ['blah'].toSet()
             service.pluginService = Mock(PluginService)
-            service.initialized = true
             service.rundeckFramework = Mock(Framework) {
 
             }

--- a/rundeckapp/src/test/groovy/rundeckapp/ApplicationTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/ApplicationTest.groovy
@@ -24,7 +24,6 @@ import spock.lang.Ignore
 import spock.lang.Specification
 import spock.lang.Unroll
 
-
 class ApplicationTest extends Specification {
 
     def "setEnvironment with both property file and groovy"() {
@@ -44,9 +43,6 @@ class ApplicationTest extends Specification {
         runtimeProps.setProperty(RundeckInitializer.PROP_LOGINMODULE_NAME,"fake")
         Application.rundeckConfig.runtimeConfiguration = runtimeProps
         Application app = new Application()
-        app.metaClass.initialize = { -> }
-        app.metaClass.loadAddons = { -> }
-        app.metaClass.loadJdbcDrivers = { -> }
         TestEnvironment env = new TestEnvironment()
 
         app.setEnvironment(env)

--- a/rundeckapp/src/test/groovy/rundeckapp/init/RundeckInitializerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/init/RundeckInitializerSpec.groovy
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rundeckapp.init
+
+import spock.lang.Specification
+
+
+class RundeckInitializerSpec extends Specification {
+    def "init server uuid - serverId file exists"() {
+        setup:
+        File configDir = File.createTempDir()
+        configDir.deleteOnExit()
+        File serverIdFile = new File(configDir,"serverId")
+        serverIdFile.createNewFile()
+        if(currentServerUuid) {
+            serverIdFile << currentServerUuid
+        }
+        System.setProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_CONFIG_DIR,configDir.absolutePath)
+
+        when:
+        RundeckInitializer initializer = new RundeckInitializer()
+        initializer.initServerUuid()
+
+        then:
+        sysPropServerIdShouldEqual == (currentServerUuid == System.getProperty("rundeck.server.uuid"))
+
+        cleanup:
+        System.clearProperty("rundeck.server.uuid")
+        System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_CONFIG_DIR)
+
+        where:
+        currentServerUuid                       | sysPropServerIdShouldEqual
+        null                                    | false
+        "684512b2-ce16-490f-9652-b9f8b9a6937b"  | true
+
+    }
+
+    def "init server uuid - no serverId file migrate from framework props"() {
+        setup:
+        String serverUuid = "aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+        File rdBaseDir = File.createTempDir()
+        File etcDir = new File(rdBaseDir,"etc")
+        etcDir.mkdir()
+        File fwkProps = new File(etcDir,"framework.properties")
+        fwkProps.createNewFile()
+        fwkProps.withPrintWriter {
+            it.println("rundeck.server.uuid="+serverUuid)
+            it.flush()
+        }
+        File configDir = File.createTempDir()
+
+
+        System.setProperty(RundeckInitConfig.SYS_PROP_RUNDECK_BASE_DIR,rdBaseDir.absolutePath)
+        System.setProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_CONFIG_DIR,configDir.absolutePath)
+
+        when:
+        RundeckInitializer initializer = new RundeckInitializer()
+        initializer.initServerUuid()
+        File serverId = new File(configDir,"serverId")
+
+        then:
+        serverId.exists()
+        serverId.text.trim() == serverUuid
+        serverUuid == System.getProperty("rundeck.server.uuid")
+
+        cleanup:
+        System.clearProperty("rundeck.server.uuid")
+        rdBaseDir.delete()
+        System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_BASE_DIR)
+        System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_CONFIG_DIR)
+
+    }
+
+    def "init server uuid - no serverId file, no framework props - populate with new random"() {
+        setup:
+        File configDir = File.createTempDir()
+        configDir.deleteOnExit()
+
+        System.setProperty(RundeckInitConfig.SYS_PROP_RUNDECK_BASE_DIR,configDir.absolutePath)
+        System.setProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_CONFIG_DIR,configDir.absolutePath)
+
+        when:
+        RundeckInitializer initializer = new RundeckInitializer()
+        initializer.initServerUuid()
+        File serverId = new File(configDir,"serverId")
+
+        then:
+        serverId.exists()
+        serverId.text.trim().size() == 36
+        System.getProperty("rundeck.server.uuid").size() == 36
+
+        cleanup:
+        System.clearProperty("rundeck.server.uuid")
+        System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_BASE_DIR)
+        System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_CONFIG_DIR)
+
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeckapp/init/RundeckInitializerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/init/RundeckInitializerSpec.groovy
@@ -32,7 +32,7 @@ class RundeckInitializerSpec extends Specification {
 
         when:
         RundeckInitializer initializer = new RundeckInitializer()
-        initializer.initServerUuid()
+        initializer.initServerUuidWithServerIdFile()
 
         then:
         sysPropServerIdShouldEqual == (currentServerUuid == System.getProperty("rundeck.server.uuid"))
@@ -68,7 +68,7 @@ class RundeckInitializerSpec extends Specification {
 
         when:
         RundeckInitializer initializer = new RundeckInitializer()
-        initializer.initServerUuid()
+        initializer.initServerUuidWithServerIdFile()
         File serverId = new File(configDir,"serverId")
 
         then:
@@ -94,7 +94,7 @@ class RundeckInitializerSpec extends Specification {
 
         when:
         RundeckInitializer initializer = new RundeckInitializer()
-        initializer.initServerUuid()
+        initializer.initServerUuidWithServerIdFile()
         File serverId = new File(configDir,"serverId")
 
         then:
@@ -104,6 +104,39 @@ class RundeckInitializerSpec extends Specification {
 
         cleanup:
         System.clearProperty("rundeck.server.uuid")
+        System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_BASE_DIR)
+        System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_CONFIG_DIR)
+
+    }
+
+    def "init server uuid - pull from framework props - server id file not used"() {
+        setup:
+        String serverUuid = "aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+        File rdBaseDir = File.createTempDir()
+        File etcDir = new File(rdBaseDir,"etc")
+        etcDir.mkdir()
+        File fwkProps = new File(etcDir,"framework.properties")
+        fwkProps.createNewFile()
+        fwkProps.withPrintWriter {
+            it.println("rundeck.server.uuid="+serverUuid)
+            it.flush()
+        }
+        File configDir = File.createTempDir()
+
+
+        System.setProperty(RundeckInitConfig.SYS_PROP_RUNDECK_BASE_DIR,rdBaseDir.absolutePath)
+        System.setProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_CONFIG_DIR,configDir.absolutePath)
+
+        when:
+        RundeckInitializer initializer = new RundeckInitializer()
+        initializer.initServerUuidWithFrameworkProps()
+
+        then:
+        serverUuid == System.getProperty("rundeck.server.uuid")
+
+        cleanup:
+        System.clearProperty("rundeck.server.uuid")
+        rdBaseDir.delete()
         System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_BASE_DIR)
         System.clearProperty(RundeckInitConfig.SYS_PROP_RUNDECK_SERVER_CONFIG_DIR)
 

--- a/rundeckapp/templates/config/rundeck-config.properties.template
+++ b/rundeckapp/templates/config/rundeck-config.properties.template
@@ -21,6 +21,4 @@ rundeck.security.authorization.preauthenticated.userRolesHeader=X-Forwarded-Role
 rundeck.security.authorization.preauthenticated.redirectLogout=false
 rundeck.security.authorization.preauthenticated.redirectUrl=/oauth2/sign_in
 
-rundeck.log4j.config.file=${rundeck.server.configDir}/log4j.properties
-
 rundeck.feature.repository.enabled=true


### PR DESCRIPTION
Refactor server uuid assignment and loading.
Cleanup initialization code, and refactor it to work the same in container and non-container installations.
Add an unsecured health check endpoint.
Add cleanup code for metrics and log storage service upon server restart or shutdown.
Add plumbing for hot restart capability.

The initialization method in the FrameworkService has been removed and the serverUuid now comes from a system property that is set in the prebootstrap phase of the Rundeck startup. This helps avoid some of the issues we've had in the past with the system triggering the initialization at the wrong time.

~~The server uuid now comes from a file called `serverId` located in the server config directory. The id from framework.properties is migrated into the file if it exists. If the environment variable `RUNDECK_SERVER_UUID` or the `rundeck.server.uuid` system property is set by the user, that value will be used for the server id and will be installed in the serverId file.~~