### PR TITLE
Add cache warmup at bootstrap time for auth and project services

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
@@ -28,7 +28,9 @@ public enum Features {
     EXECUTION_LIFECYCLE_PLUGIN("executionLifecyclePlugin"),
     LEGACY_EXEC_OUTPUT_VIEWER("legacyExecOutputViewer"),
     SIDEBAR_PROJECT_LISTING("sidebarProjectListing"),
-    USER_SESSION_PROJECTS_CACHE("userSessionProjectsCache");
+    USER_SESSION_PROJECTS_CACHE("userSessionProjectsCache"),
+    AUTH_SVC_BOOTSTRAP_WARMUP_CACHE("authorizationServiceBootstrapWarmupCache"),
+    PROJMGR_SVC_BOOTSTRAP_WARMUP_CACHE("projectManagerServiceBootstrapWarmupCache");
 
     private final String propertyName;
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -294,6 +294,8 @@ public class RundeckConfigBase {
         Enabled notificationsEditorVue = new Enabled();
         Enabled sidebarProjectListing = new Enabled(true);
         Enabled userSessionProjectsCache = new Enabled(true);
+        Enabled authorizationServiceBootstrapWarmupCache = new Enabled();
+        Enabled projectManagerServiceBootstrapWarmupCache = new Enabled();
 
         @Data
         public static class Enabled {

--- a/rundeckapp/grails-app/conf/application.groovy
+++ b/rundeckapp/grails-app/conf/application.groovy
@@ -37,6 +37,8 @@ environments {
         rundeck.feature.executionLifecyclePlugin.enabled = true
         rundeck.feature.legacyExecOutputViewer.enabled = false
         rundeck.feature.notificationsEditorVue.enabled = true
+        rundeck.feature.projectManagerServiceBootstrapWarmupCache.enabled = true
+        rundeck.feature.authorizationServiceBootstrapWarmupCache.enabled = true
         dataSource {
             dbCreate = "create-drop" // one of 'create', 'create-drop','update'
             url = "jdbc:h2:file:./db/devDb"
@@ -74,6 +76,8 @@ environments {
         rundeck.feature.executionLifecyclePlugin.enabled = true
         rundeck.feature.legacyExecOutputViewer.enabled = false
         rundeck.feature.notificationsEditorVue.enabled = true
+        rundeck.feature.projectManagerServiceBootstrapWarmupCache.enabled = true
+        rundeck.feature.authorizationServiceBootstrapWarmupCache.enabled = true
         dataSource {
             dbCreate = "update"
             url = "jdbc:h2:file:/rundeck/grailsh2"


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Preloads caches for projects and authorization at app bootstrap, to speedup user login the first time.

can be disabled with:

```properties
# disable auth cache bootstrap warmup
rundeck.feature.authorizationServiceBootstrapWarmupCache=false

#disable project cache bootstrap warmup
rundeck.feature.projectManagerServiceBootstrapWarmupCache=false
```