### PR TITLE
Sending an event to cleanup acl caches If cluster mode is active

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/AuthorizationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/AuthorizationService.groovy
@@ -380,6 +380,8 @@ class AuthorizationService implements InitializingBean, EventPublisher{
     }
 
     private void invalidateEntriesAclCache(String path) {
+        cleanCaches(path)
+
         if (frameworkService.isClusterModeEnabled()) {
             sendAndReceive(
                     'cluster.clearAclCache',
@@ -390,8 +392,6 @@ class AuthorizationService implements InitializingBean, EventPublisher{
             ) { resp ->
                 log.debug("Cleaning the cache in the cluster is ${resp.clearCacheState}: ${resp.reason}")
             }
-        } else {
-            cleanCaches(path)
         }
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/DbStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/DbStorageService.groovy
@@ -174,6 +174,7 @@ class DbStorageService implements NamespacedStorage{
         def dir, name
         (dir, name) = splitPath(path)
         def found = Storage.findByNamespaceAndDirAndName(ns?:null,dir, name)
+        found?.refresh()
         found
     }
 


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/1283

**Is this a bugfix, or an enhancement? Please describe.**
If the acl policy is changed on a instance, the others instances on cluster will keep the old policy on cache and the changes will not affect them.

**Describe the solution you've implemented**
A new event will be triggered if acl policy changes so that all instances on a cluster have their caches cleaned

**Additional context**
The DbStorageService was changed to refresh the resource after it is obtained from the database because the object returned did not contain the changes that had just been made in the db.
