### PR TITLE
Fix bold styling in markdown

### DIFF
--- a/rundeckapp/grails-app/assets/stylesheets/github-markdown.css
+++ b/rundeckapp/grails-app/assets/stylesheets/github-markdown.css
@@ -220,10 +220,6 @@
   text-decoration: underline;
 }
 
-.markdown-body strong {
-  font-weight: 600;
-}
-
 .markdown-body hr {
   height: 0;
   margin: 15px 0;


### PR DESCRIPTION
This previously had no effect but is not a good weight for the fixed Mulish font

![image](https://user-images.githubusercontent.com/271965/102299329-64edc080-3f18-11eb-8079-283f202cdc79.png)
