### PR TITLE
Fix timing of test for new notification ui

### DIFF
--- a/test/selenium/src/__tests__/selenium/jobs/job-notification.test.ts
+++ b/test/selenium/src/__tests__/selenium/jobs/job-notification.test.ts
@@ -99,6 +99,8 @@ describe('job', () => {
             // find modal save button
             const modalSaveBtn = await jobCreatePage.vueEditNotificationModalSaveBtn()
             await modalSaveBtn.click()
+            // wait until modal is hidden
+            await jobCreatePage.vueEditNotificationModalHidden()
         }
 
         //save the job
@@ -168,6 +170,8 @@ describe('job', () => {
             // find modal save button
             const modalSaveBtn = await jobCreatePage.vueEditNotificationModalSaveBtn()
             await modalSaveBtn.click()
+            // wait until modal is hidden
+            await jobCreatePage.vueEditNotificationModalHidden()
         }
         // save the job
         const save = await jobCreatePage.editSaveButton()

--- a/test/selenium/src/pages/jobCreate.page.ts
+++ b/test/selenium/src/pages/jobCreate.page.ts
@@ -160,10 +160,14 @@ export class JobCreatePage extends Page {
         return this.ctx.driver.wait(until.elementLocated(Elems.vueAddSuccessButton), 15000)
     }
 
-    async vueEditNotificationModal(){
+    async vueEditNotificationModal() {
         return this.ctx.driver.wait(until.elementLocated(Elems.vueEditNotificationModal), 15000)
     }
-    async vueEditNotificationPluginTypeDropdownMenu(){
+    async vueEditNotificationModalHidden() {
+        const modal = await this.ctx.driver.findElement(Elems.vueEditNotificationModal)
+        return this.ctx.driver.wait(until.elementIsNotVisible(modal), 15000)
+    }
+    async vueEditNotificationPluginTypeDropdownMenu() {
         return this.ctx.driver.wait(until.elementLocated(Elems.vueEditNotificationPluginTypeDropdownMenu), 15000)
     }
     async vueEditNotificationPluginTypeDropdownButton(){


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Add wait to make sure modal dismiss animation completes
