### PR TITLE
Fix: "Show all" button is not clickable #1464

### DIFF
--- a/rundeckapp/grails-app/views/framework/_tagsummary.gsp
+++ b/rundeckapp/grails-app/views/framework/_tagsummary.gsp
@@ -22,6 +22,7 @@
 <g:set var="urkey" value="${g.rkey()}"/>
 <%@ page contentType="text/html;charset=UTF-8" %>
 <g:if test="${tagsummary}">
+        <asset:javascript src="prototype.min.js" />
         <g:set var="hidetop" value="${hidetop?:tagsummary.findAll {it.value>1}.size()>30}"/>
         <g:if test="${hidetop}">
             <span class="textbtn textbtn-secondary tag"


### PR DESCRIPTION
FIX: https://github.com/rundeckpro/rundeckpro/issues/1464

is this a bug fix, or an enhancement? Please describe.
the job screen's "Show all" button is not clickable when If too many of the same tags are used in the nodes. there is a JavaScript error show on the console.

![image](https://user-images.githubusercontent.com/35808955/107371938-9f607d80-6ac3-11eb-8369-9470794c1d39.png)

Describe the solution you've implemented
Loaded prototype.min.js script on the page
