### PR TITLE
fix error creating and editing jobs in 3.3.3

### DIFF
--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -16,12 +16,20 @@
 package rundeckapp.init.servlet
 
 import com.dtolabs.rundeck.core.init.CustomWebAppInitializer
+import org.eclipse.jetty.server.Handler
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.handler.ContextHandler
 import org.eclipse.jetty.webapp.AbstractConfiguration
 import org.eclipse.jetty.webapp.WebAppContext
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.boot.web.embedded.jetty.JettyServerCustomizer
 import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory
 import org.springframework.boot.web.server.WebServerFactoryCustomizer
+import org.springframework.boot.web.servlet.ServletContextInitializer
+
+import javax.servlet.ServletContext
+import javax.servlet.ServletException
 
 /**
  * Customize embedded jetty
@@ -34,6 +42,16 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
 
     @Override
     void customize(final JettyServletWebServerFactory factory) {
+        factory.addServerCustomizers(new JettyServerCustomizer() {
+            @Override
+            void customize(Server server) {
+                for (Handler handler : server.getHandlers()) {
+                    if (handler instanceof ContextHandler) {
+                        ((ContextHandler) handler).setMaxFormKeys(2000)
+                    }
+                }
+            }
+        })
         factory.addConfigurations(new JettyConfigPropsInitParameterConfiguration(initParams))
     }
 }

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -26,10 +26,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.web.embedded.jetty.JettyServerCustomizer
 import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory
 import org.springframework.boot.web.server.WebServerFactoryCustomizer
-import org.springframework.boot.web.servlet.ServletContextInitializer
-
-import javax.servlet.ServletContext
-import javax.servlet.ServletException
 
 /**
  * Customize embedded jetty


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
bugfix: fix error creating and editing jobs for jetty form keys limit

**Describe the solution you've implemented**
increase jetty parameter `org.eclipse.jetty.server.Request.maxFormKeys` 

**Describe alternatives you've considered**
change the way notifications plugins are saved on the form 

**Additional context**
