### PR TITLE
Show date formatted correctly in the GUI #5125

### DIFF
--- a/rundeckapp/grails-app/views/execution/_wfstateSummaryLine.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfstateSummaryLine.gsp
@@ -69,7 +69,7 @@
                 <span class="timerel execution-completed text-secondary" data-bind="visible: completed()">
 
                     <g:message code="at"/>
-                    <span data-bind="text: formatTimeAtDate(endTime()), attr: {title: endTime() }">
+                    <span data-bind="text: formatTimeAtDate(endTime()), attr: {title: formatTimeAtDate(endTime()) }">
                         <g:if test="${execution.dateCompleted}">
                             <g:relativeDate atDate="${execution.dateCompleted}"/>
                         </g:if>
@@ -87,9 +87,8 @@
                     <!-- /ko -->
                 </dt>
                 <dd>
-                    <span data-bind="text: startTime()">
+                    <span data-bind="text: formatTimeAtDate(startTime())">
                     <g:if test="${execution.dateStarted}">
-                        ${execution.dateStarted}
                         <g:relativeDate atDate="${execution.dateStarted}"/>
                     </g:if>
                     </span>
@@ -98,13 +97,11 @@
                 <!-- ko if: completed() -->
                 <dt><g:message code="end" /> (<span data-bind="text: endTimeAgo()"></span>)</dt>
                 <dd >
-                    <span data-bind="text: endTime()">
+                    <span data-bind="text: formatTimeAtDate(endTime())">
                     <g:if test="${execution.dateCompleted}">
-                        ${execution.dateCompleted}
                         <g:relativeDate atDate="${execution.dateCompleted}"/>
                     </g:if>
                     </span>
-
                 </dd>
                 <!-- /ko -->
             </dl>

--- a/rundeckapp/grails-spa/packages/ui/src/components/activity/activityList.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/activity/activityList.vue
@@ -1,6 +1,6 @@
 <template>
   <div class=" activity-list">
-    
+
           <section class="section-space-bottom">
 
             <span>
@@ -30,7 +30,7 @@
 
 
           <activity-filter v-model="query" :event-bus="eventBus" :opts="filterOpts" v-if="showFilters"></activity-filter>
-          
+
           <div class="pull-right">
             <span v-if="runningOpts.allowAutoRefresh">
               <input type=checkbox id=auto-refresh v-model=autorefresh />
@@ -260,7 +260,7 @@
             <td class="eventicon " :title="reportState(rpt)" >
                 <b class="exec-status icon" :data-execstate="reportStateCss(rpt)" :data-statusstring="reportState(rpt)"></b>
             </td>
-            <td class="right date " v-tooltip.bottom="$t('info.completed.0.1',[jobCompletedISOFormat(rpt.dateCompleted),jobCompletedFromNow(rpt.dateCompleted)])">
+            <td class="right date " v-tooltip.bottom="$t('info.completed.0.1',[jobCompletedFormat(rpt.dateCompleted),jobCompletedFromNow(rpt.dateCompleted)])">
                 <span v-if="rpt.dateCompleted">
                     <span class="timeabs ">
                         {{rpt.dateCompleted | moment(momentJobFormat)}}
@@ -528,7 +528,7 @@ export default Vue.extend({
         if(exec.job && exec.job.averageDuration){
           const expected = startmo.clone()
           expected.add(exec.job.averageDuration,'ms')
-          return (this as any).$t('info.started.expected.0.1',[startmo.fromNow(), expected.fromNow()])    
+          return (this as any).$t('info.started.expected.0.1',[startmo.fromNow(), expected.fromNow()])
         }
         return (this as any).$t('info.started.0',[startmo.fromNow()])
       }
@@ -644,7 +644,7 @@ export default Vue.extend({
           this.bulkEditMode = false
         }
         this.loadActivity(this.pagination.offset)
-        
+
       }catch(error){
         this.bulkEditProgress=false
         this.bulkEditError=error
@@ -665,7 +665,7 @@ export default Vue.extend({
           params: Object.assign({offset: this.pagination.offset, max: this.pagination.max},this.query,{since:this.lastDate}),
           withCredentials: true
         })
-        
+
         if(this.lastDate>0  && response.data.since && response.data.since.count ){
             this.sincecount=response.data.since.count
         }
@@ -815,7 +815,7 @@ export default Vue.extend({
       this.activityPageHref = window._rundeck.data['activityPageHref']
       this.sinceUpdatedUrl = window._rundeck.data['sinceUpdatedUrl']
         this.autorefreshms = window._rundeck.data['autorefreshms'] || 5000
-      
+
       if(window._rundeck.data['pagination'] && window._rundeck.data['pagination'].max){
         this.pagination.max=window._rundeck.data['pagination'].max
       }


### PR DESCRIPTION
Fix: https://github.com/rundeck/rundeck/issues/6564

**Is this a bug fix, or an enhancement? Please describe.**
The start date, complete date and tooltip were being printed on the page without the standard format
![image](https://user-images.githubusercontent.com/35808955/96001139-15065680-0e0e-11eb-893a-9d717a7461df.png)
![image](https://user-images.githubusercontent.com/35808955/96001195-26e7f980-0e0e-11eb-822f-591f7e19d8e2.png)



**Describe the solution you've implemented**
Page rendering was modified to print the timestamp formatted correctly

![image](https://user-images.githubusercontent.com/35808955/96000170-023f5200-0e0d-11eb-80ad-bda1993858bd.png)
![image](https://user-images.githubusercontent.com/35808955/96000245-14b98b80-0e0d-11eb-97af-75d93128fcd0.png)

