### PR TITLE
Fix 1369: duplicate secure option doesn't work correctly

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
@@ -998,7 +998,7 @@ class EditOptsController extends ControllerBase{
         def newName = duplicateName(params.name, 1, editopts)
         newOption.name = newName
 
-        def result = _applyOptionAction(editopts, [action: 'insert', name: newName, params: newOption.toMap()])
+        def result = _applyOptionAction(editopts, [action: 'insert', name: newName, params: _getParamsFromOption(newOption)])
 
         return [actions: result, name: newName]
     }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
@@ -722,4 +722,28 @@ class EditOptsControllerSpec extends HibernateSpec implements ControllerUnitTest
 
 
     }
+    def "duplicate options secure"(){
+        given:
+        Option opt1 = new Option(name: 'abc', secureInput: true, secureExposed: true, defaultStoragePath: 'keys/asdf',required: true)
+        def opts = [opt1]
+        def editopts = opts.collectEntries { [it.name, it] }
+        controller.fileUploadService = Mock(FileUploadService)
+
+        params.scheduledExecutionId = 1L
+        params.name = "abc"
+        when:
+
+        def result = controller._duplicateOption(editopts)
+
+        then:
+        result.name == "abc_1"
+        result.actions.undo.action == "remove"
+        result.actions.undo.name == "abc_1"
+        def map1=opt1.toMap()
+        def map2=editopts['abc_1'].toMap()
+        map1.remove('name')
+        map2.remove('name')
+        map1==map2
+
+    }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fixes https://github.com/rundeckpro/rundeckpro/issues/1369

**Describe the solution you've implemented**

pass in correct values to insert duplicate option

**Describe alternatives you've considered**
replaces pr https://github.com/rundeck/rundeck/pull/6768
