### PR TITLE
Fix #6614 check plugin exists instead of configuration

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -28,6 +28,7 @@ import com.dtolabs.rundeck.core.authorization.AuthContextProvider
 import com.dtolabs.rundeck.core.authorization.Validation
 import com.dtolabs.rundeck.core.resources.format.ResourceFormatParserService
 import com.dtolabs.rundeck.core.config.Features
+import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import org.rundeck.app.acl.AppACLContext
 import org.rundeck.app.acl.ContextACLManager
 import org.rundeck.app.authorization.AppAuthContextProcessor
@@ -2121,12 +2122,18 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         def errors = []
 
-        if(defaultNodeExec !=null && (nodeConfig == null || nodeConfig.size() == 0)) {
-            errors << message(code: "domain.project.edit.plugin.missing.message", args: ['Node Executor', defaultNodeExec])
+        if(defaultNodeExec!=null) {
+            def nodeExecDescription = pluginService.getPluginDescriptor(defaultNodeExec, ServiceNameConstants.NodeExecutor)
+            if(!nodeExecDescription){
+                errors << message(code: "domain.project.edit.plugin.missing.message", args: ['Node Executor', defaultNodeExec])
+            }
         }
 
-        if(defaultFileCopy != null && (filecopyConfig == null || filecopyConfig.size() == 0)) {
-            errors << message(code: "domain.project.edit.plugin.missing.message", args: ['File Copier', defaultFileCopy])
+        if(defaultFileCopy != null) {
+            def fcopyDescription = pluginService.getPluginDescriptor(defaultFileCopy, ServiceNameConstants.FileCopier)
+            if(!fcopyDescription){
+                errors << message(code: "domain.project.edit.plugin.missing.message", args: ['File Copier', defaultFileCopy])
+            }
         }
 
         if(errors?.size() > 0) {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Fix #6614 
**Describe the solution you've implemented**
Check plugin exists instead of configuration. if the plugin has no configuration properties it would return empty map

