### PR TITLE
User manager login status not shown

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -384,7 +384,8 @@ public class RundeckConfigBase {
         String logoHires;
         Boolean clusterIdentityInHeader;
         Boolean clusterIdentityInFooter;
-
+        Boolean userSummaryShowLoginStatus;
+        Boolean userSummaryShowLoggedUsersDefault;
         Execution execution;
         PaginateJobs paginatejobs;
         StaticUserResources staticUserResources;


### PR DESCRIPTION
fix for **https://github.com/rundeck/rundeck/issues/6483**

Problem:
userSummaryShowLoginStatus is not being read

Solution:
Add userSummaryShowLoginStatus and userSummaryShowLoggedUsersDefault fields to RundeckConfigBase.java class