### PR TITLE
Emit RUNDECK_MAIL_PROPS as groovy to fix SMA email auth

### DIFF
--- a/docker/official/lib/entry.sh
+++ b/docker/official/lib/entry.sh
@@ -35,9 +35,11 @@ echo "rundeck.server.uuid = ${RUNDECK_SERVER_UUID}" > ${REMCO_TMP_DIR}/framework
 
 # Combine partial config files
 cat ${REMCO_TMP_DIR}/framework/* >> etc/framework.properties
-cat ${REMCO_TMP_DIR}/rundeck-config/* >> server/config/rundeck-config.properties
+cat ${REMCO_TMP_DIR}/rundeck-config/*.properties >> server/config/rundeck-config.properties
 cat ${REMCO_TMP_DIR}/artifact-repositories/* >> server/config/artifact-repositories.yaml
 
+# Copy the groovy config files
+cp ${REMCO_TMP_DIR}/rundeck-config/*.groovy server/config/
 
 # Store settings that may be unset in script variables
 SETTING_RUNDECK_FORWARDED="${RUNDECK_SERVER_FORWARDED:-false}"

--- a/docker/official/remco/resources.d/rundeck-config.groovy.toml
+++ b/docker/official/remco/resources.d/rundeck-config.groovy.toml
@@ -1,0 +1,4 @@
+[[template]]
+    src         = "${REMCO_TEMPLATE_DIR}/rundeck-config.groovy"
+    dst         = "${REMCO_TMP_DIR}/rundeck-config/rundeck-config.groovy"
+    mode        = "0644"

--- a/docker/official/remco/templates/rundeck-config-mail.properties
+++ b/docker/official/remco/templates/rundeck-config-mail.properties
@@ -15,10 +15,6 @@ grails.mail.username={{ getv("/rundeck/mail/smtp/username") }}
 grails.mail.password={{ getv("/rundeck/mail/smtp/password") }}
 {% endif %}
 
-{%- if exists("/rundeck/mail/props") %}
-grails.mail.props={{ getv("/rundeck/mail/props") }}
-{% endif %}
-
 {%- if exists("/rundeck/mail/from") %}
 grails.mail.default.from={{ getv("/rundeck/mail/from") }}
 {% endif %}

--- a/docker/official/remco/templates/rundeck-config.groovy
+++ b/docker/official/remco/templates/rundeck-config.groovy
@@ -1,0 +1,7 @@
+{%- if exists("/rundeck/mail/props") %}
+grails {
+  mail {
+    props = {{ getv("/rundeck/mail/props") }}
+  }
+}
+{% endif %}


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
A fix for issue #5925. As noted by the issue author and other contributors RUNDECK_MAIL_PROPS does not function as described.

**Describe the solution you've implemented**
Emit the value of RUNDECK_MAIL_PROPS in `server/config/rundeck-config.groovy` rather than the properties file.

**Describe alternatives you've considered**
This is an implementation of a suggested solution in the comment stream of #5925 and https://stackoverflow.com/questions/30601574/rundeck-gmail-smtp-not-working.

**Additional context**
RUNDECK_MAIL_* with the exception of PROPS are still emitted to the properties file. Only PROPS is emitted to the groovy file.
