### PR TITLE
SCM: Fix job sourceId not appearing in exported file path

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -837,7 +837,7 @@ class ScmController extends ControllerBase {
         jobs = jobs.findAll {
             it.extid in scmJobStatus.keySet()
         }
-        Map<String, String> scmFiles = scmService.exportFilePathsMapForJobs(project, jobs)
+        Map<String, String> scmFiles = scmService.exportFilePathsMapForJobs(project, jobs, jobPluginMeta)
 
         jobs.each { ScheduledExecution job ->
             ScmExportActionItem item = new ScmExportActionItem()
@@ -1001,7 +1001,8 @@ class ScmController extends ControllerBase {
 
             Map<String, String> scmFiles = scmService.exportFilePathsMapForJobs(
                 project,
-                uncleanJobs
+                uncleanJobs,
+                jobsPluginMeta
             )
             Map reversed = [:]
             scmFiles.each { k, v ->
@@ -1186,7 +1187,7 @@ class ScmController extends ControllerBase {
         def trackingItems = integration == 'import' ? scmService.getTrackingItemsForAction(project, actionId) : null
 
         def scmProjectStatus = scmService.getPluginStatus(authContext, integration, project)
-        def scmFiles = integration == 'export' ? scmService.exportFilePathsMapForJobs(project, jobs) : null
+        def scmFiles = integration == 'export' ? scmService.exportFilePathsMapForJobs(project, jobs, jobsPluginMeta) : null
 
         if(integration == 'import'){
             //separate files to import and to delete
@@ -1326,7 +1327,7 @@ class ScmController extends ControllerBase {
             }
             def jobsPluginMeta = scmService.getJobsPluginMeta(project)
             def scmStatus = integration == 'export' ? scmService.exportStatusForJobs(project, authContext, jobs, false, jobsPluginMeta) : null
-            def scmFiles = integration == 'export' ? scmService.exportFilePathsMapForJobs(project, jobs) : null
+            def scmFiles = integration == 'export' ? scmService.exportFilePathsMapForJobs(project, jobs, jobsPluginMeta) : null
 
             def scmProjectStatus = scmService.getPluginStatus(authContext, integration, params.project)
             def trackingItems = integration == 'import' ? scmService.getTrackingItemsForAction(project, actionId) : null

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmJobImporter.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmJobImporter.groovy
@@ -86,7 +86,6 @@ class ScmJobImporter implements ContextJobImporter {
                 [user: context.userInfo.userName, method: 'scm-import'],
                 context.authContext
         )
-        scheduledExecutionService.issueJobChangeEvents(loadresults.jobChangeEvents)
 
         if (loadresults.errjobs) {
             return ImporterResult.fail(loadresults.errjobs.collect { it.errmsg }.join(", "))
@@ -106,6 +105,7 @@ class ScmJobImporter implements ContextJobImporter {
         result.modified = result.job.version > 0
         result.successful = true
 
+        scheduledExecutionService.issueJobChangeEvents(loadresults.jobChangeEvents)
         result
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
@@ -105,7 +105,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             1 * projectHasConfiguredPlugin(integration, projectName) >> true
             1 * getInputView(_, integration, projectName, actionName) >> Mock(BasicInputView)
             1 * exportStatusForJobs(projectName,_,[],false, _) >> [:]
-            1 * exportFilePathsMapForJobs(projectName, []) >> [:]
+            1 * exportFilePathsMapForJobs(projectName, [], _) >> [:]
             1 * getRenamedJobPathsForProject(projectName) >> [:]
             1 * performExportAction(actionName, _, projectName, _, _, _) >>
             [valid: true, nextAction: [id: 'someAction']]
@@ -238,7 +238,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
                 job2: new JobStateImpl(synchState: SynchState.EXPORT_NEEDED),
                 job3: new JobStateImpl(synchState: SynchState.EXPORT_NEEDED),
             ]
-            1 * exportFilePathsMapForJobs(projectName, _) >> [
+            1 * exportFilePathsMapForJobs(projectName, _, _) >> [
                 job1: 'item1',
                 job2: 'item2',
                 job3: 'item3',
@@ -717,7 +717,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             1 * exportStatusForJobs(projectName,_,[],false,_)
             1 * getPluginStatus(_,integration, projectName)
             1 * deletedExportFilesForProject(projectName)
-            1 * exportFilePathsMapForJobs(projectName, _)
+            1 * exportFilePathsMapForJobs(projectName, _, _)
             1 * getJobsPluginMeta(projectName)
             0 * exportStatusForJobs(_,_,_,_,_)
             1 * getExportPushActionId('testproj') >> null
@@ -767,7 +767,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             1 * exportStatusForJobs(projectName, _,[], false, _)
             1 * getPluginStatus(_,integration, projectName)
             1 * deletedExportFilesForProject(projectName)
-            1 * exportFilePathsMapForJobs(projectName, _)
+            1 * exportFilePathsMapForJobs(projectName, _, _)
             1 * getInputView(_, integration, projectName, actionName) >> Mock(BasicInputView)
             1 * getJobsPluginMeta(projectName)
             0 * _(*_)
@@ -811,7 +811,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             1 * controller.scmService.exportFilePathsMapForJobs(project, {
                 it.size()==1
                 it[0].extid=='job2'
-            }) >> [
+            }, _) >> [
                 job2: '/path/to/job2'
             ]
             result.size() == 1
@@ -847,7 +847,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
                 job1: new JobStateImpl(synchState: SynchState.CLEAN),
                 job2: new JobStateImpl(synchState: SynchState.CLEAN)
             ]
-            1 * controller.scmService.exportFilePathsMapForJobs(project, []) >> [:]
+            1 * controller.scmService.exportFilePathsMapForJobs(project, [], _) >> [:]
             result.size() == 1
             result[0].itemId == 'scm/path/to/job3'
             result[0].originalId == null
@@ -881,7 +881,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             1 * controller.scmService.exportFilePathsMapForJobs(project, {
                 it.size()==1
                 it[0].extid=='job2'
-            }) >> [
+            }, _) >> [
                 job2: '/path/to/job2'
             ]
             result.size() == 1
@@ -985,7 +985,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             1 * loadProjectPluginDescriptor(projectName, integration)
             1 * getPluginStatus(_,integration, projectName)
             1 * deletedExportFilesForProject(projectName)
-            1 * exportFilePathsMapForJobs(projectName,_)
+            1 * exportFilePathsMapForJobs(projectName,_, _)
             1 * getJobsPluginMeta('testproj')
             0 * exportStatusForJobs(_,_)
             1 * getExportPushActionId('testproj') >> actionName

--- a/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
@@ -986,6 +986,8 @@ class ScmServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmService
             def result = service.exportFilePathsMapForJobs(project, jobs)
         then:
             0 * service.jobMetadataService.getJobsPluginMeta(project, ScmService.STORAGE_NAME_IMPORT)
+            1 * service.jobMetadataService.getJobPluginMeta(job1, ScmService.STORAGE_NAME_IMPORT)
+            1 * service.jobMetadataService.getJobPluginMeta(job2, ScmService.STORAGE_NAME_IMPORT)
             1 * plugin.getRelativePathForJob({it.id== 'job1id' })>> '/a/path/job1'
             1 * plugin.getRelativePathForJob({it.id=='job2id' })>>'/a/path/job2'
             result == [

--- a/rundeckapp/src/test/groovy/rundeck/services/scm/ScmJobImporterSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/scm/ScmJobImporterSpec.groovy
@@ -9,6 +9,8 @@ import rundeck.services.JobMetadataService
 import rundeck.services.ScheduledExecutionService
 import spock.lang.Specification
 
+import java.util.concurrent.atomic.AtomicInteger
+
 class ScmJobImporterSpec extends Specification {
     def "import from stream"() {
 
@@ -32,6 +34,7 @@ class ScmJobImporterSpec extends Specification {
 
             sut.scheduledExecutionService = Mock(ScheduledExecutionService)
             sut.jobMetadataService = Mock(JobMetadataService)
+            AtomicInteger counter=new AtomicInteger(0)
 
         when:
             def result = sut.importFromStream(ctx, format, input, meta, preserve)
@@ -47,7 +50,12 @@ class ScmJobImporterSpec extends Specification {
                 [user: 'bob', method: 'scm-import'],
                 _
             ) >> [jobs: [job], jobChangeEvents: []]
-            1 * sut.jobMetadataService.setJobPluginMeta(job, 'scm-import', [version: null, pluginMeta: meta])
+            1 * sut.jobMetadataService.setJobPluginMeta(job, 'scm-import', [version: null, pluginMeta: meta])>>{
+                assert counter.getAndIncrement()==0
+            }
+            1 * sut.scheduledExecutionService.issueJobChangeEvents([])>>{
+                assert counter.getAndIncrement()==1
+            }
             job.project == 'aProject'
     }
 
@@ -74,6 +82,7 @@ class ScmJobImporterSpec extends Specification {
             sut.scheduledExecutionService = Mock(ScheduledExecutionService)
             sut.jobMetadataService = Mock(JobMetadataService)
             sut.rundeckJobDefinitionManager = Mock(RundeckJobDefinitionManager)
+            AtomicInteger counter=new AtomicInteger(0)
 
         when:
             def result = sut.importFromMap(ctx, input, meta, preserve)
@@ -89,7 +98,12 @@ class ScmJobImporterSpec extends Specification {
                 [user: 'bob', method: 'scm-import'],
                 _
             ) >> [jobs: [job], jobChangeEvents: []]
-            1 * sut.jobMetadataService.setJobPluginMeta(job, 'scm-import', [version: null, pluginMeta: meta])
+            1 * sut.jobMetadataService.setJobPluginMeta(job, 'scm-import', [version: null, pluginMeta: meta])>>{
+                assert counter.getAndIncrement()==0
+            }
+            1 * sut.scheduledExecutionService.issueJobChangeEvents([])>>{
+                assert counter.getAndIncrement()==1
+            }
             job.project == 'aProject'
     }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fixes https://github.com/rundeckpro/rundeckpro/issues/1729

Fixes two issues:
1. corrects earlier change that removed metadata loading for jobs when getting export paths, and which prevented `${job.sourceId}` from working in template paths
2. Fixes an issue where imported jobs would be serialized with wrong file path when scm import and export were both enabled; the job metadata was stored after the event was fired triggering the export.  Fixed this to store the metadata before firing the job change event.
