### PR TITLE
new sshj plugin

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -7,3 +7,4 @@ rundeck:
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.1"
   - "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.0.0"
   - "com.github.rundeck-plugins:attribute-match-node-enhancer:v0.1.5"
+  - "com.github.rundeck-plugins:sshj-plugin:v0.1.0"

--- a/build.yaml
+++ b/build.yaml
@@ -7,4 +7,4 @@ rundeck:
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.1"
   - "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.0.0"
   - "com.github.rundeck-plugins:attribute-match-node-enhancer:v0.1.5"
-  - "com.github.rundeck-plugins:sshj-plugin:v0.1.0"
+  - "com.github.rundeck-plugins:sshj-plugin:v0.1.1"

--- a/testbuild.groovy
+++ b/testbuild.groovy
@@ -56,7 +56,7 @@ def coreJarFile = "core/${target}/rundeck-core-${version}.jar"
 
 //the list of bundled plugins to verify in the war and jar
 def plugins=['script','stub','localexec','copyfile','job-state','flow-control','jasypt-encryption','git','object-store','orchestrator', 'source-refresh','upvar']
-def externalPlugins=['rundeck-ansible-plugin','aws-s3-model-source','py-winrm-plugin','openssh-node-execution','multiline-regex-datacapture-filter', 'attribute-match-node-enhancer']
+def externalPlugins=['rundeck-ansible-plugin','aws-s3-model-source','py-winrm-plugin','openssh-node-execution','multiline-regex-datacapture-filter', 'attribute-match-node-enhancer','sshj-plugin']
 
 //manifest describing expected build results
 def manifest=[


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
enhancement: adding the new SSHJ plugin 
https://github.com/rundeck-plugins/sshj-plugin

**Describe the solution you've implemented**
Node Executor/ File Copier (based on SSHJ lib) as an alternative of JSCH plugin 

**Describe alternatives you've considered**

**Additional context**
* It has the same configuration name attributes as the JSCH plugin, so this [documentation](https://docs.rundeck.com/docs/administration/projects/node-execution/ssh.html) works for this plugin 

* sudo authentication is experimental 