### PR TITLE
Update ContainerRoleSource to return roles from Spring Security. 

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/web/infosec/ContainerRoleSource.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/web/infosec/ContainerRoleSource.groovy
@@ -17,6 +17,8 @@
 package org.rundeck.web.infosec
 
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
 import rundeck.services.FrameworkService
 
 import javax.servlet.http.HttpServletRequest
@@ -26,17 +28,17 @@ import javax.servlet.http.HttpServletRequest
  */
 class ContainerRoleSource implements AuthorizationRoleSource {
     boolean enabled
-    @Autowired
-    def FrameworkService frameworkService
+
     @Override
     Collection<String> getUserRoles(final String username, final HttpServletRequest request) {
+        def auth = SecurityContextHolder.getContext().getAuthentication()
+        Collection<? extends GrantedAuthority> authorities = auth.getAuthorities();
         def roles=new ArrayList<String>()
-        //try to determine roles based on aclpolicy group definitions
-        frameworkService.getFrameworkRoles().each { rolename ->
-            if (request.isUserInRole(rolename)) {
-                roles<<rolename
-            }
+
+        authorities?.each {GrantedAuthority grantedAuthority ->
+            roles.add(grantedAuthority.authority)
         }
+
         roles
     }
 }

--- a/rundeckapp/src/test/groovy/org/rundeck/web/infosec/ContainerRoleSourceSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/web/infosec/ContainerRoleSourceSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.rundeck.web.infosec
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.context.SecurityContextImpl
+import spock.lang.Specification
+
+
+class ContainerRoleSourceSpec extends Specification {
+    def "GetUserRoles"() {
+        setup:
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(user, "***",
+                                                                                           userRoles)
+        SecurityContextHolder.setContext(new SecurityContextImpl(auth))
+
+        when:
+        def roles = new ContainerRoleSource().getUserRoles(user, null)
+
+        then:
+        roles == expected
+
+        where:
+        user | userRoles | expected
+        "admin" | [new SimpleGrantedAuthority("admin"), new SimpleGrantedAuthority("user")] | ["admin", "user"]
+        "admin" | null | []
+
+    }
+}


### PR DESCRIPTION
No longer checks against Rundeck ACLs for group name match.
