### PR TITLE
RUN-151: Fix: Properly detect when a job was renamed in SCM Import

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/plugins/scm/JobImportState.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/scm/JobImportState.java
@@ -39,4 +39,8 @@ public interface JobImportState {
      * @return Actions available
      */
     List<Action> getActions();
+
+    default JobRenamed getJobRenamed(){
+        return null;
+    }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/scm/JobImporter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/scm/JobImporter.java
@@ -66,7 +66,7 @@ public interface JobImporter {
      *
      * @return result
      */
-    ImportResult importFromStream(String format, InputStream input, Map importMetadata, boolean preserveUuid, Map renamedJob);
+    ImportResult importFromStream(String format, InputStream input, Map importMetadata, boolean preserveUuid, JobRenamed renamedJob);
 
     /**
      * Deleted a job deleted remotely

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/scm/JobImporter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/scm/JobImporter.java
@@ -62,10 +62,11 @@ public interface JobImporter {
      * @param input          input stream
      * @param importMetadata metadata to attach to the job
      * @param preserveUuid   if true, preserve any UUID on import, otherwise remove it
+     * @param renamedJob     pass original ID/UUID if the job is renamed
      *
      * @return result
      */
-    ImportResult importFromStream(String format, InputStream input, Map importMetadata, boolean preserveUuid);
+    ImportResult importFromStream(String format, InputStream input, Map importMetadata, boolean preserveUuid, Map renamedJob);
 
     /**
      * Deleted a job deleted remotely

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/scm/JobRenamed.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/scm/JobRenamed.java
@@ -1,0 +1,20 @@
+package com.dtolabs.rundeck.plugins.scm;
+
+/**
+ * Get source and UUID form a renamed Job
+ */
+public interface JobRenamed {
+    /**
+     * get the job the UUID
+     *
+     * @return uuid
+     */
+    String getUuid();
+
+    /**
+     * get the job the SourceID
+     *
+     * @return sourceID
+     */
+    String getSourceId();
+}

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/scm/JobRenamed.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/scm/JobRenamed.java
@@ -17,4 +17,11 @@ public interface JobRenamed {
      * @return sourceID
      */
     String getSourceId();
+
+    /**
+     * get the job the renamed path
+     *
+     * @return renamedPath
+     */
+    String getRenamedPath();
 }

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/BaseGitPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/BaseGitPlugin.groovy
@@ -468,12 +468,13 @@ class BaseGitPlugin {
         )
     }
 
-    JobImportState createJobImportStatus(final Map map, final List<Action> actions = []) {
+    JobImportState createJobImportStatus(final Map map, final List<Action> actions = [], JobRenamed jobRenamed = null) {
         //TODO: include scm status
         return new JobImportGitState(
                 synchState: map['synch'],
                 commit: map.commitMeta ? new GitScmCommit(map.commitMeta) : null,
-                actions: actions
+                actions: actions,
+                jobRenamed: jobRenamed
         )
     }
 

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
@@ -370,6 +370,13 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
             return state
         }
 
+        if(originalPath && originalPath!=path){
+            //job renamed can lost last commit track, so not check it again
+            if(state && state.synch == SynchState.EXPORT_NEEDED){
+                return state
+            }
+        }
+
         def commit = lastCommitForPath(path)
         String ident = createStatusCacheIdent(job, commit)
 

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
@@ -528,14 +528,7 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
                 break;
 
             case JobChangeEvent.JobChangeEventType.MODIFY_RENAME:
-                if(importTracker.originalValue(newpath)){
-                    //if a job was imported with a new name traker needs to be cleaned
-                    def oldPath=importTracker.originalValue(newpath)
-                    importTracker.renamedTrackedItems.trackItem(oldPath, oldPath)
-                    importTracker.untrackPath(oldPath)
-                }else{
-                    importTracker.jobRenamed(reference, path, newpath)
-                }
+                importTracker.jobRenamed(reference, path, newpath)
         //TODO
 //            case JobChangeEvent.JobChangeEventType.CREATE:
 //            case JobChangeEvent.JobChangeEventType.MODIFY:

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
@@ -437,8 +437,10 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
                     }.join("\n")
                     )
 
-                    def findNewPath = changes.find { it.changeType == DiffEntry.ChangeType.ADD && it.newPath != null }
-                    def findOldPath = changes.find { it.changeType == DiffEntry.ChangeType.DELETE && it.oldPath != null }
+                    String jobSerializerId = job?.sourceId !=null ? job.sourceId: job.id
+
+                    def findNewPath = changes.find { it.changeType == DiffEntry.ChangeType.ADD && it.newPath && it.newPath.contains(jobSerializerId) }
+                    def findOldPath = changes.find { it.changeType == DiffEntry.ChangeType.DELETE && it.oldPath && it.oldPath.contains(jobSerializerId) }
 
                     if(findNewPath && findOldPath){
                         def oldPath = findOldPath.oldPath

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/ImportTracker.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/ImportTracker.groovy
@@ -56,9 +56,17 @@ class ImportTracker {
     }
 
     void jobRenamed(JobScmReference job, String oldpath, String newpath) {
-        untrackPath(oldpath)
-        trackJobAtPath(job, newpath)
-        renamedTrackedItems.trackItem(oldpath, newpath)
+        if(oldpath == newpath){
+            def originalPath=originalValue(newpath)
+            if(originalPath){
+                renamedTrackedItems.trackItem(originalPath, originalPath)
+                untrackPath(originalPath)
+            }
+        }else{
+            untrackPath(oldpath)
+            trackJobAtPath(job, newpath)
+            renamedTrackedItems.trackItem(oldpath, newpath)
+        }
     }
 
     void trackJobAtPath(JobScmReference job, String path) {

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/JobImportGitState.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/JobImportGitState.groovy
@@ -19,6 +19,7 @@ package org.rundeck.plugin.scm.git
 import com.dtolabs.rundeck.core.plugins.views.Action
 import com.dtolabs.rundeck.plugins.scm.ImportSynchState
 import com.dtolabs.rundeck.plugins.scm.JobImportState
+import com.dtolabs.rundeck.plugins.scm.JobRenamed
 import com.dtolabs.rundeck.plugins.scm.ScmCommitInfo
 
 /**
@@ -30,6 +31,8 @@ class JobImportGitState implements JobImportState {
     ScmCommitInfo commit
 
     List<Action> actions
+
+    JobRenamed jobRenamed
 
     @Override
     public String toString() {

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/JobRenamedImp.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/JobRenamedImp.groovy
@@ -1,0 +1,8 @@
+package org.rundeck.plugin.scm.git
+
+import com.dtolabs.rundeck.plugins.scm.JobRenamed
+
+class JobRenamedImp implements JobRenamed{
+    String uuid
+    String sourceId
+}

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/JobRenamedImp.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/JobRenamedImp.groovy
@@ -5,4 +5,5 @@ import com.dtolabs.rundeck.plugins.scm.JobRenamed
 class JobRenamedImp implements JobRenamed{
     String uuid
     String sourceId
+    String renamedPath
 }

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/imp/actions/ImportJobs.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/imp/actions/ImportJobs.groovy
@@ -110,7 +110,10 @@ class ImportJobs extends BaseAction implements GitImportAction {
                 def originalPath = plugin.importTracker.originalValue(path)
                 def jobUUID = plugin.importTracker.trackedJob(originalPath)
                 def jobCache = plugin.jobStateMap[jobUUID]
-                renamedJob = [uuid: jobUUID, sourceId: jobCache?.sourceId]
+                renamedJob = [uuid: jobUUID]
+                if(jobCache?.sourceId){
+                    renamedJob.sourceId = jobCache.sourceId
+                }
             }
 
             def importResult = importer.importFromStream(

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/imp/actions/ImportJobs.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/imp/actions/ImportJobs.groovy
@@ -105,11 +105,20 @@ class ImportJobs extends BaseAction implements GitImportAction {
             def meta = GitUtil.metaForCommit(commit)
             meta.url = plugin.config.url
 
+            def renamedJob = null
+            if(plugin.importTracker.originalValue(path)){
+                def originalPath = plugin.importTracker.originalValue(path)
+                def jobUUID = plugin.importTracker.trackedJob(originalPath)
+                def jobCache = plugin.jobStateMap[jobUUID]
+                renamedJob = [uuid: jobUUID, sourceId: jobCache?.sourceId]
+            }
+
             def importResult = importer.importFromStream(
                     plugin.config.format,
                     new ByteArrayInputStream(bytes),
                     meta,
-                    plugin.config.importPreserve
+                    plugin.config.importPreserve,
+                    renamedJob
             )
 
             if (!importResult.successful) {

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/imp/actions/ImportJobs.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/imp/actions/ImportJobs.groovy
@@ -18,6 +18,7 @@ package org.rundeck.plugin.scm.git.imp.actions
 
 import com.dtolabs.rundeck.core.plugins.views.BasicInputView
 import com.dtolabs.rundeck.plugins.scm.JobImporter
+import com.dtolabs.rundeck.plugins.scm.JobRenamed
 import com.dtolabs.rundeck.plugins.scm.ScmExportResult
 import com.dtolabs.rundeck.plugins.scm.ScmExportResultImpl
 import com.dtolabs.rundeck.plugins.scm.ScmOperationContext
@@ -28,6 +29,7 @@ import org.rundeck.plugin.scm.git.BuilderUtil
 import org.rundeck.plugin.scm.git.GitImportAction
 import org.rundeck.plugin.scm.git.GitImportPlugin
 import org.rundeck.plugin.scm.git.GitUtil
+import org.rundeck.plugin.scm.git.JobRenamedImp
 
 
 /**
@@ -105,12 +107,12 @@ class ImportJobs extends BaseAction implements GitImportAction {
             def meta = GitUtil.metaForCommit(commit)
             meta.url = plugin.config.url
 
-            def renamedJob = null
+            JobRenamedImp renamedJob = null
             if(plugin.importTracker.originalValue(path)){
                 def originalPath = plugin.importTracker.originalValue(path)
                 def jobUUID = plugin.importTracker.trackedJob(originalPath)
                 def jobCache = plugin.jobStateMap[jobUUID]
-                renamedJob = [uuid: jobUUID]
+                renamedJob = new JobRenamedImp(uuid: jobUUID)
                 if(jobCache?.sourceId){
                     renamedJob.sourceId = jobCache.sourceId
                 }

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
@@ -575,6 +575,27 @@ class GitExportPluginSpec extends Specification {
         commit1.call()
     }
 
+    static RevCommit renameCommitFile(final File gitdir, final Git git, final String oldPath, final String newPath, final String content) {
+        def outfile = new File(gitdir, oldPath)
+        def newfile = new File(gitdir, newPath)
+        outfile.renameTo(newfile)
+        newfile.withOutputStream {
+            it.write(content.bytes)
+        }
+        outfile.delete()
+        git.add().addFilepattern(oldPath).call()
+        git.add().addFilepattern(newPath).call()
+
+        CommitCommand commit1 = git.commit().setMessage('rename commit').setCommitter(new PersonIdent(
+                'test user1',
+                'test@example.com'
+        )
+        )
+        commit1.setOnly(oldPath)
+        commit1.setOnly(newPath)
+        commit1.call()
+    }
+
     def "get local file and path for job"() {
         given:
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3322,7 +3322,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     if (scmService.projectHasConfiguredExportPlugin(params.project)) {
                         pluginData.scmExportEnabled = scmService.loadScmConfig(params.project, 'export')?.enabled
                         if (pluginData.scmExportEnabled) {
-                            def jobsPluginMeta = scmService.getJobsPluginMeta(params.project)
+                            def jobsPluginMeta = scmService.getJobsPluginMeta(params.project, true)
                             pluginData.scmStatus = scmService.exportStatusForJobs(params.project, authContext, result.nextScheduled, false, jobsPluginMeta)
                             pluginData.scmExportStatus = scmService.exportPluginStatus(authContext, params.project)
                             pluginData.scmExportActions = scmService.exportPluginActions(authContext, params.project)
@@ -3346,7 +3346,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     if (scmService.projectHasConfiguredImportPlugin(params.project)) {
                         pluginData.scmImportEnabled = scmService.loadScmConfig(params.project, 'import')?.enabled
                         if (pluginData.scmImportEnabled) {
-                            def jobsPluginMeta = scmService.getJobsPluginMeta(params.project)
+                            def jobsPluginMeta = scmService.getJobsPluginMeta(params.project, false)
                             pluginData.scmImportJobStatus = scmService.importStatusForJobs(params.project, authContext, result.nextScheduled,false, jobsPluginMeta)
                             pluginData.scmImportStatus = scmService.importPluginStatus(authContext, params.project)
                             pluginData.scmImportActions = scmService.importPluginActions(authContext, params.project, pluginData.scmImportStatus)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -603,7 +603,7 @@ class ScmController extends ControllerBase {
             return
         }
 
-        def isExport = apiProjStatusIntRequest.integration == 'export'
+        boolean isExport = apiProjStatusIntRequest.integration == 'export'
         def action = isExport ? AuthConstants.ACTION_EXPORT : AuthConstants.ACTION_IMPORT
         def scmAction = isExport ? AuthConstants.ACTION_SCM_EXPORT : AuthConstants.ACTION_SCM_IMPORT
 
@@ -619,7 +619,7 @@ class ScmController extends ControllerBase {
                 def query=new ScheduledExecutionQuery()
                 query.projFilter = params.project
                 def jobs = scheduledExecutionService.listWorkflows(query, params)
-                def jobsPluginMeta = scmService.getJobsPluginMeta(params.project)
+                def jobsPluginMeta = scmService.getJobsPluginMeta(params.project, isExport)
                 //relaod all jobs to get project status
                 scmService.exportStatusForJobs(params.project, authContext, jobs.schedlist, true, jobsPluginMeta)
             }
@@ -828,7 +828,7 @@ class ScmController extends ControllerBase {
             }.findAll { it }
         } else {
             jobs = ScheduledExecution.findAllByProject(project)
-            jobPluginMeta = scmService.getJobsPluginMeta(project)
+            jobPluginMeta = scmService.getJobsPluginMeta(project, true)
         }
 
         scmJobStatus = scmService.exportStatusForJobs(project, null, jobs, true, jobPluginMeta).findAll {k,v->
@@ -991,7 +991,7 @@ class ScmController extends ControllerBase {
             List<ScheduledExecution> alljobs = ScheduledExecution.findAllByProject(project)
             Map<String, ScheduledExecution> jobMap = alljobs.collectEntries { [it.extid, it] }
 
-            def jobsPluginMeta = scmService.getJobsPluginMeta(project)
+            def jobsPluginMeta = scmService.getJobsPluginMeta(project, isExport)
 
             Map scmJobStatus = scmService.exportStatusForJobs(project, authContext, alljobs,false, jobsPluginMeta).findAll {
                 it.value.synchState != SynchState.CLEAN
@@ -1163,8 +1163,9 @@ class ScmController extends ControllerBase {
 
         def jobMap = [:]
         def scmStatus = []
-        def jobsPluginMeta = scmService.getJobsPluginMeta(project)
-        if (integration == 'export') {
+        boolean isExport = integration == 'export'
+        def jobsPluginMeta = scmService.getJobsPluginMeta(project, isExport)
+        if (isExport) {
             if(actionId && !actionId.equals(scmService.getExportPushActionId(project))){
                 jobs = jobIds.collect {
                     ScheduledExecution.getByIdOrUUID(it)
@@ -1285,7 +1286,8 @@ class ScmController extends ControllerBase {
 
         def deletePathsToJobIds = deletePaths.collectEntries { [it, scmService.deletedJobForPath(project, it)?.id] }
         def result
-        if (integration == 'export') {
+        boolean isExport = integration == 'export'
+        if (isExport) {
             result = scmService.performExportAction(
                     actionId,
                     authContext,
@@ -1325,7 +1327,7 @@ class ScmController extends ControllerBase {
             renamedJobPaths.values().each {
                 deletedPaths.remove(it)
             }
-            def jobsPluginMeta = scmService.getJobsPluginMeta(project)
+            def jobsPluginMeta = scmService.getJobsPluginMeta(project, isExport)
             def scmStatus = integration == 'export' ? scmService.exportStatusForJobs(project, authContext, jobs, false, jobsPluginMeta) : null
             def scmFiles = integration == 'export' ? scmService.exportFilePathsMapForJobs(project, jobs, jobsPluginMeta) : null
 
@@ -1717,7 +1719,8 @@ class ScmController extends ControllerBase {
             return redirect(action: 'index', params: [project: project])
         }
         def job = ScheduledExecution.getByIdOrUUID(id)
-        def jobMetaMap = [(id):scmService.getJobPluginMeta(job)]
+        String type = isExport ? scmService.STORAGE_NAME_EXPORT : scmService.STORAGE_NAME_IMPORT
+        def jobMetaMap = [(id):scmService.getJobPluginMeta(job, type)]
         def exportStatus = isExport ? scmService.exportStatusForJobs(project, authContext, [job], true, jobMetaMap) : null
         def importStatus = isExport ? null : scmService.importStatusForJobs(project, authContext, [job])
         def scmFilePaths = isExport ? scmService.exportFilePathsMapForJobs(project, [job]) : null

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -1728,8 +1728,10 @@ class ScmController extends ControllerBase {
 
         def scmImportRenamedPath = null
         if(!isExport){
-            JobRenamed scmImportRenamed = importStatus.get(job.extid).jobRenamed
-            scmImportRenamedPath = scmImportRenamed.renamedPath
+            JobRenamed scmImportRenamed = importStatus.get(job.extid)?.jobRenamed
+            if(scmImportRenamed){
+                scmImportRenamedPath = scmImportRenamed.renamedPath
+            }
         }
 
         def scmExportRenamedPath = isExport ? scmService.getRenamedJobPathsForProject(params.project)?.get(job.extid) : null

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -1723,10 +1723,17 @@ class ScmController extends ControllerBase {
         def jobMetaMap = [(id):scmService.getJobPluginMeta(job, type)]
         def exportStatus = isExport ? scmService.exportStatusForJobs(project, authContext, [job], true, jobMetaMap) : null
         def importStatus = isExport ? null : scmService.importStatusForJobs(project, authContext, [job])
-        def scmFilePaths = isExport ? scmService.exportFilePathsMapForJobs(project, [job]) : null
+        def scmFilePaths = isExport ? scmService.exportFilePathsMapForJobs(project, [job]) : scmService.importFilePathsMapForJobs(project, [job])
         def diffResult = isExport ? scmService.exportDiff(project, job) : scmService.importDiff(project, job)
-        def scmExportRenamedPath = isExport ? scmService.getRenamedJobPathsForProject(params.project)?.get(job.extid) :
-                null
+
+        def scmImportRenamedPath = null
+        if(!isExport){
+            JobRenamed scmImportRenamed = importStatus.get(job.extid).jobRenamed
+            scmImportRenamedPath = scmImportRenamed.renamedPath
+        }
+
+        def scmExportRenamedPath = isExport ? scmService.getRenamedJobPathsForProject(params.project)?.get(job.extid) : null
+
         if (params.download == 'true') {
             if (params.download) {
                 response.addHeader("Content-Disposition", "attachment; filename=\"${job.extid}.diff\"")
@@ -1741,7 +1748,8 @@ class ScmController extends ControllerBase {
                 job                 : job,
                 isScheduled         : scheduledExecutionService.isScheduled(job),
                 scmFilePaths        : scmFilePaths,
-                scmExportRenamedPath: scmExportRenamedPath,
+                scmExportRenamedPath : scmExportRenamedPath,
+                scmImportRenamedPath : scmImportRenamedPath,
                 integration         : integration
         ]
     }

--- a/rundeckapp/grails-app/services/rundeck/services/JobMetadataService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobMetadataService.groovy
@@ -39,7 +39,7 @@ class JobMetadataService {
      * @return map of metadata set by import plugin
      */
     List<PluginMeta> getJobsPluginMeta(final String project, final String type) {
-        def found = PluginMeta.findAllByProject(project)
+        def found = PluginMeta.findAllByProjectAndKeyLike(project, "%/${type}")
         return found
     }
 

--- a/rundeckapp/grails-app/services/rundeck/services/JobMetadataService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobMetadataService.groovy
@@ -87,13 +87,8 @@ class JobMetadataService {
      * Remove scm metadata for the project
      * @param project project
      */
-    def removeProjectPluginMeta(final String project) {
-        def pluginMeta = PluginMeta.findAllByProject(project)
-        if (pluginMeta) {
-            pluginMeta.each {meta->
-                meta.delete(flush: true)
-            }
-        }
+    def removeProjectPluginMeta(final String project, final String type) {
+        PluginMeta.executeUpdate('delete PluginMeta where project=:project and data_key like :data_key' , [project: project, data_key: "%/${type}"], [flush: true])
     }
 
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -710,7 +710,8 @@ class ScmService {
         try{
             def loaded = loadPluginWithConfig(integration, context, type, scmPluginConfig.config, false)
             try{
-                jobMetadataService.removeProjectPluginMeta(project)
+
+                jobMetadataService.removeProjectPluginMeta(project, integration == EXPORT ? STORAGE_NAME_EXPORT:STORAGE_NAME_IMPORT)
                 loaded?.provider?.totalClean()
             }finally{
                 loaded?.close()

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1031,7 +1031,9 @@ class ScmService {
                 if(!metadata){
                     metadata = ["srcId": importMetadata["srcId"]]
                 }else{
-                    metadata["srcId"] = importMetadata["srcId"]
+                    if(!metadata["srcId"]) {
+                        metadata["srcId"] = importMetadata["srcId"]
+                    }
                 }
             }
         }

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -852,6 +852,22 @@ class ScmService {
         files
     }
 
+    /**
+     * @param jobs list of {@link ScheduledExecution} objects
+     * @return map of job ID to file path
+     */
+    Map<String, String> importFilePathsMapForJobs(String project, List<ScheduledExecution> jobs, Map<String,Map> jobMetadata=[:]) {
+        def files = [:]
+        def plugin = getLoadedImportPluginFor project
+        if (plugin) {
+            jobs.each { ScheduledExecution job ->
+                Map metadata = jobMetadata[job.extid] ?: getJobPluginMeta(job, STORAGE_NAME_IMPORT)
+                files[job.extid] = plugin.getRelativePathForJob(scmJobRef(job, null, metadata))
+            }
+        }
+        files
+    }
+
     List<JobRevReference> jobRefsForIds(List<String> ids) {
         jobRefsForJobs(
                 ids.collect {

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ContextJobImporter.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ContextJobImporter.groovy
@@ -16,8 +16,9 @@
 
 package rundeck.services.scm
 
-import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+
 import com.dtolabs.rundeck.plugins.scm.ImportResult
+import com.dtolabs.rundeck.plugins.scm.JobRenamed
 import com.dtolabs.rundeck.plugins.scm.ScmOperationContext
 
 /**
@@ -31,7 +32,7 @@ interface ContextJobImporter {
             final InputStream input,
             final Map importMetadata,
             final boolean preserveUuid,
-            final Map renamedJob
+            final JobRenamed renamedJob
     )
 
     ImportResult importFromMap(

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ContextJobImporter.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ContextJobImporter.groovy
@@ -30,7 +30,8 @@ interface ContextJobImporter {
             final String format,
             final InputStream input,
             final Map importMetadata,
-            final boolean preserveUuid
+            final boolean preserveUuid,
+            final Map renamedJob
     )
 
     ImportResult importFromMap(

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ResolvedJobImporter.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ResolvedJobImporter.groovy
@@ -52,10 +52,11 @@ class ResolvedJobImporter implements JobImporter {
             final String format,
             final InputStream input,
             final Map importMetadata,
-            boolean preserveUuid
+            boolean preserveUuid,
+            Map renamedJob
     )
     {
-        return jobImporter.importFromStream(context, format, input, importMetadata, preserveUuid)
+        return jobImporter.importFromStream(context, format, input, importMetadata, preserveUuid, renamedJob)
     }
 
     @Override

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ResolvedJobImporter.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ResolvedJobImporter.groovy
@@ -16,9 +16,10 @@
 
 package rundeck.services.scm
 
-import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+
 import com.dtolabs.rundeck.plugins.scm.ImportResult
 import com.dtolabs.rundeck.plugins.scm.JobImporter
+import com.dtolabs.rundeck.plugins.scm.JobRenamed
 import com.dtolabs.rundeck.plugins.scm.ScmOperationContext
 
 /**
@@ -53,7 +54,7 @@ class ResolvedJobImporter implements JobImporter {
             final InputStream input,
             final Map importMetadata,
             boolean preserveUuid,
-            Map renamedJob
+            JobRenamed renamedJob
     )
     {
         return jobImporter.importFromStream(context, format, input, importMetadata, preserveUuid, renamedJob)

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmJobImporter.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmJobImporter.groovy
@@ -103,7 +103,7 @@ class ScmJobImporter implements ContextJobImporter {
         if (loadresults.idMap?.get(job.extid)) {
             data.srcId = loadresults.idMap[job.extid]
         }
-        if(renamedJob){
+        if(renamedJob && renamedJob.sourceId){
             data.srcId = renamedJob.sourceId
         }
 
@@ -133,7 +133,7 @@ class ScmJobImporter implements ContextJobImporter {
         } catch (Throwable e) {
             return ImporterResult.fail("Failed to construct job definition map: " + e.message)
         }
-        importJob(context, jobset[0], importMetadata, preserveUuid)
+        importJob(context, jobset[0], importMetadata, preserveUuid, [:])
     }
 
     @Override

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmJobImporter.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmJobImporter.groovy
@@ -41,7 +41,8 @@ class ScmJobImporter implements ContextJobImporter {
             final String format,
             final InputStream input,
             final Map importMetadata,
-            final boolean preserveUuid
+            final boolean preserveUuid,
+            final Map renamedJob
     )
     {
 
@@ -67,16 +68,21 @@ class ScmJobImporter implements ContextJobImporter {
             )
         }
 
-        importJob(context, parseresult.jobset[0], importMetadata, preserveUuid)
+        return importJob(context, parseresult.jobset[0], importMetadata, preserveUuid, renamedJob)
     }
 
     private ImportResult importJob(
             final ScmOperationContext context,
             ImportedJob<ScheduledExecution> jobData,
             final Map importMetadata,
-            final boolean preserveUuid
+            boolean preserveUuid,
+            final Map renamedJob
     )
     {
+        if(renamedJob){
+            jobData.job.uuid = renamedJob.uuid
+            preserveUuid = true
+        }
 
         jobData.job.project = context.frameworkProject
         def loadresults = scheduledExecutionService.loadImportedJobs(
@@ -97,6 +103,10 @@ class ScmJobImporter implements ContextJobImporter {
         if (loadresults.idMap?.get(job.extid)) {
             data.srcId = loadresults.idMap[job.extid]
         }
+        if(renamedJob){
+            data.srcId = renamedJob.sourceId
+        }
+
         jobMetadataService.setJobPluginMeta(job, 'scm-import', data)
 
         def result = new ImporterResult()

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmJobImporter.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmJobImporter.groovy
@@ -17,6 +17,7 @@
 package rundeck.services.scm
 
 import com.dtolabs.rundeck.plugins.scm.ImportResult
+import com.dtolabs.rundeck.plugins.scm.JobRenamed
 import com.dtolabs.rundeck.plugins.scm.ScmOperationContext
 import org.rundeck.app.components.RundeckJobDefinitionManager
 import org.rundeck.app.components.jobs.ImportedJob
@@ -42,7 +43,7 @@ class ScmJobImporter implements ContextJobImporter {
             final InputStream input,
             final Map importMetadata,
             final boolean preserveUuid,
-            final Map renamedJob
+            final JobRenamed renamedJob
     )
     {
 
@@ -76,7 +77,7 @@ class ScmJobImporter implements ContextJobImporter {
             ImportedJob<ScheduledExecution> jobData,
             final Map importMetadata,
             boolean preserveUuid,
-            final Map renamedJob
+            final JobRenamed renamedJob
     )
     {
         if(renamedJob){
@@ -133,7 +134,7 @@ class ScmJobImporter implements ContextJobImporter {
         } catch (Throwable e) {
             return ImporterResult.fail("Failed to construct job definition map: " + e.message)
         }
-        importJob(context, jobset[0], importMetadata, preserveUuid, [:])
+        importJob(context, jobset[0], importMetadata, preserveUuid, null)
     }
 
     @Override

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
@@ -303,7 +303,7 @@ class ScmLoaderService implements EventBusAware {
                 }
             }
 
-            Map<String, Map> jobPluginMeta = scmService.getJobsPluginMeta(project)
+            Map<String, Map> jobPluginMeta = scmService.getJobsPluginMeta(project, true)
             List<JobExportReference> joblist = scmService.exportjobRefsForJobs(jobs, jobPluginMeta)
 
             def key = project+"-export"
@@ -359,8 +359,8 @@ class ScmLoaderService implements EventBusAware {
             List<ScheduledExecution> jobs = getJobs(project)
             log.debug("processing ${jobs.size()} jobs")
 
-            Map<String, Map> jobPluginMeta = scmService.getJobsPluginMeta(project)
-            List<JobScmReference> joblist = scmService.scmJobRefsForJobs(jobs, jobPluginMeta)
+            Map<String, Map> jobPluginMeta = scmService.getJobsPluginMeta(project, false)
+            List<JobScmReference> joblist = scmService.scmImportJobRefsForJobs(jobs, jobPluginMeta)
 
             def key = project+"-import"
             if(!scmProjectInitLoaded.containsKey(key)){

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
@@ -7,7 +7,6 @@ import com.dtolabs.rundeck.plugins.scm.JobExportReference
 import com.dtolabs.rundeck.plugins.scm.JobScmReference
 import com.dtolabs.rundeck.plugins.scm.ScmOperationContext
 import grails.events.annotation.Subscriber
-import grails.events.bus.EventBus
 import grails.events.bus.EventBusAware
 import grails.gorm.transactions.Transactional
 import groovy.transform.CompileDynamic

--- a/rundeckapp/grails-app/views/scm/diff.gsp
+++ b/rundeckapp/grails-app/views/scm/diff.gsp
@@ -70,7 +70,7 @@
                             importCommit: importStatus?.commit,
                     ]"/>
                     </span>
-                    <g:if test="${scmFilePaths && scmFilePaths[job.extid]}">
+                    <g:if test="${scmFilePaths && scmFilePaths[job.extid] && integration=='export'}">
                         <g:if test="${scmExportRenamedPath}">
                             <div>
                                 <span class="has_tooltip text-primary" title="Original repo path" data-viewport="#section-content">
@@ -87,6 +87,25 @@
                             <g:icon name="file"/>
                             ${scmFilePaths[job.extid]}
                         </span>
+                    </g:if>
+
+                    <g:if test="${scmFilePaths && scmFilePaths[job.extid] && integration=='import'}">
+                        <span class="has_tooltip" title="Original repo path" data-viewport="#section-content">
+                            <g:icon name="file"/>
+                            ${scmFilePaths[job.extid]}
+                        </span>
+
+                        <g:if test="${scmImportRenamedPath}">
+                            <g:if test="${scmImportRenamedPath}">
+                                <g:icon name="arrow-right"/>
+                            </g:if>
+                            <div>
+                                <span class="has_tooltip text-primary" title="Repo file path" data-viewport="#section-content">
+                                    <g:icon name="file"/>
+                                    ${scmImportRenamedPath}
+                                </span>
+                            </div>
+                        </g:if>
                     </g:if>
                 </div>
                 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1419,7 +1419,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         1 * controller.scmService.projectHasConfiguredExportPlugin(project) >> true
         1 * controller.scmService.loadScmConfig(project,'export') >> scmConfig
         1 * scmConfig.getEnabled() >> enabled
-        (count) * controller.scmService.getJobsPluginMeta(project)
+        (count) * controller.scmService.getJobsPluginMeta(project, true)
         (count) * controller.scmService.exportStatusForJobs(project,_, _, _, _)
         (count) * controller.scmService.exportPluginStatus(_,project)
         (count) * controller.scmService.exportPluginActions(_,project)
@@ -1472,7 +1472,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         1 * controller.scmService.projectHasConfiguredImportPlugin(project) >> true
         1 * controller.scmService.loadScmConfig(project,'import') >> scmConfig
         1 * scmConfig.getEnabled() >> enabled
-        (count) * controller.scmService.getJobsPluginMeta(project)
+        (count) * controller.scmService.getJobsPluginMeta(project, false)
         (count) * controller.scmService.importStatusForJobs(project,_, _, _, _)
         (count) * controller.scmService.importPluginStatus(_,project)
         (count) * controller.scmService.importPluginActions(_,project,_)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
@@ -109,7 +109,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             1 * getRenamedJobPathsForProject(projectName) >> [:]
             1 * performExportAction(actionName, _, projectName, _, _, _) >>
             [valid: true, nextAction: [id: 'someAction']]
-            1 * getJobsPluginMeta(projectName)
+            1 * getJobsPluginMeta(projectName, true)
             0 * _(*_)
         }
 
@@ -249,7 +249,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
                 it*.uuid == selectedJobIds
             }, deleteditems
             ) >> [valid: true, nextAction: [id: 'someAction']]
-            1 * getJobsPluginMeta(projectName)
+            1 * getJobsPluginMeta(projectName, true)
             0 * _(*_)
         }
 
@@ -553,7 +553,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             1 * loadProjectPluginDescriptor(projectName, integration)
             1 * getTrackingItemsForAction(projectName, actionName) >> null
             1 * importStatusForJobs(projectName,_,[],_,_)
-            1 * getJobsPluginMeta(projectName)
+            1 * getJobsPluginMeta(projectName, false)
             1 * getPluginStatus(_,integration, projectName)
             0 * _(*_)
         }
@@ -718,7 +718,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             1 * getPluginStatus(_,integration, projectName)
             1 * deletedExportFilesForProject(projectName)
             1 * exportFilePathsMapForJobs(projectName, _, _)
-            1 * getJobsPluginMeta(projectName)
+            1 * getJobsPluginMeta(projectName, true)
             0 * exportStatusForJobs(_,_,_,_,_)
             1 * getExportPushActionId('testproj') >> null
             0 * _(*_)
@@ -769,7 +769,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             1 * deletedExportFilesForProject(projectName)
             1 * exportFilePathsMapForJobs(projectName, _, _)
             1 * getInputView(_, integration, projectName, actionName) >> Mock(BasicInputView)
-            1 * getJobsPluginMeta(projectName)
+            1 * getJobsPluginMeta(projectName, true)
             0 * _(*_)
         }
 
@@ -803,7 +803,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             result
             1 * controller.scmService.deletedExportFilesForProject(project)
             1 * controller.scmService.getRenamedJobPathsForProject(project) >> [:]
-            1 * controller.scmService.getJobsPluginMeta(project) >> meta
+            1 * controller.scmService.getJobsPluginMeta(project,true) >> meta
             1 * controller.scmService.exportStatusForJobs(project, _, {it.size()==2}, true, meta) >> [
                 job1: new JobStateImpl(synchState: SynchState.CLEAN),
                 job2: new JobStateImpl(synchState: state)
@@ -842,7 +842,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
                 'scm/path/to/job3': [id: 'job3', jobName: 'job', groupPath: 'a', jobNameAndGroup: 'a/job']
             ]
             1 * controller.scmService.getRenamedJobPathsForProject(project) >> [:]
-            1 * controller.scmService.getJobsPluginMeta(project) >> meta
+            1 * controller.scmService.getJobsPluginMeta(project, true) >> meta
             1 * controller.scmService.exportStatusForJobs(project, _, _, true, meta) >> [
                 job1: new JobStateImpl(synchState: SynchState.CLEAN),
                 job2: new JobStateImpl(synchState: SynchState.CLEAN)
@@ -873,7 +873,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
                 '/oldscm/path/to/job2': [id: 'job2', jobName: 'blah', groupPath: 'bloo', jobNameAndGroup: 'bloo/blah']
             ]
             1 * controller.scmService.getRenamedJobPathsForProject(project) >> [job2:'/oldscm/path/to/job2']
-            1 * controller.scmService.getJobsPluginMeta(project) >> meta
+            1 * controller.scmService.getJobsPluginMeta(project, true) >> meta
             1 * controller.scmService.exportStatusForJobs(project, _, {it.size()==2}, true, meta) >> [
                 job1: new JobStateImpl(synchState: SynchState.CLEAN),
                 job2: new JobStateImpl(synchState: SynchState.EXPORT_NEEDED)
@@ -934,7 +934,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
 
                     }
             ]
-            1 * getJobsPluginMeta(projectName)>>meta
+            1 * getJobsPluginMeta(projectName, false)>>meta
             1 * getPluginStatus(_,integration, projectName)
             1 * importStatusForJobs(projectName, _, _, false, meta) >> [
                     job1: Mock(JobImportState){getSynchState()>> ImportSynchState.CLEAN},
@@ -986,7 +986,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
             1 * getPluginStatus(_,integration, projectName)
             1 * deletedExportFilesForProject(projectName)
             1 * exportFilePathsMapForJobs(projectName,_, _)
-            1 * getJobsPluginMeta('testproj')
+            1 * getJobsPluginMeta('testproj', true)
             0 * exportStatusForJobs(_,_)
             1 * getExportPushActionId('testproj') >> actionName
             0 * _(*_)

--- a/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
@@ -953,7 +953,7 @@ class ScmServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmService
                  1 * getProvider()>>provider
                  1 * close()
             }
-            1 * service.jobMetadataService.removeProjectPluginMeta(project)
+            1 * service.jobMetadataService.removeProjectPluginMeta(project, _)
         where:
             integration << ['export','import']
             project = 'aproj'

--- a/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
@@ -609,7 +609,7 @@ class ScmServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmService
         }
 
         //store metadata about commit
-        1 * service.jobMetadataService.setJobPluginMeta(job, 'scm-import', [version: 1, pluginMeta: commitMetadata, 'name': 'test', 'groupPath': 'test'])
+        1 * service.jobMetadataService.setJobPluginMeta(job, 'scm-export', [version: 1, pluginMeta: commitMetadata, 'name': 'test', 'groupPath': 'test'])
 
         result.valid
         result.commitId == 'a-commit-id'
@@ -856,7 +856,7 @@ class ScmServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmService
             def job = new ScheduledExecution()
             service.jobMetadataService=Mock(JobMetadataService)
         when:
-            def result = service.getJobPluginMeta(job)
+            def result = service.getJobPluginMeta(job, "scm-import")
         then:
             1 * service.jobMetadataService.getJobPluginMeta(job, ScmService.STORAGE_NAME_IMPORT)>>expect
             result == expect
@@ -900,14 +900,14 @@ class ScmServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmService
         }
 
         service.jobMetadataService = Mock(JobMetadataService){
-            getJobPluginMeta(_,'scm-import')>>originalMeta
+            getJobPluginMeta(_,'scm-export')>>originalMeta
         }
         ScmExportPluginFactory exportFactory = Mock(ScmExportPluginFactory)
 
         when:
         service.refreshExportPluginMetadata(project,plugin, jobs, jobsPluginMeta)
         then:
-        jobMetadataCalls * service.jobMetadataService.setJobPluginMeta(job, 'scm-import', _)
+        jobMetadataCalls * service.jobMetadataService.setJobPluginMeta(job, 'scm-export', _)
 
         where:
         originalMeta                                                    | jobMetadataCalls
@@ -985,9 +985,9 @@ class ScmServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmService
         when:
             def result = service.exportFilePathsMapForJobs(project, jobs)
         then:
-            0 * service.jobMetadataService.getJobsPluginMeta(project, ScmService.STORAGE_NAME_IMPORT)
-            1 * service.jobMetadataService.getJobPluginMeta(job1, ScmService.STORAGE_NAME_IMPORT)
-            1 * service.jobMetadataService.getJobPluginMeta(job2, ScmService.STORAGE_NAME_IMPORT)
+            0 * service.jobMetadataService.getJobsPluginMeta(project, ScmService.STORAGE_NAME_EXPORT)
+            1 * service.jobMetadataService.getJobPluginMeta(job1, ScmService.STORAGE_NAME_EXPORT)
+            1 * service.jobMetadataService.getJobPluginMeta(job2, ScmService.STORAGE_NAME_EXPORT)
             1 * plugin.getRelativePathForJob({it.id== 'job1id' })>> '/a/path/job1'
             1 * plugin.getRelativePathForJob({it.id=='job2id' })>>'/a/path/job2'
             result == [
@@ -1080,7 +1080,7 @@ class ScmServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmService
             1 * plugin.getRelativePathForJob({
                 it.id=='123'
             })>>'/a/path'
-            1 * service.jobMetadataService.getJobPluginMeta(project,'123','scm-import')
+            1 * service.jobMetadataService.getJobPluginMeta(project,'123','scm-export')
             1 * plugin.jobChanged({ it.eventType==evtType },_)
             service.deletedJobsCache[project]['/a/path']!=null
         where:

--- a/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
@@ -48,6 +48,7 @@ import com.dtolabs.rundeck.server.plugins.services.ScmExportPluginProviderServic
 import com.dtolabs.rundeck.server.plugins.services.ScmImportPluginProviderService
 import grails.test.hibernate.HibernateSpec
 import grails.testing.services.ServiceUnitTest
+import rundeck.PluginMeta
 import rundeck.ScheduledExecution
 import rundeck.User
 import rundeck.Storage
@@ -1169,6 +1170,96 @@ class ScmServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmService
             evtType                                  | _
             JobChangeEvent.JobChangeEventType.CREATE | _
             JobChangeEvent.JobChangeEventType.MODIFY | _
+    }
+
+    def "get srcId jobs export plugin metadata"() {
+        given:
+        service.pluginConfigService = Mock(PluginConfigService)
+        service.frameworkService = Mock(FrameworkService) {
+            isClusterModeEnabled() >> true
+        }
+        service.storageService = Mock(StorageService)
+        service.pluginService = Mock(PluginService)
+        service.jobEventsService = Mock(JobEventsService)
+
+        def project = "test"
+        def job = new ScheduledExecution()
+        job.uuid = "1234"
+        job.version = 1
+        job.jobName = "test"
+        job.groupPath = "test"
+
+
+        PluginMeta importPluginMeta = new PluginMeta()
+        importPluginMeta.key = "1234/scm-import"
+        importPluginMeta.project = project
+        importPluginMeta.jsonData = '{"name":"test","groupPath":"test","srcId":"456"}'
+
+        PluginMeta exportPluginMeta = new PluginMeta()
+        exportPluginMeta.key = jobsExportMetaKey
+        exportPluginMeta.project = project
+        exportPluginMeta.jsonData = jobsExportMetaKeyJson
+
+        def jobsImportMeta = [importPluginMeta]
+        def jobsExportMeta = [exportPluginMeta]
+
+        when:
+        def result = service.getJobsPluginMeta(project,isExport)
+
+        then:
+
+        service.jobMetadataService = Mock(JobMetadataService){
+            1 * getJobsPluginMeta(_,'scm-import')>>jobsImportMeta
+            calls * getJobsPluginMeta(_,'scm-export')>>jobsExportMeta
+        }
+
+        result.get("1234")["srcId"] == checkResult
+
+        where:
+        isExport    | jobsExportMetaKey   | jobsExportMetaKeyJson                                   | calls | checkResult
+        true        | "xxx/scm-export"    | "{}"                                                    | 1     | "456"
+        false       | "xxx/scm-export"    | "{}"                                                    | 0     | "456"
+        true        | "1234/scm-export"   | '{"name":"test","groupPath":"test"}'                    | 1     | "456"
+        true        | "1234/scm-export"   | '{"name":"test","groupPath":"test","srcId":"1234"}'     | 1     | "1234"
+    }
+
+    def "get srcId job export plugin metadata"() {
+        given:
+        service.pluginConfigService = Mock(PluginConfigService)
+        service.frameworkService = Mock(FrameworkService) {
+            isClusterModeEnabled() >> true
+        }
+        service.storageService = Mock(StorageService)
+        service.pluginService = Mock(PluginService)
+        service.jobEventsService = Mock(JobEventsService)
+
+        def job = new ScheduledExecution()
+        job.uuid = "1234"
+        job.version = 1
+        job.jobName = "test"
+        job.groupPath = "test"
+
+        when:
+        def result = service.getJobPluginMeta(job,type)
+
+        then:
+
+        service.jobMetadataService = Mock(JobMetadataService){
+            1 * getJobPluginMeta(_,'scm-import')>>importMeta
+            calls * getJobPluginMeta(_,'scm-export')>>exportMeta
+        }
+
+        result["srcId"] == checkResult
+
+        where:
+        type            | exportMeta                                          | importMeta      | calls | checkResult
+        "scm-export"    | null                                                | [srcId:"456"]   | 1     | "456"
+        "scm-import"    | "{}"                                                | [srcId:"456"]   | 0     | "456"
+        "scm-export"    | [name: 'test', groupPath: 'test']                   | [srcId:"456"]   | 1     | "456"
+        "scm-export"    | [name: 'test', groupPath: 'test', srcId:"1234"]     | [srcId:"456"]   | 1     | "1234"
+        "scm-export"    | [name: 'test', groupPath: 'test', srcId:"1234"]     | null            | 1     | "1234"
+        "scm-export"    | [name: 'test', groupPath: 'test']                   | null            | 1     | null
+
     }
 
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/scm/ScmJobImporterSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/scm/ScmJobImporterSpec.groovy
@@ -37,7 +37,7 @@ class ScmJobImporterSpec extends Specification {
             AtomicInteger counter=new AtomicInteger(0)
 
         when:
-            def result = sut.importFromStream(ctx, format, input, meta, preserve)
+            def result = sut.importFromStream(ctx, format, input, meta, preserve,[:])
         then:
             result
             result.successful

--- a/rundeckapp/src/test/groovy/rundeck/services/scm/ScmJobImporterSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/scm/ScmJobImporterSpec.groovy
@@ -1,5 +1,6 @@
 package rundeck.services.scm
 
+import com.dtolabs.rundeck.plugins.scm.JobRenamed
 import com.dtolabs.rundeck.plugins.scm.ScmOperationContext
 import com.dtolabs.rundeck.plugins.scm.ScmUserInfo
 import org.rundeck.app.components.RundeckJobDefinitionManager
@@ -37,7 +38,7 @@ class ScmJobImporterSpec extends Specification {
             AtomicInteger counter=new AtomicInteger(0)
 
         when:
-            def result = sut.importFromStream(ctx, format, input, meta, preserve,[:])
+            def result = sut.importFromStream(ctx, format, input, meta, preserve,null)
         then:
             result
             result.successful
@@ -132,7 +133,7 @@ class ScmJobImporterSpec extends Specification {
         sut.scheduledExecutionService = Mock(ScheduledExecutionService)
         sut.jobMetadataService = Mock(JobMetadataService)
         AtomicInteger counter=new AtomicInteger(0)
-        def renamedJob = [uuid: "123", sourceId: "456"]
+        def renamedJob = new JobRenamedImpTemp(uuid: "123", sourceId: "456")
 
         when:
         def result = sut.importFromStream(ctx, format, input, meta, preserve,renamedJob)
@@ -158,4 +159,10 @@ class ScmJobImporterSpec extends Specification {
         job.uuid == "123"
     }
 
+}
+
+
+class JobRenamedImpTemp implements JobRenamed{
+    String uuid
+    String sourceId
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/scm/ScmJobImporterSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/scm/ScmJobImporterSpec.groovy
@@ -165,4 +165,5 @@ class ScmJobImporterSpec extends Specification {
 class JobRenamedImpTemp implements JobRenamed{
     String uuid
     String sourceId
+    String renamedPath
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
BigFix: when a job is renamed, SCM Import deletes and creates the job again

for issue https://github.com/rundeckpro/rundeckpro/issues/1731

**Describe the solution you've implemented**
- using jgit, check if a path was added and deleted (gitdiff)
- if that is the case save the renamed job in the import tracker
- when the job is imported, save the current UUID and the sourceId. Force to preserve original UUID when the job is re-imported.
- clean import trackers of the old path
- split job plugin metadata per integration

**Describe alternatives you've considered**

**Additional context**
