### PR TITLE
allowed values list in option form is displayed misaligned  in 3.3.7 

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
@@ -365,7 +365,7 @@
         </div>
         <div class="form-group opt_keystorage_disabled" style="${wdgt.styleVisible(unless:option?.defaultStoragePath)}">
             <label class="col-sm-2 control-label"><g:message code="form.option.values.label" /></label>
-            <div class="col-sm-6">
+            <div class="col-sm-3">
                 <g:set var="valueTypeListChecked" value="${!option || (!option.realValuesUrl && !option.optionValuesPluginType) ? true : false}"/>
                 <div>
                         <div class="radio">
@@ -407,7 +407,7 @@
                 </div>
 
             </div>
-            <div class="col-sm-8">
+            <div class="col-sm-7">
                 <g:set var="listvalue" value="${option?.valuesList}"/>
                 <g:set var="listjoin" value="${option?.values }"/>
                 <div id="vlist_${rkey}_section" style="${wdgt.styleVisible(if: valueTypeListChecked)}">


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
fix GUI issue introduced with https://github.com/rundeck/rundeck/pull/6642 in option form allowed values list,  which is displayed misaligned

**Describe the solution you've implemented**
div column overcome the limit in  allowed values list

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
![Screenshot from 2020-12-02 10-53-09](https://user-images.githubusercontent.com/6034968/100881359-98e2d380-348c-11eb-9517-f367230a0cfc.png)
