### PR TITLE
Fix: layout issues: scm import screen

### DIFF
--- a/rundeckapp/grails-app/views/scm/performAction.gsp
+++ b/rundeckapp/grails-app/views/scm/performAction.gsp
@@ -250,8 +250,9 @@
                             <div class="list-group-item overflowy">
                                 <div class="form-group">
                                     <g:each in="${trackingItems}" var="trackedItem">
+                                        <div class="flex justify-start items-center" style="margin-bottom:10px;">
                                         <g:set var="job" value="${trackedItem.jobId?jobMap[trackedItem.jobId]:null}"/>
-                                        <div class="checkbox col-sm-12">
+                                        <div class="checkbox flex-none"  style="margin-top: 0;margin-left: 20px;">
                                                 <g:checkBox name="chosenTrackedItem"
                                                             id="chosenTrackedItem${trackedItem.id}"
                                                             value="${trackedItem.id}"
@@ -312,6 +313,7 @@
                                             </div>
                                         </g:if>
 
+                                        </div>
                                     </g:each>
                                 </div>
                                 <g:if test="${trackingItems.size() > 1}">
@@ -335,10 +337,11 @@
                             <div class="list-group-item overflowy">
                                 <div class="form-group">
                                     <g:each in="${toDeleteItems}" var="toDeleteItem">
+                                        <div class="flex justify-start items-center" style="margin-bottom:10px;">
                                         <g:set var="job" value="${toDeleteItem.jobId?jobMap[toDeleteItem.jobId]:null}"/>
                                         <g:set var="jobst" value="${job?scmStatus?.get(job.extid)?.synchState?.toString():null}"/>
 
-                                        <div class="checkbox col-sm-12">
+                                        <div class="checkbox flex-none" style="margin-top: 0;margin-left: 20px;">
 
                                                 <g:checkBox name="chosenDeleteItem"
                                                     id="chosenDeleteItem${toDeleteItem.id}"
@@ -399,7 +402,7 @@
                                                 </span>
                                             </div>
                                         </g:if>
-
+                                        </div>
                                     </g:each>
                                 </div>
                                 <g:if test="${toDeleteItems.size() > 1}">


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Additional fixes for scm action page spacing issues:
import action items spacing



**Additional context**
before
<img width="798" alt="Screen Shot 2021-04-13 at 4 31 10 PM" src="https://user-images.githubusercontent.com/55603/114636857-dea27a80-9c7c-11eb-9072-345d430744a5.png">
<img width="911" alt="Screen Shot 2021-04-13 at 5 23 50 PM" src="https://user-images.githubusercontent.com/55603/114636932-098cce80-9c7d-11eb-95a9-3be0dbd17974.png">

