### PR TITLE
Remove outdated docs build text

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,6 @@ Artifacts:
 * `rundeckapp/build/libs/rundeck-X.Y.war`
 
 
-Other builds
-======
-
-The documentation can be built with [pandoc](http://johnmacfarlane.net/pandoc/).
-    
-Build the documentation. Artifacts in `docs/en/dist`:
-
-    cd docs
-    make
 
 RPM and DEB package builds
 =======


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Remove outdated text about building docs with pandoc.