### PR TITLE
Change username check in user gsp template

### DIFF
--- a/rundeckapp/grails-app/views/user/_user.gsp
+++ b/rundeckapp/grails-app/views/user/_user.gsp
@@ -22,7 +22,7 @@
    Created: Feb 2, 2010 3:16:55 PM
    $Id$
 --%>
-<g:set var="selfprofile" value="${user.login?.equalsIgnoreCase(request.remoteUser)}"/>
+<g:set var="selfprofile" value="${user.login?.equalsIgnoreCase(session.user)}"/>
 
 <div class="row">
     <div class="col-sm-12">


### PR DESCRIPTION
In some cases the string returned by request.getRemoteUser() is not just a username,
which causes the username check on the user gsp template to fail and the groups column will not be shown.
Changing to check against session.user fixes the issue.

Fixes: https://github.com/rundeckpro/rundeckpro/issues/1286