### PR TITLE
Duplicate options

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
@@ -38,7 +38,6 @@ class EditOptsController extends ControllerBase{
     AppAuthContextProcessor rundeckAuthContextProcessor
     def fileUploadService
     def optionValuesService
-    static Map paramOpts
     def static allowedMethods = [
             redo: 'POST',
             remove: 'POST',
@@ -1016,7 +1015,6 @@ class EditOptsController extends ControllerBase{
         }
         def newName = duplicateName(params.name, 1, editopts)
         newOption.name = newName
-
 
         def result = _applyOptionAction(editopts, [action: 'insert', name: newName, params: newOption.toMap()])
 

--- a/rundeckapp/grails-app/domain/rundeck/Option.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Option.groovy
@@ -80,6 +80,7 @@ public class Option implements Comparable{
     Boolean hidden
     Boolean sortValues
     List<String> optionValues
+    String inputType
 
 
     static belongsTo=[scheduledExecution:ScheduledExecution]
@@ -113,6 +114,7 @@ public class Option implements Comparable{
         valuesList(nullable: true)
         valuesListDelimiter(nullable: true)
         sortValues(nullable: true)
+        inputType(nullable: true)
     }
 
 
@@ -166,9 +168,6 @@ public class Option implements Comparable{
         if (null!=sortIndex) {
             map.sortIndex = sortIndex
         }
-        if(enforced){
-            map.enforced=enforced
-        }
         if(required){
             map.required=required
         }
@@ -182,9 +181,13 @@ public class Option implements Comparable{
         if(description){
             map.description=description
         }
+        if(sortValues){
+            map.sortValues = true
+        }
         if(defaultValue){
             map.value=defaultValue
         }
+
         if(defaultStoragePath){
             map.storagePath=defaultStoragePath
         }
@@ -205,11 +208,23 @@ public class Option implements Comparable{
                 map.multivalueAllSelected = true
             }
         }
+        if(inputType){
+            map.inputType = inputType
+        }
         if(secureInput){
             map.secure=secureInput
         }
+        if(enforced == true) {
+            map.put("enforcedType", "enforced")
+        }
+        if(enforced == "regex"){
+            map.put("enforcedType", inputType)
+        }
         if(secureExposed && secureInput){
             map.valueExposed= secureExposed
+        }
+        if(valuesListDelimiter){
+            map.valuesListDelimeter = valuesListDelimiter
         }
         if(optionValuesPluginType) {
             map.optionValuesPluginType = optionValuesPluginType
@@ -390,7 +405,7 @@ public class Option implements Comparable{
      */
     public Option createClone(){
         Option opt = new Option()
-        ['name', 'description', 'defaultValue', 'defaultStoragePath', 'sortIndex', 'enforced', 'required', 'isDate',
+        ['name', 'description', 'defaultValue', 'defaultStoragePath', 'sortIndex', 'enforced', 'required', 'isDate', 'inputType',
          'dateFormat', 'values', 'valuesList', 'valuesUrl', 'valuesUrlLong', 'regex', 'multivalued',
          'multivalueAllSelected', 'label',
          'delimiter', 'optionValuesPluginType',

--- a/rundeckapp/grails-app/domain/rundeck/Option.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Option.groovy
@@ -216,9 +216,10 @@ public class Option implements Comparable{
         }
         if(enforced == true) {
             map.put("enforcedType", "enforced")
+            map.enforced = true
         }
         if(enforced == "regex"){
-            map.put("enforcedType", inputType)
+            map.put("enforcedType", enforced)
         }
         if(secureExposed && secureInput){
             map.valueExposed= secureExposed

--- a/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
@@ -695,7 +695,7 @@ class EditOptsControllerSpec extends HibernateSpec implements ControllerUnitTest
 
     def "duplicate options"(){
         given:
-        Option opt1 = new Option(name: 'test', description: 'test description', inputType: 'plain', label: 'label', )
+        Option opt1 = new Option(name: 'test', description: 'test description', inputType: 'plain', label: 'label')
         Option opt2 = opt1.createClone()
         def optsmap = [test: opt2]
         controller.fileUploadService = Mock(FileUploadService)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
@@ -695,30 +695,23 @@ class EditOptsControllerSpec extends HibernateSpec implements ControllerUnitTest
 
     def "duplicate options"(){
         given:
-        Option opt1 = new Option(name: 'abc')
-        Option opt2 = new Option(name: 'def')
-        Option opt3 = new Option(name: 'ghi')
-        def opts = [opt1, opt2, opt3]
-        def editopts = opts.collectEntries { [it.name, it] }
+        Option opt1 = new Option(name: 'test', description: 'test description', inputType: 'plain', label: 'label', )
+        Option opt2 = opt1.createClone()
+        def optsmap = [test: opt2]
         controller.fileUploadService = Mock(FileUploadService)
-
-        params.scheduledExecutionId = 1L
-        params.name = "abc"
         when:
+        def result = controller._applyOptionAction(
+                optsmap,
+                [action: 'insert', name: 'test', params: opt2.toMap()]
+        )
 
-        def result = controller._duplicateOption(editopts)
-        def result1 = controller._duplicateOption(editopts)
+        Option newOption = (Option) result.option
 
         then:
-        result.name == "abc_1"
-        result.actions.undo.action == "remove"
-        result.actions.undo.name == "abc_1"
-
-        result1.name == "abc_2"
-        result1.actions.undo.action == "remove"
-        result1.actions.undo.name == "abc_2"
-
-        editopts.size() == 5
+        opt1.name == newOption.name
+        opt1.inputType == newOption.inputType
+        opt1.description == newOption.description
+        opt1.label == newOption.label
 
 
     }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
A clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing.

This is a bugfix. When duplicating a job option, most of the properties in the new option did not match that of the original option. 

**Describe the solution you've implemented**
A clear and concise description of what you want to happen.

Updated the toMap() Option method to properly set the properties on the returned map. Updated the _setOptionFromParams() function to properly set the properties on the new option based off returned map from the toMap method. Added inputType property to Options class.


