### PR TITLE
Fix: "Show all" button on Jobs list is not clickable #1464

### DIFF
--- a/rundeckapp/grails-app/views/framework/_tagsummary.gsp
+++ b/rundeckapp/grails-app/views/framework/_tagsummary.gsp
@@ -25,7 +25,7 @@
         <g:set var="hidetop" value="${hidetop?:tagsummary.findAll {it.value>1}.size()>30}"/>
         <g:if test="${hidetop}">
             <span class="textbtn textbtn-secondary tag"
-                  title="Show tag demographics" onclick="Element.toggle('nodes_tags'); Element.toggleClassName(this,'active');">
+                  title="Show tag demographics" onclick="jQuery(this).next().toggle(); jQuery(this).toggleClass('active');">
                 <i class="glyphicon glyphicon-tags text-primary "></i>
                 <g:enc>${tagsummary.size()}</g:enc> tags
                 <i class="glyphicon glyphicon-chevron-right"></i></span>
@@ -60,8 +60,8 @@
             </g:each>
             <g:if test="${singletag}">
                 <span class="btn btn-sm btn-default receiver" title="See all tags"
-                      onclick="Element.show('${enc(attr:urkey)}singletags');
-                Element.hide(this);">Show All&hellip;</span>
+                      onclick="jQuery('#${enc(attr:urkey)}singletags').show();
+                      jQuery(this).hide();">Show All&hellip;</span>
                 <span style="display:none" id="${enc(attr:urkey)}singletags">
                     <g:each var="tag" in="${singletag}">
                         <span class="summary">


### PR DESCRIPTION
FIX: https://github.com/rundeckpro/rundeckpro/issues/1464

is this a bug fix, or an enhancement? Please describe.
the job screen's "Show all" button is not clickable when If too many of the same tags are used in the nodes. there is a JavaScript error show on the console.

![image](https://user-images.githubusercontent.com/35808955/107371938-9f607d80-6ac3-11eb-8369-9470794c1d39.png)

Describe the solution you've implemented
Changing prototype to Jquery