### PR TITLE
Fixes when send an email notification when a job is marked as "Incomplete" #6401

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -848,6 +848,14 @@ public class NotificationService implements ApplicationContextAware{
         contextMap['job'] = toStringStringMap(jobMap)
         contextMap['execution']=toStringStringMap(execMap)
         contextMap['rundeck']=['href': appUrl]
+
+        if(!context?.containsKey("globals")) {
+            // Put globals in context.
+            Map<String, String> globals = frameworkService.getProjectGlobals(source.project);
+            contextMap.put("globals", globals ? globals : new HashMap<>());
+
+        }
+
         context = DataContextUtils.merge(context, contextMap)
 
         [context, execMap]


### PR DESCRIPTION
Fix https://github.com/rundeck/rundeck/issues/6401

**Is this a bug fix, or an enhancement? Please describe.**
This is a bug that appears when a job is marked as "Incomplete" and the system sends an email notification, the problem causes the string "${globals.environment}" to appear in the subject.

**Describe the solution you've implemented**
The method "frameworkService.getProjectGlobals()" has been added in the code that generates the email's subject. If the method has already been called it will be not called again.