### PR TITLE
Fixing multivalued options validation with no errors but that appear as invalid when another option (not multivalued) is invalid

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/menu/joboptions.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/joboptions.js
@@ -313,7 +313,7 @@ function Option(data) {
         return !self.enforced()
             && (
                 !self.multivalued()
-                || self.hasError()
+                || (self.hasError() && !self.hasExtended())
             )
             || self.secureInput();
     });

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2805,6 +2805,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     }
                 }
                 if (opt.multivalued) {
+                    boolean multivaluedOptionEvalFailed = false
                     if (opt.regex && !opt.enforced && optparams[opt.name]) {
                         def val
                         if (optparams[opt.name] instanceof Collection) {
@@ -2812,13 +2813,15 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                         } else {
                             val = optparams[opt.name].toString().split(Pattern.quote(opt.delimiter))
                         }
+                        List failedValues = []
                         val.grep { it }.each { value ->
                             if (!(value ==~ opt.regex)) {
-                                fail = true
+                                failedValues += value
+                                multivaluedOptionEvalFailed = true
                             }
                         }
-                        if (fail) {
-                            invalidOpt opt,lookupMessage("domain.Option.validation.regex.values",[opt.name,optparams[opt.name],opt.regex])
+                        if (multivaluedOptionEvalFailed) {
+                            invalidOpt opt,lookupMessage("domain.Option.validation.regex.values",[opt.name, failedValues,opt.regex])
                             return
                         }
                     }

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -1724,6 +1724,30 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         ['test3': 'shampooz'] | _
     }
 
+    def "validate option values, regex failure but success for multivalued option"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution()
+        se.addToOptions(new Option(name: 'test3', enforced: false, regex: 'shampoo[abc].*'))
+        se.addToOptions(new Option(name: 'test4', enforced: false, multivalued: true, regex: 'shampoo[abc].*'))
+
+        service.messageSource = Mock(MessageSource) {
+            getMessage(_, _, _) >> {
+                it[0]
+            }
+        }
+        when:
+
+        def validation = service.validateOptionValues(se, opts)
+
+        then:
+        ExecutionServiceException e = thrown()
+        e.message == 'domain.Option.validation.regex.invalid'
+
+        where:
+        opts                                                     | _
+        ['test3': 'shampooz', 'test4': ['shampooa', 'shampoob']] | _
+    }
+
     def "validate option values, enforced valid"() {
         given:
         ScheduledExecution se = new ScheduledExecution()


### PR DESCRIPTION
Fixes rundeckpro/rundeckpro#1324

Is this a bugfix, or an enhancement? Please describe.
When a job has options and multivalued options with validations, if the validation of the non-multivalued options fails, all validations for the other multivalued options also fail.

Describe the solution you've implemented
was made a change on validation so If the option validation fail, it should not impact to the other options validations

Additional context
When multivalued option validation fail, the GUI it was breaking duplicating the options fields. A fix was made on javascript