### PR TITLE
Fix: "Duplicate to other project" option visibility

### DIFF
--- a/rundeckapp/grails-app/taglib/rundeck/AuthTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/AuthTagLib.groovy
@@ -189,7 +189,7 @@ class AuthTagLib {
             def projectNames = frameworkService.projectNames(authContext)
             projectNames.each{
                 if(it != attrs.project){
-                    def decision=  authContextEvaluatorCacheManager.evaluate(authContext, resources, tests as Set, null)
+                    def decision=  authContextEvaluatorCacheManager.evaluate(authContext, resources, tests as Set, it)
                     if(!decision.find{has^it.authorized}){
                         isAuth = true
                     }


### PR DESCRIPTION
Fixes #6896.
Pass other project names to  authContextEvaluatorCacheManager.evaluate() in order to determine if the user has the specified authorization for other projects.