### PR TITLE
Fix #6449 - Sync command disabled as default and without arguments

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtils.java
@@ -304,10 +304,10 @@ public class DefaultScriptFileNodeStepUtils implements ScriptFileNodeStepUtils {
             }
 
             Map<String, String> nodeAttribute = node.getAttributes();
-            if(!"false".equals(nodeAttribute.get(NODE_ATTR_ENABLE_SYNC_COMMAND))) {
+            if(BooleanUtils.toBoolean(nodeAttribute.get(NODE_ATTR_ENABLE_SYNC_COMMAND))) {
                 //perform sync to prevent the file from being busy when running
                 final NodeExecutorResult nodeExecutorSyncResult = framework.getExecutionService().executeCommand(
-                        context, ExecArgList.fromStrings(false, "sync", filepath), node);
+                        context, ExecArgList.fromStrings(false, "sync"), node);
 
                 if (!nodeExecutorSyncResult.isSuccess()) {
                     return nodeExecutorSyncResult;

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtilsSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtilsSpec.groovy
@@ -105,13 +105,6 @@ class DefaultScriptFileNodeStepUtilsSpec extends Specification {
         }
 
         1 * executionService.executeCommand(context, {
-            (((ExecArgList) it).asFlatStringList()) == ['sync', testRemotePath]
-        }, node
-        ) >> Mock(NodeExecutorResult) {
-            isSuccess() >> true
-        }
-
-        1 * executionService.executeCommand(context, {
             (((ExecArgList) it).asFlatStringList()) == [testRemotePath, 'someargs']
         }, node
         ) >> Mock(NodeExecutorResult) {
@@ -257,18 +250,92 @@ class DefaultScriptFileNodeStepUtilsSpec extends Specification {
         }
 
         1 * executionService.executeCommand(context, {
-            (((ExecArgList) it).asFlatStringList()) == ['sync', testRemotePath]
+            (((ExecArgList) it).asFlatStringList()) == [testRemotePath, 'someargs']
         }, node
         ) >> Mock(NodeExecutorResult) {
-            isSuccess() >> true
+            isSuccess() >> false
+            getFailureMessage() >> "Cannot run program \"/tmp/2048-42562-carlos-cgl-ho-dispatch-script.tmp.sh\": error=26, File busy error"
         }
 
         1 * executionService.executeCommand(context, {
             (((ExecArgList) it).asFlatStringList()) == [testRemotePath, 'someargs']
         }, node
         ) >> Mock(NodeExecutorResult) {
-            isSuccess() >> false
-            getFailureMessage() >> "Cannot run program \"/tmp/2048-42562-carlos-cgl-ho-dispatch-script.tmp.sh\": error=26, File busy error"
+            isSuccess() >> true
+        }
+
+        1 * executionService.executeCommand(context, {
+            (((ExecArgList) it).asFlatStringList()) == ['rm', '-f', testRemotePath]
+        }, node
+        ) >> Mock(NodeExecutorResult) {
+            isSuccess() >> true
+        }
+    }
+
+    def "basic execute script file sync command"() {
+        given:
+        def utils = new DefaultScriptFileNodeStepUtils()
+        utils.fileCopierUtil = Mock(FileCopierUtil)
+
+        File scriptFile = File.createTempFile("test", ".script");
+        scriptFile.deleteOnExit()
+        ExecutionLogger executionLogger = Mock(ExecutionLogger)
+
+        StepExecutionContext context = Mock(StepExecutionContext) {
+            getFramework() >> framework
+            getFrameworkProject() >> PROJECT_NAME
+            getExecutionLogger() >> executionLogger
+        }
+        ExecutionService executionService = Mock(ExecutionService)
+        framework.frameworkServices = Mock(IFrameworkServices) {
+            getExecutionService() >> executionService
+        }
+        def node = new NodeEntryImpl('node')
+        node.setOsFamily('unix')
+        node.setAttribute('enable-sync', 'true')
+        String filepath = scriptFile.absolutePath
+        String[] args = ['someargs'].toArray()
+        String testRemotePath = '/tmp/some-path-to-script'
+        when:
+        def result = utils.executeScriptFile(
+                context,
+                node,
+                null,
+                filepath,
+                null,
+                null,
+                args,
+                null,
+                false,
+                executionService,
+                true
+        )
+        then:
+        result != null
+        1 * utils.fileCopierUtil.generateRemoteFilepathForNode(
+                node,
+                testProject,
+                framework,
+                scriptFile.getName(),
+                null,
+                null
+
+        ) >> testRemotePath
+
+        1 * executionService.fileCopyFile(context, _, node, testRemotePath) >> testRemotePath
+
+        1 * executionService.executeCommand(context, {
+            (((ExecArgList) it).asFlatStringList()) == ['chmod', '+x', testRemotePath]
+        }, node
+        ) >> Mock(NodeExecutorResult) {
+            isSuccess() >> true
+        }
+
+        1 * executionService.executeCommand(context, {
+            (((ExecArgList) it).asFlatStringList()) == ['sync']
+        }, node
+        ) >> Mock(NodeExecutorResult) {
+            isSuccess() >> true
         }
 
         1 * executionService.executeCommand(context, {
@@ -336,13 +403,6 @@ class DefaultScriptFileNodeStepUtilsSpec extends Specification {
 
         1 * executionService.executeCommand(context, {
             (((ExecArgList) it).asFlatStringList()) == ['chmod', '+x', testRemotePath]
-        }, node
-        ) >> Mock(NodeExecutorResult) {
-            isSuccess() >> true
-        }
-
-        1 * executionService.executeCommand(context, {
-            (((ExecArgList) it).asFlatStringList()) == ['sync', testRemotePath]
         }, node
         ) >> Mock(NodeExecutorResult) {
             isSuccess() >> true

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptFileNodeStepExecutor.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptFileNodeStepExecutor.java
@@ -202,7 +202,6 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
-            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult=nodeExecutorResults;
             testcopier.testResult="/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -218,7 +217,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(4, testexec.index);
+            assertEquals(3, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -229,21 +228,15 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
 
-            assertEquals(test1, testexec.testNode.get(0));
-            final String[] stringSync = testexec.testCommand.get(1);
-            assertEquals(2, stringSync.length);
-            assertEquals("sync", stringSync[0]);
-
-
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(2);
+            final String[] strings2 = testexec.testCommand.get(1);
             assertEquals(1, strings2.length);
             assertEquals(filepath, strings2[0]);
 //            assertEquals(context, testexec.testContext.get(1));
             assertEquals(test1, testexec.testNode.get(1));
 
             //second call is to exec the filepath
-            final String[] strings3 = testexec.testCommand.get(3);
+            final String[] strings3 = testexec.testCommand.get(2);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -294,7 +287,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
-            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+
             testexec.testResult=nodeExecutorResults;
             testcopier.testResult="/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -310,7 +303,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(4, testexec.index);
+            assertEquals(3, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -321,21 +314,16 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
 
-            assertEquals(test1, testexec.testNode.get(0));
-            final String[] stringSync = testexec.testCommand.get(1);
-            assertEquals(2, stringSync.length);
-            assertEquals("sync", stringSync[0]);
-
 
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(2);
+            final String[] strings2 = testexec.testCommand.get(1);
             assertEquals(1, strings2.length);
             assertEquals(filepath, strings2[0]);
 //            assertEquals(context, testexec.testContext.get(1));
             assertEquals(test1, testexec.testNode.get(1));
 
             //second call is to exec the filepath
-            final String[] strings3 = testexec.testCommand.get(3);
+            final String[] strings3 = testexec.testCommand.get(2);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -383,7 +371,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
-            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
+
             testexec.testResult=nodeExecutorResults;
             testcopier.testResult="/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -399,7 +387,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(4, testexec.index);
+            assertEquals(3, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -410,20 +398,15 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
 
-            assertEquals(test1, testexec.testNode.get(0));
-            final String[] stringSync = testexec.testCommand.get(1);
-            assertEquals(2, stringSync.length);
-            assertEquals("sync", stringSync[0]);
-
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(2);
+            final String[] strings2 = testexec.testCommand.get(1);
             assertEquals(1, strings2.length);
             assertEquals(filepath, strings2[0]);
 //            assertEquals(context, testexec.testContext.get(1));
             assertEquals(test1, testexec.testNode.get(1));
 
             //second call is to exec the filepath
-            final String[] strings3 = testexec.testCommand.get(3);
+            final String[] strings3 = testexec.testCommand.get(2);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -480,7 +463,6 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
-            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -496,7 +478,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(4, testexec.index);
+            assertEquals(3, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -507,13 +489,8 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
 
-            assertEquals(test1, testexec.testNode.get(0));
-            final String[] stringSync = testexec.testCommand.get(1);
-            assertEquals(2, stringSync.length);
-            assertEquals("sync", stringSync[0]);
-
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(2);
+            final String[] strings2 = testexec.testCommand.get(1);
             assertEquals(3, strings2.length);
             assertEquals(filepath, strings2[0]);
             assertEquals("some", strings2[1]);
@@ -522,7 +499,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testexec.testNode.get(1));
 
             //second call is to exec the filepath
-            final String[] strings3 = testexec.testCommand.get(3);
+            final String[] strings3 = testexec.testCommand.get(2);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -715,7 +692,6 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
-            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -731,7 +707,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(4, testexec.index);
+            assertEquals(3, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -742,20 +718,15 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
 
-            assertEquals(test1, testexec.testNode.get(0));
-            final String[] stringSync = testexec.testCommand.get(1);
-            assertEquals(2, stringSync.length);
-            assertEquals("sync", stringSync[0]);
-
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(2);
+            final String[] strings2 = testexec.testCommand.get(1);
             assertEquals(1, strings2.length);
             assertEquals(strings2[0], filepath);
             assertEquals(filepath, strings2[0]);
 //            assertEquals(context, testexec.testContext.get(1));
             assertEquals(test1, testexec.testNode.get(1));
             //second call is to exec the filepath
-            final String[] strings3 = testexec.testCommand.get(3);
+            final String[] strings3 = testexec.testCommand.get(2);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -825,7 +796,6 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
-            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -843,7 +813,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(4, testexec.index);
+            assertEquals(3, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -854,19 +824,14 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
 
-            assertEquals(test1, testexec.testNode.get(0));
-            final String[] stringSync = testexec.testCommand.get(1);
-            assertEquals(2, stringSync.length);
-            assertEquals("sync", stringSync[0]);
-
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(2);
+            final String[] strings2 = testexec.testCommand.get(1);
             assertEquals(1, strings2.length);
             assertEquals(filepath, strings2[0]);
 //            assertEquals(context, testexec.testContext.get(1));
             assertEquals(test1, testexec.testNode.get(1));
             //second call is to exec the filepath
-            final String[] strings3 = testexec.testCommand.get(3);
+            final String[] strings3 = testexec.testCommand.get(2);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -1078,7 +1043,6 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
-            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -1094,7 +1058,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(4, testexec.index);
+            assertEquals(3, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             final String filepath=strings[2];
@@ -1115,14 +1079,9 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 
 
 //            assertEquals(context, testexec.testContext.get(0));
-            assertEquals(test1, testexec.testNode.get(0));
-            final String[] stringSync = testexec.testCommand.get(1);
-            final String filepath1=stringSync[1];
-            assertEquals(2, stringSync.length);
-            assertEquals("sync", stringSync[0]);
 
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(2);
+            final String[] strings2 = testexec.testCommand.get(1);
             //replace ${scriptfile} with actual filepath
             for (int i = 0; i < expectedCommand.length; i++) {
                 String s = expectedCommand[i];
@@ -1134,7 +1093,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testexec.testNode.get(1));
 
             //third call to remove script
-            final String[] strings3 = testexec.testCommand.get(3);
+            final String[] strings3 = testexec.testCommand.get(2);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -1190,7 +1149,6 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
-            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -1207,7 +1165,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(4, testexec.index);
+            assertEquals(3, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -1217,19 +1175,14 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertTrue(filepath.endsWith("."+UNIX_FILE_EXT));
             assertEquals(test1, testexec.testNode.get(0));
 
-            assertEquals(test1, testexec.testNode.get(0));
-            final String[] stringSync = testexec.testCommand.get(1);
-            assertEquals(2, stringSync.length);
-            assertEquals("sync", stringSync[0]);
-
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(2);
+            final String[] strings2 = testexec.testCommand.get(1);
             assertEquals(1, strings2.length);
             assertEquals(strings2[0], filepath);
             assertEquals(filepath, strings2[0]);
             assertEquals(test1, testexec.testNode.get(1));
             //first call is chmod +x filepath
-            final String[] strings3 = testexec.testCommand.get(3);
+            final String[] strings3 = testexec.testCommand.get(2);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -1291,7 +1244,6 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
-            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final NodeStepResult interpreterResult = interpret.executeNodeStep(context, command, test1);
@@ -1308,7 +1260,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(4, testexec.index);
+            assertEquals(3, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -1318,18 +1270,13 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertTrue(filepath.endsWith("." + UNIX_FILE_EXT));
             assertEquals(test1, testexec.testNode.get(0));
 
-            assertEquals(test1, testexec.testNode.get(0));
-            final String[] stringSync = testexec.testCommand.get(1);
-            assertEquals(2, stringSync.length);
-            assertEquals("sync", stringSync[0]);
-
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(2);
+            final String[] strings2 = testexec.testCommand.get(1);
             assertEquals(1, strings2.length);
             assertEquals(filepath, strings2[0]);
 //            assertEquals(context, testexec.testContext.get(1));
             assertEquals(test1, testexec.testNode.get(1));
-            final String[] strings3 = testexec.testCommand.get(3);
+            final String[] strings3 = testexec.testCommand.get(2);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -1374,7 +1321,6 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             final ArrayList<NodeExecutorResult> nodeExecutorResults = new ArrayList<NodeExecutorResult>();
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
-            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createFailure(null, "failed", test1));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
@@ -1392,7 +1338,7 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(4, testexec.index);
+            assertEquals(3, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -1403,20 +1349,14 @@ public class TestScriptFileNodeStepExecutor extends AbstractBaseTest {
 //            assertEquals(context, testexec.testContext.get(0));
             assertEquals(test1, testexec.testNode.get(0));
 
-            assertEquals(test1, testexec.testNode.get(0));
-            final String[] stringSync = testexec.testCommand.get(1);
-            final String filepath1=stringSync[1];
-            assertEquals(2, stringSync.length);
-            assertEquals("sync", stringSync[0]);
-
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(2);
+            final String[] strings2 = testexec.testCommand.get(1);
             assertEquals(1, strings2.length);
             assertEquals(filepath, strings2[0]);
 //            assertEquals(context, testexec.testContext.get(1));
             assertEquals(test1, testexec.testNode.get(1));
             //first call is chmod +x filepath
-            final String[] strings3 = testexec.testCommand.get(3);
+            final String[] strings3 = testexec.testCommand.get(2);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptURLNodeStepExecutor.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptURLNodeStepExecutor.java
@@ -282,7 +282,6 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
-            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final test1 interaction = new TestScriptURLNodeStepExecutor.test1();
@@ -309,7 +308,7 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(4, testexec.index);
+            assertEquals(3, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             assertEquals(3, strings.length);
@@ -319,21 +318,15 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             assertTrue(filepath.endsWith(".sh"));
             assertEquals(test1, testexec.testNode.get(0));
 
-            final String[] stringsSync = testexec.testCommand.get(1);
-            assertEquals(2, stringsSync.length);
-            assertEquals("sync", stringsSync[0]);
-            assertEquals(stringsSync[1], filepath);
-            assertEquals(test1, testexec.testNode.get(1));
-
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(2);
+            final String[] strings2 = testexec.testCommand.get(1);
             assertEquals(1, strings2.length);
             assertEquals(strings2[0], filepath);
             assertEquals(filepath, strings2[0]);
             assertEquals(test1, testexec.testNode.get(1));
 
             //third call is to remove remote file
-            final String[] strings3 = testexec.testCommand.get(3);
+            final String[] strings3 = testexec.testCommand.get(2);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -404,7 +397,6 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
-            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final test1 interaction = new TestScriptURLNodeStepExecutor.test1();
@@ -431,7 +423,7 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(4, testexec.index);
+            assertEquals(3, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             final String filepath=strings[2];
@@ -441,21 +433,15 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             assertTrue("file extension not correct", filepath.endsWith("." + fileExtension));
             assertEquals(test1, testexec.testNode.get(0));
 
-            final String[] stringsSync = testexec.testCommand.get(1);
-            assertEquals(2, stringsSync.length);
-            assertEquals("sync", stringsSync[0]);
-            assertEquals(stringsSync[1], filepath);
-            assertEquals(test1, testexec.testNode.get(1));
-
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(2);
+            final String[] strings2 = testexec.testCommand.get(1);
             assertEquals(1, strings2.length);
             assertEquals(strings2[0], strings[2]);
             assertEquals(filepath, strings2[0]);
             assertEquals(test1, testexec.testNode.get(1));
 
             //third call is to remove remote file
-            final String[] strings3 = testexec.testCommand.get(3);
+            final String[] strings3 = testexec.testCommand.get(2);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);
@@ -526,7 +512,6 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
-            nodeExecutorResults.add(NodeExecutorResultImpl.createSuccess(null));
             testexec.testResult = nodeExecutorResults;
             testcopier.testResult = "/test/file/path";
             final test1 interaction = new TestScriptURLNodeStepExecutor.test1();
@@ -553,7 +538,7 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             assertEquals(test1, testcopier.testNode);
 
             //test nodeexecutor was called twice
-            assertEquals(4, testexec.index);
+            assertEquals(3, testexec.index);
             //first call is chmod +x filepath
             final String[] strings = testexec.testCommand.get(0);
             final String filepath=strings[2];
@@ -564,21 +549,15 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             assertTrue("file extension not correct", filepath.endsWith("." + UNIX_EXT));
             assertEquals(test1, testexec.testNode.get(0));
 
-            final String[] stringsSync = testexec.testCommand.get(1);
-            assertEquals(2, stringsSync.length);
-            assertEquals("sync", stringsSync[0]);
-            assertEquals(stringsSync[1], filepath);
-            assertEquals(test1, testexec.testNode.get(1));
-
             //second call is to exec the filepath
-            final String[] strings2 = testexec.testCommand.get(2);
+            final String[] strings2 = testexec.testCommand.get(1);
             assertEquals(2, strings2.length);
             assertEquals("mycommand",strings2[0]);
             assertEquals(filepath, strings2[1]);
             assertEquals(test1, testexec.testNode.get(1));
 
             //third call is to remove remote file
-            final String[] strings3 = testexec.testCommand.get(3);
+            final String[] strings3 = testexec.testCommand.get(2);
             assertEquals(3, strings3.length);
             assertEquals("rm", strings3[0]);
             assertEquals("-f", strings3[1]);


### PR DESCRIPTION
Fix #6449 

**Is this a bugfix, or an enhancement? Please describe.**
The message "sync: ignoring all arguments" appears when using script-step on Rundeck 3.3.3 for some OS despite the script is running ok.

**Describe the solution you've implemented**
Some OS were returning a warning message because the command does not use any arguments so it was dropped. I also changed the default behavior so that sync is disabled by default and being enabled via node attribute "enable-sync = true"
