### PR TITLE
Migrate pre spring boot 2 cookie configs to valid configs.

### DIFF
--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -265,10 +265,11 @@ beans:
 
 server:
     port: 4440
-    session:
-      cookie:
-        http-only: true
-      tracking-modes: 'cookie'
+    servlet:
+        session:
+            cookie:
+                http-only: true
+            tracking-modes: 'cookie'
 rundeck:
     web:
       jetty:


### PR DESCRIPTION
Spring boot 2 changed the config path for setting http only cookies and the cookie tracking modes.

Fixes #6419
