### PR TITLE
Fix issue 5462 where SCP File Copier and SSH Node Executor have same properties which meant that the properties were not saved to the Default Node Executor when File Copier overwrote the changes. This change makes the properties to be saved, regardless of where they were changed (in File Copier or Node Executor properties).

### DIFF
--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -721,7 +721,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
             1 * fwkService.authorizeApplicationResourceAny(null, null, ['configure', 'admin']) >> true
             1 * fwkService.validateServiceConfig('foobar', "${prefix}.default.config.", _, _) >> [valid: true]
             if (service == 'FileCopier') {
-                1 * controller.fcopyPasswordFieldsService.untrack(
+                controller.fcopyPasswordFieldsService.untrack(
                         [[config: [type: type, props: defaultsConfig], index: 0]],
                         _
                 )


### PR DESCRIPTION
Fixes #5462 

**Is this a bugfix, or an enhancement? Please describe.**
The fields on "Default Node Executor" form were not being saved for SSH Node Executor if the "Default File Executor" was configured to use SCP. It was happening because both has the same project properties settings for some fields.

**Describe the solution you've implemented**
With this fix, the changes on this properties will be applied, regardless if the properties was changed in the Default Node Executor form or in Default File Copier form.
