### PR TITLE
Applying "if node set empty" config for workflow strategies other than "Node First"

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/BaseWorkflowExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/BaseWorkflowExecutor.java
@@ -24,10 +24,8 @@
 package com.dtolabs.rundeck.core.execution.workflow;
 
 import com.dtolabs.rundeck.core.Constants;
-import com.dtolabs.rundeck.core.common.Framework;
-import com.dtolabs.rundeck.core.common.IFramework;
-import com.dtolabs.rundeck.core.common.INodeEntry;
-import com.dtolabs.rundeck.core.common.SelectorUtils;
+import com.dtolabs.rundeck.core.NodesetEmptyException;
+import com.dtolabs.rundeck.core.common.*;
 import com.dtolabs.rundeck.core.data.BaseDataContext;
 import com.dtolabs.rundeck.core.data.DataContext;
 import com.dtolabs.rundeck.core.dispatcher.ContextView;
@@ -874,6 +872,12 @@ public abstract class BaseWorkflowExecutor implements WorkflowExecutor {
             executionContext.getExecutionListener().getFailedNodesListener().matchedNodes(
                     stepCaptureFailedNodesListener.getMatchedNodes());
 
+        }
+    }
+
+    protected void validateNodeSet(ExecutionContext executionContext, NodesSelector nodeSelector) {
+        if (0 == executionContext.getNodes().getNodes().size()) {
+            throw new NodesetEmptyException(nodeSelector);
         }
     }
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/NodeFirstWorkflowExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/NodeFirstWorkflowExecutor.java
@@ -366,12 +366,6 @@ public class NodeFirstWorkflowExecutor extends BaseWorkflowExecutor {
         }
     }
 
-    private void validateNodeSet(ExecutionContext executionContext, NodesSelector nodeSelector) {
-        if (0 == executionContext.getNodes().getNodes().size()) {
-            throw new NodesetEmptyException(nodeSelector);
-        }
-    }
-
     static enum Reason implements FailureReason {
         WorkflowSequenceFailures,
         ExecutionServiceError


### PR DESCRIPTION
fixes https://github.com/rundeckpro/rundeckpro/issues/1149

**Is this a bugfix, or an enhancement? Please describe.**
The "If node set empty" setting had no effect when using Workflow Strategies other than "Node First"

**Describe the solution you've implemented**
The EngineWorkflowExecutor was changed to handle the workflow when no node is matched and the "if node set empty" config is marked to continue the job execution.