### PR TITLE
Set defaults for project list and cache

### DIFF
--- a/rundeckapp/grails-app/conf/application.groovy
+++ b/rundeckapp/grails-app/conf/application.groovy
@@ -39,6 +39,8 @@ environments {
         rundeck.feature.notificationsEditorVue.enabled = true
         rundeck.feature.projectManagerServiceBootstrapWarmupCache.enabled = true
         rundeck.feature.authorizationServiceBootstrapWarmupCache.enabled = true
+        rundeck.feature.sidebarProjectListing.enabled=true
+        rundeck.feature.userSessionProjectsCache.enabled=true
         dataSource {
             dbCreate = "create-drop" // one of 'create', 'create-drop','update'
             url = "jdbc:h2:file:./db/devDb"
@@ -78,6 +80,8 @@ environments {
         rundeck.feature.notificationsEditorVue.enabled = true
         rundeck.feature.projectManagerServiceBootstrapWarmupCache.enabled = true
         rundeck.feature.authorizationServiceBootstrapWarmupCache.enabled = true
+        rundeck.feature.sidebarProjectListing.enabled=true
+        rundeck.feature.userSessionProjectsCache.enabled=true
         dataSource {
             dbCreate = "update"
             url = "jdbc:h2:file:/rundeck/grailsh2"


### PR DESCRIPTION
Without the defaults set in `application.groovy` the project list will be disabled as well as the user session project list cache.

Setting these defaults to `true` resolves the issue in testing.