### PR TITLE
Fix: project list gui config values not working

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -390,7 +390,21 @@ public class RundeckConfigBase {
         StaticUserResources staticUserResources;
         Login login;
         Job job;
+        Home home;
 
+        @Data
+        public static class Home {
+            ProjectList projectList;
+        }
+        @Data
+        public static class ProjectList {
+            int detailBatchMax;
+            boolean summaryRefresh;
+            int summaryRefreshDelay;
+            int detailBatchDelay;
+            boolean pagingEnabled;
+            int pagingMax;
+        }
         @Data
         public static class Job {
             Description description;


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Config values for project list GUI were not working, and produced a warning log:

```
[2020-09-21T13:32:36,879] WARN  services.ConfigurationService - Could not get value for property: gui.home.projectList.pagingMax
```

the static config class needed updating.