### PR TITLE
Fixing enterprise download link that was point to OSS version (update available notification)

### DIFF
--- a/rundeckapp/grails-spa/packages/ui/src/components/version-notification/App.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/version-notification/App.vue
@@ -26,7 +26,15 @@
         </p>
         <p>This version was released {{currentReleaseVersion.releaseDate | moment("M/D/YYYY")}}.</p>
         <a
+          v-if="isOSSVersion"
           href="https://docs.rundeck.com/downloads.html"
+          target="_blank"
+          style="margin-bottom:1em;"
+          class="btn btn-default btn-block btn-success btn-fill"
+        >{{$t("message.getUpdate")}}</a>,
+        <a
+          v-else
+          href="https://download.rundeck.com"
           target="_blank"
           style="margin-bottom:1em;"
           class="btn btn-default btn-block btn-success btn-fill"
@@ -63,6 +71,7 @@ export default {
   data() {
     return {
       RundeckContext: null,
+      isOSSVersion: true,
       showNotificationModal: false,
       installedVersion: {
         stringVersion: "",
@@ -149,6 +158,7 @@ export default {
                 }
               }
             }
+            this.isOSSVersion = (typeof _RDPRO_EDITION === 'undefined')
           });
         }
       },


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/1386

**Is this a bugfix, or an enhancement? Please describe.**
Clicking on "Get Update" lead to oss download webpage even if the version used is the Enterprise

**Describe the solution you've implemented**
The link will change to enterprise url if the `_RDPRO_EDITION` property is not undefined
