### PR TITLE
UI layout and fixups

### DIFF
--- a/grails-repository/grails-app/views/artifact/index.gsp
+++ b/grails-repository/grails-app/views/artifact/index.gsp
@@ -24,7 +24,7 @@
 </head>
 
 <body>
-
+<div class="content">
 <g:set var="pluginInstall" value="${auth.resourceAllowedTest(
         type: 'resource',
         kind: 'plugin',
@@ -50,5 +50,6 @@
   <div id=repository-vue></div>
 </div>
 <asset:javascript src="static/pages/repository.js"/>
+</div>
 </body>
 </html>

--- a/grails-webhooks/grails-app/views/webhook/admin.gsp
+++ b/grails-webhooks/grails-app/views/webhook/admin.gsp
@@ -35,10 +35,11 @@
 </head>
 
 <body>
+<div class="content">
 <div class="container-fluid">
     <div id=webhook-vue></div>
 </div>
-
+</div>
 
 <asset:javascript src="static/pages/webhooks.js"/>
 </body>

--- a/rundeckapp/grails-app/views/404.gsp
+++ b/rundeckapp/grails-app/views/404.gsp
@@ -55,7 +55,7 @@
         <div>
           <div class="col-xs-12 col-sm-6 space-cat-container">
             <g:if test="${!grailsApplication.config.rundeck?.feature?.fourOhFour?.hideSpaceCat in [true, 'true']}">
-              <img src="${resource(dir: 'images', file: 'spacecat/saucer-cat.png')}" class="img-responsive"
+              <asset:image src="spacecat/saucer-cat.png" class="img-responsive"
                 alt="Space Cat" />
             </g:if>
           </div>

--- a/rundeckapp/grails-app/views/405.gsp
+++ b/rundeckapp/grails-app/views/405.gsp
@@ -68,7 +68,7 @@
       </div>
           <div class="laser-cat-container">
             <g:if test="${!grailsApplication.config.rundeck?.feature?.fourOhFour?.hideSpaceCat in [true, 'true']}">
-              <img src="${resource(dir: 'images', file: 'spacecat/laser-cat.png')}" class="img-responsive"
+              <asset:image src="spacecat/laser-cat.png" class="img-responsive"
                 alt="Laser Cat" />
             </g:if>
           </div>

--- a/rundeckapp/grails-app/views/common/_baseUiNext.gsp
+++ b/rundeckapp/grails-app/views/common/_baseUiNext.gsp
@@ -14,7 +14,7 @@
         </section>
     </g:if>
 
-    <section id="section-content" style="grid-area: content;">
+    <section id="section-content" style="grid-area: content;display: flex; flex-direction: column">
         <g:ifPageProperty name="page.subtitle">
             <nav id="subtitlebar" class="navbar navbar-default subtitlebar standard">
                 <div class="container-fluid">
@@ -42,8 +42,7 @@
             <motd :event-bus="EventBus" tab-page="${enc(attr:pageProperty(name:'meta.tabpage'))}" style="margin-top:15px"></motd>
         </div>
 
-        <div class="content">
-        <div id="layoutBody">
+        <div id="layoutBody" style="height: 100%; overflow: hidden;">
         <g:ifPageProperty name="page.searchbarsection">
             <nav id="searchbar" class=" searchbar has-content ${pageProperty(name: 'page.searchbarcss')}">
 
@@ -52,8 +51,7 @@
             </nav>
         </g:ifPageProperty>
         <g:layoutBody/>
-        <g:render template="/common/footer"/>
-        </div>
+%{--        <g:render template="/common/footer"/>--}%
         </div>
     </section>
 </section>

--- a/rundeckapp/grails-app/views/common/_mainbar.gsp
+++ b/rundeckapp/grails-app/views/common/_mainbar.gsp
@@ -74,7 +74,10 @@
                     </a>
                   </li>
                 </g:ifPageProperty>
-              </g:if>
+            </g:if>
+            <g:else>
+              <div id="projectPicker" data-project-label=""/>
+            </g:else>
             <g:if test="${request.getAttribute(RequestConstants.PAGE)}">
               <g:ifPageProperty name='meta.tabpage'>
                 <g:ifPageProperty name='meta.tabpage' equals='projectconfigure'>

--- a/rundeckapp/grails-app/views/common/execUnauthorized.gsp
+++ b/rundeckapp/grails-app/views/common/execUnauthorized.gsp
@@ -25,7 +25,7 @@
 
 </head>
 <body>
-
+<div class="content">
 <div id="nowRunningContent">
     <div class="pageTop">
     <div class="floatl">
@@ -53,6 +53,7 @@
         </div>
     </g:elseif>
 
+</div>
 </div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/communityNews/index.gsp
+++ b/rundeckapp/grails-app/views/communityNews/index.gsp
@@ -25,9 +25,11 @@
 </head>
 
 <body>
+<div class="content">
   <div id="community-news-vue"></div>
   <!-- VUE JS MODULES -->
   <asset:javascript src="static/pages/community-news.js"/>
   <!-- /VUE JS MODULES -->
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/execution/mailNotification/_newStatus.gsp
+++ b/rundeckapp/grails-app/views/execution/mailNotification/_newStatus.gsp
@@ -447,6 +447,7 @@
 
 <body
   style="box-sizing:border-box;margin:0;padding:0;width:100%;word-break:break-word;-webkit-font-smoothing:antialiased;">
+  <div class="content">
   <div style="display:none;font-size:0;line-height:0;">
     <!-- Add your preheader text here -->
   </div>
@@ -801,6 +802,7 @@
   </td>
   </tr>
   </table>
+  </div>
 </body>
 
 </html>

--- a/rundeckapp/grails-app/views/execution/mailNotification/_oldStatus.gsp
+++ b/rundeckapp/grails-app/views/execution/mailNotification/_oldStatus.gsp
@@ -219,6 +219,7 @@ div.progressContainer div.progressContent{
     </style>
 </head>
 <body>
+<div class="content">
 <g:set var="execfailed" value="${execstate in ['failed','aborted']}"/>
 <g:if test="${execstate=='missed'}">
     <div class="report">
@@ -390,6 +391,6 @@ div.progressContainer div.progressContent{
     <g:link absolute="true" controller="reports" params="[project: execution.project]" action="index"><g:message code="gui.menu.Events"/> &raquo;</g:link>
 </div>
 </g:else>
-
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -559,9 +559,8 @@ search
       </div>
 
   </content>
-    <div class="container-fluid">
-      <div>
-
+    <div class="content">
+        <div class="container-fluid">
               <div class="row">
                   <div class="col-sm-12">
                       <div class="card card-plain " data-ko-bind="nodeflow">
@@ -955,6 +954,7 @@ search
 
 
   </div>
+    </div>
   <g:render template="/menu/copyModal"
           model="[projectNames: projectNames]"/>
 

--- a/rundeckapp/grails-app/views/framework/_createProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_createProjectForm.gsp
@@ -101,6 +101,7 @@
 <g:set var="adminauth"
        value="${auth.resourceAllowedTest(type: 'resource', kind: 'project', action: ['create'], context: 'application')}"/>
 <g:if test="${adminauth}">
+<div class="content">
   <div class="container-fluid">
     <div class="row">
       <div class="col-xs-12">
@@ -149,5 +150,6 @@
         <div class="error note"><g:message code="unauthorized.project.create"/></div>
     </div>
 </g:else>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/framework/adhoc.gsp
+++ b/rundeckapp/grails-app/views/framework/adhoc.gsp
@@ -343,7 +343,7 @@ search
   </div>
 
 </content>
-
+<div class="content">
 <div class="container-fluid page-commands">
   <div id="nodesContent" class="row">
     <g:render template="/common/messages"/>
@@ -393,6 +393,7 @@ search
 
   </div>
     <div id="loaderror"></div>
+</div>
 </div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/framework/editProject.gsp
+++ b/rundeckapp/grails-app/views/framework/editProject.gsp
@@ -102,6 +102,7 @@
 </head>
 
 <body>
+<div class="content">
 <div class="container-fluid">
   <div class="row">
       <div class="col-sm-12">
@@ -161,6 +162,7 @@
     </g:form>
   </div>
   <g:render template="storageBrowseModalKO"/>
+</div>
 </div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/framework/editProjectConfig.gsp
+++ b/rundeckapp/grails-app/views/framework/editProjectConfig.gsp
@@ -46,6 +46,7 @@
 </head>
 
 <body>
+<div class="content">
   <div class="container-fluid">
     <div class="row">
       <div class="col-sm-12">
@@ -82,7 +83,10 @@
       </div>
       </g:form>
     </div>
+  </div>
+</div>
 
 <!--[if (gt IE 8)|!(IE)]><!--> <asset:javascript src="ace-bundle.js"/><!--<![endif]-->
+
 </body>
 </html>

--- a/rundeckapp/grails-app/views/framework/editProjectFile.gsp
+++ b/rundeckapp/grails-app/views/framework/editProjectFile.gsp
@@ -47,6 +47,7 @@
 </head>
 
 <body>
+<div class="content">
   <div class="container-fluid">
     <div class="row">
       <div class="col-sm-12">
@@ -99,6 +100,7 @@
       </g:form>
     </div>
   </div>
+</div>
 <!--[if (gt IE 8)|!(IE)]><!--> <asset:javascript src="ace-bundle.js"/><!--<![endif]-->
 </body>
 </html>

--- a/rundeckapp/grails-app/views/framework/editProjectNodeSourceFile.gsp
+++ b/rundeckapp/grails-app/views/framework/editProjectNodeSourceFile.gsp
@@ -52,7 +52,8 @@
 </head>
 
 <body>
-<div class="container-fluid">
+<div class="content">
+    <div class="container-fluid">
   <div class="row">
       <div class="col-sm-12">
           <g:render template="/common/messages"/>
@@ -146,6 +147,7 @@
 
   </div>
 
+</div>
 </div>
 <!--[if (gt IE 8)|!(IE)]><!--> <asset:javascript src="ace-bundle.js"/><!--<![endif]-->
 </body>

--- a/rundeckapp/grails-app/views/framework/editProjectNodeSources.gsp
+++ b/rundeckapp/grails-app/views/framework/editProjectNodeSources.gsp
@@ -58,6 +58,7 @@
 </head>
 
 <body>
+<div class="content">
   <div class="container-fluid">
     <div class="row">
       <div class="col-sm-12">
@@ -191,6 +192,7 @@
         </g:form>
     </div>
   </div>
+</div>
 <!--[if (gt IE 8)|!(IE)]><!--> <asset:javascript src="ace-bundle.js"/><!--<![endif]-->
 </body>
 </html>

--- a/rundeckapp/grails-app/views/framework/nodes.gsp
+++ b/rundeckapp/grails-app/views/framework/nodes.gsp
@@ -289,7 +289,7 @@
     </div>
   </div>
 </div>
-</div>
+
     %{--Form for saving/deleting node filters--}%
 
         <g:form class="form form-horizontal" useToken="true">
@@ -298,5 +298,6 @@
             <g:render template="/common/queryFilterManagerModal"
                       model="${[rkey: ukey, filterName: filterName, filterset: filterset, filterLinks: true, formId: '${ukey}filter', ko: true, deleteActionSubmit: 'deleteNodeFilter', storeActionSubmit: 'storeNodeFilter']}"/>
         </g:form>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/framework/nodes.gsp
+++ b/rundeckapp/grails-app/views/framework/nodes.gsp
@@ -53,7 +53,7 @@
 
 <g:set var="run_authorized" value="${auth.adhocAllowedTest( action:AuthConstants.ACTION_RUN,project: params.project ?: request.project)}"/>
 <g:set var="job_create_authorized" value="${auth.resourceAllowedTest(kind:'job', action: AuthConstants.ACTION_CREATE,project: params.project ?: request.project)}"/>
-
+<div class="content">
 <div id="nodesContent">
 
   <g:render template="/common/messages"/>
@@ -289,7 +289,7 @@
     </div>
   </div>
 </div>
-
+</div>
     %{--Form for saving/deleting node filters--}%
 
         <g:form class="form form-horizontal" useToken="true">

--- a/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
+++ b/rundeckapp/grails-app/views/framework/projectNodeSources.gsp
@@ -57,6 +57,7 @@
 </head>
 
 <body>
+<div class="content">
   <div class="container-fluid">
     <div class="row">
       <div class="col-xs-12">
@@ -235,6 +236,7 @@
       </div>
     </div>
   </div>
+</div>
 
 </body>
 

--- a/rundeckapp/grails-app/views/menu/acls.gsp
+++ b/rundeckapp/grails-app/views/menu/acls.gsp
@@ -148,7 +148,8 @@
 
 </head>
 <body>
-<div class="container-fluid">
+<div class="content">
+    <div class="container-fluid">
   <div class="row">
       <div class="col-sm-12">
 
@@ -331,6 +332,7 @@
       </div>
   </div>
 
+</div>
 </div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/createProjectAclFile.gsp
+++ b/rundeckapp/grails-app/views/menu/createProjectAclFile.gsp
@@ -51,7 +51,7 @@
 </head>
 
 <body>
-
+<div class="content">
 <div class="container-fluid">
     <div class="row">
         <div class="col-xs-12">
@@ -85,6 +85,7 @@
             </div>
         </g:form>
     </div>
+</div>
 </div>
 
 <!--[if (gt IE 8)|!(IE)]><!--> <asset:javascript src="ace-bundle.js"/><!--<![endif]-->

--- a/rundeckapp/grails-app/views/menu/createSystemAclFile.gsp
+++ b/rundeckapp/grails-app/views/menu/createSystemAclFile.gsp
@@ -51,6 +51,7 @@
 </head>
 
 <body>
+<div class="content">
   <div class="container-fluid">
     <div class="row">
         <div class="col-sm-12">
@@ -84,6 +85,7 @@
         </g:form>
     </div>
   </div>
+</div>
 
 <!--[if (gt IE 8)|!(IE)]><!--> <asset:javascript src="ace-bundle.js"/><!--<![endif]-->
 </body>

--- a/rundeckapp/grails-app/views/menu/editProjectAclFile.gsp
+++ b/rundeckapp/grails-app/views/menu/editProjectAclFile.gsp
@@ -51,6 +51,7 @@
 </head>
 
 <body>
+<div class="content">
 <div class="container-fluid">
   <div class="row">
       <div class="col-sm-12">
@@ -76,6 +77,7 @@
           </div>
       </g:form>
   </div>
+</div>
 </div>
 
 

--- a/rundeckapp/grails-app/views/menu/editSystemAclFile.gsp
+++ b/rundeckapp/grails-app/views/menu/editSystemAclFile.gsp
@@ -50,6 +50,7 @@
 </head>
 
 <body>
+<div class="content">
 <div class="container-fluid">
   <div class="row">
       <div class="col-sm-12">
@@ -77,7 +78,7 @@
       </g:form>
   </div>
 </div>
-
+</div>
 
 
 <!--[if (gt IE 8)|!(IE)]><!--> <asset:javascript src="ace-bundle.js"/><!--<![endif]-->

--- a/rundeckapp/grails-app/views/menu/executionMode.gsp
+++ b/rundeckapp/grails-app/views/menu/executionMode.gsp
@@ -32,6 +32,7 @@
 </head>
 
 <body>
+<div class="content">
   <div class="container-fluid">
     <div class="row">
         <div class="col-sm-12">
@@ -105,5 +106,6 @@
       </div>
     </div>
   </div>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/home.gsp
+++ b/rundeckapp/grails-app/views/menu/home.gsp
@@ -69,6 +69,7 @@
     </style>
 </head>
 <body>
+<div class="content">
   <div class="row">
     <div class="col-sm-12">
       <g:render template="/common/messages"/>
@@ -415,6 +416,7 @@
       </div>
     </div>
   </div>
+</div>
 </div>
 <!-- VUE JS MODULES -->
 <asset:javascript src="static/components/version-notification.js"/>

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -525,6 +525,7 @@ search
         </div>
         </div>
 </content>
+<div class="content">
 <g:jsonToken id="ajaxFilterTokens" />
 <div class="modal fade" id="deleteJobFilterKOModal" role="dialog" aria-labelledby="deleteJobFilterKOModalLabel" aria-hidden="true" data-ko-bind="jobFilters">
     <div class="modal-dialog ">
@@ -706,7 +707,8 @@ search
     </div>
   </div>
 </div>
-
+</div>
 <g:render template="/menu/copyModal" model="[projectNames: projectNames]"/>
+
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/licenses.gsp
+++ b/rundeckapp/grails-app/views/menu/licenses.gsp
@@ -31,6 +31,7 @@
   <title><g:message code="licenses" /></title>
 </head>
 <body>
+<div class="content">
 <div class="pageBody solo licenses">
 <g:markdown>
 
@@ -336,6 +337,7 @@
     SOFTWARE.
 
 </g:markdown>
+</div>
 </div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/logStorage.gsp
+++ b/rundeckapp/grails-app/views/menu/logStorage.gsp
@@ -44,6 +44,7 @@
 </head>
 
 <body>
+<div class="content">
   <div class="container-fluid">
     <div class="row">
         <div class="col-sm-12">
@@ -303,6 +304,7 @@
         </div>
     </div>
   </div>
+</div>
 <g:jsonToken id="page_tokens" url="${request.forwardURI}"/>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/metrics.gsp
+++ b/rundeckapp/grails-app/views/menu/metrics.gsp
@@ -30,7 +30,7 @@
     <title>Metrics Links</title>
 </head>
 <body>
-
+<div class="content">
 <div class="row">
     <div class="col-sm-10 col-sm-offset-1">
 <g:markdown>
@@ -41,6 +41,6 @@
 </g:markdown>
         </div>
     </div>
-
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/plugins.gsp
+++ b/rundeckapp/grails-app/views/menu/plugins.gsp
@@ -39,6 +39,7 @@ To change this template use File | Settings | File Templates.
         context: 'application'
 )}"/>
 <body>
+<div class="content">
   <g:if test="${flash.errors}">
       <div class="alert alert-warning">
           <a class="close" data-dismiss="alert" href="#" aria-hidden="true">&times;</a>
@@ -295,5 +296,6 @@ To change this template use File | Settings | File Templates.
   </div>
 </div>
 <g:render template="pluginInstallForm" />
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/projectAcls.gsp
+++ b/rundeckapp/grails-app/views/menu/projectAcls.gsp
@@ -107,6 +107,7 @@
                          [:]}"/>
 </head>
 <body>
+<div class="content">
 <div class="container-fluid">
   <div class="row">
     <div class="col-sm-12">
@@ -175,6 +176,7 @@
                                                 uploadModalId: 'aclUpload',
                                                 uploadAction : hasCreateAuth || hasEditAuth ? [controller: 'menu', action: 'saveProjectAclFile', params: [project: params.project, upload: true]] : null
   ]"/>
+</div>
 </div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/projectDelete.gsp
+++ b/rundeckapp/grails-app/views/menu/projectDelete.gsp
@@ -33,8 +33,10 @@
 </head>
 
 <body>
+<div class="content">
   <div class="container-fluid">
     <g:render template="projectDeleteForm"/>
   </div>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/projectExport.gsp
+++ b/rundeckapp/grails-app/views/menu/projectExport.gsp
@@ -33,6 +33,7 @@
 </head>
 
 <body>
+<div class="content">
   <div class="container-fluid">
     <div class="row">
         <div class="col-xs-12">
@@ -41,5 +42,6 @@
     </div>
     <g:render template="projectExportForm"/>
   </div>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/projectHome.gsp
+++ b/rundeckapp/grails-app/views/menu/projectHome.gsp
@@ -83,6 +83,7 @@
 
 </div>
 </content>
+<div class="content">
   <div class="conntainer-fluid">
     <div class="row">
         <div class="col-xs-12">
@@ -100,5 +101,6 @@
 
   </div>
   <asset:javascript src="static/pages/project-dashboard.js"/>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/projectImport.gsp
+++ b/rundeckapp/grails-app/views/menu/projectImport.gsp
@@ -33,12 +33,13 @@
 </head>
 
 <body>
+<div class="content">
 <div class="row">
     <div class="col-sm-12">
         <g:render template="/common/messages"/>
     </div>
 </div>
 <g:render template="projectImportForm"/>
-
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/storage.gsp
+++ b/rundeckapp/grails-app/views/menu/storage.gsp
@@ -27,6 +27,7 @@ implied. - See the License for the specific language governing permissions and -
       </head>
 
       <body>
+      <div class="content">
         <g:embedJSON id="storageData" data="[resourcePath:params.resourcePath]"/>
         <div id="page_storage" class="container-fluid">
           <div class="row">
@@ -195,4 +196,5 @@ implied. - See the License for the specific language governing permissions and -
               </div>
           </div>
         </div>
+      </div>
       </body>

--- a/rundeckapp/grails-app/views/menu/systemConfig.gsp
+++ b/rundeckapp/grails-app/views/menu/systemConfig.gsp
@@ -33,6 +33,7 @@
 </head>
 
 <body>
+<div class="content">
   <div class="container-fluid">
     <div class="row">
         <div class="col-sm-12">
@@ -119,5 +120,6 @@
       </div>
     </div>
   </div>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/systemInfo.gsp
+++ b/rundeckapp/grails-app/views/menu/systemInfo.gsp
@@ -31,6 +31,7 @@
 </head>
 
 <body>
+<div class="content">
   <div class="container-fluid">
   <div class="row">
         <div class="col-sm-12">
@@ -159,5 +160,6 @@
       </div>
     </div>
   </div>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/userSummary.gsp
+++ b/rundeckapp/grails-app/views/menu/userSummary.gsp
@@ -25,7 +25,7 @@
 </head>
 
 <body>
-
+<div class="conenet">
 <div class="card card-plain">
   <div class="card-header">
     <h3 class="card-title"><g:message code="gui.menu.Users"/></h3>
@@ -35,6 +35,7 @@
     <div class="card-content">
         <div id=user-summary-vue></div>
     </div>
+</div>
 </div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/menu/welcome.gsp
+++ b/rundeckapp/grails-app/views/menu/welcome.gsp
@@ -36,6 +36,7 @@ Time: 12:54 PM
   </style>
 </head>
 <body>
+<div class="content">
   <div class="container-fluid">
     <div class="row">
       <div class="col-xs-12">
@@ -67,5 +68,6 @@ Time: 12:54 PM
       </div>
     </div>
   </div>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/passwordUtility/index.gsp
+++ b/rundeckapp/grails-app/views/passwordUtility/index.gsp
@@ -9,6 +9,7 @@
 </head>
 
 <body>
+<div class="content">
 <div class="container-fluid">
     <div class="row">
         <div class="col-sm-12">
@@ -61,5 +62,6 @@ function updateEncrypterProps() {
     })
 }
 </script>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/reports/index.gsp
+++ b/rundeckapp/grails-app/views/reports/index.gsp
@@ -99,8 +99,7 @@ search
     <asset:javascript src="static/pages/project-activity.js" defer="defer"/>
 </head>
 <body>
-
-<div>
+<div class="content">
     <div class="pageBody container-fluid">
         <g:render template="/common/messages"/>
 

--- a/rundeckapp/grails-app/views/scheduledExecution/create.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/create.gsp
@@ -86,8 +86,8 @@
     <g:embedJSON data="${timeZones ?: []}" id="timeZonesData"/>
 </head>
 <body>
-
-
+<div class="content">
     <g:render template="/scheduledExecution/createForm" model="[scheduledExecution:scheduledExecution,crontab:crontab,iscopy:iscopy,authorized:authorized]"/>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/scheduledExecution/delete.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/delete.gsp
@@ -32,6 +32,7 @@
 
 </head>
 <body>
+<div class="content">
 <g:form controller="scheduledExecution" useToken="true" action="delete" method="post" class="form form-horizontal">
     <div class="panel panel-primary">
     <div class="panel-heading">
@@ -74,5 +75,6 @@
     </div>
     </div>
 </g:form>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/scheduledExecution/edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/edit.gsp
@@ -86,8 +86,8 @@
     <g:embedJSON data="${timeZones ?: []}" id="timeZonesData"/>
 </head>
 <body>
-
-
+<div class="content">
     <tmpl:editForm model="[scheduledExecution:scheduledExecution,crontab:crontab,authorized:authorized, notificationPlugins: notificationPlugins, sessionOpts: sessionOpts]"/>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/scheduledExecution/runbook.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/runbook.gsp
@@ -32,6 +32,7 @@
 </head>
 
 <body>
+<div class="content">
 <div class="row">
     <div class="col-sm-6">
         <g:render template="/scheduledExecution/showHead"
@@ -82,7 +83,7 @@
         </div>
     </div>
 </g:if>
-
+</div>
 </body>
 </html>
 

--- a/rundeckapp/grails-app/views/scheduledExecution/show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/show.gsp
@@ -190,9 +190,11 @@ search
 </head>
 
 <body>
+<div class="content">
 <tmpl:show scheduledExecution="${scheduledExecution}" crontab="${crontab}"/>
 <g:render template="/menu/copyModal"
           model="[projectNames: projectNames]"/>
+</div>
 </body>
 </html>
 

--- a/rundeckapp/grails-app/views/scheduledExecution/upload.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/upload.gsp
@@ -43,7 +43,8 @@
     </script>
 </head>
 <body>
-
+<div class="content">
     <tmpl:uploadForm />
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/scm/diff.gsp
+++ b/rundeckapp/grails-app/views/scm/diff.gsp
@@ -33,7 +33,7 @@
 </head>
 
 <body>
-
+<div class="content">
 <div class="row">
     <div class="col-sm-12">
         <g:render template="/common/messages"/>
@@ -165,5 +165,6 @@
         });
     });
 </g:javascript>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/scm/index.gsp
+++ b/rundeckapp/grails-app/views/scm/index.gsp
@@ -35,6 +35,7 @@
 </head>
 
 <body>
+<div class="content">
   <div class="container-fluid">
     <div class="row">
       <div class="col-sm-12">
@@ -76,5 +77,6 @@
       </div>
     </div>
   </div>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/scm/performAction.gsp
+++ b/rundeckapp/grails-app/views/scm/performAction.gsp
@@ -33,7 +33,7 @@
 </head>
 
 <body>
-
+<div class="content">
 <div class="row">
     <div class="col-sm-12">
         <g:render template="/common/messages"/>
@@ -447,6 +447,7 @@
             </div>
         </g:form>
     </div>
+</div>
 </div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/scm/setup.gsp
+++ b/rundeckapp/grails-app/views/scm/setup.gsp
@@ -45,6 +45,7 @@
 </head>
 
 <body>
+<div class="content">
   <div class="container-fluid">
     <div class="row">
         <div class="col-xs-12">
@@ -105,5 +106,6 @@
     </div>
   </div>
   <g:render template="/framework/storageBrowseModalKO"/>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/searchPlugins/index.gsp
+++ b/rundeckapp/grails-app/views/searchPlugins/index.gsp
@@ -25,10 +25,12 @@
 </head>
 
 <body>
+<div class="content">
   SEARCH PLUGINS
   <div id="plugin-search-vue"></div>
   <!-- VUE JS MODULES -->
   <asset:javascript src="static/pages/search-plugins.js"/>
   <!-- /VUE JS MODULES -->
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/user/edit.gsp
+++ b/rundeckapp/grails-app/views/user/edit.gsp
@@ -23,6 +23,7 @@
 </head>
 
 <body>
+<div class="content">
   <div class="container-fluid">
     <div class="row">
         <div class="col-xs-12">
@@ -45,5 +46,6 @@
         </div>
     </div>
   </div>
+</div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/user/list.gsp
+++ b/rundeckapp/grails-app/views/user/list.gsp
@@ -23,6 +23,7 @@
 </head>
 
 <body>
+<div class="content">
 <div class="row " id="userListPage">
 
         <div class="col-sm-10 col-sm-offset-1">
@@ -44,6 +45,7 @@
     </table>
     </div>
 
+</div>
 </div>
 </body>
 </html>

--- a/rundeckapp/grails-app/views/user/profile.gsp
+++ b/rundeckapp/grails-app/views/user/profile.gsp
@@ -62,6 +62,7 @@
             id="genPageData"/>
 </head>
 <body>
+<div class="content">
 <div class="container-fluid">
   <div class="row">
       <div class="col-xs-12">
@@ -121,6 +122,7 @@
           </div>
       </div>
   </div>
+</div>
 </div>
 </body>
 </html>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/widgets/project-select/ProjectSelectButton.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/widgets/project-select/ProjectSelectButton.vue
@@ -7,7 +7,7 @@
         <i 
             class="fas project-select-btn__left-icon"
             :class="{'fa-box-open': projectLabel, 'fa-box': !projectLabel}"/>
-        <span class="project-select-btn__label">{{projectLabel || 'Select a project...'}}</span>
+        <span class="project-select-btn__label">{{projectLabel || 'Projects'}}</span>
         <i class="fas project-select-btn__right-icon" :class="[`fa-chevron-${open ? 'up' : 'down'}`]"/>
         <Popper v-if="open">
             <div id="projectPicker" class="card project-select-btn__popper">

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/stores/Projects.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/stores/Projects.ts
@@ -25,7 +25,10 @@ export class ProjectStore {
 
     search(term: string) {
         const lowerTerm = term.toLowerCase()
-        return this.projects.filter(p => p.name.toLowerCase().includes(lowerTerm))
+        return this.projects.filter(p => {
+            const pTerm = p.label || p.name
+            return pTerm.toLowerCase().includes(lowerTerm)
+        })
     }
 }
 


### PR DESCRIPTION
* Pushes content div down to page layouts
* Removes legacy footer info from all `base.gsp` pages
* Fixes user manager "z-index" problem
* Project picker searches label first and falls back to name
* Project picker displays "Projects" now when outside project context