### PR TITLE
Remove MySQL JDBC driver from bundle

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -148,7 +148,6 @@ dependencies {
     runtime 'org.apache.logging.log4j:log4j-web:2.13.3'
 
     // Database drivers
-    runtime 'mysql:mysql-connector-java:8.0.21'
     runtime 'com.microsoft.sqlserver:mssql-jdbc:6.4.0.jre8'
     runtime 'org.mariadb.jdbc:mariadb-java-client:2.7.0'
     runtime 'org.postgresql:postgresql:42.2.13'

--- a/test/docker/docker-compose-api-mysql.yaml
+++ b/test/docker/docker-compose-api-mysql.yaml
@@ -32,7 +32,7 @@ services:
       - WAIT_NODES=rundeck1
       - CONFIG_SCRIPT_PRESTART=scripts/config-db.sh
       - "STARTUP_FAILURE_MSG=MySQLSyntaxErrorException"
-      - DATABASE_DRIVER=com.mysql.jdbc.Driver
+      - DATABASE_DRIVER=org.mariadb.jdbc.Driver
       - DATABASE_URL=jdbc:mysql://mysql:3306/rundeck?autoReconnect=true&useUnicode=yes&useSSL=false
       - DATABASE_USER=rundeck
       - DATABASE_PASS=rundeck

--- a/testbuild.groovy
+++ b/testbuild.groovy
@@ -45,7 +45,6 @@ def debug=Boolean.getBoolean('debug')?:("-debug" in args)
 
 //versions of dependency we want to verify
 def versions=[
-        mysql:'8.0.21',
         jetty:'9.4.26.v20200117',
         servlet:'api-3.1.0',
         log4j:'2.13.2'
@@ -95,7 +94,6 @@ def manifest=[
         "WEB-INF/lib/rundeck-authz-api-${version}.jar",
         "WEB-INF/lib/rundeck-authz-core-${version}.jar",
         "WEB-INF/lib/rundeck-authz-yaml-${version}.jar",
-        "WEB-INF/lib/mysql-connector-java-${versions.mysql}.jar",
         // ##file : require checksum verify to top level
         "WEB-INF/lib/rundeck-core-${version}.jar##core/${target}/rundeck-core-${version}.jar",
         "WEB-INF/lib/rundeck-storage-api-${version}.jar##rundeck-storage/rundeck-storage-api/${target}/rundeck-storage-api-${version}.jar",


### PR DESCRIPTION
Removes the MySQL driver from the bundle and updates tests to use the MariaDB Connector/J driver.