### PR TITLE
Fix: /login/authAjax redirect loop for ajax requests

### DIFF
--- a/rundeckapp/grails-app/conf/application.groovy
+++ b/rundeckapp/grails-app/conf/application.groovy
@@ -181,7 +181,7 @@ grails.plugin.springsecurity.auth.loginFormUrl = "/user/login"
 grails.plugin.springsecurity.logout.filterProcessesUrl = '/user/logout'
 grails.plugin.springsecurity.logout.afterLogoutUrl = '/user/loggedout'
 grails.plugin.springsecurity.failureHandler.defaultFailureUrl = "/user/error"
-
+grails.plugin.springsecurity.ajaxHeader = 'AJAX AUTH DISABLED\u0000'
 grails.plugin.springsecurity.logout.handlerNames = [
         'rememberMeServices',
         'securityContextLogoutHandler',


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
If ajax request happens after session expire/logout, it is
redirected to /login/authAjax which redirects to itself until
the browser fails with max redirects error.


**Describe the solution you've implemented**
This config change disables the ajax auth feature of spring security
by default
