### PR TITLE
Fix loading zero projects

### DIFF
--- a/rundeckapp/grails-app/views/menu/home.gsp
+++ b/rundeckapp/grails-app/views/menu/home.gsp
@@ -30,7 +30,7 @@
     <meta name="layout" content="base"/>
     <meta name="tabpage" content="home"/>
     <title><g:appTitle/></title>
-    <g:if test="${projectNames==null || projectNames.size() == 0}">
+    <g:if test="${!projectNames}">
         <g:embedJSON data="${[projectNames:[],projectNamesTotal:-1]}" id="projectNamesData"/>
     </g:if>
     <g:elseif test="${projectNames && projectNames.size()<50}">

--- a/rundeckapp/grails-app/views/menu/home.gsp
+++ b/rundeckapp/grails-app/views/menu/home.gsp
@@ -30,7 +30,7 @@
     <meta name="layout" content="base"/>
     <meta name="tabpage" content="home"/>
     <title><g:appTitle/></title>
-    <g:if test="${projectNames==null}">
+    <g:if test="${projectNames==null || projectNames.size() == 0}">
         <g:embedJSON data="${[projectNames:[],projectNamesTotal:-1]}" id="projectNamesData"/>
     </g:if>
     <g:elseif test="${projectNames && projectNames.size()<50}">


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
`projectNames` in `home.gsp` is not `null` with zero projects when running a  _build_.

**Describe the solution you've implemented**
Check if `null` **or** if `projectnames.Size() == 0`.

**Describe alternatives you've considered**
Checking in the javascript for it. Passing around empty lists is preferable to `null` though as it composes better, and appears to be the original intention.

**Additional context**
I could not reproduce this running in development mode; the `null` check was enough. I'm not sure why this is.. I created a build to verify the issue and then created a build with the fix to verify it was resolved..
