### PR TITLE
Fix: Create index for errorHandler on WorkflowStep table to help prevent deadlocks in MSSQL

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/WorkflowStep.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/WorkflowStep.groovy
@@ -16,6 +16,7 @@
 
 package rundeck
 
+import com.dtolabs.rundeck.app.support.DomainIndexHelper
 import com.fasterxml.jackson.databind.ObjectMapper
 import grails.gorm.dirty.checking.DirtyCheck
 
@@ -37,6 +38,10 @@ abstract class WorkflowStep {
     static mapping = {
         pluginConfigData(type: 'text')
         errorHandler lazy: false
+
+        DomainIndexHelper.generate(delegate) {
+            index 'IDX_ERROR_HANDLER', ['errorHandler']
+        }
     }
 
     public String summarize() {

--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -103,7 +103,7 @@ databaseChangeLog = {
         include file: 'core/RDOPTION.groovy'
         include file: 'core/Webhook.groovy'
         include file: 'core/ConstraintsIndexesKeys.groovy'
-        include file: 'core/Tag-3.4.0.groovy'
         include file: 'core/WorkflowStep.groovy'
+        include file: 'core/Tag-3.4.0.groovy'
 
 }

--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -104,5 +104,6 @@ databaseChangeLog = {
         include file: 'core/Webhook.groovy'
         include file: 'core/ConstraintsIndexesKeys.groovy'
         include file: 'core/Tag-3.4.0.groovy'
+        include file: 'core/WorkflowStep.groovy'
 
 }

--- a/rundeckapp/grails-app/migrations/core/WorkflowStep.groovy
+++ b/rundeckapp/grails-app/migrations/core/WorkflowStep.groovy
@@ -1,5 +1,5 @@
 databaseChangeLog = {
-    changeSet(author: "rundeckuser (generated)", id: "workflow_step") {
+    changeSet(author: "rundeckuser (generated)", id: "1619468434682") {
         preConditions(onFail: "MARK_RAN"){
             not{
                 indexExists (tableName:"workflow_step", indexName: "IDX_ERROR_HANDLER")

--- a/rundeckapp/grails-app/migrations/core/WorkflowStep.groovy
+++ b/rundeckapp/grails-app/migrations/core/WorkflowStep.groovy
@@ -1,0 +1,12 @@
+databaseChangeLog = {
+    changeSet(author: "rundeckuser (generated)", id: "workflow_step") {
+        preConditions(onFail: "MARK_RAN"){
+            not{
+                indexExists (tableName:"workflow_step", indexName: "IDX_ERROR_HANDLER")
+            }
+        }
+        createIndex(indexName: "IDX_ERROR_HANDLER", tableName: "workflow_step") {
+            column(name: "error_handler_id")
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rundeck/rundeck/issues/5848

**Is this a bugfix, or an enhancement? Please describe.**
Deleting old execution logs were causing a lot of deadlocks in the database.

**Describe the solution you've implemented**
Creating index for errorHandler on WorkflowStep table