### PR TITLE
Update Gradle to 5.6.4

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/rundeck-authz/build.gradle
+++ b/rundeck-authz/build.gradle
@@ -24,61 +24,62 @@ buildscript {
     }
 }
 
-subprojects {
-    apply plugin: 'com.jfrog.bintray'
-    apply plugin: "groovy"
+subprojects { Project it ->
+    it.afterEvaluate {
+        apply plugin: 'com.jfrog.bintray'
 
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
-        testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
-    }
-
-    jar {
-        manifest.attributes provider: 'gradle'
-    }
-
-    bintray {
-        user = findProperty("bintrayUser")
-        key = findProperty("bintrayApiKey")
-        publish = true
-        dryRun = (findProperty('dryRun') ?: 'true').toBoolean()
-        override = true
-
-        if (findProperty('bintrayUseExisting')) {
-            filesSpec {
-                from "$artifactDir/rundeck-authz/$project.name/build/libs"
-                from "$artifactDir/rundeck-authz/$project.name/build/poms"
-                into "${project.group}.${project.name}".replace('.', '/') + "/$version"
-                rename { file ->
-                    if (file =~ /^pom/)
-                        return "$project.name-${version}.pom"
-                    else
-                        return file
-                }
-            }
-        } else {
-            configurations =  ['archives']
+        repositories {
+            mavenCentral()
         }
 
-        pkg {
-            repo = 'maven'
-            name = project.name
-            userOrg = 'rundeck'
+        dependencies {
+            testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
+            testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
+        }
 
-            version {
-                mavenCentralSync {
-                    sync = true //[Default: true] Determines whether to sync the version to Maven Central.
-                    user = findProperty('sonatypeUsername') //OSS user token: mandatory
-                    password = findProperty('sonatypePassword') //OSS user password: mandatory
+        jar {
+            manifest.attributes provider: 'gradle'
+        }
+
+        bintray {
+            user = findProperty("bintrayUser")
+            key = findProperty("bintrayApiKey")
+            publish = true
+            dryRun = (findProperty('dryRun') ?: 'true').toBoolean()
+            override = true
+
+            if (findProperty('bintrayUseExisting')) {
+                filesSpec {
+                    from "$artifactDir/rundeck-authz/$project.name/build/libs"
+                    from "$artifactDir/rundeck-authz/$project.name/build/poms"
+                    into "${project.group}.${project.name}".replace('.', '/') + "/$version"
+                    rename { file ->
+                        if (file =~ /^pom/)
+                            return "$project.name-${version}.pom"
+                        else
+                            return file
+                    }
                 }
+            } else {
+                configurations = ['archives']
+            }
 
-                gpg {
-                    sign = true //Determines whether to GPG sign the files. The default is false
-                    passphrase = findProperty('signingPassword') //Optional. The passphrase for GPG signing'
+            pkg {
+                repo = 'maven'
+                name = project.name
+                userOrg = 'rundeck'
+
+                version {
+                    mavenCentralSync {
+                        sync = true //[Default: true] Determines whether to sync the version to Maven Central.
+                        user = findProperty('sonatypeUsername') //OSS user token: mandatory
+                        password = findProperty('sonatypePassword') //OSS user password: mandatory
+                    }
+
+                    gpg {
+                        sign = true //Determines whether to GPG sign the files. The default is false
+                        passphrase = findProperty('signingPassword') //Optional. The passphrase for GPG signing'
+                    }
                 }
             }
         }

--- a/rundeck-authz/build.gradle
+++ b/rundeck-authz/build.gradle
@@ -32,11 +32,6 @@ subprojects { Project it ->
             mavenCentral()
         }
 
-        dependencies {
-            testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
-            testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
-        }
-
         jar {
             manifest.attributes provider: 'gradle'
         }

--- a/rundeck-authz/rundeck-authz-api/build.gradle
+++ b/rundeck-authz/rundeck-authz-api/build.gradle
@@ -1,0 +1,1 @@
+apply plugin: "groovy"

--- a/rundeck-authz/rundeck-authz-api/build.gradle
+++ b/rundeck-authz/rundeck-authz-api/build.gradle
@@ -1,1 +1,6 @@
 apply plugin: "groovy"
+
+dependencies {
+    testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
+    testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
+}

--- a/rundeck-authz/rundeck-authz-core/build.gradle
+++ b/rundeck-authz/rundeck-authz-core/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: "groovy"
 
 dependencies {
     compile project(':rundeck-authz:rundeck-authz-api')

--- a/rundeck-authz/rundeck-authz-core/build.gradle
+++ b/rundeck-authz/rundeck-authz-core/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: "groovy"
 
 dependencies {
+    testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
+    testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
     compile project(':rundeck-authz:rundeck-authz-api')
 }

--- a/rundeck-authz/rundeck-authz-yaml/build.gradle
+++ b/rundeck-authz/rundeck-authz-yaml/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: "groovy"
 
 dependencies {
     compile project(':rundeck-authz:rundeck-authz-api')

--- a/rundeck-authz/rundeck-authz-yaml/build.gradle
+++ b/rundeck-authz/rundeck-authz-yaml/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: "groovy"
 
 dependencies {
+    testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
+    testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
     compile project(':rundeck-authz:rundeck-authz-api')
     compile project(':rundeck-authz:rundeck-authz-core')
     compile "org.yaml:snakeyaml:${snakeyamlVersion}"

--- a/rundeckapp/gradle/wrapper/gradle-wrapper.properties
+++ b/rundeckapp/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle 5.6.4 includes support for Groovy compile avoidance and incremental compile. This can greatly reduce test and startup times.

Some refactor was necessary to get the project to configure successfully.