### PR TITLE
Cleanup: jobs import api endpoint requires apiv14

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2975,18 +2975,23 @@ class ScheduledExecutionController  extends ControllerBase{
         if(!apiService.requireApi(request,response,ApiVersions.V14)){
             return
         }
+
+        //require project parameter
+        if(!apiService.requireParameters(params,response, ['project'])){
+            return
+        }
         log.debug("ScheduledExecutionController: upload " + params)
         def fileformat = params.format ?:params.fileformat ?: 'xml'
         def parseresult
-        if(request.api_version >= ApiVersions.V14 && request.format=='xml'){
+        if(request.format=='xml'){
             //xml input
             parseresult = scheduledExecutionService.parseUploadedFile(request.getInputStream(), 'xml')
-        }else if(request.api_version >= ApiVersions.V14 && request.format=='yaml'){
+        }else if(request.format=='yaml'){
             //yaml input
             parseresult = scheduledExecutionService.parseUploadedFile(request.getInputStream(), 'yaml')
         }else if (!apiService.requireParameters(params,response,['xmlBatch'])) {
             return
-        }else if (request instanceof MultipartHttpServletRequest) {
+        }else if (request instanceof MultipartHttpServletRequest && request.fileNames.toList().contains('xmlBatch')) {
             def file = request.getFile("xmlBatch")
             if (!file) {
                 return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_BAD_REQUEST,
@@ -3010,21 +3015,12 @@ class ScheduledExecutionController  extends ControllerBase{
                     code: 'api.error.jobs.import.invalid', args: [fileformat,parseresult.error]])
         }
         def jobset = parseresult.jobset
-        if(request.api_version >= ApiVersions.V14){
-            //require project parameter
-            if(!apiService.requireParameters(params,response, ['project'])){
-                return
-            }
-        }
-            //v8 override project using parameter
-        if(params.project){
-            jobset.each{it.job.project=params.project}
-        }
+
+        jobset.each{it.job.project=params.project}
 
         def changeinfo = [user: session.user,method:'apiJobsImport']
         //nb: loadJobs will get correct project auth context
         UserAndRolesAuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
-        String roleList = request.subject.getPrincipals(Group.class).collect {it.name}.join(",")
         def option = params.uuidOption
         def loadresults = scheduledExecutionService.loadImportedJobs(jobset,params.dupeOption, option, changeinfo, authContext,
                 (params?.validateJobref=='true'))

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2991,12 +2991,12 @@ class ScheduledExecutionController  extends ControllerBase{
             parseresult = scheduledExecutionService.parseUploadedFile(request.getInputStream(), 'yaml')
         }else if (!apiService.requireParameters(params,response,['xmlBatch'])) {
             return
-        }else if (request instanceof MultipartHttpServletRequest && request.fileNames.toList().contains('xmlBatch')) {
-            def file = request.getFile("xmlBatch")
-            if (!file) {
+        }else if (request.format=='multipartForm' && request instanceof MultipartHttpServletRequest) {
+            if (!request.fileNames.toList().contains('xmlBatch')) {
                 return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_BAD_REQUEST,
                         code: 'api.error.jobs.import.missing-file', args: null])
             }
+            def file = request.getFile("xmlBatch")
             parseresult = scheduledExecutionService.parseUploadedFile(file.getInputStream(), fileformat)
         }else if (params.xmlBatch) {
             String fileContent = params.xmlBatch

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -3476,6 +3476,7 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
             'application/yaml' | 'yaml' | null       | 'remove'   | null
             'application/yaml' | 'yaml' | 'update'   | null       | null
     }
+    @Unroll
     def "api jobs import xmlBatch text format #format fileformat #fformat"() {
         given:
             controller.apiService = Mock(ApiService)


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Some code cleanup for Jobs Import API
adds some tests
