### PR TITLE
Fixes #6580 by using Instant.now()

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
@@ -166,7 +166,7 @@ class QuartzJobScheduleManagerService implements JobScheduleManager, Initializin
 
     @Override
     boolean scheduleJobNow(final String quartzJobName, final String quartzJobGroup, final Map data, final boolean pending) throws JobScheduleFailure {
-        data.put('meta.created', new Date().getTime())
+        data.put('meta.created', Instant.now())
 
         String triggerGroup = pending ? TRIGGER_GROUP_PENDING : quartzJobGroup
 


### PR DESCRIPTION
Fixes #6580

Use Instant.now() in JobSchedulerService