### PR TITLE
Sec: Remove apache httpclient 3.1

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -90,6 +90,7 @@ dependencies {
     testCompile "org.codehaus.groovy:groovy-all:${groovyVersion}"
     testCompile "org.spockframework:spock-core:1.3-groovy-2.5"
     testCompile "com.squareup.retrofit2:retrofit-mock:2.7.2"
+    testCompile "com.squareup.okhttp3:mockwebserver:3.14.0"
     testCompile "cglib:cglib-nodep:2.2.2"
 
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -81,9 +81,7 @@ dependencies {
         'javax.servlet:javax.servlet-api:4.0.1'
 
 
-    compile ('commons-httpclient:commons-httpclient:3.1') {
-        exclude group:'junit', module: 'junit'
-    }
+    compile ("org.apache.httpcomponents:httpclient:${httpClientVersion}")
     compileOnly "org.projectlombok:lombok:1.18.10"
     annotationProcessor "org.projectlombok:lombok:1.18.10"
     testCompile 'junit:junit:4.8.1',

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/ScriptURLNodeStepExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/ScriptURLNodeStepExecutor.java
@@ -73,7 +73,6 @@ public class ScriptURLNodeStepExecutor implements NodeStepExecutor {
     private File cacheDir;
 
     private Framework framework;
-    private URLFileUpdater.httpClientInteraction interaction;
     private ScriptFileNodeStepUtils scriptUtils = new DefaultScriptFileNodeStepUtils();
 
     public ScriptURLNodeStepExecutor(Framework framework) {
@@ -192,10 +191,6 @@ public class ScriptURLNodeStepExecutor implements NodeStepExecutor {
         }
         final URLFileUpdater updater = urlFileUpdaterBuilder.createURLFileUpdater();
         try {
-            if (null != interaction) {
-            //allow mock
-                updater.setInteraction(interaction);
-            }
             UpdateUtils.update(updater, destinationTempFile);
 
             logger.debug("Updated nodes resources file: " + destinationTempFile);
@@ -276,11 +271,4 @@ public class ScriptURLNodeStepExecutor implements NodeStepExecutor {
         return builder.toString();
     }
 
-    URLFileUpdater.httpClientInteraction getInteraction() {
-        return interaction;
-    }
-
-    void setInteraction(URLFileUpdater.httpClientInteraction interaction) {
-        this.interaction = interaction;
-    }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/ScriptURLNodeStepExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/ScriptURLNodeStepExecutor.java
@@ -45,14 +45,14 @@ import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepExecutor;
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepResult;
 import com.dtolabs.rundeck.core.utils.Converter;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.httpclient.URIException;
-import org.apache.commons.httpclient.util.URIUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -216,16 +216,16 @@ public class ScriptURLNodeStepExecutor implements NodeStepExecutor {
 
     public static final Converter<String, String> urlPathEncoder = s -> {
         try {
-            return URIUtil.encodeWithinPath(s, UTF_8);
-        } catch (URIException e) {
+            return URLEncoder.encode(s,UTF_8).replace("+","%20");
+        } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
             return s;
         }
     };
     public static final Converter<String, String> urlQueryEncoder = s -> {
         try {
-            return URIUtil.encodeWithinQuery(s, UTF_8);
-        } catch (URIException e) {
+            return URLEncoder.encode(s,UTF_8).replace("+","%20");
+        } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
             return s;
         }

--- a/core/src/main/java/com/dtolabs/rundeck/core/http/ApacheHttpClient.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/http/ApacheHttpClient.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2021 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dtolabs.rundeck.core.http;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.*;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.*;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ApacheHttpClient implements HttpClient<HttpResponse> {
+
+    HttpClientBuilder clientBuilder = HttpClients.custom();
+    RequestConfig.Builder rqConfigBuilder = RequestConfig.custom();
+    HttpClientContext clientContext = null;
+    HttpRequestBase request = null;
+    URI                uri;
+    Map<String,String> headers = new HashMap<>();
+
+    @Override
+    public HttpClient<HttpResponse> setUri(final URI uri) {
+        this.uri = uri;
+        this.request = new HttpGet(uri);
+        return this;
+    }
+
+    @Override
+    public HttpClient<HttpResponse> setFollowRedirects(final boolean redirects) {
+        rqConfigBuilder.setRedirectsEnabled(redirects);
+        return this;
+    }
+
+    @Override
+    public HttpClient<HttpResponse> setBasicAuthCredentials(final String username, final String password) {
+        if(uri == null) throw new RuntimeException("The URI must be set first. Please call setUri(yourTargetUri)");
+        BasicCredentialsProvider credProvider = new BasicCredentialsProvider();
+        credProvider.setCredentials(new AuthScope(uri.getHost(),uri.getPort(),AuthScope.ANY_REALM,"BASIC"), new UsernamePasswordCredentials(username, password));
+        clientBuilder.setDefaultCredentialsProvider(credProvider);
+        AuthCache authCache = new BasicAuthCache();
+        BasicScheme basicAuth = new BasicScheme();
+        HttpHost target = new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());
+        authCache.put(target, basicAuth);
+        clientContext = HttpClientContext.create();
+        clientContext.setAuthCache(authCache);
+        return this;
+    }
+
+    @Override
+    public HttpClient<HttpResponse> setTimeout(final int timeoutMs) {
+        rqConfigBuilder.setConnectTimeout(timeoutMs)
+                       .setSocketTimeout(timeoutMs);
+        return this;
+    }
+
+    @Override
+    public HttpClient<HttpResponse> setMethod(final Method method) {
+        if(uri == null) throw new RuntimeException("The URI must be set first. Please call setUri(yourTargetUri)");
+        if(method == Method.GET) request = new HttpGet(uri);
+        else if(method == Method.POST) request = new HttpPost(uri);
+        else if(method == Method.PUT) request = new HttpPut(uri);
+        else throw new RuntimeException(String.format("Method %s not implemented",method.name()));
+        return this;
+    }
+
+    @Override
+    public HttpClient<HttpResponse> setRetryCount(final int count) {
+        clientBuilder.setRetryHandler(new DefaultHttpRequestRetryHandler(count,false));
+        return this;
+    }
+
+    @Override
+    public HttpClient<HttpResponse> addHeader(final String name, final String value) {
+        headers.put(name,value);
+        return this;
+    }
+
+    @Override
+    public HttpClient<HttpResponse> addPayload(final String contentType, final String payload) {
+        if(request == null) throw new RuntimeException("Please set the method to a POST or PUT before calling the addPayload method");
+        if(!(request instanceof HttpEntityEnclosingRequestBase)) throw new RuntimeException("Request must be either Post or Put.");
+        ((HttpEntityEnclosingRequestBase)request).setEntity(new StringEntity(payload, ContentType.create(contentType, "UTF-8")));
+        return this;
+    }
+
+    @Override
+    public void execute(RequestProcessor<HttpResponse> processor) throws Exception {
+        if(request == null) throw new RuntimeException("Please set the method before executing the http call");
+
+        try (CloseableHttpClient client = clientBuilder.setDefaultRequestConfig(rqConfigBuilder.build()).build()) {
+            headers.forEach((n, v) -> request.addHeader(n, v));
+            HttpResponse rsp = clientContext != null ? client.execute(request, clientContext) : client.execute(request);
+            processor.accept(rsp);
+        }
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/http/ApacheHttpClient.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/http/ApacheHttpClient.java
@@ -20,7 +20,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.AuthCache;
-import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.*;
 import org.apache.http.client.protocol.HttpClientContext;
@@ -57,7 +56,7 @@ public class ApacheHttpClient implements HttpClient<HttpResponse> {
 
     @Override
     public HttpClient<HttpResponse> setBasicAuthCredentials(final String username, final String password) {
-        if(uri == null) throw new RuntimeException("The URI must be set first. Please call setUri(yourTargetUri)");
+        if(uri == null) throw new IllegalStateException("The URI must be set first. Please call setUri(yourTargetUri)");
         BasicCredentialsProvider credProvider = new BasicCredentialsProvider();
         credProvider.setCredentials(new AuthScope(uri.getHost(),uri.getPort(),AuthScope.ANY_REALM,"BASIC"), new UsernamePasswordCredentials(username, password));
         clientBuilder.setDefaultCredentialsProvider(credProvider);
@@ -79,7 +78,7 @@ public class ApacheHttpClient implements HttpClient<HttpResponse> {
 
     @Override
     public HttpClient<HttpResponse> setMethod(final Method method) {
-        if(uri == null) throw new RuntimeException("The URI must be set first. Please call setUri(yourTargetUri)");
+        if(uri == null) throw new IllegalStateException("The URI must be set first. Please call setUri(yourTargetUri)");
         if(method == Method.GET) request = new HttpGet(uri);
         else if(method == Method.POST) request = new HttpPost(uri);
         else if(method == Method.PUT) request = new HttpPut(uri);
@@ -101,15 +100,15 @@ public class ApacheHttpClient implements HttpClient<HttpResponse> {
 
     @Override
     public HttpClient<HttpResponse> addPayload(final String contentType, final String payload) {
-        if(request == null) throw new RuntimeException("Please set the method to a POST or PUT before calling the addPayload method");
-        if(!(request instanceof HttpEntityEnclosingRequestBase)) throw new RuntimeException("Request must be either Post or Put.");
+        if(uri == null) throw new IllegalStateException("The URI must be set first. Please call setUri(yourTargetUri)");
+        if(!(request instanceof HttpEntityEnclosingRequestBase)) throw new IllegalStateException("Request must be either Post or Put. Make sure to call setMethod(Method.POST | Method.PUT) before attempting to add a payload.");
         ((HttpEntityEnclosingRequestBase)request).setEntity(new StringEntity(payload, ContentType.create(contentType, "UTF-8")));
         return this;
     }
 
     @Override
     public void execute(RequestProcessor<HttpResponse> processor) throws Exception {
-        if(request == null) throw new RuntimeException("Please set the method before executing the http call");
+        if(uri == null) throw new IllegalStateException("The URI must be set before executing the request");
 
         try (CloseableHttpClient client = clientBuilder.setDefaultRequestConfig(rqConfigBuilder.build()).build()) {
             headers.forEach((n, v) -> request.addHeader(n, v));

--- a/core/src/main/java/com/dtolabs/rundeck/core/http/ApacheHttpClient.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/http/ApacheHttpClient.java
@@ -82,7 +82,7 @@ public class ApacheHttpClient implements HttpClient<HttpResponse> {
         if(method == Method.GET) request = new HttpGet(uri);
         else if(method == Method.POST) request = new HttpPost(uri);
         else if(method == Method.PUT) request = new HttpPut(uri);
-        else throw new RuntimeException(String.format("Method %s not implemented",method.name()));
+        else throw new UnsupportedOperationException(String.format("Method %s not implemented",method.name()));
         return this;
     }
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/http/HttpClient.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/http/HttpClient.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dtolabs.rundeck.core.http;
+
+import java.net.URI;
+
+public interface HttpClient<R> {
+
+    HttpClient<R> setUri(URI uri);
+    HttpClient<R> setFollowRedirects(boolean redirects);
+    HttpClient<R> setBasicAuthCredentials(String username, String password);
+    HttpClient<R> setTimeout(int timeoutMs);
+    HttpClient<R> setMethod(Method method);
+    HttpClient<R> setRetryCount(int count);
+    HttpClient<R> addHeader(String name, String value);
+    HttpClient<R> addPayload(String contentType, String payload);
+    void execute(RequestProcessor<R> processor) throws Exception;
+
+    enum Method {
+        GET,POST,PUT,DELETE,HEAD,OPTIONS
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/http/RequestProcessor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/http/RequestProcessor.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dtolabs.rundeck.core.http;
+
+@FunctionalInterface
+public interface RequestProcessor<R> {
+    void accept(R r) throws Exception;
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/URLResourceModelSource.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/URLResourceModelSource.java
@@ -58,7 +58,6 @@ public class URLResourceModelSource implements ResourceModelSource, Configurable
     private File destinationTempFile;
     private File destinationCacheData;
     private String tempFileName;
-    URLFileUpdater.httpClientInteraction interaction;
 
     public URLResourceModelSource(final Framework framework) {
         this.framework = framework;
@@ -275,10 +274,6 @@ public class URLResourceModelSource implements ResourceModelSource, Configurable
         }
         final URLFileUpdater updater = urlFileUpdaterBuilder.createURLFileUpdater();
         try {
-            if (null != interaction) {
-                //allow mock
-                updater.setInteraction(interaction);
-            }
             UpdateUtils.update(updater, destinationTempFile);
 
             logger.debug("Updated nodes resources file: " + destinationTempFile);

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/ScriptURLNodeStepExecutorSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/ScriptURLNodeStepExecutorSpec.groovy
@@ -39,9 +39,12 @@ import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext
 import com.dtolabs.rundeck.core.execution.workflow.WFSharedContext
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepResult
 import com.dtolabs.rundeck.core.tools.AbstractBaseTest
-import org.apache.commons.httpclient.Header
-import org.apache.commons.httpclient.HttpClient
-import org.apache.commons.httpclient.HttpMethod
+import org.apache.http.Header
+import org.apache.http.HttpRequest
+import org.apache.http.client.methods.HttpUriRequest
+import org.apache.http.client.protocol.HttpClientContext
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.message.BasicHeader
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -137,7 +140,7 @@ class ScriptURLNodeStepExecutorSpec extends Specification {
 
         interaction.httpResultCode = 200
         interaction.httpStatusText = "OK"
-        interaction.responseHeaders.put("Content-Type", new Header("Content-Type", "text/plain"))
+        interaction.responseHeaders.put("Content-Type", new BasicHeader("Content-Type", "text/plain"))
         String testcontent = "test script content @data.value@"
         ByteArrayInputStream stringStream = new ByteArrayInputStream(testcontent.getBytes())
         interaction.bodyStream = stringStream
@@ -234,7 +237,7 @@ class ScriptURLNodeStepExecutorSpec extends Specification {
 
         interaction.httpResultCode = 200
         interaction.httpStatusText = "OK"
-        interaction.responseHeaders.put("Content-Type", new Header("Content-Type", "text/plain"))
+        interaction.responseHeaders.put("Content-Type", new BasicHeader("Content-Type", "text/plain"))
         String testcontent = "test script content"
         ByteArrayInputStream stringStream = new ByteArrayInputStream(testcontent.getBytes())
         interaction.bodyStream = stringStream
@@ -308,7 +311,7 @@ class ScriptURLNodeStepExecutorSpec extends Specification {
 
         interaction.httpResultCode = 200
         interaction.httpStatusText = "OK"
-        interaction.responseHeaders.put("Content-Type", new Header("Content-Type", "text/plain"))
+        interaction.responseHeaders.put("Content-Type", new BasicHeader("Content-Type", "text/plain"))
         String testcontent = "test script content"
         ByteArrayInputStream stringStream = new ByteArrayInputStream(testcontent.getBytes())
         interaction.bodyStream = stringStream
@@ -460,22 +463,15 @@ class ScriptURLNodeStepExecutorSpec extends Specification {
         int httpResultCode = 0
         private String httpStatusText
         InputStream bodyStream
-        HttpMethod method
-        HttpClient client
+        HttpUriRequest request
+        CloseableHttpClient client
+        HttpClientContext context
         IOException toThrowExecute
         IOException toThrowResponseBody
         boolean releaseConnectionCalled
         Boolean followRedirects
         HashMap<String, String> requestHeaders = new HashMap<String, String>()
         HashMap<String, Header> responseHeaders = new HashMap<String, Header>()
-
-        void setMethod(HttpMethod method) {
-            this.method = method
-        }
-
-        void setClient(HttpClient client) {
-            this.client = client
-        }
 
         int executeMethod() throws IOException {
             return httpResultCode

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/http/ApacheHttpClientSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/http/ApacheHttpClientSpec.groovy
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dtolabs.rundeck.core.http
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.apache.http.HttpResponse
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.util.concurrent.TimeUnit
+
+class ApacheHttpClientSpec extends Specification {
+
+    @Shared
+    MockWebServer server
+
+    def setupSpec() {
+        server = new MockWebServer()
+        server.start()
+    }
+
+    def cleanupSpec() {
+        server.shutdown()
+    }
+
+    def "Execute"() {
+        when:
+        MockResponse mrsp = new MockResponse().setResponseCode(200).setBody("This is a test")
+        server.enqueue(mrsp)
+        ApacheHttpClient client = new ApacheHttpClient()
+        client.setUri(server.url("test.txt").uri())
+        client.addHeader("custom","my-val")
+        String actual = null
+        client.execute { rsp ->
+            actual = rsp.getEntity().content.text
+        }
+        RecordedRequest request = server.takeRequest();
+
+        then:
+        actual == "This is a test"
+        !request.headers.get("Authorization")
+        request.headers.get("custom") == "my-val"
+    }
+
+    def "Execute With BasicAuth"() {
+        when:
+        MockResponse mrsp = new MockResponse().setResponseCode(200).setBody("This is a test")
+        server.enqueue(mrsp)
+        ApacheHttpClient client = new ApacheHttpClient();
+        client.setUri(server.url("responder").uri())
+        String user = "auser"
+        String pwd = "apassword"
+        client.setBasicAuthCredentials(user,pwd)
+        String actual = null
+        client.execute { rsp ->
+            actual = rsp.getEntity().content.text
+        }
+        RecordedRequest request = server.takeRequest();
+        String authHeaderVal = request.headers.get("Authorization")
+        String creds = new String(Base64.decoder.decode(authHeaderVal.split(" ")[1]))
+
+        then:
+        actual == "This is a test"
+        authHeaderVal == "Basic YXVzZXI6YXBhc3N3b3Jk"
+        creds == "${user}:${pwd}"
+    }
+
+    def "Test Post"() {
+        when:
+        String responseStr = "Got the data"
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(responseStr))
+        ApacheHttpClient client = new ApacheHttpClient()
+        client.setUri(server.url("/post-target").uri())
+        client.setMethod(HttpClient.Method.POST)
+        String payload = '{"data":"something important"}'
+        client.addPayload("application/json",payload)
+        String out = null
+        client.execute { rsp ->
+            out = rsp.entity.content.text
+        }
+        RecordedRequest postRq = server.takeRequest()
+
+        then:
+        postRq.body.readUtf8() == payload
+        postRq.method == "POST"
+        postRq.headers.get("Content-Type") == "application/json; charset=UTF-8"
+
+    }
+
+    def "set retry test"() {
+        when:
+        HttpClient check = new RetryCheckVerifyApacheClientHttp()
+        check.setRetryCount(3)
+
+        then:
+        check.retryWasAdded
+
+    }
+
+    class RetryCheckVerifyApacheClientHttp extends ApacheHttpClient {
+
+        boolean retryWasAdded = false
+
+        @Override
+        HttpClient<HttpResponse> setRetryCount(final int count) {
+            retryWasAdded = true
+            return super.setRetryCount(count)
+        }
+    }
+
+    def "timeout test"() {
+        when:
+        server.enqueue(new MockResponse().setBody("Will never be received").setBodyDelay(1, TimeUnit.SECONDS).setResponseCode(200))
+        ApacheHttpClient client = new ApacheHttpClient()
+        client.setUri(server.url("/slow-responder").uri())
+        client.setTimeout(250)
+        String out = null
+        client.execute {rsp -> out = rsp.entity.content.text }
+
+        then:
+        thrown(SocketTimeoutException)
+        !out
+    }
+
+}

--- a/core/src/test/java/com/dtolabs/rundeck/core/common/impl/TestURLFileUpdater.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/common/impl/TestURLFileUpdater.java
@@ -104,7 +104,7 @@ public class TestURLFileUpdater extends TestCase {
         updater.updateFile(tempfile);
         assertTrue(tempfile.isFile());
         assertTrue(tempfile.length() > 0);
-        System.out.println(server.takeRequest().getPath());
+        server.takeRequest();
 
         //make another request. assert etag, If-modified-since are used.
 

--- a/core/src/test/java/com/dtolabs/rundeck/core/common/impl/TestURLFileUpdater.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/common/impl/TestURLFileUpdater.java
@@ -24,9 +24,11 @@
 package com.dtolabs.rundeck.core.common.impl;
 
 import junit.framework.TestCase;
-import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpMethod;
+import org.apache.http.Header;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicHeader;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -64,21 +66,27 @@ public class TestURLFileUpdater extends TestCase {
     static class test1 implements URLFileUpdater.httpClientInteraction {
         int httpResultCode = 0;
         private String httpStatusText;
-        InputStream bodyStream;
-        HttpMethod method;
-        HttpClient client;
+        InputStream         bodyStream;
+        HttpUriRequest      request;
+        CloseableHttpClient client;
+        HttpClientContext context;
         IOException toThrowExecute;
         IOException toThrowResponseBody;
         boolean releaseConnectionCalled;
         Boolean followRedirects;
-        HashMap<String, String> requestHeaders = new HashMap<String, String>();
+        HashMap<String, String> requestHeaders  = new HashMap<String, String>();
         HashMap<String, Header> responseHeaders = new HashMap<String, Header>();
 
-        public void setMethod(HttpMethod method) {
-            this.method = method;
+        @Override
+        public void setContext(final HttpClientContext context) {
+            this.context = context;
         }
 
-        public void setClient(HttpClient client) {
+        public void setRequest(HttpUriRequest request) {
+            this.request = request;
+        }
+
+        public void setClient(CloseableHttpClient client) {
             this.client = client;
         }
 
@@ -119,7 +127,7 @@ public class TestURLFileUpdater extends TestCase {
         final test1 test1 = new test1();
         test1.httpResultCode = 200;
         test1.httpStatusText = "OK";
-        test1.responseHeaders.put("Content-Type", new Header("Content-Type", "text/yaml"));
+        test1.responseHeaders.put("Content-Type", new BasicHeader("Content-Type", "text/yaml"));
         String yamlcontent = YAML_NODES_TEST;
         ByteArrayInputStream stringStream = new ByteArrayInputStream(yamlcontent.getBytes());
         test1.bodyStream = stringStream;
@@ -128,7 +136,7 @@ public class TestURLFileUpdater extends TestCase {
         tempfile.deleteOnExit();
         updater.updateFile(tempfile);
 
-        assertNotNull(test1.method);
+        assertNotNull(test1.request);
         assertNotNull(test1.client);
         assertNotNull(test1.followRedirects);
         assertNotNull(test1.releaseConnectionCalled);
@@ -149,10 +157,10 @@ public class TestURLFileUpdater extends TestCase {
         final test1 test1 = new test1();
         test1.httpResultCode = 200;
         test1.httpStatusText = "OK";
-        test1.responseHeaders.put("Content-Type", new Header("Content-Type", "text/yaml"));
+        test1.responseHeaders.put("Content-Type", new BasicHeader("Content-Type", "text/yaml"));
         //include etag, last-modified
-        test1.responseHeaders.put("ETag", new Header("ETag", "monkey1"));
-        test1.responseHeaders.put("Last-Modified", new Header("Last-Modified", "blahblee"));
+        test1.responseHeaders.put("ETag", new BasicHeader("ETag", "monkey1"));
+        test1.responseHeaders.put("Last-Modified", new BasicHeader("Last-Modified", "blahblee"));
 
         final ByteArrayInputStream stringStream = new ByteArrayInputStream(YAML_NODES_TEST.getBytes());
         test1.bodyStream = stringStream;
@@ -162,7 +170,7 @@ public class TestURLFileUpdater extends TestCase {
         assertTrue(tempfile.isFile());
         assertTrue(tempfile.length() > 0);
 
-        assertNotNull(test1.method);
+        assertNotNull(test1.request);
         assertNotNull(test1.client);
         assertNotNull(test1.followRedirects);
         assertNotNull(test1.releaseConnectionCalled);
@@ -174,8 +182,8 @@ public class TestURLFileUpdater extends TestCase {
         test2.httpResultCode = 304;
         test2.httpStatusText = "Not Modified";
         //include etag, last-modified
-        test2.responseHeaders.put("ETag", new Header("ETag", "monkey1"));
-        test2.responseHeaders.put("Last-Modified", new Header("Last-Modified", "blahblee"));
+        test2.responseHeaders.put("ETag", new BasicHeader("ETag", "monkey1"));
+        test2.responseHeaders.put("Last-Modified", new BasicHeader("Last-Modified", "blahblee"));
 
         test2.bodyStream = null;
         updater.setInteraction(test2);
@@ -185,7 +193,7 @@ public class TestURLFileUpdater extends TestCase {
         assertTrue(tempfile.length()>0);
 
 
-        assertNotNull(test2.method);
+        assertNotNull(test2.request);
         assertNotNull(test2.client);
         assertNotNull(test2.followRedirects);
         assertNotNull(test2.releaseConnectionCalled);

--- a/core/src/test/java/com/dtolabs/rundeck/core/common/impl/TestURLFileUpdater.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/common/impl/TestURLFileUpdater.java
@@ -24,18 +24,12 @@
 package com.dtolabs.rundeck.core.common.impl;
 
 import junit.framework.TestCase;
-import org.apache.http.Header;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.message.BasicHeader;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.HashMap;
+import java.io.*;
+import java.nio.file.Files;
 
 /**
  * TestURLFileUpdater is ...
@@ -62,84 +56,31 @@ public class TestURLFileUpdater extends TestCase {
         super(name);
     }
 
+    MockWebServer server;
 
-    static class test1 implements URLFileUpdater.httpClientInteraction {
-        int httpResultCode = 0;
-        private String httpStatusText;
-        InputStream         bodyStream;
-        HttpUriRequest      request;
-        CloseableHttpClient client;
-        HttpClientContext context;
-        IOException toThrowExecute;
-        IOException toThrowResponseBody;
-        boolean releaseConnectionCalled;
-        Boolean followRedirects;
-        HashMap<String, String> requestHeaders  = new HashMap<String, String>();
-        HashMap<String, Header> responseHeaders = new HashMap<String, Header>();
+    @Override
+    protected void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
 
-        @Override
-        public void setContext(final HttpClientContext context) {
-            this.context = context;
-        }
-
-        public void setRequest(HttpUriRequest request) {
-            this.request = request;
-        }
-
-        public void setClient(CloseableHttpClient client) {
-            this.client = client;
-        }
-
-        public int executeMethod() throws IOException {
-            return httpResultCode;
-        }
-
-        public String getStatusText() {
-            return httpStatusText;
-        }
-
-        public InputStream getResponseBodyAsStream() throws IOException {
-            return bodyStream;
-        }
-
-        public void releaseConnection() {
-            releaseConnectionCalled = true;
-        }
-
-        public void setRequestHeader(String name, String value) {
-            requestHeaders.put(name, value);
-        }
-
-        public Header getResponseHeader(String name) {
-            return responseHeaders.get(name);
-        }
-
-
-        public void setFollowRedirects(boolean follow) {
-            followRedirects = follow;
-        }
+    @Override
+    protected void tearDown() throws Exception {
+        server.shutdown();
     }
 
     public void testUpdateBasic() throws Exception {
-        URLFileUpdater updater = new URLFileUpdater(new URL("http://example.com/test"), null, -1, null, null, false,
+        URLFileUpdater updater = new URLFileUpdater(server.url("test").url(), null, -1, null, null, false,
             null, null);
 
-        final test1 test1 = new test1();
-        test1.httpResultCode = 200;
-        test1.httpStatusText = "OK";
-        test1.responseHeaders.put("Content-Type", new BasicHeader("Content-Type", "text/yaml"));
-        String yamlcontent = YAML_NODES_TEST;
-        ByteArrayInputStream stringStream = new ByteArrayInputStream(yamlcontent.getBytes());
-        test1.bodyStream = stringStream;
-        updater.setInteraction(test1);
+        server.enqueue(new MockResponse().setResponseCode(200).addHeader("Content-Type", "text/yaml").setBody(YAML_NODES_TEST));
         File tempfile = File.createTempFile("test", ".yaml");
         tempfile.deleteOnExit();
         updater.updateFile(tempfile);
 
-        assertNotNull(test1.request);
-        assertNotNull(test1.client);
-        assertNotNull(test1.followRedirects);
-        assertNotNull(test1.releaseConnectionCalled);
+        ByteArrayOutputStream tempFileContent = new ByteArrayOutputStream();
+        Files.copy(tempfile.toPath(),tempFileContent);
+        assertEquals(YAML_NODES_TEST,new String(tempFileContent.toByteArray()));
 
     }
 
@@ -150,56 +91,38 @@ public class TestURLFileUpdater extends TestCase {
         tempfile.deleteOnExit();
         File cachemeta = File.createTempFile("test", ".properties");
         cachemeta.deleteOnExit();
-        URLFileUpdater updater = new URLFileUpdater(new URL("http://example.com/test"), null, -1, cachemeta, tempfile,
+        URLFileUpdater updater = new URLFileUpdater(server.url("cache-test").url(), null, -1, cachemeta, tempfile,
             true, null, null);
 
-
-        final test1 test1 = new test1();
-        test1.httpResultCode = 200;
-        test1.httpStatusText = "OK";
-        test1.responseHeaders.put("Content-Type", new BasicHeader("Content-Type", "text/yaml"));
-        //include etag, last-modified
-        test1.responseHeaders.put("ETag", new BasicHeader("ETag", "monkey1"));
-        test1.responseHeaders.put("Last-Modified", new BasicHeader("Last-Modified", "blahblee"));
-
-        final ByteArrayInputStream stringStream = new ByteArrayInputStream(YAML_NODES_TEST.getBytes());
-        test1.bodyStream = stringStream;
-        updater.setInteraction(test1);
+        server.enqueue(new MockResponse()
+                               .setResponseCode(200)
+                               .addHeader("ETag", "monkey1")
+                               .addHeader("Last-Modified", "blahblee")
+                               .addHeader("Content-Type", "text/yaml")
+                               .setBody(YAML_NODES_TEST));
 
         updater.updateFile(tempfile);
         assertTrue(tempfile.isFile());
         assertTrue(tempfile.length() > 0);
-
-        assertNotNull(test1.request);
-        assertNotNull(test1.client);
-        assertNotNull(test1.followRedirects);
-        assertNotNull(test1.releaseConnectionCalled);
+        System.out.println(server.takeRequest().getPath());
 
         //make another request. assert etag, If-modified-since are used.
 
-
-        final test1 test2 = new test1();
-        test2.httpResultCode = 304;
-        test2.httpStatusText = "Not Modified";
-        //include etag, last-modified
-        test2.responseHeaders.put("ETag", new BasicHeader("ETag", "monkey1"));
-        test2.responseHeaders.put("Last-Modified", new BasicHeader("Last-Modified", "blahblee"));
-
-        test2.bodyStream = null;
-        updater.setInteraction(test2);
-
+        server.enqueue(new MockResponse()
+                               .setResponseCode(304)
+                               .addHeader("ETag", "monkey1")
+                               .addHeader("Last-Modified", "blahblee"));
         updater.updateFile(tempfile);
         assertTrue(tempfile.isFile());
         assertTrue(tempfile.length()>0);
 
+        ByteArrayOutputStream tempFileContent = new ByteArrayOutputStream();
+        Files.copy(tempfile.toPath(),tempFileContent);
+        assertEquals(YAML_NODES_TEST,new String(tempFileContent.toByteArray()));
 
-        assertNotNull(test2.request);
-        assertNotNull(test2.client);
-        assertNotNull(test2.followRedirects);
-        assertNotNull(test2.releaseConnectionCalled);
-        assertEquals("monkey1", test2.requestHeaders.get("If-None-Match"));
-        assertEquals("blahblee", test2.requestHeaders.get("If-Modified-Since"));
-
+        RecordedRequest rq = server.takeRequest();
+        assertEquals("monkey1", rq.getHeader("If-None-Match"));
+        assertEquals("blahblee", rq.getHeader("If-Modified-Since"));
 
     }
 

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptURLNodeStepExecutor.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptURLNodeStepExecutor.java
@@ -38,9 +38,10 @@ import com.dtolabs.rundeck.core.execution.workflow.steps.FailureReason;
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepResult;
 import com.dtolabs.rundeck.core.tools.AbstractBaseTest;
 import com.dtolabs.rundeck.core.utils.FileUtils;
-import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpMethod;
+import org.apache.http.Header;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.CloseableHttpClient;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -172,21 +173,27 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
     static class test1 implements URLFileUpdater.httpClientInteraction {
         int httpResultCode = 0;
         private String httpStatusText;
-        InputStream bodyStream;
-        HttpMethod method;
-        HttpClient client;
-        IOException toThrowExecute;
+        InputStream    bodyStream;
+        HttpUriRequest      request;
+        CloseableHttpClient client;
+        HttpClientContext context;
+        IOException         toThrowExecute;
         IOException toThrowResponseBody;
         boolean releaseConnectionCalled;
         Boolean followRedirects;
-        HashMap<String, String> requestHeaders = new HashMap<String, String>();
+        HashMap<String, String> requestHeaders  = new HashMap<String, String>();
         HashMap<String, Header> responseHeaders = new HashMap<String, Header>();
 
-        public void setMethod(HttpMethod method) {
-            this.method = method;
+        @Override
+        public void setContext(final HttpClientContext context) {
+            this.context = context;
         }
 
-        public void setClient(HttpClient client) {
+        public void setRequest(HttpUriRequest request) {
+            this.request = request;
+        }
+
+        public void setClient(CloseableHttpClient client) {
             this.client = client;
         }
 

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptURLNodeStepExecutor.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptURLNodeStepExecutor.java
@@ -24,28 +24,17 @@
 package com.dtolabs.rundeck.core.execution.workflow.steps.node.impl;
 
 import com.dtolabs.rundeck.core.common.*;
-import com.dtolabs.rundeck.core.common.impl.URLFileUpdater;
 import com.dtolabs.rundeck.core.data.BaseDataContext;
 import com.dtolabs.rundeck.core.dispatcher.ContextView;
 import com.dtolabs.rundeck.core.dispatcher.DataContextUtils;
 import com.dtolabs.rundeck.core.execution.ExecutionContext;
-import com.dtolabs.rundeck.core.execution.ExecutionContextImpl;
-import com.dtolabs.rundeck.core.execution.StepExecutionItem;
 import com.dtolabs.rundeck.core.execution.service.*;
-import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext;
 import com.dtolabs.rundeck.core.execution.workflow.WFSharedContext;
 import com.dtolabs.rundeck.core.execution.workflow.steps.FailureReason;
-import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepResult;
 import com.dtolabs.rundeck.core.tools.AbstractBaseTest;
 import com.dtolabs.rundeck.core.utils.FileUtils;
-import org.apache.http.Header;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.client.CloseableHttpClient;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 
@@ -168,63 +157,6 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
             return testResult.get(index++);
         }
 
-    }
-
-    static class test1 implements URLFileUpdater.httpClientInteraction {
-        int httpResultCode = 0;
-        private String httpStatusText;
-        InputStream    bodyStream;
-        HttpUriRequest      request;
-        CloseableHttpClient client;
-        HttpClientContext context;
-        IOException         toThrowExecute;
-        IOException toThrowResponseBody;
-        boolean releaseConnectionCalled;
-        Boolean followRedirects;
-        HashMap<String, String> requestHeaders  = new HashMap<String, String>();
-        HashMap<String, Header> responseHeaders = new HashMap<String, Header>();
-
-        @Override
-        public void setContext(final HttpClientContext context) {
-            this.context = context;
-        }
-
-        public void setRequest(HttpUriRequest request) {
-            this.request = request;
-        }
-
-        public void setClient(CloseableHttpClient client) {
-            this.client = client;
-        }
-
-        public int executeMethod() throws IOException {
-            return httpResultCode;
-        }
-
-        public String getStatusText() {
-            return httpStatusText;
-        }
-
-        public InputStream getResponseBodyAsStream() throws IOException {
-            return bodyStream;
-        }
-
-        public void releaseConnection() {
-            releaseConnectionCalled = true;
-        }
-
-        public void setRequestHeader(String name, String value) {
-            requestHeaders.put(name, value);
-        }
-
-        public Header getResponseHeader(String name) {
-            return responseHeaders.get(name);
-        }
-
-
-        public void setFollowRedirects(boolean follow) {
-            followRedirects = follow;
-        }
     }
 
     public void testExpandUrlString() throws Exception {

--- a/core/src/test/java/com/dtolabs/rundeck/core/resources/TestURLResourceModelSource.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/resources/TestURLResourceModelSource.java
@@ -24,21 +24,16 @@
 package com.dtolabs.rundeck.core.resources;
 
 import com.dtolabs.rundeck.core.common.Framework;
-import com.dtolabs.rundeck.core.common.FrameworkProject;
 import com.dtolabs.rundeck.core.common.INodeSet;
 import com.dtolabs.rundeck.core.common.IRundeckProject;
-import com.dtolabs.rundeck.core.common.impl.URLFileUpdater;
 import com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException;
 import com.dtolabs.rundeck.core.tools.AbstractBaseTest;
 import com.dtolabs.rundeck.core.utils.FileUtils;
-import org.apache.http.Header;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.message.BasicHeader;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import java.io.*;
-import java.util.HashMap;
 import java.util.Properties;
 
 /**
@@ -68,6 +63,8 @@ public class TestURLResourceModelSource extends AbstractBaseTest {
 
     IRundeckProject frameworkProject;
 
+    MockWebServer server;
+
     public void setUp() {
         super.setUp();
         final Framework frameworkInstance = getFrameworkInstance();
@@ -78,13 +75,17 @@ public class TestURLResourceModelSource extends AbstractBaseTest {
                 new File("src/test/resources/com/dtolabs/rundeck/core/common/test-nodes1.xml"),
                 frameworkProject
         );
-
+        server = new MockWebServer();
+        try {
+            server.start();
+        } catch(Exception e) { throw new RuntimeException(e); }
     }
 
     public void tearDown() throws Exception {
         super.tearDown();
         File projectdir = new File(getFrameworkProjectsBase(), PROJ_NAME);
         FileUtils.deleteDir(projectdir);
+        server.shutdown();
     }
 
     public void testConfigureProperties() throws Exception {
@@ -164,170 +165,74 @@ public class TestURLResourceModelSource extends AbstractBaseTest {
         assertEquals(false, provider.configuration.useCache);
     }
 
-    static class test1 implements URLFileUpdater.httpClientInteraction{
-        int httpResultCode=0;
-        private String httpStatusText;
-        InputStream         bodyStream;
-        HttpUriRequest      request;
-        CloseableHttpClient client;
-        HttpClientContext   context;
-        IOException         toThrowExecute;
-        IOException toThrowResponseBody;
-        boolean releaseConnectionCalled;
-        Boolean followRedirects;
-        HashMap<String, String> requestHeaders  = new HashMap<String, String>();
-        HashMap<String, Header> responseHeaders = new HashMap<String, Header>();
 
-        @Override
-        public void setContext(final HttpClientContext context) {
-            this.context = context;
-        }
-
-        public void setRequest(HttpUriRequest request) {
-            this.request=request;
-        }
-
-        public void setClient(CloseableHttpClient client) {
-            this.client=client;
-        }
-
-        public int executeMethod() throws IOException {
-            return httpResultCode;
-        }
-
-        public String getStatusText() {
-            return httpStatusText;
-        }
-
-        public InputStream getResponseBodyAsStream() throws IOException {
-            return bodyStream;
-        }
-
-        public void releaseConnection() {
-            releaseConnectionCalled=true;
-        }
-
-        public void setRequestHeader(String name, String value) {
-            requestHeaders.put(name, value);
-        }
-
-        public Header getResponseHeader(String name) {
-            return responseHeaders.get(name);
-        }
-
-
-        public void setFollowRedirects(boolean follow) {
-            followRedirects=follow;
-        }
-    }
     public void testGetNodesYaml() throws Exception {
         URLResourceModelSource provider = new URLResourceModelSource(getFrameworkInstance());
         final URLResourceModelSource.Configuration build = URLResourceModelSource.Configuration.build();
 
         build.project(PROJ_NAME);
-        build.url("http://example.com/test");
+        build.url(server.url("test").toString());
 
         provider.configure(build.getProperties());
-        final test1 test1 = new test1();
-        test1.httpResultCode=200;
-        test1.httpStatusText="OK";
-        test1.responseHeaders.put("Content-Type", new BasicHeader("Content-Type", "text/yaml"));
-        String yamlcontent = YAML_NODES_TEST;
-        ByteArrayInputStream stringStream = new ByteArrayInputStream(yamlcontent.getBytes());
-        test1.bodyStream=stringStream;
-        provider.interaction= test1;
+        server.enqueue(new MockResponse().setResponseCode(200).addHeader("Content-Type", "text/yaml").setBody(YAML_NODES_TEST));
         final INodeSet nodes = provider.getNodes();
         assertNotNull(nodes);
         assertEquals(1, nodes.getNodes().size());
         assertNotNull(nodes.getNode("testnode1"));
 
-        assertNotNull(test1.request);
-        assertNotNull(test1.client);
-        assertNotNull(test1.followRedirects);
-        assertNotNull(test1.releaseConnectionCalled);
-
     }
+
     public void testGetNodesXml() throws Exception {
         URLResourceModelSource provider = new URLResourceModelSource(getFrameworkInstance());
         final URLResourceModelSource.Configuration build = URLResourceModelSource.Configuration.build();
 
         build.project(PROJ_NAME);
-        build.url("http://example.com/test");
+        build.url(server.url("test").toString());
 
         provider.configure(build.getProperties());
-        final test1 test1 = new test1();
-        test1.httpResultCode=200;
-        test1.httpStatusText="OK";
-        test1.responseHeaders.put("Content-Type", new BasicHeader("Content-Type", "text/xml"));
-        ByteArrayInputStream stringStream = new ByteArrayInputStream(XML_NODES_TEXT.getBytes());
-        test1.bodyStream=stringStream;
-        provider.interaction= test1;
+        server.enqueue(new MockResponse().setResponseCode(200).addHeader("Content-Type", "text/xml").setBody(XML_NODES_TEXT));
         final INodeSet nodes = provider.getNodes();
         assertNotNull(nodes);
         assertEquals(1, nodes.getNodes().size());
         assertNotNull(nodes.getNode("testnode1"));
-
-        assertNotNull(test1.request);
-        assertNotNull(test1.client);
-        assertNotNull(test1.followRedirects);
-        assertNotNull(test1.releaseConnectionCalled);
     }
     public void testGetNodesCaching() throws Exception {
         URLResourceModelSource provider = new URLResourceModelSource(getFrameworkInstance());
         final URLResourceModelSource.Configuration build = URLResourceModelSource.Configuration.build();
 
         build.project(PROJ_NAME);
-        build.url("http://example.com/test");
+        build.url(server.url("cache-test").toString());
         build.cache(true);
 
         provider.configure(build.getProperties());
-        final test1 test1 = new test1();
-        test1.httpResultCode=200;
-        test1.httpStatusText="OK";
-        test1.responseHeaders.put("Content-Type", new BasicHeader("Content-Type", "text/yaml"));
         //include etag, last-modified
-        test1.responseHeaders.put("ETag", new BasicHeader("ETag", "monkey1"));
-        test1.responseHeaders.put("Last-Modified", new BasicHeader("Last-Modified", "blahblee"));
-
-        final ByteArrayInputStream stringStream = new ByteArrayInputStream(YAML_NODES_TEST.getBytes());
-        test1.bodyStream=stringStream;
-        provider.interaction= test1;
+        server.enqueue(new MockResponse()
+                               .setResponseCode(200)
+                               .addHeader("ETag", "monkey1")
+                               .addHeader("Last-Modified", "blahblee")
+                               .addHeader("Content-Type", "text/yaml")
+                               .setBody(YAML_NODES_TEST));
 
         final INodeSet nodes = provider.getNodes();
         assertNotNull(nodes);
         assertEquals(1, nodes.getNodes().size());
         assertNotNull(nodes.getNode("testnode1"));
-
-        assertNotNull(test1.request);
-        assertNotNull(test1.client);
-        assertNotNull(test1.followRedirects);
-        assertNotNull(test1.releaseConnectionCalled);
+        server.takeRequest();
 
         //make another request. assert etag, If-modified-since are used.
-
-
-        final test1 test2 = new test1();
-        test2.httpResultCode = 304;
-        test2.httpStatusText = "Not Modified";
-        //include etag, last-modified
-        test2.responseHeaders.put("ETag", new BasicHeader("ETag", "monkey1"));
-        test2.responseHeaders.put("Last-Modified", new BasicHeader("Last-Modified", "blahblee"));
-
-        test2.bodyStream = null;
-        provider.interaction = test2;
+        server.enqueue(new MockResponse()
+                               .setResponseCode(304)
+                               .addHeader("ETag", "monkey1")
+                               .addHeader("Last-Modified", "blahblee"));
 
         final INodeSet nodes2 = provider.getNodes();
         assertNotNull(nodes2);
         assertEquals(1, nodes2.getNodes().size());
         assertNotNull(nodes2.getNode("testnode1"));
 
-        assertNotNull(test2.request);
-        assertNotNull(test2.client);
-        assertNotNull(test2.followRedirects);
-        assertNotNull(test2.releaseConnectionCalled);
-        assertEquals("monkey1", test2.requestHeaders.get("If-None-Match"));
-        assertEquals("blahblee", test2.requestHeaders.get("If-Modified-Since"));
-
+        RecordedRequest rq = server.takeRequest();
+        assertEquals("monkey1", rq.getHeader("If-None-Match"));
+        assertEquals("blahblee", rq.getHeader("If-Modified-Since"));
 
     }
     /**

--- a/core/src/test/java/com/dtolabs/rundeck/core/resources/TestURLResourceModelSource.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/resources/TestURLResourceModelSource.java
@@ -78,7 +78,9 @@ public class TestURLResourceModelSource extends AbstractBaseTest {
         server = new MockWebServer();
         try {
             server.start();
-        } catch(Exception e) { throw new RuntimeException(e); }
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
     }
 
     public void tearDown() throws Exception {

--- a/core/src/test/java/com/dtolabs/rundeck/core/resources/TestURLResourceModelSource.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/resources/TestURLResourceModelSource.java
@@ -79,6 +79,7 @@ public class TestURLResourceModelSource extends AbstractBaseTest {
         try {
             server.start();
         } catch(Exception e) {
+            //  deepcode ignore DontUsePrintStackTrace: Prevent deepcode from flagging this in test code.
             e.printStackTrace();
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,14 +27,14 @@ grailsCentralUrl=https://grails.org/plugins
 jacksonDatabindVersion=2.10.5.1
 snakeyamlVersion=1.28
 gsonVersion=2.8.6
-httpClientVersion=4.5.12
+httpClientVersion=4.5.13
 bouncyCastleVersion=1.68
 #
 # Override of spring-boot dependencies versions.
 # available properties at:
 # https://github.com/spring-projects/spring-boot/blob/1.5.x/spring-boot-dependencies/pom.xml
 #
-jetty.version=9.4.38.v20210224
+jetty.version=9.4.39.v20210325
 spring.version=5.1.18.RELEASE
 spring-security.version=5.1.11.RELEASE
 log4j2.version=2.13.2

--- a/rundeckapp/grails-app/conf/application.groovy
+++ b/rundeckapp/grails-app/conf/application.groovy
@@ -192,4 +192,3 @@ grails.plugin.springsecurity.logout.handlerNames = [
 grails.plugin.springsecurity.providerNames = [
         'anonymousAuthenticationProvider',
         'rememberMeAuthenticationProvider']
-

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -891,8 +891,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
      */
     def getWorkflowDescriptionTree(String project,Workflow workflow,readAuth,maxDepth=3){
         def jobids=[:]
-        def cmdData={}
-        cmdData={x,WorkflowStep step->
+        def cmdData={x,WorkflowStep step->
             def map=readAuth?step.toMap():step.toDescriptionMap()
             map.remove('plugins')
             if(map.type){

--- a/testbuild.groovy
+++ b/testbuild.groovy
@@ -45,7 +45,7 @@ def debug=Boolean.getBoolean('debug')?:("-debug" in args)
 
 //versions of dependency we want to verify
 def versions=[
-        jetty:'9.4.38.v20210224',
+        jetty:'9.4.39.v20210325',
         servlet:'api-3.1.0',
         log4j:'2.13.2'
 ]


### PR DESCRIPTION
Replace  apache http client 3.1 with newer apache http client version. Created new http client interface and replaced the locations where the 3.1 code was used with the new interface.