### PR TITLE
Fixes arguments of method called to handle schedules from project config API

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
@@ -1467,7 +1467,7 @@ class ProjectController extends ControllerBase{
                 || (isScheduleDisabledNow != newScheduleDisabledStatus))
         if(reschedule){
             frameworkService.handleProjectSchedulingEnabledChange(
-                    project,
+                    project?.getName(),
                     isExecutionDisabledNow,
                     isScheduleDisabledNow,
                     newExecutionDisabledStatus,

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectController2Spec.groovy
@@ -1098,9 +1098,10 @@ class ProjectController2Spec extends HibernateSpec implements ControllerUnitTest
         }
     }
     private def mockFrameworkServiceForProjectConfigPut(boolean exists, boolean authorized, String action,
-                                                        LinkedHashMap props, boolean success, String errorMessage,
-                                                        String propFileText){
+                                                        LinkedHashMap currentProps, boolean success, String errorMessage,
+                                                        String propFileText, boolean handleScheduling = false){
         mockWith(FrameworkService){
+            Map newConfigProps = [:]
             existsFrameworkProject{String name->
                 exists
             }
@@ -1115,18 +1116,24 @@ class ProjectController2Spec extends HibernateSpec implements ControllerUnitTest
                 assertEquals('test1',name)
                 Mock(IRundeckProject){
                     getName()>>'test1'
-                    getProjectProperties()>>props
+                    getProjectProperties()>>currentProps
                 }
             }
             setFrameworkProjectConfig{proj,configProps->
-                assertEquals props,configProps
+//                assertEquals props,configProps
+                newConfigProps = configProps
                 [success: success,error: errorMessage]
+            }
+            if(handleScheduling) {
+                handleProjectSchedulingEnabledChange { String proj, isExecutionDisabledNow, isScheduleDisabledNow, newExecutionDisabledStatus, newScheduleDisabledStatus ->
+
+                }
             }
             if(!success){
                 return
             }
             loadProjectProperties { proj ->
-                props
+                newConfigProps
             }
         }
     }
@@ -1470,10 +1477,54 @@ class ProjectController2Spec extends HibernateSpec implements ControllerUnitTest
         assertEquals HttpServletResponse.SC_OK, response.status
         assertEquals "config", response.xml.name()
         assertEquals 2, response.xml.property.size()
-        assertEquals 'prop1', response.xml.property[0].'@key'.text()
-        assertEquals 'value1', response.xml.property[0].'@value'.text()
-        assertEquals 'prop2', response.xml.property[1].'@key'.text()
-        assertEquals 'value2', response.xml.property[1].'@value'.text()
+        assertEquals 'prop2', response.xml.property[0].'@key'.text()
+        assertEquals 'value2', response.xml.property[0].'@value'.text()
+        assertEquals 'prop1', response.xml.property[1].'@key'.text()
+        assertEquals 'value1', response.xml.property[1].'@value'.text()
+    }
+
+    void apiProjectConfigPut_xml_disabling_execution_success(){
+        when:
+        //controller.apiService.messageSource = mockWith(MessageSource) { getMessage { code, args,defval, locale -> code } }
+        controller.apiService = new ApiService()
+        controller.frameworkService= mockFrameworkServiceForProjectConfigPut(true, true, 'configure',
+                ['project.disable.executions': 'false'], true, null, 'text', true)
+            controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor){
+                authorizeApplicationResourceAny(_, _, ['configure', AuthConstants.ACTION_ADMIN]) >> true
+            }
+        request.api_version = 11
+        params.project = 'test1'
+        request.method='PUT'
+        request.xml='<config><property key="project.disable.executions" value="true"/></config>'
+        controller.apiProjectConfigPut()
+        then:
+        assertEquals HttpServletResponse.SC_OK, response.status
+        assertEquals "config", response.xml.name()
+        assertEquals 1, response.xml.property.size()
+        assertEquals 'project.disable.executions', response.xml.property[0].'@key'.text()
+        assertEquals 'true', response.xml.property[0].'@value'.text()
+    }
+
+    void apiProjectConfigPut_xml_disabling_schedule_success(){
+        when:
+        //controller.apiService.messageSource = mockWith(MessageSource) { getMessage { code, args,defval, locale -> code } }
+        controller.apiService = new ApiService()
+        controller.frameworkService= mockFrameworkServiceForProjectConfigPut(true, true, 'configure',
+                ['project.disable.schedule': 'false'], true, null, 'text', true)
+            controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor){
+                authorizeApplicationResourceAny(_, _, ['configure', AuthConstants.ACTION_ADMIN]) >> true
+            }
+        request.api_version = 11
+        params.project = 'test1'
+        request.method='PUT'
+        request.xml='<config><property key="project.disable.schedule" value="true"/></config>'
+        controller.apiProjectConfigPut()
+        then:
+        assertEquals HttpServletResponse.SC_OK, response.status
+        assertEquals "config", response.xml.name()
+        assertEquals 1, response.xml.property.size()
+        assertEquals 'project.disable.schedule', response.xml.property[0].'@key'.text()
+        assertEquals 'true', response.xml.property[0].'@value'.text()
     }
 
     void apiProjectConfigPut_json_success(){
@@ -1495,6 +1546,46 @@ class ProjectController2Spec extends HibernateSpec implements ControllerUnitTest
         assertEquals HttpServletResponse.SC_OK, response.status
         assertEquals 'value1', response.json.prop1
         assertEquals 'value2', response.json.prop2
+    }
+
+    void apiProjectConfigPut_json_disabling_executions_success(){
+        when:
+        controller.apiService = new ApiService()
+        mockCodec(JSONCodec)
+        controller.apiService.messageSource = mockWith(MessageSource) { getMessage { code, args,defval, locale -> code } }
+        controller.frameworkService= mockFrameworkServiceForProjectConfigPut(true, true, 'configure',
+                ['project.disable.executions': 'true'], true, null, 'text', true)
+            controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor){
+                authorizeApplicationResourceAny(_, _, ['configure', AuthConstants.ACTION_ADMIN]) >> true
+            }
+        request.api_version = 11
+        params.project = 'test1'
+        request.json='{"project.disable.executions":"false"}'
+        request.method='PUT'
+        controller.apiProjectConfigPut()
+        then:
+        assertEquals HttpServletResponse.SC_OK, response.status
+        assertEquals 'false', response.json.getAt('project.disable.executions')
+    }
+
+    void apiProjectConfigPut_json_disabling_schedule_success(){
+        when:
+        controller.apiService = new ApiService()
+        mockCodec(JSONCodec)
+        controller.apiService.messageSource = mockWith(MessageSource) { getMessage { code, args,defval, locale -> code } }
+        controller.frameworkService= mockFrameworkServiceForProjectConfigPut(true, true, 'configure',
+                ['project.disable.schedule': 'true'], true, null, 'text', true)
+            controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor){
+                authorizeApplicationResourceAny(_, _, ['configure', AuthConstants.ACTION_ADMIN]) >> true
+            }
+        request.api_version = 11
+        params.project = 'test1'
+        request.json='{"project.disable.schedule":"false"}'
+        request.method='PUT'
+        controller.apiProjectConfigPut()
+        then:
+        assertEquals HttpServletResponse.SC_OK, response.status
+        assertEquals 'false', response.json.getAt('project.disable.schedule')
     }
 
 


### PR DESCRIPTION
Fixes https://github.com/rundeck/rundeck-cli/issues/346

**Is this a bugfix, or an enhancement? Please describe.**
When trying to enable/disable project schedule/execution via API or Rundeck CLI, Rundeck was returning an error 500

**Describe the solution you've implemented**
The argument expect the project name and not a IRundeckProject type. This was happening only on the first run because in the following runs the method is not called again
