### PR TITLE
Add usersync configuration options to Docker Remco templates

### DIFF
--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -40,6 +40,11 @@ rundeck.security.authorization.preauthenticated.userRolesHeader={{ getv("/rundec
 # Redirect to upstream logout url
 rundeck.security.authorization.preauthenticated.redirectLogout={{ getv("/rundeck/preauth/redirect/logout", "false") }}
 rundeck.security.authorization.preauthenticated.redirectUrl={{ getv("/rundeck/preauth/redirect/url", "/oauth2/sign_in") }}
+# user sync
+rundeck.security.authorization.preauthenticated.userSyncEnabled={{ getv("/rundeck/preauth/usersync/enabled", "false") }}
+rundeck.security.authorization.preauthenticated.userFirstNameHeader={{ getv("/rundeck/preauth/usersync/firstname", "X-Forwarded-User-FirstName") }}
+rundeck.security.authorization.preauthenticated.userLastNameHeader={{ getv("/rundeck/preauth/usersync/lastname", "X-Forwarded-User-LastName") }}
+rundeck.security.authorization.preauthenticated.userEmailHeader={{ getv("/rundeck/preauth/usersync/email", "X-Forwarded-User-Email") }}
 
 {% if exists("/rundeck/security/syncldapuser") %}
 rundeck.security.syncLdapUser={{ getv("/rundeck/security/syncldapuser") }}


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This fixes #6744 by adding configuration hooks for the preauth user sync.

**Describe the solution you've implemented**
See above.

**Describe alternatives you've considered**
N/A — This is a minor change using existing patterns.

**Additional context**
N/A
