### PR TITLE
Node Executor or File Copier Plugin are missing #6436

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ to build, i.e. 3.2.7
     git clone https://github.com/rundeck/packaging
     ./gradlew build -Penvironment=release
     cd packaging
+
+For 3.2.x builds, check out the `maint-3.2.x` branch of `packaging`
+
+    git checkout maint-3.2.x
     mkdir -p artifacts
     cp ../rundeckapp/build/libs/rundeck*.war artifacts/
     ./gradlew -PpackageRelease=$RELEASE_VERSION clean packageArtifacts

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Build the documentation. Artifacts in `docs/en/dist`:
     cd docs
     make
 
+RPM and DEB package builds
+=======
+
 To build .rpm and .deb packages, you must first clone [the rundeck packaging repo](https://github.com/rundeck/packaging) into the rundeck repo.
 A sample list of simple build steps is below, where $RELEASE_VERSION is the version you want
 to build, i.e. 3.2.7

--- a/README.md
+++ b/README.md
@@ -43,15 +43,19 @@ Build the documentation. Artifacts in `docs/en/dist`:
     cd docs
     make
 
-You can build .rpm or .deb files (requires pandoc to build the docs):
+To build .rpm and .deb packages, you must first clone [the rundeck packaging repo](https://github.com/rundeck/packaging) into the rundeck repo.
+A sample list of simple build steps is below, where $RELEASE_VERSION is the version you want
+to build, i.e. 3.2.7
 
-Build the RPM. Artifacts in `packaging/rpmdist/RPMS/noarch/*.rpm`
-
-    make rpm
-    
-Build the .deb. Artifacts in `packaging/*.deb`:
-
-    make deb
+    git clone https://github.com/rundeck/rundeck
+    cd rundeck
+    git checkout refs/tags/v$RELEASE_VERSION
+    git clone https://github.com/rundeck/packaging
+    ./gradlew build -Penvironment=release
+    cd packaging
+    mkdir -p artifacts
+    cp ../rundeckapp/build/libs/rundeck*.war artifacts/
+    ./gradlew -PpackageRelease=$RELEASE_VERSION clean packageArtifacts
 
 To build clean:
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -2044,6 +2044,15 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         final nodeConfig = frameworkService.getNodeExecConfigurationForType(defaultNodeExec, project)
         final filecopyConfig = frameworkService.getFileCopyConfigurationForType(defaultFileCopy, project)
 
+        def errors = []
+
+        if(nodeConfig == null || nodeConfig.size() == 0) {
+            errors << message(code: "domain.project.edit.plugin.missing.message", args: ['Node Executor', defaultNodeExec])
+        }
+
+        if(filecopyConfig == null || filecopyConfig.size() == 0) {
+            errors << message(code: "domain.project.edit.plugin.missing.message", args: ['File Copier', defaultFileCopy])
+        }
 
         // Reset Password Fields in Session
         execPasswordFieldsService.reset()
@@ -2060,6 +2069,11 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                 'extraConfig.',
                 fwkProject.projectProperties
         )
+
+        if(errors?.size() > 0) {
+            request.errors = errors
+        }
+
         //sort the beans in order to control the way they are shown on the form
         extraConfig = extraConfig.sort { it.key.toLowerCase() }
         [

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -2045,12 +2045,12 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         final filecopyConfig = frameworkService.getFileCopyConfigurationForType(defaultFileCopy, project)
 
         def errors = []
-
-        if(nodeConfig == null || nodeConfig.size() == 0) {
+        
+        if(defaultNodeExec !=null && (nodeConfig == null || nodeConfig.size() == 0)) {
             errors << message(code: "domain.project.edit.plugin.missing.message", args: ['Node Executor', defaultNodeExec])
         }
 
-        if(filecopyConfig == null || filecopyConfig.size() == 0) {
+        if(defaultFileCopy != null && (filecopyConfig == null || filecopyConfig.size() == 0)) {
             errors << message(code: "domain.project.edit.plugin.missing.message", args: ['File Copier', defaultFileCopy])
         }
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
@@ -505,7 +505,16 @@ class WorkflowController extends ControllerBase {
         if (result.error) {
             log.error(result.error)
             item=result.item
-            def itemDescription = item.instanceOf(PluginStep) ? getPluginStepDescription(item.nodeStep, item.type) : null
+
+            def itemDescription
+            def dynamicProperties
+            if(item && item.instanceOf(PluginStep)){
+                itemDescription = getPluginStepDescription(item.nodeStep, item.type)
+                dynamicProperties = getDynamicProperties(params.project,
+                        item.type,
+                        item.nodeStep,
+                        rundeckAuthorizedServicesProvider.getServicesWith(auth))
+            }
 
             def newitemtype = params['newitemtype']
             def origitemtype = params['origitemtype']
@@ -514,6 +523,7 @@ class WorkflowController extends ControllerBase {
                     template: "/execution/wfitemEdit",
                     model: [
                             item                : result.item,
+                            dynamicProperties   : dynamicProperties,
                             key                 : params.key,
                             num                 : params.num,
                             scheduledExecutionId: params.scheduledExecutionId,

--- a/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
@@ -152,7 +152,7 @@ public class JobExec extends WorkflowStep implements IWorkflowJobItem{
             map.description = description
         }
         if(failOnDisable){
-            map.failOnDisable = failOnDisable
+            map.jobref.failOnDisable = failOnDisable
         }
         if(importOptions){
             map.jobref.importOptions = importOptions
@@ -235,6 +235,10 @@ public class JobExec extends WorkflowStep implements IWorkflowJobItem{
         }
         if(map.jobref.failOnDisable){
             if (map.jobref.failOnDisable in ['true', true]) {
+                exec.failOnDisable = true
+            }
+        }else if(map.failOnDisable){
+            if (map.failOnDisable in ['true', true]) {
                 exec.failOnDisable = true
             }
         }

--- a/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
@@ -246,7 +246,12 @@ public class JobExec extends WorkflowStep implements IWorkflowJobItem{
             if (map.jobref.importOptions in ['true', true]) {
                 exec.importOptions = true
             }
+        } else if(map.importOptions) {
+            if (map.importOptions in ['true', true]) {
+                exec.importOptions = true
+            }
         }
+
         if(map.jobref.ignoreNotifications){
             if (map.jobref.ignoreNotifications in ['true', true]) {
                 exec.ignoreNotifications = true

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -487,6 +487,7 @@ framework.service.TourLoader.label.plural=Tour Loader Plugins
 framework.service.TourLoader.description=Create tours that guide users through the user interface.
 domain.Project.edit.NodeExecutor.explanation=The Node Executor is responsible for executing commands and scripts on remote nodes.
 domain.Project.edit.FileCopier.explanation=The File Copier is responsible for copying scripts as files to remote nodes before they are executed.
+domain.project.edit.plugin.missing.message= {0} configuration was invalid: Invalid provider type: {1}, not found 
 framework.service.error.missing-provider=Provider not found: {0}
 message.none.set=None set
 domain.Project.field.resourcesUrl=Resource Model Source URL

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -473,6 +473,7 @@ framework.service.StorageConverter.label.plural=Plugins de Convertidor de Almace
 framework.service.StorageConverter.description=Convierte y Codifica los datos de Almacenamiento
 domain.Project.edit.NodeExecutor.explanation=El Ejecutador de Nodo es responsable de ejecutar los comandos y scripts en los nodos remotos..
 domain.Project.edit.FileCopier.explanation=La Copiadora de Archivos es responsable de la copia de los scripts como archivos a nodos remotos antes de ser ejecutados.
+domain.project.edit.plugin.missing.message=la configuración de {0} no es válida: tipo de proveedor no válido: {1}, no encontrado
 framework.service.error.missing-provider=Proveedor no encontrado: {0}
 message.none.set=Ninguno establecido
 domain.Project.field.resourcesUrl=URL de Recursos Modelo Fuente

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -848,6 +848,14 @@ public class NotificationService implements ApplicationContextAware{
         contextMap['job'] = toStringStringMap(jobMap)
         contextMap['execution']=toStringStringMap(execMap)
         contextMap['rundeck']=['href': appUrl]
+
+        if(!context?.containsKey("globals")) {
+            // Put globals in context.
+            Map<String, String> globals = frameworkService.getProjectGlobals(source.project);
+            contextMap.put("globals", globals ? globals : new HashMap<>());
+
+        }
+
         context = DataContextUtils.merge(context, contextMap)
 
         [context, execMap]

--- a/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
@@ -333,13 +333,16 @@ class JobExecSpec extends HibernateSpec {
                 ],
                 description: 'a monkey'
         ]
+
         if(failOnDisable != null) {
             map.jobref.failOnDisable = failOnDisable
         }
+      
         when:
         def result = JobExec.jobExecFromMap(map)
 
         then:
+
         result.failOnDisable == (failOnDisable?.equals('true')?:null)
         where:
         failOnDisable    | _
@@ -373,6 +376,34 @@ class JobExecSpec extends HibernateSpec {
 
     }
 
+    def "map with importOptions"() {
+        given:
+        def map = [
+                jobref     : [
+                        group      : 'group',
+                        name       : 'name'
+                ],
+                description: 'a monkey'
+        ]
+
+        if(importOption != null) {
+            map.importOptions = importOption
+        }
+
+        when:
+        def result = JobExec.jobExecFromMap(map)
+
+        then:
+        result.importOptions == (importOption?.equals('true')?:null)
+
+        where:
+        importOption    | _
+        'true'          | _
+        'false'         | _
+        null            | _
+
+    }  
+  
     static uuid1 = UUID.randomUUID().toString()
     static uuid2 = UUID.randomUUID().toString()
     static uuid3 = UUID.randomUUID().toString()

--- a/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
@@ -273,6 +273,106 @@ class JobExecSpec extends HibernateSpec {
 
     }
 
+    def "to map with failOnDisable"() {
+        when:
+        Map map = new JobExec(
+                jobGroup: 'group',
+                jobName: 'name',
+                description: 'a monkey',
+                nodeFilter: 'abc def',
+                failOnDisable: failOnDisable,
+                nodeThreadcount: 2,
+        ).toMap()
+
+        then:
+
+        if(failOnDisable) {
+            map == [
+                    jobref     : [
+                            group        : 'group',
+                            name         : 'name',
+                            failOnDisable: 'true',
+                            nodefilters  : [
+                                    filter  : 'abc def',
+                                    dispatch: [
+                                            threadcount: 2
+                                    ]
+                            ]
+                    ],
+                    description: 'a monkey'
+            ]
+        }else{
+            map == [
+                    jobref     : [
+                            group        : 'group',
+                            name         : 'name',
+                            nodefilters  : [
+                                    filter  : 'abc def',
+                                    dispatch: [
+                                            threadcount: 2
+                                    ]
+                            ]
+                    ],
+                    description: 'a monkey'
+            ]
+        }
+
+        where:
+        failOnDisable    | _
+        true            | _
+        false           | _
+        null            | _
+    }
+
+    def "from map with failOnDisable"() {
+        given:
+        def map = [
+                jobref     : [
+                        group      : 'group',
+                        name       : 'name'
+                ],
+                description: 'a monkey'
+        ]
+        if(failOnDisable != null) {
+            map.jobref.failOnDisable = failOnDisable
+        }
+        when:
+        def result = JobExec.jobExecFromMap(map)
+
+        then:
+        result.failOnDisable == (failOnDisable?.equals('true')?:null)
+        where:
+        failOnDisable    | _
+        'true'          | _
+        'false'         | _
+        null            | _
+
+    }
+    def "from map with failOnDisable (backwards compat)"() {
+        given:
+        def map = [
+                jobref     : [
+                        group      : 'group',
+                        name       : 'name'
+                ],
+                description: 'a monkey'
+        ]
+        if(failOnDisable != null) {
+            map.failOnDisable = failOnDisable
+        }
+        when:
+        def result = JobExec.jobExecFromMap(map)
+
+        then:
+        result.failOnDisable == (failOnDisable?.equals('true')?:null)
+        where:
+        failOnDisable    | _
+        'true'          | _
+        'false'         | _
+        null            | _
+
+    }
+
     static uuid1 = UUID.randomUUID().toString()
     static uuid2 = UUID.randomUUID().toString()
     static uuid3 = UUID.randomUUID().toString()

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerTest.groovy
@@ -813,4 +813,104 @@ class FrameworkControllerTest extends HibernateSpec implements ControllerUnitTes
         assertEquals(label,model["projectLabel"])
 
     }
+
+    public void editProjectNodeExecutorPluginNotFound() {
+        given:
+        def label = "Label for project"
+        def fwk = new MockFor(FrameworkService, true)
+
+        fwk.demand.getAuthContextForSubject { subject -> return null}
+        fwk.demand.authResourceForProject {project -> return null}
+        fwk.demand.authorizeApplicationResourceAny {ctx, e, actions -> true }
+
+        def proj = new MockFor(IRundeckProject)
+        proj.demand.getProjectProperties(1..8){-> ["project.label":label]}
+
+        fwk.demand.getFrameworkProject { name-> proj.proxyInstance() }
+        fwk.demand.listDescriptions { -> [[withPasswordFieldDescription], null, null] }
+
+        fwk.demand.getDefaultNodeExecutorService { prj -> "TestPluginsNodeExecutor" }
+        fwk.demand.getDefaultFileCopyService { prj -> "WinRMcpPython" }
+
+        fwk.demand.getNodeExecConfigurationForType { nodeExec,prj -> null }
+        fwk.demand.getFileCopyConfigurationForType { fcpy,prj -> "WinRMcpPython" }
+        fwk.demand.loadProjectConfigurableInput {prefix,props -> [:] }
+
+        controller.frameworkService = fwk.proxyInstance()
+
+        def execPFmck = new MockFor(PasswordFieldsService,true)
+        def fcopyPFmck = new MockFor(PasswordFieldsService,true)
+
+        execPFmck.demand.reset{ -> return null}
+        execPFmck.demand.track{a, b -> return null}
+        fcopyPFmck.demand.reset{ -> return null}
+        fcopyPFmck.demand.track{a, b -> return null}
+
+        controller.execPasswordFieldsService = execPFmck.proxyInstance()
+        controller.fcopyPasswordFieldsService = fcopyPFmck.proxyInstance()
+
+        def passwordFieldsService = new PasswordFieldsService()
+        passwordFieldsService.fields.put("dummy", "stuff")
+
+        controller.resourcesPasswordFieldsService = passwordFieldsService
+
+        params.project = "edit_test_project"
+
+        when:
+        def model = controller.editProject()
+
+        then:
+        assertNotNull(request.errors)
+
+    }
+
+    public void editProjectFileCopyPluginNotFound() {
+        given:
+        def label = "Label for project"
+        def fwk = new MockFor(FrameworkService, true)
+
+        fwk.demand.getAuthContextForSubject { subject -> return null}
+        fwk.demand.authResourceForProject {project -> return null}
+        fwk.demand.authorizeApplicationResourceAny {ctx, e, actions -> true }
+
+        def proj = new MockFor(IRundeckProject)
+        proj.demand.getProjectProperties(1..8){-> ["project.label":label]}
+
+        fwk.demand.getFrameworkProject { name-> proj.proxyInstance() }
+        fwk.demand.listDescriptions { -> [[withPasswordFieldDescription], null, null] }
+
+        fwk.demand.getDefaultNodeExecutorService { prj -> "ssh-exec" }
+        fwk.demand.getDefaultFileCopyService { prj -> "TestPluginsFileCopy" }
+
+        fwk.demand.getNodeExecConfigurationForType { nodeExec,prj -> "ssh-exec" }
+        fwk.demand.getFileCopyConfigurationForType { fcpy,prj -> null }
+        fwk.demand.loadProjectConfigurableInput {prefix,props -> [:] }
+
+        controller.frameworkService = fwk.proxyInstance()
+
+        def execPFmck = new MockFor(PasswordFieldsService,true)
+        def fcopyPFmck = new MockFor(PasswordFieldsService,true)
+
+        execPFmck.demand.reset{ -> return null}
+        execPFmck.demand.track{a, b -> return null}
+        fcopyPFmck.demand.reset{ -> return null}
+        fcopyPFmck.demand.track{a, b -> return null}
+
+        controller.execPasswordFieldsService = execPFmck.proxyInstance()
+        controller.fcopyPasswordFieldsService = fcopyPFmck.proxyInstance()
+
+        def passwordFieldsService = new PasswordFieldsService()
+        passwordFieldsService.fields.put("dummy", "stuff")
+
+        controller.resourcesPasswordFieldsService = passwordFieldsService
+
+        params.project = "edit_test_project"
+
+        when:
+        def model = controller.editProject()
+
+        then:
+        assertNotNull(request.errors)
+
+    }
 }


### PR DESCRIPTION
Fix https://github.com/rundeck/rundeck/issues/6436

**Is this a bug fix, or an enhancement? Please describe.**
If a node executor or file copier plugin are missing, the project's "Default Node Executor" or "Default File Copier" section will appear empty. 
This error is generated when importing a project that has a node executor or file copier plugins selected from a cluster to another cluster that does not have these plugins previously installed

**Describe the solution you've implemented**
Validation messages are added so that the user knows that the plugin is not available

![image](https://user-images.githubusercontent.com/35808955/92514909-1af29180-f1e9-11ea-832a-788d16714c71.png)


