### PR TITLE
DB Migration fixup

### DIFF
--- a/docker/official/README.md
+++ b/docker/official/README.md
@@ -150,6 +150,10 @@ Set this if using an alternative backend from h2.
 
 ### `RUNDECK_DATABASE_PASSWORD`
 
+### `RUNDECK_DATABASE_MIGRATE_ONSTART=true`
+
+Toggles database migrations on startup. Defaults to `true`.
+
 ### `RUNDECK_LOGGING_STRATEGY=CONSOLE`
 
 The default console strategy configures log4j to send all output to stdout

--- a/docker/official/README.md
+++ b/docker/official/README.md
@@ -150,9 +150,10 @@ Set this if using an alternative backend from h2.
 
 ### `RUNDECK_DATABASE_PASSWORD`
 
-### `RUNDECK_DATABASE_MIGRATE_ONSTART=true`
+### `RUNDECK_DATABASE_MIGRATE_ONSTART`
 
-Toggles database migrations on startup. Defaults to `true`.
+Toggles database migrations on startup. Defaults to the Rundeck
+default. Can be `true` or `false`.
 
 ### `RUNDECK_LOGGING_STRATEGY=CONSOLE`
 

--- a/docker/official/remco/templates/log4j2.properties
+++ b/docker/official/remco/templates/log4j2.properties
@@ -139,12 +139,13 @@ logger.jetty.level = warn
 logger.jetty.additivity = false
 logger.jetty.appenderRef.stdout.ref = STDOUT
 
-
+# Grails Database Migration Plugin
 logger.migration.name = org.grails.plugins.databasemigration
 logger.migration.level = info
 logger.migration.additivity = false
 logger.migration.appenderRef.stdout.ref = STDOUT
 
+# Liquibase Migrations
 logger.liquibase.name = liquibase
 logger.liquibase.level = info
 logger.liquibase.additivity = false

--- a/docker/official/remco/templates/log4j2.properties
+++ b/docker/official/remco/templates/log4j2.properties
@@ -139,6 +139,17 @@ logger.jetty.level = warn
 logger.jetty.additivity = false
 logger.jetty.appenderRef.stdout.ref = STDOUT
 
+
+logger.migration.name = org.grails.plugins.databasemigration
+logger.migration.level = info
+logger.migration.additivity = false
+logger.migration.appenderRef.stdout.ref = STDOUT
+
+logger.liquibase.name = liquibase
+logger.liquibase.level = info
+logger.liquibase.additivity = false
+logger.liquibase.appenderRef.stdout.ref = STDOUT
+
 #
 # file - DailyRollingFileAppender
 #

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -15,7 +15,9 @@ rundeck.multiURL.enabled={{ getv("/rundeck/multiurl/enabled", "false") }}
 
 server.servlet.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
 
-dataSource.dbCreate = {{ getv("/rundeck/database/create", "update") }}
+dataSource.dbCreate = {{ getv("/rundeck/database/create", "none") }}
+grails.plugin.databasemigration.updateOnStart={{ getv("/rundeck/database/migrate/onstart", "true") }}
+
 dataSource.url = {{ getv("/rundeck/database/url", printf("jdbc:h2:file:%s/server/data/grailsdb;DB_CLOSE_ON_EXIT=FALSE", rundeckHome)) }}
 dataSource.username = {{ getv("/rundeck/database/username", "") }}
 dataSource.password = {{ getv("/rundeck/database/password", "") }}

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -15,8 +15,12 @@ rundeck.multiURL.enabled={{ getv("/rundeck/multiurl/enabled", "false") }}
 
 server.servlet.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
 
-dataSource.dbCreate = {{ getv("/rundeck/database/create", "none") }}
-grails.plugin.databasemigration.updateOnStart={{ getv("/rundeck/database/migrate/onstart", "true") }}
+{% if exists("/rundeck/database/create") %}
+dataSource.dbCreate = {{ getv("/rundeck/database/create", "") }}
+{% endif %}
+{% if exists("/rundeck/database/migrate/onstart") %}
+grails.plugin.databasemigration.updateOnStart={{ getv("/rundeck/database/migrate/onstart", "") }}
+{% endif %}
 
 dataSource.url = {{ getv("/rundeck/database/url", printf("jdbc:h2:file:%s/server/data/grailsdb;DB_CLOSE_ON_EXIT=FALSE", rundeckHome)) }}
 dataSource.username = {{ getv("/rundeck/database/username", "") }}

--- a/docker/official/test/remco/test.yml
+++ b/docker/official/test/remco/test.yml
@@ -5,6 +5,10 @@ rundeck:
       maxsize: '50000000'
   server:
     name: superserver
+  database:
+    create: update
+    migrate:
+      onstart: 'true'
   config:
     storage:
       converter:

--- a/rundeckapp/grails-app/migrations/core/NodeFilter.groovy
+++ b/rundeckapp/grails-app/migrations/core/NodeFilter.groovy
@@ -58,4 +58,23 @@ databaseChangeLog = {
             column(name: "project", type: '${varchar255.type}')
         }
     }
+
+    changeSet(author: "rundeckuser (generated)", failOnError:"false", id: "3.4.0-1616620097", dbms: "h2") {
+        comment { 'rename "filter" to FILTER' }
+        preConditions(onFail: 'MARK_RAN') {
+            grailsPrecondition {
+                check {
+                    def ran = sql.firstRow("SELECT count(*) as num FROM INFORMATION_SCHEMA.columns where table_name ='NODE_FILTER' and column_name  = 'filter'").num
+                    if(ran==0) fail('precondition is not satisfied')
+                }
+            }
+        }
+        grailsChange {
+            change {
+                sql.execute("ALTER TABLE node_filter RENAME COLUMN \"filter\" TO FILTER;")
+            }
+            rollback {
+            }
+        }
+    }
 }

--- a/rundeckapp/templates/config/log4j2.properties.template
+++ b/rundeckapp/templates/config/log4j2.properties.template
@@ -263,11 +263,11 @@ logger.springBeanPropertyDescriptor.additivity = false
 logger.springBeanPropertyDescriptor.appenderRef.stdout.ref = STDOUT
 
 logger.migration.name = org.grails.plugins.databasemigration
-logger.migration.level = debug
+logger.migration.level = info
 logger.migration.additivity = false
 logger.migration.appenderRef.stdout.ref = STDOUT
 
 logger.liquibase.name = liquibase
-logger.liquibase.level = debug
+logger.liquibase.level = info
 logger.liquibase.additivity = false
 logger.liquibase.appenderRef.stdout.ref = STDOUT

--- a/rundeckapp/templates/config/log4j2.properties.template
+++ b/rundeckapp/templates/config/log4j2.properties.template
@@ -261,3 +261,13 @@ logger.springBeanPropertyDescriptor.name = org.springframework.beans.GenericType
 logger.springBeanPropertyDescriptor.level = error
 logger.springBeanPropertyDescriptor.additivity = false
 logger.springBeanPropertyDescriptor.appenderRef.stdout.ref = STDOUT
+
+logger.migration.name = org.grails.plugins.databasemigration
+logger.migration.level = debug
+logger.migration.additivity = false
+logger.migration.appenderRef.stdout.ref = STDOUT
+
+logger.liquibase.name = liquibase
+logger.liquibase.level = debug
+logger.liquibase.additivity = false
+logger.liquibase.appenderRef.stdout.ref = STDOUT

--- a/test/api/test-job-long-run.sh
+++ b/test/api/test-job-long-run.sh
@@ -10,7 +10,7 @@ source $DIR/include.sh
 ###
 
 # job exec
-args="sleep 7"
+args="sleep 12"
 
 project=$2
 if [ "" == "$2" ] ; then

--- a/test/docker/dockers/rundeck/scripts/start_rundeck.sh
+++ b/test/docker/dockers/rundeck/scripts/start_rundeck.sh
@@ -233,7 +233,7 @@ rdeck.base=/home/rundeck
 rss.enabled=false
 server.address=0.0.0.0
 grails.serverURL=${RUNDECK_URL}
-dataSource.dbCreate = update
+dataSource.dbCreate = none
 dataSource.url = jdbc:h2:file:/home/rundeck/server/data/grailsdb;DB_CLOSE_ON_EXIT=FALSE
 dataSource.properties.removeAbandoned=true
 dataSource.properties.removeAbandonedTimeout=5

--- a/test/docker/dockers/rundeck/scripts/start_rundeck.sh
+++ b/test/docker/dockers/rundeck/scripts/start_rundeck.sh
@@ -236,7 +236,7 @@ grails.serverURL=${RUNDECK_URL}
 dataSource.dbCreate = none
 dataSource.url = jdbc:h2:file:/home/rundeck/server/data/grailsdb;DB_CLOSE_ON_EXIT=FALSE
 dataSource.properties.removeAbandoned=true
-dataSource.properties.removeAbandonedTimeout=5
+dataSource.properties.removeAbandonedTimeout=10
 
 # Pre Auth mode settings
 rundeck.security.authorization.preauthenticated.enabled=false

--- a/test/docker/dockers/tomcat/rundeck-config.properties
+++ b/test/docker/dockers/tomcat/rundeck-config.properties
@@ -6,7 +6,7 @@ rdeck.base=/usr/local/tomcat/webapps/rundeck/rundeck
 rss.enabled=false
 server.address=127.0.0.1
 grails.serverURL=http://127.0.0.1:8080/rundeck
-dataSource.dbCreate = update
+dataSource.dbCreate = none
 dataSource.url = jdbc:h2:file:/usr/local/tomcat/webapps/rundeck/rundeck/server/data/grailsdb;DB_CLOSE_ON_EXIT=FALSE
 
 # Pre Auth mode settings


### PR DESCRIPTION
* Adds the `grails.plugin.databasemigration.updateOnStart` option to Docker
* Defaults the above and `dbCreate` settings to the Rundeck default if no override is provided
* Fixes failing tests due to connection abandon timeout
* Adjusts the `node_filter` filter column
* Adds loggers for the Grails db migration plugin and Liquibase set to `INFO`

This would supersede #6923