### PR TITLE
Enh: Add button to Commit SCM changes in jobs list page

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/plugins/scm/ScmExportPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/scm/ScmExportPlugin.java
@@ -169,4 +169,13 @@ public interface ScmExportPlugin {
     default Map clusterFixJobs(ScmOperationContext context, List<JobExportReference> jobs, Map<String,String> originalPaths){
         return null;
     }
+
+    /**
+     * It gets the action id for push action
+     *
+     * @return action name id for push
+     */
+    default String getExportPushActionId(){
+        return null;
+    }
 }

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
@@ -231,7 +231,11 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
                     actions << PROJECT_PUSH_ACTION_ID
                 }
             }
-            return actionRefs(actions)
+            if(actions && !actions.isEmpty()){
+                return actionRefs(actions)
+            }else{
+                return null
+            }
         } else {
             null
         }

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
@@ -194,6 +194,10 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
         actions.subMap(Arrays.asList(ids)).values().collect { ActionBuilder.from(it) }
     }
 
+    protected List<Action> actionRefs(List ids) {
+        actions.subMap(ids).values().collect { ActionBuilder.from(it) }
+    }
+
     @Override
     List<Action> actionsAvailableForContext(ScmOperationContext context) {
         if (context.jobId) {
@@ -203,19 +207,31 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
         } else if (context.frameworkProject) {
             //actions in project view
             def status = getStatusInternal(context, false)
+            def actions = []
             if (!status.gitStatus.clean) {
-                actionRefs PROJECT_COMMIT_ACTION_ID
-            } else if (status.state == SynchState.EXPORT_NEEDED) {
+                actions << PROJECT_COMMIT_ACTION_ID
+            }else if (status.state == SynchState.EXPORT_NEEDED) {
                 //need a push
-                actionRefs PROJECT_PUSH_ACTION_ID
+                actions << PROJECT_PUSH_ACTION_ID
             } else if (status.state == SynchState.REFRESH_NEEDED) {
                 //need to fast forward
-                actionRefs PROJECT_SYNCH_ACTION_ID
+                actions << PROJECT_SYNCH_ACTION_ID
             } else if(!config.shouldFetchAutomatically()){
-                actionRefs PROJECT_FETCH_ACTION_ID
+                actions << PROJECT_FETCH_ACTION_ID
             }else{
                 null
             }
+            //It only checks for push action if no push or refresh is yet added to actions
+            if((!actions || !actions.contains(PROJECT_PUSH_ACTION_ID)) && !actions.contains(PROJECT_SYNCH_ACTION_ID)){
+                status = git.status().call()
+                def synchState = new GitExportSynchState()
+                synchState.gitStatus = status
+                def bstat = BranchTrackingStatus.of(repo, branch)
+                if (bstat && bstat.aheadCount > 0) {
+                    actions << PROJECT_PUSH_ACTION_ID
+                }
+            }
+            return actionRefs(actions)
         } else {
             null
         }
@@ -609,6 +625,11 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
         }
 
         retSt
+    }
+
+    @Override
+    String getExportPushActionId(){
+        return PROJECT_PUSH_ACTION_ID
     }
 
 }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -1148,14 +1148,16 @@ class ScmController extends ControllerBase {
         def jobMap = [:]
         def scmStatus = []
         if (integration == 'export') {
-            jobs = jobIds.collect {
-                ScheduledExecution.getByIdOrUUID(it)
-            }
-            scmStatus = scmService.exportStatusForJobsWithoutClusterFix(authContext, jobs).findAll {
-                it.value.synchState != SynchState.CLEAN
-            }
-            jobs = jobs.findAll {
-                it.extid in scmStatus.keySet()
+            if(actionId && !actionId.equals(scmService.getExportPushActionId(project))){
+                jobs = jobIds.collect {
+                    ScheduledExecution.getByIdOrUUID(it)
+                }
+                scmStatus = scmService.exportStatusForJobsWithoutClusterFix(authContext, jobs).findAll {
+                    it.value.synchState != SynchState.CLEAN
+                }
+                jobs = jobs.findAll {
+                    it.extid in scmStatus.keySet()
+                }
             }
         } else {
             (trackingItems*.jobId).each {

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1518,6 +1518,11 @@ class ScmService {
 
     }
 
+    def getExportPushActionId(project){
+        def plugin = getLoadedExportPluginFor project
+        return plugin?.getExportPushActionId()
+    }
+
 }
 
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
@@ -715,6 +715,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             1 * deletedExportFilesForProject(projectName)
             1 * exportFilePathsMapForJobs(_)
             0 * exportStatusForJobs(_,_)
+            1 * getExportPushActionId('testproj') >> null
             0 * _(*_)
         }
 
@@ -782,4 +783,53 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
         integration | _
         'export'    | _
     }
+
+    def "perform export shouldn't call clusterFix with push action match"() {
+        given:
+        def projectName = 'testproj'
+        def actionName = 'testAction'
+        params.actionId = actionName
+        params.project = projectName
+        params.integration = integration
+
+        controller.frameworkService = Mock(FrameworkService) {
+            0 * _(*_)
+        }
+        controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
+            1 * authResourceForProject(projectName)
+            1 * authorizeApplicationResourceAny(_, _, _)>>true
+
+            getAuthContextForSubjectAndProject(_, projectName) >> Mock(UserAndRolesAuthContext)
+        }
+
+        controller.scmService = Mock(ScmService) {
+            1 * projectHasConfiguredPlugin(integration, projectName) >> true
+            1 * getInputView(_, integration, projectName, actionName) >> Mock(BasicInputView)
+            1 * getRenamedJobPathsForProject(projectName) >> [:]
+            1 * loadProjectPluginDescriptor(projectName, integration)
+            0 * exportStatusForJobsWithoutClusterFix(_,[])
+            1 * getPluginStatus(_,integration, projectName)
+            1 * deletedExportFilesForProject(projectName)
+            1 * exportFilePathsMapForJobs(_)
+            0 * exportStatusForJobs(_,_)
+            1 * getExportPushActionId('testproj') >> actionName
+            0 * _(*_)
+        }
+
+        response.format = 'json'
+        request.method = 'POST'
+        request.contentType = 'application/json'
+        request.content = '{"input":null}'.bytes
+
+        when:
+        controller.performAction(integration, projectName, actionName)
+
+        then:
+        response.status == 200
+
+        where:
+        integration | _
+        'export'    | _
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/1710

The button was added in jobs list page instead of job show because when the user performs a push it cannot choose the commit to push, so if this would be in jobs show page, the user could think that he is pushing just that single job instead of all the pending commits.

The modification in scm controller was to avoid showing the pending jobs to be commited when the requested action is to push and also to know the push action id a new method was added to the export interface.

![imagen](https://user-images.githubusercontent.com/50217398/115306605-15bdd380-a136-11eb-8ff7-2cc1226cabb3.png)
