### PR TITLE
Changes to allow upload an empty file to a job option.

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -3167,7 +3167,7 @@ class ScheduledExecutionController  extends ControllerBase{
                 if (name.startsWith(optionParameterPrefix)) {
                     //process file option upload
                     String optname = name.substring(optionParameterPrefix.length())
-                    if (optname in fileOptionNames && !file.empty) {
+                    if (optname in fileOptionNames && (!file.empty || file.originalFilename)) {
                         try {
                             String ref = fileUploadService.receiveFile(
                                     file.inputStream,

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -643,6 +643,7 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
                         commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]
                 ).save()
         )
+
         se.save()
 
         def exec = new Execution(
@@ -682,6 +683,75 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
 
 
         request.subject = new Subject()
+        setupFormTokens(params)
+        when:
+        request.method = 'POST'
+        controller.runJobInline(command, extra)
+
+        then:
+        response.status == 200
+        response.contentType.contains 'application/json'
+        response.json == [
+                href   : "/execution/follow/${exec.id}",
+                success: true,
+                id     : exec.id,
+                follow : false
+        ]
+
+    }
+
+    def "run job now inline with option file and the file is empty"() {
+        given:
+        def se = new ScheduledExecution(
+                jobName: 'monkey1', project: 'testProject', description: 'blah',
+                workflow: new Workflow(
+                        commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]
+                ).save()
+        )
+        se.addToOptions([name: "OPT1", optionType: "file"])
+        se.save()
+
+        def exec = new Execution(
+                user: "testuser", project: "testproj", loglevel: 'WARN',
+                workflow: new Workflow(
+                        commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]
+                ).save()
+        ).save()
+
+        def testcontext = Mock(UserAndRolesAuthContext) {
+            getUsername() >> 'test'
+            getRoles() >> (['test'] as Set)
+        }
+
+        controller.frameworkService = Mock(FrameworkService) {
+            getAuthContextForSubjectAndProject(*_) >> testcontext
+            authorizeProjectJobAll(*_) >> true
+        }
+
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService) {
+            1 * getByIDorUUID(_) >> se
+            isProjectExecutionEnabled(_) >> true
+        }
+
+
+        controller.executionService = Mock(ExecutionService) {
+            1 * getExecutionsAreActive() >> true
+            1 * executeJob(se, testcontext, _,  {opts->
+                opts['runAtTime']==null && opts['executionType']=='user'
+            }) >> [executionId: exec.id]
+        }
+        controller.fileUploadService = Mock(FileUploadService){
+            //assert the empty file will be uploaded
+            1 * receiveFile(_,_,_,'afile.txt', 'OPT1',_,_,_,_) >> 'aref'
+        }
+
+        def command = new RunJobCommand()
+        command.id = se.id.toString()
+        def extra = new ExtraCommand()
+
+
+        request.subject = new Subject()
+        request.addFile(new GrailsMockMultipartFile('extra.option.OPT1', 'afile.txt', 'application/octet-stream', ''.bytes))
         setupFormTokens(params)
         when:
         request.method = 'POST'


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/1213

**Is this a bugfix, or an enhancement? Please describe.**
File was not uploaded to a job option if it is empty

**Describe the solution you've implemented**
A verification was changed to allow an empty file to be uploaded.
