### PR TITLE
Apply margin rule to direct card footer children

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/theme-next/scss/paper/_cards.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme-next/scss/paper/_cards.scss
@@ -157,7 +157,7 @@
     .card-footer > .card-footer{
         margin-top: 10px;
     }
-    .card-footer :not(.btn-group) > .btn + .btn {
+    .card-footer :not(.btn-group) > .btn + .btn, .card-footer > .btn + .btn {
         margin-left: 10px;
     }
     .text-warning{

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme-next/scss/paper/_cards.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme-next/scss/paper/_cards.scss
@@ -153,13 +153,16 @@
             display: inline-block;
         }
 
+        // Space adjacent buttons as long as they are not in a button group
+        > .btn + .btn,
+        :not(.btn-group) > .btn + .btn {
+            margin-left: 10px;
+        }
     }
     .card-footer > .card-footer{
         margin-top: 10px;
     }
-    .card-footer :not(.btn-group) > .btn + .btn, .card-footer > .btn + .btn {
-        margin-left: 10px;
-    }
+
     .text-warning{
         margin: 0 10px;
     }


### PR DESCRIPTION
Fixes button spacing in card footers when buttons are direct children of the footer.

Good ol' CSS.