### PR TITLE
Add indexes on Execution and LogFileStorageRequest columns that are used in queries.

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -162,6 +162,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData {
             index 'EXEC_IDX_4', ['dateCompleted', 'scheduledExecution']
             index 'EXEC_IDX_5', ['scheduledExecution', 'status']
             index 'EXEC_IDX_6', ['user','dateStarted']
+            index 'EXEC_IDX_7', ['serverNodeUUID']
         }
     }
 

--- a/rundeckapp/grails-app/domain/rundeck/LogFileStorageRequest.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/LogFileStorageRequest.groovy
@@ -16,6 +16,8 @@
 
 package rundeck
 
+import com.dtolabs.rundeck.app.support.DomainIndexHelper
+
 class LogFileStorageRequest {
     Execution execution
     String pluginName
@@ -31,5 +33,12 @@ class LogFileStorageRequest {
         execution nullable: false, unique: true
         pluginName maxSize: 255
         filetype nullable: true
+    }
+
+
+    static mapping = {
+        DomainIndexHelper.generate(delegate) {
+            index 'LOGFILESTORAGE_IDX_1', ['completed']
+        }
     }
 }

--- a/rundeckapp/grails-app/migrations/core/ConstraintsIndexesKeys.groovy
+++ b/rundeckapp/grails-app/migrations/core/ConstraintsIndexesKeys.groovy
@@ -492,5 +492,26 @@ databaseChangeLog = {
         addForeignKeyConstraint(baseColumnNames: "workflow_id", baseTableName: "execution", constraintName: "FKs7kalwep0lr5r39cntcu0pev6", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "workflow", validate: "true")
     }
 
+    changeSet(author: "rundeckuser (generated)", id: "3.4.0-76") {
+        preConditions(onFail: "MARK_RAN"){
+            not{
+                indexExists (tableName:"execution", indexName: "EXEC_IDX_7")
+            }
+        }
+        createIndex(indexName: "EXEC_IDX_7", tableName: "execution") {
+            column(name: "server_nodeuuid")
+        }
+    }
+
+    changeSet(author: "rundeckuser (generated)", id: "3.4.0-77") {
+        preConditions(onFail: "MARK_RAN"){
+            not{
+                indexExists (tableName:"log_file_storage_request", indexName: "LOGFILESTORAGE_IDX_1")
+            }
+        }
+        createIndex(indexName: "LOGFILESTORAGE_IDX_1", tableName: "log_file_storage_request") {
+            column(name: "completed")
+        }
+    }
 
 }


### PR DESCRIPTION
Adding indexes on the server_nodeuuid column of the execution table, and the completed column of log_file_storage_request improves the app performance.