### PR TITLE
Fix: Oracle saves empty fields as null and results in bug in comparison code

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/DbStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/DbStorageService.groovy
@@ -183,7 +183,7 @@ class DbStorageService implements NamespacedStorage{
                 eq('dir', dir)
             }else{
                 or{
-                    eq('dir', dir)
+                    eq('dir', '')
                     isNull('dir')
                 }
             }

--- a/rundeckapp/grails-app/services/rundeck/services/DbStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/DbStorageService.groovy
@@ -179,7 +179,14 @@ class DbStorageService implements NamespacedStorage{
             }else{
                 isNull('namespace')
             }
-            eq('dir', dir)
+            if(dir){
+                eq('dir', dir)
+            }else{
+                or{
+                    eq('dir', dir)
+                    isNull('dir')
+                }
+            }
             eq('name', name)
             cache(false)
         }


### PR DESCRIPTION
… cannot retrieve them in the create criteria when it is equated against an empty string

IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".

**Is this a bugfix, or an enhancement? Please describe.**
bugfix.  Oracle saves empty strings as null and when queried upon in the createCriteria, they are not retrieved in eq of the dir column which contains a null value against an empty string

**Describe the solution you've implemented**
check to see if the !dir is true, then check to see if the dir field is equal to the parameter or is null 

**Describe alternatives you've considered**
rewriting the query but this is the most efficient way forward.

