### PR TITLE
Update notifications: enable vue ui in production, update selenium tests

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -285,6 +285,7 @@ public class RundeckConfigBase {
         Enabled jobLifecyclePlugin = new Enabled();
         Enabled executionLifecyclePlugin = new Enabled();
         Enabled legacyExecOutputViewer = new Enabled();
+        Enabled notificationsEditorVue = new Enabled();
 
         @Data
         public static class Enabled {

--- a/rundeckapp/grails-app/conf/application.groovy
+++ b/rundeckapp/grails-app/conf/application.groovy
@@ -73,6 +73,7 @@ environments {
         rundeck.feature.cleanExecutionsHistoryJob.enabled = true
         rundeck.feature.executionLifecyclePlugin.enabled = true
         rundeck.feature.legacyExecOutputViewer.enabled = false
+        rundeck.feature.notificationsEditorVue.enabled = true
         dataSource {
             dbCreate = "update"
             url = "jdbc:h2:file:/rundeck/grailsh2"

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -461,12 +461,17 @@ beans={
             SimpleDataFilterPlugin,
             RenderDatatypeFilterPlugin,
             QuietFilterPlugin,
-            HighlightFilterPlugin,
-            //dummy notification plugins
-            DummyEmailNotificationPlugin,
-            DummyWebhookNotificationPlugin,
+            HighlightFilterPlugin
     ].each {
         "rundeckAppPlugin_${it.simpleName}"(PluginFactoryBean, it)
+    }
+    if(!(application.config.rundeck?.feature?.notificationsEditorVue?.enabled in [false,'false'])) {
+        //enable dummy notification plugins for new Notifications UI
+        [
+            DummyEmailNotificationPlugin,
+            DummyWebhookNotificationPlugin,].each {
+            "rundeckAppPlugin_${it.simpleName}"(PluginFactoryBean, it)
+        }
     }
 
     //TODO: scan defined plugins:

--- a/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editNotificationsForm.gsp
@@ -17,7 +17,7 @@
 <%@ page import="rundeck.controllers.ScheduledExecutionController; com.dtolabs.rundeck.plugins.ServiceNameConstants" %>
 
 <feature:enabled name="notificationsEditorVue">
-    <div class="job-editor-vue">
+    <div class="job-editor-vue" id="job-editor-notifications-vue">
         <app :event-bus="EventBus" />
     </div>
 </feature:enabled>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
@@ -57,7 +57,11 @@
 
         <div v-for="(group,gindex) in groupedProperties" :key="group.name">
             <div v-if="!group.name">
-              <div v-for="(prop,pindex) in group.props" :key="'g_'+gindex+'/'+prop.name" :class="'form-group '+(prop.required?'required':'')+(validation &&validation.errors[prop.name]?' has-error':'')">
+              <div v-for="(prop,pindex) in group.props"
+                   :key="'g_'+gindex+'/'+prop.name"
+                   :class="'form-group '+(prop.required?'required':'')+(validation &&validation.errors[prop.name]?' has-error':'')"
+                   :data-prop-name="prop.name"
+              >
                 <plugin-prop-edit v-model="inputValues[prop.name]"
                                 :prop="prop"
                                 :input-values="inputValues"
@@ -77,7 +81,11 @@
                 </span>
               </summary>
 
-              <div v-for="(prop,pindex) in group.props" :key="'g_'+gindex+'/'+prop.name" :class="'form-group '+(prop.required?'required':'')+(validation &&validation.errors[prop.name]?' has-error':'')">
+              <div v-for="(prop,pindex) in group.props"
+                   :key="'g_'+gindex+'/'+prop.name"
+                   :class="'form-group '+(prop.required?'required':'')+(validation &&validation.errors[prop.name]?' has-error':'')"
+                   :data-prop-name="prop.name"
+              >
                 <plugin-prop-edit v-model="inputValues[prop.name]"
                                 :prop="prop"
                                 :input-values="inputValues"

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
@@ -12,7 +12,7 @@
       </div>
       <div class="main-section">
       <div v-for="(trigger) in notifyTypes"  >
-          <div  class="list-group" >
+          <div  class="list-group" :id="'job-notifications-'+trigger">
             <div class="list-group-item flex-container flex-align-items-baseline flex-justify-space-between">
               <span class="flex-item " :class="{'text-secondary':(!hasNotificationsForTrigger(trigger))}">
               <i class="fas" :class="triggerIcons[trigger]"></i>
@@ -100,7 +100,7 @@
 
 
 
-    <modal v-model="editModal" :title="$t(editIndex<0?'Create Notification':'Edit Notification')" size="lg">
+    <modal v-model="editModal" :title="$t(editIndex<0?'Create Notification':'Edit Notification')" size="lg" id="job-notifications-edit-modal">
       <div>
         <div class="form-group"  >
           <label class="col-sm-2 control-label  " >
@@ -108,7 +108,7 @@
           </label>
           <div class="col-sm-10 form-control-static">
 
-            <dropdown ref="dropdown">
+            <dropdown ref="dropdown" id="notification-edit-trigger-dropdown">
               <btn type="simple" class=" btn-hover  btn-secondary dropdown-toggle">
                 <span class="caret"></span>
                 &nbsp;
@@ -123,6 +123,7 @@
               <template slot="dropdown">
                 <li v-for="trigger in notifyTypes"
                     @click="setEditNotificationTrigger(trigger)"
+                    :data-trigger="trigger"
                 >
                   <a role="button">
                     <i class="fas" :class="triggerIcons[trigger]"></i>
@@ -144,7 +145,7 @@
               Notification Type
             </label>
             <div class="col-sm-10  form-control-static">
-              <dropdown ref="dropdown">
+              <dropdown ref="dropdown" id="notification-edit-type-dropdown">
                 <btn type="simple"  class="btn-simple btn-hover  btn-secondary dropdown-toggle">
                   <span class="caret"></span>
                   &nbsp;
@@ -163,7 +164,9 @@
                 </btn>
                 <template slot="dropdown">
                   <li v-for="plugin in sortedProviders" :key="plugin.name">
-                    <a role="button" @click="setEditNotificationType(plugin.name)">
+                    <a role="button"
+                       @click="setEditNotificationType(plugin.name)"
+                       :data-plugin-type="plugin.name">
                       <plugin-info
                           :detail="plugin"
                           :show-description="true"
@@ -192,6 +195,7 @@
         </div>
 
         <plugin-config
+            id="notification-edit-config"
             :mode="editIndex===-1 ? 'create':'edit'"
             :serviceName="'Notification'"
             v-model="editNotification"
@@ -206,10 +210,12 @@
       </div>
 
       <div slot="footer">
-        <btn @click="cancelEditNotification">{{ $t('Cancel') }}</btn>
+        <btn @click="cancelEditNotification" id="job-notifications-edit-modal-btn-cancel">{{ $t('Cancel') }}</btn>
         &nbsp;
-        <btn @click="saveNotification" type="primary"
+        <btn @click="saveNotification"
+             type="primary"
              :disabled="!editNotificationTrigger || !editNotification.type"
+             id="job-notifications-edit-modal-btn-save"
         >{{ $t('Save') }}</btn>
         <span v-if="editValidation && !editValidation.valid" class="text-warning">
           Please correct the highlighted errors.

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/notification/DummyEmailNotificationPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/notification/DummyEmailNotificationPlugin.groovy
@@ -61,8 +61,10 @@ class DummyEmailNotificationPlugin implements NotificationPlugin {
         title = "Subject",
         description = '''Template for the email subject. Can contain property references: ${group.key}
 
-See [Documentation](https://docs.rundeck.com/docs/administration/configuration/email-settings.html#custom-email-templates)''',
-        required = true
+A default template of `${notification.eventStatus} [${exec.project}] ${job.group}/${job.name} ${exec.argstring}}` will be used unless 
+overridden in the configuration file.
+
+See [Documentation](https://docs.rundeck.com/docs/administration/configuration/email-settings.html#custom-email-templates)'''
     )
     String subject
     @PluginProperty(

--- a/test/selenium/src/__tests__/selenium/jobs/job-notification.test.ts
+++ b/test/selenium/src/__tests__/selenium/jobs/job-notification.test.ts
@@ -6,6 +6,7 @@ import {JobCreatePage} from 'pages/jobCreate.page'
 import {JobShowPage} from "pages/jobShow.page"
 import {until, By, Key} from 'selenium-webdriver'
 import '@rundeck/testdeck/test/rundeck'
+import {sleep} from "@rundeck/testdeck/async/util"
 
 // We will initialize and cleanup in the before/after methods
 let ctx = CreateContext({projects: ['SeleniumBasic']})
@@ -23,7 +24,7 @@ beforeAll(async () => {
 
 describe('job', () => {
     it('create job with notifications', async () => {
-        
+
         await jobCreatePage.get()
         await ctx.driver.wait(until.urlContains('/job/create'), 25000)
         let jobName=await jobCreatePage.jobNameInput()
@@ -51,23 +52,54 @@ describe('job', () => {
 
         //wait until edit form section for step is removed from dom
         await ctx.driver.wait(until.stalenessOf(wfstepEditDiv), 15000)
-        
-        let notificationsTab=await jobCreatePage.notificationsTab()
+
+        const notificationsTab = await jobCreatePage.notificationsTab()
         await notificationsTab.click()
 
-        let enableNotificationInput= await jobCreatePage.enableNotificationInput()
-        await enableNotificationInput.click()
+        const vueNotificationEditSections = await jobCreatePage.vueNotificationEditSections()
+        const newEmail = 'test@rundeck.com'
+        if (vueNotificationEditSections.length < 1) {
+            // legacy ui
+            const enableNotificationInput = await jobCreatePage.enableNotificationInput()
+            await enableNotificationInput.click()
 
-        let notifyOnsuccessEmail= await jobCreatePage.notifyOnsuccessEmail()
-        expect(notifyOnsuccessEmail).toBeDefined()
 
-        await notifyOnsuccessEmail.click()
+            const notifyOnsuccessEmail = await jobCreatePage.notifyOnsuccessEmail()
+            expect(notifyOnsuccessEmail).toBeDefined()
 
-        let notifySuccessRecipients= await jobCreatePage.notifySuccessRecipients()
-        expect(notifySuccessRecipients).toBeDefined()
-        let newEmail='test@rundeck.com'
-        notifySuccessRecipients.clear()
-        notifySuccessRecipients.sendKeys(newEmail)
+            await notifyOnsuccessEmail.click()
+
+            const notifySuccessRecipients = await jobCreatePage.notifySuccessRecipients()
+            expect(notifySuccessRecipients).toBeDefined()
+            await notifySuccessRecipients.clear()
+            await notifySuccessRecipients.sendKeys(newEmail)
+        } else {
+            // vue ui
+
+            const vueAddSuccessbutton = await jobCreatePage.vueAddSuccessbutton()
+            await vueAddSuccessbutton.click()
+
+            const vueEditNotificationModal = await jobCreatePage.vueEditNotificationModal()
+            const typeDropdown = await jobCreatePage.vueEditNotificationPluginTypeDropdownButton()
+            await typeDropdown.click()
+
+            const emailItem = await jobCreatePage.vueEditNotificationPluginTypeDropdownMenuItem('email')
+            await sleep(1500)
+            await emailItem.click()
+
+            // wait for config section to appear
+            const notificationConfig = await jobCreatePage.vueNotificationConfig()
+
+            // fill recipients input section
+            const recipientsFormGroup = await jobCreatePage.vueNotificationConfigFillPropText('recipients', newEmail)
+
+            // Optional fill subject input section
+            // const subjectFormGroup = await jobCreatePage.vueNotificationConfigFillPropText('subject', 'test subject')
+
+            // find modal save button
+            const modalSaveBtn = await jobCreatePage.vueEditNotificationModalSaveBtn()
+            await modalSaveBtn.click()
+        }
 
         //save the job
         let save = await jobCreatePage.saveButton()
@@ -89,26 +121,56 @@ describe('job', () => {
         await jobCreatePage.getEditPage('b7b68386-3a52-46dc-a28b-1a4bf6ed87de')
         await ctx.driver.wait(until.urlContains('/job/edit'), 30000)
 
-        let notificationsTab=await jobCreatePage.notificationsTab()
+        const notificationsTab = await jobCreatePage.notificationsTab()
         await notificationsTab.click()
 
 
-        let enableNotificationInput= await jobCreatePage.enableNotificationInput()
-        await enableNotificationInput.click()
+        const vueNotificationEditSections = await jobCreatePage.vueNotificationEditSections()
+        const newEmail = 'test@rundeck.com'
+        if (vueNotificationEditSections.length < 1) {
+            // legacy ui
+            const enableNotificationInput = await jobCreatePage.enableNotificationInput()
+            await enableNotificationInput.click()
 
-        let notifyOnsuccessEmail= await jobCreatePage.notifyOnsuccessEmail()
-        expect(notifyOnsuccessEmail).toBeDefined()
 
-        await notifyOnsuccessEmail.click()
+            const notifyOnsuccessEmail = await jobCreatePage.notifyOnsuccessEmail()
+            expect(notifyOnsuccessEmail).toBeDefined()
 
-        let notifySuccessRecipients= await jobCreatePage.notifySuccessRecipients()
-        expect(notifySuccessRecipients).toBeDefined()
-        let newEmail='test@rundeck.com'
-        notifySuccessRecipients.clear()
-        notifySuccessRecipients.sendKeys(newEmail)
+            await notifyOnsuccessEmail.click()
 
-        //save the job
-        let save = await jobCreatePage.editSaveButton()
+            const notifySuccessRecipients = await jobCreatePage.notifySuccessRecipients()
+            expect(notifySuccessRecipients).toBeDefined()
+            await notifySuccessRecipients.clear()
+            await notifySuccessRecipients.sendKeys(newEmail)
+        } else {
+            // vue ui
+
+            const vueAddSuccessbutton = await jobCreatePage.vueAddSuccessbutton()
+            await vueAddSuccessbutton.click()
+
+            const vueEditNotificationModal = await jobCreatePage.vueEditNotificationModal()
+            const typeDropdown = await jobCreatePage.vueEditNotificationPluginTypeDropdownButton()
+            await typeDropdown.click()
+
+            const emailItem = await jobCreatePage.vueEditNotificationPluginTypeDropdownMenuItem('email')
+            await sleep(1500)
+            await emailItem.click()
+
+            // wait for config section to appear
+            const notificationConfig = await jobCreatePage.vueNotificationConfig()
+
+            // fill recipients input section
+            const recipientsFormGroup = await jobCreatePage.vueNotificationConfigFillPropText('recipients', newEmail)
+
+            // Optional fill subject input section
+            // const subjectFormGroup = await jobCreatePage.vueNotificationConfigFillPropText('subject', 'test subject')
+
+            // find modal save button
+            const modalSaveBtn = await jobCreatePage.vueEditNotificationModalSaveBtn()
+            await modalSaveBtn.click()
+        }
+        // save the job
+        const save = await jobCreatePage.editSaveButton()
         await save.click()
 
         await ctx.driver.wait(until.urlContains('/job/show'), 35000)

--- a/test/selenium/src/pages/jobCreate.page.ts
+++ b/test/selenium/src/pages/jobCreate.page.ts
@@ -1,7 +1,7 @@
-import {By, WebElement, WebElementPromise, until} from 'selenium-webdriver'
+import {By, until, WebElementPromise} from 'selenium-webdriver'
 
 import {Page} from '@rundeck/testdeck/page'
-import { Context } from '@rundeck/testdeck/context';
+import {Context} from '@rundeck/testdeck/context'
 
 export const Elems= {
     jobNameInput  : By.css('form input[name="jobName"]'),
@@ -32,8 +32,17 @@ export const Elems= {
     storagebrowseClose: By.xpath('//*[@id="storagebrowse"]/div/div/div[3]/button[1]'),
 
     notificationsTab: By.css("#job_edit_tabs > li > a[href=\'#tab_notifications\']"),
+    notificationsTabContent: By.css("#tab_notifications"),
     enableNotifications: By.css('#notifiedTrue'),
     notifyOnsuccessEmail: By.css('#notifyOnsuccessEmail'),
+    vueNotificationEditSection: By.css('#job-editor-notifications-vue'),
+    vueAddSuccessButton: By.css('#job-notifications-onstart > .list-group-item:first-child > button'),
+    vueEditNotificationModal: By.css('#job-notifications-edit-modal'),
+    vueEditNotificationModalSaveBtn: By.css('#job-notifications-edit-modal-btn-save'),
+    vueEditNotificationModalCancelBtn: By.css('#job-notifications-edit-modal-btn-cancel'),
+    vueEditNotificationPluginTypeDropdownButton: By.css('#notification-edit-type-dropdown > button'),
+    vueEditNotificationPluginTypeDropdownMenu: By.css('#notification-edit-type-dropdown > ul'),
+    vueNotificationConfig: By.css('#notification-edit-config'),
     notifySuccessRecipients: By.css('#notifySuccessRecipients'),
     tabNodes  : By.css('#job_edit_tabs > li > a[href=\'#tab_nodes\']'),
     doNodedispatchTrue  : By.xpath('//*[@id="doNodedispatchTrue"]'),
@@ -137,12 +146,57 @@ export class JobCreatePage extends Page {
         return this.ctx.driver.wait(until.elementLocated(Elems.option0li),15000)
     }
 
+    async enableNotificationInputElement() {
+        return this.ctx.driver.findElement(Elems.enableNotifications)
+    }
     async enableNotificationInput(){
         return this.ctx.driver.wait(until.elementLocated(Elems.enableNotifications),15000)
     }
 
     async notifyOnsuccessEmail(){
         return this.ctx.driver.wait(until.elementLocated(Elems.notifyOnsuccessEmail),15000)
+    }
+    async vueAddSuccessbutton(){
+        return this.ctx.driver.wait(until.elementLocated(Elems.vueAddSuccessButton), 15000)
+    }
+
+    async vueEditNotificationModal(){
+        return this.ctx.driver.wait(until.elementLocated(Elems.vueEditNotificationModal), 15000)
+    }
+    async vueEditNotificationPluginTypeDropdownMenu(){
+        return this.ctx.driver.wait(until.elementLocated(Elems.vueEditNotificationPluginTypeDropdownMenu), 15000)
+    }
+    async vueEditNotificationPluginTypeDropdownButton(){
+        return this.ctx.driver.findElement(Elems.vueEditNotificationPluginTypeDropdownButton)
+    }
+    async vueEditNotificationModalSaveBtn() {
+        return this.ctx.driver.findElement(Elems.vueEditNotificationModalSaveBtn)
+    }
+    async vueEditNotificationPluginTypeDropdownMenuItem(type: string) {
+        return this.ctx.driver.wait(
+          until.elementLocated(
+            By.css('#notification-edit-type-dropdown > ul > li > a[data-plugin-type=\'' + type + '\']')),
+          15000
+        )
+    }
+    async vueNotificationConfigFormGroupForProp(name: string) {
+        return this.ctx.driver.wait(
+          until.elementLocated(
+            By.css('#notification-edit-config div.form-group[data-prop-name=\'' + name + '\']')
+          ),
+          15000
+        )
+    }
+    async vueNotificationConfigFillPropText(name: string, text: string) {
+        const recipientsFormGroup = await this.vueNotificationConfigFormGroupForProp(name)
+        expect(recipientsFormGroup).toBeDefined()
+        const formField = await recipientsFormGroup.findElement(By.css('input[type=text]'))
+        expect(formField).toBeDefined()
+        await formField.clear()
+        return formField.sendKeys(text)
+    }
+    async vueNotificationConfig() {
+        return this.ctx.driver.wait(until.elementLocated(Elems.vueNotificationConfig), 15000)
     }
 
     async notifySuccessRecipients(){
@@ -151,6 +205,9 @@ export class JobCreatePage extends Page {
 
     async notificationsTab(){
         return await this.ctx.driver.findElement(Elems.notificationsTab)
+    }
+    async vueNotificationEditSections() {
+        return this.ctx.driver.findElements(Elems.vueNotificationEditSection)
     }
     async tabNodes(){
         return await this.ctx.driver.findElement(Elems.tabNodes)


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

- [x] Enables the `notificationsEditorVue` feature for production
- [x] update selenium tests for vue UI
- [x] fix: email notification subject field should not be required
- [x] fix: define notificationsEditorVue feature in static config
- [x] fix: if notificationsEditorVue is false, don't setup dummy plugins