### PR TITLE
Remove JPA annotations from EventStore

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/StoredEvent.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/StoredEvent.groovy
@@ -1,71 +1,43 @@
 package rundeck
 
+import com.dtolabs.rundeck.app.domain.EventSeverity
 import com.dtolabs.rundeck.core.event.Event
-import com.fasterxml.jackson.annotation.JsonFormat
 import grails.compiler.GrailsCompileStatic
-import groovy.transform.CompileStatic
-import org.hibernate.validator.constraints.Length
 
-import javax.persistence.*
-import javax.validation.constraints.*
-
-@Entity()
-@Table(name = "stored_event", indexes = [
-    @Index(columnList = "project_name"),
-    @Index(columnList = "subsystem"),
-    @Index(columnList = "last_updated"),
-    @Index(columnList = "sequence"),
-    @Index(columnList = "object_id"),
-    @Index(columnList = "topic")
-])
 @GrailsCompileStatic
 class StoredEvent implements Event {
+    String serverUUID
+    EventSeverity severity = EventSeverity.INFO
+    String projectName
+    String subsystem
+    String topic
+    String objectId
+    Long sequence = 0
+    Date lastUpdated
+    int schemaVersion = 0
+    String meta
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING)
-    @CompileStatic
-    enum EventSeverity {
-        ERROR(0),
-        WARN(1),
-        INFO(2),
-        DEBUG(3),
-        TRACE(4)
-
-        final int id
-        private EventSeverity(int id) { this.id = id }
+    static constraints = {
+        projectName(maxSize: 255)
+        serverUUID(maxSize: 36)
+        subsystem(maxSize: 128)
+        objectId(nullable: true, maxSize: 64)
+        topic(maxSize: 255)
+        meta(nullable: true)
     }
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    Long id
+    static mapping = {
+        projectName index: 'STORED_EVENT_IDX_PROJECT_NAME'
+        subsystem index: 'STORED_EVENT_IDX_SUBSYSTEM'
+        lastUpdated index: 'STORED_EVENT_IDX_LAST_UPDATED'
+        sequence index: 'STORED_EVENT_IDX_SEQUENCE'
+        topic index: 'STORED_EVENT_IDX_TOPIC'
+        objectId index: 'STORED_EVENT_IDX_OBJECT_ID'
 
-    @Size(max=36)
-    @Column(name = "server_uuid")
-    String serverUUID
-
-    @Enumerated(EnumType.ORDINAL)
-    EventSeverity severity = EventSeverity.INFO
-
-    @Column(name = "project_name", length = 255)
-    String projectName
-
-    @Column(length = 128)
-    String subsystem
-
-    @Column(length = 255)
-    String topic
-
-    @Column(name = "object_id", length = 64)
-    String objectId
-
-    Long sequence = 0
-
-    @Column(name = "last_updated")
-    Date lastUpdated
-
-    @Column(name = "schema_version")
-    int schemaVersion = 0
-
-    @Lob
-    String meta
+        serverUUID column: 'server_uuid'
+        meta type: 'text'
+        severity enumType: 'ordinal'
+    }
 
     StoredEvent() {}
 

--- a/rundeckapp/grails-app/domain/rundeck/StoredEvent.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/StoredEvent.groovy
@@ -37,6 +37,7 @@ class StoredEvent implements Event {
         serverUUID column: 'server_uuid'
         meta type: 'text'
         severity enumType: 'ordinal'
+        version false
     }
 
     StoredEvent() {}

--- a/rundeckapp/grails-app/services/rundeck/services/GormEventStoreService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/GormEventStoreService.groovy
@@ -46,7 +46,7 @@ class GormEventStoreService implements EventStoreService {
                 event.sequence,
                 eventMetaString)
 
-        domainEvent.save()
+        domainEvent.save(failOnError: true)
     }
 
     @Transactional

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/domain/EventSeverity.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/domain/EventSeverity.groovy
@@ -1,0 +1,17 @@
+package com.dtolabs.rundeck.app.domain
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import groovy.transform.CompileStatic
+
+@JsonFormat(shape = JsonFormat.Shape.STRING)
+@CompileStatic
+enum EventSeverity {
+    ERROR(0),
+    WARN(1),
+    INFO(2),
+    DEBUG(3),
+    TRACE(4)
+
+    final int id
+    private EventSeverity(int id) { this.id = id }
+}

--- a/rundeckapp/src/test/groovy/rundeck/GormEventStoreServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/GormEventStoreServiceSpec.groovy
@@ -24,7 +24,7 @@ class GormEventStoreServiceSpec extends Specification {
     def setupSpec() {
         hibernateDatastore = new HibernateDatastore(StoredEvent)
         framework = Mock(FrameworkService) {
-            it.serverUUID >> 'ABCDEFG'
+            it.serverUUID >> '16b02806-f4b3-4628-9d9c-2dd2cc67d53c'
         }
         service = new GormEventStoreService()
         service.frameworkService = framework
@@ -35,12 +35,14 @@ class GormEventStoreServiceSpec extends Specification {
     }
 
     @Rollback
-    def "test basic store and query"() {
+    def "test basic store and querys"() {
         def event = new Foo(event: 'test')
 
         when:
         service.storeEvent(new Evt(
                 projectName: 'test',
+                subsystem: 'test',
+                topic: 'test',
                 meta: event
         ))
 
@@ -60,9 +62,9 @@ class GormEventStoreServiceSpec extends Specification {
     def "test queries"() {
         when:
         service.storeEventBatch([
-                [projectName: 'A', subsystem: 'webhooks'] as Evt,
-                [projectName: 'A', subsystem: 'cluster'] as Evt,
-                [projectName: 'B', subsystem: 'cluster'] as Evt,
+                [projectName: 'A', topic: 'test', subsystem: 'webhooks'] as Evt,
+                [projectName: 'A', topic: 'test', subsystem: 'cluster'] as Evt,
+                [projectName: 'B', topic: 'test', subsystem: 'cluster'] as Evt,
         ])
 
         def oneRes = service.query([projectName: 'A', subsystem: 'webhooks'] as EvtQuery)
@@ -76,9 +78,9 @@ class GormEventStoreServiceSpec extends Specification {
     def "test count query does not include events in results"() {
         when:
         service.storeEventBatch([
-                [projectName: 'A', subsystem: 'webhooks'] as Evt,
-                [projectName: 'A', subsystem: 'cluster'] as Evt,
-                [projectName: 'B', subsystem: 'cluster'] as Evt,
+                [projectName: 'A', topic: 'test', subsystem: 'webhooks'] as Evt,
+                [projectName: 'A', topic: 'test', subsystem: 'cluster'] as Evt,
+                [projectName: 'B', topic: 'test', subsystem: 'cluster'] as Evt,
         ])
 
         def oneRes = service.query([projectName: 'A', subsystem: 'webhooks', queryType: EventQueryType.COUNT] as EvtQuery)
@@ -96,9 +98,9 @@ class GormEventStoreServiceSpec extends Specification {
         def scoped = service.scoped([projectName: 'C'] as Evt, null)
 
         scoped.storeEventBatch([
-                [projectName: 'A'] as Evt,
-                [projectName: 'A'] as Evt,
-                [projectName: 'B'] as Evt,
+                [projectName: 'A', topic: 'test', subsystem: 'test'] as Evt,
+                [projectName: 'A', topic: 'test', subsystem: 'test'] as Evt,
+                [projectName: 'B', topic: 'test', subsystem: 'test'] as Evt,
         ])
 
         def scopedRes = scoped.query([projectName: 'C'] as EvtQuery)
@@ -112,9 +114,9 @@ class GormEventStoreServiceSpec extends Specification {
     def "test scoped service scopes queries"() {
         when:
         service.storeEventBatch([
-                [projectName: 'A'] as Evt,
-                [projectName: 'A'] as Evt,
-                [projectName: 'B'] as Evt,
+                [projectName: 'A', topic: 'test', subsystem: 'test'] as Evt,
+                [projectName: 'A', topic: 'test', subsystem: 'test'] as Evt,
+                [projectName: 'B', topic: 'test', subsystem: 'test'] as Evt,
         ])
 
         // Scopes queries to project B
@@ -131,9 +133,9 @@ class GormEventStoreServiceSpec extends Specification {
     def "test wildcard topic query"() {
         when:
         service.storeEventBatch([
-                [topic: 'foo/bar'] as Evt,
-                [topic: 'foo/bar/baz'] as Evt,
-                [topic: 'foo/baz'] as Evt,
+                [topic: 'foo/bar', projectName: 'test', subsystem: 'test'] as Evt,
+                [topic: 'foo/bar/baz', projectName: 'test', subsystem: 'test'] as Evt,
+                [topic: 'foo/baz',projectName: 'test', subsystem: 'test'] as Evt,
         ])
 
 
@@ -148,9 +150,9 @@ class GormEventStoreServiceSpec extends Specification {
     def "test pagination"() {
         when:
         service.storeEventBatch([
-                [meta: "ONE", sequence: 0] as Evt,
-                [meta: "TWO", sequence: 1] as Evt,
-                [meta: "THREE", sequence: 2] as Evt,
+                [projectName: 'test', topic: 'test', subsystem: 'test', meta: "ONE", sequence: 0] as Evt,
+                [projectName: 'test', topic: 'test', subsystem: 'test', meta: "TWO", sequence: 1] as Evt,
+                [projectName: 'test', topic: 'test', subsystem: 'test', meta: "THREE", sequence: 2] as Evt,
         ])
 
         def oneRes = service.query([maxResults: 1, offset: 0] as EvtQuery)
@@ -165,9 +167,9 @@ class GormEventStoreServiceSpec extends Specification {
     def "test delete"() {
         when:
         service.storeEventBatch([
-                [projectName: 'A'] as Evt,
-                [projectName: 'A'] as Evt,
-                [projectName: 'B'] as Evt,
+                [projectName: 'A', topic: 'test', subsystem: 'test'] as Evt,
+                [projectName: 'A', topic: 'test', subsystem: 'test'] as Evt,
+                [projectName: 'B', topic: 'test', subsystem: 'test'] as Evt,
         ])
 
         def threeRes = service.query([:] as EvtQuery)


### PR DESCRIPTION
The identity generation type of `IDENTITY` did not work with Oracle. `AUTO` in theory would pick the best strategy for the database, however Hibernate 5.0 started using a sequence table for MySQL which is undesirable due to increased locking creating an effective `serialization` situation.

This can be worked around with a `@GenericGenerator(strategy='native')` to let the db dialect advise on the best strategy, however it causes a new sequence to be created along side the GORM mapped sequence. It may have been possible to re-use the GORM sequence, however it starts to get very messy and bespoke at this point.

The JPA annotations were removed in favor of GORM entity mappings. Table creation now works on Oracle and the best ident generation strategies are used(auto gen for MySQL, sequence for Postgresql and Oracle).