### PR TITLE
Issues/6693 slow job list show page

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -267,7 +267,6 @@ class ExecutionController extends ControllerBase{
                 enext                 : enext,
                 eprev                 : eprev,
                 inputFilesMap         : inputFilesMap,
-                projectNames          : authProjectsToCreate,
                 clusterModeEnabled    : frameworkService.isClusterModeEnabled()
         ]
     }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -249,19 +249,6 @@ class ExecutionController extends ControllerBase{
             order('dateStarted', 'desc')
         }
 
-        def projectNames = frameworkService.projectNames(authContext)
-        def authProjectsToCreate = []
-        projectNames.each{
-            if(it != params.project && rundeckAuthContextProcessor.authorizeProjectResource(
-                    authContext,
-                    AuthConstants.RESOURCE_TYPE_JOB,
-                    AuthConstants.ACTION_CREATE,
-                    it
-            )){
-                authProjectsToCreate.add(it)
-            }
-        }
-
         eprev = result ? result[0] : null
         def readAuth=rundeckAuthContextProcessor.authorizeProjectExecutionAny(authContext, e, [AuthConstants.ACTION_READ])
         def workflowTree = scheduledExecutionService.getWorkflowDescriptionTree(e.project, e.workflow, readAuth,0)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -322,25 +322,6 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         def framework = frameworkService.getRundeckFramework()
         def rdprojectconfig = framework.projectManager.loadProjectConfig(params.project)
         results.jobExpandLevel = scheduledExecutionService.getJobExpandLevel(rdprojectconfig)
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(
-                session.subject,
-                params.project
-        )
-
-        def projectNames = frameworkService.projectNames(authContext)
-        def authProjectsToCreate = []
-        projectNames.each{
-            if(it != params.project && rundeckAuthContextProcessor.authorizeProjectResource(
-                    authContext,
-                    AuthConstants.RESOURCE_TYPE_JOB,
-                    AuthConstants.ACTION_CREATE,
-                    it
-            )){
-                authProjectsToCreate.add(it)
-            }
-        }
-
-        results.projectNames = authProjectsToCreate
         results.clusterModeEnabled = frameworkService.isClusterModeEnabled()
         results.jobListIds = results.nextScheduled?.collect {ScheduledExecution job->
             job.extid
@@ -2466,6 +2447,29 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
 
         render(contentType:'application/json',text:
                 ([projectNames: fprojects] )as JSON
+        )
+    }
+
+    def authProjectsToCreateAjax() {
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(
+                session.subject,
+                params.project
+        )
+
+        def projectNames = frameworkService.projectNames(authContext)
+        def authProjectsToCreate = []
+        projectNames.each {
+            if (it != params.project && rundeckAuthContextProcessor.authorizeProjectResource(
+                    authContext,
+                    AuthConstants.RESOURCE_TYPE_JOB,
+                    AuthConstants.ACTION_CREATE,
+                    it
+            )) {
+                authProjectsToCreate.add(it)
+            }
+        }
+        render(contentType: 'application/json', text:
+                ([projectNames: authProjectsToCreate]) as JSON
         )
     }
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2451,9 +2451,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     }
 
     def authProjectsToCreateAjax() {
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(
-                session.subject,
-                params.project
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(
+                session.subject
         )
 
         def projectNames = frameworkService.projectNames(authContext)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -536,20 +536,6 @@ class ScheduledExecutionController  extends ControllerBase{
             }
         }
 
-        def projectNames = frameworkService.projectNames(authContext)
-        def authProjectsToCreate = []
-        projectNames.each{
-            if(it != params.project && rundeckAuthContextProcessor.authorizeProjectResource(
-                    authContext,
-                    AuthConstants.RESOURCE_TYPE_JOB,
-                    AuthConstants.ACTION_CREATE,
-                    it
-            )){
-                authProjectsToCreate.add(it)
-            }
-        }
-        dataMap.projectNames = authProjectsToCreate
-
         withFormat{
             html{
                 dataMap

--- a/rundeckapp/grails-app/views/common/_js.gsp
+++ b/rundeckapp/grails-app/views/common/_js.gsp
@@ -46,6 +46,7 @@
         frameworkReloadNodes: "${createLink(controller:"framework",action:"reloadNodes",params:projParams)}",
         frameworkNodeSummaryAjax: "${createLink(controller:"framework",action:"nodeSummaryAjax",params:projParams)}",
         frameworkDeleteNodeFilterAjax: "${createLink(controller:"framework",action:"deleteNodeFilterAjax",params:projParams)}",
+        authProjectsToCreateAjax: "${g.createLink(controller: 'menu', action: 'authProjectsToCreateAjax',params:projParams)}",
         menuDeleteJobFilterAjax: "${createLink(controller:"menu",action:"deleteJobFilterAjax",params:projParams)}",
         menuSaveJobFilterAjax: "${createLink(controller:"menu",action:"saveJobFilterAjax",params:projParams)}",
         reportsEventsAjax: "${g.createLink(controller: 'reports', action: 'eventsAjax',params:projParams)}",

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -1242,6 +1242,19 @@ search
         PageActionHandlers.registerHandler('copy_other_project',function(el){
             jQuery('#jobid').val(el.data('jobId'));
             jQuery('#selectProject').modal();
+            jQuery.ajax({
+                dataType:'json',
+                method: 'GET',
+                url:_genUrl(appLinks.authProjectsToCreateAjax),
+                success:function(data){
+                    jQuery('#jobProject').empty();
+                    for (let i in data.projectNames ) {
+                        jQuery('#jobProject').append(
+                            '<option value="' + data.projectNames[i] + '">' + data.projectNames[i] + '</option>'
+                        );
+                    }
+                }
+            });
         });
         followState();
         var outDetails = window.location.hash;

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -269,6 +269,19 @@ search
             PageActionHandlers.registerHandler('copy_other_project',function(el){
                 jQuery('#jobid').val(el.data('jobId'));
                 jQuery('#selectProject').modal();
+                jQuery.ajax({
+                    dataType:'json',
+                    method: 'GET',
+                    url:_genUrl(appLinks.authProjectsToCreateAjax),
+                    success:function(data){
+                        jQuery('#jobProject').empty();
+                        for (let i in data.projectNames ) {
+                            jQuery('#jobProject').append(
+                                '<option value="' + data.projectNames[i] + '">' + data.projectNames[i] + '</option>'
+                            );
+                        }
+                    }
+                });
             });
 
 

--- a/rundeckapp/grails-app/views/scheduledExecution/show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/show.gsp
@@ -98,6 +98,19 @@ search
             PageActionHandlers.registerHandler('copy_other_project',function(el){
                 jQuery('#jobid').val(el.data('jobId'));
                 jQuery('#selectProject').modal();
+                jQuery.ajax({
+                    dataType:'json',
+                    method: 'GET',
+                    url:_genUrl(appLinks.authProjectsToCreateAjax),
+                    success:function(data){
+                        jQuery('#jobProject').empty();
+                        for (let i in data.projectNames ) {
+                            jQuery('#jobProject').append(
+                                '<option value="' + data.projectNames[i] + '">' + data.projectNames[i] + '</option>'
+                            );
+                        }
+                    }
+                });
             });
             if (jQuery('#execFormRunButton').length) {
                 let clicked=false


### PR DESCRIPTION
Fixes issue #6693 slow job list very slow jobs list page and job show page when there are many (2000+) projects.  This is an enhancement and due to the project names which the user has create authorization for to be returned to the page.  This job name list is only needed when Duplicate this job to another project selection is clicked.  Solution is to use an ajax call when this selection is chosen.