### PR TITLE
Fix execution log viewer not updating settings on running job

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logBuilder.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logBuilder.ts
@@ -106,6 +106,10 @@ export class LogBuilder {
     }
   }
 
+  updateProp(opts: IBuilderOpts) {
+    this.opts = Object.assign(LogBuilder.DefaultOpts(), opts)
+  }
+
   addLines(entries: Array<ExecutionOutputEntry>) {
     const items = entries.map( e => {
       return this.addLine(e, false)

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logViewer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logViewer.vue
@@ -478,9 +478,14 @@ export default class LogViewer extends Vue {
     }
 
     private handleNewLine(entries: Array<any>) {
+       const updatableProps: Array<keyof IEventViewerSettings> = ['nodeBadge', 'gutter', 'timestamps', 'lineWrap', 'command']
 
       for (const vue of entries) {
         // @ts-ignore
+          for (const prop of updatableProps) {
+              vue.$options.props[prop] = this.settings[prop]
+              vue[prop] = this.settings[prop]
+          }
         const selected = vue.$options.entry.lineNumber == this.jumpToLine
         vue.$on('line-select', this.handleLineSelect)
         if (selected) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logViewer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logViewer.vue
@@ -211,6 +211,25 @@ export default class LogViewer extends Vue {
           this.$options.vues.forEach(v => v[prop] = newVal[prop])
         }
       }
+
+      this.logBuilder.updateProp({
+        node: this.node,
+        stepCtx: this.stepCtx,
+        nodeIcon: this.settings.nodeBadge,
+        maxLines: 20000,
+        command: {
+          visible: this.settings.command
+        },
+        time: {
+          visible: this.settings.timestamps
+        },
+        gutter: {
+          visible: this.settings.gutter
+        },
+        content: {
+          lineWrap: this.settings.lineWrap
+        }
+      })
     }
 
     private consumeLogs: boolean = true
@@ -478,14 +497,8 @@ export default class LogViewer extends Vue {
     }
 
     private handleNewLine(entries: Array<any>) {
-       const updatableProps: Array<keyof IEventViewerSettings> = ['nodeBadge', 'gutter', 'timestamps', 'lineWrap', 'command']
-
       for (const vue of entries) {
         // @ts-ignore
-          for (const prop of updatableProps) {
-              vue.$options.props[prop] = this.settings[prop]
-              vue[prop] = this.settings[prop]
-          }
         const selected = vue.$options.entry.lineNumber == this.jumpToLine
         vue.$on('line-select', this.handleLineSelect)
         if (selected) {


### PR DESCRIPTION
Fixes rundeckpro/rundeckpro#1334

While running a job some settings from the new execution viewer does not keep saved as being enabled/disabled during the job execution.

I.e, during job execution > select settings > uncheck Display Gutter > Gutter disappears > when output is updated it reverts back to how it was configured since job started.

Fixed by assigning the current settings props in the store to the new entries before they are pushed to the log builder
