### PR TITLE
Creating a new log filter plugin to mask sensitive output log text

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -500,6 +500,7 @@ beans={
             HTMLViewConverterPlugin,
             //log filters
             MaskPasswordsFilterPlugin,
+            MaskLogOutputByRegexPlugin,
             SimpleDataFilterPlugin,
             RenderDatatypeFilterPlugin,
             QuietFilterPlugin,

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/MaskLogOutputByRegexPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/MaskLogOutputByRegexPlugin.groovy
@@ -1,0 +1,66 @@
+package com.dtolabs.rundeck.server.plugins.logging
+
+import com.dtolabs.rundeck.core.logging.LogEventControl
+import com.dtolabs.rundeck.core.logging.PluginLoggingContext
+import com.dtolabs.rundeck.core.plugins.Plugin
+import com.dtolabs.rundeck.core.plugins.configuration.PropertyValidator
+import com.dtolabs.rundeck.core.plugins.configuration.ValidationException
+import com.dtolabs.rundeck.plugins.descriptions.PluginDescription
+import com.dtolabs.rundeck.plugins.descriptions.PluginProperty
+import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
+
+import java.util.regex.Pattern
+import java.util.regex.PatternSyntaxException
+
+@Plugin(name = MaskLogOutputByRegexPlugin.PROVIDER_NAME, service = 'LogFilter')
+@PluginDescription(title = 'Mask Log Output By Regex',
+        description = "Mask sensitive output that match the defined Regex")
+
+class MaskLogOutputByRegexPlugin implements LogFilterPlugin {
+    public static final String PROVIDER_NAME = 'mask-log-output-regex'
+
+    @PluginProperty(
+            title = "Pattern",
+            description = "Regular Expression for matching output data.",
+            required = true,
+            validatorClass = MaskLogOutputByRegexPlugin.RegexValidator
+    )
+    String regex
+
+    @PluginProperty(
+            title = "Replacement",
+            description = "Text to replace secure values",
+            defaultValue = "[SECURE]",
+            required = true
+    )
+    String replacement
+
+    @PluginProperty(
+            title = 'Mask only value on key/value text based',
+            description = '''If true, will mask only value on a key/value text based. The regular expression must define two Capturing Groups.''',
+            defaultValue = 'false'
+    )
+    Boolean maskOnlyValue
+
+
+    static class RegexValidator implements PropertyValidator {
+        @Override
+        boolean isValid(final String value) throws ValidationException {
+            try {
+                def compile = Pattern.compile(value)
+                return true
+            } catch (PatternSyntaxException e) {
+                throw new ValidationException(e.message, e)
+            }
+        }
+    }
+
+    @Override
+    void handleEvent(final PluginLoggingContext context, final LogEventControl event) {
+        def message = event.message
+        if (event.eventType == 'log' && message) {
+            String remessage = message.replaceAll(regex, (maskOnlyValue ? '$1' + replacement : replacement))
+            event.setMessage(remessage)
+        }
+    }
+}

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/MaskLogOutputByRegexPluginSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/MaskLogOutputByRegexPluginSpec.groovy
@@ -1,0 +1,51 @@
+package com.dtolabs.rundeck.server.plugins.logging
+
+import com.dtolabs.rundeck.core.dispatcher.ContextView
+import com.dtolabs.rundeck.core.execution.workflow.DataOutput
+import com.dtolabs.rundeck.core.logging.LogEventControl
+import com.dtolabs.rundeck.core.logging.LogLevel
+import com.dtolabs.rundeck.core.logging.PluginLoggingContext
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class MaskLogOutputByRegexPluginSpec extends Specification {
+    @Unroll
+    def "test"() {
+        given:
+        def plugin = new MaskLogOutputByRegexPlugin()
+        plugin.regex = regex
+        plugin.replacement = replacement
+        plugin.maskOnlyValue = maskOnlyValue
+        def sharedoutput = new DataOutput(ContextView.global())
+        def context = Mock(PluginLoggingContext) {
+            getOutputContext() >> sharedoutput
+        }
+        def events = []
+        lines.each { line ->
+            events << Mock(LogEventControl) {
+                getMessage() >> line
+                getEventType() >> 'log'
+                getLoglevel() >> LogLevel.NORMAL
+            }
+        }
+
+        when:
+        plugin.init(context)
+        events.each {
+            plugin.handleEvent(context, it)
+        }
+        plugin.complete(context)
+
+        then:
+        events.each {
+            1 * it.setMessage({ expect.contains(it) })
+        }
+
+        where:
+        replacement | regex                      | lines                                                                               | expect                                                                             | maskOnlyValue
+        "[****]"    | "-Dsome-password=pwsd123"  | ['-Drun.active=true -Dsome-password=pwsd123 -Drundeck.server.logDir=some/path/dir'] | ['-Drun.active=true [****] -Drundeck.server.logDir=some/path/dir']                 | false
+        "[****]"    | "(-Dsome-password=)(\\w+)" | ['-Drun.active=true -Dsome-password=pwsd123 -Drundeck.server.logDir=some/path/dir'] | ['-Drun.active=true -Dsome-password=[****] -Drundeck.server.logDir=some/path/dir'] | true
+        "[SECURE]"  | "(RD_JOB_PASSWORD=)(.*)"   | ["RD_JOB_USER_NAME=admin", "RD_JOB_PASSWORD=pswd123"]                               | ["RD_JOB_USER_NAME=admin", "RD_JOB_PASSWORD=[SECURE]"]                             | true
+        "[SECURE]"  | "(RD_JOB_PASSWORD=)(.*)"   | ["RD_JOB_USER_NAME=admin", "RD_JOB_PASSWORD=pswd123"]                               | ["RD_JOB_USER_NAME=admin", "[SECURE]"]                                             | false
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/1372

**Is this a bugfix, or an enhancement? Please describe.**
Sensitive data was being printed on log output as decribed on the linked issue where passwords from rundeckd file was being shown when performing some system commands

**Describe the solution you've implemented**
Was created a log filter plugin to define a regex to capture and mask sensitive data
