### PR TITLE
SCM Import: fix import of renamed jobs 

### DIFF
--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
@@ -569,6 +569,9 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
 
 
     Map clusterFixJobs(ScmOperationContext context, final List<JobExportReference> jobs, final Map<String,String> originalPaths){
+        //force fetch
+        fetchFromRemote(context)
+
         def retSt = [:]
         List<JobExportReference> refreshJobCache = []
 

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
@@ -325,9 +325,7 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
         def ident = job.id + ':' +
                 String.valueOf(job.version) +
                 ':' +
-                (commit ? commit.name : '') +
-                ":" +
-                (getLocalFileForJob(job)?.exists())
+                (commit ? commit.name : '')
         ident
     }
 
@@ -717,9 +715,11 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
 
 
     Map clusterFixJobs(ScmOperationContext context, List<JobScmReference> jobs, Map<String,String> originalPaths){
-        Status st = git.status().call()
+        //force fetch
+        fetchFromRemote(context)
+
         def bstat = BranchTrackingStatus.of(repo, branch)
-        if(st.clean && bstat && bstat.behindCount>0){
+        if (bstat && bstat.behindCount > 0) {
             try {
                 PullResult result = gitPull(context)
                 jobs.each{job ->
@@ -760,20 +760,4 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
         }
     }
 
-    def cleanJobStatusCache(List<String> selectedPaths){
-        if (!inited) {
-            return null
-        }
-
-        def jobsToClean = []
-        jobStateMap?.each { key, metadata ->
-            if(selectedPaths.contains(metadata.path) ){
-                jobsToClean << metadata
-            }
-        }
-        jobsToClean.each {job->
-            log.debug("cleanJobStatusCache(${job.id}): ${job}")
-            jobStateMap.remove(job.id)
-        }
-    }
 }

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/imp/actions/ImportJobs.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/imp/actions/ImportJobs.groovy
@@ -73,6 +73,22 @@ class ImportJobs extends BaseAction implements GitImportAction {
         StringBuilder sb = new StringBuilder()
         boolean success = true
 
+        deletedJobs?.each { jobId ->
+            def importResult = importer.deleteJob(
+                    context.frameworkProject,
+                    jobId
+            )
+            if (!importResult.successful) {
+                success = false
+                sb << ("Failed deleting job with id: ${jobId}: " + importResult.errorMessage)
+            } else {
+                sb << ("Succeeded deleting job with id ${jobId} ")
+            }
+
+        }
+
+        def jobsChanged = []
+
         //walk the repo files and look for possible candidates
         plugin.walkTreePaths('HEAD^{tree}', true) { TreeWalk walk ->
             def path = walk.getPathString()
@@ -95,6 +111,8 @@ class ImportJobs extends BaseAction implements GitImportAction {
                     meta,
                     plugin.config.importPreserve
             )
+
+            jobsChanged.add(importResult.getJob())
             if (!importResult.successful) {
                 success = false
                 sb << ("Failed importing: ${walk.getPathString()}: " + importResult.errorMessage)
@@ -104,20 +122,10 @@ class ImportJobs extends BaseAction implements GitImportAction {
             }
         }
 
-        deletedJobs?.each { jobId ->
-            def importResult = importer.deleteJob(
-                context.frameworkProject,
-                jobId
-            )
-            if (!importResult.successful) {
-                success = false
-                sb << ("Failed deleting job with id: ${jobId}: " + importResult.errorMessage)
-            } else {
-                sb << ("Succeeded deleting job with id ${jobId} ")
-            }
-
+        if(jobsChanged){
+            plugin.refreshJobsStatus(jobsChanged)
         }
-        plugin.cleanJobStatusCache(selectedPaths)
+
         def result = new ScmExportResultImpl()
         result.success = success
         result.message = "Git Import " + (success ? "successful" : "failed")

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/imp/actions/ImportJobs.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/imp/actions/ImportJobs.groovy
@@ -112,11 +112,13 @@ class ImportJobs extends BaseAction implements GitImportAction {
                     plugin.config.importPreserve
             )
 
-            jobsChanged.add(importResult.getJob())
             if (!importResult.successful) {
                 success = false
                 sb << ("Failed importing: ${walk.getPathString()}: " + importResult.errorMessage)
             } else {
+                if(importResult.getJob()){
+                    jobsChanged.add(importResult.getJob())
+                }
                 plugin.importTracker.trackJobAtPath(importResult.job,walk.getPathString())
                 sb << ("Succeeded importing ${walk.getPathString()}: ${importResult}")
             }

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitImportPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitImportPluginSpec.groovy
@@ -16,6 +16,7 @@
 
 package org.rundeck.plugin.scm.git
 
+import com.dtolabs.rundeck.plugins.scm.ImportResult
 import com.dtolabs.rundeck.plugins.scm.ImportSynchState
 import com.dtolabs.rundeck.plugins.scm.JobImporter
 import com.dtolabs.rundeck.plugins.scm.JobScmReference
@@ -354,6 +355,72 @@ class GitImportPluginSpec extends Specification {
         result.message == '1 file(s) need to be imported'
         result.importNeeded == 1
         result.state == ImportSynchState.IMPORT_NEEDED
+    }
+
+    def "perform import renamed job"() {
+        given:
+        def projectName = 'GitImportPluginSpec'
+        def gitdir = new File(tempdir, 'scm')
+        def origindir = new File(tempdir, 'origin')
+        def actionId = "import-jobs"
+        Import config = createTestConfig(gitdir, origindir)
+
+        Git git = GitExportPluginSpec.createGit(origindir)
+        def commit = GitExportPluginSpec.addCommitFile(origindir, git, 'test/job-123.xml', 'blah')
+        git.close()
+
+        ScmOperationContext context = Mock(ScmOperationContext) {
+            getFrameworkProject() >> projectName
+        }
+
+        JobImporter importer = Mock(JobImporter)
+        List<String> selectedPaths = ["test/job-123.xml"]
+        List<String> deletePaths = ["123"]
+
+        def job = Mock(JobScmReference) {
+            getScmImportMetadata() >> ["commitId":commit.name]
+            getProject() >> projectName
+            getId() >> '123'
+            getJobName() >> 'job1'
+            getGroupPath() >> ''
+            getJobAndGroup() >> 'job1'
+        }
+
+        def plugin = new GitImportPlugin(config, [])
+        plugin.initialize(context)
+        plugin.importTracker = Mock(ImportTracker){
+            trackedPaths() >> ['test/job-123.xml']
+            getTrackedCommits() >> ['test/job-123.xml' : '123']
+            getTrackedJobIds() >> ['test/job-123.xml':'123']
+        }
+
+        when:
+        def ret = plugin.scmImport(context, actionId,
+                importer,
+                selectedPaths,
+                deletePaths,
+                [:]
+        )
+
+
+
+        then:
+
+        1*importer.deleteJob(projectName, "123")>>Mock(ImportResult){
+            isSuccessful()>>true
+        }
+
+        then:
+        1*importer.importFromStream(_,_,_,_)>>Mock(ImportResult){
+            isSuccessful()>>true
+            getJob()>>job
+        }
+
+        then:
+        plugin.jobStateMap["123"]!=null
+        plugin.jobStateMap["123"]["synch"]!= ImportSynchState.CLEAN
+        ret != null
+        ret.success
     }
 
 }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -1156,7 +1156,6 @@ class ScmController extends ControllerBase {
         renamedJobPaths.values().each {
             deletedPaths.remove(it)
         }
-        def trackingItems = integration == 'import' ? scmService.getTrackingItemsForAction(project, actionId) : null
         List<ScheduledExecution> jobs = []
         def toDeleteItems = []
         def skipCleanItems = []
@@ -1177,12 +1176,14 @@ class ScmController extends ControllerBase {
                 }
             }
         } else {
-            (trackingItems*.jobId).each {
+            jobIds.each {
                 jobMap[it] = ScheduledExecution.getByIdOrUUID(it)
             }
             jobs = (jobMap.values() as List).findAll { it != null }
             scmStatus = scmService.importStatusForJobs(project, authContext, jobs, false, jobsPluginMeta)
         }
+
+        def trackingItems = integration == 'import' ? scmService.getTrackingItemsForAction(project, actionId) : null
 
         def scmProjectStatus = scmService.getPluginStatus(authContext, integration, project)
         def scmFiles = integration == 'export' ? scmService.exportFilePathsMapForJobs(project, jobs) : null

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
@@ -205,9 +205,6 @@ class ScmLoaderService implements EventBusAware {
             def username = pluginConfig.getSetting("username")
             def roles = pluginConfig.getSettingList("roles")
             ScmOperationContext context = scmService.scmOperationContext(username, roles, project)
-            //check global status
-            //needed to perform fetch
-            plugin.getStatus(context)
 
             List<ScheduledExecution> jobs = getJobs(project)
             List<String> deleted = []
@@ -291,9 +288,6 @@ class ScmLoaderService implements EventBusAware {
             def username = pluginConfig.getSetting("username")
             def roles = pluginConfig.getSettingList("roles")
             ScmOperationContext context = scmService.scmOperationContext(username, roles, project)
-            //check global status
-            //needed to perform fetch
-            plugin.getStatus(context)
 
             List<ScheduledExecution> jobs = getJobs(project)
             log.debug("processing ${jobs.size()} jobs")

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
@@ -926,17 +926,17 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             1 * getTrackingItemsForAction(projectName, actionName) >> [
                     Mock(ScmImportTrackedItem){
                         getId()>> job1.id
-                        getJobId()>>job1.id
+                        getJobId()>>job1.uuid
                     },
                     Mock(ScmImportTrackedItem){
                         getId()>>job2.id
-                        getJobId()>>job2.id
+                        getJobId()>>job2.uuid
 
                     }
             ]
             1 * getJobsPluginMeta(projectName)>>meta
             1 * getPluginStatus(_,integration, projectName)
-            1 * importStatusForJobs(projectName, _, {it.size()==2}, false, meta) >> [
+            1 * importStatusForJobs(projectName, _, _, false, meta) >> [
                     job1: Mock(JobImportState){getSynchState()>> ImportSynchState.CLEAN},
                     job2: Mock(JobImportState){getSynchState()>> ImportSynchState.IMPORT_NEEDED}
             ]


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
fix for: https://github.com/rundeckpro/rundeckpro/issues/1727

**Describe the solution you've implemented**
- in ImportJobs, run the delete before importing the new job version
- removing plugin.getStatus from ScmLoaderService. If the pull automatic is enabled, the clusterFix won't refresh job status. clusterFix will call the fetch directly before the run.
- hasJobStatusCached was always returning null in GitImportPlugin

**Describe alternatives you've considered**

**Additional context**
