### PR TITLE
Fixes webhook notification issue that use credentials in URL

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Notification.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Notification.groovy
@@ -100,6 +100,19 @@ public class Notification {
         return [recipients: content]
     }
 
+    /**
+     * Return the configuration map for a url notification
+     *
+     * @return
+     */
+    public Map urlConfiguration(){
+        if (content?.startsWith('{') && content?.endsWith('}')) {
+            //parse as json
+            return getConfiguration()
+        }
+        return [urls: content]
+    }
+
     public static Notification fromMap(String key, Map data){
         Notification n = new Notification(eventTrigger:key)
         if(data.email || data.recipients){
@@ -126,6 +139,7 @@ public class Notification {
             n.type='url'
             n.format=data.format
             n.content=data.urls
+            n.configuration=[urls: data.urls, httpMethod: data.method]
         }else if(data.type){
             n.type=data.type
             if(data.configuration && data.configuration instanceof Map){
@@ -142,7 +156,8 @@ public class Notification {
         if(type=='email'){
             return ['email':mailConfiguration()]
         }else if(type=='url'){
-            return [urls:content,format:format]
+            Map urlsConfiguration = urlConfiguration()
+            return [urls: urlsConfiguration.urls, httpMethod: urlsConfiguration.httpMethod,format:format]
         }else if(type){
             def config=[:]
             if(content){
@@ -165,7 +180,8 @@ public class Notification {
             configuration.remove('attachLogInFile')
             return [type:'email', trigger:eventTrigger, config: configuration]
         }else if(type=='url'){
-            return [type: 'url', trigger:eventTrigger, config: [urls: content, format: format]]
+            Map urlsConfiguration = urlConfiguration()
+            return [type: 'url', trigger:eventTrigger, config: [urls: urlsConfiguration.urls, format: format, httpMethod: urlsConfiguration.httpMethod]]
         }else if(type){
             def config=[:]
             if(content){
@@ -193,6 +209,7 @@ public class Notification {
         }else if(data.type=='url'){
             n.format=data.config.format
             n.content=data.config.urls
+            n.configuration=[urls: data.config.urls, httpMethod: data.config.method]
         }else if(data.type){
             if(data.config && data.config instanceof Map){
                 n.configuration=data.config

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -2322,7 +2322,9 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     private boolean validateDefinitionUrlNotification(ScheduledExecution scheduledExecution, String trigger, Notification notif){
         def failed
         def fieldNamesUrl = NOTIFICATION_FIELD_NAMES_URL
-        def arr = notif.content?.split(",")
+        Map urlsConfiguration = notif.urlConfiguration()
+        String urls = urlsConfiguration.urls
+        def arr = urls?.split(",")
         def validCount=0
         arr?.each { String url ->
             boolean valid = false

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/notification/DummyWebhookNotificationPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/notification/DummyWebhookNotificationPlugin.groovy
@@ -18,7 +18,7 @@ import com.dtolabs.rundeck.plugins.notification.NotificationPlugin
  */
 @Plugin(name = 'url', service = ServiceNameConstants.Notification)
 @PluginDescription(title = 'Send Webhook',
-    description = '''Send a HTTP POST request to one ore more URLs.''')
+    description = '''Send a HTTP request to one ore more URLs.''')
 @PluginMetadata(key = 'faicon', value = 'globe')
 class DummyWebhookNotificationPlugin implements NotificationPlugin {
     @PluginProperty(
@@ -79,6 +79,16 @@ class DummyWebhookNotificationPlugin implements NotificationPlugin {
     @SelectValues(values = ['xml','json'])
     @SelectLabels(values = ['XML','JSON'])
     String format
+
+    @PluginProperty(
+        title = "Method",
+        description = "HTTP method",
+        required = false,
+        defaultValue = 'post'
+    )
+    @SelectValues(values = ['get','post'])
+    @SelectLabels(values = ['GET','POST'])
+    String method
 
     @Override
     boolean postNotification(final String trigger, final Map executionData, final Map config) {

--- a/rundeckapp/src/test/groovy/rundeck/NotificationSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/NotificationSpec.groovy
@@ -69,12 +69,8 @@ class NotificationSpec extends Specification {
             result == expected
         where:
             data                                                                      | expected
-            [eventTrigger: 'onsuccess', type: 'url', content: 'asdf', format: 'xml']  | [type: 'url', trigger:
-                'onsuccess', config                                                          : [urls: 'asdf', format:
-                'xml']]
-            [eventTrigger: 'onsuccess', type: 'url', content: 'asdf', format: 'json'] | [type: 'url', trigger:
-                'onsuccess', config                                                          : [urls: 'asdf', format:
-                'json']]
+            [eventTrigger: 'onsuccess', type: 'url', content: 'asdf', format: 'xml']  | [type:'url', trigger:'onsuccess', config:[urls:'asdf', format:'xml', httpMethod:null]]
+            [eventTrigger: 'onsuccess', type: 'url', content: 'asdf', format: 'json'] | [type:'url', trigger:'onsuccess', config:[urls:'asdf', format:'json', httpMethod:null]]
     }
 
     @Unroll
@@ -91,7 +87,7 @@ class NotificationSpec extends Specification {
         then:
             result.eventTrigger == trigger
             result.type == type
-            result.content == expect
+            result.urlConfiguration().urls == expect
             result.format == expectformat
         where:
             trigger     | config                        | expect | expectformat

--- a/rundeckapp/src/test/groovy/rundeck/NotificationSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/NotificationSpec.groovy
@@ -74,6 +74,20 @@ class NotificationSpec extends Specification {
     }
 
     @Unroll
+    def "urlConfiguration webhook"() {
+        given:
+            Notification n = new Notification(data)
+        when:
+            def result = n.urlConfiguration()
+        then:
+            result == expected
+        where:
+        data                                                                                                      | expected
+        [content: 'asdf', format: 'xml']                                  | [urls: 'asdf']
+        [content: '{"urls": "asdf", "httpMethod":"GET"}'] | [urls: 'asdf', httpMethod: "GET"]
+    }
+
+    @Unroll
     def "fromNormalizedMap webhook"() {
         given:
             def type = 'url'

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -836,6 +836,7 @@ class NotificationServiceSpec extends HibernateSpec implements ServiceUnitTest<N
         result.success
         (rq.getHeader("X-RunDeck-Notification-SHA256-Digest") != null) == generatedDigestExists
         rq.getHeader("Content-Type") == expectedContentType
+        rq.getHeader("Authorization")?.startsWith("Basic")
         rq.body.readUtf8() == payload
 
         where:
@@ -859,6 +860,7 @@ class NotificationServiceSpec extends HibernateSpec implements ServiceUnitTest<N
         when:
         def result = NotificationService.postDataUrl(endpoint,format,payload,"success","suceeded","1234", NotificationService.GET)
         RecordedRequest rq = httpServer.takeRequest()
+        rq.getMethod() == "GET"
 
         then:
         result.success
@@ -878,6 +880,8 @@ class NotificationServiceSpec extends HibernateSpec implements ServiceUnitTest<N
         when:
         def result = NotificationService.postDataUrl(endpoint,format,payload,"success","suceeded","1234", NotificationService.GET)
         RecordedRequest rq = httpServer.takeRequest()
+        rq.getMethod() == "GET"
+        rq.getHeader("Authorization")?.startsWith("Basic")
 
         then:
         result.success

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -4780,7 +4780,7 @@ class ScheduledExecutionServiceSpec extends HibernateSpec implements ServiceUnit
             job.notifications.size() == 1
             job.notifications[0].type == 'url'
             job.notifications[0].eventTrigger == 'onsuccess'
-            job.notifications[0].content=='aurl'
+            job.notifications[0].urlConfiguration().urls=='aurl'
             job.notifications[0].format==formatin
         where:
             formatin | _


### PR DESCRIPTION
Fixes #6690 

**Is this a bugfix, or an enhancement? Please describe.**
Webhook notification is not working if use credentials on URL like `user:password@url`

**Describe the solution you've implemented**
When trying to reproduce the issue, I realized that Jenkins returns this error if it uses POST and not GET to trigger a job remotely. These changes are a suggestion to be able to use the webhook notification to make a GET request.
