### PR TITLE
Fix modal on commands and joblist screen

### DIFF
--- a/rundeckapp/grails-app/views/framework/_nodesEmbedKO.gsp
+++ b/rundeckapp/grails-app/views/framework/_nodesEmbedKO.gsp
@@ -24,7 +24,7 @@
            class=" col-xs-6 node_ident embedded_node tight"
            tabindex="0"
            role="button"
-           data-viewport="#main-panel"
+           data-viewport="#section-content"
            data-placement="auto"
            data-container="body"
            data-delay="{&quot;show&quot;:0,&quot;hide&quot;:200}"

--- a/rundeckapp/grails-app/views/menu/_jobslist.gsp
+++ b/rundeckapp/grails-app/views/menu/_jobslist.gsp
@@ -146,7 +146,7 @@
                                 <g:if test="${ nextExecution}">
                                     <g:if test="${serverClusterNodeUUID && !remoteClusterNodeUUID}">
                                         <span class="text-warning has_tooltip" title="${message(code:"scheduledExecution.scheduled.cluster.orphan.title")}"
-                                            data-container="#main-panel"
+                                            data-container="#section-content"
                                             data-placement="auto bottom"
                                         >
                                             <g:icon name="alert"/>
@@ -165,7 +165,7 @@
                                 </g:if>
                                 <g:elseif test="${ !projectExecutionModeActive|| !scheduledExecution.hasExecutionEnabled()}">
                                     <span class="scheduletime disabled has_tooltip text-secondary" data-toggle="tooltip"
-                                          data-container="#main-panel"
+                                          data-container="#section-content"
                                           data-placement="auto bottom"
                                           title="${g.message(code: 'disabled.schedule.run')}">
                                         <i class="glyphicon glyphicon-pause"></i>
@@ -176,7 +176,7 @@
                                     <span class="scheduletime disabled has_tooltip text-secondary"
                                           title="${g.message(code: 'scheduleExecution.schedule.disabled')}"
                                           data-toggle="tooltip"
-                                          data-container="#main-panel"
+                                          data-container="#section-content"
                                           data-placement="auto bottom">
                                         <i class="glyphicon glyphicon-pause"></i>
                                         <span class="detail"><g:message code="never"/></span>
@@ -186,7 +186,7 @@
                                     <span class="scheduletime disabled has_tooltip text-secondary"
                                           title="${g.message(code: 'project.schedule.disabled')}"
                                           data-toggle="tooltip"
-                                          data-container="#main-panel"
+                                          data-container="#section-content"
                                           data-placement="auto bottom">
                                         <i class="glyphicon glyphicon-pause"></i>
                                         <span class="detail"><g:message code="never"/></span>
@@ -196,7 +196,7 @@
                                     <span class="scheduletime willnotrun has_tooltip text-warning"
                                           title="${g.message(code: 'job.schedule.will.never.fire')}"
                                           data-toggle="tooltip"
-                                          data-container="#main-panel"
+                                          data-container="#section-content"
                                           data-placement="auto bottom">
                                         <i class="glyphicon glyphicon-time"></i>
                                         <span class="detail"><g:message code="never"/></span>


### PR DESCRIPTION
Fixes up references to the old `#main-panel`. This was causing a commands page model to be "in the way" while also not visible.

![modal-fixup](https://user-images.githubusercontent.com/271965/111853078-706dd080-88e7-11eb-8acd-ea4b98694ee9.gif)
