### PR TITLE
UI Update: Notifications editor

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginRegistry.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginRegistry.java
@@ -162,6 +162,15 @@ public interface PluginRegistry {
      */
     ValidatedPlugin validatePluginByName(String name, PluggableProviderService service, Map instanceConfiguration);
     /**
+     * Validate a provider for a service with an instance configuration
+     * @param name name of bean or provider
+     * @param service provider service
+     * @param instanceConfiguration config map
+     * @param ignoredScope scope to ignore
+     * @return Map containing valid:true/false, and report: {@link com.dtolabs.rundeck.core.plugins.configuration.Validator.Report}
+     */
+    ValidatedPlugin validatePluginByName(String name, PluggableProviderService service, Map instanceConfiguration, PropertyScope ignoredScope) ;
+    /**
      * Load a plugin instance with the given bean or provider name
      * @param name name of bean or provider
      * @param service provider service

--- a/rundeckapp/grails-app/conf/application.groovy
+++ b/rundeckapp/grails-app/conf/application.groovy
@@ -34,6 +34,7 @@ environments {
         rundeck.feature.cleanExecutionsHistoryJob.enabled = true
         rundeck.feature.executionLifecyclePlugin.enabled = true
         rundeck.feature.legacyExecOutputViewer.enabled = false
+        rundeck.feature.notificationsEditorVue.enabled = true
         dataSource {
             dbCreate = "create-drop" // one of 'create', 'create-drop','update'
             url = "jdbc:h2:file:./db/devDb"

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -48,6 +48,8 @@ import com.dtolabs.rundeck.server.plugins.logging.*
 import com.dtolabs.rundeck.server.plugins.logs.*
 import com.dtolabs.rundeck.server.plugins.logstorage.TreeExecutionFileStoragePlugin
 import com.dtolabs.rundeck.server.plugins.logstorage.TreeExecutionFileStoragePluginFactory
+import com.dtolabs.rundeck.server.plugins.notification.DummyEmailNotificationPlugin
+import com.dtolabs.rundeck.server.plugins.notification.DummyWebhookNotificationPlugin
 import com.dtolabs.rundeck.server.plugins.services.*
 import com.dtolabs.rundeck.server.plugins.storage.DbStoragePlugin
 import com.dtolabs.rundeck.server.plugins.storage.DbStoragePluginFactory
@@ -458,6 +460,9 @@ beans={
             RenderDatatypeFilterPlugin,
             QuietFilterPlugin,
             HighlightFilterPlugin,
+            //dummy notification plugins
+            DummyEmailNotificationPlugin,
+            DummyWebhookNotificationPlugin,
     ].each {
         "rundeckAppPlugin_${it.simpleName}"(PluginFactoryBean, it)
     }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
@@ -2,6 +2,7 @@ package rundeck.controllers
 
 import com.dtolabs.rundeck.app.support.PluginResourceReq
 import com.dtolabs.rundeck.core.authorization.AuthContext
+import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
 import org.rundeck.app.spi.AuthorizedServicesProvider
 import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.plugins.PluginValidator
@@ -286,7 +287,25 @@ class PluginController extends ControllerBase {
             config = request.JSON.config
         }
         config = ParamsUtil.cleanMap(config)
-        def validation = pluginService.validatePluginConfig(service, name, config)
+        PropertyScope ignoredScope=null
+        if(params.ignoredScope){
+            try{
+                ignoredScope=PropertyScope.valueOf(params.ignoredScope.toString())
+            } catch (IllegalArgumentException e) {
+                response.status = 400
+                return respond(
+                    [status: 400, formats: ['json']],
+                    (Object) [
+                        error: g.message(
+                            code: 'request.error.invalidrequest.message',
+                            args: [params.ignoredScope]
+                        )
+                    ]
+                )
+            }
+
+        }
+        def validation = pluginService.validatePluginConfig(service, name, config, ignoredScope)
         if(!validation){
             response.status=404
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
@@ -287,6 +287,14 @@ class PluginController extends ControllerBase {
         }
         config = ParamsUtil.cleanMap(config)
         def validation = pluginService.validatePluginConfig(service, name, config)
+        if(!validation){
+            response.status=404
+
+            return render(contentType: 'application/json') {
+                valid false
+                delegate.error ('Provider not found for '+service+': '+name)
+            }
+        }
         def errorsMap = validation.report.errors
         def decomp = ParamsUtil.decomposeMap(errorsMap)
 //        System.err.println("config: $config, errors: $errorsMap, decomp: $decomp")

--- a/rundeckapp/grails-app/domain/rundeck/Notification.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Notification.groovy
@@ -158,11 +158,11 @@ public class Notification {
             def configuration = mailConfiguration()
             if(configuration.attachLog && configuration.attachLogInline){
                 configuration.attachType='inline'
-                configuration.remove('attachLogInline')
             }else if(configuration.attachLog && configuration.attachLogInFile){
                 configuration.attachType='file'
-                configuration.remove('attachLogInFile')
             }
+            configuration.remove('attachLogInline')
+            configuration.remove('attachLogInFile')
             return [type:'email', trigger:eventTrigger, config: configuration]
         }else if(type=='url'){
             return [type: 'url', trigger:eventTrigger, config: [urls: content, format: format]]

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -755,7 +755,7 @@ scheduledExecution.property.notifyAvgDurationThreshold.description=Optional dura
   - percentage of average: `20%`\n\
   - time delta from the average: `+20s`, `+20`\n\
   - absolute time: `30s`, `5m`\n\
-  Use `s`,`m`,`h`,'d','w','y' etc as time units for seconds, minutes, hours, etc.\n\
+  Use `s`,`m`,`h`,`d`,`w`,`y` etc as time units for seconds, minutes, hours, etc.\n\
   Unit will be seconds if it is not specified.\n\n\
   Can include option value references like `${option.avgDurationThreshold}`.
 scheduledExecution.property.notifyAvgDurationThreshold.label=Threshold

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -751,12 +751,13 @@ scheduledExecution.property.timeout.description=The maximum time for an executio
   or specify time units: "120m", "2h", "3d".  Use blank or 0 to indicate no timeout. Can include option value \
   references like "${option.timeout}".
 scheduledExecution.property.timeout.label=Timeout
-scheduledExecution.property.notifyAvgDurationThreshold.description=Add or set a threshold value to the avg duration in order to trigger this notification. Options: \
-  - percentage => eg: 20% \
-  - time delta => eg: +20s, +20  \
-  - absolute time => 30s, 5m \
-  Time in seconds if you don't specify time units \
-  Can include option value references like ${option.avgDurationThreshold}.
+scheduledExecution.property.notifyAvgDurationThreshold.description=Optional duration threshold to trigger the notifications. If not specified, the Job Average duration will be used.\n\n\
+  - percentage of average: `20%`\n\
+  - time delta from the average: `+20s`, `+20`\n\
+  - absolute time: `30s`, `5m`\n\
+  Use `s`,`m`,`h`,'d','w','y' etc as time units for seconds, minutes, hours, etc.\n\
+  Unit will be seconds if it is not specified.\n\n\
+  Can include option value references like `${option.avgDurationThreshold}`.
 scheduledExecution.property.notifyAvgDurationThreshold.label=Threshold
 scheduledExecution.property.retry.label=Retry
 scheduledExecution.property.retry.description=Maximum number of times to retry execution when this job is directly invoked.  Retry will occur if the job fails or times out, but not if it is manually killed. Can use an option value reference like "${option.retry}".

--- a/rundeckapp/grails-app/services/rundeck/services/PluginService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/PluginService.groovy
@@ -134,6 +134,19 @@ class PluginService implements ResourceFormats {
         PluggableProviderService providerService = createPluggableService((Class) serviceType)
         return rundeckPluginRegistry?.validatePluginByName(provider, providerService, config)
     }
+    /**
+     * Configure a new plugin using a specific property resolver for configuration
+     * @param service service
+     * @param provider provider name
+     * @param config instance configuration data
+     * @param ignoredScope property scope to ignore
+     * @return validation
+     */
+    def ValidatedPlugin validatePluginConfig(String service, String provider, Map config, PropertyScope ignoredScope) {
+        Class serviceType = getPluginTypeByService(service)
+        PluggableProviderService providerService = createPluggableService((Class) serviceType)
+        return rundeckPluginRegistry?.validatePluginByName(provider, providerService, config, ignoredScope)
+    }
 
     /**
      *

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -2909,6 +2909,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     @CompileStatic
     public void jobDefinitionNotifications(ScheduledExecution scheduledExecution, ScheduledExecution input,Map params, UserAndRoles userAndRoles) {
         Collection<Notification> notificationSet=[]
+        boolean replaceAll=false
         if(input){
             if(input.notifications) {
                 notificationSet.addAll(input.notifications.collect{Notification.fromMap(it.eventTrigger,it.toMap())})
@@ -2916,6 +2917,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }else if(params.jobNotificationsJson){
             def notificationsData = JSON.parse(params.jobNotificationsJson.toString())
             if(notificationsData instanceof JSONArray){
+                replaceAll=true
                 for(Object item: notificationsData){
                     if(item instanceof JSONObject){
                         notificationSet.add(Notification.fromNormalizedMap(item))
@@ -2941,7 +2943,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         def addedNotifications=[]
         notificationSet.each{Notification n->
             //modify existing notification
-            def oldn = scheduledExecution.findNotification(n.eventTrigger,n.type)
+            Notification oldn = replaceAll?null:scheduledExecution.findNotification(n.eventTrigger,n.type)
             if(oldn){
                 oldn.content=n.content
                 oldn.format=n.format

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -23,9 +23,12 @@ import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
 import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException
 import com.dtolabs.rundeck.core.plugins.ValidatedPlugin
+import grails.converters.JSON
 import grails.gorm.transactions.NotTransactional
 import grails.orm.HibernateCriteriaBuilder
 import groovy.transform.CompileStatic
+import org.grails.web.json.JSONArray
+import org.grails.web.json.JSONElement
 import org.hibernate.criterion.DetachedCriteria
 import org.hibernate.criterion.Projections
 import org.hibernate.criterion.Subqueries
@@ -2909,6 +2912,15 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         if(input){
             if(input.notifications) {
                 notificationSet.addAll(input.notifications.collect{Notification.fromMap(it.eventTrigger,it.toMap())})
+            }
+        }else if(params.jobNotificationsJson){
+            def notificationsData = JSON.parse(params.jobNotificationsJson.toString())
+            if(notificationsData instanceof JSONArray){
+                for(Object item: notificationsData){
+                    if(item instanceof JSONObject){
+                        notificationSet.add(Notification.fromNormalizedMap(item))
+                    }
+                }
             }
         }else if(params.notified != 'false'){
             def notifications = parseParamNotifications(params)

--- a/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsForm.gsp
@@ -15,6 +15,13 @@
   --}%
 
 <%@ page import="rundeck.controllers.ScheduledExecutionController; com.dtolabs.rundeck.plugins.ServiceNameConstants" %>
+
+<feature:enabled name="notificationsEditorVue">
+    <div class="job-editor-vue">
+        <app :event-bus="EventBus" />
+    </div>
+</feature:enabled>
+<feature:disabled name="notificationsEditorVue">
 <g:set var="notifications" value="${scheduledExecution.notifications}"/>
 <g:set var="defSuccess" value="${scheduledExecution.findNotification(ScheduledExecutionController.ONSUCCESS_TRIGGER_NAME, ScheduledExecutionController.EMAIL_NOTIFICATION_TYPE)}"/>
 <g:set var="isSuccess" value="${'true' == params[ScheduledExecutionController.NOTIFY_ONSUCCESS_EMAIL] || null== params[ScheduledExecutionController.NOTIFY_ONSUCCESS_EMAIL] && defSuccess}"/>
@@ -170,3 +177,4 @@
                   adminauth: adminauth,
                   serviceName: ServiceNameConstants.Notification
           ]}"/>
+</feature:disabled>

--- a/rundeckapp/grails-app/views/scheduledExecution/create.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/create.gsp
@@ -30,7 +30,49 @@
     <asset:javascript src="util/yellowfade.js"/>
     <asset:javascript src="util/tab-router.js"/>
     <g:jsMessages code="page.unsaved.changes"/>
+<feature:enabled name="notificationsEditorVue">
+    <asset:javascript src="static/pages/job/editor.js" defer="defer"/>
+    <g:jsMessages code="
+    yes,
+    no,
+    scheduledExecution.property.notified.label.text,
+    scheduledExecution.property.notifyAvgDurationThreshold.label,
+    scheduledExecution.property.notifyAvgDurationThreshold.description,
+    to,
+    subject,
+    notification.email.description,
+    notification.email.subject.description,
+    notification.email.subject.helpLink,
+    attach.output.log,
+    attach.output.log.asFile,
+    attach.output.log.inline,
+    notification.webhook.field.title,
+    notification.webhook.field.description,
+    notify.url.format.label,
+    notify.url.format.xml,
+    notify.url.format.json,
+"/>
+    <g:jsMessages codes="${[
+            'onsuccess',
+            'onfailure',
+            'onstart',
+            'onavgduration',
+            'onretryablefailure'
+    ].collect{'notification.event.'+it}}"/>
+
+    <g:embedJSON id="jobNotificationsJSON"
+                 data="${ [notifications:scheduledExecution.notifications?.collect{it.toNormalizedMap()}?:[],
+                           notifyAvgDurationThreshold:scheduledExecution?.notifyAvgDurationThreshold,
+                 ]}"/>
+</feature:enabled>
     <g:javascript>
+
+        <feature:enabled name="notificationsEditorVue">
+        window._rundeck = Object.assign(window._rundeck || {}, {
+            data: {notificationData: loadJsonData('jobNotificationsJSON')}
+        })
+        </feature:enabled>
+        console.log("loaded data",window._rundeck)
         var workflowEditor = new WorkflowEditor();
         var confirm = new PageConfirm(message('page.unsaved.changes'));
         _onJobEdit(confirm.setNeedsConfirm);

--- a/rundeckapp/grails-app/views/scheduledExecution/create.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/create.gsp
@@ -32,6 +32,7 @@
     <g:jsMessages code="page.unsaved.changes"/>
 <feature:enabled name="notificationsEditorVue">
     <asset:javascript src="static/pages/job/editor.js" defer="defer"/>
+    <asset:stylesheet src="static/css/pages/job/editor.css" />
     <g:jsMessages code="
     yes,
     no,

--- a/rundeckapp/grails-app/views/scheduledExecution/edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/edit.gsp
@@ -30,7 +30,49 @@
     <asset:javascript src="util/yellowfade.js"/>
     <asset:javascript src="util/tab-router.js"/>
     <g:jsMessages code="page.unsaved.changes"/>
+    <feature:enabled name="notificationsEditorVue">
+        <asset:javascript src="static/pages/job/editor.js" defer="defer"/>
+        <g:jsMessages code="
+    yes,
+    no,
+    scheduledExecution.property.notified.label.text,
+    scheduledExecution.property.notifyAvgDurationThreshold.label,
+    scheduledExecution.property.notifyAvgDurationThreshold.description,
+    to,
+    subject,
+    notification.email.description,
+    notification.email.subject.description,
+    notification.email.subject.helpLink,
+    attach.output.log,
+    attach.output.log.asFile,
+    attach.output.log.inline,
+    notification.webhook.field.title,
+    notification.webhook.field.description,
+    notify.url.format.label,
+    notify.url.format.xml,
+    notify.url.format.json,
+"/>
+        <g:jsMessages codes="${[
+                'onsuccess',
+                'onfailure',
+                'onstart',
+                'onavgduration',
+                'onretryablefailure'
+        ].collect{'notification.event.'+it}}"/>
+
+        <g:embedJSON id="jobNotificationsJSON"
+                     data="${ [notifications:scheduledExecution.notifications?.collect{it.toNormalizedMap()}?:[],
+                               notifyAvgDurationThreshold:scheduledExecution?.notifyAvgDurationThreshold,
+                     ]}"/>
+    </feature:enabled>
+
     <g:javascript>
+
+        <feature:enabled name="notificationsEditorVue">
+            window._rundeck = Object.assign(window._rundeck || {}, {
+                data: {notificationData: loadJsonData('jobNotificationsJSON')}
+            })
+        </feature:enabled>
         var workflowEditor = new WorkflowEditor();
         var confirm = new PageConfirm(message('page.unsaved.changes'));
         _onJobEdit(confirm.setNeedsConfirm);

--- a/rundeckapp/grails-app/views/scheduledExecution/edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/edit.gsp
@@ -32,6 +32,7 @@
     <g:jsMessages code="page.unsaved.changes"/>
     <feature:enabled name="notificationsEditorVue">
         <asset:javascript src="static/pages/job/editor.js" defer="defer"/>
+        <asset:stylesheet src="static/css/pages/job/editor.css" />
         <g:jsMessages code="
     yes,
     no,

--- a/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
@@ -5568,6 +5568,16 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -9579,6 +9589,13 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filesize": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
@@ -11943,6 +11960,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -16297,6 +16315,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -19987,6 +20006,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -20309,6 +20329,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
@@ -49,7 +49,7 @@
         </span>
         <span v-for="prop in props" :key="prop.name" class="configprop">
 
-            <plugin-prop-view :prop="prop" :value="config[prop.name]"  v-if="prop.type === 'Boolean' || config[prop.name]"/>
+            <plugin-prop-view :prop="prop" :value="config[prop.name]"  v-if="(prop.type === 'Boolean' || config[prop.name]) && isPropInScope(prop)"/>
 
         </span>
       </div>
@@ -140,7 +140,9 @@ export default Vue.extend({
     'savedProps',
     'pluginConfig',
     'validation',
-    'validationWarningText'
+    'validationWarningText',
+    'scope',
+    'defaultScope'
   ],
   data () {
     return {
@@ -273,6 +275,23 @@ export default Vue.extend({
       }
       return true
     },
+    isPropInScope(testProp: any): boolean {
+      // determine if property is visible in scope
+      const testScope = testProp.scope || this.defaultScope
+      const allowedScope = this.scope
+      if (!allowedScope || !testScope || testScope==='Unspecified') {
+        //no specific scope
+        return true
+      }else if(allowedScope==='Project' && (testScope.startsWith('Project'))){
+        return true
+      }else if(allowedScope==='Framework' && (testScope==='Framework' || testScope==='Project')){
+        return true
+      }else if(allowedScope==='Instance' && (testScope.startsWith('Instance'))){
+        return true
+      }
+
+      return false
+    },
     isGroupedProp(testProp: any): boolean {
       // determine if property is visible based on required prop value
       const grouping = testProp.options && testProp.options['grouping']
@@ -324,7 +343,7 @@ export default Vue.extend({
     visibility (): { [name: string]: boolean } {
       const visibility: { [name: string]: boolean } = {}
       this.props.forEach((prop: any) => {
-        visibility[prop.name] = this.isPropVisible(prop)
+        visibility[prop.name] = this.isPropVisible(prop) && this.isPropInScope(prop,this.defaultScope)
         if (!visibility[prop.name]) {
           Vue.delete(visibility, prop.name)
         }
@@ -350,7 +369,10 @@ export default Vue.extend({
        this.props.forEach(prop => {
          const name=prop.options && prop.options['groupName']
          const secondary = prop.options && prop.options['grouping']
-         if(!name && !secondary){
+         const inScope = this.isPropInScope(prop)
+         if(!inScope) {
+           return
+         }else if(!name && !secondary){
             unnamed.props.push(prop)
          }else{
            let gname=name||'-'

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
@@ -238,6 +238,7 @@ export default Vue.extend({
       }
     },
     loadPluginData(data: any) {
+      this.props = data.props
       if(data.dynamicProps) {
         this.props.forEach((prop: any) => {
           if (data.dynamicProps[prop.name]) {
@@ -245,7 +246,6 @@ export default Vue.extend({
           }
         })
       }
-      this.props = data.props
       this.detail = data
       this.prepareInputs()
     },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
@@ -343,7 +343,7 @@ export default Vue.extend({
     visibility (): { [name: string]: boolean } {
       const visibility: { [name: string]: boolean } = {}
       this.props.forEach((prop: any) => {
-        visibility[prop.name] = this.isPropVisible(prop) && this.isPropInScope(prop,this.defaultScope)
+        visibility[prop.name] = this.isPropVisible(prop) && this.isPropInScope(prop)
         if (!visibility[prop.name]) {
           Vue.delete(visibility, prop.name)
         }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/utils/AceEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/utils/AceEditor.vue
@@ -35,8 +35,8 @@
   </div>
 </template>
 <script lang="ts">
+import '../../utilities/braceFix'
 import Vue from 'vue'
-// import * as ace from 'brace'
 import Ace from 'vue2-ace-editor'
 
 import 'brace/ext/language_tools'

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/utils/ExtendedDescription.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/utils/ExtendedDescription.vue
@@ -1,0 +1,64 @@
+<template>
+  <span>
+    <details class="more-info" :class="extendedCss" v-if="extraDescription">
+          <summary>
+              <span :class="descriptionCss" >{{shortDescription}}</span>
+              <span class="more-indicator-verbiage btn-link btn-xs">More &hellip; </span>
+              <span class="less-indicator-verbiage btn-link btn-xs">Less </span>
+          </summary>
+          <div class="more-info-content">
+            <markdown-it-vue class="markdown-body" :content="extraDescription"/>
+          </div>
+      </details>
+      <span :class="basicCss" v-else>{{text}}</span>
+  </span>
+</template>
+<script lang="ts">
+
+import MarkdownItVue from 'markdown-it-vue'
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'ExtendedDescription',
+  components: {MarkdownItVue},
+  computed:{
+    shortDescription() :string{
+      const desc = this.text
+      if (desc && desc.indexOf("\n") > 0) {
+        return desc.substring(0, desc.indexOf("\n"));
+      }
+      return desc;
+    },
+    extraDescription() :string|null{
+      const desc = this.text
+      if (desc && desc.indexOf("\n") > 0) {
+        return desc.substring(desc.indexOf("\n") + 1);
+      }
+      return null;
+    }
+  },
+  props: {
+    'text': {
+      type: String,
+      required: false,
+      default: ''
+    },
+    'extendedCss': {
+      type: String,
+      required: false,
+      default: ''
+    },
+    'descriptionCss': {
+      type: String,
+      required: false,
+      default: ''
+    },
+    'basicCss': {
+      type: String,
+      required: false,
+      default: ''
+    }
+  }
+})
+
+</script>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/modules/pluginService.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/modules/pluginService.ts
@@ -93,11 +93,16 @@ export const getServiceProviderDescription = async (svcName:string, provider:str
 }
 
 
-export const validatePluginConfig = async (svcName:string, provider:string, config:any) => {
+export const validatePluginConfig = async (svcName:string, provider:string, config:any, ignoredScope:string|null = null) => {
   const params = await getParameters()
+  const qparams = {} as {[key:string]:string}
+  if(ignoredScope!=null){
+    qparams['ignoredScope']=ignoredScope
+  }
   const resp = await client.sendRequest({
     pathTemplate: `/plugin/validate/{svcName}/{provider}`,
     pathParameters: {svcName:svcName,provider:provider},
+    queryParameters:qparams,
     baseUrl: params.rdBase,
     method: 'POST',
     body: {config: config}

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/utilities/braceFix.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/utilities/braceFix.ts
@@ -1,0 +1,12 @@
+/**
+ * Brace uses it's own require implementation, acequire, that seems to conflict
+ * with webpack and ES6 imports. This swaps acequire for the working require in
+ * an import hoisting friendly module.
+ * 
+ * This must occur before brace is imported or the export value of "undefined"
+ * will be cached.
+ */
+// @ts-ignore
+window.ace.acequire = window.ace.require
+
+export default ''

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/utilities/braceFix.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/utilities/braceFix.ts
@@ -1,5 +1,5 @@
 /**
- * Brace uses it's own require implementation, acequire, that seems to conflict
+ * Brace uses its own require implementation, acequire, that seems to conflict
  * with webpack and ES6 imports. This swaps acequire for the working require in
  * an import hoisting friendly module.
  * 

--- a/rundeckapp/grails-spa/packages/ui-trellis/vue.config.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/vue.config.js
@@ -54,7 +54,7 @@ module.exports = {
       else
         return '[name].js'
     }
-    config.output.library = 'rundeckCore'
+    config.output.library = 'rundeckUiTrellis'
     config.output.libraryTarget = 'commonjs2'
 
     config.externals = [

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
@@ -53,6 +53,8 @@
                     :show-title="true"
                     :show-description="true"
                     :key="'g_'+i+'/'+notif.type+':config'"
+                    scope="Instance"
+                    default-scope="Instance"
                 />
               </div>
 
@@ -192,6 +194,8 @@
             :show-title="false"
             :show-description="false"
             :validation="editValidation"
+            scope="Instance"
+            default-scope="Instance"
         ></plugin-config>
 
       </div>
@@ -399,7 +403,8 @@ export default {
       const validation = await pluginService.validatePluginConfig(
           'Notification',
           this.editNotification.type,
-          this.editNotification.config
+          this.editNotification.config,
+          'Project'
       )
       if (!validation.valid) {
         this.editValidation = validation

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
@@ -61,6 +61,12 @@
                   <span class="caret"></span>
                 </btn>
                 <template slot="dropdown">
+                  <li @click="doCopyNotification(notif)">
+                    <a role="button">
+                      {{$t('Copy...')}}
+                    </a>
+                  </li>
+                  <li role="separator" class="divider"></li>
                   <li @click="doDeleteNotification(notif)">
                     <a role="button">
                       {{$t('Delete')}}
@@ -295,6 +301,14 @@ export default {
       if(ndx>=0){
         this.notifications.splice(ndx,1)
       }
+    },
+    async doCopyNotification(notif){
+      this.editNotificationTrigger=notif.trigger
+      this.editNotification= {type:notif.type,config:Object.assign({},notif.config)}
+      this.editIndex=-1
+      this.editValidation=null
+      this.editError=null
+      this.editModal=true
     },
     async cancelEditNotification(){
       this.editModal=false

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
@@ -67,26 +67,27 @@
                 />
               </div>
 
-
-              <dropdown ref="dropdown" menu-right>
-                <btn type="simple" class=" btn-hover  btn-secondary dropdown-toggle">
-                  <span class="caret"></span>
-                </btn>
-                <template slot="dropdown">
-                  <li @click="doCopyNotification(notif)">
-                    <a role="button">
-                      {{$t('Duplicate...')}}
-                    </a>
-                  </li>
-                  <li role="separator" class="divider"></li>
-                  <li @click="doDeleteNotification(notif)">
-                    <a role="button">
-                      {{$t('Delete')}}
-                    </a>
-                  </li>
-                </template>
-              </dropdown>
-              <btn type="secondary" size="sm" @click="doEditNotification(notif)">Edit</btn>
+              <div>
+                <dropdown ref="dropdown" menu-right>
+                  <btn type="simple" class=" btn-hover  btn-secondary dropdown-toggle">
+                    <span class="caret"></span>
+                  </btn>
+                  <template slot="dropdown">
+                    <li @click="doCopyNotification(notif)">
+                      <a role="button">
+                        {{$t('Duplicate...')}}
+                      </a>
+                    </li>
+                    <li role="separator" class="divider"></li>
+                    <li @click="doDeleteNotification(notif)">
+                      <a role="button">
+                        {{$t('Delete')}}
+                      </a>
+                    </li>
+                  </template>
+                </dropdown>
+                <btn type="secondary" size="sm" @click="doEditNotification(notif)">Edit</btn>
+              </div>
             </div>
           </div>
 

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
@@ -61,7 +61,7 @@
                   <span class="caret"></span>
                 </btn>
                 <template slot="dropdown">
-                  <li @click="doDeleteNotification(i)">
+                  <li @click="doDeleteNotification(notif)">
                     <a role="button">
                       {{$t('Delete')}}
                     </a>
@@ -287,8 +287,11 @@ export default {
       this.editError=null
       this.editModal=true
     },
-    async doDeleteNotification(ndx){
-      this.notifications.splice(ndx,1)
+    async doDeleteNotification(notif){
+      let ndx=this.notifications.findIndex(n=>n===notif)
+      if(ndx>=0){
+        this.notifications.splice(ndx,1)
+      }
     },
     async cancelEditNotification(){
       this.editModal=false

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
@@ -10,7 +10,8 @@
       <div v-if="notifications.length < 1" >
         <p class="text-muted">No Notifications are defined. Click an event below to add a Notification for that Trigger.</p>
       </div>
-      <div v-for="(trigger) in notifyTypes" class=" main-section" >
+      <div class="main-section">
+      <div v-for="(trigger) in notifyTypes"  >
           <div  class="list-group" >
             <div class="list-group-item flex-container flex-align-items-baseline flex-justify-space-between">
               <span class="flex-item " :class="{'text-secondary':(!hasNotificationsForTrigger(trigger))}">
@@ -92,7 +93,7 @@
           </div>
 
         </div>
-
+      </div>
     </div>
 
 

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
@@ -63,7 +63,7 @@
                 <template slot="dropdown">
                   <li @click="doCopyNotification(notif)">
                     <a role="button">
-                      {{$t('Copy...')}}
+                      {{$t('Duplicate...')}}
                     </a>
                   </li>
                   <li role="separator" class="divider"></li>

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
@@ -53,23 +53,9 @@
                 </div>
               </div>
             </div>
-            <div v-for="(notif,i) in getNotificationsForTrigger(trigger)" v-if="getNotificationsForTrigger(trigger)" class="list-group-item flex-container">
-              <div   class="flex-item flex-grow-1" style="margin-left: 20px">
-                <plugin-config
-                    serviceName="Notification"
-                    :provider="notif.type"
-                    :config="notif.config"
-                    mode="show"
-                    :show-title="true"
-                    :show-description="true"
-                    :key="'g_'+i+'/'+notif.type+':config'"
-                    scope="Instance"
-                    default-scope="Instance"
-                />
-              </div>
-
-              <div>
-                <dropdown ref="dropdown" menu-right>
+            <div v-for="(notif,i) in getNotificationsForTrigger(trigger)" v-if="getNotificationsForTrigger(trigger)" class="list-group-item flex-container flex-justify-start">
+              <div style="margin-right:10px;">
+                <dropdown ref="dropdown" append-to-body>
                   <btn type="simple" class=" btn-hover  btn-secondary dropdown-toggle">
                     <span class="caret"></span>
                   </btn>
@@ -87,8 +73,24 @@
                     </li>
                   </template>
                 </dropdown>
-                <btn type="secondary" size="sm" @click="doEditNotification(notif)">Edit</btn>
               </div>
+              <div class="flex-item flex-grow-1" >
+
+                <plugin-config
+                    serviceName="Notification"
+                    :provider="notif.type"
+                    :config="notif.config"
+                    mode="show"
+                    :show-title="true"
+                    :show-description="true"
+                    :key="'g_'+i+'/'+notif.type+':config'"
+                    scope="Instance"
+                    default-scope="Instance"
+                />
+              </div>
+
+              <btn type="secondary" size="sm" @click="doEditNotification(notif)">Edit</btn>
+
             </div>
           </div>
 

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
@@ -1,0 +1,418 @@
+<template>
+  <div>
+
+    <div >
+      <div class="form-group form-inline">
+
+        <label class="col-sm-2 control-label">
+          Average Duration {{$t('scheduledExecution.property.notifyAvgDurationThreshold.label')}}
+        </label>
+        <div class="col-sm-10  ">
+            <input type='text'
+                   name="notifyAvgDurationThreshold"
+                   v-model="notifyAvgDurationThreshold"
+                   id="schedJobNotifyAvgDurationThreshold"
+                   class="form-control"
+                   size="40"/>
+            <span class="help-block">{{ $t('scheduledExecution.property.notifyAvgDurationThreshold.description') }}</span>
+        </div>
+
+      </div>
+    </div>
+    <div >
+      <btn @click="addNotification()">Add Notification</btn>
+      <div v-if="notifications.length < 1" style="padding: 50px;">
+        <p class="text-muted">No Notifications</p>
+      </div>
+      <div class="list-group" v-else>
+        <div v-for="(notif,i) in notifications" class="list-group-item flex-container">
+          <div   class="flex-item flex-grow-1">
+            {{$t('notification.event.'+notif.trigger)}}
+            <div v-if="notif.type==='email'">
+
+              <plugin-config
+                  :config="notif.config"
+                  :plugin-config="getBuiltinPluginConfig(notif.type)"
+                  mode="show"
+                  :show-title="true"
+                  :show-description="true"
+                  :key="'g_'+i+'/'+notif.type+':config'"
+                  />
+            </div>
+            <div v-else-if="notif.type==='url'">
+
+              <plugin-config
+                  :config="notif.config"
+                  :plugin-config="getBuiltinPluginConfig(notif.type)"
+                  mode="show"
+                  :show-title="true"
+                  :show-description="true"
+                  :key="'g_'+i+'/'+notif.type+':config'"
+              />
+            </div>
+            <plugin-config
+                serviceName="Notification"
+                :provider="notif.type"
+                :config="notif.config"
+                mode="show"
+                :show-title="true"
+                :show-description="true"
+                :key="'g_'+i+'/'+notif.type+':config'"
+                v-else-if="notif.type"
+            />
+          </div>
+          <btn @click="doEditNotification(i)">Edit</btn>
+          <btn @click="doDeleteNotification(i)" type="danger">Delete</btn>
+        </div>
+
+      </div>
+    </div>
+
+
+
+    <modal v-model="editModal" :title="$t(editIndex<0?'Create Notification':'Edit Notification')" size="lg">
+      <div>
+        <div class="form-group"  >
+          <label class="col-sm-2 control-label  " >
+            Trigger:
+          </label>
+          <div class="col-sm-10">
+
+            <dropdown ref="dropdown">
+              <btn type="simple" class="btn-simple btn-hover  btn-secondary dropdown-toggle">
+                <span class="caret"></span>
+                &nbsp;
+                <span v-if="editNotificationTrigger" class="text-info">
+                  {{ $t('notification.event.' + editNotificationTrigger) }}
+                </span>
+                <span v-else>
+                  Select a Trigger
+                </span>
+              </btn>
+              <template slot="dropdown">
+                <li v-for="trigger in notifyTypes"
+                    @click="editNotificationTrigger=trigger"
+                >
+                  <a role="button">{{ $t('notification.event.' + trigger) }}</a>
+                </li>
+              </template>
+            </dropdown>
+
+          </div>
+
+        </div>
+
+
+        <div v-if="editNotificationTrigger" >
+
+          <div class="form-group">
+            <label class="col-sm-2 control-label  " >
+              Notification Type:
+            </label>
+            <div class="col-sm-10">
+              <dropdown ref="dropdown">
+                <btn type="simple"  class="btn-simple btn-hover  btn-secondary dropdown-toggle">
+                  <span class="caret"></span>
+                  &nbsp;
+                  <span v-if="editNotification.type && getProviderFor(editNotification.type)">
+                    <plugin-info
+                        :detail="getProviderFor(editNotification.type)"
+                        :show-description="false"
+                        :show-extended="false"
+                        description-css="help-block"
+                    >
+                      </plugin-info>
+                  </span>
+                  <span v-else>
+                  Select a Notification
+                  </span>
+                </btn>
+                <template slot="dropdown">
+                  <li v-for="plugin in pluginProviders" :key="plugin.name">
+                    <a role="button" @click="editNotification.type=plugin.name">
+                      <plugin-info
+                          :detail="plugin"
+                          :show-description="true"
+                          :show-extended="false"
+                          description-css="help-block"
+                      >
+                      </plugin-info>
+                    </a>
+                  </li>
+                </template>
+              </dropdown>
+              <div v-if="editNotification.type && getProviderFor(editNotification.type)">
+                    <plugin-info
+                        :detail="getProviderFor(editNotification.type)"
+                        :show-description="true"
+                        :show-extended="false"
+                        :show-title="false"
+                        :show-icon="false"
+                        description-css="help-block"
+                    >
+                      </plugin-info>
+                  </div>
+<!--          <div class="list-group">-->
+<!--            <a-->
+<!--                v-for="plugin in pluginProviders"-->
+<!--                v-bind:key="plugin.name"-->
+<!--                href="#"-->
+<!--                class="list-group-item"-->
+<!--                @click="editNotification.type=plugin.name"-->
+<!--            >-->
+<!--              <plugin-info-->
+<!--                  :detail="plugin"-->
+<!--                  :show-description="true"-->
+<!--                  :show-extended="false"-->
+<!--                  description-css="help-block"-->
+<!--              >-->
+<!--              </plugin-info>-->
+<!--            </a>-->
+<!--          </div>-->
+          </div>
+        </div>
+        </div>
+        <div v-if="editNotification.type==='email'">
+
+          <plugin-config
+
+              :mode="editIndex===-1 ? 'create':'edit'"
+              :plugin-config="getBuiltinPluginConfig(editNotification.type)"
+              v-model="editNotification"
+              :key="'edit_config'+editIndex+'/'+editNotification.type"
+              :show-title="false"
+              :show-description="false"
+              :validation="editValidation"
+          ></plugin-config>
+
+        </div>
+        <div v-else-if="editNotification.type==='url'">
+
+          <plugin-config
+
+              :mode="editIndex===-1 ? 'create':'edit'"
+              :plugin-config="getBuiltinPluginConfig(editNotification.type)"
+              v-model="editNotification"
+              :key="'edit_config'+editIndex+'/'+editNotification.type"
+              :show-title="false"
+              :show-description="false"
+              :validation="editValidation"
+          ></plugin-config>
+        </div>
+        <plugin-config
+
+            :mode="editIndex===-1 ? 'create':'edit'"
+            :serviceName="'Notification'"
+            v-model="editNotification"
+            :key="'edit_config'+editIndex+'/'+editNotification.type"
+            :show-title="false"
+            :show-description="false"
+            :validation="editValidation"
+            v-else-if="editNotification.type"
+        ></plugin-config>
+
+      </div>
+
+      <div slot="footer">
+        <btn @click="cancelEditNotification">Cancel</btn>
+        <btn @click="saveNotification" type="primary">Save</btn>
+      </div>
+    </modal>
+  </div>
+</template>
+<script>
+
+
+import {
+  getRundeckContext,
+  RundeckContext
+} from "@rundeck/ui-trellis"
+
+import Expandable from "@rundeck/ui-trellis/lib/components/utils/Expandable.vue";
+import PluginInfo from "@rundeck/ui-trellis/lib/components/plugins/PluginInfo.vue";
+import PluginConfig from "@rundeck/ui-trellis/lib/components/plugins/pluginConfig.vue";
+import pluginService from "@rundeck/ui-trellis/lib/modules/pluginService";
+import PluginValidation from "@rundeck/ui-trellis/lib/interfaces/PluginValidation";
+
+export default {
+  name: 'NotificationsEditor',
+  props: ['eventBus', 'notificationData'],
+  components: {PluginInfo,PluginConfig},
+  data () {
+    return {
+      project: null,
+      rdBase: null,
+      notifyAvgDurationThreshold:null,
+      pluginProviders: [],
+      pluginLabels: {},
+      notifyTypes:[
+          'onsuccess',
+          'onfailure',
+          'onstart',
+          'onavgduration',
+          'onretryablefailure'
+      ],
+      notifications:[],
+      editNotificationTrigger:null,
+      editNotification:{},
+      editValidation:null,
+      editIndex:-1,
+      editModal:false
+    }
+  },
+  methods:{
+
+    async addNotification(){
+      this.editNotificationTrigger = null
+      this.editNotification={type:null,config:{}}
+      this.editIndex=-1
+      this.editModal=true
+    },
+    async doEditNotification(ndx){
+      this.editIndex=ndx
+      this.editNotificationTrigger=this.notifications[ndx].trigger
+      this.editNotification=this.notifications[ndx]
+      this.editModal=true
+    },
+    async doDeleteNotification(ndx){
+      this.notifications.splice(ndx,1)
+    },
+    async cancelEditNotification(){
+      this.editModal=false
+      this.editIndex=-1
+      this.editNotification={}
+      this.editNotificationTrigger=null
+    },
+    saveNotification(){
+      this.editModal=false
+      if(this.editIndex<0){
+        this.editNotification.trigger=this.editNotificationTrigger
+        this.editIndex=-1
+        this.notifications.push(Object.assign({},this.editNotification))
+        this.editNotification={}
+      }else{
+        this.editNotification.trigger=this.editNotificationTrigger
+        this.notifications[this.editIndex]=Object.assign({},this.editNotification)
+        this.editIndex=-1
+        this.editNotification={}
+      }
+    },
+    getBuiltinPluginConfig(name){
+      return {
+        email:{
+          name:"email",
+          description:'Send an email to multiple recipients, and customize the subject line.',
+          title: 'Send Email',
+          providerMetadata:{
+            faicon:"envelope"
+          },
+          props:[
+            {
+              name:'recipients',
+              desc:this.$t('notification.email.description'),
+              title:this.$t('to'),
+              required:true,
+            },
+            {
+              name:'subject',
+              desc: this.$t('notification.email.subject.description')
+                    + '\n\n[Documentation]('+
+                           (this.$t('notification.email.subject.helpLink'))
+                           +')',
+              title:this.$t('subject'),
+              required:true,
+            },
+            {
+              name:'attachLog',
+              desc: '',
+              title:this.$t('attach.output.log'),
+              type:'Boolean'
+            },
+            {
+              name:'attachType',
+              desc: 'Attach as a file, or inline to the message',
+              title:'Attachment type',
+              type:'Select',
+              defaultValue:'file',
+              allowed:[
+                  'file',
+                  'inline'
+              ],
+              selectLabels:{
+                file:'As a File',
+                inline:'Inline',
+              },
+              renderingOptions:{
+
+              }
+            },
+          ]
+        },
+        url:{
+          description: "Send a HTTP POST request to one ore more URLs.",
+          icon:"email",
+          name:"url",
+          title:"Send Webhook",
+          providerMetadata:{
+            faicon:"globe"
+          },
+          props:[
+            {
+              name:'urls',
+              desc:this.$t('notification.webhook.field.description'),
+              title:this.$t('notification.webhook.field.title'),
+              required:true,
+              options:{
+                displayType:'MULTI_LINE'
+              }
+            },
+            {
+              name:'format',
+              desc:'',
+              title:this.$t('notify.url.format.label'),
+              type:'Select',
+              required:true,
+              allowed:['xml','json'],
+              selectLabels:{
+                xml:this.$t('notify.url.format.xml'),
+                json:this.$t('notify.url.format.json'),
+              }
+            }
+          ]
+        }
+      }[name]
+    },
+
+    getBuiltinProviderDescs(){
+      return [
+        this.getBuiltinPluginConfig('email'),
+        this.getBuiltinPluginConfig('url'),
+      ]
+    },
+    getProviderFor(name){
+      return this.pluginProviders.find(p => p.name === name)
+    }
+  },
+  watch:{
+    notifications(){
+      this.$emit('changed',this.notifications)
+    }
+  },
+  async mounted () {
+    if (window._rundeck && window._rundeck.rdBase && window._rundeck.projectName) {
+      this.rdBase = window._rundeck.rdBase
+      this.project = window._rundeck.projectName
+      this.notifications = [].concat(this.notificationData.notifications || [])
+      this.notifyAvgDurationThreshold = this.notificationData.notifyAvgDurationThreshold
+    }
+    pluginService
+        .getPluginProvidersForService('Notification')
+        .then(data => {
+          if (data.service) {
+            this.pluginProviders = [].concat(this.getBuiltinProviderDescs()).concat(data.descriptions);
+            this.pluginLabels = data.labels;
+          }
+        });
+  }
+}
+</script>

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
@@ -68,7 +68,7 @@
                   </li>
                 </template>
               </dropdown>
-              <btn type="secondary" size="sm" @click="doEditNotification(i)">Edit</btn>
+              <btn type="secondary" size="sm" @click="doEditNotification(notif)">Edit</btn>
             </div>
           </div>
           <div v-else class="list-placeholder">
@@ -279,10 +279,13 @@ export default {
       this.editError=null
       this.editModal=true
     },
-    async doEditNotification(ndx){
-      this.editIndex=ndx
-      this.editNotificationTrigger=this.notifications[ndx].trigger
-      this.editNotification=this.notifications[ndx]
+    async doEditNotification(notif){
+      this.editIndex=this.notifications.findIndex(n=>n===notif)
+      if(this.editIndex<0){
+        return
+      }
+      this.editNotificationTrigger=this.notifications[this.editIndex].trigger
+      this.editNotification=this.notifications[this.editIndex]
       this.editValidation=null
       this.editError=null
       this.editModal=true

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
@@ -10,7 +10,7 @@
       <div v-if="notifications.length < 1" >
         <p class="text-muted">No Notifications are defined. Click an event below to add a Notification for that Trigger.</p>
       </div>
-      <div v-for="(trigger) in notifyTypes" class="md-width-75 main-section" >
+      <div v-for="(trigger) in notifyTypes" class=" main-section" >
           <div  class="list-group" >
             <div class="list-group-item flex-container flex-align-items-baseline flex-justify-space-between">
               <span class="flex-item " :class="{'text-secondary':(!hasNotificationsForTrigger(trigger))}">
@@ -482,11 +482,6 @@ export default {
 }
 .list-placeholder{
   margin-bottom: 20px;
-}
-@media (min-width: 768px) {
-  .md-width-75{
-    max-width: 75%
-  }
 }
 .main-section{
   margin-top: 20px;

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
@@ -36,10 +36,19 @@
                            v-model="notifyAvgDurationThreshold"
                            id="schedJobNotifyAvgDurationThreshold"
                            class="form-control"
+                           :placeholder="$t('jobAverageDurationPlaceholder')"
                            size="40"/>
+                    <span class="input-group-addon btn btn-info btn-md"  id="jobAvgInfoBtn">
+                        <i class="glyphicon glyphicon-question-sign "></i>
+                    </span>
                   </div>
-                  <extended-description :text="$t('scheduledExecution.property.notifyAvgDurationThreshold.description')"
-                                        class="help-block"/>
+
+                  <popover :title="$t('scheduledExecution.property.notifyAvgDurationThreshold.label')" target="#jobAvgInfoBtn">
+                    <template slot="popover">
+                      <markdown-it-vue class="markdown-body" :content="$t('scheduledExecution.property.notifyAvgDurationThreshold.description')"/>
+                    </template>
+                  </popover>
+
                 </div>
               </div>
             </div>

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
@@ -10,15 +10,15 @@
       <div v-if="notifications.length < 1" >
         <p class="text-muted">No Notifications are defined. Click an event below to add a Notification for that Trigger.</p>
       </div>
-      <div v-for="(trigger) in notifyTypes" >
-          <div  class="list-group" v-if="hasNotificationsForTrigger(trigger)">
-            <div class="list-group-item flex-container flex-align-items-baseline flex-justify-start">
+      <div v-for="(trigger) in notifyTypes" class="md-width-75 main-section" >
+          <div  class="list-group" >
+            <div class="list-group-item flex-container flex-align-items-baseline flex-justify-space-between">
               <span class="flex-item " :class="{'text-secondary':(!hasNotificationsForTrigger(trigger))}">
               <i class="fas" :class="triggerIcons[trigger]"></i>
               {{$t('notification.event.'+trigger)}}
               </span>
-              <btn type="simple"
-                   class=" btn-hover  btn-secondary"
+              <btn type="secondary"
+                   class="  flex-item"
                    size="sm" @click="addNotification(trigger)">
                 <i class="fas fa-plus"></i>
                 Add Notification
@@ -80,15 +80,7 @@
               <btn type="secondary" size="sm" @click="doEditNotification(notif)">Edit</btn>
             </div>
           </div>
-          <div v-else class="list-placeholder">
-            <btn type="simple"
-                 class=" btn-hover  btn-secondary"
-                 size="md" @click="addNotification(trigger)">
-              <i class="fas" :class="triggerIcons[trigger]"></i>
-              &nbsp;
-              {{$t('notification.event.'+trigger)}}
-            </btn>
-          </div>
+
         </div>
 
     </div>
@@ -472,7 +464,7 @@ export default {
   }
 }
 </script>
-<style lang="scss">
+<style lang="scss" scoped>
 .list-group-item {
   &.list-group-item-secondary {
     border-width: 0;
@@ -480,5 +472,13 @@ export default {
 }
 .list-placeholder{
   margin-bottom: 20px;
+}
+@media (min-width: 768px) {
+  .md-width-75{
+    max-width: 75%
+  }
+}
+.main-section{
+  margin-top: 20px;
 }
 </style>

--- a/rundeckapp/grails-spa/packages/ui/src/components/util/UndoRedo.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/util/UndoRedo.vue
@@ -1,0 +1,69 @@
+<template>
+  <span>
+    <btn :class="{disabled:!hasUndo}" @click="doUndo" size="xs">
+      <i class="glyphicon glyphicon-step-backward"></i>
+      Undo
+    </btn>
+    <btn :class="{disabled:!hasRedo}" @click="doRedo" size="xs">
+      Redo
+      <i class="glyphicon glyphicon-step-forward"></i>
+    </btn>
+  </span>
+</template>
+<script lang="ts">
+
+import Vue from "vue"
+
+export default Vue.extend({
+  name: "UndoRedo",
+  props: {
+    'eventBus': Vue,
+    'ident': String,
+    'max': Number
+  },
+  data() {
+    return {
+      stack: <any>[],
+      index: 0,
+    }
+  },
+  computed: {
+    hasUndo(): boolean {
+      return this.stack.length > this.index
+    },
+    hasRedo(): boolean {
+      return this.index > 0
+    }
+  },
+  methods: {
+    addChange(val: any) {
+      if (this.index > 0) {
+        this.stack.splice(0, this.index)
+        this.index = 0
+      }
+      this.stack.unshift(val)
+    },
+    doUndo() {
+      if(this.index>=this.stack.length){
+        return
+      }
+      let newindex = this.index + 1
+      let change = this.stack[this.index]
+      this.index = newindex
+      this.eventBus.$emit('undo', change)
+    },
+    doRedo() {
+      if (this.index < 1) {
+        return
+      }
+      let newindex = this.index - 1
+      let change = this.stack[newindex]
+      this.index = newindex
+      this.eventBus.$emit('redo', change)
+    }
+  },
+  mounted() {
+    this.eventBus.$on('change', this.addChange)
+  }
+})
+</script>

--- a/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/App.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/App.vue
@@ -32,6 +32,8 @@ export default {
   methods:{
     changed(data){
       this.updatedData=data
+      //nb: hook to indicate job was editted, defined in jobedit.js
+      window.jobWasEdited()
     }
   },
   async mounted () {

--- a/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/App.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/App.vue
@@ -1,0 +1,51 @@
+<template>
+  <div >
+    <notifications-editor :notification-data="notificationData" :event-bus="eventBus" v-if="notificationData" @changed="changed"/>
+    <json-embed :output-data="updatedData" field-name="jobNotificationsJson"/>
+  </div>
+</template>
+
+<script>
+import NotificationsEditor from '../../../components/job/notifications/NotificationsEditor.vue'
+import JsonEmbed from './JsonEmbed.vue'
+
+import {
+  getRundeckContext,
+  RundeckContext
+} from "@rundeck/ui-trellis"
+
+export default {
+  name: 'App',
+  props:['eventBus' ],
+  components: {
+    NotificationsEditor,
+    JsonEmbed
+  },
+  data () {
+    return {
+      project: null,
+      rdBase: null,
+      notificationData: null,
+      updatedData:null
+    }
+  },
+  methods:{
+    changed(data){
+      this.updatedData=data
+    }
+  },
+  async mounted () {
+    if (window._rundeck && window._rundeck.rdBase && window._rundeck.projectName) {
+      this.rdBase = window._rundeck.rdBase
+      this.project = window._rundeck.projectName
+      if(window._rundeck && window._rundeck.data){
+        this.notificationData = window._rundeck.data.notificationData
+        this.updatedData=this.notificationData
+      }
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/JsonEmbed.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/JsonEmbed.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <input type="hidden" v-model="json" :name="fieldName"/>
-    <pre><code>{{json}}</code></pre>
   </div>
 </template>
 <script>

--- a/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/JsonEmbed.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/JsonEmbed.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <input type="hidden" v-model="json" :name="fieldName"/>
+    <pre><code>{{json}}</code></pre>
+  </div>
+</template>
+<script>
+
+
+export default {
+  name: 'JsonEmbed',
+  props: ['fieldName','outputData'],
+  computed:{
+    json(){
+      return JSON.stringify(this.outputData)
+    }
+  }
+}
+</script>

--- a/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/i18n.js
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/i18n.js
@@ -6,6 +6,7 @@ const translationStrings = {
         Delete: 'Delete',
         Cancel: 'Cancel',
         Revert: 'Revert',
+        jobAverageDurationPlaceholder:'leave blank for Job Average duration',
         uiv: {
             modal: {
                 cancel: "Cancel",

--- a/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/i18n.js
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/i18n.js
@@ -1,0 +1,20 @@
+// Ready translated locale messages
+const translationStrings = {
+    en_US: {
+        Edit: 'Edit',
+        Save: 'Save',
+        Delete: 'Delete',
+        Cancel: 'Cancel',
+        Revert: 'Revert',
+        uiv: {
+            modal: {
+                cancel: "Cancel",
+                ok: "OK"
+            }
+        }
+    }
+}
+
+module.exports = {
+    messages: translationStrings
+}

--- a/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/main.js
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/main.js
@@ -5,7 +5,7 @@ import Vue2Filters from 'vue2-filters'
 import VueCookies from 'vue-cookies'
 import App from './App'
 import * as uiv from 'uiv'
-import international from '../../project-activity/i18n'
+import international from './i18n'
 import VueI18n from 'vue-i18n'
 import moment from 'moment'
 import {

--- a/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/main.js
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/main.js
@@ -1,0 +1,63 @@
+// The Vue build version to load with the `import` command
+// (runtime-only or standalone) has been set in webpack.base.conf with an alias.
+import Vue from 'vue'
+import Vue2Filters from 'vue2-filters'
+import VueCookies from 'vue-cookies'
+import App from './App'
+import * as uiv from 'uiv'
+import international from '../../project-activity/i18n'
+import VueI18n from 'vue-i18n'
+import moment from 'moment'
+import {
+    EventBus
+} from '@rundeck/ui-trellis/lib/utilities/vueEventBus'
+import uivLang from '@rundeck/ui-trellis/lib/utilities/uivi18n'
+
+Vue.config.productionTip = false
+
+Vue.use(uiv)
+Vue.use(VueI18n)
+Vue.use(Vue2Filters)
+Vue.use(VueCookies)
+
+let messages = international.messages
+let locale = window._rundeck.locale || 'en_US'
+let lang = window._rundeck.language || 'en'
+moment.locale(locale)
+
+// include any i18n injected in the page by the app
+messages =
+    {
+        [locale]: Object.assign(
+            {},
+            uivLang[locale] || uivLang[lang] || {},
+            window.Messages,
+            messages[locale] || messages[lang] || messages['en_US'] || {}
+        )
+    }
+const els = document.body.getElementsByClassName('job-editor-vue')
+
+for (var i = 0; i < els.length; i++) {
+    const e = els[i]
+
+    // Create VueI18n instance with options
+    const i18n = new VueI18n({
+        silentTranslationWarn: true,
+        locale: locale, // set locale
+        messages // set locale messages,
+
+    })
+    /* eslint-disable no-new */
+    new Vue({
+        el: e,
+        data(){
+            return{
+                EventBus,
+            }
+        },
+        components: { App },
+        i18n
+    })
+
+
+}

--- a/rundeckapp/grails-spa/packages/ui/vue.config.js
+++ b/rundeckapp/grails-spa/packages/ui/vue.config.js
@@ -19,7 +19,8 @@ module.exports = {
     'pages/execution-show': { entry: './src/pages/execution-show/main.js'},
     'pages/webhooks': { entry: './src/pages/webhooks/main.js'},
     'pages/user-summary': {entry: './src/pages/menu/main.js'},
-    'pages/dynamic-form': {entry: './src/pages/dynamic-form/main.js'}
+    'pages/dynamic-form': {entry: './src/pages/dynamic-form/main.js'},
+    'pages/job/editor': {entry: './src/pages/job/editor/main.js'},
 
   },
 

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
@@ -275,6 +275,17 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
         return validatePluginByName(name, service, resolver, PropertyScope.InstanceOnly)
     }
     /**
+     * Validate a provider for a service with an instance configuration
+     * @param name name of bean or provider
+     * @param service provider service
+     * @param instanceConfiguration config map
+     * @return Map containing valid:true/false, and report: {@link Validator.Report}
+     */
+    ValidatedPlugin validatePluginByName(String name, PluggableProviderService service, Map instanceConfiguration, PropertyScope ignoredScope) {
+        final PropertyResolver resolver = PropertyResolverFactory.createInstanceResolver(instanceConfiguration);
+        return validatePluginByName(name, service, resolver, PropertyScope.InstanceOnly, ignoredScope)
+    }
+    /**
      * Validate a provider for a service using a property resolver and a
      * default property scope
      * @param name name of bean or provider

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/notification/DummyEmailNotificationPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/notification/DummyEmailNotificationPlugin.groovy
@@ -1,0 +1,92 @@
+package com.dtolabs.rundeck.server.plugins.notification
+
+import com.dtolabs.rundeck.core.plugins.Plugin
+import com.dtolabs.rundeck.core.plugins.configuration.PropertyValidator
+import com.dtolabs.rundeck.core.plugins.configuration.ValidationException
+import com.dtolabs.rundeck.plugins.ServiceNameConstants
+import com.dtolabs.rundeck.plugins.descriptions.PluginDescription
+import com.dtolabs.rundeck.plugins.descriptions.PluginMetadata
+import com.dtolabs.rundeck.plugins.descriptions.PluginProperty
+import com.dtolabs.rundeck.plugins.descriptions.SelectLabels
+import com.dtolabs.rundeck.plugins.descriptions.SelectValues
+import com.dtolabs.rundeck.plugins.notification.NotificationPlugin
+import rundeck.services.AnyDomainEmailValidator
+
+
+/**
+ * Provides descriptor of the built-in Email notification functionality. Current implementation
+ * lives in NotificationServicee
+ */
+@Plugin(name = 'email', service = ServiceNameConstants.Notification)
+@PluginDescription(title = 'Send Email',
+    description = '''Send an email to multiple recipients, and customize the subject line.''')
+@PluginMetadata(key = 'faicon', value = 'envelope')
+class DummyEmailNotificationPlugin implements NotificationPlugin {
+    @PluginProperty(
+        title = 'To',
+        description = '''comma-separated email addresses. You can substitute these variables: ${job.user.name}, ${job.user.email}''',
+        required = true,validatorClass = EmailValidator)
+
+    String recipients
+    static class EmailValidator implements PropertyValidator{
+        @Override
+        boolean isValid(final String value) throws ValidationException {
+            def arr = value?.split(",")
+            boolean failed=false
+            def validator = new AnyDomainEmailValidator()
+            def validcount=0
+            def errs=[]
+            arr?.each { email ->
+                if(email && email.indexOf('${')>=0){
+                    //don't reject embedded prop refs
+                    validcount++
+                }else if (email && !validator.isValid(email)) {
+                    failed = true
+                    errs << "Invalid email address: ${email}"
+                }else if(email){
+                    validcount++
+                }
+            }
+            if(errs){
+                throw new ValidationException(errs.join(', '))
+            }
+            if(validcount<1){
+                throw new ValidationException('Cannot be blank')
+            }
+            return true
+        }
+    }
+
+    @PluginProperty(
+        title = "Subject",
+        description = '''Template for the email subject. Can contain property references: ${group.key}
+
+See [Documentation](https://docs.rundeck.com/docs/administration/configuration/email-settings.html#custom-email-templates)''',
+        required = true
+    )
+    String subject
+    @PluginProperty(
+        title = 'Include log output',
+        description = 'Note: Log output can only be included for success or failure triggers.'
+    )
+    Boolean attachLog
+
+    @PluginProperty(
+        title = 'Attachment type',
+        defaultValue = 'file'
+    )
+    @SelectValues(values = [
+        'file',
+        'inline'
+    ])
+    @SelectLabels(values = [
+        'Attached as file to email',
+        'Inline to email'
+    ])
+    String attachType
+
+    @Override
+    boolean postNotification(final String trigger, final Map executionData, final Map config) {
+        throw new UnsupportedOperationException("Dummy plugin implementation")
+    }
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/notification/DummyWebhookNotificationPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/notification/DummyWebhookNotificationPlugin.groovy
@@ -1,0 +1,87 @@
+package com.dtolabs.rundeck.server.plugins.notification
+
+import com.dtolabs.rundeck.core.plugins.Plugin
+import com.dtolabs.rundeck.core.plugins.configuration.PropertyValidator
+import com.dtolabs.rundeck.core.plugins.configuration.ValidationException
+import com.dtolabs.rundeck.plugins.ServiceNameConstants
+import com.dtolabs.rundeck.plugins.descriptions.PluginDescription
+import com.dtolabs.rundeck.plugins.descriptions.PluginMetadata
+import com.dtolabs.rundeck.plugins.descriptions.PluginProperty
+import com.dtolabs.rundeck.plugins.descriptions.RenderingOption
+import com.dtolabs.rundeck.plugins.descriptions.SelectLabels
+import com.dtolabs.rundeck.plugins.descriptions.SelectValues
+import com.dtolabs.rundeck.plugins.notification.NotificationPlugin
+
+
+/**
+ * Dummy Webhook notification provider, implementation lives in NotificationService
+ */
+@Plugin(name = 'url', service = ServiceNameConstants.Notification)
+@PluginDescription(title = 'Send Webhook',
+    description = '''Send a HTTP POST request to one ore more URLs.''')
+@PluginMetadata(key = 'faicon', value = 'globe')
+class DummyWebhookNotificationPlugin implements NotificationPlugin {
+    @PluginProperty(
+        title = "URL(s)",
+        description = "Enter comma-separated URLs",
+        required = true,
+        validatorClass =
+        WebhookUrlValidator
+    )
+    @RenderingOption(key = 'displayType', value = 'MULTI_LINE')
+    String urls
+
+    static class WebhookUrlValidator implements PropertyValidator{
+        @Override
+        boolean isValid(final String value) throws ValidationException {
+            def arr = value?.split(",")
+            def validCount=0
+            def errs=[]
+            arr?.each { String url ->
+                boolean valid = false
+                try {
+                    def newurl=new URL(url)
+                    valid=true
+//                    if(newurl.protocol in ['http','https']){
+//                        valid = !!newurl.host
+//                    }else{
+//                        valid=true
+//                    }
+                } catch (MalformedURLException e) {
+                    valid = false
+                }
+                if (url && !valid) {
+                    errs<< "Invalid URL: ${url}"
+                }else if(url && valid){
+                    validCount++
+                }
+            }
+            if(errs){
+                throw new ValidationException(
+                    errs.join(', ')
+                )
+            }
+            if(validCount<1){
+                throw new ValidationException(
+                    'Webhook URL cannot be blank'
+                )
+            }
+            return true
+        }
+    }
+
+    @PluginProperty(
+        title = "Payload Format",
+        description = "",
+        required = true,
+        defaultValue = 'xml'
+    )
+    @SelectValues(values = ['xml','json'])
+    @SelectLabels(values = ['XML','JSON'])
+    String format
+
+    @Override
+    boolean postNotification(final String trigger, final Map executionData, final Map config) {
+        throw new UnsupportedOperationException("Dummy plugin implementation")
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/NotificationSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/NotificationSpec.groovy
@@ -1,0 +1,136 @@
+package rundeck
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class NotificationSpec extends Specification {
+    @Unroll
+    def "toNormalizedMap email"() {
+        given:
+            Notification n = new Notification(data)
+        when:
+            def result = n.toNormalizedMap()
+        then:
+            result == expected
+        where:
+            data | expected
+            [eventTrigger: 'onsuccess', type: 'email', configuration: [
+                recipients     : 'asdf',
+                subject        : 'subj1',
+                attachLog      : true,
+                attachLogInline: true
+            ]]   | [type: 'email', trigger: 'onsuccess', config: [recipients: 'asdf', subject: 'subj1', attachLog:
+                true, attachType                                            : 'inline']]
+            [eventTrigger: 'onfailure', type: 'email', configuration: [
+                recipients     : 'asdf',
+                subject        : 'subj1',
+                attachLog      : true,
+                attachLogInFile: true
+            ]]   | [type: 'email', trigger: 'onfailure', config: [recipients: 'asdf', subject: 'subj1', attachLog:
+                true, attachType                                            : 'file']]
+            [eventTrigger: 'onretryablefailure', type: 'email', configuration: [
+                recipients     : 'asdf',
+                subject        : 'subj1',
+                attachLog      : false,
+                attachLogInFile: true
+            ]]   | [type: 'email', trigger: 'onretryablefailure', config: [recipients: 'asdf', subject: 'subj1',
+                                                                           attachLog : false]]
+    }
+
+    @Unroll
+    def "fromNormalizedMap email"() {
+        given:
+            def type = 'email'
+            def data = [
+                type   : type,
+                trigger: trigger,
+                config : config
+            ]
+        when:
+            def result = Notification.fromNormalizedMap(data)
+        then:
+            result.eventTrigger == trigger
+            result.type == type
+            result.configuration == expect
+        where:
+            trigger     | config | expect
+            'onsuccess' | [recipients: 'recip1',subject: 'subj1',attachLog:true,attachType:'inline'] | [recipients: 'recip1',subject: 'subj1',attachLog: true,attachLogInline: true]
+            'onsuccess' | [recipients: 'recip1',subject: 'subj1',attachLog:true,attachType:'file'] | [recipients: 'recip1',subject: 'subj1',attachLog: true,attachLogInFile: true]
+            'onsuccess' | [recipients: 'recip1',subject: 'subj1',attachLog:false] | [recipients: 'recip1',subject: 'subj1',attachLog: false]
+    }
+
+    @Unroll
+    def "toNormalizedMap webhook"() {
+        given:
+            Notification n = new Notification(data)
+        when:
+            def result = n.toNormalizedMap()
+        then:
+            result == expected
+        where:
+            data                                                                      | expected
+            [eventTrigger: 'onsuccess', type: 'url', content: 'asdf', format: 'xml']  | [type: 'url', trigger:
+                'onsuccess', config                                                          : [urls: 'asdf', format:
+                'xml']]
+            [eventTrigger: 'onsuccess', type: 'url', content: 'asdf', format: 'json'] | [type: 'url', trigger:
+                'onsuccess', config                                                          : [urls: 'asdf', format:
+                'json']]
+    }
+
+    @Unroll
+    def "fromNormalizedMap webhook"() {
+        given:
+            def type = 'url'
+            def data = [
+                type   : type,
+                trigger: trigger,
+                config : config
+            ]
+        when:
+            def result = Notification.fromNormalizedMap(data)
+        then:
+            result.eventTrigger == trigger
+            result.type == type
+            result.content == expect
+            result.format == expectformat
+        where:
+            trigger     | config                        | expect | expectformat
+            'onsuccess' | [urls: 'blah', format: 'xml'] | 'blah' | 'xml'
+            'onsuccess' | [urls: 'blah', format: 'json'] | 'blah' | 'json'
+
+    }
+    @Unroll
+    def "toNormalizedMap plugin"() {
+        given:
+            Notification n = new Notification(data)
+        when:
+            def result = n.toNormalizedMap()
+        then:
+            result == expected
+        where:
+            data                                                                              | expected
+            [eventTrigger: 'onsuccess', type: 'aplugin', configuration: [something: 'vague']] |
+            [type: 'aplugin', trigger: 'onsuccess', config: [something: 'vague']]
+    }
+    @Unroll
+    def "fromNormalizedMap plugin"() {
+        given:
+            def type = 'aplugin'
+            def data = [
+                type   : type,
+                trigger: trigger,
+                config : config
+            ]
+        when:
+            def result = Notification.fromNormalizedMap(data)
+        then:
+            result.eventTrigger == trigger
+            result.type == type
+            result.configuration == expect
+        where:
+            trigger     | config       | expect
+            'onsuccess' | [abc: 'xyz'] | [abc: 'xyz']
+            'onfailure' | [zyx: 123]   | [zyx: 123]
+
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/controllers/PluginControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/PluginControllerSpec.groovy
@@ -61,6 +61,30 @@ class PluginControllerSpec extends Specification implements ControllerUnitTest<P
             '{"config":{}}' | [:]
             TEST_JSON1      | [actions: [[type: 'testaction1', config: [actions: [stringvalue: 'asdf']]]]]
     }
+    void "pluginPropertiesValidateAjax missing plugin"() {
+        given:
+            request.content = json.bytes
+            request.contentType = 'application/json'
+            request.method = 'POST'
+            request.addHeader('x-rundeck-ajax', 'true')
+            def service = 'AService'
+            def name = 'someproperty'
+            params.service = service
+            params.name = name
+            controller.pluginService = Mock(PluginService)
+        when:
+            def result = controller.pluginPropertiesValidateAjax( service, name)
+        then:
+            1 * controller.pluginService.validatePluginConfig(service, name, expected/*, project*/) >> null
+            0 * controller.pluginService._(*_)
+            response.status == 404
+            response.json != null
+            response.json.valid == false
+        where:
+            json            | expected
+            '{"config":{}}' | [:]
+            TEST_JSON1      | [actions: [[type: 'testaction1', config: [actions: [stringvalue: 'asdf']]]]]
+    }
 
     void "plugin detail"() {
         given:

--- a/rundeckapp/src/test/groovy/rundeck/controllers/PluginControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/PluginControllerSpec.groovy
@@ -3,6 +3,7 @@ package rundeck.controllers
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.plugins.PluginMetadata
+import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
 import com.dtolabs.rundeck.plugins.rundeck.UIPlugin
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import com.dtolabs.rundeck.server.plugins.services.UIPluginProviderService
@@ -50,7 +51,7 @@ class PluginControllerSpec extends Specification implements ControllerUnitTest<P
         when:
             def result = controller.pluginPropertiesValidateAjax( service, name)
         then:
-            1 * controller.pluginService.validatePluginConfig(service, name, expected/*, project*/) >>
+            1 * controller.pluginService.validatePluginConfig(service, name, expected, null) >>
             new ValidatedPlugin(valid: true, report: Validator.buildReport().build())
             0 * controller.pluginService._(*_)
             response.status == 200
@@ -60,6 +61,57 @@ class PluginControllerSpec extends Specification implements ControllerUnitTest<P
             json            | expected
             '{"config":{}}' | [:]
             TEST_JSON1      | [actions: [[type: 'testaction1', config: [actions: [stringvalue: 'asdf']]]]]
+    }
+    void "validate ignored scope"() {
+        given:
+            request.content = json.bytes
+            request.contentType = 'application/json'
+            request.method = 'POST'
+            request.addHeader('x-rundeck-ajax', 'true')
+            def service = 'AService'
+            def name = 'someproperty'
+            params.service = service
+            params.name = name
+            params.ignoredScope=scopeText
+            controller.pluginService = Mock(PluginService)
+        when:
+            def result = controller.pluginPropertiesValidateAjax( service, name)
+        then:
+            1 * controller.pluginService.validatePluginConfig(service, name, _,expectScope) >>
+            new ValidatedPlugin(valid: true, report: Validator.buildReport().build())
+            0 * controller.pluginService._(*_)
+            response.status == 200
+        where:
+            json       | scopeText   | expectScope
+            TEST_JSON1 | null        | null
+            TEST_JSON1 | 'Instance'  | PropertyScope.Instance
+            TEST_JSON1 | 'Project'   | PropertyScope.Project
+            TEST_JSON1 | 'Framework' | PropertyScope.Framework
+    }
+    void "validate ignored scope invalid"() {
+        given:
+            request.content = json.bytes
+            request.contentType = 'application/json'
+            request.method = 'POST'
+            request.addHeader('x-rundeck-ajax', 'true')
+            def service = 'AService'
+            def name = 'someproperty'
+            params.service = service
+            params.name = name
+            params.ignoredScope=scopeText
+            controller.pluginService = Mock(PluginService)
+        when:
+            def result = controller.pluginPropertiesValidateAjax( service, name)
+        then:
+            0 * controller.pluginService._(*_)
+            response.status == 400
+            response.json!=null
+            response.json.error=='request.error.invalidrequest.message'
+
+        where:
+            json       | scopeText
+            TEST_JSON1 | 'wrong'
+            TEST_JSON1 | 'other'
     }
     void "pluginPropertiesValidateAjax missing plugin"() {
         given:
@@ -75,7 +127,7 @@ class PluginControllerSpec extends Specification implements ControllerUnitTest<P
         when:
             def result = controller.pluginPropertiesValidateAjax( service, name)
         then:
-            1 * controller.pluginService.validatePluginConfig(service, name, expected/*, project*/) >> null
+            1 * controller.pluginService.validatePluginConfig(service, name, expected, null) >> null
             0 * controller.pluginService._(*_)
             response.status == 404
             response.json != null
@@ -344,7 +396,7 @@ class PluginControllerSpec extends Specification implements ControllerUnitTest<P
             response.status == 200
 
             response.contentType.startsWith 'application/json'
-            
+
             1 * controller.uiPluginService.getUiPluginProviderService() >> uiPluginProviderService
             1 * controller.uiPluginService.getPluginMessage('UI', 'test1', 'plugin.title', _, _) >> 'ptitle'
             1 * controller.uiPluginService.getPluginMessage('UI', 'test1', 'plugin.description', _, _) >>

--- a/rundeckapp/src/test/groovy/rundeck/services/PluginServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/PluginServiceTests.groovy
@@ -93,6 +93,7 @@ class PluginServiceTests extends Specification {
         boolean validateWithResolverCalled
         boolean validateWithResolverIgnoredCalled
         boolean validateWithMapCalled
+        boolean validateWithMapAndIgnoredCalled
         boolean validateWithFrameworkCalled
         boolean listPluginDescriptorsCalled
         boolean listPluginsCalled
@@ -192,6 +193,17 @@ class PluginServiceTests extends Specification {
         @Override
         ValidatedPlugin validatePluginByName(String name, PluggableProviderService service, Map instanceConfiguration) {
             validateWithMapCalled=true
+            return pluginValidation
+        }
+
+        @Override
+        ValidatedPlugin validatePluginByName(
+            final String name,
+            final PluggableProviderService service,
+            final Map instanceConfiguration,
+            final PropertyScope ignoredScope
+        ) {
+            validateWithMapAndIgnoredCalled=true
             return pluginValidation
         }
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -4658,6 +4658,22 @@ class ScheduledExecutionServiceSpec extends HibernateSpec implements ServiceUnit
             job.notifications[0].configuration==[blah:'blee',bloo:123]
     }
 
+    def "job definition notifications from jobNotificationsJson allow multiple with same trigger and type"() {
+        given:
+            def job = new ScheduledExecution(notifications:[
+                new Notification(eventTrigger: 'onfailure',type:'aplugin',configuration:[bloop:'blep'])
+            ])
+            def json='[{"type":"aplugin","trigger":"onsuccess","config":{"blah":"blee","bloo":123}},' +
+                     '{"type":"aplugin","trigger":"onsuccess","config":{"blem":"blee","beef":456}}]'
+            def params = [jobNotificationsJson: json]
+            def auth = Mock(UserAndRolesAuthContext)
+        when:
+            service.jobDefinitionNotifications(job, null, params, auth)
+        then:
+            job.notifications.size() == 2
+            job.notifications.find{it.configuration==[blah:'blee',bloo:123]}!=null
+            job.notifications.find{it.configuration==[blem:'blee',beef:456]}!=null
+    }
     def "scm create jobs using scm_create without permission"(){
         given:
         setupDoUpdate()


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Replace old form field mechanism with Vue components.

**Describe the solution you've implemented**

* Vue UI to edit notifications
* existing notification data is passed as json to the Vue (edit existing job)
* Notification data is stored as json in a single form field
* json data is inflated when constructing job definition
* Adds two "dummy" plugins for the email/webhooks builtin notification types, allowing normal plugin UI generation to be driven by them
  * the email/webhook notification implementation still happens through the builtin code (todo: move this to plugins themselves)
* added undo/redo feature

**Additional context**

Old form based method was very old, and hit a Jetty limit of 1000 form fields(!) in some recent enterprise tests.

Enable new Vue method using feature flag `rundeck.feature.notificationsEditorVue.enabled=true`

**Todos**

- [ ] Refine UI design
- [x] Fix issue in Vue code: Ace editor not loading correctly for display/editing of plugin config properties
- [ ] remove old form-based code completely (gsp views, backend parsing/validation)