### PR TITLE
Changing to consider logged user roles for ACL cache

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -28,7 +28,6 @@ import com.dtolabs.rundeck.core.authentication.Group
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
-import com.dtolabs.rundeck.server.AuthContextEvaluatorCacheManager
 import org.rundeck.app.spi.AuthorizedServicesProvider
 import org.rundeck.app.components.RundeckJobDefinitionManager
 import org.rundeck.app.spi.AuthorizedServicesProvider
@@ -149,7 +148,6 @@ class ScheduledExecutionController  extends ControllerBase{
     ExecutionLifecyclePluginService executionLifecyclePluginService
     RundeckJobDefinitionManager rundeckJobDefinitionManager
     AuthorizedServicesProvider rundeckAuthorizedServicesProvider
-    AuthContextEvaluatorCacheManager authContextEvaluatorCacheManager
 
 
     def index = { redirect(controller:'menu',action:'jobs',params:params) }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/AuthContextEvaluatorCacheManager.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/AuthContextEvaluatorCacheManager.groovy
@@ -105,10 +105,29 @@ class AuthContextEvaluatorCacheManager {
             evaluate.call()
         }
 
+        boolean compareAuthContext(AuthContextEvaluatorCacheKey key){
+            if(this.authContext instanceof SubjectAuthContext){
+                return this.authContext.getUsername() == key.authContext?.getUsername() && this.authContext.getRoles()?.equals(key.authContext?.getRoles())
+            }
+
+            return this.authContext == key.authContext
+        }
+
+        int hashAuthContext(){
+            if(this.authContext instanceof SubjectAuthContext){
+                return Objects.hash(
+                        this.authContext?.getUsername()?.hashCode(),
+                        this.authContext?.getRoles()?.hashCode()
+                )
+            }
+
+            return this.authContext?.hashCode()
+        }
+
         @Override
         int hashCode() {
             return Objects.hash(
-                    this.authContext instanceof SubjectAuthContext ? this.authContext?.getUsername()?.hashCode() : this.authContext?.hashCode(),
+                    this.hashAuthContext(),
                     this.resources?.hashCode(),
                     this.actions?.hashCode(),
                     this.resourceMap?.hashCode(),
@@ -130,7 +149,7 @@ class AuthContextEvaluatorCacheManager {
                     this.action == c.action &&
                     this.resourceMap == c.resourceMap &&
                     this.resources == c.resources &&
-                    ( this.authContext instanceof SubjectAuthContext ? this.authContext?.getUsername() == c.authContext?.getUsername() : this.authContext == this.authContext)
+                    this.compareAuthContext(c)
         }
     }
 }

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/AuthContextEvaluatorCacheManagerSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/AuthContextEvaluatorCacheManagerSpec.groovy
@@ -1,0 +1,172 @@
+package com.dtolabs.rundeck.server
+
+import com.dtolabs.rundeck.core.authorization.Attribute
+import com.dtolabs.rundeck.core.authorization.Decision
+import com.dtolabs.rundeck.core.authorization.Explanation
+import com.dtolabs.rundeck.core.authorization.SubjectAuthContext
+import org.grails.testing.GrailsUnitTest
+import spock.lang.Specification
+
+import javax.security.auth.Subject
+
+class AuthContextEvaluatorCacheManagerSpec  extends Specification implements GrailsUnitTest {
+    def "acl evaluation should cache with same args"() {
+        given:
+        AuthContextEvaluatorCacheManager authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
+        authContextEvaluatorCacheManager.enabled = enabled
+        SubjectAuthContext subjectAuthContext1 = Mock(SubjectAuthContext){
+            getUsername() >> { "username1" }
+            getRoles() >> { ["role1"] as Set }
+            calls * evaluate(_,_,_) >> { createDecision("action", true) }
+        }
+        Map resource1 = [akey: "value"]
+        String action1 = "action1"
+        String project1 = "project1"
+        when:
+        def evaluation1 = authContextEvaluatorCacheManager.evaluate(subjectAuthContext1, resource1, action1, project1)
+        def evaluation2 = authContextEvaluatorCacheManager.evaluate(subjectAuthContext1, resource, action, project)
+
+        then:
+        evaluation1
+        evaluation2
+        evaluation1.isAuthorized()
+        evaluation2.isAuthorized()
+
+        where:
+        calls | enabled  | resource                 | action    | project
+        1     | true     | [akey: "value"]          | "action1" | "project1"
+        2     | false    | [akey: "value"]          | "action1" | "project1"
+        2     | true     | [otherkey: "othervalue"] | "action1" | "project1"
+        2     | true     | [akey: "value"]          | "action2" | "project1"
+        2     | true     | [akey: "value"]          | "action1" | "project2"
+    }
+
+    def "acl evaluation with multiple actions and resources should cache with same args"() {
+        given:
+        AuthContextEvaluatorCacheManager authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
+        authContextEvaluatorCacheManager.enabled = enabled
+        SubjectAuthContext subjectAuthContext1 = Mock(SubjectAuthContext){
+            getUsername() >> { "username1" }
+            getRoles() >> { ["role1"] as Set }
+            calls * evaluate(_,_,_) >> { [createDecision("action", true)] as Set }
+        }
+        List resources1 = [[akey1: "value1"],[akey2: "value2"]]
+        List actions1 = ["action1", "action2"]
+        String project1 = "project1"
+        when:
+        Set<Decision> evaluation1 = authContextEvaluatorCacheManager.evaluate(subjectAuthContext1, resources1 as Set, actions1 as Set, project1)
+        Set<Decision> evaluation2 = authContextEvaluatorCacheManager.evaluate(subjectAuthContext1, resource as Set, action as Set, project)
+
+        then:
+        evaluation1
+        evaluation2
+        evaluation1.first()?.isAuthorized()
+        evaluation2.first()?.isAuthorized()
+
+        where:
+        calls | enabled | resource                               | action                 | project
+        1     | true    | [[akey1: "value1"], [akey2: "value2"]] | ["action1", "action2"] | "project1"
+        2     | false   | [[akey1: "value1"], [akey2: "value2"]] | ["action1"]            | "project1"
+        2     | true    | [[otherkey: "othervalue"]]             | ["action1"]            | "project1"
+        2     | true    | [[akey: "value"]]                      | ["action2"]            | "project1"
+        2     | true    | [[akey: "value"]]                      | ["action1"]            | "project2"
+    }
+
+    def "invalidate all entries from cache"() {
+        given:
+        AuthContextEvaluatorCacheManager authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
+        authContextEvaluatorCacheManager.enabled = true
+        SubjectAuthContext subjectAuthContext1 = Mock(SubjectAuthContext){
+            getUsername() >> { "username1" }
+            getRoles() >> { ["role1"] as Set }
+            2 * evaluate(_,_,_) >> { [createDecision("action", true)] as Set }
+        }
+        List resources1 = [[akey1: "value1"],[akey2: "value2"]]
+        List actions1 = ["action1", "action2"]
+        String project1 = "project1"
+        when:
+        Set<Decision> evaluation1 = authContextEvaluatorCacheManager.evaluate(subjectAuthContext1, resources1 as Set, actions1 as Set, project1)
+        authContextEvaluatorCacheManager.invalidateAllCacheEntries()
+        Set<Decision> evaluation2 = authContextEvaluatorCacheManager.evaluate(subjectAuthContext1, resources1 as Set, actions1 as Set, project1)
+
+        then:
+        evaluation1
+        evaluation2
+        evaluation1.first()?.isAuthorized()
+        evaluation2.first()?.isAuthorized()
+    }
+
+    def "acl cache should be refreshed if roles or username is changed"() {
+        given:
+        AuthContextEvaluatorCacheManager authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
+        authContextEvaluatorCacheManager.enabled = true
+        SubjectAuthContext subjectAuthContext1 = Mock(SubjectAuthContext){
+            getUsername() >> { "username1" }
+            getRoles() >> { ["role1"] as Set }
+            evaluate(_,_,_) >> { createDecision("action", true) }
+        }
+
+        SubjectAuthContext subjectAuthContext2 = Mock(SubjectAuthContext){
+            getUsername() >> { username }
+            getRoles() >> { roles as Set }
+            evaluate(_,_,_) >> { createDecision("action", false) }
+        }
+        Map resource = [akey: "value"]
+        String action = "action1"
+        String project = "project1"
+        when:
+        def evaluation1 = authContextEvaluatorCacheManager.evaluate(subjectAuthContext1, resource, action, project)
+        def evaluation2 = authContextEvaluatorCacheManager.evaluate(subjectAuthContext2, resource, action, project)
+
+        then:
+        evaluation1
+        evaluation2
+        evaluation1.isAuthorized()
+        !evaluation2.isAuthorized()
+
+        where:
+        username    | roles
+        "username2" | ["role1"]
+        "username1" | ["role2"]
+        "username1" | ["role1", "role2"]
+    }
+
+    Decision createDecision(String action, boolean isAuthorized) {
+        return new Decision() {
+            @Override
+            boolean isAuthorized() {
+                return isAuthorized
+            }
+
+            @Override
+            Explanation explain() {
+                return null
+            }
+
+            @Override
+            long evaluationDuration() {
+                return 0
+            }
+
+            @Override
+            Map<String, String> getResource() {
+                return null
+            }
+
+            @Override
+            String getAction() {
+                return action
+            }
+
+            @Override
+            Set<Attribute> getEnvironment() {
+                return null
+            }
+
+            @Override
+            Subject getSubject() {
+                return null
+            }
+        }
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -25,7 +25,6 @@ import com.dtolabs.rundeck.core.common.NodeSetImpl
 import com.dtolabs.rundeck.core.common.NodesSelector
 import com.dtolabs.rundeck.core.utils.NodeSet
 import com.dtolabs.rundeck.core.utils.OptsUtil
-import com.dtolabs.rundeck.server.AuthContextEvaluatorCacheManager
 import grails.test.hibernate.HibernateSpec
 import grails.testing.web.controllers.ControllerUnitTest
 import org.apache.commons.fileupload.FileItem
@@ -489,8 +488,8 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         controller.orchestratorPluginService=Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
         controller.featureService = Mock(FeatureService)
-        controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        controller.authContextEvaluatorCacheManager.frameworkService = controller.frameworkService
+        
+        
         when:
         request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
 
@@ -565,8 +564,8 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
                 it[2]<<"format: $format"
             }
         }
-        controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        controller.authContextEvaluatorCacheManager.frameworkService = controller.frameworkService
+        
+        
         when:
         request.parameters = [id: se.id.toString(), project: 'project1']
         response.format = format
@@ -1108,8 +1107,8 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         controller.pluginService = Mock(PluginService)
             controller.featureService = Mock(FeatureService)
 
-        controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        controller.authContextEvaluatorCacheManager.frameworkService = controller.frameworkService
+        
+        
         when:
         params.project = 'testProject'
         request.method = 'POST'
@@ -1325,8 +1324,8 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         controller.pluginService = Mock(PluginService)
             controller.featureService = Mock(FeatureService)
 
-        controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        controller.authContextEvaluatorCacheManager.frameworkService = controller.frameworkService
+        
+        
         when:
         params.project = 'testProject'
         request.method = 'POST'
@@ -1406,8 +1405,8 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         controller.orchestratorPluginService=Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
             controller.featureService = Mock(FeatureService)
-        controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        controller.authContextEvaluatorCacheManager.frameworkService = controller.frameworkService
+        
+        
         when:
         request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
 
@@ -1499,8 +1498,8 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         controller.orchestratorPluginService=Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
             controller.featureService = Mock(FeatureService)
-        controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        controller.authContextEvaluatorCacheManager.frameworkService = controller.frameworkService
+        
+        
         when:
         request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
 
@@ -1597,8 +1596,8 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         controller.orchestratorPluginService=Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
             controller.featureService = Mock(FeatureService)
-        controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        controller.authContextEvaluatorCacheManager.frameworkService = controller.frameworkService
+        
+        
         when:
         request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
 
@@ -1832,8 +1831,8 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         controller.orchestratorPluginService=Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
             controller.featureService = Mock(FeatureService)
-        controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        controller.authContextEvaluatorCacheManager.frameworkService = controller.frameworkService
+        
+        
         when:
         request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
 
@@ -1903,8 +1902,8 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         controller.orchestratorPluginService=Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
             controller.featureService = Mock(FeatureService)
-        controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        controller.authContextEvaluatorCacheManager.frameworkService = controller.frameworkService
+        
+        
         when:
         request.parameters = [id: se.id.toString(),project:'project1']
 
@@ -1977,8 +1976,8 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         controller.orchestratorPluginService=Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
             controller.featureService = Mock(FeatureService)
-        controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        controller.authContextEvaluatorCacheManager.frameworkService = controller.frameworkService
+        
+        
         when:
         request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
 
@@ -2056,8 +2055,8 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         controller.orchestratorPluginService = Mock(OrchestratorPluginService)
         controller.pluginService = Mock(PluginService)
             controller.featureService = Mock(FeatureService)
-        controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        controller.authContextEvaluatorCacheManager.frameworkService = controller.frameworkService
+        
+        
         when:
         request.parameters = [id: se.id.toString(), project: 'project1', retryFailedExecId: exec.id.toString()]
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerTests.groovy
@@ -23,7 +23,6 @@ import com.dtolabs.rundeck.core.authentication.Username
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.*
-import com.dtolabs.rundeck.server.AuthContextEvaluatorCacheManager
 import grails.test.hibernate.HibernateSpec
 import grails.testing.web.controllers.ControllerUnitTest
 import groovy.mock.interceptor.MockFor
@@ -2139,12 +2138,6 @@ class ScheduledExecutionControllerTests extends HibernateSpec implements Control
         sec.featureService=mockWith(FeatureService){
             featurePresent(){name->false}
         }
-        sec.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        sec.authContextEvaluatorCacheManager.frameworkService = mockWith(FrameworkService){
-            getAuthContextForSubjectAndProject { subject,proj -> testUserAndRolesContext() }
-            projectNames {authContext -> ["projecName1"]}
-            authorizeProjectResource {a,b,c,d -> true}
-        }
         def params = [id: se.id.toString(),project:'project1']
         sec.params.putAll(params)
         def model = sec.show()
@@ -2242,12 +2235,7 @@ class ScheduledExecutionControllerTests extends HibernateSpec implements Control
         sec.featureService=mockWith(FeatureService){
             featurePresent(){name->false}
         }
-        sec.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        sec.authContextEvaluatorCacheManager.frameworkService = mockWith(FrameworkService){
-            getAuthContextForSubjectAndProject { subject,proj -> testUserAndRolesContext() }
-            projectNames {authContext -> ["projecName1"]}
-            authorizeProjectResource {a,b,c,d -> true}
-        }
+
         def params = [id: se.id.toString(),project:'project1']
         sec.params.putAll(params)
         def model = sec.show()
@@ -2360,12 +2348,7 @@ class ScheduledExecutionControllerTests extends HibernateSpec implements Control
             featurePresent(){name->false}
         }
 
-        sec.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        sec.authContextEvaluatorCacheManager.frameworkService = mockWith(FrameworkService){
-            getAuthContextForSubjectAndProject { subject,proj -> testUserAndRolesContext() }
-            projectNames {authContext -> ["projecName1"]}
-            authorizeProjectResource {a,b,c,d -> true}
-        }
+
 
         def params = [id: se.id.toString(),project:'project1']
         sec.params.putAll(params)
@@ -2474,12 +2457,6 @@ class ScheduledExecutionControllerTests extends HibernateSpec implements Control
         }
         sec.featureService=mockWith(FeatureService){
             featurePresent(){name->false}
-        }
-        sec.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        sec.authContextEvaluatorCacheManager.frameworkService = mockWith(FrameworkService){
-            getAuthContextForSubjectAndProject { subject,proj -> testUserAndRolesContext() }
-            projectNames {authContext -> ["projecName1"]}
-            authorizeProjectResource {a,b,c,d -> true}
         }
 
         def params = [id: se.id.toString(),project:'project1']
@@ -2591,12 +2568,6 @@ class ScheduledExecutionControllerTests extends HibernateSpec implements Control
         sec.featureService=mockWith(FeatureService){
             featurePresent(){name->false}
         }
-        sec.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        sec.authContextEvaluatorCacheManager.frameworkService = mockWith(FrameworkService){
-            getAuthContextForSubjectAndProject { subject,proj -> testUserAndRolesContext() }
-            projectNames {authContext -> ["projecName1"]}
-            authorizeProjectResource {a,b,c,d -> true}
-        }
 
         def params = [id: se.id.toString(),project:'project1']
         sec.params.putAll(params)
@@ -2704,12 +2675,6 @@ class ScheduledExecutionControllerTests extends HibernateSpec implements Control
         }
         sec.featureService=mockWith(FeatureService){
             featurePresent(){name->false}
-        }
-        sec.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        sec.authContextEvaluatorCacheManager.frameworkService = mockWith(FrameworkService){
-            getAuthContextForSubjectAndProject { subject,proj -> testUserAndRolesContext() }
-            projectNames {authContext -> ["projecName1"]}
-            authorizeProjectResource {a,b,c,d -> true}
         }
 
         def params = [id: se.id.toString(),project:'project1']
@@ -2845,12 +2810,6 @@ class ScheduledExecutionControllerTests extends HibernateSpec implements Control
 
         sec.featureService=mockWith(FeatureService){
             featurePresent(){name->false}
-        }
-        sec.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
-        sec.authContextEvaluatorCacheManager.frameworkService = mockWith(FrameworkService){
-            getAuthContextForSubjectAndProject { subject,proj -> testUserAndRolesContext() }
-            projectNames {authContext -> ["projecName1"]}
-            authorizeProjectResource {a,b,c,d -> true}
         }
         def params = [id: se.id.toString(),project:'project1',retryExecId:exec.id.toString()]
         sec.params.putAll(params)


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/1275

**Is this a bugfix, or an enhancement? Please describe.**
When using `ReloadablePropertyFileLoginModule`, if the user properties is changed on `realm.properties` file the changes have no effect without restart Rundeck because the ACL rules validation will already stored in cache.

**Describe the solution you've implemented**
Now, if roles changes the cache value will not be used.

**Additional context**
 Also removed some unused lines of codes
