### PR TITLE
Layout fixups

### DIFF
--- a/rundeckapp/grails-app/views/common/_baseUiNext.gsp
+++ b/rundeckapp/grails-app/views/common/_baseUiNext.gsp
@@ -9,7 +9,7 @@
 
 <section id="section-main" class="${projectName ? 'with-project' : ''}" style="grid-area: main;">
     <g:if test="${projectName}">
-        <section id="section-navbar" style="grid-area: nav; background-color: blue;}">
+        <section id="section-navbar" style="grid-area: nav;}">
             <div id="navbar"/>
         </section>
     </g:if>

--- a/rundeckapp/grails-app/views/menu/_sysConfigNavMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_sysConfigNavMenu.gsp
@@ -85,7 +85,7 @@
 <g:if test="${pluginRead && repoEnabled}">
   <li class="dropdown-submenu">
     <a href="#">Plugins <span class="caret"></span></a>
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu dropdown-menu-right">
       <li>
         <a href="${g.createLink(uri:'/artifact/index/repositories')}">
             <g:message code="gui.menu.FindPlugins"/>

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme-next/scss/paper/_view.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme-next/scss/paper/_view.scss
@@ -23,6 +23,7 @@
 
 #section-navbar {
     overflow: hidden;
+    background-color: $black-background-color;
 }
 
 #section-content {


### PR DESCRIPTION
* Fixes the plugin subnav menu alignment so it's no longer stacked on top of the primary menu
* Removes the blue navbar flicker by setting the grid section to match the background color of the navbar