### PR TITLE
SCM: Fix #6957 renamed path should not be shown for new jobs

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1483,7 +1483,7 @@ class ScmService {
                 def jobFullName = job.generateFullName()
                 def origFullName = [orig.groupPath?:'',orig.name].join("/")
 
-                if( jobFullName != origFullName){
+                if(orig && jobFullName != origFullName){
 
                     log.debug("job ${job.groupPath}/${job.jobName} was renamed, previuos name: ${orig.groupPath}/${orig.name}" )
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Fix #6957 

**Describe the solution you've implemented**
Only compare name change when previous name metadata is present.
