### PR TITLE
Handles job pagination (if enabled) on referenced job picker modal

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/jobedit.js
+++ b/rundeckapp/grails-app/assets/javascripts/jobedit.js
@@ -1550,6 +1550,7 @@ function _doRevertOptsAction() {
 var uuidField;
 var jobNameFieldId;
 var jobGroupFieldId;
+var jobChooseModalId;
 
 function jobChosen(uuid, name, group, elem) {
   jobWasEdited();
@@ -1570,12 +1571,15 @@ function loadJobChooserModal(elem, uuid, nameid, groupid, projectid, modalid, mo
     jQuery('#' + modalid).modal('hide');
     return;
   }
+
+  jobChooseModalId = modalid;
   uuidField = uuid;
   jobNameFieldId = nameid;
   jobGroupFieldId = groupid;
   var project = selFrameworkProject;
 
   if (projectid) {
+    projectFieldId = projectid
     project = jQuery('#' + projectid).val();
   }
   jQuery(elem).button('loading').addClass('active');
@@ -1589,6 +1593,7 @@ function loadJobChooserModal(elem, uuid, nameid, groupid, projectid, modalid, mo
       jQuery(elem).button('reset').removeClass('active');
       jQuery('#' + modalcontentid).html(resp);
       jQuery('#' + modalid).modal('show');
+      jQuery('#' + modalid + " #modal-pagination").show();
     },
     error: function (jqxhr, status, resp) {
       showError("Error performing request: menuJobsPicker: " + resp);

--- a/rundeckapp/grails-app/views/menu/_groupTree.gsp
+++ b/rundeckapp/grails-app/views/menu/_groupTree.gsp
@@ -1,3 +1,4 @@
+<%@ page import="java.math.RoundingMode" %>
 %{--
   - Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
   -
@@ -129,7 +130,8 @@
     <g:if test="${currentJobs}">
         <g:timerStart key="_groupTree2.gsp-jobslist"/>
         <div>
-        <g:render template="jobslist" model="[projectScheduleModeActive:projectScheduleModeActive,projectExecutionModeActive:projectExecutionModeActive,jobslist:currentJobs,total:currentJobs?.size(),nextExecutions:nextExecutions,jobauthorizations:jobauthorizations,authMap:authMap,max:max,offset:offset,paginateParams:paginateParams,sortEnabled:true,headers:false,wasfiltered:wasfiltered,small:small?true:false,jobsjscallback:jobsjscallback,runAuthRequired:runAuthRequired]"/>
+            <g:render template="jobslist" model="[projectScheduleModeActive:projectScheduleModeActive,projectExecutionModeActive:projectExecutionModeActive,jobslist:currentJobs,total:currentJobs?.size(),nextExecutions:nextExecutions,jobauthorizations:jobauthorizations,authMap:authMap,max:max,offset:offset,paginateParams:paginateParams,sortEnabled:true,headers:false,wasfiltered:wasfiltered,small:small?true:false,jobsjscallback:jobsjscallback,runAuthRequired:runAuthRequired]"/>
+            <g:render template="jobPickerModalPagination" model="[max:max, total: total, offset: offset, jobsListSize: currentJobs?.size()]"/>
         </div>
         <g:timerEnd key="_groupTree2.gsp-jobslist"/>
     </g:if>

--- a/rundeckapp/grails-app/views/menu/_jobPickerModalPagination.gsp
+++ b/rundeckapp/grails-app/views/menu/_jobPickerModalPagination.gsp
@@ -1,21 +1,26 @@
 <g:if test="${max && max < total && jobsListSize < total}">
-    <div id="modal-pagination" style="display: none">
-        <span>
-            offset ${offset}
-            total ${total}
-            max ${max}
-        </span>
-        <div>
-            Showing ${offset+1}-${offset+max > total ? total : offset+max} of ${total}
-        </div>
-        <div class="gsp-pager">
-            <g:set var="numPages" value="${new java.math.BigDecimal(total/max).setScale(0, java.math.RoundingMode.UP)}"/>
-            <a class="prevLink" style="display: none" onclick="handleModalPagination(this, ${offset-max}, ${max}, ${total});">Previous</a>
-            <g:each in="${1..numPages}" var="step">
-                <span style="display: ${step == 1 ? 'inline' : 'none'}" class="currentStep step-${step}">${step}</span>
-                <a style="display: ${step == 1 ? 'none' : 'inline'}" onclick="handleModalPagination(this, ${(step-1)*max}, ${max}, ${total});" class="step step-${step}">${step}</a>
-            </g:each>
-            <a class="nextLink" onclick="handleModalPagination(this, ${offset+max}, ${max}, ${total});">Next</a>
+    <div id="modal-pagination" style="display: none;">
+        <div style="display:flex; justify-content: space-between; align-items: center;margin-top: 10px;">
+            <div class="gsp-pager">
+                <div class="modal-pagination">
+                    <g:set var="numPages" value="${new java.math.BigDecimal(total/max).setScale(0, java.math.RoundingMode.UP)}"/>
+                    <div class="modal-pagination-item">
+                        <a class="prevLink" style="display: none" onclick="handleModalPagination(this, ${offset-max}, ${max}, ${total});">Previous</a>
+                    </div>
+                    <g:each in="${1..numPages}" var="step">
+                        <div class="modal-pagination-item">
+                            <span style="display: ${step == 1 ? 'inline' : 'none'}" class="currentStep step-${step}">${step}</span>
+                            <a style="display: ${step == 1 ? 'none' : 'inline'}" onclick="handleModalPagination(this, ${(step-1)*max}, ${max}, ${total});" class="step step-${step}">${step}</a>
+                        </div>
+                    </g:each>
+                    <div class="modal-pagination-item">
+                        <a class="nextLink" onclick="handleModalPagination(this, ${offset+max}, ${max}, ${total});">Next</a>
+                    </div>
+                </div>
+            </div>
+            <div>
+                Showing ${offset+1}-${offset+max > total ? total : offset+max} of ${total}
+            </div>
         </div>
     </div>
 </g:if>

--- a/rundeckapp/grails-app/views/menu/_jobPickerModalPagination.gsp
+++ b/rundeckapp/grails-app/views/menu/_jobPickerModalPagination.gsp
@@ -1,0 +1,74 @@
+<g:if test="${max && max < total && jobsListSize < total}">
+    <div id="modal-pagination" style="display: none">
+        <span>
+            offset ${offset}
+            total ${total}
+            max ${max}
+        </span>
+        <div>
+            Showing ${offset+1}-${offset+max > total ? total : offset+max} of ${total}
+        </div>
+        <div class="gsp-pager">
+            <g:set var="numPages" value="${new java.math.BigDecimal(total/max).setScale(0, java.math.RoundingMode.UP)}"/>
+            <a class="prevLink" style="display: none" onclick="handleModalPagination(this, ${offset-max}, ${max}, ${total});">Previous</a>
+            <g:each in="${1..numPages}" var="step">
+                <span style="display: ${step == 1 ? 'inline' : 'none'}" class="currentStep step-${step}">${step}</span>
+                <a style="display: ${step == 1 ? 'none' : 'inline'}" onclick="handleModalPagination(this, ${(step-1)*max}, ${max}, ${total});" class="step step-${step}">${step}</a>
+            </g:each>
+            <a class="nextLink" onclick="handleModalPagination(this, ${offset+max}, ${max}, ${total});">Next</a>
+        </div>
+    </div>
+</g:if>
+
+<g:javascript>
+    function handleModalPagination(elem, offset, max, total) {
+        jQuery(document).ready(function() {
+        jQuery(".modal").on("hidden.bs.modal", function() {
+            jQuery(".modal-body").html("");
+        });
+        });
+        if (jQuery(elem).hasClass('active')) {
+            jQuery('#' + jobChooseModalId).modal('hide');
+            return;
+        }
+        var project = selFrameworkProject;
+        if (projectFieldId) {
+            project = jQuery('#' + projectFieldId).val();
+        }
+        jQuery(elem).button('loading').addClass('active');
+
+        jQuery.ajax({
+            url: _genUrl(appLinks.menuJobsPicker, {
+                jobsjscallback: 'true',
+                runAuthRequired: true,
+                projFilter: project,
+                offset: offset
+            }),
+            success: function (resp, status, jqxhr) {
+                var modal = jQuery('#' + jobChooseModalId);
+                jQuery(elem).button('reset').removeClass('active');
+                modal.find('#' + jobChooseModalId + "_content .job-display-tree").html(resp);
+                modal.find("#modal-pagination").show()
+                modal.find('a.step').show()
+                modal.find('span.currentStep').hide()
+                modal.find('a.step-' + ((offset/max) + 1) ).hide()
+                modal.find('span.step-' + ((offset/max) + 1) ).show()
+                if(offset+max > total) {
+                    modal.find('.nextLink').hide()
+                } else {
+                    modal.find('.nextLink').show()
+                }
+                if(offset-max < 0) {
+                    modal.find('.prevLink').hide()
+                } else {
+                    modal.find('.prevLink').show()
+                }
+            },
+            error: function (jqxhr, status, resp) {
+                showError("Error performing request: menuJobsPicker: " + resp);
+                jQuery(elem).button('reset').removeClass('active');
+            }
+        });
+    }
+</g:javascript>
+

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/paper/_tabs-navs-pagination.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/paper/_tabs-navs-pagination.scss
@@ -315,3 +315,42 @@
 @include pagination($success-color, 'success');
 @include pagination($warning-color, 'warning');
 @include pagination($danger-color, 'danger');
+
+.modal-pagination{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  &-item{
+    // border-top: 1px solid #cecece;
+    // border-bottom: 1px solid #cecece;
+    // border-right: 1px solid #cecece;
+    padding: 6px 7px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    list-style-type: none;
+    margin: 0;
+    border-radius: 0;
+    cursor: pointer;
+    &:first-child{
+      // border: 1px solid #cecece;
+      // border-top-left-radius: 5px;
+      // border-bottom-left-radius: 5px;
+    }
+    &:last-child{
+      // border-left: 0 solid #cecece;
+      // border-top-right-radius: 5px;
+      // border-bottom-right-radius: 5px;
+    }
+  }
+  .currentStep{
+    width: 20px;
+    height: 20px;
+    border: 1px solid #000;
+    border-radius: 4rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
fixes https://github.com/rundeckpro/rundeckpro/issues/1571

**Is this a bugfix, or an enhancement? Please describe.**
If job pagination is enabled, there is no way to handle pagination on modal to choose job reference

**Describe the solution you've implemented**
Was included pagination mechanism to handle pagination calling controller without reloading page
