### PR TITLE
Set projectKeyStorage feature flag to be true by default .   Fix issu…

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -336,7 +336,7 @@ public class RundeckConfigBase {
         Enabled uiNext = new Enabled(false);
         Enabled workflowDesigner = new Enabled(true);
         Enabled eventStore = new Enabled(true);
-        Enabled projectKeyStorage = new Enabled();
+        Enabled projectKeyStorage = new Enabled(true);
 
         @Data
         public static class Enabled {

--- a/rundeckapp/grails-app/assets/javascripts/storageBrowseKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/storageBrowseKO.js
@@ -412,8 +412,7 @@ function StorageBrowser(baseUrl, rootPath) {
             self.resources([]);
             var reload=false;
             self.selectedPath(null);
-            if(self.rootBasePath() != path)
-                self.inputPath(self.relativePath(path));
+            self.inputPath(self.relativePathRoot(self.rootBasePath(), path))
             if(reload){
                 self.browseToInputPath();
             }

--- a/rundeckapp/grails-app/assets/javascripts/storageBrowseKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/storageBrowseKO.js
@@ -20,6 +20,7 @@
 //= require knockout-onenter
 
 
+
 function StorageResource() {
     var self = this;
     self.meta = ko.observable({});
@@ -411,7 +412,8 @@ function StorageBrowser(baseUrl, rootPath) {
             self.resources([]);
             var reload=false;
             self.selectedPath(null);
-            self.inputPath(self.relativePath(path));
+            if(self.rootBasePath() != path)
+                self.inputPath(self.relativePath(path));
             if(reload){
                 self.browseToInputPath();
             }


### PR DESCRIPTION
Is this a bugfix, or an enhancement?
Bugfix. Enterprise 1593
Creating a new Key via Project Key Storage from Project Page link duplicates the path statement so the key ends up getting created in.  This occurs when  rootBasePath is any value other than 'keys', and the rootBasePath does not contain any values, the inputPath duplicates.  Also, projectKeyStorage feature flag should be true by default . 

**Describe the solution you've implemented**
When rooBasePath is not 'Keys' and does not contain entries in it's directory, the notFound method sets the inputPath to the relative path.  This is fixed by not resetting the inputPath when rootBasePath is equal to the path with no entries. 

