### PR TITLE
Support to multiple URL's

### DIFF
--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -11,7 +11,7 @@ rss.enabled=false
 server.address={{ getv("/rundeck/server/address", "0.0.0.0") }}
 server.servlet.context-path={{ getv("/rundeck/server/contextpath", "/") }}
 grails.serverURL={{ getv("/rundeck/grails/url", "http://127.0.0.1:4440") }}
-rundeck.multiURL.enabled={{ getv("/rundeck/multiURL/enabled", "false") }}
+rundeck.multiURL.enabled={{ getv("/rundeck/multiurl/enabled", "false") }}
 
 server.servlet.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
 

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -11,6 +11,7 @@ rss.enabled=false
 server.address={{ getv("/rundeck/server/address", "0.0.0.0") }}
 server.servlet.context-path={{ getv("/rundeck/server/contextpath", "/") }}
 grails.serverURL={{ getv("/rundeck/grails/url", "http://127.0.0.1:4440") }}
+rundeck.multiURL.enabled={{ getv("/rundeck/multiURL/enabled", "false") }}
 
 server.servlet.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
 

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -43,6 +43,7 @@ import com.dtolabs.rundeck.core.storage.AuthRundeckStorageTree
 import com.dtolabs.rundeck.core.storage.StorageTreeFactory
 import com.dtolabs.rundeck.core.storage.TreeStorageManager
 import com.dtolabs.rundeck.core.utils.GrailsServiceInjectorJobListener
+import com.dtolabs.rundeck.core.utils.RequestAwareLinkGenerator
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.server.plugins.PluginCustomizer
 import com.dtolabs.rundeck.server.plugins.RundeckEmbeddedPluginExtractor
@@ -122,6 +123,20 @@ beans={
 //            arguments = ["classpath:log4j.properties"]
 //        }
 //    }
+    if (application.config.rundeck.multiURL?.enabled in ['true',true]) {
+        Class requestAwareLinkGeneratorClass = RequestAwareLinkGenerator
+        String serverURL = application.config.grails.serverURL
+        String contextPath = application.config.server.servlet["context-path"]
+        if (serverURL && (contextPath && "/" != contextPath)) {
+            log.info("RequestAwareLinkGenerator using url ${serverURL} and context-path ${contextPath}")
+            grailsLinkGenerator(requestAwareLinkGeneratorClass, serverURL, contextPath) {}
+        } else if (serverURL) {
+            log.info("context-path not set, RequestAwareLinkGenerator using url ${serverURL}")
+            grailsLinkGenerator(requestAwareLinkGeneratorClass, serverURL) {}
+        } else {
+            log.warn("rundeck.multiURL enabled but no grails.serverURL found. This feature will be disabled.")
+        }
+    }
     defaultGrailsServiceInjectorJobListener(GrailsServiceInjectorJobListener){
         name= 'defaultGrailsServiceInjectorJobListener'
         services=[grailsApplication: ref('grailsApplication'),

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/core/utils/RequestAwareLinkGenerator.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/core/utils/RequestAwareLinkGenerator.groovy
@@ -1,0 +1,54 @@
+package com.dtolabs.rundeck.core.utils
+
+import org.grails.web.mapping.DefaultLinkGenerator
+import grails.web.mapping.LinkGenerator
+import org.grails.web.servlet.mvc.GrailsWebRequest
+
+class RequestAwareLinkGenerator extends DefaultLinkGenerator implements LinkGenerator {
+
+    RequestAwareLinkGenerator(String serverBaseURL, String contextPath) {
+        super(serverBaseURL, contextPath)
+        println "RequestAwareLinkGenerator = ${serverBaseURL} ${contextPath}"
+    }
+
+    RequestAwareLinkGenerator(String serverBaseURL) {
+        super(serverBaseURL)
+    }
+
+    /**
+     * @return serverURL based on the baseUrl of the incoming request.
+     */
+    String makeServerURL() {
+        GrailsWebRequest webRequest = GrailsWebRequest.lookup()
+        if (webRequest) {
+            String baseUrl = webRequest.baseUrl
+            return baseUrl
+        } else {
+            String serverUrl = super.makeServerURL()
+            return serverUrl
+        }
+    }
+
+    String link(Map attrs, String encoding = 'UTF-8') {
+        String cp = super.getContextPath()
+        String url = super.link(attrs, encoding)
+        if (cp) {
+            String serverUrl = makeServerURL()
+
+            // this will strip out the context path from url
+            // e.g.: cp=/rdk url=/rdk/menu/executionMode => menu/executionMode
+            if (cp != null && url.indexOf(cp) == 0) url = url.substring(cp.length())
+
+            // in some cases, the url is resolved as "context"/"fullurl", the previous step removes the context part so
+            // its safe to return the url
+            // e.g.: cp=/rdk url=/rdk/http://rundeck.local:4440/rdk/tour/listAll => http://rundeck.local:4440/rdk/tour/listAll
+            if (serverUrl != null && url.indexOf(serverUrl) == 0) return url
+
+            // e.g.: cp=/rdk url=/menu/executionMode => menu/executionMode
+            if (url[0] == '/') url = url.substring(1)
+
+            return serverUrl + "/" + url
+        }
+        return url
+    }
+}


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
With this PR, we can now enable `multiURL` option (`rundeck.multiURL.enabled`). With this option enabled, we can access the server using different url's.

**Describe the solution you've implemented**
The implementation is based on override grails DefaultLinkGenerator.

**Expected behaviour**

Start rundeck server with a `grails.serverURL` (with or without `server.servlet.context-path`), `rundeck.multiURL.enabled=true` and access the service through `grails.serverURL`, a secondary DNS pointing to the same server, the server IP, etc.

- each of accessed url will ask for login and password;
- the address in navigation bar will not change;
- notifications will use `grails.serverURL`;

**Additional context**
This also fixes #5795.
