### PR TITLE
Implement navbar sort priority for menu items

### DIFF
--- a/core/src/main/java/org/rundeck/app/gui/MenuItem.java
+++ b/core/src/main/java/org/rundeck/app/gui/MenuItem.java
@@ -29,6 +29,13 @@ public interface MenuItem {
      */
     public MenuType getType();
 
+    /**
+     * Sort key
+     */
+    default Integer getPriority() {
+        return 0;
+    }
+
     enum MenuDomain {
         SYSTEM,
         PROJECT,

--- a/grails-webhooks/src/main/groovy/webhooks/menu/WebhooksMenuItem.groovy
+++ b/grails-webhooks/src/main/groovy/webhooks/menu/WebhooksMenuItem.groovy
@@ -29,6 +29,7 @@ class WebhooksMenuItem implements MenuItem, AuthMenuItem {
     String title = "Webhooks"
     String titleCode = "Webhooks.title"
     MenuType type = MenuType.PROJECT
+    Integer priority = 700
 
     @Autowired
     LinkGenerator grailsLinkGenerator

--- a/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
@@ -1930,6 +1930,9 @@ ansi-bg-default'''))
         applicationContext.getBeansOfType(MenuItem).
                 findAll { it.value.type == menuType }.
                 findAll { checkEnabled.apply(it.value) }.
+                sort {a, b->
+                    a.value.priority <=> b.value.priority
+                }.
                 each { name, MenuItem item ->
                     out << body((var): item)
                 }

--- a/rundeckapp/grails-app/views/common/_navBarProjectSettingsData.gsp
+++ b/rundeckapp/grails-app/views/common/_navBarProjectSettingsData.gsp
@@ -175,6 +175,7 @@
             id: 'nav-${item.title.toLowerCase().replace(' ', '-')}-link',
             container: 'nav-project-settings',
             group: 'plugins',
+            priority: '${enc(attr: item.priority)}',
             class: '${enc(attr: item.iconCSS ?: 'fas fa-plug')}',
             link: '${enc(attr: item.getProjectHref(projectName))}',
             label: '${g.message(code: item.titleCode, default: item.title)}',

--- a/rundeckapp/grails-app/views/common/_navData.gsp
+++ b/rundeckapp/grails-app/views/common/_navData.gsp
@@ -124,6 +124,7 @@
                     type: 'link',
                     id: 'nav-${item.title.toLowerCase().replace(' ', '-')}-link',
                     group: 'main',
+                    priority: '${enc(attr: item.priority)}',
                     class: '${enc(attr: item.iconCSS ?: 'fas fa-plug')}',
                     link: '${enc(attr: item.getProjectHref(projectName))}',
                     label: '${g.message(code: item.titleCode, default: item.title)}',

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/navbar/navbar.stories.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/navbar/navbar.stories.ts
@@ -20,6 +20,7 @@ export const navBar = () => {
         {
             "type": "link",
             "id": "nav-project-dashboard-link",
+            priority: 0,
             "container": "root",
             "group": "main",
             "class": "fas fa-clipboard-list",
@@ -31,6 +32,7 @@ export const navBar = () => {
         {
             "type": "link",
             "id": "nav-jobs-link",
+            priority: 0,
             "container": "root",
             "group": "main",
             "class": "fas fa-tasks",
@@ -41,6 +43,7 @@ export const navBar = () => {
         {
             "type": "link",
             "id": "nav-nodes-link",
+            priority: 0,
             "container": "root",
             "group": "main",
             "class": "fas fa-sitemap",
@@ -51,6 +54,7 @@ export const navBar = () => {
         {
             "type": "link",
             "id": "nav-commands-link",
+            priority: 0,
             "container": "root",
             "group": "main",
             "class": "fas fa-terminal",
@@ -61,6 +65,7 @@ export const navBar = () => {
         {
             "type": "link",
             "id": "nav-activity-link",
+            priority: 0,
             "container": "root",
             "group": "main",
             "class": "fas fa-history",
@@ -71,6 +76,7 @@ export const navBar = () => {
         {
             "type": "link",
             "id": "nav-schedules-link",
+            priority: 0,
             "container": "root",
             "group": "main",
             "class": "fas fa-clock",
@@ -81,6 +87,7 @@ export const navBar = () => {
         {
             "type": "link",
             "id": "nav-healthcheck-link",
+            priority: 0,
             "container": "root",
             "group": "main",
             "class": "fas fa-heartbeat",
@@ -91,6 +98,7 @@ export const navBar = () => {
         {
             "type": "link",
             "id": "nav-tours-link",
+            priority: 0,
             "container": "root",
             "group": "main",
             "class": "glyphicon glyphicon-question-sign",
@@ -101,6 +109,7 @@ export const navBar = () => {
         {
             "type": "link",
             "id": "nav-calendars-link",
+            priority: 0,
             "container": "root",
             "group": "main",
             "class": "fas fa-calendar-alt",
@@ -111,6 +120,7 @@ export const navBar = () => {
         {
             "type": "link",
             "id": "nav-reactions-link",
+            priority: 0,
             "container": "root",
             "group": "main",
             "class": "fas fa-plug",
@@ -121,6 +131,7 @@ export const navBar = () => {
         {
             "type": "link",
             "id": "nav-webhooks-link",
+            priority: 0,
             "container": "root",
             "group": "main",
             "class": "fas fa-plug",
@@ -131,6 +142,7 @@ export const navBar = () => {
         {
             "type": "container",
             "id": "nav-project-settings",
+            priority: 0,
             "container": "root",
             "group": "bottom",
             "class": "fas fa-cogs",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/stores/NavBar.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/stores/NavBar.ts
@@ -9,6 +9,7 @@ export class NavBar {
 
     overflowItem: NavContainer = {
         id: 'overflow',
+        priority: 0,
         type: 'container',
         style: 'list',
         group: 'bottom',
@@ -25,23 +26,30 @@ export class NavBar {
         }
     }
 
+    /** Returns items in proper sort order */
+    getItems() {
+        return this.items.slice().sort((a, b) => a.priority - b.priority)
+    }
+
+    @action
     addItems(items: Array<NavItem>) {
         items.forEach(i => this.items.push(i))
+        this.items.sort((a, b) => a.priority - b.priority)
     }
 
     containerGroupItems(container: string, group: string) {
-            const items = this.items.filter(i => i.group == group && i.container == container)
+            const items = this.getItems().filter(i => i.group == group && i.container == container)
             return items
     }
 
     containerItems(container: string) {
-        const items = this.items.filter(i => i.container == container)
+        const items = this.getItems().filter(i => i.container == container)
 
         return items
     }
 
     groupItems(group: string) {
-        const items = this.items.filter(i => i.group == group)
+        const items = this.getItems().filter(i => i.group == group)
         return items
     }
 
@@ -74,6 +82,7 @@ export class NavBar {
 
 export interface NavItem {
     id: string
+    priority: number
     class?: string
     label?: string
     container?: string


### PR DESCRIPTION
Add the ability to specify a priority, defaulted to `0`, on menu items.

The navbar UI will sort the items based on this priority key for display.