### PR TITLE
retrieving scheduled executions without using cache

### DIFF
--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/config/Export.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/config/Export.groovy
@@ -92,7 +92,7 @@ Template".
 
     @PluginProperty(
             title = "Base branch on",
-            description = "Create the new branch based on the existen branch",
+            description = "Create the new branch based on the existent branch",
             defaultValue = 'master',
             required = false
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -1127,7 +1127,10 @@ class ScmController extends ControllerBase {
         if (params.id) {
             jobIds = [params.id].flatten()
         } else {
-            jobIds = ScheduledExecution.findAllByProject(params.project).collect {
+            jobIds = ScheduledExecution.createCriteria().list{
+                eq('project', params.project)
+                cache(false)
+            }.collect {
                 it.extid
             }
             if (integration == 'export') {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -1130,8 +1130,9 @@ class ScmController extends ControllerBase {
             jobIds = ScheduledExecution.createCriteria().list{
                 eq('project', params.project)
                 cache(false)
-            }.collect {
-                it.extid
+                projections {
+                    property("uuid")
+                }
             }
             if (integration == 'export') {
                 deletedPaths = scmService.deletedExportFilesForProject(params.project)


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/1657

Modified to not use cache when searching for scheduled executions.
