### PR TITLE
Remove vendor.js script tag from base

### DIFF
--- a/rundeckapp/grails-app/views/layouts/base.gsp
+++ b/rundeckapp/grails-app/views/layouts/base.gsp
@@ -71,10 +71,6 @@
     <g:render template="/common/js"/>
     <g:render template="/common/css"/>
 
-    <!-- VUE JS REQUIREMENTS -->
-    <asset:javascript src="static/vendor.js"/>
-    <!-- /VUE JS REQUIREMENTS -->
-
     <!-- VUE CSS MODULES -->
     <asset:stylesheet href="static/css/components/motd.css"/>
     <asset:stylesheet href="static/css/components/version.css"/>


### PR DESCRIPTION
Fixes #6538 .

It is no longer created by the bundler. Attempting to load the missing asset shouldn't have been causing perceptible performance issues though; supported by the timings that have been posted.