### PR TITLE
Fix #6497 500 error on exec query api for missing project

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -2162,6 +2162,10 @@ setTimeout(function(){
                             args: ['project']
                     ])
         }
+
+        if (!apiService.requireExists(response, frameworkService.existsFrameworkProject(params.project), ['Project', params.project])) {
+            return
+        }
         AuthContext authContext = frameworkService.getAuthContextForSubjectAndProject(session.subject,params.project)
 
         if (request.api_version < ApiVersions.V14 && !(response.format in ['all','xml'])) {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -76,6 +76,22 @@ class ExecutionControllerSpec extends HibernateSpec implements ControllerUnitTes
         )
 
     }
+    def "api execution query project dne"() {
+        setup:
+        def query = new ExecutionQuery()
+        controller.apiService = Mock(ApiService)
+        controller.frameworkService = Mock(FrameworkService)
+        controller.executionService = Mock(ExecutionService)
+        params.project='test'
+        when:
+        def result = controller.apiExecutionsQuery(query)
+        then:
+        1 * controller.apiService.requireVersion(_, _, 5) >> true
+        1 * controller.frameworkService.existsFrameworkProject('test') >> false
+        1 * controller.apiService.requireExists(_, false,['Project','test'])>>false
+        0 * controller.executionService.queryExecutions(*_)
+
+    }
 
     def "api execution no existing execution"() {
         given:

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -139,6 +139,8 @@ class ExecutionControllerSpec extends HibernateSpec implements ControllerUnitTes
                                                         code  : "api.error.parameter.required",
                                                         args  : ['project']]
         )
+        1 * controller.frameworkService.existsFrameworkProject('test') >> true
+        1 * controller.apiService.requireExists(_,true,['Project','test']) >> true
         1 * controller.frameworkService.getAuthContextForSubjectAndProject(_, 'test')
         1 * controller.apiService.renderErrorFormat(_, [
                 status: HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE,
@@ -167,6 +169,8 @@ class ExecutionControllerSpec extends HibernateSpec implements ControllerUnitTes
                                                         code  : "api.error.parameter.required",
                                                         args  : ['project']]
         )
+        1 * controller.frameworkService.existsFrameworkProject('test') >> true
+        1 * controller.apiService.requireExists(_,true,['Project','test']) >> true
         1 * controller.frameworkService.getAuthContextForSubjectAndProject(_, 'test')
 
         1 * controller.executionService.queryExecutions(query, 0, 20) >> [result: [], total: 1]
@@ -207,6 +211,8 @@ class ExecutionControllerSpec extends HibernateSpec implements ControllerUnitTes
 
         1 * controller.executionService.queryExecutions(query, 0, 20) >> [result: [], total: 1]
         1 * controller.frameworkService.filterAuthorizedProjectExecutionsAll(_, [], [AuthConstants.ACTION_READ]) >> []
+        1 * controller.frameworkService.existsFrameworkProject('test') >> true
+        1 * controller.apiService.requireExists(_,true,['Project','test']) >> true
     }
     def "api execution query, parse olderFilter param"() {
         setup:
@@ -233,6 +239,9 @@ class ExecutionControllerSpec extends HibernateSpec implements ControllerUnitTes
 
         1 * controller.executionService.queryExecutions(query, 0, 20) >> [result: [], total: 1]
         1 * controller.frameworkService.filterAuthorizedProjectExecutionsAll(_, [], [AuthConstants.ACTION_READ]) >> []
+
+        1 * controller.frameworkService.existsFrameworkProject('test') >> true
+        1 * controller.apiService.requireExists(_,true,['Project','test']) >> true
     }
 
     class TestReader implements StreamingLogReader {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerTests.groovy
@@ -315,6 +315,7 @@ class ExecutionControllerTests extends HibernateSpec implements ControllerUnitTe
         def controller = new ExecutionController()
         ApiController.metaClass.message = { params -> params?.code ?: 'messageCodeMissing' }
         def fwkControl = new MockFor(FrameworkService, false)
+        fwkControl.demand.existsFrameworkProject{ proj -> return true }
         fwkControl.demand.getAuthContextForSubjectAndProject{ subj,proj -> return null }
         fwkControl.demand.filterAuthorizedProjectExecutionsAll {fwk,results,actions->
             return []
@@ -333,6 +334,10 @@ class ExecutionControllerTests extends HibernateSpec implements ControllerUnitTe
         def svcMock = new MockFor(ApiService, false)
         svcMock.demand.requireVersion { request, response, int min ->
             assertEquals(5, min)
+            return true
+        }
+        svcMock.demand.requireExists {  response, test,args ->
+            assertEquals(['Project','Test'], args)
             return true
         }
         controller.apiService = svcMock.proxyInstance()
@@ -425,6 +430,7 @@ class ExecutionControllerTests extends HibernateSpec implements ControllerUnitTe
         def execs = createTestExecs()
 
         def fwkControl = new MockFor(FrameworkService, false)
+        fwkControl.demand.existsFrameworkProject{ proj -> return true }
         fwkControl.demand.getAuthContextForSubjectAndProject{ subj,proj -> return null }
         fwkControl.demand.filterAuthorizedProjectExecutionsAll { framework, List<Execution> results, Collection actions ->
             assert results == []
@@ -447,6 +453,10 @@ class ExecutionControllerTests extends HibernateSpec implements ControllerUnitTe
         def svcMock = new MockFor(ApiService, false)
         svcMock.demand.requireVersion { request, response, int min ->
             assertEquals(5, min)
+            return true
+        }
+        svcMock.demand.requireExists {  response, test,args ->
+            assertEquals(['Project','WRONG'], args)
             return true
         }
         svcMock.demand.renderSuccessXml { request, response ->


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Fix #6497 500 error if project is not found for executions query API
