### PR TITLE
Mitigate h2 errors

### DIFF
--- a/docker/official/README.md
+++ b/docker/official/README.md
@@ -136,7 +136,7 @@ the container.
 
 ### `RUNDECK_DATABASE_URL`
 
-Defaults to `jdbc:h2:file:/home/rundeck/server/data/grailsdb;MVCC=true`. The default configuration utilizes an h2 file for data storage.
+Defaults to `jdbc:h2:file:/home/rundeck/server/data/grailsdb;DB_CLOSE_ON_EXIT=FALSE`. The default configuration utilizes an h2 file for data storage.
 
 ### `RUNDECK_DATABASE_DRIVER`
 

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -16,7 +16,7 @@ rundeck.multiURL.enabled={{ getv("/rundeck/multiurl/enabled", "false") }}
 server.servlet.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
 
 dataSource.dbCreate = {{ getv("/rundeck/database/create", "update") }}
-dataSource.url = {{ getv("/rundeck/database/url", printf("jdbc:h2:file:%s/server/data/grailsdb;MVCC=true;DB_CLOSE_ON_EXIT=FALSE", rundeckHome)) }}
+dataSource.url = {{ getv("/rundeck/database/url", printf("jdbc:h2:file:%s/server/data/grailsdb;DB_CLOSE_ON_EXIT=FALSE", rundeckHome)) }}
 dataSource.username = {{ getv("/rundeck/database/username", "") }}
 dataSource.password = {{ getv("/rundeck/database/password", "") }}
 {% if exists("/rundeck/database/driver") %}

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -16,7 +16,7 @@ rundeck.multiURL.enabled={{ getv("/rundeck/multiurl/enabled", "false") }}
 server.servlet.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
 
 dataSource.dbCreate = {{ getv("/rundeck/database/create", "update") }}
-dataSource.url = {{ getv("/rundeck/database/url", printf("jdbc:h2:file:%s/server/data/grailsdb;MVCC=true", rundeckHome)) }}
+dataSource.url = {{ getv("/rundeck/database/url", printf("jdbc:h2:file:%s/server/data/grailsdb;MVCC=true;DB_CLOSE_ON_EXIT=FALSE", rundeckHome)) }}
 dataSource.username = {{ getv("/rundeck/database/username", "") }}
 dataSource.password = {{ getv("/rundeck/database/password", "") }}
 {% if exists("/rundeck/database/driver") %}

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -144,7 +144,7 @@ dependencies {
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: "${httpClientVersion}"
     profile "org.grails.profiles:web"
 //    runtime "org.springframework:spring-test:5.0.3.RELEASE"
-    runtime "com.h2database:h2:1.4.199"
+    runtime "com.h2database:h2:1.4.200"
     runtime 'org.apache.logging.log4j:log4j-web:2.13.3'
 
     // Database drivers

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -144,7 +144,7 @@ dependencies {
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: "${httpClientVersion}"
     profile "org.grails.profiles:web"
 //    runtime "org.springframework:spring-test:5.0.3.RELEASE"
-    runtime "com.h2database:h2:1.4.200"
+    runtime "com.h2database:h2:1.4.199"
     runtime 'org.apache.logging.log4j:log4j-web:2.13.3'
 
     // Database drivers

--- a/rundeckapp/templates/config/rundeck-config.properties.template
+++ b/rundeckapp/templates/config/rundeck-config.properties.template
@@ -7,7 +7,7 @@ rss.enabled=false
 server.address=${server.hostname}
 grails.serverURL=http://${server.hostname}:${server.http.port}${server.web.context}
 dataSource.dbCreate = update
-dataSource.url = jdbc:h2:file:${server.datastore.path};MVCC=true
+dataSource.url = jdbc:h2:file:${server.datastore.path};MVCC=true;DB_CLOSE_ON_EXIT=FALSE
 
 # Pre Auth mode settings
 rundeck.security.authorization.preauthenticated.enabled=false

--- a/rundeckapp/templates/config/rundeck-config.properties.template
+++ b/rundeckapp/templates/config/rundeck-config.properties.template
@@ -7,7 +7,7 @@ rss.enabled=false
 server.address=${server.hostname}
 grails.serverURL=http://${server.hostname}:${server.http.port}${server.web.context}
 dataSource.dbCreate = update
-dataSource.url = jdbc:h2:file:${server.datastore.path};MVCC=true;DB_CLOSE_ON_EXIT=FALSE
+dataSource.url = jdbc:h2:file:${server.datastore.path};DB_CLOSE_ON_EXIT=FALSE
 
 # Pre Auth mode settings
 rundeck.security.authorization.preauthenticated.enabled=false

--- a/test/docker/dockers/rundeck/scripts/start_rundeck.sh
+++ b/test/docker/dockers/rundeck/scripts/start_rundeck.sh
@@ -244,7 +244,7 @@ rss.enabled=false
 server.address=0.0.0.0
 grails.serverURL=${RUNDECK_URL}
 dataSource.dbCreate = update
-dataSource.url = jdbc:h2:file:/home/rundeck/server/data/grailsdb;MVCC=true
+dataSource.url = jdbc:h2:file:/home/rundeck/server/data/grailsdb;DB_CLOSE_ON_EXIT=FALSE
 dataSource.properties.removeAbandoned=true
 dataSource.properties.removeAbandonedTimeout=5
 

--- a/test/docker/dockers/tomcat/rundeck-config.properties
+++ b/test/docker/dockers/tomcat/rundeck-config.properties
@@ -7,7 +7,7 @@ rss.enabled=false
 server.address=127.0.0.1
 grails.serverURL=http://127.0.0.1:8080/rundeck
 dataSource.dbCreate = update
-dataSource.url = jdbc:h2:file:/usr/local/tomcat/webapps/rundeck/rundeck/server/data/grailsdb;MVCC=true
+dataSource.url = jdbc:h2:file:/usr/local/tomcat/webapps/rundeck/rundeck/server/data/grailsdb;DB_CLOSE_ON_EXIT=FALSE
 
 # Pre Auth mode settings
 rundeck.security.authorization.preauthenticated.enabled=false


### PR DESCRIPTION
resolves #6003

* Removes `MVCC` which had been deprecated and a noop but will cause error in `1.4.200+`
* Instructs h2 not to shutdown when VM is shutting down to mitigate hibernate errors during shutdown

This does not bump the H2 version. We are currently on the second-to-last patch release of H2 which has not been updated in over a year. The latest patch release removes the `MVCC` jdbc parameter and throws an error if it is used. The Grails GORM project still uses this directive and it is causing a test to break. They have removed it in `7.1`, but that is not the latest release version: https://www.gitmemory.com/issue/grails/grails-core/11630/705501839 .