### PR TITLE
ImportOptios flag is not importing correctly when upload a job definition #6442

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/JobExec.groovy
@@ -242,7 +242,12 @@ public class JobExec extends WorkflowStep implements IWorkflowJobItem{
             if (map.jobref.importOptions in ['true', true]) {
                 exec.importOptions = true
             }
+        } else if(map.importOptions) {
+            if (map.importOptions in ['true', true]) {
+                exec.importOptions = true
+            }
         }
+
         if(map.jobref.ignoreNotifications){
             if (map.jobref.ignoreNotifications in ['true', true]) {
                 exec.ignoreNotifications = true

--- a/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
@@ -291,7 +291,7 @@ class JobExecSpec extends HibernateSpec {
         def result = JobExec.jobExecFromMap(map)
 
         then:
-        result.importOptions == importOption
+        result.importOptions == (importOption?.equals('true')?:null)
 
         where:
         importOption    | _

--- a/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
@@ -273,6 +273,34 @@ class JobExecSpec extends HibernateSpec {
 
     }
 
+    def "map with importOptions"() {
+        given:
+        def map = [
+                jobref     : [
+                        group      : 'group',
+                        name       : 'name'
+                ],
+                description: 'a monkey'
+        ]
+
+        if(importOption != null) {
+            map.importOptions = importOption
+        }
+
+        when:
+        def result = JobExec.jobExecFromMap(map)
+
+        then:
+        result.importOptions == importOption
+
+        where:
+        importOption    | _
+        'true'          | _
+        'false'         | _
+        null            | _
+
+    }
+
     static uuid1 = UUID.randomUUID().toString()
     static uuid2 = UUID.randomUUID().toString()
     static uuid3 = UUID.randomUUID().toString()


### PR DESCRIPTION
Fix https://github.com/rundeck/rundeck/issues/6442

**Is this a bug fix, or an enhancement? Please describe.**
When the user imports a job definition with the "_importOptions_" flag set to "_true_", Rundeck fails to save it on the database.

**Describe the solution you've implemented**
Fixed the job importing logic by adding an added an alternative block to the code that obtains  "_importOptions_" from “_commands_” when there are no options on “_jobref_”