### PR TITLE
Enh: Change default server.address to localhost instead of hostname to generate default rundeck-config.properties

### DIFF
--- a/rundeckapp/templates/config/rundeck-config.properties.template
+++ b/rundeckapp/templates/config/rundeck-config.properties.template
@@ -4,7 +4,7 @@ rdeck.base=${rdeck.base}
 
 #rss.enabled if set to true enables RSS feeds that are public (non-authenticated)
 rss.enabled=false
-server.address=127.0.0.1
+server.address=localhost
 server.port=${server.http.port}
 grails.serverURL=http://localhost:${server.http.port}${server.web.context}
 dataSource.dbCreate = none

--- a/rundeckapp/templates/config/rundeck-config.properties.template
+++ b/rundeckapp/templates/config/rundeck-config.properties.template
@@ -4,7 +4,8 @@ rdeck.base=${rdeck.base}
 
 #rss.enabled if set to true enables RSS feeds that are public (non-authenticated)
 rss.enabled=false
-server.address=${server.hostname}
+server.address=127.0.0.1
+server.port=${server.http.port}
 grails.serverURL=http://${server.hostname}:${server.http.port}${server.web.context}
 dataSource.dbCreate = none
 dataSource.url = jdbc:h2:file:${server.datastore.path};DB_CLOSE_ON_EXIT=FALSE

--- a/rundeckapp/templates/config/rundeck-config.properties.template
+++ b/rundeckapp/templates/config/rundeck-config.properties.template
@@ -6,7 +6,7 @@ rdeck.base=${rdeck.base}
 rss.enabled=false
 server.address=127.0.0.1
 server.port=${server.http.port}
-grails.serverURL=http://${server.hostname}:${server.http.port}${server.web.context}
+grails.serverURL=http://localhost:${server.http.port}${server.web.context}
 dataSource.dbCreate = none
 dataSource.url = jdbc:h2:file:${server.datastore.path};DB_CLOSE_ON_EXIT=FALSE
 grails.plugin.databasemigration.updateOnStart=true


### PR DESCRIPTION
By default, rundeck uses the machine hostname to generate both `server.address` and `grails.serverURL` properties when building the default rundeck-config.properties at first run. However, this assumes that the hostname is resolvable through DNS or /etc/hosts, which is not always the case, causing two side effects:

- The application binds to just one network interface, which can be any of the available.
- The grails.serverURL points to an unresolvable URL.

This causes the application to be unreachable after the first run, requiring the installer to run it, take it down to adjust the generated file, and run it again.

This PR makes the following changes to the default properties file to address those issues:
- server.address is now assigned to 0.0.0.0 so the application binds to all available network interfaces.
- default grails.serverURL is now http://localhost:$port/$context so at least the app is always reachable at localhost after the first run.
- adds server.port property explicitly so installers can change the listen port without having to google/review the documentation.



