### PR TITLE
dynamic properties are not loaded when on form validation error

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
@@ -506,7 +506,7 @@ class WorkflowController extends ControllerBase {
             log.error(result.error)
             item=result.item
 
-            def itemDescription = null
+            def itemDescription
             def dynamicProperties
             if(item && item.instanceOf(PluginStep)){
                 itemDescription = getPluginStepDescription(item.nodeStep, item.type)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
@@ -505,7 +505,16 @@ class WorkflowController extends ControllerBase {
         if (result.error) {
             log.error(result.error)
             item=result.item
-            def itemDescription = item.instanceOf(PluginStep) ? getPluginStepDescription(item.nodeStep, item.type) : null
+
+            def itemDescription = null
+            def dynamicProperties
+            if(item && item.instanceOf(PluginStep)){
+                itemDescription = getPluginStepDescription(item.nodeStep, item.type)
+                dynamicProperties = getDynamicProperties(params.project,
+                        item.type,
+                        item.nodeStep,
+                        rundeckAuthorizedServicesProvider.getServicesWith(auth))
+            }
 
             def newitemtype = params['newitemtype']
             def origitemtype = params['origitemtype']
@@ -514,6 +523,7 @@ class WorkflowController extends ControllerBase {
                     template: "/execution/wfitemEdit",
                     model: [
                             item                : result.item,
+                            dynamicProperties   : dynamicProperties,
                             key                 : params.key,
                             num                 : params.num,
                             scheduledExecutionId: params.scheduledExecutionId,


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
bugfix:
When you save a step plugin with errors, and the plugin uses dynamic properties, the dynamic properties are not loaded on the form.

**Describe the solution you've implemented**
Call dynamic properties when the validation form returns an error

**Describe alternatives you've considered**

**Additional context**
