### PR TITLE
fix: 500 error for workflow API response if no read or view auth

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -657,9 +657,13 @@ class ScheduledExecutionController  extends ControllerBase{
                 ),
                 AuthConstants.ACTION_VIEW, 'Job', params.id
         )) {
-            return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_FORBIDDEN,
-                                                           code  : 'api.error.item.unauthorized', args: ['View', 'Job ' +
-                    'ID', jobid]]
+            return apiService.renderErrorFormat(
+                response,
+                [
+                    status: HttpServletResponse.SC_FORBIDDEN,
+                    code  : 'api.error.item.unauthorized',
+                    args: ['View', 'Job ' + 'ID', params.id]
+                ]
             )
         }
         def maxDepth=3


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fixes a 500 error calling the Job Workflow API, if the user doesn't have the `read` or `view` authorization for the job. It should return appropriate unauthorized response.

**Describe the solution you've implemented**
Fix a typo.
