### PR TITLE
Show date in ISO 8601 format in the GUI #6582

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -1387,6 +1387,11 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
     self.formatTimeAtDate=function(text){
         return MomentUtil.formatTimeAtDate(text);
     };
+
+    self.formatTimeInLocalTimeZone=function(text){
+        return MomentUtil.formatTimeInLocalTimeZone(text, "YYYY-MM-DDTHH:mm:ss");
+    }
+
     self.formatDurationHumanize=function(ms){
         return MomentUtil.formatDurationHumanize(ms);
     };

--- a/rundeckapp/grails-app/assets/javascripts/momentutil.js
+++ b/rundeckapp/grails-app/assets/javascripts/momentutil.js
@@ -130,6 +130,14 @@
         }
         var duration = moment.duration(ms);
         return duration.humanize();
+    },
+    formatTimeInLocalTimeZone : function(text, format){
+        var time = moment.isMoment(text) ? text : moment(text);
+        if (text && time.isValid()) {
+            return time.local().format(format);
+        } else {
+            return '';
+        }
     }
 };
 })();

--- a/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
@@ -244,6 +244,14 @@ class UtilityTagLib{
         out << duration
     }
 
+
+    def relativeDateFomater = {attrs,body ->
+        if(attrs.atDate) {
+            SimpleDateFormat dateFormater = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+            out << dateFormater.format(attrs.atDate);
+        }
+    }
+
     def relativeDate = { attrs, body ->
         out << relativeDateString(attrs + [html: attrs.html != null ? attrs.html : true], body)
     }

--- a/rundeckapp/grails-app/views/execution/_wfstateSummaryLine.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfstateSummaryLine.gsp
@@ -69,7 +69,7 @@
                 <span class="timerel execution-completed text-secondary" data-bind="visible: completed()">
 
                     <g:message code="at"/>
-                    <span data-bind="text: formatTimeAtDate(endTime()), attr: {title: endTime() }">
+                    <span data-bind="text: formatTimeAtDate(endTime()), attr: {title: formatTimeInLocalTimeZone(endTime()) }">
                         <g:if test="${execution.dateCompleted}">
                             <g:relativeDate atDate="${execution.dateCompleted}"/>
                         </g:if>
@@ -87,24 +87,16 @@
                     <!-- /ko -->
                 </dt>
                 <dd>
-                    <span data-bind="text: startTime()">
                     <g:if test="${execution.dateStarted}">
-                        ${execution.dateStarted}
-                        <g:relativeDate atDate="${execution.dateStarted}"/>
+                        <g:relativeDateFomater atDate="${execution.dateStarted}"/>
                     </g:if>
-                    </span>
-
                 </dd>
                 <!-- ko if: completed() -->
                 <dt><g:message code="end" /> (<span data-bind="text: endTimeAgo()"></span>)</dt>
                 <dd >
-                    <span data-bind="text: endTime()">
                     <g:if test="${execution.dateCompleted}">
-                        ${execution.dateCompleted}
-                        <g:relativeDate atDate="${execution.dateCompleted}"/>
+                        <g:relativeDateFomater atDate="${execution.dateCompleted}"/>
                     </g:if>
-                    </span>
-
                 </dd>
                 <!-- /ko -->
             </dl>

--- a/rundeckapp/grails-spa/packages/ui/src/components/activity/activityList.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/activity/activityList.vue
@@ -1,6 +1,6 @@
 <template>
   <div class=" activity-list">
-    
+
           <section class="section-space-bottom">
 
             <span>
@@ -30,7 +30,7 @@
 
 
           <activity-filter v-model="query" :event-bus="eventBus" :opts="filterOpts" v-if="showFilters"></activity-filter>
-          
+
           <div class="pull-right">
             <span v-if="runningOpts.allowAutoRefresh">
               <input type=checkbox id=auto-refresh v-model=autorefresh />
@@ -260,7 +260,7 @@
             <td class="eventicon " :title="reportState(rpt)" >
                 <b class="exec-status icon" :data-execstate="reportStateCss(rpt)" :data-statusstring="reportState(rpt)"></b>
             </td>
-            <td class="right date " v-tooltip.bottom="$t('info.completed.0.1',[jobCompletedISOFormat(rpt.dateCompleted),jobCompletedFromNow(rpt.dateCompleted)])">
+            <td class="right date " v-tooltip.bottom="$t('info.completed.0.1',[jobLocalCompletedISOFormat(rpt.dateCompleted),jobCompletedFromNow(rpt.dateCompleted)])">
                 <span v-if="rpt.dateCompleted">
                     <span class="timeabs ">
                         {{rpt.dateCompleted | moment(momentJobFormat)}}
@@ -446,6 +446,7 @@ export default Vue.extend({
       loadingRunning: false,
       loadError:null,
       momentJobFormat:'M/DD/YY h:mm a',
+      momentJobISOFormat:'YYYY/MM/DDTHH:mm:ss',
       momentRunFormat:'h:mm a',
       bulkEditMode:false,
       bulkSelectedIds: [] as string[],
@@ -508,6 +509,12 @@ export default Vue.extend({
       }
       return moment(date).toISOString()
     },
+    jobLocalCompletedISOFormat(date:string){
+      if(!date){
+        return ''
+      }
+      return moment(date).format(this.momentJobISOFormat)
+    },
     jobCompletedFromNow(date:string){
       if(!date){
         return ''
@@ -528,7 +535,7 @@ export default Vue.extend({
         if(exec.job && exec.job.averageDuration){
           const expected = startmo.clone()
           expected.add(exec.job.averageDuration,'ms')
-          return (this as any).$t('info.started.expected.0.1',[startmo.fromNow(), expected.fromNow()])    
+          return (this as any).$t('info.started.expected.0.1',[startmo.fromNow(), expected.fromNow()])
         }
         return (this as any).$t('info.started.0',[startmo.fromNow()])
       }
@@ -644,7 +651,7 @@ export default Vue.extend({
           this.bulkEditMode = false
         }
         this.loadActivity(this.pagination.offset)
-        
+
       }catch(error){
         this.bulkEditProgress=false
         this.bulkEditError=error
@@ -665,7 +672,7 @@ export default Vue.extend({
           params: Object.assign({offset: this.pagination.offset, max: this.pagination.max},this.query,{since:this.lastDate}),
           withCredentials: true
         })
-        
+
         if(this.lastDate>0  && response.data.since && response.data.since.count ){
             this.sincecount=response.data.since.count
         }
@@ -815,7 +822,7 @@ export default Vue.extend({
       this.activityPageHref = window._rundeck.data['activityPageHref']
       this.sinceUpdatedUrl = window._rundeck.data['sinceUpdatedUrl']
         this.autorefreshms = window._rundeck.data['autorefreshms'] || 5000
-      
+
       if(window._rundeck.data['pagination'] && window._rundeck.data['pagination'].max){
         this.pagination.max=window._rundeck.data['pagination'].max
       }


### PR DESCRIPTION
Fix: https://github.com/rundeck/rundeck/issues/6582

**Is this a bug fix, or an enhancement? Please describe.**
The start date, complete date and tooltip were being printed on the page without the date in ISO 8601 format

![image](https://user-images.githubusercontent.com/35808955/96001139-15065680-0e0e-11eb-893a-9d717a7461df.png)
![image](https://user-images.githubusercontent.com/35808955/96001195-26e7f980-0e0e-11eb-822f-591f7e19d8e2.png)



**Describe the solution you've implemented**
Page rendering was modified to print the timestamp the date in ISO 8601 format correctly

![image](https://user-images.githubusercontent.com/35808955/97186982-bc757880-1780-11eb-8d0f-d83010cfb211.png)
![image](https://user-images.githubusercontent.com/35808955/97187156-f0509e00-1780-11eb-8e1d-1a2c965f25bd.png)


