### PR TITLE
Fix to get schedules both via addon (enterprise-schedules) and via job scheduling (job edit page)

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3163,7 +3163,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         }
 
 
-        def list = jobSchedulesService.getAllScheduled(uuid, null)
+        def list = jobSchedulesService.getAllScheduled(uuid)
         //filter authorized jobs
         Map<String, UserAndRolesAuthContext> projectAuths = [:]
         def authForProject = { String project ->

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3163,7 +3163,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         }
 
 
-        def list = ScheduledExecution.findAllByServerNodeUUIDAndScheduled(uuid,true)
+        def list = jobSchedulesService.getAllScheduled(uuid, null)
         //filter authorized jobs
         Map<String, UserAndRolesAuthContext> projectAuths = [:]
         def authForProject = { String project ->

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -59,6 +59,7 @@ import rundeck.services.ConfigurationService
 import rundeck.services.ExecutionService
 import rundeck.services.FrameworkService
 import rundeck.services.JobSchedulesService
+import rundeck.services.LocalJobSchedulesManager
 import rundeck.services.ScheduledExecutionService
 import rundeck.services.ScmService
 import rundeck.services.UserService
@@ -213,6 +214,9 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         def testUUID = UUID.randomUUID().toString()
         controller.apiService = Mock(ApiService)
         controller.frameworkService = Mock(FrameworkService)
+        controller.jobSchedulesService = new JobSchedulesService()
+        controller.jobSchedulesService.rundeckJobSchedulesManager = new LocalJobSchedulesManager()
+
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)
                     ScheduledExecution job1 = new ScheduledExecution(createJobParams(jobName:'job1'))
         job1.scheduled=true
@@ -247,6 +251,8 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         def testUUID = UUID.randomUUID().toString()
         def uuid2 = UUID.randomUUID().toString()
         controller.apiService = Mock(ApiService)
+        controller.jobSchedulesService = new JobSchedulesService()
+        controller.jobSchedulesService.rundeckJobSchedulesManager = new LocalJobSchedulesManager()
         controller.frameworkService = Mock(FrameworkService)
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)
                     ScheduledExecution job1 = new ScheduledExecution(createJobParams(jobName:'job1'))


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/1442

**Is this a bugfix, or an enhancement? Please describe.**
The API to get scheduled jobs was returning only jobs scheduled from job edit page but not the ones scheduled by enterprise-scheduled addon.

And the API to get job forecast, the field `futureScheduledExecutions` was being filled only with schedules via addon (if there was one where the job was linked)

**Describe the solution you've implemented**
The method of the controller was changed to get all scheduled jobs from jobSchedulesService and was created another PR (https://github.com/rundeckpro/enterprise-schedules/pull/63) to fix the addon so that the API to get job forecast returns the future scheduled executions correctly