### PR TITLE
fix issue with filter in NOD_FILTER being quoted

### DIFF
--- a/rundeckapp/grails-app/migrations/core/NodeFilter.groovy
+++ b/rundeckapp/grails-app/migrations/core/NodeFilter.groovy
@@ -58,4 +58,24 @@ databaseChangeLog = {
             column(name: "project", type: '${varchar255.type}')
         }
     }
+
+    changeSet(author: "rundeckuser (generated)", failOnError:"false", id: "3.4.0-100", dbms: "h2") {
+        comment { 'rename filter to "FILTER' }
+        preConditions(onFail: 'CONTINUE') {
+            grailsPrecondition {
+                check {
+                    def ran = sql.firstRow("SELECT count(*) as num FROM INFORMATION_SCHEMA.columns where table_name ='NODE_FILTER' and column_name  = 'filter'").num
+
+                    if(ran==0) fail('precondition is not satisfied')
+                }
+            }
+        }
+        grailsChange {
+            change {
+                sql.execute("ALTER TABLE node_filter RENAME COLUMN \"filter\" TO FILTER;")
+            }
+            rollback {
+            }
+        }
+    }
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
bugfix
**Describe the solution you've implemented**
changeset to change "filter" to FILTER

**Additional context**
Filter is a liquibase reserved keyword.  Needed to resolve this on node_filter table.  More context: 
https://stackoverflow.com/questions/10789994/make-h2-treat-quoted-name-and-unquoted-name-as-the-same
