### PR TITLE
Fix/job life cycle node list

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -4179,7 +4179,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
     def checkBeforeJobExecution(ScheduledExecution scheduledExecution, optparams, props, authContext) {
 
-        INodeSet nodes = scheduledExecutionService.getNodes(scheduledExecution, props.filter, authContext)
+        INodeSet nodes = scheduledExecutionService.getNodes(scheduledExecution, props.filter, authContext, new HashSet<String>([AuthConstants.ACTION_READ, AuthConstants.ACTION_RUN]))
         def nodeFilter = props.filter? props.filter : scheduledExecution.asFilter()
         JobPreExecutionEventImpl event = new JobPreExecutionEventImpl(
                 scheduledExecution.jobName,

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -4091,7 +4091,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     }
 
     def runBeforeSave(ScheduledExecution scheduledExecution, UserAndRolesAuthContext authContext){
-        INodeSet nodeSet = getNodes(scheduledExecution, scheduledExecution.asFilter(), authContext, null)
+        INodeSet nodeSet = getNodes(scheduledExecution, scheduledExecution.asFilter())
         JobPersistEventImpl jobPersistEvent = new JobPersistEventImpl(
                 scheduledExecution.jobName,
                 scheduledExecution.project,
@@ -4185,16 +4185,16 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     }
 
     /**
-     * Return a NodeSet using the filters during job save
+     * Return a NodeSet for the given filter, it will filter by authorized ones if authContext is not null
+     *
+     * @param scheduledExecution
+     * @param filter
+     * @param authContext
+     * @param actions
+     *
+     * @return INodeSet
      */
-    def getNodes(scheduledExecution, filter, authContext){
-        getNodes(scheduledExecution, filter, authContext, new HashSet<String>(Arrays.asList("read", "run")))
-    }
-
-    /**
-     * Return a NodeSet for the given filter with only read access needed
-     */
-    def getNodes(scheduledExecution, filter, authContext, Set<String> actions){
+    def getNodes(scheduledExecution, filter, authContext = null, Set<String> actions = null){
 
         NodesSelector nodeselector
         if (scheduledExecution.doNodedispatch) {
@@ -4216,12 +4216,15 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             nodeselector = null
         }
 
-        INodeSet nodeSet = frameworkService.filterAuthorizedNodes(
-                scheduledExecution.project,
-                actions,
-                frameworkService.filterNodeSet(nodeselector, scheduledExecution.project),
-                authContext)
-        nodeSet
+        if(authContext){
+            return frameworkService.filterAuthorizedNodes(
+                    scheduledExecution.project,
+                    actions,
+                    frameworkService.filterNodeSet(nodeselector, scheduledExecution.project),
+                    authContext)
+        }else{
+            return frameworkService.filterNodeSet(nodeselector, scheduledExecution.project)
+        }
     }
 
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -4091,7 +4091,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     }
 
     def runBeforeSave(ScheduledExecution scheduledExecution, UserAndRolesAuthContext authContext){
-        INodeSet nodeSet = getNodes(scheduledExecution, null, authContext)
+        INodeSet nodeSet = getNodes(scheduledExecution, scheduledExecution.asFilter(), authContext, null)
         JobPersistEventImpl jobPersistEvent = new JobPersistEventImpl(
                 scheduledExecution.jobName,
                 scheduledExecution.project,
@@ -4188,6 +4188,13 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
      * Return a NodeSet using the filters during job save
      */
     def getNodes(scheduledExecution, filter, authContext){
+        getNodes(scheduledExecution, filter, authContext, new HashSet<String>(Arrays.asList("read", "run")))
+    }
+
+    /**
+     * Return a NodeSet for the given filter with only read access needed
+     */
+    def getNodes(scheduledExecution, filter, authContext, Set<String> actions){
 
         NodesSelector nodeselector
         if (scheduledExecution.doNodedispatch) {
@@ -4211,7 +4218,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
         INodeSet nodeSet = frameworkService.filterAuthorizedNodes(
                 scheduledExecution.project,
-                new HashSet<String>(Arrays.asList("read", "run")),
+                actions,
                 frameworkService.filterNodeSet(nodeselector, scheduledExecution.project),
                 authContext)
         nodeSet

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceTests.groovy
@@ -146,7 +146,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -181,7 +181,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             1 * getServerUUID()
         }
         svc.scheduledExecutionService = Mock(ScheduledExecutionService){
-            1 * getNodes(_,_,_)
+            1 * getNodes(_,_,_,_)
         }
         svc.jobLifecyclePluginService = Mock(JobLifecyclePluginService){
             1 * beforeJobExecution(_,_)
@@ -228,7 +228,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -274,7 +274,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -314,7 +314,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -356,7 +356,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -445,7 +445,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -492,7 +492,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -534,7 +534,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -575,7 +575,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -616,7 +616,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -663,7 +663,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -713,7 +713,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -744,7 +744,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -775,7 +775,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -807,7 +807,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -837,7 +837,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -886,7 +886,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -2412,7 +2412,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -2459,7 +2459,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->
@@ -2521,7 +2521,7 @@ class ExecutionServiceTests extends HibernateSpec implements ServiceUnitTest<Exe
             }
         }
         svc.scheduledExecutionService = mockWith(ScheduledExecutionService){
-            getNodes(1..1){ scheduledExecution, filter, authContext ->
+            getNodes(1..1){ scheduledExecution, filter, authContext, actions ->
                 null
             }
             getOptionsFromScheduleExecutionMap(1..1){scheduledExecutionMap ->

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionServiceSpec.groovy
@@ -84,10 +84,12 @@ public class ScheduledExecutionServiceSpec extends HibernateSpec {
         def schedlist = new ScheduledExecution(jobName:'test1',groupPath:'group1', project:'aproject')
         ScheduledExecutionService service = new ScheduledExecutionService()
         def authContext = Mock(AuthContext)
-        service.frameworkService = Mock(FrameworkService)
         def fwknode = new NodeEntryImpl('fwknode')
         def filtered = new NodeSetImpl([fwknode: fwknode])
-        service.frameworkService.filterAuthorizedNodes('aproject', new HashSet<String>(Arrays.asList("read", "run")), _, _) >> filtered
+        service.frameworkService = Mock(FrameworkService){
+            1 * filterAuthorizedNodes('aproject', null, _, _) >> filtered
+        }
+
         def result = service.getNodes(schedlist, null, authContext)
         then:
         assertEquals result, filtered
@@ -98,10 +100,11 @@ public class ScheduledExecutionServiceSpec extends HibernateSpec {
         def schedlist = new ScheduledExecution(jobName:'test1',groupPath:'group1', project:'aproject')
         ScheduledExecutionService service = new ScheduledExecutionService()
         def authContext = Mock(AuthContext)
-        service.frameworkService = Mock(FrameworkService)
         def fwknode = new NodeEntryImpl('fwknode')
         def filtered = new NodeSetImpl([fwknode: fwknode])
-        service.frameworkService.filterAuthorizedNodes('aproject', _ , _, _) >> filtered
+        service.frameworkService = Mock(FrameworkService){
+            1 * filterAuthorizedNodes('aproject', _ , _, _) >> filtered
+        }
         def result = service.getNodes(schedlist, null, authContext, new HashSet<String>(Arrays.asList("read")))
         then:
         assertEquals result, filtered

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionServiceSpec.groovy
@@ -1,5 +1,9 @@
 package rundeck
 
+import com.dtolabs.rundeck.core.authorization.AuthContext
+import com.dtolabs.rundeck.core.common.IFrameworkNodes
+import com.dtolabs.rundeck.core.common.NodeEntryImpl
+import com.dtolabs.rundeck.core.common.NodeSetImpl
 import grails.test.hibernate.HibernateSpec
 import groovy.mock.interceptor.MockFor
 
@@ -39,6 +43,34 @@ import static org.junit.Assert.*
 public class ScheduledExecutionServiceSpec extends HibernateSpec {
 
     List<Class> getDomainClasses() { [ScheduledExecution, Workflow,CommandExec]}
+
+    void testGetNodes(){
+        when:
+        def schedlist = new ScheduledExecution(jobName:'test1',groupPath:'group1', project:'aproject')
+        ScheduledExecutionService service = new ScheduledExecutionService()
+        def authContext = Mock(AuthContext)
+        service.frameworkService = Mock(FrameworkService)
+        def fwknode = new NodeEntryImpl('fwknode')
+        def filtered = new NodeSetImpl([fwknode: fwknode])
+        service.frameworkService.filterAuthorizedNodes('aproject', new HashSet<String>(Arrays.asList("read", "run")), _, _) >> filtered
+        def result = service.getNodes(schedlist, null, authContext)
+        then:
+        assertEquals result, filtered
+    }
+
+    void testGetNodesWithActions(){
+        when:
+        def schedlist = new ScheduledExecution(jobName:'test1',groupPath:'group1', project:'aproject')
+        ScheduledExecutionService service = new ScheduledExecutionService()
+        def authContext = Mock(AuthContext)
+        service.frameworkService = Mock(FrameworkService)
+        def fwknode = new NodeEntryImpl('fwknode')
+        def filtered = new NodeSetImpl([fwknode: fwknode])
+        service.frameworkService.filterAuthorizedNodes('aproject', _ , _, _) >> filtered
+        def result = service.getNodes(schedlist, null, authContext, new HashSet<String>(Arrays.asList("read")))
+        then:
+        assertEquals result, filtered
+    }
 
     public void testGetGroups(){
         when:


### PR DESCRIPTION
This is a bug fix for issue https://github.com/rundeckpro/rundeckpro/issues/1409

Issue: Previously when using job life cycle plugins, the node list was only passed to the plugin implementation only if the user had read and run permissions on the nodes.

Solution: It no longer requires user node permissions to send the matches nodes to the method "beforeSaveJob" from JobLifecyclePlugins.
