### PR TITLE
fix: Constructor.newInstance can throw runtime error, not just exception

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/service/ProviderCreationException.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/service/ProviderCreationException.java
@@ -16,10 +16,10 @@
 
 /*
 * ProviderCreationError.java
-* 
+*
 * User: Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
 * Created: 3/22/11 3:15 PM
-* 
+*
 */
 package com.dtolabs.rundeck.core.execution.service;
 
@@ -37,11 +37,11 @@ public class ProviderCreationException extends ProviderLoaderException {
         super(msg, serviceName, providerName);
     }
 
-    public ProviderCreationException(Exception cause, String serviceName, String providerName) {
+    public ProviderCreationException(Throwable cause, String serviceName, String providerName) {
         super(cause, serviceName, providerName);
     }
 
-    public ProviderCreationException(String msg, Exception cause, String serviceName, String providerName) {
+    public ProviderCreationException(String msg, Throwable cause, String serviceName, String providerName) {
         super(msg, cause, serviceName, providerName);
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/service/ProviderLoaderException.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/service/ProviderLoaderException.java
@@ -16,10 +16,10 @@
 
 /*
 * ProviderLoaderException.java
-* 
+*
 * User: Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
 * Created: 4/13/11 9:46 AM
-* 
+*
 */
 package com.dtolabs.rundeck.core.execution.service;
 
@@ -39,11 +39,11 @@ public class ProviderLoaderException extends ServiceProviderException {
         super(msg, serviceName, providerName);
     }
 
-    public ProviderLoaderException(Exception cause, String serviceName, String providerName) {
+    public ProviderLoaderException(Throwable cause, String serviceName, String providerName) {
         super(cause, serviceName, providerName);
     }
 
-    public ProviderLoaderException(String msg, Exception cause, String serviceName, String providerName) {
+    public ProviderLoaderException(String msg, Throwable cause, String serviceName, String providerName) {
         super(msg, cause, serviceName, providerName);
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/service/ServiceProviderException.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/service/ServiceProviderException.java
@@ -16,10 +16,10 @@
 
 /*
 * ProviderServiceException.java
-* 
+*
 * User: Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
 * Created: 3/22/11 3:16 PM
-* 
+*
 */
 package com.dtolabs.rundeck.core.execution.service;
 
@@ -43,12 +43,12 @@ public class ServiceProviderException extends ExecutionServiceException {
         this.providerName = providerName;
     }
 
-    public ServiceProviderException(Exception cause, String serviceName, String providerName) {
+    public ServiceProviderException(Throwable cause, String serviceName, String providerName) {
         super(cause, serviceName);
         this.providerName = providerName;
     }
 
-    public ServiceProviderException(String msg, Exception cause, String serviceName, String providerName) {
+    public ServiceProviderException(String msg, Throwable cause, String serviceName, String providerName) {
         super(msg + " provider: " + providerName, cause, serviceName);
         this.providerName = providerName;
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/BaseProviderRegistryService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/BaseProviderRegistryService.java
@@ -16,10 +16,10 @@
 
 /*
 * BaseRegistryService.java
-* 
+*
 * User: Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
 * Created: 3/21/11 6:26 PM
-* 
+*
 */
 package com.dtolabs.rundeck.core.plugins;
 
@@ -81,7 +81,7 @@ public abstract class BaseProviderRegistryService<T>
             return method.newInstance(framework);
         } catch (NoSuchMethodException ignored) {
 
-        } catch (Exception e) {
+        } catch (Throwable e) {
             throw new ProviderCreationException("Unable to create provider instance: " + e.getMessage(), e, getName(),
                 providerName);
         }


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**
Fix potential issue loading plugins I encountered a runtime error during instance initialization caused by ClassNotFound exception loading a plugin, this caused the Plugins > Show Installed Plugins page to hang.  this seems like a rare occurrence, but the fix would treat it as any other failure loading plugin classes.
