### PR TITLE
Fixes the UserGroupSource to pass the username to the script

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/service/ScriptUserGroupSource.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/service/ScriptUserGroupSource.java
@@ -16,6 +16,7 @@
 package com.dtolabs.rundeck.core.execution.service;
 
 import com.dtolabs.rundeck.core.data.DataContext;
+import com.dtolabs.rundeck.core.data.MutableDataContext;
 import com.dtolabs.rundeck.core.dispatcher.DataContextUtils;
 import com.dtolabs.rundeck.core.execution.ExecArgList;
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepException;
@@ -43,6 +44,7 @@ public class ScriptUserGroupSource extends BaseScriptPlugin implements UserGroup
     private static final Logger                LOG          = LoggerFactory.getLogger(ScriptOptionValues.class);
     private static final String                START_MARKER = "==START_GROUPS==";
     private static final String                END_MARKER   = "==END_GROUPS==";
+    private static final String                USERNAME   = "username";
     private final        ServiceProviderLoader pluginManager;
     public ScriptUserGroupSource(final ScriptPluginProvider provider, final ServiceProviderLoader pluginManager) {
         super(provider);
@@ -56,7 +58,14 @@ public class ScriptUserGroupSource extends BaseScriptPlugin implements UserGroup
 
     @Override
     public List<String> getGroups(final String username, Map<String,Object> config) {
-        DataContext ctx = createScriptDataContext(DataContextUtils.context("config", MapData.toStringStringMap(config)).getData());
+        MutableDataContext dataContext = DataContextUtils.context("config", MapData.toStringStringMap(config));
+
+        //including username on context
+        Map<String, String> usernameConfigMap = new HashMap<String, String>();
+        usernameConfigMap.put(USERNAME, username);
+        dataContext.put("session", usernameConfigMap);
+
+        DataContext ctx = createScriptDataContext(dataContext.getData());
         final ExecArgList scriptArgsList = createScriptArgsList(ctx);
         ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         ByteArrayOutputStream errStream = new ByteArrayOutputStream();

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/service/ScriptUserGroupSourceSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/service/ScriptUserGroupSourceSpec.groovy
@@ -45,10 +45,32 @@ class ScriptUserGroupSourceSpec extends Specification {
 
     }
 
+    def "GetGroups passing username to the script as argument"() {
+        when:
+
+        TestScriptUserGroupSourceProvider testProvider = new TestScriptUserGroupSourceProvider()
+        testProvider.scriptFile = File.createTempFile("user","groups")
+        testProvider.scriptFile.setExecutable(true,true)
+        testProvider.archiveFile = File.createTempFile("user","archive")
+        testProvider.contentsBaseDir = File.createTempDir()
+        testProvider.scriptArgs = "\${session.username}"
+        testProvider.scriptFile << """echo "==START_GROUPS=="
+                                    echo "\$1"
+                                    echo "==END_GROUPS==" """
+        ScriptUserGroupSource scriptOptionValues = new ScriptUserGroupSource(testProvider, Stub(ServiceProviderLoader))
+        def result = scriptOptionValues.getGroups("test",[:])
+
+        then:
+        result.size() == 1
+        result[0] == "test"
+
+    }
+
     class TestScriptUserGroupSourceProvider implements ScriptPluginProvider {
         File scriptFile
         File archiveFile
         File contentsBaseDir
+        String scriptArgs
 
         @Override
         String getName() {
@@ -72,7 +94,7 @@ class ScriptUserGroupSourceSpec extends Specification {
 
         @Override
         String getScriptArgs() {
-            return null
+            return scriptArgs
         }
 
         @Override


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/1493

**Is this a bugfix, or an enhancement? Please describe.**
Was not possible to pass the username logged in the session to the UserGroupSource plugin if it uses a script to handle it

**Describe the solution you've implemented**
This changes include the username to the context so that it's possible to define `script-args: ${session.username}` and pass the username as argument to the script
