### PR TITLE
modified css for log output when printing screen from the browser

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/custom/execution-output-styles.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/custom/execution-output-styles.scss
@@ -116,3 +116,15 @@
     background-color: #333333;
   }
 }
+
+@media print {
+  .main-panel{
+    overflow: visible  !important;
+  }
+  .card-content-full-width{
+    height: auto  !important;
+  }
+  .execution-log {
+    overflow: visible  !important;
+  }
+}


### PR DESCRIPTION
Fix for https://github.com/rundeckpro/rundeckpro/issues/1267

It will show all the log output when printing from the browser.

![imagen](https://user-images.githubusercontent.com/50217398/95028381-46e12580-0676-11eb-9675-ea78f1cb50d3.png)
