### PR TITLE
Flip job schedule enabled api test timing update

### DIFF
--- a/test/api/test-job-flip-scheduleEnabled.sh
+++ b/test/api/test-job-flip-scheduleEnabled.sh
@@ -186,7 +186,7 @@ echo "TEST: when schedule is on, job does execute"
 generate_projectName_and_jobName
 create_proj_and_job $projectName $jobName
 assert_job_execution_count $jobId "0"
-sleep 11
+sleep 12
 assert_job_execution_count $jobId "1"
 delete_proj $projectName
 
@@ -198,7 +198,7 @@ generate_projectName_and_jobName
 create_proj_and_job $projectName $jobName
 assert_job_execution_count $jobId "0"
 disable_schedule $jobId
-sleep 11
+sleep 12
 assert_job_execution_count $jobId "0"
 delete_proj $projectName
 
@@ -210,8 +210,9 @@ generate_projectName_and_jobName
 create_proj_and_job $projectName $jobName
 assert_job_execution_count $jobId "0"
 disable_schedule $jobId
+sleep 2
 enable_schedule $jobId
-sleep 11
+sleep 12
 assert_job_execution_count $jobId "1"
 delete_proj $projectName
 


### PR DESCRIPTION
Update timing to let scheduling operations have time to complete in flip job schedule enabled api test.
