### PR TITLE
Add group: and user: urn support for ACL subjects

### DIFF
--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
@@ -96,7 +96,7 @@ public class RuleEvaluator implements AclRuleSetAuthorization {
 
     }
 
-    private static boolean matchesContexts(
+    public static boolean matchesContexts(
             final AclRule rule,
             final AclSubject subject,
             final Set<Attribute> environment
@@ -104,100 +104,55 @@ public class RuleEvaluator implements AclRuleSetAuthorization {
     {
         if (rule.getEnvironment() != null) {
             final EnvironmentalContext environment1 = rule.getEnvironment();
-            if (!environment1.isValid()) {
-//                logger.warn(rule.toString() + ": Context section not valid: " + environment1.toString());
-            }
             if (!environment1.matches(environment)) {
-//                if (logger.isDebugEnabled()) {
-//                    logger.debug(rule.toString() + ": environment not matched: " + environment1.toString());
-//                }
                 return false;
             }
         } else if (null != environment && environment.size() > 0) {
-//            logger.debug(rule.toString() + ": empty environment not matched");
             return false;
         }
 
-        if(rule.isBy()) {
-            if (subject.getUsername() != null && rule.getUsername() != null) {
-
-                if (subject.getUsername().equals(rule.getUsername())
-                        || matchesPattern(subject.getUsername(), rule.getUsername())
-                        ) {
-                    return true;
-                } else if (rule.getUsername() != null) {
-//                    if (logger.isDebugEnabled()) {
-//                        logger.debug(rule.toString() + ": username not matched: " + rule.getUsername());
-//                    }
-                }
+        boolean isBy = rule.isBy();
+        if (subject.getUsername() != null && rule.getUsername() != null) {
+            if (subject.getUsername().equals(rule.getUsername())
+                || matchesPattern(subject.getUsername(), rule.getUsername())
+            ) {
+                return isBy;
             }
-
-
-            if (subject.getGroups() != null && subject.getGroups().size() > 0) {
-                // no username matched, check groups.
-                if (subject.getGroups().contains(rule.getGroup())
-                        || matchesAnyPatterns(subject.getGroups(), rule.getGroup())) {
-                    return true;
-                } else if (subject.getGroups().size() > 0) {
-//                    if (logger.isDebugEnabled()) {
-//                        logger.debug(rule.toString() + ": group not matched: " + rule.getGroup());
-//                    }
-                }
-            }
-
-            if (subject.getUrn() != null && rule.getUrn() != null) {
-                if (subject.getUrn().equals(rule.getUrn())) {
-                    return true;
-                }
-            }
-
-            //rule urn match for user: urn against username
-            if (subject.getUsername() != null && rule.getUrn() != null && rule.getUrn().startsWith("user:")) {
-                if (("user:"+subject.getUsername()).equals(rule.getUrn())) {
-                    return true;
-                }
-            }
-            //rule urn match for role: urn against groups
-            if (subject.getGroups() != null && rule.getUrn() != null && rule.getUrn().startsWith("group:")) {
-                if (subject
-                        .getGroups()
-                        .stream()
-                        .map(a -> "group:" + a)
-                        .collect(Collectors.toSet())
-                        .contains(rule.getUrn())) {
-                    return true;
-                }
-            }
-        }else { //notBy acl
-            if (subject.getUsername() != null && rule.getUsername() != null) {
-                if (subject.getUsername().equals(rule.getUsername())
-                        || matchesPattern(subject.getUsername(), rule.getUsername())
-                        ) {
-                    return false;
-                } else if (rule.getUsername() != null) {
-//                    if (logger.isDebugEnabled()) {
-//                        logger.debug(rule.toString() + ": username not excluded: " + rule.getUsername());
-//                    }
-                }
-            }
-            if (subject.getGroups().size() > 0) {
-                if (subject.getGroups().contains(rule.getGroup())
-                        || matchesAnyPatterns(subject.getGroups(), rule.getGroup())) {
-                    return false;
-                } else if (subject.getGroups().size() > 0) {
-//                    if (logger.isDebugEnabled()) {
-//                        logger.debug(rule.toString() + ": group not excluded: " + rule.getGroup());
-//                    }
-                }
-            }
-            if (subject.getUrn() != null && rule.getUrn() != null) {
-                if (subject.getUrn().equals(rule.getUrn())) {
-                    return false;
-                }
-            }
-            return true;
         }
-        return false;
+
+
+        if (subject.getGroups() != null && subject.getGroups().size() > 0) {
+            // no username matched, check groups.
+            if (subject.getGroups().contains(rule.getGroup())
+                || matchesAnyPatterns(subject.getGroups(), rule.getGroup())) {
+                return isBy;
+            }
+        }
+
+        if (subject.getUrn() != null && rule.getUrn() != null) {
+            if (subject.getUrn().equals(rule.getUrn())) {
+                return isBy;
+            }
+        }
+
+        //rule urn match for user: urn against username
+        if (subject.getUsername() != null && rule.getUrn() != null && rule.getUrn().startsWith("user:")) {
+            if (("user:" + subject.getUsername()).equals(rule.getUrn())) {
+                return isBy;
+            }
+        }
+        //rule urn match for role: urn against groups
+        if (subject.getGroups() != null && rule.getUrn() != null && rule.getUrn().startsWith("group:")) {
+            if (subject
+                    .getGroups()
+                    .stream()
+                    .map(a -> "group:" + a)
+                    .collect(Collectors.toSet())
+                    .contains(rule.getUrn())) {
+                return isBy;
+            }
+        }
+        return !isBy;
     }
 
     public static boolean matchesAnyPatterns(final Collection<String> groups, final String patternStr) {

--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
@@ -150,6 +150,24 @@ public class RuleEvaluator implements AclRuleSetAuthorization {
                     return true;
                 }
             }
+
+            //rule urn match for user: urn against username
+            if (subject.getUsername() != null && rule.getUrn() != null && rule.getUrn().startsWith("user:")) {
+                if (("user:"+subject.getUsername()).equals(rule.getUrn())) {
+                    return true;
+                }
+            }
+            //rule urn match for role: urn against groups
+            if (subject.getGroups() != null && rule.getUrn() != null && rule.getUrn().startsWith("role:")) {
+                if (subject
+                        .getGroups()
+                        .stream()
+                        .map(a -> "role:" + a)
+                        .collect(Collectors.toSet())
+                        .contains(rule.getUrn())) {
+                    return true;
+                }
+            }
         }else { //notBy acl
             if (subject.getUsername() != null && rule.getUsername() != null) {
                 if (subject.getUsername().equals(rule.getUsername())

--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
@@ -158,11 +158,11 @@ public class RuleEvaluator implements AclRuleSetAuthorization {
                 }
             }
             //rule urn match for role: urn against groups
-            if (subject.getGroups() != null && rule.getUrn() != null && rule.getUrn().startsWith("role:")) {
+            if (subject.getGroups() != null && rule.getUrn() != null && rule.getUrn().startsWith("group:")) {
                 if (subject
                         .getGroups()
                         .stream()
-                        .map(a -> "role:" + a)
+                        .map(a -> "group:" + a)
                         .collect(Collectors.toSet())
                         .contains(rule.getUrn())) {
                     return true;

--- a/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
+++ b/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
@@ -616,7 +616,7 @@ class RuleEvaluatorSpec extends Specification {
                         sourceIdentity: 'i',
                         username      : null,
                         group         : null,
-                        urn           : 'role:urnrole1',
+                        urn           : 'group:urnrole1',
                         environment   : BasicEnvironmentalContext.staticContextFor("application", "rundeck")
                 ],
                 [
@@ -630,7 +630,7 @@ class RuleEvaluatorSpec extends Specification {
                         sourceIdentity: 'k',
                         username      : null,
                         group         : null,
-                        urn           : 'role:urnrole2',
+                        urn           : 'group:urnrole2',
                         environment   : BasicEnvironmentalContext.staticContextFor("project", "testproj1")
                 ],
                 [
@@ -676,7 +676,7 @@ class RuleEvaluatorSpec extends Specification {
         //urn
         null      | null                   | 'project:testproj1'    | null        | ['h']
 
-        //urn role: and user: specifier in acl
+        //urn group: and user: specifier in acl
         'auser'   | ['urnrole1']           | null    | null        | ['i']
         'auser'   | ['urnrole1','dev']     | null    | null        | ['a', 'i']
         'urnuserA'| ['asdf']               | null    | null        | ['j']

--- a/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
+++ b/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
@@ -687,6 +687,62 @@ class RuleEvaluatorSpec extends Specification {
 
     }
 
+    @Unroll
+    def "matchesContexts"() {
+        given:
+
+            AclSubject subject = Mock(AclSubject) {
+                getUsername() >> testuser
+                getGroups() >> testgroups
+                getUrn() >> testurn
+            }
+            def rule = basicRule([username: null, group: null, urn: null, by:isby] + detail)
+            def env = projenv ? [new Attribute(AuthorizationUtil.PROJECT_BASE_URI, projenv)] as Set :
+                      AuthorizationUtil.RUNDECK_APP_ENV
+
+        expect:
+            RuleEvaluator.matchesContexts(rule, subject, env) == expect
+        where:
+            detail                  | isby  | projenv | testuser | testgroups | testurn        | expect
+            [group: 'dev']          | true  | null    | 'bob'    | ['dev']    | null           | true
+            [group: 'qa']           | true  | null    | 'bob'    | ['dev']    | null           | false
+            [group: '(dev|qa)']     | true  | null    | 'bob'    | ['dev']    | null           | true
+            [group: '(dev|qa)']     | true  | null    | 'bob'    | ['qa']     | null           | true
+            [group: '(dev|qa)']     | true  | null    | 'bob'    | ['prod']   | null           | false
+            [group: 'dev']          | false | null    | 'bob'    | ['dev']    | null           | false
+            [group: 'qa']           | false | null    | 'bob'    | ['dev']    | null           | true
+            [group: '(dev|qa)']     | false | null    | 'bob'    | ['dev']    | null           | false
+            [group: '(dev|qa)']     | false | null    | 'bob'    | ['qa']     | null           | false
+            [group: '(dev|qa)']     | false | null    | 'bob'    | ['prod']   | null           | true
+
+            [username: 'bob']       | true  | null    | 'bob'    | ['dev']    | null           | true
+            [username: 'sam']       | true  | null    | 'bob'    | ['dev']    | null           | false
+            [username: '(bob|sam)'] | true  | null    | 'bob'    | ['dev']    | null           | true
+            [username: '(bob|sam)'] | true  | null    | 'sam'    | ['dev']    | null           | true
+            [username: '(bob|sam)'] | true  | null    | 'ann'    | ['dev']    | null           | false
+            [username: 'bob']       | false | null    | 'bob'    | ['dev']    | null           | false
+            [username: 'sam']       | false | null    | 'bob'    | ['dev']    | null           | true
+            [username: '(bob|sam)'] | false | null    | 'bob'    | ['dev']    | null           | false
+            [username: '(bob|sam)'] | false | null    | 'sam'    | ['dev']    | null           | false
+            [username: '(bob|sam)'] | false | null    | 'ann'    | ['dev']    | null           | true
+
+            [urn: 'group:dev']      | true  | null    | 'bob'    | ['dev']    | null           | true
+            [urn: 'group:qa']       | true  | null    | 'bob'    | ['dev']    | null           | false
+
+            [urn: 'group:dev']      | false | null    | 'bob'    | ['dev']    | null           | false
+            [urn: 'group:qa']       | false | null    | 'bob'    | ['dev']    | null           | true
+
+            [urn: 'user:bob']       | true  | null    | 'bob'    | ['dev']    | null           | true
+            [urn: 'user:sam']       | true  | null    | 'bob'    | ['dev']    | null           | false
+            [urn: 'user:bob']       | false | null    | 'bob'    | ['dev']    | null           | false
+            [urn: 'user:sam']       | false | null    | 'bob'    | ['dev']    | null           | true
+
+            [urn: 'project:blah']   | true  | null    | null     | null       | 'project:blah' | true
+            [urn: 'project:blee']   | true  | null    | null     | null       | 'project:blah' | false
+            [urn: 'project:blah']   | false | null    | null     | null       | 'project:blah' | false
+            [urn: 'project:blee']   | false | null    | null     | null       | 'project:blah' | true
+    }
+
 
     def "test allow using notBy group"(){
         given:
@@ -806,27 +862,30 @@ class RuleEvaluatorSpec extends Specification {
     }
 
 
+    AclRule basicRule(Map detail) {
+        new Rule(
+            [
+                sourceIdentity: "test1",
+                description   : "bob job allow exec, deny delete for admin group",
+                equalsResource: [
+                    jobName: 'bob'
+                ],
+                resourceType  : 'job',
+                regexMatch    : false,
+                containsMatch : false,
+                equalsMatch   : true,
+                username      : null,
+                group         : 'admin',
+                allowActions  : ['EXECUTE'] as Set,
+                denyActions   : ['DELETE'] as Set,
+                by: true,
+                environment   : BasicEnvironmentalContext.staticContextFor("application", "rundeck")
+            ] + detail
+        )
+    }
     AclRuleSet basicRulesFromList(List input) {
-        def rules = input.collect { detail ->
-            new Rule(
-                    [
-                            sourceIdentity: "test1",
-                            description   : "bob job allow exec, deny delete for admin group",
-                            equalsResource: [
-                                    jobName: 'bob'
-                            ],
-                            resourceType  : 'job',
-                            regexMatch    : false,
-                            containsMatch : false,
-                            equalsMatch   : true,
-                            username      : null,
-                            group         : 'admin',
-                            allowActions  : ['EXECUTE'] as Set,
-                            denyActions   : ['DELETE'] as Set,
-                            by: true,
-                            environment   : BasicEnvironmentalContext.staticContextFor("application", "rundeck")
-                    ] + detail
-            )
+        def rules = input.collect {Map detail ->
+            basicRule(detail)
         } as Set
         new AclRuleSetImpl(rules)
     }

--- a/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
+++ b/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
@@ -611,6 +611,34 @@ class RuleEvaluatorSpec extends Specification {
                         group         : null,
                         urn           : 'project:testproj1',
                         environment   : BasicEnvironmentalContext.staticContextFor("application", "rundeck")
+                ],
+                [
+                        sourceIdentity: 'i',
+                        username      : null,
+                        group         : null,
+                        urn           : 'role:urnrole1',
+                        environment   : BasicEnvironmentalContext.staticContextFor("application", "rundeck")
+                ],
+                [
+                        sourceIdentity: 'j',
+                        username      : null,
+                        group         : null,
+                        urn           : 'user:urnuserA',
+                        environment   : BasicEnvironmentalContext.staticContextFor("application", "rundeck")
+                ],
+                [
+                        sourceIdentity: 'k',
+                        username      : null,
+                        group         : null,
+                        urn           : 'role:urnrole2',
+                        environment   : BasicEnvironmentalContext.staticContextFor("project", "testproj1")
+                ],
+                [
+                        sourceIdentity: 'l',
+                        username      : null,
+                        group         : null,
+                        urn           : 'user:urnuserB',
+                        environment   : BasicEnvironmentalContext.staticContextFor("project", "testproj1")
                 ]
         ]
         )
@@ -647,6 +675,15 @@ class RuleEvaluatorSpec extends Specification {
 
         //urn
         null      | null                   | 'project:testproj1'    | null        | ['h']
+
+        //urn role: and user: specifier in acl
+        'auser'   | ['urnrole1']           | null    | null        | ['i']
+        'auser'   | ['urnrole1','dev']     | null    | null        | ['a', 'i']
+        'urnuserA'| ['asdf']               | null    | null        | ['j']
+        'auser'   | ['urnrole2']           | null    | 'testproj1' | ['k']
+        'auser'   | ['urnrole2','blah']    | null    | 'testproj1' | ['d','k']
+        'urnuserB'| ['asdf']               | null    | 'testproj1' | ['l']
+
 
     }
 


### PR DESCRIPTION
This extends the ACL Policy format to allow using URNs
for user or role/group subjects in an exact match.

Using a `by: urn: "user:bob"` clause in the ACLpolicy defines
an exact match for a username "bob".

Using `by: urn: "group:dev"` defines exact match for group "dev".


**Is this a bugfix, or an enhancement? Please describe.**

Enhances ACL policy format to let an exact user or group match occur using the `urn:` clause.

