### PR TITLE
Update testcontainers to 1.15.0 release for better mac integration

### DIFF
--- a/plugins/object-store-plugin/build.gradle
+++ b/plugins/object-store-plugin/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     // Use the awesome Spock testing and specification framework
     testCompile 'org.spockframework:spock-core:1.3-groovy-2.5'
     testCompile "com.squareup.okhttp3:mockwebserver:3.11.0"
-    testCompile "org.testcontainers:testcontainers:1.12.1"
+    testCompile "org.testcontainers:testcontainers:1.15.0"
 }
 
 repositories {


### PR DESCRIPTION
Update testcontainers to 1.15.0 release for better mac integration.

Ensures compatibility with later versions of DockerDesktop on mac.