### PR TITLE
Handling case when executing a job through the API without Node selected by default

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -3357,6 +3357,10 @@ class ScheduledExecutionController  extends ControllerBase{
         if (jobLoglevel) {
             inputOpts["loglevel"] = jobLoglevel
         }
+        if (!scheduledExecution.hasNodesSelectedByDefault()){
+            inputOpts['_replaceNodeFilters']='true'
+        }
+
         // convert api parameters to node filter parameters
         def filters = jobFilter?[filter:jobFilter]:FrameworkController.extractApiNodeFilterParams(params)
         if (filters) {

--- a/test/api/test-job-run.sh
+++ b/test/api/test-job-run.sh
@@ -46,6 +46,25 @@ cat > $DIR/temp.out <<END
         </command>
       </sequence>
    </job>
+   <job>
+      <name>cli job</name>
+      <group>api-test/job-run</group>
+      <description></description>
+      <loglevel>INFO</loglevel>
+      <dispatch>
+        <threadcount>1</threadcount>
+        <keepgoing>true</keepgoing>
+      </dispatch>
+      <nodefilters>
+        <filter>.*</filter>
+      </nodefilters>
+      <nodesSelectedByDefault>false</nodesSelectedByDefault>
+      <sequence>
+        <command>
+        <exec>$xmlargs</exec>
+        </command>
+      </sequence>
+   </job>
 </joblist>
 
 END
@@ -71,9 +90,10 @@ $SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
 #case there should only be 1 failed or 1 succeeded since we submit only 1
 
 succount=$($XMLSTARLET sel -T -t -v "/result/succeeded/@count" $DIR/curl.out)
-jobid=$($XMLSTARLET sel -T -t -v "/result/succeeded/job/id" $DIR/curl.out)
+jobid=$($XMLSTARLET sel -T -t -v "/result/succeeded/job[@index=1]/id" $DIR/curl.out)
+jobid2=$($XMLSTARLET sel -T -t -v "/result/succeeded/job[@index=2]/id" $DIR/curl.out)
 
-if [ "1" != "$succount" -o "" == "$jobid" ] ; then
+if [ "2" != "$succount" -o "" == "$jobid" ] ; then
     errorMsg  "Upload was not successful."
     exit 
 fi
@@ -114,6 +134,118 @@ api_waitfor_execution $execid || fail "Failed waiting for execution $execid to c
 
 # test execution status
 # 
+runurl="${APIURL}/execution/${execid}"
+
+params=""
+
+# get listing
+docurl ${runurl}?${params} > $DIR/curl.out
+if [ 0 != $? ] ; then
+    errorMsg "ERROR: failed query request"
+    exit 2
+fi
+
+$SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
+
+#Check projects list
+itemcount=$($XMLSTARLET sel -T -t -v "/result/executions/@count" $DIR/curl.out)
+assert "1" "$itemcount" "execution count should be 1"
+status=$($XMLSTARLET sel -T -t -v "/result/executions/execution/@status" $DIR/curl.out)
+assert "succeeded" "$status" "execution status should be succeeded"
+
+echo "OK"
+
+###
+# should fail if dont select any node and nodesSelectedByDefault is false
+###
+
+echo "TEST: POST job/id/run should fail"
+
+
+# now submit req
+runurl="${APIURL}/job/${jobid2}/run"
+params=""
+
+# get listing
+$CURL -H "$AUTHHEADER" -X POST ${runurl}?${params} > $DIR/curl.out || fail "failed request: ${runurl}"
+
+$SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
+
+#get execid
+
+execcount=$($XMLSTARLET sel -T -t -v "/result/executions/@count" $DIR/curl.out)
+execid=$($XMLSTARLET sel -T -t -v "/result/executions/execution/@id" $DIR/curl.out)
+
+if [ "1" == "${execcount}" -a "" != "${execid}" ] ; then
+    :
+else
+    errorMsg "FAIL: expected run success message for execution id. (count: ${execcount}, id: ${execid})"
+    exit 2
+fi
+
+#wait for execution to complete
+
+api_waitfor_execution $execid || fail "Failed waiting for execution $execid to complete"
+
+# test execution status
+#
+runurl="${APIURL}/execution/${execid}"
+
+params=""
+
+# get listing
+docurl ${runurl}?${params} > $DIR/curl.out
+if [ 0 != $? ] ; then
+    errorMsg "ERROR: failed query request"
+    exit 2
+fi
+
+$SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
+
+#Check projects list
+itemcount=$($XMLSTARLET sel -T -t -v "/result/executions/@count" $DIR/curl.out)
+assert "1" "$itemcount" "execution count should be 1"
+status=$($XMLSTARLET sel -T -t -v "/result/executions/execution/@status" $DIR/curl.out)
+assert "failed" "$status" "execution status should be failed"
+
+echo "OK"
+
+###
+# should succeeded if select any node and nodesSelectedByDefault is false
+###
+
+echo "TEST: POST job/id/run should fail"
+
+
+# now submit req
+runurl="${APIURL}/job/${jobid2}/run"
+params=""
+JSONDATA='{ "filter":"name: .*" }'
+
+# get listing
+$CURL -H "$AUTHHEADER" -X POST --data-binary "$JSONDATA" -H content-type:application/json \
+  -H accept:application/xml ${runurl}?${params} > $DIR/curl.out || fail "failed request: ${runurl}"
+
+$SHELL $SRC_DIR/api-test-success.sh $DIR/curl.out || exit 2
+
+#get execid
+
+execcount=$($XMLSTARLET sel -T -t -v "/result/executions/@count" $DIR/curl.out)
+execid=$($XMLSTARLET sel -T -t -v "/result/executions/execution/@id" $DIR/curl.out)
+
+if [ "1" == "${execcount}" -a "" != "${execid}" ] ; then
+    :
+else
+    errorMsg "FAIL: expected run success message for execution id. (count: ${execcount}, id: ${execid})"
+    exit 2
+fi
+
+#wait for execution to complete
+
+api_waitfor_execution $execid || fail "Failed waiting for execution $execid to complete"
+
+# test execution status
+#
 runurl="${APIURL}/execution/${execid}"
 
 params=""


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/1467

**Is this a bugfix, or an enhancement? Please describe.**
If the user should explicitly select target nodes when running a job and no filters for Node Selection is passed through API request, the job was not failing. 

**Describe the solution you've implemented**
If a job does not have nodes selected by default, so the node filters should be replaced by the filter passed through API request. If none is passed, the job will fail.