### PR TITLE
Pro property loader wasn't decrypting property value

### DIFF
--- a/rundeckapp/grails-app/init/rundeckapp/init/ReloadableRundeckPropertySource.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/ReloadableRundeckPropertySource.groovy
@@ -16,7 +16,6 @@
 package rundeckapp.init
 
 import com.dtolabs.rundeck.core.properties.CoreConfigurationPropertiesLoader
-import groovy.transform.CompileStatic
 import org.springframework.core.env.PropertiesPropertySource
 import org.springframework.core.env.PropertySource
 
@@ -46,7 +45,7 @@ class ReloadableRundeckPropertySource {
             Properties tmp = rundeckConfigPropertyFileLoader.loadProperties()
             rundeckProps.clear()
             tmp.each {key, value ->
-                rundeckProps[key] = value
+                rundeckProps[key] = tmp.get(key)
             }
         }
     }


### PR DESCRIPTION
Some property file loaders require the get method to be called to transform the value data.

This fixes an issue where the property value was not being decrypted by the encrypted property loader in pro.
https://github.com/rundeckpro/rundeckpro/issues/1456
