### PR TITLE
edit framework controller to accept resourceModelSources config when creating a new project

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -903,7 +903,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def pconfigurable = frameworkService.validateProjectConfigurableInput(
                 params.extraConfig,
                 'extraConfig.',
-                { String category -> category != 'resourceModelSource' }
+                null
         )
         if (pconfigurable.errors) {
             errors.addAll(pconfigurable.errors)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -905,6 +905,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                 'extraConfig.',
                 null
         )
+
         if (pconfigurable.errors) {
             errors.addAll(pconfigurable.errors)
         }

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -1175,6 +1175,11 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
             def validProps = v.getProjectConfigProperties().findAll { it.name in valid }
             validProps.findAll { it.type == Property.Type.Boolean }.
                     each {
+
+                        if(!input[it.name]){
+                            input[it.name] = it.defaultValue
+                        }
+
                         if (input[it.name] != 'true') {
                             input[it.name] = 'false'
                         }

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -1184,15 +1184,6 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
                             input[it.name] = 'false'
                         }
                     }
-            validProps.findAll { it.type == Property.Type.String }.
-                    each {
-                        if(!input[it.name]){
-                            input[it.name] = it.defaultValue
-                        }
-                        if(!input[it.name]){
-                            input.remove(it.name)
-                        }
-                    }
             validProps.findAll { it.type == Property.Type.Options }.
                     each {
                         if (input[it.name] instanceof Collection) {

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -1184,6 +1184,15 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
                             input[it.name] = 'false'
                         }
                     }
+            validProps.findAll { it.type == Property.Type.String }.
+                    each {
+                        if(!input[it.name]){
+                            input[it.name] = it.defaultValue
+                        }
+                        if(!input[it.name]){
+                            input.remove(it.name)
+                        }
+                    }
             validProps.findAll { it.type == Property.Type.Options }.
                     each {
                         if (input[it.name] instanceof Collection) {

--- a/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
@@ -246,7 +246,7 @@ class FrameworkServiceSpec extends Specification implements ServiceUnitTest<Fram
             testConfigurableBean(TestConfigurableBean) {
                 projectConfigProperties = ScheduledExecutionService.ProjectConfigProperties
                 propertiesMapping = ScheduledExecutionService.ConfigPropertiesMapping
-                categories = [groupExpandLevel: 'gui', disableExecution: 'executionMode', disableSchedule: 'executionMode', healthcheck: '']
+                categories = [groupExpandLevel: 'gui', disableExecution: 'executionMode', disableSchedule: 'executionMode',]
             }
         }
         String prefix = 'extraConfig.'

--- a/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
@@ -246,7 +246,7 @@ class FrameworkServiceSpec extends Specification implements ServiceUnitTest<Fram
             testConfigurableBean(TestConfigurableBean) {
                 projectConfigProperties = ScheduledExecutionService.ProjectConfigProperties
                 propertiesMapping = ScheduledExecutionService.ConfigPropertiesMapping
-                categories = [groupExpandLevel: 'gui', disableExecution: 'executionMode', disableSchedule: 'executionMode',]
+                categories = [groupExpandLevel: 'gui', disableExecution: 'executionMode', disableSchedule: 'executionMode', healthcheck: '']
             }
         }
         String prefix = 'extraConfig.'


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Enhancement

**Describe the solution you've implemented**
By default, Node Health checks and the Health Status enhancer will now be turned on in new projects for Enterprise customers. 
Updated the category predicate to include the resourceModelSources so they are included. Also updated the default value for the rundeckProHealthChecker and added a check for if the inputMap value at a key is null. If it is, set the value to its default value.

Added a iterator on valid props of the string type. If it is null, set to the defaultValue. If it is still null, remove it from the map to avoid a null pointer exception.
