### PR TITLE
SCM Export: Git error 500 happening on manual pulls

### DIFF
--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
@@ -471,7 +471,7 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
         def status = hasJobStatusCached(job, originalPath)
 
         //check if local commit has changed from the stored status
-        if(status['synch'] == SynchState.CLEAN){
+        if(status && status['synch'] == SynchState.CLEAN){
             def commit = lastCommitForPath(originalPath)
             def storedCommitId = ((JobScmReference)job).scmImportMetadata?.commitId
             if(storedCommitId != null && commit == null){
@@ -499,7 +499,7 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
         }
         def status = hasJobStatusCached(job, originalPath)
         //check if local commit has changed from the stored status
-        if(status['synch'] == SynchState.CLEAN){
+        if(status && status['synch'] == SynchState.CLEAN){
             def commit = lastCommitForPath(originalPath)
             def storedCommitId = ((JobScmReference)job).scmImportMetadata?.commitId
             if(storedCommitId != null && commit == null){

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
@@ -385,7 +385,7 @@ class GitExportPluginSpec extends Specification {
         plugin.initialize(Mock(ScmOperationContext))
 
         def serializer = Mock(JobSerializer)
-        def jobref = Stub(JobExportReference) {
+        def jobref = Stub(JobScmReference) {
             getJobName() >> 'name'
             getGroupPath() >> 'a/b'
             getId() >> 'xyz'
@@ -426,7 +426,7 @@ class GitExportPluginSpec extends Specification {
         plugin.initialize(Mock(ScmOperationContext))
 
         def serializer = Mock(JobSerializer)
-        def jobref = Stub(JobExportReference) {
+        def jobref = Stub(JobScmReference) {
             getJobName() >> 'name'
             getGroupPath() >> 'a/b'
             getId() >> 'xyz'
@@ -1061,7 +1061,7 @@ class GitExportPluginSpec extends Specification {
         def localfile = new File(gitdir, 'blah-xyz.xml')
 
         def serializer = Mock(JobSerializer)
-        def jobref = Stub(JobExportReference) {
+        def jobref = Stub(JobScmReference) {
             getJobName() >> 'blah'
             getGroupPath() >> ''
             getId() >> 'xyz'
@@ -1109,7 +1109,7 @@ class GitExportPluginSpec extends Specification {
                 return 10
             }
         }
-        def jobref = Stub(JobExportReference) {
+        def jobref = Stub(JobScmReference) {
             getJobName() >> 'blah'
             getGroupPath() >> ''
             getId() >> 'xyz'
@@ -1161,7 +1161,7 @@ class GitExportPluginSpec extends Specification {
                 throw new IllegalArgumentException('failure')
             }
         }
-        def jobref = Stub(JobExportReference) {
+        def jobref = Stub(JobScmReference) {
             getJobName() >> 'blah'
             getGroupPath() >> ''
             getId() >> 'xyz'
@@ -1216,7 +1216,7 @@ class GitExportPluginSpec extends Specification {
             0 * serialize(*_)
 
         }
-        def jobref = Stub(JobExportReference) {
+        def jobref = Stub(JobScmReference) {
             getJobName() >> 'blah'
             getGroupPath() >> ''
             getId() >> 'xyz'
@@ -1335,7 +1335,7 @@ class GitExportPluginSpec extends Specification {
             getVersion() >> 1
             getJobSerializer() >> serializer
         }
-        def jobref = Stub(JobExportReference) {
+        def jobref = Stub(JobScmReference) {
             getJobName() >> 'blah2'
             getGroupPath() >> ''
             getId() >> 'xyz'
@@ -1543,7 +1543,7 @@ class GitExportPluginSpec extends Specification {
         plugin.initialize(Mock(ScmOperationContext))
 
         def serializer = Mock(JobSerializer)
-        def jobref = Stub(JobExportReference) {
+        def jobref = Stub(JobScmReference) {
             getJobName() >> 'name'
             getGroupPath() >> 'a/b'
             getId() >> 'xyz'
@@ -1579,7 +1579,7 @@ class GitExportPluginSpec extends Specification {
         plugin.initialize(Mock(ScmOperationContext))
 
         def serializer = Mock(JobSerializer)
-        def jobref = Stub(JobExportReference) {
+        def jobref = Stub(JobScmReference) {
             getJobName() >> 'name'
             getGroupPath() >> 'a/b'
             getId() >> 'xyz'

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3396,6 +3396,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     if (scmService.projectHasConfiguredExportPlugin(params.project)) {
                         pluginData.scmExportEnabled = scmService.loadScmConfig(params.project, 'export')?.enabled
                         if (pluginData.scmExportEnabled) {
+                            scmService.checkJobRenamed(params.project, result.nextScheduled)
+
                             pluginData.scmStatus = scmService.exportStatusForJobs(authContext, result.nextScheduled)
                             pluginData.scmExportStatus = scmService.exportPluginStatus(authContext, params.project)
                             pluginData.scmExportActions = scmService.exportPluginActions(authContext, params.project)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -24,7 +24,6 @@ import com.dtolabs.rundeck.app.gui.GroupedJobListLinkHandler
 import com.dtolabs.rundeck.app.gui.JobListLinkHandlerRegistry
 import com.dtolabs.rundeck.app.support.*
 import com.dtolabs.rundeck.core.authorization.AuthContext
-import com.dtolabs.rundeck.core.authorization.AuthContextProvider
 import com.dtolabs.rundeck.core.authorization.AuthorizationUtil
 import com.dtolabs.rundeck.core.authorization.RuleSetValidation
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
@@ -3391,6 +3390,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     //initialize if in another node
                     scmService.initProject(params.project, 'export')
                     scmService.fixExportStatus(authContext, params.project, result.nextScheduled)
+                    scmService.checkStoredSCMStatus(params.project, result.nextScheduled)
                 }
                 try {
                     if (scmService.projectHasConfiguredExportPlugin(params.project)) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -1144,7 +1144,7 @@ class ScmController extends ControllerBase {
             jobs = jobIds.collect {
                 ScheduledExecution.getByIdOrUUID(it)
             }
-            scmStatus = scmService.exportStatusForJobs(authContext, jobs).findAll {
+            scmStatus = scmService.exportStatusForJobsWithoutClusterFix(authContext, jobs).findAll {
                 it.value.synchState != SynchState.CLEAN
             }
             jobs = jobs.findAll {
@@ -1287,7 +1287,7 @@ class ScmController extends ControllerBase {
             renamedJobPaths.values().each {
                 deletedPaths.remove(it)
             }
-            def scmStatus = scmService.exportStatusForJobs(authContext, jobs)
+            def scmStatus = scmService.exportStatusForJobsWithoutClusterFix(authContext, jobs)
             def scmFiles = integration == 'export' ? scmService.exportFilePathsMapForJobs(jobs) : null
 
             def scmProjectStatus = scmService.getPluginStatus(authContext, integration, params.project)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -977,7 +977,7 @@ class ScmController extends ControllerBase {
             List<ScheduledExecution> alljobs = ScheduledExecution.findAllByProject(project)
             Map<String, ScheduledExecution> jobMap = alljobs.collectEntries { [it.extid, it] }
 
-            Map scmJobStatus = scmService.exportStatusForJobs(authContext, alljobs).findAll {
+            Map scmJobStatus = scmService.exportStatusForJobsWithoutClusterFix(authContext, alljobs).findAll {
                 it.value.synchState != SynchState.CLEAN
             }
 

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1106,7 +1106,6 @@ class ScmService {
      * @return
      */
     Map<String, JobState> exportStatusForJobs(UserAndRolesAuthContext auth, List<ScheduledExecution> jobs) {
-        def status = [:]
         def clusterMode = frameworkService.isClusterModeEnabled()
         if(jobs && jobs.size()>0 && clusterMode){
             def project = jobs.get(0).project
@@ -1114,7 +1113,18 @@ class ScmService {
                 fixExportStatus(auth, project, jobs)
             }
         }
+        def status = exportStatusForJobsWithoutClusterFix(auth, jobs)
 
+        status
+    }
+
+    /**
+     * Return a map of status for jobs (without cluster fix)
+     * @param jobs
+     * @return
+     */
+    Map<String, JobState> exportStatusForJobsWithoutClusterFix(UserAndRolesAuthContext auth, List<ScheduledExecution> jobs) {
+        def status = [:]
         exportjobRefsForJobs(jobs).each { jobReference ->
             def plugin = getLoadedExportPluginFor jobReference.project
             if (plugin) {
@@ -1123,6 +1133,7 @@ class ScmService {
                 log.debug("Status for job ${jobReference}: ${status[jobReference.id]}, origpath: ${originalPath}")
             }
         }
+
         status
     }
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1440,6 +1440,14 @@ class ScmService {
                 }
             }
 
+
+        }
+    }
+
+    def checkJobRenamed(String project, List<ScheduledExecution> jobs){
+        def plugin = getLoadedExportPluginFor project
+
+        if (plugin) {
             //check if jobs has changed the name and are not registered
             jobs.each { job ->
 
@@ -1483,6 +1491,7 @@ class ScmService {
                 }
             }
         }
+
     }
 
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1442,11 +1442,18 @@ class ScmService {
 
             //check if jobs has changed the name and are not registered
             jobs.each { job ->
+
+                log.debug("check if job ${job.id} was renamed")
+
                 def orig = jobMetadataService.getJobPluginMeta(job, 'scm-import') ?: [:]
                 def jobReference = (JobScmReference)exportJobRef(job)
 
-                if( (orig.name && !orig.groupPath && orig.name != job.jobName) ||
-                    (orig.name && orig.groupPath  && orig.name != job.jobName && orig.groupPath != job.groupPath)){
+                def jobFullName = job.generateFullName()
+                def origFullName = [orig.groupPath?:'',orig.name].join("/")
+
+                if( jobFullName != origFullName){
+
+                    log.debug("job ${job.groupPath}/${job.jobName} was renamed, previuos name: ${orig.groupPath}/${orig.name}" )
 
                     boolean renameProcess = true
                     if (renamedJobsCache && renamedJobsCache[project] && renamedJobsCache[project][jobReference.id] ){
@@ -1458,7 +1465,6 @@ class ScmService {
                         origScmRef.jobName = orig.name
                         origScmRef.groupPath = orig.groupPath
 
-                        log.debug("job ${job.groupPath}/${job.jobName} was renamed, previuos name: ${orig.groupPath}/${orig.name}" )
                         log.debug("reprocessing renamed job")
 
                         //record original path for renamed job, if it is different

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1239,7 +1239,7 @@ class ScmService {
                 jobs.each { job ->
                     def orig = jobMetadataService.getJobPluginMeta(job, 'scm-import') ?: [:]
 
-                    def newmeta = [version: job.version, pluginMeta: result.commit.asMap()]
+                    def newmeta = [version: job.version, pluginMeta: result.commit.asMap(), name: job.jobName, groupPath: job.groupPath]
 
                     jobMetadataService.setJobPluginMeta(
                             job,
@@ -1457,6 +1457,9 @@ class ScmService {
                         def origScmRef = (JobScmReference)exportJobRef(job)
                         origScmRef.jobName = orig.name
                         origScmRef.groupPath = orig.groupPath
+
+                        log.debug("job ${job.groupPath}/${job.jobName} was renamed, previuos name: ${orig.groupPath}/${orig.name}" )
+                        log.debug("reprocessing renamed job")
 
                         //record original path for renamed job, if it is different
                         def origpath = plugin.getRelativePathForJob(origScmRef)

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1404,6 +1404,30 @@ class ScmService {
         }
     }
 
+    // check if jobs has the SCM metadata stored in the DB
+    void checkStoredSCMStatus(String project, List<ScheduledExecution> jobs) {
+        def plugin = getLoadedExportPluginFor project
+
+        if (plugin) {
+            //synch import commit info to exported commit data
+            jobs.each { job ->
+                def jobReference = (JobScmReference)exportJobRef(job)
+
+                //need to save status in DB
+                if(jobReference.scmImportMetadata == null){
+                    def jobStatus = plugin.getJobStatus(jobReference)
+                    def newmeta = [version: job.version, pluginMeta: jobStatus.commit.asMap()]
+
+                    jobMetadataService.setJobPluginMeta(
+                            job,
+                            'scm-import',
+                            newmeta
+                    )
+                }
+            }
+        }
+    }
+
 }
 
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
@@ -103,7 +103,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
 
             1 * projectHasConfiguredPlugin(integration, projectName) >> true
             1 * getInputView(_, integration, projectName, actionName) >> Mock(BasicInputView)
-            1 * exportStatusForJobs(_,[]) >> [:]
+            1 * exportStatusForJobsWithoutClusterFix(_,[]) >> [:]
             1 * exportFilePathsMapForJobs([]) >> [:]
             1 * getRenamedJobPathsForProject(projectName) >> [:]
             1 * performExportAction(actionName, _, projectName, _, _, _) >>

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
@@ -28,6 +28,7 @@ import com.dtolabs.rundeck.plugins.scm.ScmImportTrackedItemBuilder
 import com.dtolabs.rundeck.plugins.scm.SynchState
 import grails.test.hibernate.HibernateSpec
 import grails.testing.web.controllers.ControllerUnitTest
+import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 import org.rundeck.app.authorization.AppAuthContextEvaluator
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import rundeck.CommandExec
@@ -45,6 +46,11 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
 
     List<Class> getDomainClasses() { [ScheduledExecution, Workflow, CommandExec] }
 
+    protected setupFormTokens(session) {
+        def token = SynchronizerTokensHolder.store(session)
+        params[SynchronizerTokensHolder.TOKEN_KEY] = token.generateToken('/test')
+        params[SynchronizerTokensHolder.TOKEN_URI] = '/test'
+    }
 
     void "scm action cancel redirects to jobs page"() {
         given:
@@ -590,5 +596,101 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             endpoint         | integration
             'apiPluginInput' | 'import'
             'apiPluginInput' | 'export'
+    }
+
+    def "perform export shouldn't call clusterFix"() {
+        given:
+        def projectName = 'testproj'
+        def actionName = 'testAction'
+        params.actionId = actionName
+        params.project = projectName
+        params.integration = integration
+
+        controller.frameworkService = Mock(FrameworkService) {
+            0 * _(*_)
+        }
+        controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
+            1 * authResourceForProject(projectName)
+            1 * authorizeApplicationResourceAny(_, _, _)>>true
+
+            getAuthContextForSubjectAndProject(_, projectName) >> Mock(UserAndRolesAuthContext)
+        }
+
+        controller.scmService = Mock(ScmService) {
+            1 * projectHasConfiguredPlugin(integration, projectName) >> true
+            1 * getInputView(_, integration, projectName, actionName) >> Mock(BasicInputView)
+            1 * getRenamedJobPathsForProject(projectName) >> [:]
+            1 * loadProjectPluginDescriptor(projectName, integration)
+            1 * exportStatusForJobsWithoutClusterFix(_,[])
+            1 * getPluginStatus(_,integration, projectName)
+            1 * deletedExportFilesForProject(projectName)
+            1 * exportFilePathsMapForJobs(_)
+            0 * exportStatusForJobs(_,_)
+            0 * _(*_)
+        }
+
+        response.format = 'json'
+        request.method = 'POST'
+        request.contentType = 'application/json'
+        request.content = '{"input":null}'.bytes
+
+        when:
+        controller.performAction(integration, projectName, actionName)
+
+        then:
+        response.status == 200
+
+        where:
+        integration | _
+        'export'    | _
+    }
+
+    def "performActionSubmit export shouldn't call clusterFix"() {
+        given:
+        def projectName = 'testproj'
+        def actionName = 'testAction'
+        params.actionId = actionName
+        params.project = projectName
+        params.integration = integration
+        setupFormTokens(session)
+
+        controller.frameworkService = Mock(FrameworkService) {
+            0 * _(*_)
+        }
+        controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
+            1 * authResourceForProject(projectName)
+            1 * authorizeApplicationResourceAny(_, _, _)>>true
+
+            getAuthContextForSubjectAndProject(_, projectName) >> Mock(UserAndRolesAuthContext)
+        }
+
+        controller.scmService = Mock(ScmService) {
+            1 * projectHasConfiguredPlugin(integration, projectName) >> true
+            1 * performExportAction(_,_,projectName,_,_,_) >> [valid: false]
+            1 * getRenamedJobPathsForProject(projectName) >> [:]
+            1 * loadProjectPluginDescriptor(projectName, integration)
+            1 * exportStatusForJobsWithoutClusterFix(_,[])
+            1 * getPluginStatus(_,integration, projectName)
+            1 * deletedExportFilesForProject(projectName)
+            1 * exportFilePathsMapForJobs(_)
+            1 * getInputView(_, integration, projectName, actionName) >> Mock(BasicInputView)
+            0 * exportStatusForJobs(_,_)
+            0 * _(*_)
+        }
+
+        response.format = 'json'
+        request.method = 'POST'
+        request.contentType = 'application/json'
+        request.content = '{"input":null}'.bytes
+
+        when:
+        controller.performActionSubmit(integration, projectName, actionName)
+
+        then:
+        response.status != null
+
+        where:
+        integration | _
+        'export'    | _
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
@@ -231,7 +231,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
 
             1 * projectHasConfiguredPlugin(integration, projectName) >> true
             1 * getInputView(_, integration, projectName, actionName) >> Mock(BasicInputView)
-            1 * exportStatusForJobs(_,_) >> [
+            1 * exportStatusForJobsWithoutClusterFix(_,_) >> [
                 job1: new JobStateImpl(synchState: SynchState.EXPORT_NEEDED),
                 job2: new JobStateImpl(synchState: SynchState.EXPORT_NEEDED),
                 job3: new JobStateImpl(synchState: SynchState.EXPORT_NEEDED),

--- a/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
@@ -790,7 +790,7 @@ class ScmServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmService
     }
 
 
-    def "update plugin meta adding job name/group"() {
+    def "update job plugin metadata"() {
         given:
         service.pluginConfigService = Mock(PluginConfigService)
         service.frameworkService = Mock(FrameworkService) {
@@ -855,8 +855,11 @@ class ScmServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmService
 
 
         where:
-        originalMeta                       | jobMetadataCalls
-        [name: 'test', groupPath: 'test', pluginMeta: [commit:'123']]  | 0
-        [pluginMeta: [commit:'123']]                                 | 1
+        originalMeta                                                    | jobMetadataCalls
+        [name: 'test', groupPath: 'test', pluginMeta: [commit:'123']]   | 0
+        [pluginMeta: [commit:'123']]                                    | 1
+        [:]                                                             | 1
+        [name: 'test', groupPath: 'test']                               | 1
+
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
@@ -560,6 +560,8 @@ class ScmServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmService
         }
         def job = new ScheduledExecution()
         job.version = 1
+        job.jobName = "test"
+        job.groupPath = "test"
         def bobuser = new User(login: 'bob').save()
 
         //returned by export result, should be stored in job metadata
@@ -585,7 +587,7 @@ class ScmServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmService
         }
 
         //store metadata about commit
-        1 * service.jobMetadataService.setJobPluginMeta(job, 'scm-import', [version: 1, pluginMeta: commitMetadata])
+        1 * service.jobMetadataService.setJobPluginMeta(job, 'scm-import', [version: 1, pluginMeta: commitMetadata, 'name': 'test', 'groupPath': 'test'])
 
         result.valid
         result.commitId == 'a-commit-id'


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
bug fixes:
* fix error 500 in the manual pull from remote repository.
* detected when local repo has a different version than jobs definition. Sync local repo version with the job definition.

**Describe the solution you've implemented**
part of the code introduced to make the plugin works in cluster mode produces an error because can perform automatic pulls and checkouts. That code doesn't need to be called when the user performs actions like commit or sync.
Also, in cases where remote changes are added outside rundeck, the plugin needs to sync the local repository with the job definition. 

**Describe alternatives you've considered**

**Additional context**
