### PR TITLE
Project list updates

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
@@ -26,7 +26,9 @@ public enum Features {
     WORKFLOW_DYNAMIC_STEP_SUMMARY_GUI("workflowDynamicStepSummaryGUI"),
     JOB_LIFECYCLE_PLUGIN("jobLifecyclePlugin"),
     EXECUTION_LIFECYCLE_PLUGIN("executionLifecyclePlugin"),
-    LEGACY_EXEC_OUTPUT_VIEWER("legacyExecOutputViewer");
+    LEGACY_EXEC_OUTPUT_VIEWER("legacyExecOutputViewer"),
+    SIDEBAR_PROJECT_LISTING("sidebarProjectListing"),
+    USER_SESSION_PROJECTS_CACHE("userSessionProjectsCache");
 
     private final String propertyName;
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -49,6 +49,12 @@ public class RundeckConfigBase {
     RundeckAjaxConfig ajax;
     RundeckMetricsConfig metrics;
     RundeckExecutionConfig execution;
+    UserSessionProjectsCache userSessionProjectsCache;
+
+    @Data
+    public static class UserSessionProjectsCache {
+        Long refreshDelay;
+    }
 
     @Data
     public static class RundeckExecutionConfig {
@@ -286,6 +292,8 @@ public class RundeckConfigBase {
         Enabled executionLifecyclePlugin = new Enabled();
         Enabled legacyExecOutputViewer = new Enabled();
         Enabled notificationsEditorVue = new Enabled();
+        Enabled sidebarProjectListing = new Enabled(true);
+        Enabled userSessionProjectsCache = new Enabled(true);
 
         @Data
         public static class Enabled {

--- a/rundeckapp/grails-app/assets/javascripts/menu/home.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/home.js
@@ -344,7 +344,8 @@ function HomeData(data) {
     self.loadProjectNames=function(){
         self.loadProjectNamesAsync().then( function (data) {
             if(self.opts().loadProjectsMode === 'full') {
-                self.projectNames(data.projectNames)
+                self.projectNames.removeAll();
+                data.projectNames.forEach(p=>self.projectNames.push(p))
                 self.projectNamesTotal(data.projectNames.length)
                 self.loadedProjectNames(true)
             }else{
@@ -390,7 +391,7 @@ function HomeData(data) {
         }
         self.filtered.filters.push(self.getSearchFilter());
         self.beginLoad();
-        if (self.projectCount() != self.projectNamesTotal()) {
+        if (self.projectCount() !== self.projectNamesTotal()) {
             self.loadProjectNames();
         }
     };

--- a/rundeckapp/grails-app/assets/javascripts/menu/home.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/home.js
@@ -311,7 +311,9 @@ function HomeData(data) {
     //initial setup
     self.beginLoad = function () {
 
-        if (self.doRefresh()) {
+        if(!self.loaded()){
+            self.loadSummary()
+        }else if (self.doRefresh()) {
             setTimeout(self.loadSummary, self.refreshDelay());
         }
     };

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -28,6 +28,7 @@ import com.dtolabs.rundeck.core.authorization.AuthorizationUtil
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.IRundeckProject
+import com.dtolabs.rundeck.core.config.Features
 import com.dtolabs.rundeck.core.extension.ApplicationExtension
 import com.dtolabs.rundeck.plugins.scm.ScmPluginException
 import com.dtolabs.rundeck.server.plugins.services.StorageConverterPluginProviderService
@@ -49,6 +50,7 @@ import rundeck.*
 import rundeck.codecs.JobsYAMLCodec
 import rundeck.services.*
 import rundeck.services.authorization.PoliciesValidation
+import rundeck.services.feature.FeatureService
 
 import javax.security.auth.Subject
 import javax.servlet.http.HttpServletResponse
@@ -76,6 +78,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     RundeckJobDefinitionManager rundeckJobDefinitionManager
     JobListLinkHandlerRegistry jobListLinkHandlerRegistry
     AuthContextEvaluatorCacheManager authContextEvaluatorCacheManager
+    FeatureService featureService
 
     def configurationService
     ScmService scmService
@@ -2191,11 +2194,13 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         }
 
         AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
-        long start = System.currentTimeMillis()
 
-        def fprojects = frameworkService.refreshSessionProjects(authContext, session)
-
-        log.debug("frameworkService.projectNames(context)... ${System.currentTimeMillis() - start}")
+        def fprojects=null
+        if(session.frameworkProjects || featureService.featurePresent(Features.SIDEBAR_PROJECT_LISTING)) {
+            long start = System.currentTimeMillis()
+            fprojects = frameworkService.refreshSessionProjects(authContext, session, params.refresh=='true')
+            log.debug("frameworkService.projectNames(context)... ${System.currentTimeMillis() - start}")
+        }
         def stats=cachedSummaryProjectStats(fprojects)
 
         //isFirstRun = true //as

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2201,12 +2201,13 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             fprojects = frameworkService.refreshSessionProjects(authContext, session, params.refresh=='true')
             log.debug("frameworkService.projectNames(context)... ${System.currentTimeMillis() - start}")
         }
-        def stats=cachedSummaryProjectStats(fprojects)
-
+        def statsLoaded = fprojects!=null
+        def stats = statsLoaded ? cachedSummaryProjectStats(fprojects) : [:]
         //isFirstRun = true //as
         render(view: 'home', model: [
                 isFirstRun:isFirstRun,
                 projectNames: fprojects,
+                statsLoaded: statsLoaded,
                 execCount:stats.execCount,
                 totalFailedCount:stats.totalFailedCount,
                 recentUsers:stats.recentUsers,
@@ -2384,7 +2385,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
         long start = System.currentTimeMillis()
         def fprojects = frameworkService.projectNames(authContext)
-        def flabels = frameworkService.projectLabels(authContext)
+        def flabels = frameworkService.projectLabels(authContext,fprojects)
         session.frameworkProjects = fprojects
         session.frameworkLabels = flabels
         log.debug("frameworkService.projectNames(context)... ${System.currentTimeMillis() - start}")

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2387,12 +2387,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
 
     def projectNamesAjax() {
         AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
-        long start = System.currentTimeMillis()
-        def fprojects = frameworkService.projectNames(authContext)
-        def flabels = frameworkService.projectLabels(authContext,fprojects)
-        session.frameworkProjects = fprojects
-        session.frameworkLabels = flabels
-        log.debug("frameworkService.projectNames(context)... ${System.currentTimeMillis() - start}")
+        def fprojects = frameworkService.refreshSessionProjects(authContext, session)
 
         render(contentType:'application/json',text:
                 ([projectNames: fprojects] )as JSON

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2201,8 +2201,12 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             fprojects = frameworkService.refreshSessionProjects(authContext, session, params.refresh=='true')
             log.debug("frameworkService.projectNames(context)... ${System.currentTimeMillis() - start}")
         }
-        def statsLoaded = fprojects!=null
-        def stats = statsLoaded ? cachedSummaryProjectStats(fprojects) : [:]
+        def statsLoaded = false
+        def stats=[:]
+        if(fprojects && session.summaryProjectStats){
+            stats=cachedSummaryProjectStats(fprojects)
+            statsLoaded=true
+        }
         //isFirstRun = true //as
         render(view: 'home', model: [
                 isFirstRun:isFirstRun,

--- a/rundeckapp/grails-app/views/common/_sidebar.gsp
+++ b/rundeckapp/grails-app/views/common/_sidebar.gsp
@@ -59,6 +59,7 @@
 </g:if>
 <g:if test="${session?.user && request.subject }">
 <g:set var="projectName" value="${params.project ?: request.project}"/>
+<feature:enabled name="sidebarProjectListing">
 <g:if test="${session.frameworkProjects}">
     <li id="projectSelect">
       <a href="#" data-toggle="collapse">
@@ -77,6 +78,7 @@
                   ]}"/>
     </li>
 </g:if>
+</feature:enabled>
 <g:if test="${projectName}">
     <li id="nav-project-dashboard-link" class="${enc(attr: homeselected)}">
       <g:link controller="menu" action="projectHome" params="[project: project ?: projectName]">

--- a/rundeckapp/grails-app/views/menu/home.gsp
+++ b/rundeckapp/grails-app/views/menu/home.gsp
@@ -30,13 +30,16 @@
     <meta name="layout" content="base"/>
     <meta name="tabpage" content="home"/>
     <title><g:appTitle/></title>
-    <g:if test="${projectNames.size()<50}">
-        <g:embedJSON data="${[projectNames:projectNames,projectNamesTotal:projectNames.size()]}" id="projectNamesData"/>
+    <g:if test="${projectNames==null}">
+        <g:embedJSON data="${[projectNames:[],projectNamesTotal:-1]}" id="projectNamesData"/>
     </g:if>
+    <g:elseif test="${projectNames && projectNames.size()<50}">
+        <g:embedJSON data="${[projectNames:projectNames,projectNamesTotal:projectNames.size()]}" id="projectNamesData"/>
+    </g:elseif>
     <g:else>
         <g:embedJSON data="${[projectNames:projectNames[0..49],projectNamesTotal:projectNames.size()]}" id="projectNamesData"/>
     </g:else>
-    <g:embedJSON data="${[loaded:true,execCount:execCount,totalFailedCount:totalFailedCount,recentUsers:recentUsers,recentProjects:recentProjects]}" id="statsData"/>
+    <g:embedJSON data="${[loaded:statsLoaded,execCount:execCount,totalFailedCount:totalFailedCount,recentUsers:recentUsers,recentProjects:recentProjects]}" id="statsData"/>
 
     <g:embedJSON data="${[
             detailBatchMax        : params.getInt('detailBatchMax')?:cfg.getInteger(config: 'gui.home.projectList.detailBatchMax', default: 15).toInteger(),
@@ -167,8 +170,8 @@
         </div>
     </div>
 </div>
-<g:if test="${projectNames.size()<1}">
-  <div class="container-fluid">
+
+  <div class="container-fluid" data-bind="if: projectCount()<1 && loadedProjectNames()">
     <div class="row">
         <div class="col-sm-12">
           <div class="card">
@@ -209,7 +212,7 @@
         </div>
     </div>
   </div>
-</g:if>
+
 <div class="container-fluid">
   <div class="row">
     <div class="col-xs-12">

--- a/rundeckapp/grails-app/views/menu/home.gsp
+++ b/rundeckapp/grails-app/views/menu/home.gsp
@@ -36,9 +36,9 @@
     <g:elseif test="${projectNames && projectNames.size()<50}">
         <g:embedJSON data="${[projectNames:projectNames,projectNamesTotal:projectNames.size()]}" id="projectNamesData"/>
     </g:elseif>
-    <g:else>
+    <g:elseif test="${projectNames}">
         <g:embedJSON data="${[projectNames:projectNames[0..49],projectNamesTotal:projectNames.size()]}" id="projectNamesData"/>
-    </g:else>
+    </g:elseif>
     <g:embedJSON data="${[loaded:statsLoaded,execCount:execCount,totalFailedCount:totalFailedCount,recentUsers:recentUsers,recentProjects:recentProjects]}" id="statsData"/>
 
     <g:embedJSON data="${[
@@ -97,11 +97,15 @@
         <div class="col-sm-12 col-md-5">
           <div class="card">
             <div class="card-content" style="padding-bottom: 20px;">
-              <span class="h3 text-primary">
+              <span class="h3 text-primary" data-bind="if: loadedProjectNames()">
                   <span data-bind="messageTemplate: projectNamesTotal, messageTemplatePluralize:true">
                       <g:message code="page.home.section.project.title" />|<g:message code="page.home.section.project.title.plural" />
                   </span>
               </span>
+            <span class="text-h3 text-muted" data-bind="if: !loadedProjectNames()">
+                <b class="fas fa-spinner fa-spin loading-spinner"></b>
+                <g:message code="page.home.loading.projects" />
+            </span>
               <auth:resourceAllowed action="create" kind="project" context="application">
                 <g:link controller="framework" action="createProject" class="btn  btn-success pull-right">
                     <g:message code="page.home.new.project.button.label" />
@@ -129,8 +133,8 @@
         <div class="col-sm-12 col-md-7">
           <div class="card">
             <div class="card-content">
-              <span data-bind="if: !loaded()">
-                <b class="fas fa-spinner fa-spin loading-spinner text-muted fa-lg"></b>
+              <span data-bind="if: !loaded()" class="text-muted">
+                  ...
               </span>
               <div data-bind="if: projectCount() > 1 && loaded()">
                 %{--app summary info--}%
@@ -170,7 +174,6 @@
         </div>
     </div>
 </div>
-
   <div class="container-fluid" data-bind="if: projectCount()<1 && loadedProjectNames()">
     <div class="row">
         <div class="col-sm-12">
@@ -216,21 +219,15 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col-xs-12">
-      <div class="card" data-bind="if:  projectCount()>0 ">
+      <div class="card" >
         <div class="card-content">
-          <div data-bind="if: !loadedProjectNames() && projectCount()<1">
-            <div class="">
-                <g:message code="page.home.loading.projects" />
-                <b class="fas fa-spinner fa-spin loading-spinner text-muted fa-2x"></b>
-            </div>
-          </div>
-          <div data-bind="if: projectCount()>0">
+          <div>
             <div class="input-group">
               <!-- <span class="input-group-addon"><i class="fa fa-search"></i></span> -->
               <input type="search" name="search" placeholder="${message(code:"page.home.search.projects.input.placeholder")}" class="form-control input-sm" data-bind="value: search" />
               <span class="input-group-addon"><g:icon name="search"/></span>
             </div>
-            <div data-bind="if: filtered.enabledFiltersCount()>0">
+            <div data-bind="if: filtered.enabledFiltersCount()>0 && loadedProjectNames()">
               <div class="alert alert-info">
                 <span data-bind="messageTemplate: searchedProjectsCount(), messageTemplatePluralize:true, css: { 'text-info': searchedProjectsCount()>0, 'text-warning': searchedProjectsCount()<1 }">
                     <g:message code="page.home.search.project.title" />|<g:message code="page.home.search.project.title.plural" />

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/utils/Pagination.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/utils/Pagination.vue
@@ -37,7 +37,7 @@
              :class="navigationClass"
              :title="'Page '+page.page">{{page.page}}</a>
           <span v-else
-                :class="valueClass"
+                :class="navigationClass"
                 :title="'Page '+page.page">{{page.page}}</span>
         </li>
         <li :class="{disabled:!hasNextButton||disabled}">

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -28,6 +28,7 @@ import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.authorization.ValidationSet
 import com.dtolabs.rundeck.core.authorization.providers.Policy
 import com.dtolabs.rundeck.core.authorization.providers.PolicyCollection
+import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.server.AuthContextEvaluatorCacheManager
 import grails.test.hibernate.HibernateSpec
 import grails.testing.web.controllers.ControllerUnitTest
@@ -56,6 +57,7 @@ import rundeck.services.ScheduledExecutionService
 import rundeck.services.ScmService
 import rundeck.services.UserService
 import rundeck.services.authorization.PoliciesValidation
+import rundeck.services.feature.FeatureService
 import rundeck.services.scm.ScmPluginConfig
 import rundeck.services.scm.ScmPluginConfigData
 import spock.lang.Unroll
@@ -69,6 +71,19 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
 
     List<Class> getDomainClasses() { [ScheduledExecution, CommandExec, Workflow, Project, Execution, User, AuthToken, ScheduledExecutionStats, UserService] }
 
+    def "home without sidebar feature"(){
+        given:
+            controller.configurationService=Mock(ConfigurationService)
+            controller.frameworkService=Mock(FrameworkService){
+                getRundeckFramework()>>Mock(IFramework)
+            }
+            controller.featureService=Mock(FeatureService)
+        when:
+            def result = controller.home()
+        then:
+            model!=null
+            model.projectNames==null
+    }
     def "api job detail xml"() {
         given:
         def testUUID = UUID.randomUUID().toString()

--- a/test/api/test-metrics.sh
+++ b/test/api/test-metrics.sh
@@ -41,8 +41,8 @@ test_metrics_metrics(){
     VAL=$(jq -r '.counters | length'  "${file}" )
     [ "$VAL" -gt 0 ] || fail "Expected > 0 for .counters in $file but was $VAL"
     assert_json_value '8' '.meters | length'  "${file}"
-    assert_json_value '31' '.timers | length'  "${file}"
-    
+    assert_json_value '30' '.timers | length'  "${file}"
+
     test_succeed
 
     rm "${file}"


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Extends https://github.com/rundeck/rundeck/pull/6513

more improvements to project list (home) page speed

- [x] project stats loading deferred to ajax request unless already cached
- [x] projectNamesAjax uses session cache from #6513 
- [x] update home ui to work better when everything is loaded async, and to support pro plugin behavior