### PR TITLE
Move System Report config menu link to bean definition

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -18,6 +18,7 @@
 import com.dtolabs.rundeck.app.api.ApiMarshallerRegistrar
 import com.dtolabs.rundeck.app.gui.GroupedJobListLinkHandler
 import com.dtolabs.rundeck.app.gui.JobListLinkHandlerRegistry
+import com.dtolabs.rundeck.app.gui.SystemReportMenuItem
 import com.dtolabs.rundeck.app.gui.UserSummaryMenuItem
 import com.dtolabs.rundeck.app.internal.framework.ConfigFrameworkPropertyLookupFactory
 import com.dtolabs.rundeck.app.config.RundeckConfig
@@ -573,6 +574,7 @@ beans={
     }
 
     userSummaryMenuItem(UserSummaryMenuItem)
+    systemReportMenuItem(SystemReportMenuItem)
 
     rundeckUserDetailsService(RundeckUserDetailsService)
     rundeckJaasAuthorityGranter(RundeckJaasAuthorityGranter){

--- a/rundeckapp/grails-app/views/menu/_sysConfigNavMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_sysConfigNavMenu.gsp
@@ -72,11 +72,6 @@
       </g:link>
     </li>
     <li>
-      <g:link controller="menu" action="systemInfo">
-        <g:message code="gui.menu.SystemInfo"/>
-      </g:link>
-    </li>
-    <li>
       <g:link shown="${g.logStorageEnabled()}" controller="menu" action="logStorage">
         <g:message code="gui.menu.LogStorage"/>
       </g:link>

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/gui/SystemReportMenuItem.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/gui/SystemReportMenuItem.groovy
@@ -1,0 +1,41 @@
+package com.dtolabs.rundeck.app.gui
+
+import com.dtolabs.rundeck.core.authorization.AuthContextEvaluator
+import com.dtolabs.rundeck.core.authorization.AuthorizationUtil
+import com.dtolabs.rundeck.core.authorization.Decision
+import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import grails.web.mapping.LinkGenerator
+import groovy.transform.CompileStatic
+import org.rundeck.app.gui.AuthMenuItem
+import org.rundeck.core.auth.AuthConstants
+import org.springframework.beans.factory.annotation.Autowired
+
+@CompileStatic
+class SystemReportMenuItem implements AuthMenuItem {
+    @Autowired
+    LinkGenerator grailsLinkGenerator
+    @Autowired
+    AuthContextEvaluator rundeckAuthContextEvaluator
+
+    final MenuType type = MenuType.SYSTEM_CONFIG
+    final String titleCode = 'gui.menu.SystemInfo'
+    final String title = 'System Report'
+
+    @Override
+    String getHref() {
+        return grailsLinkGenerator.link(
+            action: "menu",
+            controller: "systemInfo"
+        )
+    }
+
+    @Override
+    boolean isEnabled(final UserAndRolesAuthContext auth) {
+        return rundeckAuthContextEvaluator.
+            authorizeApplicationResourceAny(
+                auth,
+                AuthConstants.RESOURCE_TYPE_SYSTEM,
+                [AuthConstants.ACTION_READ, AuthConstants.ACTION_ADMIN]
+            )
+    }
+}


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Refactor the System Report system config menu item to be defined in a bean.
