### PR TITLE
Scm:  Loader Fix  and Sync Config Changes

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -55,6 +55,7 @@ public class RundeckConfigBase {
     UserSessionProjectsCache userSessionProjectsCache;
     RundeckNotificationConfig notification;
     RundeckApiConfig api;
+    ScmLoader scmLoader;
 
     @Data
     public static class UserSessionProjectsCache {
@@ -554,6 +555,12 @@ public class RundeckConfigBase {
     @Data
     public static class RundeckNotificationConfig {
         Long threadTimeOut;
+    }
+
+    @Data
+    public static class ScmLoader {
+        Long delay;
+        Long interval;
     }
 
     public static final Map<String,String> DEPRECATED_PROPS = ImmutableMap.of(

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
@@ -583,26 +583,26 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
             retSt.behind = true
         }
 
-        jobs.each { job ->
-            def storedCommitId = ((JobScmReference)job).scmImportMetadata?.commitId
-            def path = getRelativePathForJob(job)
-            def commitId = lastCommitForPath(path)
-
-            if(storedCommitId != null && commitId == null){
-                //file to delete-pull
-                git.rm().addFilepattern(path).call()
-                retSt.deleted.add(path)
-                refreshJobCache.add(job)
-            }else if(storedCommitId != null && commitId?.name != storedCommitId){
-                if(toPull){
-                    git.checkout().addPath(path).call()
-                }
-                retSt.restored.add(job)
-                refreshJobCache.add(job)
-            }
-        }
-
         if(toPull){
+            jobs.each { job ->
+                def storedCommitId = ((JobScmReference)job).scmImportMetadata?.commitId
+                def path = getRelativePathForJob(job)
+                def commitId = lastCommitForPath(path)
+
+                if(storedCommitId != null && commitId == null){
+                    //file to delete-pull
+                    git.rm().addFilepattern(path).call()
+                    retSt.deleted.add(path)
+                    refreshJobCache.add(job)
+                }else if(storedCommitId != null && commitId?.name != storedCommitId){
+                    if(toPull){
+                        git.checkout().addPath(path).call()
+                    }
+                    retSt.restored.add(job)
+                    refreshJobCache.add(job)
+                }
+            }
+
             retSt.pull = true
             try{
                 gitPull(context)

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
@@ -1439,10 +1439,19 @@ class GitExportPluginSpec extends Specification {
         ScmOperationContext context = Mock(ScmOperationContext)
         //create a git dir
         def git = createGit(origindir)
-
+        addCommitFile(origindir, git, 'blah-abc.xml', 'blah')
         git.close()
         def plugin = new GitExportPlugin(config)
         plugin.initialize(Mock(ScmOperationContext))
+
+        git = createGit(origindir)
+        addCommitFile(origindir, git, 'blah-abc.xml', 'blah2')
+        git.push()
+        git.close()
+
+        def gitScm = openGit(gitdir)
+        plugin.fetchFromRemote(context, gitScm)
+
 
         def serializer = Mock(JobSerializer)
         def jobref = Stub(JobScmReference) {
@@ -1510,6 +1519,14 @@ class GitExportPluginSpec extends Specification {
         git.close()
         def plugin = new GitExportPlugin(config)
         plugin.initialize(Mock(ScmOperationContext))
+
+        git = createGit(origindir)
+        addCommitFile(origindir, git, 'a/b/name-abc.xml', 'blah2')
+        git.push()
+        git.close()
+
+        def gitScm = openGit(gitdir)
+        plugin.fetchFromRemote(context, gitScm)
 
         def jobref = Stub(JobScmReference) {
             getJobName() >> 'name'
@@ -1818,8 +1835,17 @@ class GitExportPluginSpec extends Specification {
 
         git.close()
 
+        def context = Mock(ScmOperationContext)
         def plugin = new GitExportPlugin(config)
-        plugin.initialize(Mock(ScmOperationContext))
+        plugin.initialize(context)
+
+        git = createGit(origindir)
+        addCommitFile(origindir, git, 'a/b/testjob-xyz.xml', 'blah2')
+        git.push()
+        git.close()
+
+        def gitScm = openGit(gitdir)
+        plugin.fetchFromRemote(context, gitScm)
 
         def outfile = new File(origindir, 'a/b/testjob-xyz.xml')
         AtomicLong latch = new AtomicLong(-1)
@@ -1830,7 +1856,6 @@ class GitExportPluginSpec extends Specification {
 
         plugin.jobStateMap[jobId]= [id:jobId, ident: "${jobId}:1:${commit.name}:true", "synch": SynchState.CLEAN]
 
-        def context = Mock(ScmOperationContext)
         def serializer = Mock(JobSerializer)
         def jobref = Stub(JobScmReference) {
             getJobName() >> 'testjob'

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1481,10 +1481,6 @@ class ScmService {
         def jobFullName = job.generateFullName()
         def origFullName = [jobPluginMeta.groupPath?:'',jobPluginMeta.name].join("/")
 
-        log.info("original name")
-        log.info(origFullName)
-        log.info(jobPluginMeta)
-
         if(jobPluginMeta && jobPluginMeta.name && jobFullName != origFullName){
 
             log.debug("job ${job.groupPath}/${job.jobName} was renamed, previuos name: ${jobPluginMeta.groupPath}/${jobPluginMeta.name}" )

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1481,7 +1481,11 @@ class ScmService {
         def jobFullName = job.generateFullName()
         def origFullName = [jobPluginMeta.groupPath?:'',jobPluginMeta.name].join("/")
 
-        if( jobFullName != origFullName){
+        log.info("original name")
+        log.info(origFullName)
+        log.info(jobPluginMeta)
+
+        if(jobPluginMeta && jobPluginMeta.name && jobFullName != origFullName){
 
             log.debug("job ${job.groupPath}/${job.jobName} was renamed, previuos name: ${jobPluginMeta.groupPath}/${jobPluginMeta.name}" )
 

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -53,12 +53,10 @@ import com.dtolabs.rundeck.plugins.scm.ScmUserInfo
 import com.dtolabs.rundeck.plugins.scm.ScmUserInfoMissing
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
 import com.dtolabs.rundeck.core.plugins.ValidatedPlugin
-import com.dtolabs.rundeck.plugins.scm.SynchState
 import com.dtolabs.rundeck.server.plugins.services.ScmExportPluginProviderService
 import com.dtolabs.rundeck.server.plugins.services.ScmImportPluginProviderService
 import org.rundeck.app.components.RundeckJobDefinitionManager
 import rundeck.ScheduledExecution
-import rundeck.Storage
 import rundeck.User
 import rundeck.services.scm.ContextJobImporter
 import rundeck.services.scm.ResolvedJobImporter
@@ -682,6 +680,7 @@ class ScmService {
             def changeListener = loadedImportListeners.remove(project)
             jobEventsService.removeListener(changeListener)
         }
+        initedProjects.remove(integration + '/' + project)
         loaded?.provider?.cleanup()
     }
 
@@ -1160,17 +1159,9 @@ class ScmService {
 
                 def jobReference = exportJobRef(job, jobPluginMeta)
 
-                if(jobPluginMeta){
-                    //check if job was renamed
-                    checkExportJobRenamed(plugin, project, job, (JobScmReference)jobReference, jobPluginMeta)
-                }
-
                 def originalPath = getRenamedPathForJobId(jobReference.project, jobReference.id)
                 JobState jobState = plugin.getJobStatus(jobReference, originalPath)
                 status[jobReference.id] = jobState
-
-                // synch commit info to exported commit data
-                checkExportJobStatus(plugin, job, (JobScmReference)jobReference, jobPluginMeta, jobState)
 
                 log.debug("Status for job ${jobReference}: ${status[jobReference.id]}, origpath: ${originalPath}")
             }
@@ -1526,6 +1517,24 @@ class ScmService {
     def getExportPushActionId(project){
         def plugin = getLoadedExportPluginFor project
         return plugin?.getExportPushActionId()
+    }
+
+    def refreshExportPluginMetadata(String project, ScmExportPlugin plugin, List<ScheduledExecution> jobs, Map<String, Map> jobsPluginMeta ){
+        jobs.each { job ->
+            Map jobPluginMeta =  jobsPluginMeta.get(job.uuid)
+            JobExportReference jobReference = exportJobRef(job, jobPluginMeta)
+
+            if(jobPluginMeta){
+                //check if job was renamed
+                checkExportJobRenamed(plugin, project, job, (JobScmReference)jobReference, jobPluginMeta)
+            }
+
+            String originalPath = getRenamedPathForJobId(jobReference.project, jobReference.id)
+            JobState jobState = plugin.getJobStatus(jobReference, originalPath)
+
+            // synch commit info to exported commit data
+            checkExportJobStatus(plugin, job, (JobScmReference)jobReference, jobPluginMeta, jobState)
+        }
     }
 
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
@@ -787,7 +787,64 @@ class ScmServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmService
         "test"   | "test"    | 0
     }
 
+    def "exportStatusForJobs calls plugin cluster fix in cluster mode"() {
+        given:
+        service.pluginConfigService = Mock(PluginConfigService)
+        service.frameworkService = Mock(FrameworkService) {
+            isClusterModeEnabled() >> true
+        }
+        service.storageService = Mock(StorageService)
+        service.pluginService = Mock(PluginService)
+        service.jobEventsService = Mock(JobEventsService)
 
+        def project = "test"
+
+        service.rundeckAuthContextProvider = Mock(AuthContextProvider) {
+            getAuthContextForUserAndRolesAndProject(_,_,_) >>
+                    Mock(UserAndRolesAuthContext) {
+                        getUsername() >> 'admin'
+                    }
+        }
+        def job = new ScheduledExecution()
+        job.version = 1
+        job.jobName = "test"
+        job.groupPath = "test"
+
+        def jobs = [job]
+        def integration = "export"
+        def originalMeta = [name: "test", groupPath: "tes"]
+
+        ScmExportPlugin plugin = Mock(ScmExportPlugin)
+
+        service.jobMetadataService = Mock(JobMetadataService){
+            getJobPluginMeta(_,'scm-import')>>originalMeta
+        }
+
+        def auth = Mock(UserAndRolesAuthContext) {
+            getUsername() >> 'admin'
+        }
+        service.initedProjects<<"import/" + project
+        service.initedProjects<<"export/" + project
+        service.loadedExportPlugins[project]=Closeables.closeableProvider(plugin)
+
+        when:
+        service.exportStatusForJobs(project, auth, jobs,true)
+        then:
+        2 * service.pluginConfigService.loadScmConfig(
+                project,
+                "etc/scm-${integration}.properties",
+                "scm.$integration"
+        ) >> Mock(ScmPluginConfigData) {
+            getEnabled() >> true
+            getSetting("username")>>"admin"
+            getSettingList("roles")>>["admin"]
+            _ * getType() >> 'pluginType'
+            getConfig() >> [plugin: 'config']
+        }
+
+        1 * plugin.clusterFixJobs(_,_,_)>> [:]
+        1 * plugin.getJobStatus(_,_)>> Mock(JobState)
+    }
 
     def "get job plugin meta"(){
         given:


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

- check if the config was changed: issue https://github.com/rundeckpro/rundeckpro/issues/1726
- improve background process refresh
- expose background process configuration variables

```
rundeck.scmLoader.delay=1
rundeck.scmLoader.interval=10
```

**Describe the solution you've implemented**
* save config properties in the cache to check if stored values changed. If there is a change, SCM plugin is unregister and initialized again
* in GitExportPlugin, clusterFix jobs check must run only if detects a remote change
* ScmLoaderService must perform a fetch before call clusterFix (this improve the sync time between clusters)
* preload pluginMeta in ScmLoaderService
* moving the plugin meta refresh and the rename check from MenuController to ScmLoaderService 

**Describe alternatives you've considered**

**Additional context**
