### PR TITLE
restrictOptName must be applied just for option name

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/jobedit.js
+++ b/rundeckapp/grails-app/assets/javascripts/jobedit.js
@@ -1182,14 +1182,19 @@ function _updateOptsUndoRedo() {
 
 function _configureInputRestrictions(target) {
   jQuery(target).find('input[type=text]').on('keydown', noenter);
-  jQuery(target).select('input.restrictOptName[type=text]').on('keydown', function (e) {
+
+  jQuery(target).find('.restrictOptName').each( function(){
+      jQuery(this).on('keydown', function (e) {
         var inputRGEX = /^[a-zA-Z_0-9.\t-]*$/;
         var inputResult = inputRGEX.test(e.key);
         if(!(inputResult))
-          {
-            stopEvent (e)
-          }
-        });
+        {
+          stopEvent (e)
+        }
+    });
+
+  } )
+
 }
 
 function _isjobScheduled() {


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Fix issue https://github.com/rundeck/rundeck/issues/6430
`restrictOptName` must be applied just for the option name in job edition form

**Describe the solution you've implemented**
apply the restrict option just  for the option name

**Describe alternatives you've considered**

**Additional context**
