### PR TITLE
Improve project list loading for user session

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -204,7 +204,7 @@ class FrameworkService implements ApplicationContextAware, AuthContextProcessor,
             resources << authResourceForProject(projName)
         }
         def authed = authorizeApplicationResourceSet(authContext, resources, [AuthConstants.ACTION_READ,AuthConstants.ACTION_ADMIN] as Set)
-        return new ArrayList(new HashSet(authed.collect{it.name})).sort()
+        return authed*.name.sort()
     }
     def projectLabels (AuthContext authContext) {
         def projectNames = projectNames(authContext)

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -211,7 +211,7 @@ class FrameworkService implements ApplicationContextAware, AuthContextProcessor,
         def projectMap = [:]
         projectNames.each { project ->
             def fwkProject = getFrameworkProject(project)
-            def label = fwkProject.getProperty("project.label")
+            def label = fwkProject.hasProperty("project.label")?fwkProject.getProperty("project.label"):null
             projectMap.put(project,label?:project)
         }
         projectMap

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -211,7 +211,7 @@ class FrameworkService implements ApplicationContextAware, AuthContextProcessor,
         def projectMap = [:]
         projectNames.each { project ->
             def fwkProject = getFrameworkProject(project)
-            def label = fwkProject.getProjectProperties().get("project.label")
+            def label = fwkProject.getProperty("project.label")
             projectMap.put(project,label?:project)
         }
         projectMap

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -254,11 +254,10 @@ class FrameworkService implements ApplicationContextAware, AuthContextProcessor,
      * @param session @param var @return
      */
     def refreshSessionProjects(AuthContext authContext, session){
-        def fprojects = projectNames(authContext)
         def flabels = projectLabels(authContext)
-        session.frameworkProjects = fprojects
+        session.frameworkProjects = flabels.keySet().toSorted()
         session.frameworkLabels = flabels
-        fprojects
+        return session.frameworkProjects
     }
 
     def scheduleCleanerExecutions(String project,

--- a/rundeckapp/grails-app/views/framework/_projectSelect.gsp
+++ b/rundeckapp/grails-app/views/framework/_projectSelect.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<g:set var="projectSet" value="${projects.sort()}"/>
+<g:set var="projectSet" value="${projects}"/>
 <g:set var="selectParams" value="${selectParams?:[:]}"/>
 
 <div class="dropdown" style="line-height: 3.5em;margin-left: .8em;">

--- a/rundeckapp/grails-app/views/framework/_projectSelectSidebar.gsp
+++ b/rundeckapp/grails-app/views/framework/_projectSelectSidebar.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<g:set var="projectSet" value="${projects.sort()}"/>
+<g:set var="projectSet" value="${projects}"/>
 <g:set var="selectParams" value="${selectParams?:[:]}"/>
 
 <div class="subnav" style="display:none">

--- a/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
@@ -510,6 +510,7 @@ class FrameworkServiceSpec extends Specification implements ServiceUnitTest<Fram
                         def name = it[0]
                         return Mock(IRundeckProject) {
                             getProperty('project.label') >> (name + ' Label')
+                            hasProperty('project.label') >> true
                         }
                     }
                 }

--- a/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
@@ -509,9 +509,7 @@ class FrameworkServiceSpec extends Specification implements ServiceUnitTest<Fram
                     getFrameworkProject(_) >> {
                         def name = it[0]
                         return Mock(IRundeckProject) {
-                            getProjectProperties() >> [
-                                'project.label': name + ' Label'
-                            ]
+                            getProperty('project.label') >> (name + ' Label')
                         }
                     }
                 }

--- a/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
@@ -23,7 +23,9 @@ import com.dtolabs.rundeck.core.authorization.AclRuleImpl
 import com.dtolabs.rundeck.core.authorization.AclRuleSet
 import com.dtolabs.rundeck.core.authorization.AclRuleSetAuthorization
 import com.dtolabs.rundeck.core.authorization.AclRuleSetImpl
+import com.dtolabs.rundeck.core.authorization.AuthContextEvaluator
 import com.dtolabs.rundeck.core.authorization.Authorization
+import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.FrameworkProject
 import com.dtolabs.rundeck.core.common.IFramework
@@ -47,6 +49,7 @@ import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder
 import grails.test.mixin.TestFor
 import grails.testing.services.ServiceUnitTest
+import org.grails.plugins.metricsweb.MetricService
 import org.rundeck.app.spi.Services
 import org.rundeck.core.projects.ProjectConfigurable
 import rundeck.PluginStep
@@ -488,6 +491,49 @@ class FrameworkServiceSpec extends Specification implements ServiceUnitTest<Fram
             result.roles.containsAll(['agroup', 'bgroup'])
             result.authorization.ruleSet.rules.containsAll(rules1.rules)
             result.authorization.ruleSet.rules.containsAll(rules2.rules)
+
+    }
+
+    def "refresh session projects"() {
+        given:
+            def auth = Mock(UserAndRolesAuthContext)
+            def session = [:]
+            service.metricService=Mock(MetricService){
+                withTimer(_,_,_)>>{
+                    it[2].call()
+                }
+            }
+            service.rundeckFramework = Mock(Framework) {
+                getFrameworkProjectMgr() >> Stub(ProjectManager) {
+                    listFrameworkProjectNames() >> names
+                    getFrameworkProject(_) >> {
+                        def name = it[0]
+                        return Mock(IRundeckProject) {
+                            getProjectProperties() >> [
+                                'project.label': name + ' Label'
+                            ]
+                        }
+                    }
+                }
+            }
+            service.rundeckAuthContextEvaluator = Mock(AuthContextEvaluator) {
+                authorizeApplicationResourceSet(auth, _, _) >> {
+                    return it[1].findAll{it.name in authed}
+                }
+                authResourceForProject(_)>>{
+                    return [name:(it[0])]
+                }
+            }
+        when:
+            def result = service.refreshSessionProjects(auth, session)
+        then:
+            result == sortedList
+            session.frameworkProjects == sortedList
+            session.frameworkLabels == labels
+        where:
+            names           | authed          | sortedList      | labels
+            ['z', 'y', 'x'] | ['z', 'y', 'x'] | ['x', 'y', 'z'] | [z: 'z Label', x: 'x Label', y: 'y Label']
+            ['z', 'y', 'x'] | ['z', 'y',]     | ['y', 'z']      | [z: 'z Label', y: 'y Label']
 
     }
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Cleanup and improve loading Project list and labels for the user session.

* fixes a Concurrent Modification Exception sometimes seen in server log at the `projects.sort()` call within gsps by ensuring session project data is sorted prior to gsp rendering
* removes extra call that loads and authorizes list of projects when loading project labels
* simplifies some code
