### PR TITLE
Fix: ProjectManager fileCache config requires static config

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -181,7 +181,12 @@ public class RundeckConfigBase {
     @Data
     public static class RundeckProjectManagerServiceConfig {
         ProjectCache projectCache;
+        FileCache fileCache;
 
+        @Data
+        public static class FileCache {
+            String spec;
+        }
         @Data
         public static class ProjectCache {
             String spec;


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Fix: error message about `fileCache` configuration, the ProjectManagerService requires a static config definition for the fileCache.
