### PR TITLE
Fix: when acl cache is cleaned, auth eval cache should be notified

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/AuthorizationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/AuthorizationService.groovy
@@ -294,9 +294,10 @@ class AuthorizationService implements AuthManager, InitializingBean, EventBusAwa
         cleanCaches(SourceKey.forContext(AppACLContext.system(), systemPath))
     }
 
-    void cleanCaches(SourceKey path){
-        sourceCache.invalidate(path)
-        storedPolicyPathsCache.invalidate(path.identity)
+    void cleanCaches(SourceKey key){
+        sourceCache.invalidate(key)
+        storedPolicyPathsCache.invalidate(key.identity)
+        eventBus.notify('acl.modified', [storage:'core-storage', context: key.context, path: key.file])
     }
 
     @Override
@@ -353,7 +354,6 @@ class AuthorizationService implements AuthManager, InitializingBean, EventBusAwa
      * @param path path
      */
     private void pathWasModified(AppACLContext context, String path){
-        eventBus.notify('acl.modified', [storage:'core-storage', context: context, path: path])
         log.debug("Path modified/deleted: ${path}, invalidating")
         cleanCaches(SourceKey.forContext(context, path))
         if(context.system) {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix: when acl cache is cleaned, the authorization eval cache should also be cleaned, by sending acl.modified event

**Additional context**

Related to cluster messaging changes around cache cleanup