### PR TITLE
Adjust EventStore column max lengths

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/StoredEvent.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/StoredEvent.groovy
@@ -37,22 +37,23 @@ class StoredEvent implements Event {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id
 
-    @Size(max=50)
+    @Size(max=36)
     @Column(name = "server_uuid")
     String serverUUID
 
     @Enumerated(EnumType.ORDINAL)
     EventSeverity severity = EventSeverity.INFO
 
-    @Column(name = "project_name")
+    @Column(name = "project_name", length = 255)
     String projectName
 
+    @Column(length = 128)
     String subsystem
 
-    @Column(length = 1024)
+    @Column(length = 255)
     String topic
 
-    @Column(name = "object_id", length = 512)
+    @Column(name = "object_id", length = 64)
     String objectId
 
     Long sequence = 0


### PR DESCRIPTION
Index size of `3072` can cause issues depending on database configuration and `1024` characters is likely overly large. Reduced to `255` and added extra explicit max constraints to columns.

```
CREATE TABLE `stored_event` (
  `id` bigint(20) NOT NULL AUTO_INCREMENT,
  `last_updated` datetime(6) DEFAULT NULL,
  `meta` longtext,
  `object_id` varchar(64) DEFAULT NULL,
  `project_name` varchar(255) DEFAULT NULL,
  `schema_version` int(11) DEFAULT NULL,
  `sequence` bigint(20) DEFAULT NULL,
  `server_uuid` varchar(36) DEFAULT NULL,
  `severity` int(11) DEFAULT NULL,
  `subsystem` varchar(128) DEFAULT NULL,
  `topic` varchar(255) DEFAULT NULL,
  PRIMARY KEY (`id`),
  KEY `IDX2ggk8b4ha1gtyq671u34ggo40` (`project_name`),
  KEY `IDXq0qhj662jxkdkydtt3ks62vy2` (`subsystem`),
  KEY `IDXtol9rfxy40x2iq6xb6p557920` (`last_updated`),
  KEY `IDXmjk30m5bvfquc2h5xav85cxlv` (`sequence`),
  KEY `IDXhej7kc4lo8hbgbm5r240x6xm4` (`object_id`),
  KEY `IDX9jn50aj3qk87d4l9q6dvleksh` (`topic`)
) ENGINE=InnoDB DEFAULT CHARSET=latin1
```