### PR TITLE
Fix the display of Enterprise plugins when listing plugins

### DIFF
--- a/rundeckapp/grails-spa/packages/ui/src/pages/repository/components/PluginCard.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/repository/components/PluginCard.vue
@@ -84,6 +84,10 @@ export default {
     displayCard() {
       if (this.showWhichPlugins === null) {
         return true;
+      } else if(this.result.support === 'Enterprise Exclusive' && this.showWhichPlugins === true && window._RDPRO_EDITION) {
+        return true
+      } else if(this.result.support === 'Enterprise Exclusive' && this.showWhichPlugins === false && window._RDPRO_EDITION) {
+        return false
       } else {
         return this.showWhichPlugins === this.result.installed;
       }


### PR DESCRIPTION
Fix the display of Enterprise plugins when going to the "Find Plugins" page, then choosing to filter by installed and uninstalled.
