### PR TITLE
Node Executor or File Copier Plugin are missing #6436

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -2089,6 +2089,19 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         final nodeConfig = frameworkService.getNodeExecConfigurationForType(defaultNodeExec, project)
         final filecopyConfig = frameworkService.getFileCopyConfigurationForType(defaultFileCopy, project)
 
+        def errors = []
+
+        if(defaultNodeExec !=null && (nodeConfig == null || nodeConfig.size() == 0)) {
+            errors << message(code: "domain.project.edit.plugin.missing.message", args: ['Node Executor', defaultNodeExec])
+        }
+
+        if(defaultFileCopy != null && (filecopyConfig == null || filecopyConfig.size() == 0)) {
+            errors << message(code: "domain.project.edit.plugin.missing.message", args: ['File Copier', defaultFileCopy])
+        }
+
+        if(errors?.size() > 0) {
+            request.errors = errors
+        }
 
         // Reset Password Fields in Session
         execPasswordFieldsService.reset()

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -487,6 +487,7 @@ framework.service.TourLoader.label.plural=Tour Loader Plugins
 framework.service.TourLoader.description=Create tours that guide users through the user interface.
 domain.Project.edit.NodeExecutor.explanation=The Node Executor is responsible for executing commands and scripts on remote nodes.
 domain.Project.edit.FileCopier.explanation=The File Copier is responsible for copying scripts as files to remote nodes before they are executed.
+domain.project.edit.plugin.missing.message= {0} configuration was invalid: Invalid provider type: {1}, not found
 framework.service.error.missing-provider=Provider not found: {0}
 message.none.set=None set
 domain.Project.field.resourcesUrl=Resource Model Source URL

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -473,6 +473,7 @@ framework.service.StorageConverter.label.plural=Plugins de Convertidor de Almace
 framework.service.StorageConverter.description=Convierte y Codifica los datos de Almacenamiento
 domain.Project.edit.NodeExecutor.explanation=El Ejecutador de Nodo es responsable de ejecutar los comandos y scripts en los nodos remotos..
 domain.Project.edit.FileCopier.explanation=La Copiadora de Archivos es responsable de la copia de los scripts como archivos a nodos remotos antes de ser ejecutados.
+domain.project.edit.plugin.missing.message=la configuración de {0} no es válida: tipo de proveedor no válido: {1}, no encontrado
 framework.service.error.missing-provider=Proveedor no encontrado: {0}
 message.none.set=Ninguno establecido
 domain.Project.field.resourcesUrl=URL de Recursos Modelo Fuente

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerTest.groovy
@@ -969,4 +969,105 @@ class FrameworkControllerTest extends HibernateSpec implements ControllerUnitTes
         assertEquals(label,model["projectLabel"])
 
     }
+
+    public void editProjectNodeExecutorPluginNotFound() {
+        given:
+        def label = "Label for project"
+        def fwk = new MockFor(FrameworkService, true)
+
+        fwk.demand.getAuthContextForSubject { subject -> return null}
+        fwk.demand.authResourceForProject {project -> return null}
+        fwk.demand.authorizeApplicationResourceAny {ctx, e, actions -> true }
+
+        def proj = new MockFor(IRundeckProject)
+        proj.demand.getProjectProperties(1..8){-> ["project.label":label]}
+
+        fwk.demand.getFrameworkProject { name-> proj.proxyInstance() }
+        fwk.demand.listDescriptions { -> [[withPasswordFieldDescription], null, null] }
+
+        fwk.demand.getDefaultNodeExecutorService { prj -> "TestPluginsNodeExecutor" }
+        fwk.demand.getDefaultFileCopyService { prj -> "WinRMcpPython" }
+
+        fwk.demand.getNodeExecConfigurationForType { nodeExec,prj -> null }
+        fwk.demand.getFileCopyConfigurationForType { fcpy,prj -> "WinRMcpPython" }
+        fwk.demand.loadProjectConfigurableInput {prefix,props -> [:] }
+
+        controller.frameworkService = fwk.proxyInstance()
+
+        def execPFmck = new MockFor(PasswordFieldsService,true)
+        def fcopyPFmck = new MockFor(PasswordFieldsService,true)
+
+        execPFmck.demand.reset{ -> return null}
+        execPFmck.demand.track{a, b -> return null}
+        fcopyPFmck.demand.reset{ -> return null}
+        fcopyPFmck.demand.track{a, b -> return null}
+
+        controller.execPasswordFieldsService = execPFmck.proxyInstance()
+        controller.fcopyPasswordFieldsService = fcopyPFmck.proxyInstance()
+
+        def passwordFieldsService = new PasswordFieldsService()
+        passwordFieldsService.fields.put("dummy", "stuff")
+
+        controller.resourcesPasswordFieldsService = passwordFieldsService
+
+        params.project = "edit_test_project"
+
+        when:
+        def model = controller.editProject()
+
+        then:
+        assertNotNull(request.errors)
+
+    }
+
+    public void editProjectFileCopyPluginNotFound() {
+        given:
+        def label = "Label for project"
+        def fwk = new MockFor(FrameworkService, true)
+
+        fwk.demand.getAuthContextForSubject { subject -> return null}
+        fwk.demand.authResourceForProject {project -> return null}
+        fwk.demand.authorizeApplicationResourceAny {ctx, e, actions -> true }
+
+        def proj = new MockFor(IRundeckProject)
+        proj.demand.getProjectProperties(1..8){-> ["project.label":label]}
+
+        fwk.demand.getFrameworkProject { name-> proj.proxyInstance() }
+        fwk.demand.listDescriptions { -> [[withPasswordFieldDescription], null, null] }
+
+        fwk.demand.getDefaultNodeExecutorService { prj -> "ssh-exec" }
+        fwk.demand.getDefaultFileCopyService { prj -> "TestPluginsFileCopy" }
+
+        fwk.demand.getNodeExecConfigurationForType { nodeExec,prj -> "ssh-exec" }
+        fwk.demand.getFileCopyConfigurationForType { fcpy,prj -> null }
+        fwk.demand.loadProjectConfigurableInput {prefix,props -> [:] }
+
+        controller.frameworkService = fwk.proxyInstance()
+
+        def execPFmck = new MockFor(PasswordFieldsService,true)
+        def fcopyPFmck = new MockFor(PasswordFieldsService,true)
+
+        execPFmck.demand.reset{ -> return null}
+        execPFmck.demand.track{a, b -> return null}
+        fcopyPFmck.demand.reset{ -> return null}
+        fcopyPFmck.demand.track{a, b -> return null}
+
+        controller.execPasswordFieldsService = execPFmck.proxyInstance()
+        controller.fcopyPasswordFieldsService = fcopyPFmck.proxyInstance()
+
+        def passwordFieldsService = new PasswordFieldsService()
+        passwordFieldsService.fields.put("dummy", "stuff")
+
+        controller.resourcesPasswordFieldsService = passwordFieldsService
+
+        params.project = "edit_test_project"
+
+        when:
+        def model = controller.editProject()
+
+        then:
+        assertNotNull(request.errors)
+
+    }
+
 }


### PR DESCRIPTION
Fix https://github.com/rundeck/rundeck/issues/6436

**Is this a bug fix, or an enhancement? Please describe.**
If a node executor or file copier plugin are missing, the project's "Default Node Executor" or "Default File Copier" section will appear empty. 
This error is generated when importing a project that has a node executor or file copier plugins selected from a cluster to another cluster that does not have these plugins previously installed

**Describe the solution you've implemented**
Validation messages are added so that the user knows that the plugin is not available

![image](https://user-images.githubusercontent.com/35808955/92514909-1af29180-f1e9-11ea-832a-788d16714c71.png)