### PR TITLE
fix: cannot use context path url with selenium tests

### DIFF
--- a/test/testdeck/src/context.ts
+++ b/test/testdeck/src/context.ts
@@ -30,7 +30,7 @@ export class Context {
     }
 
     urlFor(path: string) {
-        return Url.resolve(this.baseUrl, path)
+        return `${this.baseUrl.endsWith('/') ? this.baseUrl.substring(0, this.baseUrl.length - 1) : this.baseUrl}/${path.startsWith('/') ? path.substring(1) : path}`
     }
 
     friendlyTestName() {


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**
`bin/deck test --url http://host:4440/rundeck` does not work correctly

**Describe the solution you've implemented**
- [x] fix url creation, just append and clean up / chars
- [ ] (there's probably a better way to do it)

