### PR TITLE
Add bcrypt credential type for PropertyFileLoginModule

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -230,6 +230,7 @@ bootRun {
             '-Xmx2048m')
     systemProperties(System.properties)
     String springProfilesActive = 'spring.profiles.active'
+    systemProperty "rundeck.jaaslogin", "true"
     systemProperty springProfilesActive, System.getProperty(springProfilesActive)
     systemProperty "build.ident", project.version
     sourceResources sourceSets.main

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -230,7 +230,6 @@ bootRun {
             '-Xmx2048m')
     systemProperties(System.properties)
     String springProfilesActive = 'spring.profiles.active'
-    systemProperty "rundeck.jaaslogin", "true"
     systemProperty springProfilesActive, System.getProperty(springProfilesActive)
     systemProperty "build.ident", project.version
     sourceResources sourceSets.main

--- a/rundeckapp/src/main/groovy/org/rundeck/jaas/jetty/BcryptCredentialProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/jaas/jetty/BcryptCredentialProvider.groovy
@@ -20,6 +20,10 @@ class BcryptCredentialProvider implements CredentialProvider {
         boolean check(Object credentials) {
             return BCrypt.checkpw(credentials as String, hash)
         }
+
+        static String encodePassword(String raw) {
+           return String.format("%s%s",__TYPE,BCrypt.hashpw(raw,BCrypt.gensalt()))
+        }
     }
 
     String getPrefix() {

--- a/rundeckapp/src/main/groovy/org/rundeck/jaas/jetty/BcryptCredentialProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/jaas/jetty/BcryptCredentialProvider.groovy
@@ -1,0 +1,33 @@
+package org.rundeck.jaas.jetty
+
+import org.eclipse.jetty.util.security.Credential
+import org.eclipse.jetty.util.security.CredentialProvider
+import org.springframework.security.crypto.bcrypt.BCrypt
+
+
+class BcryptCredentialProvider implements CredentialProvider {
+    class BcryptCredential extends Credential {
+        private static final String __TYPE = "BCRYPT:";
+
+        String hash
+
+        BcryptCredential(String hash) {
+            super()
+            this.hash = hash.substring(__TYPE.length())
+        }
+
+        boolean check(Object credentials) {
+            return BCrypt.checkpw(credentials as String, hash)
+        }
+    }
+
+    String getPrefix() {
+        return BcryptCredential.__TYPE
+    }
+
+    @Override
+    Credential getCredential(String credential) {
+        return new BcryptCredential(credential)
+    }
+}
+

--- a/rundeckapp/src/main/groovy/org/rundeck/jaas/jetty/BcryptCredentialProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/jaas/jetty/BcryptCredentialProvider.groovy
@@ -1,10 +1,11 @@
 package org.rundeck.jaas.jetty
 
+import groovy.transform.CompileStatic
 import org.eclipse.jetty.util.security.Credential
 import org.eclipse.jetty.util.security.CredentialProvider
 import org.springframework.security.crypto.bcrypt.BCrypt
 
-
+@CompileStatic
 class BcryptCredentialProvider implements CredentialProvider {
     class BcryptCredential extends Credential {
         private static final String __TYPE = "BCRYPT:";

--- a/rundeckapp/src/main/groovy/org/rundeck/security/JettyCompatibleSpringSecurityPasswordEncoder.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/JettyCompatibleSpringSecurityPasswordEncoder.groovy
@@ -18,6 +18,8 @@ package org.rundeck.security
 import org.eclipse.jetty.util.security.Credential
 import org.eclipse.jetty.util.security.Password
 import org.grails.web.util.WebUtils
+import org.rundeck.jaas.jetty.BcryptCredentialProvider
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 class JettyCompatibleSpringSecurityPasswordEncoder implements PasswordEncoder {
     String getUsername() {
@@ -34,6 +36,7 @@ class JettyCompatibleSpringSecurityPasswordEncoder implements PasswordEncoder {
         if(encPass.startsWith("MD5:")) return Credential.MD5.digest(rawPass.toString()) == encPass
         if(encPass.startsWith("OBF:")) return Password.obfuscate(rawPass.toString()) == encPass
         if(encPass.startsWith("CRYPT:")) return Credential.Crypt.crypt(username, rawPass.toString()) == encPass
+        if(encPass.startsWith("BCRYPT:")) return new BcryptCredentialProvider().getCredential(encPass).check(rawPass)
         return encPass == rawPass
     }
 }

--- a/rundeckapp/src/main/groovy/org/rundeck/security/passwordutil/HiddenInputPasswordUtilityEncrypter.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/passwordutil/HiddenInputPasswordUtilityEncrypter.groovy
@@ -21,6 +21,7 @@ import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyUtil
 import org.eclipse.jetty.util.security.Credential
 import org.eclipse.jetty.util.security.Password
+import org.rundeck.jaas.jetty.BcryptCredentialProvider
 
 
 class HiddenInputPasswordUtilityEncrypter implements PasswordUtilityEncrypter {
@@ -48,6 +49,7 @@ class HiddenInputPasswordUtilityEncrypter implements PasswordUtilityEncrypter {
         if(!pwdCheck) returnVal.put("Error","Password Verification value is null");
         if(!pwd.equals(pwdCheck)) returnVal.put("Error","Password and Password Verification values do not match");
         if(!returnVal.isEmpty()) return returnVal;
+        returnVal.put("bcrypt", BcryptCredentialProvider.BcryptCredential.encodePassword(pwd));
         returnVal.put("obfuscate", Password.obfuscate(pwd));
         returnVal.put("md5", Credential.MD5.digest(pwd));
         if(un) returnVal.put("crypt", Credential.Crypt.crypt(un,pwd));

--- a/rundeckapp/src/main/groovy/org/rundeck/security/passwordutil/JettyPasswordUtilityEncrypter.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/passwordutil/JettyPasswordUtilityEncrypter.groovy
@@ -20,6 +20,8 @@ import com.dtolabs.rundeck.core.plugins.configuration.Property
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyUtil
 import org.eclipse.jetty.util.security.Credential
 import org.eclipse.jetty.util.security.Password
+import org.rundeck.jaas.jetty.BcryptCredentialProvider
+import org.springframework.security.crypto.bcrypt.BCrypt
 
 
 class JettyPasswordUtilityEncrypter implements PasswordUtilityEncrypter {
@@ -38,6 +40,7 @@ class JettyPasswordUtilityEncrypter implements PasswordUtilityEncrypter {
         def result = [:]
         String valToEncrypt = params.get("valueToEncrypt")
         String un = params.get("username")
+        result.bcrypt = BcryptCredentialProvider.BcryptCredential.encodePassword(valToEncrypt)
         result.obfuscate = Password.obfuscate(valToEncrypt)
         result.md5 = Credential.MD5.digest(valToEncrypt)
         if(un) {

--- a/rundeckapp/src/main/resources/META-INF/services/org.eclipse.jetty.util.security.CredentialProvider
+++ b/rundeckapp/src/main/resources/META-INF/services/org.eclipse.jetty.util.security.CredentialProvider
@@ -1,0 +1,1 @@
+org.rundeck.jaas.jetty.BcryptCredentialProvider

--- a/rundeckapp/src/test/groovy/org/rundeck/security/passwordutil/JettyPasswordUtilityEncrypterTest.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/security/passwordutil/JettyPasswordUtilityEncrypterTest.groovy
@@ -27,7 +27,8 @@ class JettyPasswordUtilityEncrypterTest extends Specification {
         params.valueToEncrypt = "anyoldpassword"
         def output = encrypter.encrypt(params)
         then:
-        output.size() == 3
+        output.size() == 4
+        output["bcrypt"].startsWith("BCRYPT:")
         output["obfuscate"].startsWith("OBF:")
         output["md5"].startsWith("MD5:")
         output["crypt"].startsWith("CRYPT:")

--- a/rundeckapp/src/test/groovy/rundeckapp/cli/CommandLineSetupTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/cli/CommandLineSetupTest.groovy
@@ -88,14 +88,15 @@ class CommandLineSetupTest extends Specification {
             ex = tex
         }
 
-        def output = sysOut.toString().split('\\n')
+        def output = sysOut.toString().split('\\n').toList()
 
         then:
         ex.message == "system.exit 0"
-        output[output.length -4 ].contains("==ENCRYPTED OUTPUT==")
-        output[output.length -3 ].startsWith("obfuscate:")
-        output[output.length -2 ].startsWith("md5:")
-        output[output.length -1 ].startsWith("crypt:")
+        output.find { it.startsWith("==ENCRYPTED OUTPUT==") }
+        output.find { it.startsWith("bcrypt:") }
+        output.find { it.startsWith("obfuscate:") }
+        output.find { it.startsWith("crypt:") }
+        output.find { it.startsWith("md5:") }
 
     }
 
@@ -117,14 +118,15 @@ class CommandLineSetupTest extends Specification {
             ex = tex
         }
 
-        def output = sysOut.toString().split('\\n')
+        def output = sysOut.toString().split('\\n').toList()
 
         then:
         ex.message == "system.exit 0"
-        output[output.length -4 ].contains("==ENCRYPTED OUTPUT==")
-        output[output.length -3 ].startsWith("obfuscate:")
-        output[output.length -2 ].startsWith("crypt:")
-        output[output.length -1 ].startsWith("md5:")
+        output.find { it.startsWith("==ENCRYPTED OUTPUT==") }
+        output.find { it.startsWith("bcrypt:") }
+        output.find { it.startsWith("obfuscate:") }
+        output.find { it.startsWith("crypt:") }
+        output.find { it.startsWith("md5:") }
 
     }
 


### PR DESCRIPTION
Addresses #6817 

* Adds a bcrypt credential provider and type
* Requires jaas login to be enabled
* Spring security version we use apparently does not support salt revisions so `$2a$` but not `$2y$` works