### PR TITLE
Avoiding error when parsing user roles that contain commas

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2023,7 +2023,7 @@ class ScheduledExecutionController  extends ControllerBase{
         scheduledExecution.minute = String.valueOf(cal.get(java.util.Calendar.MINUTE))
         scheduledExecution.hour = String.valueOf(cal.get(java.util.Calendar.HOUR_OF_DAY))
         scheduledExecution.user = authContext.username
-        scheduledExecution.userRoleList = authContext.roles.join(",")
+        scheduledExecution.userRoles = authContext.roles as List<String>
         if(params.project ){
 
             if(!frameworkService.existsFrameworkProject(params.project) ) {

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -23,6 +23,8 @@ import com.dtolabs.rundeck.core.common.FrameworkResource
 import com.dtolabs.rundeck.core.execution.ExecutionReference
 import com.dtolabs.rundeck.core.jobs.JobReference
 import com.dtolabs.rundeck.util.XmlParserUtil
+import com.google.gson.Gson
+import groovy.json.JsonOutput
 import rundeck.services.ExecutionService
 import rundeck.services.execution.ExecutionReferenceImpl
 
@@ -200,12 +202,18 @@ class Execution extends ExecutionContext implements EmbeddedJsonData {
 
 
     public setUserRoles(List l) {
-        setUserRoleList(l?.join(","))
+        def json = JsonOutput.toJson(l)
+        setUserRoleList(json)
     }
 
     public List getUserRoles() {
         if (userRoleList) {
-            return Arrays.asList(userRoleList.split(/,/))
+            try {
+                Gson gson = new Gson()
+                return gson.fromJson(userRoleList, List.class)
+            } catch(com.google.gson.JsonSyntaxException ex) {
+                return Arrays.asList(userRoleList.split(/,/))
+            }
         } else {
             return []
         }

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -23,6 +23,7 @@ import com.dtolabs.rundeck.core.common.FrameworkResource
 import com.dtolabs.rundeck.core.execution.ExecutionReference
 import com.dtolabs.rundeck.core.jobs.JobReference
 import com.dtolabs.rundeck.util.XmlParserUtil
+import com.fasterxml.jackson.core.JsonParseException
 import com.google.gson.Gson
 import groovy.json.JsonOutput
 import rundeck.services.ExecutionService
@@ -202,16 +203,15 @@ class Execution extends ExecutionContext implements EmbeddedJsonData {
 
 
     public setUserRoles(List l) {
-        def json = JsonOutput.toJson(l)
+        def json = serializeJsonList(l)
         setUserRoleList(json)
     }
 
     public List getUserRoles() {
         if (userRoleList) {
             try {
-                Gson gson = new Gson()
-                return gson.fromJson(userRoleList, List.class)
-            } catch(com.google.gson.JsonSyntaxException ex) {
+                return asJsonList(userRoleList)
+            } catch(JsonParseException ex) {
                 return Arrays.asList(userRoleList.split(/,/))
             }
         } else {

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -26,6 +26,7 @@ import com.dtolabs.rundeck.core.jobs.JobOption
 import com.dtolabs.rundeck.core.plugins.PluginConfigSet
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.jobs.JobOptionImpl
+import com.fasterxml.jackson.core.JsonParseException
 import com.google.gson.Gson
 import groovy.json.JsonOutput
 import org.quartz.Calendar
@@ -662,7 +663,7 @@ class ScheduledExecution extends ExecutionContext implements EmbeddedJsonData {
     }
 
     public setUserRoles(List l){
-        def json = JsonOutput.toJson(l)
+        def json = serializeJsonList(l)
         setUserRoleList(json)
     }
 
@@ -670,9 +671,8 @@ class ScheduledExecution extends ExecutionContext implements EmbeddedJsonData {
         if(userRoleList){
             //check if the string is a valid JSON
             try {
-                Gson gson = new Gson()
-                return gson.fromJson(userRoleList, List.class)
-            } catch(com.google.gson.JsonSyntaxException ex) {
+                return asJsonList(userRoleList)
+            } catch(JsonParseException ex) {
                 return Arrays.asList(userRoleList.split(/,/))
             }
 

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3321,7 +3321,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
         def scheduledExecution = importedJob.job
         scheduledExecution.user = authContext.username
-        scheduledExecution.userRoleList = authContext.roles.join(',')
+        scheduledExecution.userRoles = authContext.roles as List<String>
         Map validation=[:]
         boolean failed  = !validateJobDefinition(importedJob, authContext, params, validation, validateJobref)
 
@@ -3456,7 +3456,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
         def scheduledExecution = importedJob.job
         scheduledExecution.user = authContext.username
-        scheduledExecution.userRoleList = authContext.roles.join(',')
+        scheduledExecution.userRoles = authContext.roles as List<String>
 
         Map validation = [:]
         boolean failed = !validateJobDefinition(importedJob, authContext, params, validation, validateJobref)

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionTest.groovy
@@ -58,6 +58,36 @@ class ExecutionTest extends HibernateSpec  {
         assertFalse("Invalid: "+se.errors.allErrors*.toString().join(","), validate)
         assertTrue(se.errors.hasFieldErrors('serverNodeUUID'))
     }
+
+    void "testUserRoleListAsString"() {
+        when:
+        Execution se = createBasicExecution()
+        se.userRoleList = userRolesListAsString
+        def x = se.getUserRoles()
+        then:
+        assertEquals "incorrect number of roles found", userRoles.size(), x.size()
+        assertEquals "invalid role item", userRoles, x
+
+        where:
+        userRoles         | userRolesListAsString
+        ["a", "b", "c"]   | "a,b,c"
+        []                | null
+    }
+
+    void "testSetUserRoles"() {
+        when:
+        Execution se = createBasicExecution()
+        se.setUserRoles(userRoles)
+        then:
+        assertEquals "incorrect string value", userRolesList, se.userRoleList
+        assertEquals "incorrect user roles list", result, se.getUserRoles()
+
+        where:
+        userRoles                                | userRolesList                                    | result
+        ["a", "b", "c"]                          | "[\"a\",\"b\",\"c\"]"                            | ["a", "b", "c"]
+        ["a, with commas", "b with spaces", "c"] | "[\"a, with commas\",\"b with spaces\",\"c\"]"   | ["a, with commas", "b with spaces", "c"]
+        null                                     | null                                             | []
+    }
     void testValidRetry() {
         when:
         Execution se = createBasicExecution()

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionTest.groovy
@@ -432,6 +432,23 @@ class ScheduledExecutionTest  {
         assertEquals "incorrect number of roles found", 0, x.size()
     }
 
+    @Test void testUserRolesAsString() {
+        def ScheduledExecution se = new ScheduledExecution()
+        assertNull "should be null", se.userRoleList
+//        se.setUserRoles(["a,with,commas", "b, with commas", "c without commas"])
+        se.userRoleList = "a,b,c"
+        assertEquals "User roles not set correctly", "a,b,c", se.userRoleList
+        def x = se.getUserRoles()
+        assertEquals "incorrect number of roles found", 3, x.size()
+        assertEquals "invalid role item", "a", x[0]
+        assertEquals "invalid role item", "b", x[1]
+        assertEquals "invalid role item", "c", x[2]
+
+        se.userRoleList = null
+        x = se.getUserRoles()
+        assertEquals "incorrect number of roles found", 0, x.size()
+    }
+
     @Test void testUserRolesADWithDN() {
         def ScheduledExecution se = new ScheduledExecution()
         assertNull "should be null", se.userRoleList

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionTest.groovy
@@ -416,6 +416,22 @@ class ScheduledExecutionTest  {
         assertEquals "incorrect number of roles found", 0, x.size()
     }
 
+    @Test void testUserRolesWithCommas() {
+        def ScheduledExecution se = new ScheduledExecution()
+        assertNull "should be null", se.userRoleList
+        se.setUserRoles(["a,with,commas", "b, with commas", "c without commas"])
+        assertEquals "User roles not set correctly", "[\"a,with,commas\",\"b, with commas\",\"c without commas\"]", se.userRoleList
+        def x = se.getUserRoles()
+        assertEquals "incorrect number of roles found", 3, x.size()
+        assertEquals "invalid role item", "a,with,commas", x[0]
+        assertEquals "invalid role item", "b, with commas", x[1]
+        assertEquals "invalid role item", "c without commas", x[2]
+
+        se.userRoleList = null
+        x = se.getUserRoles()
+        assertEquals "incorrect number of roles found", 0, x.size()
+    }
+
     @Test void testUserRolesADWithDN() {
         def ScheduledExecution se = new ScheduledExecution()
         assertNull "should be null", se.userRoleList

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -1385,7 +1385,7 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
                 authorizeProjectExecutionAny(_, exec, _) >> true
 
                 _ * getAuthContextForSubjectAndProject(_, _) >> Mock(UserAndRolesAuthContext) {
-                    getRoles() >> ['a', 'b']
+                    getRoles() >> roles
                     getUsername() >> 'bob'
                 }
             }
@@ -1393,10 +1393,19 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         def result = controller.createFromExecution()
         then:
         controller.scheduledExecutionService = Mock(ScheduledExecutionService){
-            1 * prepareCreateEditJob(params, _, _,_) >> [scheduledExecution: new ScheduledExecution()]
+            1 * prepareCreateEditJob(params, _, _,_) >> {
+                [scheduledExecution: it[1]]
+            }
         }
         response.status == 200
         model.scheduledExecution != null
+        model.scheduledExecution.userRoleList == userRoleList
+        model.scheduledExecution.userRoles == roles
+
+        where:
+        roles                   | userRoleList
+        ['a', 'b']              | "[\"a\",\"b\"]"
+        ['a, with commas', 'b'] | "[\"a, with commas\",\"b\"]"
     }
 
 


### PR DESCRIPTION
fixes https://github.com/rundeckpro/rundeckpro/issues/1507

**Is this a bugfix, or an enhancement? Please describe.**
Executions were breaking if user roles had commas in it

**Describe the solution you've implemented**
There was a code that transforms the list of roles in a Json format string. So, the code was changed to use that instead of store the list as a simple text with the roles joined by a comma.