### PR TITLE
Update base Docker image

### DIFF
--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -1,4 +1,4 @@
-FROM rundeck/ubuntu-base@sha256:e9f21a4252c80b145a18c2d0de55453073b551c5ca737d449df4d942f0d1a443
+FROM rundeck/ubuntu-base@sha256:4c2bf3da1b01cbfae43a17b9e7967895166ef90133adc02ea2cb177eee1fab6c
 
 COPY --chown=rundeck:root .build .
 RUN java -jar rundeck.war --installonly \

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -1,6 +1,6 @@
 # Build remco from specific commit
 ##################################
-FROM golang
+FROM golang:1.14
 
 RUN go get github.com/HeavyHorst/remco/cmd/remco
 RUN cd $GOPATH/src/github.com/HeavyHorst/remco && \


### PR DESCRIPTION
Addresses #6850 

Refreshes the base Ubuntu 18.04 image used to build the Docker images.