### PR TITLE
Enh: Adding access to Key Storage for Webhook Plugins

### DIFF
--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -12,6 +12,7 @@ import com.dtolabs.rundeck.core.plugins.configuration.PluginAdapterUtility
 import com.dtolabs.rundeck.core.plugins.configuration.PluginCustomConfigValidator
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
 import com.dtolabs.rundeck.core.plugins.configuration.Validator
+import com.dtolabs.rundeck.core.storage.keys.KeyStorageTree
 import com.dtolabs.rundeck.core.webhook.WebhookEventContextImpl
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.descriptions.PluginCustomConfig
@@ -43,6 +44,7 @@ class WebhookService {
     def apiService
     def messageSource
     def userService
+    def projectManagerService
     def rundeckAuthTokenManagerService
     def storageService
     def gormEventStoreService
@@ -70,6 +72,8 @@ class WebhookService {
                     new SimpleServiceProvider([(EventStoreService): scopedStore])
             )
         }
+        def keyStorageService = storageService.storageTreeWithContext(authContext)
+        contextServices = contextServices.combine(new SimpleServiceProvider([(KeyStorageTree): keyStorageService]))
 
         WebhookEventContext context = new WebhookEventContextImpl(contextServices)
 

--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -44,7 +44,6 @@ class WebhookService {
     def apiService
     def messageSource
     def userService
-    def projectManagerService
     def rundeckAuthTokenManagerService
     def storageService
     def gormEventStoreService

--- a/grails-webhooks/src/test/groovy/webhooks/WebhookServiceSpec.groovy
+++ b/grails-webhooks/src/test/groovy/webhooks/WebhookServiceSpec.groovy
@@ -65,6 +65,8 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
         data.sender = "asender"
         data.contentType = "text/plain"
         data.data = new ByteArrayInputStream("my event data".bytes)
+        service.storageService = Mock(MockStorageService)
+
 
         when:
         def mockPropertyResolver = Mock(PropertyResolver)
@@ -89,10 +91,7 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
                 webhookProviderService
             }
         }
-        service.storageService = Mock(MockStorageService){
-            storageTreeWithContext(_) >> {Mock(KeyStorageTree)}
-        }
-        
+
         TestWebhookEventPlugin testPlugin = new TestWebhookEventPlugin()
 
         service.pluginService = Mock(MockPluginService) {
@@ -104,9 +103,11 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
         def responder = service.processWebhook("test-webhook-event","{}",data,mockUserAuth,request)
 
         then:
+        1 * service.storageService.storageTreeWithContext(_) >> Mock(KeyStorageTree)
         testPlugin.captured.data.text=="my event data"
         testPlugin.captured.headers["X-Rundeck-TestHdr"] == "Hdr1"
         responder instanceof DefaultWebhookResponder
+
     }
 
     class TestWebhookEventPlugin implements WebhookEventPlugin {

--- a/grails-webhooks/src/test/groovy/webhooks/WebhookServiceSpec.groovy
+++ b/grails-webhooks/src/test/groovy/webhooks/WebhookServiceSpec.groovy
@@ -30,6 +30,7 @@ import com.dtolabs.rundeck.core.plugins.configuration.PluginCustomConfigValidato
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolver
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
 import com.dtolabs.rundeck.core.plugins.configuration.Validator
+import com.dtolabs.rundeck.core.storage.keys.KeyStorageTree
 import com.dtolabs.rundeck.core.webhook.WebhookEventException
 import com.dtolabs.rundeck.plugins.descriptions.PluginCustomConfig
 import com.dtolabs.rundeck.plugins.webhook.DefaultWebhookResponder
@@ -88,6 +89,10 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
                 webhookProviderService
             }
         }
+        service.storageService = Mock(MockStorageService){
+            storageTreeWithContext(_) >> {Mock(KeyStorageTree)}
+        }
+        
         TestWebhookEventPlugin testPlugin = new TestWebhookEventPlugin()
 
         service.pluginService = Mock(MockPluginService) {


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Add a the keyStorage service provider to the context services being passed to onevent, so web hook processing can use key storage