### PR TITLE
performance: Update ACL list GUI pages to have asynch behavior

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -403,7 +403,17 @@ public class RundeckConfigBase {
         Login login;
         Job job;
         Home home;
+        GuiSystemConfig system;
 
+        @Data
+        public static class GuiSystemConfig{
+            AclList aclList;
+        }
+        @Data
+        public static class AclList{
+            Boolean pagingEnabled;
+            int pagingMax;
+        }
         @Data
         public static class Home {
             ProjectList projectList;

--- a/rundeckapp/grails-app/assets/javascripts/util/loader.js
+++ b/rundeckapp/grails-app/assets/javascripts/util/loader.js
@@ -1,0 +1,30 @@
+//= require knockout.min
+
+function Loadable ( dataLoader) {
+    let self = this
+    self.loaded = ko.observable(false)
+    self.loading = ko.observable(false)
+    self.error = ko.observable(false)
+    self.errorMessage = ko.observable()
+    self.onError=function(err){
+        self.loading(false)
+        self.error(true)
+        self.errorMessage(err)
+    }
+    self.onData = function (input) {
+        try {
+            dataLoader(input)
+            self.loaded(true)
+        } catch (e) {
+            self.onError(e)
+        }
+        self.loading(false)
+    }
+    self.begin = function () {
+        self.loading(true)
+    }
+    self.finished = function () {
+        self.loaded(true)
+        self.loading(false)
+    }
+}

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -1416,18 +1416,51 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     private List<Map> listProjectAclFiles(IRundeckProject project) {
         def projectlist = project.listDirPaths('acls/').findAll { it ==~ /.*\.aclpolicy$/ }.collect {
             def id = it.replaceAll(/^acls\//, '')
-            Map meta = getCachedPolicyMeta(id, project.name, null) {
-                def policy = loadProjectPolicyValidation(project, id)
-                def meta = policyMetaFromValidation(policy)
-                meta
-            }
             [
                     id  : id,
                     name: AclFile.idToName(id),
-                    meta: (meta ?: [:])
+                    valid: true
             ]
         }
         projectlist
+    }
+    def ajaxProjectAclMeta() {
+        AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
+
+        if (!params.project) {
+            return renderErrorView('Project parameter is required')
+        }
+        if (unauthorizedResponse(
+            frameworkService.authorizeApplicationResourceAny(
+                authContext,
+                frameworkService.authResourceForProjectAcl(params.project),
+                [AuthConstants.ACTION_READ, AuthConstants.ACTION_ADMIN]
+            ),
+            AuthConstants.ACTION_READ, 'ACL for Project', params.project
+        )) {
+            return
+        }
+        def project = frameworkService.getFrameworkProject(params.project)
+
+        if ( !(request.JSON) || !request.JSON.files) {
+            response.status = HttpServletResponse.SC_BAD_REQUEST
+            return respond([error: [message: g.message(code:'api.error.invalid.request',args:['JSON body must contain files entry'])]], formats: ['json'])
+        }
+        def list = request.JSON.files ?: []
+        def result = list.collect{String fname->
+            def validation = loadProjectPolicyValidation(project, fname)
+            Map meta = getCachedPolicyMeta(fname, project.name, null) {
+                policyMetaFromValidation(validation)
+            }
+            [
+                    id  : fname,
+                    name: AclFile.idToName(fname),
+                    meta: (meta ?: [:]),
+                    validation: validation?.errors,
+                    valid: validation?.valid
+            ]
+        }
+        respond((Object) result, formats: ['json'])
     }
 
     def createProjectAclFile() {
@@ -1688,7 +1721,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         authorizationService.validateYamlPolicy(null, fname, file)
     }
 
-    private loadSystemPolicyStorage(String fname) {
+    private PoliciesValidation loadSystemPolicyStorage(String fname) {
         def exists = authorizationService.existsPolicyFile(fname)
         if (exists) {
             return authorizationService.validateYamlPolicy(
@@ -1717,9 +1750,6 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             [
                     id   : fname,
                     name : AclFile.idToName(fname),
-                    meta : getCachedPolicyMeta(fname, null, 'storage') {
-                        policyMetaFromValidation(loadSystemPolicyStorage(fname))
-                    },
                     valid: true
             ]
         }
@@ -1730,6 +1760,39 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 aclStoredList: stored,
                 clusterMode  : isClusterModeAclsLocalFileEditDisabled()
         ]
+    }
+    def ajaxSystemAclMeta(){
+        AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
+
+        if (unauthorizedResponse(
+            frameworkService.authorizeApplicationResourceAny(
+                authContext,
+                AuthConstants.RESOURCE_TYPE_SYSTEM_ACL,
+                [AuthConstants.ACTION_READ, AuthConstants.ACTION_ADMIN]
+            ),
+            AuthConstants.ACTION_READ, 'System configuration')) {
+            return
+        }
+        //list of acl files
+
+        if ( !(request.JSON) || !request.JSON.files) {
+            response.status = HttpServletResponse.SC_BAD_REQUEST
+            return respond([error: [message: g.message(code:'api.error.invalid.request',args:['JSON body must contain files entry'])]], formats: ['json'])
+        }
+        def list = request.JSON.files ?: []
+        def result = list.collect{String fname->
+            def validation = loadSystemPolicyStorage(fname)
+            [
+                id   : fname,
+                name : AclFile.idToName(fname),
+                meta : getCachedPolicyMeta(fname, null, 'storage') {
+                    policyMetaFromValidation(validation)
+                },
+                validation: validation?.errors,
+                valid: validation?.valid
+            ]
+        }
+        respond((Object) result, formats: ['json'])
     }
 
     protected boolean isClusterModeAclsLocalFileEditDisabled() {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -102,6 +102,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             saveSystemAclFile              : 'POST',
             deleteSystemAclFile            : 'POST',
             listExport                     : 'POST',
+            ajaxProjectAclMeta             : 'POST',
+            ajaxSystemAclMeta              : 'POST',
     ]
 
     @CompileStatic
@@ -1429,7 +1431,9 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     }
     def ajaxProjectAclMeta() {
         AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
-
+        if (requireAjax(controller: 'menu', action: 'projectAcls', params: params)) {
+            return
+        }
         if (!params.project) {
             return renderErrorView('Project parameter is required')
         }
@@ -1765,6 +1769,9 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         ]
     }
     def ajaxSystemAclMeta(){
+        if(requireAjax(controller: 'menu',action:'acls')){
+            return
+        }
         AuthContext authContext = frameworkService.getAuthContextForSubject(session.subject)
 
         if (unauthorizedResponse(

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -1730,14 +1730,14 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
 
     private PoliciesValidation loadSystemPolicyStorage(String fname) {
         def exists = authorizationService.existsPolicyFile(fname)
-        if (exists) {
-            return authorizationService.validateYamlPolicy(
-                    null,
-                    fname,
-                    authorizationService.getPolicyFileContents(fname)
-            )
+        if (!exists) {
+            return null
         }
-        null
+        return authorizationService.validateYamlPolicy(
+                null,
+                fname,
+                authorizationService.getPolicyFileContents(fname)
+        )
     }
     private Map systemAclsModel() {
         def fwkConfigDir = frameworkService.getFrameworkConfigDir()

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -1381,6 +1381,9 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     }
 
     protected PoliciesValidation loadProjectPolicyValidation(IRundeckProject fwkProject, String ident) {
+        if(!fwkProject.existsFileResource('acls/'+ident)){
+            return null
+        }
         def baos = new ByteArrayOutputStream()
         fwkProject.loadFileResource('acls/' + ident, baos)
         def fileText = baos.toString('UTF-8')
@@ -1456,8 +1459,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     id  : fname,
                     name: AclFile.idToName(fname),
                     meta: (meta ?: [:]),
-                    validation: validation?.errors,
-                    valid: validation?.valid
+                    validation: validation ? validation.errors : [(fname): ['Not found']],
+                    valid: !!validation?.valid
             ]
         }
         respond((Object) result, formats: ['json'])
@@ -1787,9 +1790,9 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 name : AclFile.idToName(fname),
                 meta : getCachedPolicyMeta(fname, null, 'storage') {
                     policyMetaFromValidation(validation)
-                },
-                validation: validation?.errors,
-                valid: validation?.valid
+                }?:[:],
+                validation: validation ? validation.errors : [(fname): ['Not found']],
+                valid: !!validation?.valid
             ]
         }
         respond((Object) result, formats: ['json'])

--- a/rundeckapp/grails-app/views/menu/_aclListItemKO.gsp
+++ b/rundeckapp/grails-app/views/menu/_aclListItemKO.gsp
@@ -27,5 +27,5 @@
        title="${message(code: "aclpolicy.format.validation.failed")}"></i>
 </span>
 <span data-bind="text: name"></span>
-<span data-bind="text: resume()"></span>
+<span data-bind="text: resume"></span>
 </script>

--- a/rundeckapp/grails-app/views/menu/_aclValidationRowKO.gsp
+++ b/rundeckapp/grails-app/views/menu/_aclValidationRowKO.gsp
@@ -67,7 +67,7 @@
               <g:message code="edit"/>
             </a>
         </g:if>
-        <!-- ko if: meta() -->
+        <!-- ko if: meta() && meta().policies -->
         <ul data-bind="foreach:  { data: meta().policies, as: 'policy' }">
             <li>
                 <span class="text-primary" data-bind="text: policy.description()">

--- a/rundeckapp/grails-app/views/menu/_aclValidationRowKO.gsp
+++ b/rundeckapp/grails-app/views/menu/_aclValidationRowKO.gsp
@@ -18,6 +18,10 @@
 <div data-bind="css: {'flash_info':wasSaved}" style="border-top:1px solid #cfcfca; padding-top:1em;">
     <div class=" hover-action-holder">
         <span class="h3" data-bind="template: { name: 'acl-policy-ident', data:$data }"></span>
+          <span data-bind="if: loader.loading" class="text-muted">...</span>
+          <span data-bind="if: loader.error" class="text-warning">
+              <span data-bind="text: loader.errorMessage"></span>
+          </span>
           <!-- ko if: wasSaved -->
           <span class="label label-success">
               <g:icon name="saved"/>
@@ -63,6 +67,7 @@
               <g:message code="edit"/>
             </a>
         </g:if>
+        <!-- ko if: meta() -->
         <ul data-bind="foreach:  { data: meta().policies, as: 'policy' }">
             <li>
                 <span class="text-primary" data-bind="text: policy.description()">
@@ -75,6 +80,7 @@
                 </ul>
             </li>
         </ul>
+        <!-- /ko -->
     </div>
 </div>
 

--- a/rundeckapp/grails-app/views/menu/acls.gsp
+++ b/rundeckapp/grails-app/views/menu/acls.gsp
@@ -100,7 +100,7 @@
                     max: ${params.getInt('pagingMax')?:cfg.getInteger(config: 'gui.system.aclList.pagingMax', default: 30).toInteger()}
                 }
             })
-            window.stpolicies = new PolicyFiles(storedpolicies);
+            window.stpolicies = new PolicyFiles(storedpolicies,_rundeck.rdBase+'/menu/ajaxSystemAclMeta');
             new PagerVueAdapter(window.stpolicies.paging, 'acl-stored')
             ko.applyBindings(stpolicies, jQuery('#storedPolicies')[0]);
             ko.applyBindings(stpolicies, jQuery('#deleteStorageAclPolicy')[0]);

--- a/rundeckapp/grails-app/views/menu/projectAcls.gsp
+++ b/rundeckapp/grails-app/views/menu/projectAcls.gsp
@@ -73,6 +73,7 @@
     <asset:javascript src="menu/aclListing.js"/>
     <script type="application/javascript">
         var checkUploadForm;
+        let project="${enc(js:params.project)}"
         jQuery(function () {
             var data = loadJsonData('aclPolicyList');
             jQuery.extend(data,{
@@ -81,7 +82,7 @@
                     max: ${params.getInt('pagingMax')?:cfg.getInteger(config: 'gui.system.aclList.pagingMax', default: 30).toInteger()}
                 }
             })
-            window.policies = new PolicyFiles(data);
+            window.policies = new PolicyFiles(data,_genUrl(_rundeck.rdBase+'/menu/ajaxProjectAclMeta',{project:project}));
             new PagerVueAdapter(window.policies.paging, 'acl-stored')
             ko.applyBindings(policies, jQuery('#policyList')[0]);
             ko.applyBindings(policies, jQuery('#deleteAclPolicy')[0]);

--- a/rundeckapp/grails-app/views/menu/projectAcls.gsp
+++ b/rundeckapp/grails-app/views/menu/projectAcls.gsp
@@ -66,6 +66,10 @@
     <g:set var="projectLabel" value="${session.frameworkLabels?session.frameworkLabels[params.project]:params.project}"/>
     <title><g:message code="page.title.project.access.control.0" args="${[projectLabel]}"/></title>
 
+    <!-- VUE JS REQUIREMENTS -->
+    <asset:javascript src="static/components/ko-paginator.js"/>
+    <!-- /VUE JS REQUIREMENTS -->
+
     <asset:javascript src="menu/aclListing.js"/>
     <script type="application/javascript">
         var checkUploadForm;
@@ -78,6 +82,7 @@
                 }
             })
             window.policies = new PolicyFiles(data);
+            new PagerVueAdapter(window.policies.paging, 'acl-stored')
             ko.applyBindings(policies, jQuery('#policyList')[0]);
             ko.applyBindings(policies, jQuery('#deleteAclPolicy')[0]);
             <g:if test="${hasCreateAuth}" >
@@ -143,7 +148,7 @@
         </div>
 
         <div class="card-content" id="policyList">
-            <g:render template="aclsPagingKO"/>
+            <g:render template="aclsPagingKO" model="[name: 'acl-stored']"/>
             <g:render template="aclKOTemplates"/>
             <div data-bind="foreach: policiesView">
               <g:render template="/menu/aclValidationRowKO"


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

* [x] Project and System ACL GUI pages  load ACL policy metadata asynchronously on demand instead of ahead of time
* [x] Fix a bug: no pagination shown in Project ACL page

**Describe the solution you've implemented**

* only load list of ACL names ahead of time
* defer metadata loading about ACLs (validation, structure) to on-demand when paged into view

**Additional context**

Fix very slow loading of system ACLs page with many thousands of ACLs.
