### PR TITLE
Report incomplete status in abort response reason

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1732,7 +1732,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 }
             }
             result.abortstate = success ? ABORT_PENDING : ABORT_FAILED
-            result.reason = success ? '' : 'Unable to modify the execution'
+            result.reason = success ? null : 'Unable to modify the execution'
             if (success) {
                 def didCancel = scheduledExecutionService.interruptJob(
                         quartzJobInstanceId,
@@ -1741,7 +1741,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                         isadhocschedule
                 )
                 result.abortstate = didCancel ? ABORT_PENDING : ABORT_FAILED
-                result.reason = didCancel ? '' : 'Unable to interrupt the running job'
+                result.reason = didCancel ? null : 'Unable to interrupt the running job'
             }
             result.jobstate = EXECUTION_RUNNING
         } else if (null == dateCompleted) {
@@ -1760,6 +1760,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 )
             result.abortstate = ABORT_ABORTED
             result.jobstate = EXECUTION_ABORTED
+            if(forceIncomplete){
+                result.reason = 'Marked as ' + cleanupStatus
+            }
         } else {
             result.jobstate = getExecutionState(e)
             result.status = 'previously ' + result.jobstate

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -2509,6 +2509,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
     @Unroll
     def "abort execution"() {
         given:
+        def serverUuid='541bf763-39a6-44ff-8c68-c9d53f6eec33'
         service.scheduledExecutionService = Mock(ScheduledExecutionService)
         service.metricService = Mock(MetricService)
         service.frameworkService = Mock(FrameworkService)
@@ -2531,7 +2532,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
                 user: 'userB',
                 project: 'AProject',
                 status: isadhocschedule ? 'scheduled' : null,
-                serverNodeUUID: (cmatch ? null : UUID.randomUUID().toString()),
+                serverNodeUUID: (cmatch ? null : serverUuid),
                 workflow: new Workflow(
                         keepgoing: true,
                         commands: [new CommandExec([adhocRemoteString: 'test buddy'])]
@@ -2562,6 +2563,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         e.id != null
         result.abortstate == eAbortstate
         result.jobstate == eJobstate
+        result.reason == reason
         e.status == (isadhocschedule&&wasScheduledPreviously?'scheduled':estatus)
         e.cancelled == ecancelled
         e.abortedby==(cmatch?(asuser?:'userB'):null)
@@ -2582,31 +2584,31 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
 
         where:
-        isadhocschedule | wasScheduledPreviously | didinterrupt | iscluster | cmatch | forced | eAbortstate | eJobstate | estatus | ecancelled | asuser
-        true            | true                   | true         | false     | true   | false  | 'pending'   | 'running' | 'false' | false | null
-        true            | true                   | true         | false     | true   | false  | 'pending'   | 'running' | 'false' | false | 'userC'
-        false           | true                   | true         | false     | true   | false  | 'pending'   | 'running'| null | false| null
-        false           | true                   | true         | false     | true   | false  | 'pending'   | 'running'| null | false| 'userC'
-        true            | false                  | true         | false     | true   | false  | 'aborted'   | 'aborted'| 'false' | true| null
-        true            | false                  | true         | false     | true   | false  | 'aborted'   | 'aborted'| 'false' | true| 'userC'
-        false           | false                  | true         | false     | true   | false  | 'aborted'   | 'aborted'| 'false' | true| null
-        false           | false                  | true         | false     | true   | false  | 'aborted'   | 'aborted'| 'false' | true| 'userC'
-        true            | true                   | false        | false     | true   | false  | 'failed'    | 'running'| 'false' | false| null
-        true            | true                   | false        | false     | true   | false  | 'failed'    | 'running'| 'false' | false| 'userC'
-        false           | true                   | false        | false     | true   | false  | 'failed'    | 'running'| null | false| null
-        false           | true                   | false        | false     | true   | false  | 'failed'    | 'running'| null | false| 'userC'
-        true            | false                  | false        | false     | true   | false  | 'aborted'   | 'aborted'| 'false' | true| null
-        true            | false                  | false        | false     | true   | false  | 'aborted'   | 'aborted'| 'false' | true| 'userC'
-        false           | false                  | false        | false     | true   | false  | 'aborted'   | 'aborted'| 'false' | true| null
-        false           | false                  | false        | false     | true   | false  | 'aborted'   | 'aborted'| 'false' | true| 'userC'
-        true            | true                   | true         | true      | true   | false  | 'pending'   | 'running'| 'false' | false| null
-        true            | true                   | true         | true      | true   | false  | 'pending'   | 'running'| 'false' | false| 'userC'
-        true            | true                   | true         | true      | false  | false  | 'failed'    | 'running'| 'false' | false| null
-        true            | true                   | true         | true      | false  | false  | 'failed'    | 'running'| 'false' | false| 'userC'
-        false           | true                   | false        | false     | true  | true   | 'aborted'   | 'aborted' | 'incompletestatus' | false| null
-        false           | true                   | false        | false     | true  | true   | 'aborted'   | 'aborted' | 'incompletestatus' | false| 'userC'
-        false           | false                   | false        | false     | true  | true   | 'aborted'   | 'aborted' | 'incompletestatus' | false| null
-        false           | false                   | false        | false     | true  | true   | 'aborted'   | 'aborted' | 'incompletestatus' | false| 'userC'
+        isadhocschedule | wasScheduledPreviously | didinterrupt | iscluster | cmatch | forced | eAbortstate | eJobstate| estatus            | ecancelled | asuser  |reason
+        true            | true                   | true         | false     | true   | false  | 'pending'   | 'running'| 'false'            | false      | null    | null
+        true            | true                   | true         | false     | true   | false  | 'pending'   | 'running'| 'false'            | false      | 'userC' | null
+        false           | true                   | true         | false     | true   | false  | 'pending'   | 'running'| null               | false      | null    | null
+        false           | true                   | true         | false     | true   | false  | 'pending'   | 'running'| null               | false      | 'userC' | null
+        true            | false                  | true         | false     | true   | false  | 'aborted'   | 'aborted'| 'false'            | true       | null    | null
+        true            | false                  | true         | false     | true   | false  | 'aborted'   | 'aborted'| 'false'            | true       | 'userC' | null
+        false           | false                  | true         | false     | true   | false  | 'aborted'   | 'aborted'| 'false'            | true       | null    | null
+        false           | false                  | true         | false     | true   | false  | 'aborted'   | 'aborted'| 'false'            | true       | 'userC' | null
+        true            | true                   | false        | false     | true   | false  | 'failed'    | 'running'| 'false'            | false      | null    | 'Unable to interrupt the running job'
+        true            | true                   | false        | false     | true   | false  | 'failed'    | 'running'| 'false'            | false      | 'userC' | 'Unable to interrupt the running job'
+        false           | true                   | false        | false     | true   | false  | 'failed'    | 'running'| null               | false      | null    | 'Unable to interrupt the running job'
+        false           | true                   | false        | false     | true   | false  | 'failed'    | 'running'| null               | false      | 'userC' | 'Unable to interrupt the running job'
+        true            | false                  | false        | false     | true   | false  | 'aborted'   | 'aborted'| 'false'            | true       | null    | null
+        true            | false                  | false        | false     | true   | false  | 'aborted'   | 'aborted'| 'false'            | true       | 'userC' | null
+        false           | false                  | false        | false     | true   | false  | 'aborted'   | 'aborted'| 'false'            | true       | null    | null
+        false           | false                  | false        | false     | true   | false  | 'aborted'   | 'aborted'| 'false'            | true       | 'userC' | null
+        true            | true                   | true         | true      | true   | false  | 'pending'   | 'running'| 'false'            | false      | null    | null
+        true            | true                   | true         | true      | true   | false  | 'pending'   | 'running'| 'false'            | false      | 'userC' | null
+        true            | true                   | true         | true      | false  | false  | 'failed'    | 'running'| 'false'            | false      | null    | 'Execution is running on a different cluster server: 541bf763-39a6-44ff-8c68-c9d53f6eec33'
+        true            | true                   | true         | true      | false  | false  | 'failed'    | 'running'| 'false'            | false      | 'userC' | 'Execution is running on a different cluster server: 541bf763-39a6-44ff-8c68-c9d53f6eec33'
+        false           | true                   | false        | false     | true   | true   | 'aborted'   | 'aborted'| 'incompletestatus' | false      | null    | 'Marked as incompletestatus'
+        false           | true                   | false        | false     | true   | true   | 'aborted'   | 'aborted'| 'incompletestatus' | false      | 'userC' | 'Marked as incompletestatus'
+        false           | false                  | false        | false     | true   | true   | 'aborted'   | 'aborted'| 'incompletestatus' | false      | null    | 'Marked as incompletestatus'
+        false           | false                  | false        | false     | true   | true   | 'aborted'   | 'aborted'| 'incompletestatus' | false      | 'userC' | 'Marked as incompletestatus'
 
     }
 


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**

Reports the 'incomplete' status in the abort response reason field. Updates tests.