### PR TITLE
fix:  use aclFileManager to read project acls for export

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -865,13 +865,13 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
                             }
                             if (isExportAcls) {
                                 //acls
-                                def policies = project.listDirPaths('acls/').grep(~/^.*\.aclpolicy$/)
+                                def manager = aclFileManagerService.forContext(AppACLContext.project(project.name))
+                                def policies = manager.listStoredPolicyFiles()
                                 if (policies) {
                                     dir('acls/') {
-                                        policies.each { path ->
-                                            def fname = path.substring('acls/'.length())
+                                        policies.each { fname ->
                                             zip.fileStream(fname) { OutputStream stream ->
-                                                project.loadFileResource(path, stream)
+                                                manager.loadPolicyFileContents(fname,stream)
                                             }
                                         }
                                     }


### PR DESCRIPTION
fix:  use aclFileManager to read project acls for export


**Is this a bugfix, or an enhancement? Please describe.**

Fixes https://github.com/rundeckpro/rundeckpro/issues/1668

