### PR TITLE
Notification plugin key storage

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/AcceptsServices.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/AcceptsServices.java
@@ -1,0 +1,8 @@
+package com.dtolabs.rundeck.core.plugins.configuration;
+
+import org.rundeck.app.spi.Services;
+
+interface AcceptsServices {
+
+    public void setServices(Services services);
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/AcceptsServices.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/AcceptsServices.java
@@ -2,7 +2,7 @@ package com.dtolabs.rundeck.core.plugins.configuration;
 
 import org.rundeck.app.spi.Services;
 
-interface AcceptsServices {
+public interface AcceptsServices {
 
-    public void setServices(Services services);
+    void setServices(Services services);
 }

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -512,7 +512,7 @@ public class NotificationService implements ApplicationContextAware{
                         }
                     }
 
-                    didsend=triggerPlugin(trigger,execMap,n.type, frameworkService.getFrameworkPropertyResolver(source.project, config))
+                    didsend=triggerPlugin(trigger,execMap,n.type, frameworkService.getFrameworkPropertyResolver(source.project, config), content)
                 }else{
                     log.error("Unsupported notification type: " + n.type);
                 }

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -23,6 +23,8 @@ import com.dtolabs.rundeck.core.logging.LogEvent
 import com.dtolabs.rundeck.core.logging.LogUtil
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolver
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
+import com.dtolabs.rundeck.core.storage.StorageTree
+import com.dtolabs.rundeck.core.storage.keys.KeyStorageTree
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
 import com.dtolabs.rundeck.plugins.notification.NotificationPlugin
@@ -45,6 +47,7 @@ import org.apache.commons.httpclient.methods.PostMethod
 import org.apache.commons.httpclient.methods.StringRequestEntity
 import org.apache.commons.httpclient.params.HttpClientParams
 import org.rundeck.app.AppConstants
+import org.rundeck.app.spi.RundeckSpiBaseServicesProvider
 import org.rundeck.app.spi.Services
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
@@ -700,10 +703,16 @@ public class NotificationService implements ApplicationContextAware{
      * @param type plugin type
      * @param config user configuration
      */
-    private boolean triggerPlugin(String trigger, Map data,String type, PropertyResolver resolver){
+    private boolean triggerPlugin(String trigger, Map data,String type, PropertyResolver resolver, Map content){
 
+        Map<Class, Object> servicesMap = [:]
+        servicesMap.put(KeyStorageTree, content.context.storageTree)
+
+        def services = new RundeckSpiBaseServicesProvider(
+                services: servicesMap
+        )
         //load plugin and configure with config values
-        def result = pluginService.configurePlugin(type, notificationPluginProviderService, resolver, PropertyScope.Instance)
+        def result = pluginService.configurePlugin(type, notificationPluginProviderService, resolver, PropertyScope.Instance, services)
         if (!result?.instance) {
             return false
         }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/KeyStorageSelector.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/KeyStorageSelector.vue
@@ -344,7 +344,7 @@
     export default Vue.extend({
         name: 'KeyStorageSelector',
         props: [
-            'keyPath',
+            'value',
             'storageFilter',
             'allowUpload'
         ],
@@ -382,11 +382,11 @@
                 this.invalid = false;
                 this.setRootPath();
                 this.clean();
-                if (this.keyPath != null) {
-                    const parentDir = this.parentDirString(this.keyPath)
+                if (this.value != null) {
+                    const parentDir = this.parentDirString(this.value)
                     this.loadDir(parentDir);
                     this.loadUpPath();
-                    this.defaultSelectKey(this.keyPath);
+                    this.defaultSelectKey(this.value);
                 }
                 this.modalOpen = true;
             },
@@ -905,13 +905,13 @@
             },
         },
         watch: {
-            keyPath(newValue, oldValue) {
+            value(newValue, oldValue) {
                 this.setRootPath();
                 this.clean();
 
-                if (this.keyPath != null) {
+                if (this.value != null) {
                     this.defaultSelectKey(newValue);
-                    this.loadDir(this.parentDirString(this.keyPath));
+                    this.loadDir(this.parentDirString(this.value));
                 }
 
                 this.$emit('input', newValue);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropEdit.vue
@@ -192,6 +192,11 @@
       <div v-if="prop.options && prop.options['selectionAccessor']==='RUNDECK_JOB'" class="col-sm-5">
         <job-config-picker v-model="currentValue"></job-config-picker>
       </div>
+      <div v-if="prop.options && prop.options['selectionAccessor']==='STORAGE_PATH'" class="col-sm-5">
+        <key-storage-selector v-model="currentValue" :storage-filter="prop.options['storage-file-meta-filter']"
+                              :allow-upload="true"/>
+
+      </div>
       <slot
         v-else-if="prop.options && prop.options['selectionAccessor'] "
         name="accessors"
@@ -226,6 +231,8 @@ import MarkdownItVue from 'markdown-it-vue'
 // import 'markdown-it-vue/dist/markdown-it-vue.css'
 
 import JobConfigPicker from './JobConfigPicker.vue'
+import KeyStorageSelector from './KeyStorageSelector.vue'
+
 import AceEditor from '../utils/AceEditor.vue'
 import PluginPropVal from './pluginPropVal.vue'
 import { client } from '../../modules/rundeckClient'
@@ -234,7 +241,8 @@ export default Vue.extend({
     AceEditor,
     JobConfigPicker,
     MarkdownItVue,
-    PluginPropVal
+    PluginPropVal,
+    KeyStorageSelector
   },
   props:{
     'prop':{

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -30,6 +30,9 @@ import com.dtolabs.rundeck.core.logging.LogUtil
 import com.dtolabs.rundeck.core.logging.StreamingLogReader
 import com.dtolabs.rundeck.core.plugins.ConfiguredPlugin
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
+import com.dtolabs.rundeck.core.plugins.configuration.AcceptsServices
+import com.dtolabs.rundeck.core.storage.StorageTree
+import com.dtolabs.rundeck.core.storage.keys.KeyStorageTree
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.notification.NotificationPlugin
 import grails.plugins.mail.MailMessageBuilder
@@ -350,7 +353,7 @@ class NotificationServiceSpec extends HibernateSpec implements ServiceUnitTest<N
 
         then:
         1 * service.frameworkService.getFrameworkPropertyResolver(_, config)
-        1 * service.pluginService.configurePlugin(_,_,_,_)>>new ConfiguredPlugin(
+        1 * service.pluginService.configurePlugin(_,_,_,_,_)>>new ConfiguredPlugin(
                 mockPlugin,
                 [:]
         )
@@ -536,7 +539,7 @@ class NotificationServiceSpec extends HibernateSpec implements ServiceUnitTest<N
 
         then:
         1 * service.frameworkService.getFrameworkPropertyResolver(_, config)
-        1 * service.pluginService.configurePlugin(_,_,_,_)>>new ConfiguredPlugin(
+        1 * service.pluginService.configurePlugin(_,_,_,_,_)>>new ConfiguredPlugin(
                 mockPlugin,
                 [:]
         )
@@ -604,7 +607,7 @@ class NotificationServiceSpec extends HibernateSpec implements ServiceUnitTest<N
 
         then:
         1 * service.frameworkService.getFrameworkPropertyResolver(_, testResult)
-        1 * service.pluginService.configurePlugin(_,_,_,_)>>new ConfiguredPlugin(
+        1 * service.pluginService.configurePlugin(_,_,_,_,_)>>new ConfiguredPlugin(
                 mockPlugin,
                 [:]
         )


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
enhancement: 
* adding access to key storage for notification plugins. So, authentication parameters can be loaded from key storage
* enabling key storage selector on VUE plugin form 

**Describe the solution you've implemented**
Notification plugins must AcceptsServices to get access to key storage services.
```
class TestNotificationPlugin implements NotificationPlugin, AcceptsServices{

        private Services services

        @Override
        void setServices(Services services) {
            this.services = services
        }

        @Override
        boolean postNotification(String trigger, Map executionData, Map config) {
            StorageTree storageTree = this.services.getService(KeyStorageTree)
            def resource = storageTree.getPassword("keys/path/sth")
            .....
        }
    }
```


**Describe alternatives you've considered**

**Additional context**
