### PR TITLE
Fix old property for contextPath was being used to set the context ref in the UI

### DIFF
--- a/rundeckapp/grails-app/init/rundeckapp/init/RundeckInitializer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/RundeckInitializer.groovy
@@ -305,7 +305,7 @@ class RundeckInitializer {
     private static final Map<String, List<String>> LEGACY_SYS_PROP_CONVERSION = [
         'server.http.port'                      : ['server.port'],
         'server.http.host'                      : ['server.host', 'server.address'],
-        (RundeckInitConfig.SYS_PROP_WEB_CONTEXT): ['server.contextPath'],
+        (RundeckInitConfig.SYS_PROP_WEB_CONTEXT): ['server.servlet.context-path'],
         'rundeck.jetty.connector.forwarded'     : ['server.useForwardHeaders']
     ]
 

--- a/rundeckapp/grails-app/views/layouts/base.gsp
+++ b/rundeckapp/grails-app/views/layouts/base.gsp
@@ -131,7 +131,7 @@
 
         window._rundeck = Object.assign(window._rundeck || {}, {
         rdBase: '${g.createLink(uri:"/",absolute:true)}',
-        context: '${grailsApplication.config.server.contextPath}',
+        context: '${grailsApplication.config.server.servlet.'context-path'}',
         apiVersion: '${com.dtolabs.rundeck.app.api.ApiVersions.API_CURRENT_VERSION}',
         language: '${response.locale?.language ?: request.locale?.language}',
         locale: '${response.locale?.toString() ?: request.locale?.toString()}',

--- a/rundeckapp/src/integration-test/groovy/rundeck/init/RundeckInitializerTest.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/init/RundeckInitializerTest.groovy
@@ -72,12 +72,12 @@ class RundeckInitializerTest extends Specification {
         System.getProperty(newProp) == val
 
         where:
-        origProp                            | newProp                    | val
-        'server.http.port'                  | 'server.port'              | '4441'
-        'server.http.host'                  | 'server.host'              | 'hostoverride'
-        'server.http.host'                  | 'server.address'           | 'hostoverride'
-        'server.web.context'                | 'server.contextPath'       | '/rundeck'
-        'rundeck.jetty.connector.forwarded' | 'server.useForwardHeaders' | 'true'
+        origProp                            | newProp                       | val
+        'server.http.port'                  | 'server.port'                 | '4441'
+        'server.http.host'                  | 'server.host'                 | 'hostoverride'
+        'server.http.host'                  | 'server.address'              | 'hostoverride'
+        'server.web.context'                | 'server.servlet.context-path' | '/rundeck'
+        'rundeck.jetty.connector.forwarded' | 'server.useForwardHeaders'    | 'true'
     }
 
     def "process property partial files in war files"() {


### PR DESCRIPTION
Fixes #6512

Update to use new context path property.
