### PR TITLE
Changing place of the hiddenField "origName" to be possible renaming options when editing a job

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
@@ -42,6 +42,10 @@
             </div>
         </g:if>
 
+        <g:if test="${origName || option?.name && !newoption}">
+            <g:hiddenField name="origName" value="${origName?origName:option?.name}"/>
+        </g:if>
+
         <div class="form-group">
 
             <label for="opttype_${rkey}" class="col-sm-2 control-label    ${hasErrors(
@@ -191,9 +195,6 @@
                             />
             </div>
 
-            <g:if test="${origName || option?.name && !newoption}">
-                <g:hiddenField name="origName" value="${origName?origName:option?.name}"/>
-            </g:if>
         </div>
 
         <div class="opt_sec_enabled form-group ${hasErrors(bean: option, field: 'defaultStoragePath', 'has-error')}"


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/1212

**Is this a bugfix, or an enhancement? Please describe.**
There is an issue when editing an option of a job where is not possible to change the its name.

**Describe the solution you've implemented**
Was needed to change the place of a hidden field with the original name so that this field can be passed to controller when editing the option.