### PR TITLE
Fix community news post dates

### DIFF
--- a/rundeckapp/grails-spa/packages/ui/src/pages/community-news/CommunityNewsFeed.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/community-news/CommunityNewsFeed.vue
@@ -23,7 +23,7 @@
               <h6
                 class="pub-date"
                 style="padding-bottom:.6em; color: #989898;"
-              >{{blog.publish_date | moment("MMMM do YYYY hh:mm")}}</h6>
+              >{{blog.publish_date | moment("MMMM Do YYYY hh:mm")}}</h6>
               <h3 class="blog-title">{{blog.title}}</h3>
             </div>
             <div>{{blog.meta_description}}</div>


### PR DESCRIPTION
Fixes the date formatting so the correct date is displayed.

![image](https://user-images.githubusercontent.com/271965/106032942-bc925680-6096-11eb-9e5b-ce1e1b7b23f5.png)
