### PR TITLE
Fixup login and logout footer and scrolling

### DIFF
--- a/rundeckapp/grails-app/views/user/loggedout.gsp
+++ b/rundeckapp/grails-app/views/user/loggedout.gsp
@@ -45,7 +45,6 @@
     <g:render template="/common/css"/>
 </head>
 <body id="loginpage">
-  <div class="wrapper wrapper-full-page">
     <div class="full-page login-page">
     <!-- <div class="full-page login-page" data-color="" data-image="static/img/background/background-2.jpg"> -->
       <div class="content">
@@ -97,6 +96,5 @@
     </div>
     <g:render template="/common/footer"/>
   </div>
-</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/user/login.gsp
+++ b/rundeckapp/grails-app/views/user/login.gsp
@@ -82,7 +82,6 @@
     </style>
 </head>
 <body id="loginpage">
-  <div class="wrapper wrapper-full-page">
     <div class="full-page login-page">
     <!-- <div class="full-page login-page" data-color="" data-image="static/img/background/background-2.jpg"> -->
       <div class="content">
@@ -219,6 +218,5 @@
       </script>
     <g:render template="/common/footer"/>
   </div>
-</div>
 </body>
 </html>

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme-next/scss/pages/login.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme-next/scss/pages/login.scss
@@ -26,7 +26,8 @@
 
   .footer,
   .footer .copyright {
-    color: #d5d5d5 !important;
+    background-color: $default-background-color;
+    color: $font-color !important;
 
     & a:not(.btn) {
       text-decoration: underline;

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme-next/scss/paper/_pages.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme-next/scss/paper/_pages.scss
@@ -81,7 +81,6 @@
   .footer nav>ul a:not(.btn),
   .footer .copyright,
   .footer .copyright a {
-    color: $white-color;
     font-size: $font-size-base;
   }
 
@@ -89,7 +88,9 @@
 
 .login-page,
 .lock-page {
-
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   // .four-oh-four{
   >.content {
     padding-top: 10vh;

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme-next/scss/paper/_view.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme-next/scss/paper/_view.scss
@@ -44,3 +44,9 @@
         grid-auto-columns: 65px 1fr;
     }
 }
+
+#loginpage {
+    height: 100vh;
+    width: 100vw;
+    overflow: hidden;
+}


### PR DESCRIPTION
* Uses new background color for footer
* Jiggles the layout to remove the scrolling that appeared regardless of page height

![image](https://user-images.githubusercontent.com/271965/108434462-4e603000-720d-11eb-9b2e-cc7db0280136.png)
