### PR TITLE
cleanup execution in non-cluster mode 

### DIFF
--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
@@ -169,10 +169,11 @@ class ExecutionsCleanUp implements InterruptableJob {
 
         Map jobList = executionService.queryExecutions(createCriteria(
                 project,
+                frameworkService.isClusterModeEnabled(),
                 maxDaysToKeep,
                 maximumDeletionSize,
-                frameworkService.isClusterModeEnabled()?serverUUID:null,
-                frameworkService.isClusterModeEnabled()?listDeadMembers:null,
+                serverUUID,
+                listDeadMembers,
                 removeNullServerUUID)
 
         )
@@ -239,7 +240,7 @@ class ExecutionsCleanUp implements InterruptableJob {
         return null != total ? total : 0
     }
 
-    private Closure createCriteria(String project, Integer maxDaysToKeep = 0, Integer maxDetetionSize = 500, String serverNodeUUID = null, List<String> deadMembers = null, boolean removeNullServerUUID = false){
+    private Closure createCriteria(String project, boolean isClusterEnabled, Integer maxDaysToKeep = 0, Integer maxDetetionSize = 500, String serverNodeUUID = null, List<String> deadMembers = null, boolean removeNullServerUUID = false){
         Date endDate=ExecutionQuery.parseRelativeDate("${maxDaysToKeep}d")
         return {isCount ->
             if(!isCount){
@@ -249,7 +250,7 @@ class ExecutionsCleanUp implements InterruptableJob {
                 }
             }
 
-            if(serverNodeUUID){
+            if(isClusterEnabled){
                 if(!deadMembers){
                     eq('serverNodeUUID', serverNodeUUID)
                 }else{
@@ -265,8 +266,6 @@ class ExecutionsCleanUp implements InterruptableJob {
                     }
 
                 }
-            } else {
-                isNull('serverNodeUUID')
             }
 
             eq('project', project)

--- a/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionsCleanUpTest.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionsCleanUpTest.groovy
@@ -58,11 +58,12 @@ class ExecutionsCleanUpTest extends GroovyTestCase{
             endDate
         }
         Date execDate = new Date(2015 - 1900, 02, 03)
+        FrameworkService frameworkService = initNonClusterFrameworkService()
+
         ScheduledExecution se = setupJob(projName)
-        Execution execution = setupExecution(se, projName, execDate, execDate)
+        Execution execution = setupExecution(se, projName, execDate, execDate, frameworkService.getServerUUID())
         ExecutionsCleanUp job = new ExecutionsCleanUp()
 
-        FrameworkService frameworkService = initNonClusterFrameworkService()
         List execIdsToExclude = job.searchExecutions(
                 frameworkService,
                 new ExecutionService(),
@@ -97,8 +98,6 @@ class ExecutionsCleanUpTest extends GroovyTestCase{
 
 
         logFileStorageService.demand.getExecutionFiles(1..999) { e , filters, endpoint ->  [:] }
-
-        Execution execution = setupExecution(se, projName, execDate, execDate)
 
         Assert.assertEquals(true, execIdsToExclude.size() > 0)
 
@@ -164,7 +163,7 @@ class ExecutionsCleanUpTest extends GroovyTestCase{
 
     }
 
-    Execution setupExecution(ScheduledExecution se, String projName, Date startDate, Date finishDate) {
+    Execution setupExecution(ScheduledExecution se, String projName, Date startDate, Date finishDate, String serverUUID = null) {
         Execution e
         Execution.withNewTransaction {
             e = new Execution(
@@ -179,8 +178,11 @@ class ExecutionsCleanUpTest extends GroovyTestCase{
                             commands: [new CommandExec(
                                     [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
                             )]
-                    )
+                    ),
             )
+            if(serverUUID){
+                e.serverNodeUUID = serverUUID
+            }
             e.save()
         }
         return e


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
bug fix: execution cleanup doesn't work as expected when cluster mode is off
cleanup execution in non-cluster mode shouldn't filter by serverNodeUuid.

**Describe the solution you've implemented**
remove serverNodeUuid filter on execution table when cluster mode is off

**Describe alternatives you've considered**

**Additional context**
 issue https://github.com/rundeck/rundeck/issues/6674
