### PR TITLE
Add ability for Node Sources to use Key Storage

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/authentication/Urn.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authentication/Urn.java
@@ -1,0 +1,23 @@
+package com.dtolabs.rundeck.core.authentication;
+
+import java.io.Serializable;
+import java.security.Principal;
+
+public class Urn  implements Principal, Serializable {
+    private static final long serialVersionUID = 1L;
+    private final String urnName;
+
+    public Urn(String urnName) {
+        this.urnName = urnName;
+    }
+
+    @Override
+    public String getName() {
+        return urnName;
+    }
+
+    @Override
+    public String toString() {
+        return "RUNDECK urnName: " + this.urnName;
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/AclsUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/AclsUtil.java
@@ -122,7 +122,12 @@ public class AclsUtil {
         };
     }
 
-    public static Subject getSubjectUrn(String project){
+    /**
+     * Create URN Subject for a project
+     *
+     * @param project  project name
+     */
+    public static Subject getSubjectUrnForProject(String project){
         String urn = "project:"+project;
         Subject t = new Subject();
         t.getPrincipals().add(new Urn(urn));

--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/AclsUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/AclsUtil.java
@@ -17,10 +17,12 @@
 package com.dtolabs.rundeck.core.authorization;
 
 import com.dtolabs.rundeck.core.authentication.Group;
+import com.dtolabs.rundeck.core.authentication.Urn;
 import com.dtolabs.rundeck.core.authentication.Username;
 import com.dtolabs.rundeck.core.authorization.providers.Logger;
 import com.dtolabs.rundeck.core.authorization.providers.Policies;
 
+import javax.security.auth.Subject;
 import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
@@ -40,10 +42,10 @@ public class AclsUtil {
      * @return authorization from source
      */
     public static AclRuleSetAuthorization createAuthorization(AclRuleSetSource aclRuleSetSource) {
-        return logging(RuleEvaluator.createRuleEvaluator(aclRuleSetSource, TypedSubject.aclSubjectCreator(Username.class, Group.class)));
+        return logging(RuleEvaluator.createRuleEvaluator(aclRuleSetSource, TypedSubject.aclSubjectCreator(Username.class, Group.class, Urn.class)));
     }
     public static AclRuleSetAuthorization createAuthorization(Policies policies) {
-        return logging(RuleEvaluator.createRuleEvaluator(policies, TypedSubject.aclSubjectCreator(Username.class, Group.class)));
+        return logging(RuleEvaluator.createRuleEvaluator(policies, TypedSubject.aclSubjectCreator(Username.class, Group.class, Urn.class)));
     }
 
     private static AclRuleSetAuthorization logging(AclRuleSetAuthorization authorization) {
@@ -80,7 +82,7 @@ public class AclsUtil {
             return logging(
                     RuleEvaluator.createRuleEvaluator(
                             merge(a1, b1),
-                            TypedSubject.aclSubjectCreator(Username.class, Group.class)
+                            TypedSubject.aclSubjectCreator(Username.class, Group.class, Urn.class)
                     )
             );
         }
@@ -118,5 +120,12 @@ public class AclsUtil {
                 return new AclRuleSetImpl(aclRules);
             }
         };
+    }
+
+    public static Subject getSubjectUrn(String project){
+        String urn = "project:"+project;
+        Subject t = new Subject();
+        t.getPrincipals().add(new Urn(urn));
+        return t;
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/authorization/SubjectUserAndRoles.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authorization/SubjectUserAndRoles.java
@@ -1,6 +1,7 @@
 package com.dtolabs.rundeck.core.authorization;
 
 import com.dtolabs.rundeck.core.authentication.Group;
+import com.dtolabs.rundeck.core.authentication.Urn;
 import com.dtolabs.rundeck.core.authentication.Username;
 
 import javax.security.auth.Subject;
@@ -38,6 +39,15 @@ public class SubjectUserAndRoles
             }
         }
         return roles;
+    }
+
+    @Override
+    public String getUrn() {
+        Set<Urn> principals = subject.getPrincipals(Urn.class);
+        if (principals.size() > 0) {
+            return principals.iterator().next().getName();
+        }
+        return null;
     }
 
     protected Subject getSubject() {

--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/AclRule.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/AclRule.java
@@ -46,6 +46,8 @@ public interface AclRule {
 
     public String getGroup();
 
+    public String getUrn();
+
     public Set<String> getAllowActions();
 
     public EnvironmentalContext getEnvironment();

--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/AclRuleBuilder.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/AclRuleBuilder.java
@@ -119,6 +119,11 @@ public class AclRuleBuilder {
         return this;
     }
 
+    public AclRuleBuilder urn(final String urn) {
+        aclRuleImpl.urn = urn;
+        return this;
+    }
+
     public AclRuleBuilder allowActions(final Set<String> allowActions) {
         aclRuleImpl.allowActions = allowActions;
         return this;

--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/AclRuleImpl.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/AclRuleImpl.java
@@ -40,6 +40,7 @@ public class AclRuleImpl implements AclRule {
     Map<String, Object> equalsResource;
     String username;
     String group;
+    String urn;
     Set<String> allowActions;
     EnvironmentalContext environment;
     Set<String> denyActions;
@@ -64,6 +65,7 @@ public class AclRuleImpl implements AclRule {
         equalsResource = (prototype.getEqualsResource());
         username = (prototype.getUsername());
         group = (prototype.getGroup());
+        urn = (prototype.getUrn());
         allowActions = (prototype.getAllowActions());
         denyActions = (prototype.getDenyActions());
         environment = (prototype.getEnvironment());
@@ -127,6 +129,15 @@ public class AclRuleImpl implements AclRule {
     }
 
     @Override
+    public String getUrn() {
+        return urn;
+    }
+
+    public void setUrn(String urn) {
+        this.urn = urn;
+    }
+
+    @Override
     public String toString() {
         return "ACLRule<"  + sourceIdentity + ">{" +
                "'" + description + '\'' +
@@ -143,6 +154,7 @@ public class AclRuleImpl implements AclRule {
                 (by?" for":" not-for")+": {"+
                (null!=username?" username='" + username + '\'':"") +
                (null!=group?" group='" + group + '\'':"") +
+               (null!=urn?" urn='" + urn + '\'':"") +
                "}" +
                (allowActions!=null&& allowActions.size()>0? " allow=" + allowActions : "") +
                ( denyActions!=null && denyActions.size()>0 ?" deny=" + denyActions : "" ) +

--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/AclSubject.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/AclSubject.java
@@ -24,4 +24,5 @@ import java.util.Set;
 public interface AclSubject {
     public String getUsername();
     public Set<String> getGroups();
+    public String getUrn();
 }

--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/AuthContextProvider.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/AuthContextProvider.java
@@ -67,7 +67,7 @@ public interface AuthContextProvider {
     public UserAndRolesAuthContext getAuthContextForUserAndRoles(String user, List<String> rolelist);
 
     /**
-     * Synthesize context given user name, role list, and project
+     * Create auth context for a project context (Using URN)
      *
      * @param project  project name
      */

--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/AuthContextProvider.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/AuthContextProvider.java
@@ -65,4 +65,12 @@ public interface AuthContextProvider {
      * @param rolelist list of roles
      */
     public UserAndRolesAuthContext getAuthContextForUserAndRoles(String user, List<String> rolelist);
+
+    /**
+     * Synthesize context given user name, role list, and project
+     *
+     * @param project  project name
+     */
+    public UserAndRolesAuthContext getAuthContextForUrnProject(String project);
+
 }

--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
@@ -145,6 +145,15 @@ public class RuleEvaluator implements AclRuleSetAuthorization {
 //                    }
                 }
             }
+
+            if (subject.getUrn() != null && rule.getUrn() != null) {
+
+                if (subject.getUrn().equals(rule.getUrn())
+                        || matchesPattern(subject.getUrn(), rule.getUrn())
+                ) {
+                    return true;
+                }
+            }
         }else { //notBy acl
             if (subject.getUsername() != null && rule.getUsername() != null) {
                 if (subject.getUsername().equals(rule.getUsername())
@@ -165,6 +174,14 @@ public class RuleEvaluator implements AclRuleSetAuthorization {
 //                    if (logger.isDebugEnabled()) {
 //                        logger.debug(rule.toString() + ": group not excluded: " + rule.getGroup());
 //                    }
+                }
+            }
+            if (subject.getUrn() != null && rule.getUrn() != null) {
+
+                if (subject.getUrn().equals(rule.getUrn())
+                        || matchesPattern(subject.getUrn(), rule.getUrn())
+                ) {
+                    return false;
                 }
             }
             return true;

--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
@@ -134,7 +134,7 @@ public class RuleEvaluator implements AclRuleSetAuthorization {
             }
 
 
-            if (subject.getGroups().size() > 0) {
+            if (subject.getGroups() != null && subject.getGroups().size() > 0) {
                 // no username matched, check groups.
                 if (subject.getGroups().contains(rule.getGroup())
                         || matchesAnyPatterns(subject.getGroups(), rule.getGroup())) {

--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
@@ -178,9 +178,7 @@ public class RuleEvaluator implements AclRuleSetAuthorization {
             }
             if (subject.getUrn() != null && rule.getUrn() != null) {
 
-                if (subject.getUrn().equals(rule.getUrn())
-                        || matchesPattern(subject.getUrn(), rule.getUrn())
-                ) {
+                if (subject.getUrn().equals(rule.getUrn())) {
                     return false;
                 }
             }

--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
@@ -147,10 +147,7 @@ public class RuleEvaluator implements AclRuleSetAuthorization {
             }
 
             if (subject.getUrn() != null && rule.getUrn() != null) {
-
-                if (subject.getUrn().equals(rule.getUrn())
-                        || matchesPattern(subject.getUrn(), rule.getUrn())
-                ) {
+                if (subject.getUrn().equals(rule.getUrn())) {
                     return true;
                 }
             }
@@ -177,7 +174,6 @@ public class RuleEvaluator implements AclRuleSetAuthorization {
                 }
             }
             if (subject.getUrn() != null && rule.getUrn() != null) {
-
                 if (subject.getUrn().equals(rule.getUrn())) {
                     return false;
                 }

--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/TypedSubject.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/TypedSubject.java
@@ -11,14 +11,16 @@ public class TypedSubject
 {
     private Class<? extends Principal> userType;
     private Class<? extends Principal> groupType;
+    private Class<? extends Principal> urnType;
 
-    public TypedSubject(final Class<? extends Principal> userType, final Class<? extends Principal> groupType) {
+    public TypedSubject(final Class<? extends Principal> userType, final Class<? extends Principal> groupType, final Class<? extends Principal> urnType) {
         this.userType = userType;
         this.groupType = groupType;
+        this.urnType = urnType;
     }
 
-    public static RuleEvaluator.AclSubjectCreator aclSubjectCreator(final Class<? extends Principal> userType, final Class<? extends Principal> groupType){
-        return new TypedSubject(userType, groupType);
+    public static RuleEvaluator.AclSubjectCreator aclSubjectCreator(final Class<? extends Principal> userType, final Class<? extends Principal> groupType, final Class<? extends Principal> urnType){
+        return new TypedSubject(userType, groupType, urnType);
     }
 
     @Override
@@ -41,6 +43,16 @@ public class TypedSubject
                 groupNames.add(groupPrincipal.getName());
             }
         }
+
+        Set<? extends Principal> urnsPrincipals = subject.getPrincipals(urnType);
+        final String urnNames;
+        if (urnsPrincipals.size() > 0) {
+            Principal urnName = urnsPrincipals.iterator().next();
+            urnNames = urnName.getName();
+        } else {
+            urnNames = null;
+        }
+
         return new AclSubject() {
             @Override
             public String getUsername() {
@@ -50,6 +62,11 @@ public class TypedSubject
             @Override
             public Set<String> getGroups() {
                 return groupNames;
+            }
+
+            @Override
+            public String getUrn() {
+                return urnNames;
             }
         };
     }

--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/UserAndRoles.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/UserAndRoles.java
@@ -32,4 +32,9 @@ public interface UserAndRoles {
      * @return list of user roles
      */
     public Set<String> getRoles();
+
+    /**
+     * @return urns
+     */
+    public String getUrn();
 }

--- a/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/AclRuleBuilderSpec.groovy
+++ b/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/AclRuleBuilderSpec.groovy
@@ -126,4 +126,43 @@ class AclRuleBuilderSpec extends Specification {
         rule.environment != null
         rule.environment.isValid()
     }
+
+    def "urn build"(){
+        def builder = AclRuleBuilder.builder()
+        given:
+        builder.with {
+            description "blah"
+            sourceIdentity "sblah"
+            resourceType "rblah"
+            equalsResource( [a: 'b'])
+            containsResource( [c: 'd'])
+            subsetResource( [e: 'f'])
+            regexResource( [g: 'h'])
+            allowActions(['ablah', 'ablah2'] as Set)
+            denyActions(['dblah', 'dblah2'] as Set)
+            environment Mock(EnvironmentalContext){
+                isValid()>>true
+            }
+            urn("project:test")
+        }
+        def rule=builder.build()
+        expect:
+        rule!=null
+        rule.description=='blah'
+        rule.sourceIdentity=='sblah'
+        rule.resourceType=='rblah'
+        rule.equalsResource==[a:'b']
+        rule.containsResource==[c:'d']
+        rule.subsetResource==[e:'f']
+        rule.regexResource==[g:'h']
+        rule.allowActions==['ablah','ablah2'] as Set
+        rule.denyActions==['dblah','dblah2'] as Set
+        rule.containsMatch
+        rule.regexMatch
+        rule.equalsMatch
+        rule.subsetMatch
+        rule.urn == "project:test"
+        rule.environment!=null
+        rule.environment.isValid()
+    }
 }

--- a/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
+++ b/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
@@ -43,6 +43,14 @@ class RuleEvaluatorSpec extends Specification {
         }
     }
 
+    static class Urn implements Principal{
+        String name
+
+        Urn(final String name) {
+            this.name = name
+        }
+    }
+
     Subject basicSubject(final String user, final String... groups) {
         def subject = new Subject()
         subject.principals<< new Username(user)
@@ -50,7 +58,7 @@ class RuleEvaluatorSpec extends Specification {
         subject
     }
     def Authorization newRuleEvaluator(AclRuleSet ruleSet) {
-        RuleEvaluator.createRuleEvaluator(ruleSet, TypedSubject.aclSubjectCreator(Username, Group))
+        RuleEvaluator.createRuleEvaluator(ruleSet, TypedSubject.aclSubjectCreator(Username, Group, Urn))
     }
 
     def "test allow project context regex"(){
@@ -928,11 +936,15 @@ class RuleEvaluatorSpec extends Specification {
 
         String group;
 
+        String urn;
+
         Set<String> allowActions
 
         EnvironmentalContext environment;
 
         Set<String> denyActions;
         boolean by;
+
+
     }
 }

--- a/rundeck-authz/rundeck-authz-yaml/src/main/java/com/dtolabs/rundeck/core/authorization/providers/Policy.java
+++ b/rundeck-authz/rundeck-authz-yaml/src/main/java/com/dtolabs/rundeck/core/authorization/providers/Policy.java
@@ -54,6 +54,13 @@ public interface Policy extends AclRuleSetSource {
      */
     public Set<String> getGroups();
 
+    /**
+     *
+     * Return a list of urns objects associated with this policy.
+     *
+     * @return groups
+     */
+    public Set<String> getUrns();
 
     /**
      * @return the environmental context to test the Policy against an input environment

--- a/rundeck-authz/rundeck-authz-yaml/src/main/java/com/dtolabs/rundeck/core/authorization/providers/YamlParsePolicy.java
+++ b/rundeck-authz/rundeck-authz-yaml/src/main/java/com/dtolabs/rundeck/core/authorization/providers/YamlParsePolicy.java
@@ -43,6 +43,8 @@ public class YamlParsePolicy implements Policy {
     public static final String NOT_BY_SECTION = "notBy";
     public static final String USERNAME_KEY = "username";
     public static final String GROUP_KEY = "group";
+    public static final String URN_KEY = "urn";
+
     ACLPolicyDoc policyDoc;
     String sourceIdent;
     int sourceIndex;
@@ -51,6 +53,7 @@ public class YamlParsePolicy implements Policy {
 
     private Set<String> usernames = new HashSet<String>();
     private Set<String> groups = new HashSet<String>();
+    private Set<String> urns = new HashSet<String>();
     private Set<AclRule> rules = new HashSet<>();
     private boolean isBy;
 
@@ -147,20 +150,27 @@ public class YamlParsePolicy implements Policy {
             AclRuleBuilder ruleBuilder = AclRuleBuilder.builder(envProto).group(group);
             rules.addAll(createRules(ruleBuilder));
         }
+        for (String urn : urns) {
+            AclRuleBuilder ruleBuilder = AclRuleBuilder.builder(envProto).urn(urn);
+            rules.addAll(createRules(ruleBuilder));
+        }
     }
 
     private void parseByClause() {
 
         Object u = null;
         Object g = null;
+        Object urn = null;
         if(null != policyDoc.getBy()) {
             this.isBy = true;
             u = policyDoc.getBy().getUsername();
             g = policyDoc.getBy().getGroup();
+            urn = policyDoc.getBy().getUrn();
         }else if(null != policyDoc.getNotBy()){
             this.isBy=false;
             u = policyDoc.getNotBy().getUsername();
             g = policyDoc.getNotBy().getGroup();
+            urn = policyDoc.getNotBy().getUrn();
         }
 
         if (null != u) {
@@ -214,7 +224,33 @@ public class YamlParsePolicy implements Policy {
                 );
             }
         }
-        if (groups.size() < 1 && usernames.size() < 1) {
+
+        if (null != urn) {
+            if (urn instanceof String) {
+                addUrn((String) urn);
+            } else if (g instanceof Collection) {
+                for (final Object o : (Collection) urn) {
+                    if (o instanceof String) {
+                        addUrn((String) o);
+                    } else {
+                        throw new AclPolicySyntaxException(
+                                "Section '" +
+                                        URN_KEY +
+                                        ":' should contain only Strings, but saw a: " +
+                                        o.getClass().getName()
+                        );
+                    }
+                }
+            } else {
+                throw new AclPolicySyntaxException(
+                        "Section '" +
+                                URN_KEY +
+                                ":' should be a list or a String, but it was: " +
+                                urn.getClass().getName()
+                );
+            }
+        }
+        if (groups.size() < 1 && usernames.size() < 1 && urns.size() < 1) {
             if (null != validation) {
                 validation.addError(
                         sourceIdent,
@@ -224,6 +260,8 @@ public class YamlParsePolicy implements Policy {
                         GROUP_KEY +
                         ":' and/or '" +
                         USERNAME_KEY +
+                        ":' and/or '" +
+                        URN_KEY +
                         ":'"
                 );
             }
@@ -232,6 +270,10 @@ public class YamlParsePolicy implements Policy {
 
     private void addGroup(String g) {
         groups.add(g);
+    }
+
+    private void addUrn(String urn) {
+        urns.add(urn);
     }
 
     private void addUsername(String u) {
@@ -246,7 +288,7 @@ public class YamlParsePolicy implements Policy {
         }
 
         if (null != policyDoc.getBy() &&
-                (null == policyDoc.getBy().getGroup() && null == policyDoc.getBy().getUsername())) {
+                (null == policyDoc.getBy().getGroup() && null == policyDoc.getBy().getUsername() && null == policyDoc.getBy().getUrn())) {
 
             throw new AclPolicySyntaxException(
                     "Section '" + BY_SECTION +
@@ -255,11 +297,14 @@ public class YamlParsePolicy implements Policy {
                     GROUP_KEY +
                     ":' and/or '" +
                     USERNAME_KEY +
+                    ":' and/or '" +
+                    URN_KEY +
                     ":'"
+
             );
         }
         if (null != policyDoc.getNotBy() &&
-                (null == policyDoc.getNotBy().getGroup() && null == policyDoc.getNotBy().getUsername())) {
+                (null == policyDoc.getNotBy().getGroup() && null == policyDoc.getNotBy().getUsername() && null == policyDoc.getNotBy().getUrn())) {
 
             throw new AclPolicySyntaxException(
                     "Section '" + NOT_BY_SECTION +
@@ -268,6 +313,8 @@ public class YamlParsePolicy implements Policy {
                             GROUP_KEY +
                             ":' and/or '" +
                             USERNAME_KEY +
+                            ":' and/or '" +
+                            URN_KEY +
                             ":'"
             );
         }

--- a/rundeck-authz/rundeck-authz-yaml/src/main/java/com/dtolabs/rundeck/core/authorization/providers/YamlParsePolicy.java
+++ b/rundeck-authz/rundeck-authz-yaml/src/main/java/com/dtolabs/rundeck/core/authorization/providers/YamlParsePolicy.java
@@ -550,6 +550,11 @@ public class YamlParsePolicy implements Policy {
     }
 
     @Override
+    public Set<String> getUrns() {
+        return urns;
+    }
+
+    @Override
     public String getDescription() {
         return policyDoc.getDescription();
     }

--- a/rundeck-authz/rundeck-authz-yaml/src/main/java/com/dtolabs/rundeck/core/authorization/providers/yaml/model/ACLPolicyDoc.java
+++ b/rundeck-authz/rundeck-authz-yaml/src/main/java/com/dtolabs/rundeck/core/authorization/providers/yaml/model/ACLPolicyDoc.java
@@ -354,6 +354,7 @@ public class ACLPolicyDoc {
     public static class By {
         private Object username;
         private Object group;
+        private Object urn;
 
         public Object getUsername() {
             return username;
@@ -369,6 +370,14 @@ public class ACLPolicyDoc {
 
         public void setGroup(Object group) {
             this.group = group;
+        }
+
+        public Object getUrn() {
+            return urn;
+        }
+
+        public void setUrn(Object urn) {
+            this.urn = urn;
         }
 
         @Override
@@ -376,6 +385,7 @@ public class ACLPolicyDoc {
             return "By{" +
                    "username=" + username +
                    ", group=" + group +
+                   ", urn=" + urn +
                    '}';
         }
     }
@@ -383,6 +393,7 @@ public class ACLPolicyDoc {
     public static class NotBy {
         private Object username;
         private Object group;
+        private Object urn;
 
         public Object getUsername() {
             return username;
@@ -400,11 +411,20 @@ public class ACLPolicyDoc {
             this.group = group;
         }
 
+        public Object getUrn() {
+            return urn;
+        }
+
+        public void setUrn(Object urn) {
+            this.urn = urn;
+        }
+
         @Override
         public String toString() {
             return "NotBy{" +
                     "username=" + username +
                     ", group=" + group +
+                    ", urn=" + urn +
                     '}';
         }
     }

--- a/rundeck-authz/rundeck-authz-yaml/src/test/groovy/com/dtolabs/rundeck/core/authorization/providers/YamlProviderSpec.groovy
+++ b/rundeck-authz/rundeck-authz-yaml/src/test/groovy/com/dtolabs/rundeck/core/authorization/providers/YamlProviderSpec.groovy
@@ -646,4 +646,22 @@ id: any string
         validation.errors.size()==1
         validation.errors['test1[1]']==["Type rule 'for: { type: [...] }' entry at index [1] Using notBy Can't be of type 'allow:' only'deny:'"]
     }
+
+    def "validate basic ok URN"(){
+        when:
+        def validation = validationForString '''
+context:
+    project: test
+by:
+    urn: project:test
+for:
+    type:
+        - allow: '*'
+description: blah
+id: any string
+''', new ValidationSet()
+
+        then:
+        validation.valid
+    }
 }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -3536,11 +3536,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                 return renderErrorView("Project parameter is required")
             }
 
-            String user = "system"
-            Set<String> group = ["system"].toSet()
             String keyPath = "keys/"
-
-            def result = frameworkService.evaluateAclAccessKeyStorage(user, group, keyPath)
+            def result = frameworkService.evaluateProjectAccessKeyStorage(params.project, keyPath)
 
             render(
                     result as JSON,

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -3527,31 +3527,5 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         }
         render(status: HttpServletResponse.SC_NO_CONTENT)
     }
-
-    def evaluateKeyStorageAccessNodeResource(){
-        withForm {
-            g.refreshFormTokensHeader()
-
-            if (!params.project) {
-                return renderErrorView("Project parameter is required")
-            }
-
-            String keyPath = "keys/"
-            def result = frameworkService.evaluateProjectAccessKeyStorage(params.project, keyPath)
-
-            render(
-                    result as JSON,
-                    contentType: 'application/json'
-            ) as Object
-        }.invalidToken {
-            return apiService.renderErrorFormat(
-                    response, [
-                    status: HttpServletResponse.SC_BAD_REQUEST,
-                    code  : 'request.error.invalidtoken.message',
-            ]
-            )
-        }
-
-    }
 }
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -3527,5 +3527,34 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         }
         render(status: HttpServletResponse.SC_NO_CONTENT)
     }
+
+    def evaluateKeyStorageAccessNodeResource(){
+        withForm {
+            g.refreshFormTokensHeader()
+
+            if (!params.project) {
+                return renderErrorView("Project parameter is required")
+            }
+
+            String user = "system"
+            Set<String> group = ["system"].toSet()
+            String keyPath = "keys/"
+
+            def result = frameworkService.evaluateAclAccessKeyStorage(user, group, keyPath)
+
+            render(
+                    result as JSON,
+                    contentType: 'application/json'
+            ) as Object
+        }.invalidToken {
+            return apiService.renderErrorFormat(
+                    response, [
+                    status: HttpServletResponse.SC_BAD_REQUEST,
+                    code  : 'request.error.invalidtoken.message',
+            ]
+            )
+        }
+
+    }
 }
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -1407,6 +1407,9 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 if(it.usernames?.size()>0){
                     by = by+' usernames: '+it.usernames.join(", ")
                 }
+                if(it.urns?.size()>0){
+                    by = by+' urn: '+it.urns.join(", ")
+                }
 
                 [
                         description: it.description,

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -1832,7 +1832,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             fileText = params.fileText
         }
         //TODO: templates
-        [project: params.project, fileText:fileText]
+        [fileType: params.fileType, fileText:fileText]
     }
 
     def editSystemAclFile(SysAclFile input) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -1487,8 +1487,13 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         )) {
             return
         }
+
+        String fileText = ""
+        if(params.fileText){
+            fileText = params.fileText
+        }
         //TODO: templates
-        [project: params.project]
+        [project: params.project, fileText:fileText]
     }
 
     def editProjectAclFile(ProjAclFile input) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -1826,8 +1826,13 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         if (params.fileType == 'fs' && isClusterModeAclsLocalFileEditDisabled()) {
             return renderErrorView(message(code:"clusterMode.acls.localfiles.modify.disabled.warning.message"))
         }
+
+        String fileText = ""
+        if(params.fileText){
+            fileText = params.fileText
+        }
         //TODO: templates
-        [fileType: params.fileType]
+        [project: params.project, fileText:fileText]
     }
 
     def editSystemAclFile(SysAclFile input) {

--- a/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
+++ b/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
@@ -273,6 +273,8 @@ class UrlMappings {
         "/project/$project/events/$action?/$id?(.$format)?"(controller: 'reports')
         "/project/$project/configure"(controller: 'framework', action: 'editProject')
         "/project/$project/nodes/sources"(controller: 'framework', action: 'projectNodeSources')
+        "/project/$project/nodes/sources/storageaccess"(controller: 'framework', action: 'evaluateKeyStorageAccessNodeResource')
+
         "/project/$project/nodes/sources/edit"(controller: 'framework', action: 'editProjectNodeSources')
         "/project/$project/nodes/source/$index/edit"(controller: 'framework', action: 'editProjectNodeSourceFile')
         "/project/$project/nodes/source/$index/save"(controller: 'framework', action: 'saveProjectNodeSourceFile')

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -1300,41 +1300,4 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
         }
         return new File(vardir, FIRST_LOGIN_FILE)
     }
-
-    Map evaluateProjectAccessKeyStorage(String project, String keyPath){
-        Subject subject = AclsUtil.getSubjectUrnForProject(project)
-        UserAndRolesAuthContext authorization = rundeckAuthContextProvider.getAuthContextForSubject(subject)
-        Set<String> actions = AuthResources.appStorageActions.toSet()
-
-       def paths = [keyPath].toSet()
-
-        Set<Map<String, String>> resources = paths.collect { path ->
-            AuthorizationUtil.resource(AuthConstants.TYPE_STORAGE, ["path":path])
-        }.toSet()
-
-        Set<Decision> decisions = authorization.evaluate(resources, actions, AuthorizationUtil.RUNDECK_APP_ENV)
-        Map<String, Map<String, Object>> results = [:]
-
-        decisions.each { Decision decision ->
-            String path = decision.resource.path
-            if (!results[path]) {
-                results[path] = new HashMap<String, Object>()
-
-            }
-
-            results[path] << [
-                    authorized : decision.authorized,
-                    resource   : decision.resource,
-                    action     : decision.action,
-                    environment: decision.environment.collect {
-                        def key = Attribute.propertyKeyForURIBase(it, AuthorizationUtil.URI_BASE)
-                        [property: key, value: it.value]
-                    }.flatten().first(),
-                    code       : decision.explain().code.toString(),
-                    description: decision.explain().toString(),
-            ]
-        }
-
-        results
-    }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -19,7 +19,11 @@ package rundeck.services
 import com.dtolabs.rundeck.app.support.ExecutionCleanerConfig
 import com.dtolabs.rundeck.app.support.ExecutionCleanerConfigImpl
 import com.dtolabs.rundeck.app.support.ExecutionQuery
+import com.dtolabs.rundeck.core.authentication.Group
+import com.dtolabs.rundeck.core.authentication.Username
 import com.dtolabs.rundeck.core.authorization.*
+import com.dtolabs.rundeck.core.authorization.providers.Policies
+import com.dtolabs.rundeck.core.authorization.providers.PolicyCollection
 import com.dtolabs.rundeck.core.cluster.ClusterInfoService
 import com.dtolabs.rundeck.core.common.*
 import com.dtolabs.rundeck.core.config.Features
@@ -42,7 +46,10 @@ import grails.events.bus.EventBus
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import org.grails.plugins.metricsweb.MetricService
+import org.rundeck.app.acl.AppACLContext
+import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.core.auth.AuthConstants
+import org.rundeck.core.auth.AuthResources
 import org.rundeck.core.projects.ProjectConfigurable
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
@@ -50,6 +57,7 @@ import rundeck.PluginStep
 import rundeck.ScheduledExecution
 import rundeck.services.feature.FeatureService
 
+import javax.security.auth.Subject
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import javax.servlet.http.HttpSession
@@ -86,6 +94,7 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
     ConfigurationService configurationService
     FeatureService featureService
     ExecutorService executorService
+    AppAuthContextProcessor rundeckAuthContextProcessor
 
     String getRundeckBase(){
         return rundeckFramework.baseDir.absolutePath
@@ -1281,7 +1290,7 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
         return (PluggableProviderService<T>)storagePluginProviderService
     }
 
-    public File getFirstLoginFile() {
+    public File getFirstLoginFile(Subject subject) {
         String vardir
         if(rundeckFramework.hasProperty('framework.var.dir')) {
             vardir = rundeckFramework.getProperty('framework.var.dir')
@@ -1290,4 +1299,55 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
         }
         return new File(vardir, FIRST_LOGIN_FILE)
     }
+
+    Map evaluateAclAccessKeyStorage(String user, Set<String> groups, String keyPath){
+        Subject subject = makeSubject(user, groups)
+
+        UserAndRolesAuthContext authorization = rundeckAuthContextProvider.getAuthContextForSubject(subject)
+        Set<String> actions = AuthResources.appStorageActions.toSet()
+
+       def paths = [keyPath].toSet()
+
+        Set<Map<String, String>> resources = paths.collect { path ->
+            AuthorizationUtil.resource(AuthConstants.TYPE_STORAGE, ["path":path])
+        }.toSet()
+
+        Set<Decision> decisions = authorization.evaluate(resources, actions, AuthorizationUtil.RUNDECK_APP_ENV)
+        Map<String, Map<String, Object>> results = [:]
+
+        decisions.each { Decision decision ->
+            String path = decision.resource.path
+            if (!results[path]) {
+                results[path] = new HashMap<String, Object>()
+
+            }
+
+            results[path] << [
+                    authorized : decision.authorized,
+                    resource   : decision.resource,
+                    action     : decision.action,
+                    environment: decision.environment.collect {
+                        def key = Attribute.propertyKeyForURIBase(it, AuthorizationUtil.URI_BASE)
+                        [property: key, value: it.value]
+                    }.flatten().first(),
+                    code       : decision.explain().code.toString(),
+                    description: decision.explain().toString(),
+            ]
+        }
+
+        results
+    }
+
+    private Subject makeSubject(final String argUser1user, final Collection<String> groupsList1) {
+        Subject t = new Subject();
+        String user = argUser1user != null ? argUser1user : "user";
+        t.getPrincipals().add(new Username(user));
+        if (null != groupsList1) {
+            for (String s : groupsList1) {
+                t.getPrincipals().add(new Group(s));
+            }
+        }
+        return t;
+    }
+
 }

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -1291,7 +1291,7 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
         return (PluggableProviderService<T>)storagePluginProviderService
     }
 
-    public File getFirstLoginFile(Subject subject) {
+    public File getFirstLoginFile() {
         String vardir
         if(rundeckFramework.hasProperty('framework.var.dir')) {
             vardir = rundeckFramework.getProperty('framework.var.dir')

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.app.support.ExecutionCleanerConfig
 import com.dtolabs.rundeck.app.support.ExecutionCleanerConfigImpl
 import com.dtolabs.rundeck.app.support.ExecutionQuery
 import com.dtolabs.rundeck.core.authentication.Group
+import com.dtolabs.rundeck.core.authentication.Urn
 import com.dtolabs.rundeck.core.authentication.Username
 import com.dtolabs.rundeck.core.authorization.*
 import com.dtolabs.rundeck.core.authorization.providers.Policies
@@ -1300,9 +1301,8 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
         return new File(vardir, FIRST_LOGIN_FILE)
     }
 
-    Map evaluateAclAccessKeyStorage(String user, Set<String> groups, String keyPath){
-        Subject subject = makeSubject(user, groups)
-
+    Map evaluateProjectAccessKeyStorage(String project, String keyPath){
+        Subject subject = AclsUtil.getSubjectUrn(project)
         UserAndRolesAuthContext authorization = rundeckAuthContextProvider.getAuthContextForSubject(subject)
         Set<String> actions = AuthResources.appStorageActions.toSet()
 
@@ -1337,17 +1337,4 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
 
         results
     }
-
-    private Subject makeSubject(final String argUser1user, final Collection<String> groupsList1) {
-        Subject t = new Subject();
-        String user = argUser1user != null ? argUser1user : "user";
-        t.getPrincipals().add(new Username(user));
-        if (null != groupsList1) {
-            for (String s : groupsList1) {
-                t.getPrincipals().add(new Group(s));
-            }
-        }
-        return t;
-    }
-
 }

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -1302,7 +1302,7 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
     }
 
     Map evaluateProjectAccessKeyStorage(String project, String keyPath){
-        Subject subject = AclsUtil.getSubjectUrn(project)
+        Subject subject = AclsUtil.getSubjectUrnForProject(project)
         UserAndRolesAuthContext authorization = rundeckAuthContextProvider.getAuthContextForSubject(subject)
         Set<String> actions = AuthResources.appStorageActions.toSet()
 

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -125,15 +125,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
     }
 
     KeyStorageTree getDefaultAuthorizingProjectServices(String project){
-        String accessUsername = "system"
-        String accessRole = "system"
-
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForUserAndRolesAndProject(
-                accessUsername,
-                [accessRole],
-                project
-        )
-
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForUrnProject(project)
         return getStorageService().storageTreeWithContext(authContext)
     }
 

--- a/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
+++ b/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
@@ -44,7 +44,7 @@
     })
     window._rundeck = Object.assign(window._rundeck || {}, {
             data: {
-                projectAclConfigPageUrl:"${enc(js:createLink(controller:'menu',action:'projectAcls',params:[project:params.project?:project]))}",
+                projectAclConfigPageUrl:"${enc(js:createLink(controller:'menu',action:'createProjectAclFile',params:[project:params.project?:project]))}",
             }
         });
   </g:javascript>

--- a/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
+++ b/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
@@ -42,6 +42,11 @@
     jQuery(function () {
       setupTabRouter('#node_config_tabs', 'node_');
     })
+    window._rundeck = Object.assign(window._rundeck || {}, {
+            data: {
+                projectAclConfigPageUrl:"${enc(js:createLink(controller:'menu',action:'projectAcls',params:[project:params.project?:project]))}",
+            }
+        });
   </g:javascript>
   <!-- VUE JS MODULES -->
   <asset:javascript src="static/pages/project-nodes-config.js" defer="defer" />

--- a/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
+++ b/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
@@ -45,6 +45,8 @@
     window._rundeck = Object.assign(window._rundeck || {}, {
             data: {
                 projectAclConfigPageUrl:"${enc(js:createLink(controller:'menu',action:'createProjectAclFile',params:[project:params.project?:project]))}",
+                systemAclConfigPageUrl:"${enc(js:createLink(controller:'menu',action:'createSystemAclFile'))}",
+
             }
         });
   </g:javascript>

--- a/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
+++ b/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
@@ -196,6 +196,10 @@
                                                           @reset="EventBus.$emit('page-reset','Node Sources')"
                                                           :event-bus="EventBus">
                               </project-node-sources-config>
+
+                              <project-node-sources-help class="project-plugin-config-vue" :event-bus="EventBus">
+
+                              </project-node-sources-help>
                         </div>
 
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
@@ -258,6 +258,11 @@ export default Vue.extend({
       }
       this.detail = data
       this.prepareInputs()
+
+      let storageAccess = this.hasKeyStorageAccess();
+      if(storageAccess){
+        this.notifyHasKeyStorageAccess();
+      }
     },
     async loadProvider(provider: any) {
       try{
@@ -306,6 +311,18 @@ export default Vue.extend({
       const groupName = testProp.options && testProp.options['groupName']
 
       return grouping || groupName
+    },
+    hasKeyStorageAccess(): boolean {
+      let storageAccess = false;
+      this.props.forEach((prop: any, index)=>{
+        if(prop.options!=null && prop.options['selectionAccessor']){
+          storageAccess = true;
+        }
+      });
+      return storageAccess;
+    },
+    notifyHasKeyStorageAccess(){
+      this.$emit("hasKeyStorageAccess", this.provider)
     },
     loadForMode(){
       if (this.serviceName && this.provider) {

--- a/rundeckapp/grails-spa/packages/ui/package-lock.json
+++ b/rundeckapp/grails-spa/packages/ui/package-lock.json
@@ -23994,6 +23994,122 @@
         "tslint": "^5.20.1",
         "webpack": "^4.0.0",
         "yorkie": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "fork-ts-checker-webpack-plugin-v5": {
+          "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
+          "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
+          "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@types/json-schema": "^7.0.5",
+            "chalk": "^4.1.0",
+            "cosmiconfig": "^6.0.0",
+            "deepmerge": "^4.2.2",
+            "fs-extra": "^9.0.0",
+            "memfs": "^3.1.2",
+            "minimatch": "^3.0.4",
+            "schema-utils": "2.7.0",
+            "semver": "^7.3.2",
+            "tapable": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "@vue/cli-plugin-vuex": {
@@ -24072,6 +24188,16 @@
           "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
           "dev": true
         },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
         "autoprefixer": {
           "version": "9.8.6",
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
@@ -24112,6 +24238,34 @@
             "ssri": "^7.0.0",
             "unique-filename": "^1.1.1"
           }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
         },
         "debug": {
           "version": "4.3.1",
@@ -24163,6 +24317,13 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
         },
         "json5": {
           "version": "1.0.1",
@@ -24268,6 +24429,16 @@
             "minipass": "^3.1.1"
           }
         },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
         "terser-webpack-plugin": {
           "version": "2.3.8",
           "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.8.tgz",
@@ -24290,6 +24461,42 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
+        },
+        "vue-loader-v16": {
+          "version": "npm:vue-loader@16.1.2",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
+          "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "hash-sum": "^2.0.0",
+            "loader-utils": "^2.0.0"
+          },
+          "dependencies": {
+            "json5": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+              "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimist": "^1.2.5"
+              }
+            },
+            "loader-utils": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+              "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+              }
+            }
+          }
         }
       }
     },
@@ -29908,122 +30115,6 @@
         "worker-rpc": "^0.1.0"
       }
     },
-    "fork-ts-checker-webpack-plugin-v5": {
-      "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
-      "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@types/json-schema": "^7.0.5",
-        "chalk": "^4.1.0",
-        "cosmiconfig": "^6.0.0",
-        "deepmerge": "^4.2.2",
-        "fs-extra": "^9.0.0",
-        "memfs": "^3.1.2",
-        "minimatch": "^3.0.4",
-        "schema-utils": "2.7.0",
-        "semver": "^7.3.2",
-        "tapable": "^1.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "schema-utils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "ajv": "^6.12.2",
-            "ajv-keywords": "^3.4.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "form-data": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
@@ -30119,16 +30210,16 @@
       }
     },
     "fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
       "dev": true,
       "optional": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
+        "universalify": "^1.0.0"
       }
     },
     "fs-minipass": {
@@ -31628,9 +31719,9 @@
       }
     },
     "import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -35132,6 +35223,15 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "jsonparse": {
@@ -41555,9 +41655,9 @@
       }
     },
     "universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
       "dev": true,
       "optional": true
     },
@@ -41981,75 +42081,6 @@
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
             "json5": "^1.0.1"
-          }
-        }
-      }
-    },
-    "vue-loader-v16": {
-      "version": "npm:vue-loader@16.1.2",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
-      "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "hash-sum": "^2.0.0",
-        "loader-utils": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         }
       }

--- a/rundeckapp/grails-spa/packages/ui/package-lock.json
+++ b/rundeckapp/grails-spa/packages/ui/package-lock.json
@@ -23544,6 +23544,11 @@
         "pretty-format": "^25.2.1"
       }
     },
+    "@types/js-yaml": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.5.tgz",
+      "integrity": "sha512-JCcp6J0GV66Y4ZMDAQCXot4xprYB+Zfd3meK9+INSJeVZwJmHAW30BBEEkPzXswMXuiyReUGOP3GxrADc9wPww=="
+    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
@@ -29407,8 +29412,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esrecurse": {
       "version": "4.3.0",
@@ -35097,7 +35101,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"

--- a/rundeckapp/grails-spa/packages/ui/package-lock.json
+++ b/rundeckapp/grails-spa/packages/ui/package-lock.json
@@ -23544,11 +23544,6 @@
         "pretty-format": "^25.2.1"
       }
     },
-    "@types/js-yaml": {
-      "version": "3.12.5",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.5.tgz",
-      "integrity": "sha512-JCcp6J0GV66Y4ZMDAQCXot4xprYB+Zfd3meK9+INSJeVZwJmHAW30BBEEkPzXswMXuiyReUGOP3GxrADc9wPww=="
-    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
@@ -23999,122 +23994,6 @@
         "tslint": "^5.20.1",
         "webpack": "^4.0.0",
         "yorkie": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
-        },
-        "fork-ts-checker-webpack-plugin-v5": {
-          "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
-          "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
-          "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@types/json-schema": "^7.0.5",
-            "chalk": "^4.1.0",
-            "cosmiconfig": "^6.0.0",
-            "deepmerge": "^4.2.2",
-            "fs-extra": "^9.0.0",
-            "memfs": "^3.1.2",
-            "minimatch": "^3.0.4",
-            "schema-utils": "2.7.0",
-            "semver": "^7.3.2",
-            "tapable": "^1.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "schema-utils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "ajv": "^6.12.2",
-            "ajv-keywords": "^3.4.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "@vue/cli-plugin-vuex": {
@@ -24193,16 +24072,6 @@
           "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
           "dev": true
         },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
         "autoprefixer": {
           "version": "9.8.6",
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
@@ -24243,34 +24112,6 @@
             "ssri": "^7.0.0",
             "unique-filename": "^1.1.1"
           }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
         },
         "debug": {
           "version": "4.3.1",
@@ -24322,13 +24163,6 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
         },
         "json5": {
           "version": "1.0.1",
@@ -24434,16 +24268,6 @@
             "minipass": "^3.1.1"
           }
         },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
         "terser-webpack-plugin": {
           "version": "2.3.8",
           "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.8.tgz",
@@ -24466,42 +24290,6 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.1.2",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
-          "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
-          },
-          "dependencies": {
-            "json5": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-              "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "minimist": "^1.2.5"
-              }
-            },
-            "loader-utils": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-              "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-              }
-            }
-          }
         }
       }
     },
@@ -29412,7 +29200,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esrecurse": {
       "version": "4.3.0",
@@ -30119,6 +29908,122 @@
         "worker-rpc": "^0.1.0"
       }
     },
+    "fork-ts-checker-webpack-plugin-v5": {
+      "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
+      "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@types/json-schema": "^7.0.5",
+        "chalk": "^4.1.0",
+        "cosmiconfig": "^6.0.0",
+        "deepmerge": "^4.2.2",
+        "fs-extra": "^9.0.0",
+        "memfs": "^3.1.2",
+        "minimatch": "^3.0.4",
+        "schema-utils": "2.7.0",
+        "semver": "^7.3.2",
+        "tapable": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "form-data": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
@@ -30214,16 +30119,16 @@
       }
     },
     "fs-extra": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
       "optional": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
       }
     },
     "fs-minipass": {
@@ -31723,9 +31628,9 @@
       }
     },
     "import-fresh": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
-      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -35101,6 +35006,7 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -35226,15 +35132,6 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
-      },
-      "dependencies": {
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "jsonparse": {
@@ -41658,9 +41555,9 @@
       }
     },
     "universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true,
       "optional": true
     },
@@ -42084,6 +41981,75 @@
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
             "json5": "^1.0.1"
+          }
+        }
+      }
+    },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.1.2",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
+      "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }

--- a/rundeckapp/grails-spa/packages/ui/package.json
+++ b/rundeckapp/grails-spa/packages/ui/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@rundeck/client": "0.2.1",
+    "@types/js-yaml": "^3.12.5",
     "ace-builds": "1.4.12",
     "ant-design-vue": "1.6.2",
     "axios": "^0.18.0",
@@ -26,6 +27,7 @@
     "core-js": "^3.6.4",
     "fuse.js": "^3.4.4",
     "lodash": "^4.17.15",
+    "js-yaml": "^3.13.1",
     "markdown-it": "^10.0.0",
     "markdown-it-vue": "^1.0.11",
     "mobx": "^5.15.4",

--- a/rundeckapp/grails-spa/packages/ui/package.json
+++ b/rundeckapp/grails-spa/packages/ui/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@rundeck/client": "0.2.1",
-    "@types/js-yaml": "^3.12.5",
     "ace-builds": "1.4.12",
     "ant-design-vue": "1.6.2",
     "axios": "^0.18.0",
@@ -27,7 +26,6 @@
     "core-js": "^3.6.4",
     "fuse.js": "^3.4.4",
     "lodash": "^4.17.15",
-    "js-yaml": "^3.13.1",
     "markdown-it": "^10.0.0",
     "markdown-it-vue": "^1.0.11",
     "mobx": "^5.15.4",

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectNodeSourcesConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectNodeSourcesConfig.vue
@@ -107,7 +107,7 @@ export default Vue.extend({
     },
     checkUnauthorized(){
       this.sourcesData.forEach( (source:NodeSource)=>{
-        if(source.errors!==undefined && source.errors.indexOf("Unauthorized access")){
+        if(source.errors!==undefined &&  (source.errors.indexOf("Unauthorized access") > 0 ||source.errors.indexOf("storage") > 0) ){
           this.eventBus.$emit('nodes-unauthorized',this.sourcesData.length)
         }else{
           this.eventBus.$emit('nodes-unauthorized',0)

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectNodeSourcesConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectNodeSourcesConfig.vue
@@ -100,12 +100,26 @@ export default Vue.extend({
     async loadNodeSourcesData() {
       try {
         this.sourcesData = await getProjectNodeSources();
+        this.checkUnauthorized();
       } catch (e) {
         return console.warn("Error getting node sources list", e);
       }
+    },
+    checkUnauthorized(){
+      this.sourcesData.forEach( (source:NodeSource)=>{
+        if(source.errors!==undefined && source.errors.indexOf("Unauthorized access")){
+          this.eventBus.$emit('nodes-unauthorized',this.sourcesData.length)
+        }else{
+          this.eventBus.$emit('nodes-unauthorized',0)
+        }
+      })
+    },
+  },
+  watch: {
+    sourcesData: function(val, oldVal) {
+         this.checkUnauthorized();
     }
   },
-
   mounted() {
     this.rundeckContext = getRundeckContext();
     const self = this;

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectNodeSourcesHelp.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectNodeSourcesHelp.vue
@@ -7,8 +7,9 @@
         <p>{{$t('unauthorized.status.help.2')}}</p>
         <p>{{$t('unauthorized.status.help.3')}}</p>
 
-        <form method="POST" :action="projectAclConfigPageUrl">
-          <input type="hidden" name="fileText" :value="aclExample"/>
+        <div v-if="createProjectAcl">
+          <form method="POST" :action="projectAclConfigPageUrl">
+            <input type="hidden" name="fileText" :value="aclExample"/>
 
           <i18n path="unauthorized.status.help.4" tag="p" >
             <button class="btn btn-sm btn-default" type="submit">{{ $t('acl.config.link.title') }}</button>
@@ -18,7 +19,8 @@
             <pre>{{aclExample}}
             </pre>
           </details>
-        </form>
+         </form>
+        </div>
 
         <form method="POST" :action="systemAclConfigPageUrl">
           <input type="hidden" name="fileText" :value="systemAclExample"/>
@@ -58,7 +60,8 @@ export default Vue.extend({
       projectAclConfigPageUrl:"",
       systemAclConfigPageUrl:"",
       aclExample: "",
-      systemAclExample: ""
+      systemAclExample: "",
+      createProjectAcl: false
     }
   },
   computed: {

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectNodeSourcesHelp.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectNodeSourcesHelp.vue
@@ -16,11 +16,23 @@
           <details>
             <summary>{{$t('acl.example.summary')}}</summary>
             <pre>{{aclExample}}
-          </pre>
+            </pre>
           </details>
-
         </form>
 
+        <form method="POST" :action="systemAclConfigPageUrl">
+          <input type="hidden" name="fileText" :value="systemAclExample"/>
+          <input type="hidden" name="fileType" value="storage"/>
+
+          <i18n path="unauthorized.status.help.5" tag="p" >
+            <button class="btn btn-sm btn-default" type="submit">{{ $t('acl.config.system.link.title') }}</button>
+          </i18n>
+          <details>
+            <summary>{{$t('acl.example.summary')}}</summary>
+            <pre>{{systemAclExample}}
+            </pre>
+          </details>
+        </form>
 
       </alert>
 
@@ -44,7 +56,9 @@ export default Vue.extend({
       unauthorized: false,
       project: "",
       projectAclConfigPageUrl:"",
-      aclExample: ""
+      systemAclConfigPageUrl:"",
+      aclExample: "",
+      systemAclExample: ""
     }
   },
   computed: {
@@ -61,11 +75,23 @@ export default Vue.extend({
   mounted(){
     if(window._rundeck.data) {
       this.projectAclConfigPageUrl  = window._rundeck.data.projectAclConfigPageUrl
+      this.systemAclConfigPageUrl =  window._rundeck.data.systemAclConfigPageUrl
     }
 
     this.project = getRundeckContext().projectName;
     this.aclExample = "by:\n" +
       "  urn: project:" + this.project + "\n" +
+      "for:\n" +
+      "  storage:\n" +
+      "    - match: \n" +
+      "        path: 'keys/project/" + this.project + "/.*'\n" +
+      "      allow: [read] \n" +
+      "description: Allow access to key storage"
+
+    this.systemAclExample = "by:\n" +
+      "  urn: project:" + this.project + "\n" +
+      "context: \n" +
+      "   application: rundeck\n" +
       "for:\n" +
       "  storage:\n" +
       "    - match: \n" +

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectNodeSourcesHelp.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectNodeSourcesHelp.vue
@@ -11,19 +11,11 @@
           <input type="hidden" name="fileText" :value="aclExample"/>
 
           <i18n path="unauthorized.status.help.4" tag="p" >
-            <button type="submit">{{ $t('acl.config.link.title') }}</button>
+            <button class="btn btn-sm btn-default" type="submit">{{ $t('acl.config.link.title') }}</button>
           </i18n>
           <details>
             <summary>{{$t('acl.example.summary')}}</summary>
-            <pre>
-by:
-  urn: project:{{project}}
-for:
-  storage:
-    - match:
-        path: 'keys/project/{{project}}/.*'
-      allow: [read]
-description: Allow access to key storage
+            <pre>{{aclExample}}
           </pre>
           </details>
 
@@ -67,8 +59,11 @@ export default Vue.extend({
   },
 
   mounted(){
+    if(window._rundeck.data) {
+      this.projectAclConfigPageUrl  = window._rundeck.data.projectAclConfigPageUrl + "/create"
+    }
+
     this.project = getRundeckContext().projectName;
-    this.projectAclConfigPageUrl  = "/project/"+this.project+"/admin/acls/create"
     this.aclExample = "by:\n" +
       "  urn: project:" + this.project + "\n" +
       "for:\n" +

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectNodeSourcesHelp.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectNodeSourcesHelp.vue
@@ -60,7 +60,7 @@ export default Vue.extend({
 
   mounted(){
     if(window._rundeck.data) {
-      this.projectAclConfigPageUrl  = window._rundeck.data.projectAclConfigPageUrl + "/create"
+      this.projectAclConfigPageUrl  = window._rundeck.data.projectAclConfigPageUrl
     }
 
     this.project = getRundeckContext().projectName;

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectNodeSourcesHelp.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectNodeSourcesHelp.vue
@@ -1,0 +1,96 @@
+<template>
+  <div>
+    <div v-if="unauthorized">
+
+      <alert type="warning"   >
+        <p><b>{{$t('unauthorized.status.help.1')}}</b></p>
+        <p>{{$t('unauthorized.status.help.2')}}</p>
+        <p>{{$t('unauthorized.status.help.3')}}</p>
+
+        <form method="POST" :action="projectAclConfigPageUrl">
+          <input type="hidden" name="fileText" :value="aclExample"/>
+
+          <i18n path="unauthorized.status.help.4" tag="p" >
+            <button type="submit">{{ $t('acl.config.link.title') }}</button>
+          </i18n>
+          <details>
+            <summary>{{$t('acl.example.summary')}}</summary>
+            <pre>
+by:
+  urn: project:{{project}}
+for:
+  storage:
+    - match:
+        path: 'keys/project/{{project}}/.*'
+      allow: [read]
+description: Allow access to key storage
+          </pre>
+          </details>
+
+        </form>
+
+
+      </alert>
+
+    </div>
+
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { getRundeckContext, RundeckContext } from "@rundeck/ui-trellis";
+
+export default Vue.extend({
+  name: "ProjectNodeSourcesHelp",
+  props:{
+    eventBus:{type:Vue,required:false}
+  },
+  data(){
+    return {
+      count:0,
+      unauthorized: false,
+      project: "",
+      projectAclConfigPageUrl:"",
+      aclExample: ""
+    }
+  },
+  computed: {
+    empty: function(): any {
+      return this.count===0;
+    },
+  },
+  watch: {
+    unauthorized: function(val, oldVal) {
+      this.$forceUpdate();
+    }
+  },
+
+  mounted(){
+    this.project = getRundeckContext().projectName;
+    this.projectAclConfigPageUrl  = "/project/"+this.project+"/admin/acls/create"
+    this.aclExample = "by:\n" +
+      "  urn: project:" + this.project + "\n" +
+      "for:\n" +
+      "  storage:\n" +
+      "    - match: \n" +
+      "        path: 'keys/project/" + this.project + "/.*'\n" +
+      "      allow: [read] \n" +
+      "description: Allow access to key storage"
+
+    this.eventBus.$on('nodes-unauthorized',(count: number)=>{
+      if(count>0){
+        this.unauthorized=true;
+      }else{
+        this.unauthorized=false;
+      }
+
+    });
+
+  }
+});
+</script>
+
+<style scoped>
+
+</style>

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectPluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectPluginConfig.vue
@@ -531,7 +531,7 @@ export default Vue.extend({
           const storageAuth = result['keys/']
           this.keyStorageAuthorized = storageAuth.authorized
         }
-      })
+      }).catch(error => console.error(error));
     }
   },
   mounted() {
@@ -560,7 +560,8 @@ export default Vue.extend({
         this.notifyPluginConfigs();
 
         this.getKeyStorageAuthorization();
-      });
+      }).catch(error => console.error(error));
+
       pluginService
         .getPluginProvidersForService(this.serviceName)
         .then(data => {
@@ -568,7 +569,7 @@ export default Vue.extend({
             this.pluginProviders = data.descriptions;
             this.pluginLabels = data.labels;
           }
-        });
+        }).catch(error => console.error(error));
 
 
     }

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectPluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectPluginConfig.vue
@@ -499,8 +499,7 @@ export default Vue.extend({
     async createAcl(){
       if(this.aclDescription !== ''){
         try{
-          const res = await createProjectAcl(this.aclDescription );
-          console.log(res)
+          await createProjectAcl(this.aclDescription );
           this.modalAclOpen = false;
         }catch(e){
           this.createAclError = `${e}`;

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectPluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectPluginConfig.vue
@@ -517,6 +517,7 @@ export default Vue.extend({
         try{
           await createProjectAcl(this.aclDescription );
           this.getKeyStorageAuthorization();
+          this.savePlugins();
           this.modalAclOpen = false;
         }catch(e){
           this.createAclError = `${e}`;

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectPluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectPluginConfig.vue
@@ -495,7 +495,6 @@ export default Vue.extend({
       this.pluginConfigsModified();
     },
     hasKeyStorageAccess(provider: any){
-      console.log(provider);
       this.pluginStorageAccess.push(provider)
 
     },

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectPluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/ProjectPluginConfig.vue
@@ -209,7 +209,7 @@ import axios from "axios";
 import Vue from "vue";
 import { Notification } from "uiv";
 import { getRundeckContext, RundeckContext } from "@rundeck/ui-trellis";
-import { createProjectAcl, getProjectStorageAccess } from "./nodeSourcesUtil";
+import {createProjectAcl, getProjectStorageAccess, StorageAccess} from "./nodeSourcesUtil";
 
 import Expandable from "@rundeck/ui-trellis/lib/components/utils/Expandable.vue";
 import PluginInfo from "@rundeck/ui-trellis/lib/components/plugins/PluginInfo.vue";
@@ -526,10 +526,9 @@ export default Vue.extend({
       }
     },
     getKeyStorageAuthorization(){
-      getProjectStorageAccess().then(result =>{
-        if(result !== null){
-          const storageAuth = result['keys/']
-          this.keyStorageAuthorized = storageAuth.authorized
+      getProjectStorageAccess().then( (storageAuth:StorageAccess) =>{
+        if(storageAuth !== null){
+          this.keyStorageAuthorized = storageAuth.authorized;
         }
       }).catch(error => console.error(error));
     }

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/i18n.js
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/i18n.js
@@ -6,19 +6,48 @@ const translationStrings = {
     Delete: 'Delete',
     Cancel: 'Cancel',
     Revert: 'Revert',
+    CreateAcl: 'Create ACL',
+    CreateAclName: 'ACL Description',
+    CreateAclTitle: 'Create Key Storage ACL for the project',
     'Edit Nodes': 'Edit Nodes',
     'Modify': 'Modify',
     'Edit Node Sources': 'Edit Node Sources',
     'The Node Source had an error': 'The Node Source had an error',
     'Validation errors': 'Validation errors',
     'empty.message.default': 'None configured. Click {0} to add a new plugin.',
+    'keystorage.access.message.default': 'This plugin need ACL permissions to access the key storage.',
+    'createacl.name.required': 'The ACL name is required',
     uiv: {
       modal: {
         cancel: "Cancel",
         ok: "OK"
       }
     }
-  }
+  },
+  es: {
+    Edit: 'Editar',
+    Save: 'Guardar',
+    Delete: 'Borrar',
+    Cancel: 'Cancelar',
+    Revert: 'Revertir',
+    CreateAcl: 'Crear ACL',
+    CreateAclName: 'Descripción de la ACL',
+    CreateAclTitle: 'Crear Key Storage ACL para el proyecto',
+    'Edit Nodes': 'Editar Nodos',
+    'Modify': 'Modificar',
+    'Edit Node Sources': 'Editar Configuracion de Nodes',
+    'The Node Source had an error': 'La configuracion tiene errores',
+    'Validation errors': 'Validación de errores',
+    'empty.message.default': 'Sin configuracion. Click  en {0} para agregar un nuevo plugin.',
+    'keystorage.access.message.default': 'Este plugin necesita permisos ACL para acceder al `key storage`.',
+    'createacl.name.required': 'El nombre de la ACL es obligatorio',
+    uiv: {
+      modal: {
+        cancel: "Cancelar",
+        ok: "OK"
+      }
+    }
+  },
 }
 
 module.exports = {

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/i18n.js
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/i18n.js
@@ -15,7 +15,7 @@ const translationStrings = {
     'The Node Source had an error': 'The Node Source had an error',
     'Validation errors': 'Validation errors',
     'empty.message.default': 'None configured. Click {0} to add a new plugin.',
-    'keystorage.access.message.default': 'This plugin need ACL permissions to access the key storage.',
+    'keystorage.access.message.default': 'A plugin needs ACL permissions to access the key storage.',
     'createacl.name.required': 'The ACL name is required',
     uiv: {
       modal: {
@@ -39,7 +39,7 @@ const translationStrings = {
     'The Node Source had an error': 'La configuracion tiene errores',
     'Validation errors': 'Validación de errores',
     'empty.message.default': 'Sin configuracion. Click  en {0} para agregar un nuevo plugin.',
-    'keystorage.access.message.default': 'Este plugin necesita permisos ACL para acceder al `key storage`.',
+    'keystorage.access.message.default': 'Un plugin necesita permisos ACL para acceder al `key storage`.',
     'createacl.name.required': 'El nombre de la ACL es obligatorio',
     uiv: {
       modal: {

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/i18n.js
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/i18n.js
@@ -19,8 +19,11 @@ const translationStrings = {
     'unauthorized.status.help.1': 'Some Node Source returned an "Unauthorized" message.',
     'unauthorized.status.help.2': 'The Node Source plugin might need access to the Key Storage Resource. it could be enabled by Access Control Policy entries.',
     'unauthorized.status.help.3': 'Please be sure that the ACL policies enable "read" access to the Key Storage in this project for the project URN path (urn:project:name). ',
-    'unauthorized.status.help.4': 'Go to {0} to update ACL Policies for this project. ',
+    'unauthorized.status.help.4': 'Go to {0} to create a Project ACL ',
+    'unauthorized.status.help.5': 'Go to {0} to create a System ACL ',
+
     'acl.config.link.title': 'Project Settings > Access Control',
+    'acl.config.system.link.title': 'System Settings > Access Control',
     'acl.example.summary': 'Example ACL Policy',
 
     uiv: {
@@ -49,8 +52,12 @@ const translationStrings = {
     'unauthorized.status.help.1': 'Un plugin Node Source retornó un "Unauthorized" mensaje .',
     'unauthorized.status.help.2': 'El plugin Node Source podria necesitar acceso al Key Storage. Se podria habilitar creando una nueva ACL Policy, or alguna ACL existente necesita ser modificada.',
     'unauthorized.status.help.3': 'Por favor asegurate de que la ACL Policy tiene access de lectura ("read") para el Key Storage en este proyecto ( urn:project:name). ',
-    'unauthorized.status.help.4': 'Ir a {0} para crear una ACL Policy para este proyecto. ',
+    'unauthorized.status.help.4': 'Ir a {0} para crear una ACL Policy al nivel de proyecto. ',
+    'unauthorized.status.help.5': 'Ir a {0} para crear una ACL Policy a nivel del sistema. ',
+
     'acl.config.link.title': 'Project Settings > Access Control',
+    'acl.config.system.link.title': 'System Settings > Access Control',
+
     'acl.example.summary': 'Ejemplo de ACL Policy',
     uiv: {
       modal: {

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/i18n.js
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/i18n.js
@@ -15,8 +15,14 @@ const translationStrings = {
     'The Node Source had an error': 'The Node Source had an error',
     'Validation errors': 'Validation errors',
     'empty.message.default': 'None configured. Click {0} to add a new plugin.',
-    'keystorage.access.message.default': 'A plugin needs ACL permissions to access the key storage.',
-    'createacl.name.required': 'The ACL name is required',
+
+    'unauthorized.status.help.1': 'Some Node Source returned an "Unauthorized" message.',
+    'unauthorized.status.help.2': 'The Node Source plugin might need access to the Key Storage Resource. it could be enabled by Access Control Policy entries.',
+    'unauthorized.status.help.3': 'Please be sure that the ACL policies enable "read" access to the Key Storage in this project for the project URN path (urn:project:name). ',
+    'unauthorized.status.help.4': 'Go to {0} to update ACL Policies for this project. ',
+    'acl.config.link.title': 'Project Settings > Access Control',
+    'acl.example.summary': 'Example ACL Policy',
+
     uiv: {
       modal: {
         cancel: "Cancel",
@@ -39,8 +45,13 @@ const translationStrings = {
     'The Node Source had an error': 'La configuracion tiene errores',
     'Validation errors': 'Validación de errores',
     'empty.message.default': 'Sin configuracion. Click  en {0} para agregar un nuevo plugin.',
-    'keystorage.access.message.default': 'Un plugin necesita permisos ACL para acceder al `key storage`.',
-    'createacl.name.required': 'El nombre de la ACL es obligatorio',
+
+    'unauthorized.status.help.1': 'Un plugin Node Source retornó un "Unauthorized" mensaje .',
+    'unauthorized.status.help.2': 'El plugin Node Source podria necesitar acceso al Key Storage. Se podria habilitar creando una nueva ACL Policy, or alguna ACL existente necesita ser modificada.',
+    'unauthorized.status.help.3': 'Por favor asegurate de que la ACL Policy tiene access de lectura ("read") para el Key Storage en este proyecto ( urn:project:name). ',
+    'unauthorized.status.help.4': 'Ir a {0} para crear una ACL Policy para este proyecto. ',
+    'acl.config.link.title': 'Project Settings > Access Control',
+    'acl.example.summary': 'Ejemplo de ACL Policy',
     uiv: {
       modal: {
         cancel: "Cancelar",

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/main.js
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/main.js
@@ -5,6 +5,7 @@ import Vue2Filters from 'vue2-filters'
 import VueCookies from 'vue-cookies'
 import ProjectPluginConfig from './ProjectPluginConfig'
 import ProjectNodeSourcesConfig from './ProjectNodeSourcesConfig'
+import ProjectNodeSourcesHelp from './ProjectNodeSourcesHelp'
 import WriteableProjectNodeSources from './WriteableProjectNodeSources'
 import PageConfirm from '../../components/PageConfirm'
 import * as uiv from 'uiv'
@@ -57,6 +58,7 @@ for (var i = 0; i < els.length; i++) {
       ProjectPluginConfig,
       ProjectNodeSourcesConfig,
       WriteableProjectNodeSources,
+      ProjectNodeSourcesHelp,
       PageConfirm
     },
     i18n

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/nodeSourcesUtil.ts
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/nodeSourcesUtil.ts
@@ -20,6 +20,11 @@ export interface NodeSource {
   resources: NodeSourceResources
   errors?:string
 }
+export interface StorageAccess{
+  authorized: boolean;
+  action: string;
+  description: string;
+}
 export async function getProjectNodeSources(): Promise<NodeSource[]> {
 
   const rundeckContext = getRundeckContext()
@@ -74,7 +79,7 @@ export async function createProjectAcl( aclDescription: string): Promise<void> {
 
 }
 
-export async function getProjectStorageAccess(): Promise<any> {
+export async function getProjectStorageAccess(): Promise<StorageAccess> {
 
   const rundeckContext = getRundeckContext()
   const resp = await rundeckContext.rundeckClient.sendRequest({
@@ -86,11 +91,11 @@ export async function getProjectStorageAccess(): Promise<any> {
   if (!resp.parsedBody) {
     throw new Error(`Error getting node sources list for ${rundeckContext.projectName}`)
   }
-  if(resp.status != 200){
-    return null;
+  if(resp.status !== 200){
+    return {authorized: false} as StorageAccess;
   }
   else {
-    return resp.parsedBody as any
+    return resp.parsedBody as StorageAccess;
   }
 }
 

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/nodeSourcesUtil.ts
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/nodeSourcesUtil.ts
@@ -51,7 +51,7 @@ export async function createProjectAcl( aclDescription: string): Promise<void> {
       application: 'rundeck'
     },
     by: {
-      group: 'system'
+      urn: `project:${rundeckContext.projectName}`
     },
     for: {
       storage: [
@@ -95,7 +95,8 @@ export async function getProjectStorageAccess(): Promise<StorageAccess> {
     return {authorized: false} as StorageAccess;
   }
   else {
-    return resp.parsedBody as StorageAccess;
+    const body = resp.parsedBody;
+    return body["keys/"] as StorageAccess;
   }
 }
 

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/nodeSourcesUtil.ts
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/nodeSourcesUtil.ts
@@ -60,9 +60,8 @@ export async function createProjectAcl( aclDescription: string): Promise<void> {
   const content = {
     "contents": aclContent
   }
-  console.log(content)
 
-  const resp = await client.sendRequest({
+  const resp = await rundeckContext.rundeckClient.sendRequest({
     pathTemplate: '/api/{apiVersion}/system/acl/{aclName}',
     pathParameters: {aclName: name, apiVersion: rundeckContext.apiVersion},
     baseUrl: rundeckContext.rdBase,
@@ -74,3 +73,24 @@ export async function createProjectAcl( aclDescription: string): Promise<void> {
   }
 
 }
+
+export async function getProjectStorageAccess(): Promise<any> {
+
+  const rundeckContext = getRundeckContext()
+  const resp = await rundeckContext.rundeckClient.sendRequest({
+    pathTemplate: 'project/{projectName}/nodes/sources/storageaccess',
+    pathParameters: rundeckContext,
+    baseUrl: rundeckContext.rdBase,
+    method: 'POST'
+  })
+  if (!resp.parsedBody) {
+    throw new Error(`Error getting node sources list for ${rundeckContext.projectName}`)
+  }
+  if(resp.status != 200){
+    return null;
+  }
+  else {
+    return resp.parsedBody as any
+  }
+}
+

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/nodeSourcesUtil.ts
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/nodeSourcesUtil.ts
@@ -37,7 +37,7 @@ export async function getProjectNodeSources(): Promise<NodeSource[]> {
   }
 }
 
-export async function createProjectAcl( aclDescription: string): Promise<any> {
+export async function createProjectAcl( aclDescription: string): Promise<void> {
   const rundeckContext = getRundeckContext()
 
   const aclDefinition = {
@@ -69,11 +69,8 @@ export async function createProjectAcl( aclDescription: string): Promise<any> {
     body: content,
     method: 'POST'
   })
-  if (resp.status!=201) {
+  if (resp.status!==201) {
     throw new Error(`Error creating acl for project ${rundeckContext.projectName}`)
-  }
-  else {
-    return resp.parsedBody
   }
 
 }

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/nodeSourcesUtil.ts
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-nodes-config/nodeSourcesUtil.ts
@@ -1,5 +1,4 @@
 import { client } from '../../services/rundeckClient'
-import yaml from 'js-yaml';
 
 import {
   getRundeckContext,
@@ -41,62 +40,3 @@ export async function getProjectNodeSources(): Promise<NodeSource[]> {
     return resp.parsedBody as NodeSource[]
   }
 }
-
-export async function createProjectAcl( aclDescription: string): Promise<void> {
-  const rundeckContext = getRundeckContext()
-
-  const aclDefinition = {
-    description: aclDescription,
-    context: {
-      application: 'rundeck'
-    },
-    by: {
-      urn: `project:${rundeckContext.projectName}`
-    },
-    for: {
-      storage: [
-        {allow: '*'}
-      ]
-    }
-  };
-  const aclContent = yaml.dump(aclDefinition);
-  const name = `keystorage-access-${rundeckContext.projectName}.aclpolicy`
-
-  const content = {
-    "contents": aclContent
-  }
-
-  const resp = await rundeckContext.rundeckClient.sendRequest({
-    pathTemplate: '/api/{apiVersion}/system/acl/{aclName}',
-    pathParameters: {aclName: name, apiVersion: rundeckContext.apiVersion},
-    baseUrl: rundeckContext.rdBase,
-    body: content,
-    method: 'POST'
-  })
-  if (resp.status!==201) {
-    throw new Error(`Error creating acl for project ${rundeckContext.projectName}`)
-  }
-
-}
-
-export async function getProjectStorageAccess(): Promise<StorageAccess> {
-
-  const rundeckContext = getRundeckContext()
-  const resp = await rundeckContext.rundeckClient.sendRequest({
-    pathTemplate: 'project/{projectName}/nodes/sources/storageaccess',
-    pathParameters: rundeckContext,
-    baseUrl: rundeckContext.rdBase,
-    method: 'POST'
-  })
-  if (!resp.parsedBody) {
-    throw new Error(`Error getting node sources list for ${rundeckContext.projectName}`)
-  }
-  if(resp.status !== 200){
-    return {authorized: false} as StorageAccess;
-  }
-  else {
-    const body = resp.parsedBody;
-    return body["keys/"] as StorageAccess;
-  }
-}
-

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/AuthContextEvaluatorCacheManager.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/AuthContextEvaluatorCacheManager.groovy
@@ -132,7 +132,7 @@ class AuthContextEvaluatorCacheManager implements AuthCache, InitializingBean{
                 authContext instanceof UserAndRolesAuthContext) {
                 UserAndRolesAuthContext uar1 = (UserAndRolesAuthContext) authContext
                 UserAndRolesAuthContext uar2 = (UserAndRolesAuthContext) key.authContext
-                return uar1.getUsername() == uar2?.getUsername() && uar1.getRoles()?.equals(uar2?.getRoles())
+                return uar1.getUsername() == uar2?.getUsername() && uar1.getRoles()?.equals(uar2?.getRoles()) && uar1.getUrn() == uar2.getUrn()
             }
 
             return this.authContext == key.authContext
@@ -143,7 +143,8 @@ class AuthContextEvaluatorCacheManager implements AuthCache, InitializingBean{
                 UserAndRolesAuthContext uar1 = (UserAndRolesAuthContext) authContext
                 return Objects.hash(
                     uar1.getUsername()?.hashCode(),
-                    uar1.getRoles()?.hashCode()
+                    uar1.getRoles()?.hashCode(),
+                    uar1.getUrn()?.hashCode()
                 )
             }
 

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/BaseAuthContextProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/BaseAuthContextProvider.groovy
@@ -1,7 +1,6 @@
 package org.rundeck.app.authorization
 
 import com.dtolabs.rundeck.core.authentication.Group
-import com.dtolabs.rundeck.core.authentication.Urn
 import com.dtolabs.rundeck.core.authentication.Username
 import com.dtolabs.rundeck.core.authorization.AclsUtil
 import com.dtolabs.rundeck.core.authorization.AuthContextProvider
@@ -103,7 +102,7 @@ class BaseAuthContextProvider implements AuthContextProvider {
             )
         }
 
-        Subject subject = AclsUtil.getSubjectUrn(project)
+        Subject subject = AclsUtil.getSubjectUrnForProject(project)
 
         return new SubjectAuthContext(
                 subject,

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/BaseAuthContextProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/BaseAuthContextProvider.groovy
@@ -1,7 +1,9 @@
 package org.rundeck.app.authorization
 
 import com.dtolabs.rundeck.core.authentication.Group
+import com.dtolabs.rundeck.core.authentication.Urn
 import com.dtolabs.rundeck.core.authentication.Username
+import com.dtolabs.rundeck.core.authorization.AclsUtil
 import com.dtolabs.rundeck.core.authorization.AuthContextProvider
 import com.dtolabs.rundeck.core.authorization.SubjectAuthContext
 import com.dtolabs.rundeck.core.authorization.SubjectUserAndRoles
@@ -89,6 +91,23 @@ class BaseAuthContextProvider implements AuthContextProvider {
         return new SubjectAuthContext(
             subject,
             authorizationService.getAuthorizationForSubject(new SubjectUserAndRoles(subject))
+        )
+    }
+
+    @Override
+    UserAndRolesAuthContext getAuthContextForUrnProject(String project) {
+        if (!project) {
+            throw new RuntimeException(
+                    "getAuthContextForUrnProject: Cannot get AuthContext without project: " +
+                            "${project}"
+            )
+        }
+
+        Subject subject = AclsUtil.getSubjectUrn(project)
+
+        return new SubjectAuthContext(
+                subject,
+                authorizationService.getAuthorizationForSubject(new SubjectUserAndRoles(subject))
         )
     }
 }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/BaseAuthContextProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/BaseAuthContextProvider.groovy
@@ -106,7 +106,7 @@ class BaseAuthContextProvider implements AuthContextProvider {
 
         return new SubjectAuthContext(
                 subject,
-                authorizationService.getAuthorizationForSubject(new SubjectUserAndRoles(subject))
+                authorizationService.getProjectAuthorizationForSubject(new SubjectUserAndRoles(subject), project)
         )
     }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
enhancement
Add ability for ResourceModel Node Sources to use Key Storage

**Describe the solution you've implemented**
* when a Resource model needs key storage access, a message is displayed to add a default ACL that gives permissions to the project.
* A new ACL definition that includes in the `by` clause a URN path based on the project name, like `by: 
urn:project:demo`

**Describe alternatives you've considered**

**Additional context**

<img width="1135" alt="Screen Shot 2021-01-22 at 13 23 45" src="https://user-images.githubusercontent.com/6034968/105516851-1bca2280-5cb5-11eb-9684-d3649706f962.png">
