### PR TITLE
Fix: externally deleted job not reflected in scm import status

### DIFF
--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/BaseGitPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/BaseGitPlugin.groovy
@@ -157,7 +157,6 @@ class BaseGitPlugin {
             outfile = mapper.fileForJob(job)
         }
         AtomicLong counter = fileCounterFor(outfile)
-        logger.debug("Start serialize[${Thread.currentThread().name}]...")
 
         synchronized (counter) {
             //other threads serializing the same job must wait until we complete
@@ -207,7 +206,6 @@ class BaseGitPlugin {
                                 "Failed to serialize job, no content was written for job ${job}"
                         )
                     }
-                    logger.debug("Serialized[${Thread.currentThread().name}] ${job} ${format} to ${outfile}")
 
                     Files.move(temp.toPath(), outfile.toPath(), StandardCopyOption.REPLACE_EXISTING)
                 }finally{
@@ -217,10 +215,9 @@ class BaseGitPlugin {
                 }
             } else {
                 //another thread already serialized this or earlier revision of the job, should not
-                logger.debug("SKIP serialize[${Thread.currentThread().name}] for ${job} to ${outfile}")
+                logger.trace("SKIP serialize[${Thread.currentThread().name}] for ${job} to ${outfile}")
             }
         }
-        logger.debug("Done serialize[${Thread.currentThread().name}]...")
     }
 
     def serializeTemp(final JobExportReference job, String format, boolean preserveId, boolean useSourceId) {

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
@@ -335,7 +335,6 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
         File origfile = mapper.fileForJob(event.originalJobReference)
         File outfile = mapper.fileForJob(exportReference)
         String origPath = null
-        log.debug("Job event (${event}), writing to path: ${outfile}")
         switch (event.eventType) {
             case JobChangeEvent.JobChangeEventType.DELETE:
                 origfile.delete()
@@ -375,10 +374,8 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
         String ident = createStatusCacheIdent(job, commit)
 
         if (state && state.ident == ident) {
-            log.debug("hasJobStatusCached(${ident}): FOUND for path $path")
             return state
         }
-        log.debug("hasJobStatusCached(${ident}): (no) for path $path")
 
         null
     }
@@ -420,16 +417,13 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
             statusb.addPath(originalPath)
         }
         Status status = statusb.call()
-//        log.debug(debugStatus(status))
         SynchState synchState = synchStateForStatus(status, commit, path)
         def scmState = scmStateForStatus(status, commit, path)
-        log.debug("for new path: commit ${commit}, synch: ${synchState}, scm: ${scmState}")
 
         if (originalPath) {
             def origCommit = lastCommitForPath(originalPath)
             SynchState osynchState = synchStateForStatus(status, origCommit, originalPath)
             def oscmState = scmStateForStatus(status, origCommit, originalPath)
-            log.debug("for original path: commit ${origCommit}, synch: ${osynchState}, scm: ${oscmState}")
             if (origCommit && !commit) {
                 commit = origCommit
             }
@@ -451,7 +445,6 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
             jobstat['commitId'] = commit.name
             jobstat['commitMeta'] = GitUtil.metaForCommit(commit)
         }
-        log.debug("refreshJobStatus(${job.id}): ${jobstat}")
 
         jobStateMap[job.id] = jobstat
 
@@ -498,23 +491,11 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
 
     @Override
     JobState getJobStatus(final JobExportReference job, final String originalPath) {
-        log.debug("getJobStatus(${job.id},${originalPath}): ${job}")
-        if (!inited) {
-            return null
-        }
-        def status = hasJobStatusCached(job, originalPath)
-
-        if (!status) {
-            status = refreshJobStatus(job, originalPath)
-        }
-
-
-        return createJobStatus(status, jobActionsForStatus(status))
+        getJobStatus(job, originalPath, true)
     }
 
     @Override
     JobState getJobStatus(final JobExportReference job, final String originalPath, final boolean serialize) {
-        log.debug("getJobStatus(${job.id},${originalPath}): ${job}, serialize ${serialize}")
         if (!inited) {
             return null
         }

--- a/rundeckapp/grails-app/services/rundeck/services/JobMetadataService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobMetadataService.groovy
@@ -138,7 +138,6 @@ class JobMetadataService {
             found.project = project
             found.key = key
         }
-        log.debug("setJobPluginMeta(${project},${id},${type}) to ${metadata}")
         found.setPluginData(metadata)
         found.save(flush: true)
     }

--- a/rundeckapp/grails-app/services/rundeck/services/JobMetadataService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobMetadataService.groovy
@@ -51,10 +51,13 @@ class JobMetadataService {
      */
     Map getJobPluginMeta(final String project, final String id, final String type) {
         def key = id + '/' + type
-        def found = PluginMeta.findByProjectAndKey(project, key)
-        if (found) {
-            log.debug("found job metadata for ${id}: ${found.pluginData}")
-            return found.pluginData
+        try {
+            def found = PluginMeta.findByProjectAndKey(project, key)
+            if (found) {
+                return found.pluginData
+            }
+        } catch (Throwable e) {
+            log.trace("Exception getting plugin meta for job", e)
         }
         return null
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1474,7 +1474,6 @@ class ScmService {
 
     //check if the job was renamed
     def checkExportJobRenamed(ScmExportPlugin plugin, String project, ScheduledExecution job, JobScmReference jobReference, def jobPluginMeta){
-        log.debug("check if job ${job.id} was renamed")
         def jobFullName = job.generateFullName()
         def origFullName = [jobPluginMeta.groupPath?:'',jobPluginMeta.name].join("/")
 
@@ -1492,7 +1491,6 @@ class ScmService {
                 origScmRef.jobName = jobPluginMeta.name
                 origScmRef.groupPath = jobPluginMeta.groupPath
 
-                log.debug("reprocessing renamed job")
 
                 //record original path for renamed job, if it is different
                 def origpath = plugin.getRelativePathForJob(origScmRef)

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
@@ -5,10 +5,9 @@ import com.dtolabs.rundeck.core.jobs.JobRevReference
 import com.dtolabs.rundeck.plugins.scm.JobChangeEvent
 import com.dtolabs.rundeck.plugins.scm.JobExportReference
 import com.dtolabs.rundeck.plugins.scm.JobScmReference
-import com.dtolabs.rundeck.plugins.scm.JobState
-import com.dtolabs.rundeck.plugins.scm.ScmExportPlugin
 import com.dtolabs.rundeck.plugins.scm.ScmOperationContext
 import grails.events.annotation.Subscriber
+import grails.events.bus.EventBus
 import grails.events.bus.EventBusAware
 import grails.gorm.transactions.Transactional
 import groovy.transform.CompileDynamic
@@ -25,6 +24,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import java.util.function.Consumer
 
 @CompileStatic
 class ScmLoaderService implements EventBusAware {
@@ -81,7 +81,7 @@ class ScmLoaderService implements EventBusAware {
 
     def startScmLoader(String project, String integration){
 
-        def state = new ScmExportLoaderStateImpl()
+        def state = new ScmLoaderStateImpl()
         //enable project integration cache loader
         def scheduler = scheduledExecutor.scheduleAtFixedRate(
                 {
@@ -95,7 +95,7 @@ class ScmLoaderService implements EventBusAware {
                             if (integration == scmService.EXPORT) {
                                 processScmExportLoader(project, pluginConfigData, state)
                             }else{
-                                processScmImportLoader(project, pluginConfigData)
+                                processScmImportLoader(project, pluginConfigData, state)
                             }
 
                         } catch (Throwable t) {
@@ -141,7 +141,7 @@ class ScmLoaderService implements EventBusAware {
      * state container interface for export loader
      */
     @CompileStatic
-    static interface ScmExportLoaderState {
+    static interface ScmLoaderState {
         boolean getInited()
 
         void setInited(boolean val)
@@ -149,13 +149,25 @@ class ScmLoaderService implements EventBusAware {
         void addJobs(List<ScheduledExecution> jobs)
 
         Map<String, JobRevReference> getScannedJobs()
+
+        /**
+         * Detects jobs that were deleted
+         * @param jobs current job list
+         * @param knownDeletedIds known deleted job Ids
+         * @param handleDeletedIds consume list of deleted job references
+         */
+        void detectDeletedJobs(
+            List<ScheduledExecution> jobs,
+            List<String> knownDeletedIds,
+            Consumer<List<JobRevReference>> handleDeletedIds
+        )
     }
 
     /**
      * state implementation for export loader
      */
     @CompileStatic
-    static class ScmExportLoaderStateImpl implements ScmExportLoaderState {
+    static class ScmLoaderStateImpl implements ScmLoaderState {
         boolean inited
         Map<String, JobRevReference> scannedJobs = new HashMap<>()
 
@@ -174,6 +186,27 @@ class ScmLoaderService implements EventBusAware {
                     )
             }
         }
+
+        @Override
+        void detectDeletedJobs(
+            final List<ScheduledExecution> jobs,
+            List<String> knownDeletedIds,
+            Consumer<List<JobRevReference>> handleDeletedIds
+        ) {
+            List<String> jobids = jobs*.extid
+            List<JobRevReference> deletedRefs=[]
+            if (!jobids.containsAll(scannedJobs.keySet())) {
+                List<String> deleted = []
+                deleted.addAll((Collection<String>) scannedJobs.keySet())
+                deleted.removeAll(jobids)
+                deleted.removeAll(knownDeletedIds)
+                //remove known deleted jobs
+                deletedRefs = deleted.collect{scannedJobs.remove(it)}
+            }
+            scannedJobs.clear()
+            addJobs(jobids.collect { id -> jobs.find { it.extid == id } })
+            handleDeletedIds.accept(deletedRefs)
+        }
     }
 
     /**
@@ -184,7 +217,7 @@ class ScmLoaderService implements EventBusAware {
      * @return
      */
     @Transactional
-    def processScmExportLoader(String project, ScmPluginConfigData pluginConfig, ScmExportLoaderState state) {
+    def processScmExportLoader(String project, ScmPluginConfigData pluginConfig, ScmLoaderState state) {
 
         if (!scmService.projectHasConfiguredExportPlugin(project)) {
             return
@@ -200,34 +233,26 @@ class ScmLoaderService implements EventBusAware {
         def plugin = scmService.getLoadedExportPluginFor(project)
 
         if (plugin) {
-            log.debug("export plugin found")
-
             def username = pluginConfig.getSetting("username")
             def roles = pluginConfig.getSettingList("roles")
             ScmOperationContext context = scmService.scmOperationContext(username, roles, project)
 
             List<ScheduledExecution> jobs = getJobs(project)
-            List<String> deleted = []
             log.debug("processing ${jobs.size()} jobs")
             if (!state.inited) {
                 state.inited = true
                 state.addJobs(jobs)
             } else {
                 //detect deleted jobs
-                List<String> jobids = jobs*.extid
-                if (!jobids.containsAll(state.scannedJobs.keySet())) {
-                    deleted.addAll((Collection<String>) state.scannedJobs.keySet())
-                    deleted.removeAll(jobids)
-                    //remove known deleted jobs
-                    def deletedfiles = scmService.deletedExportFilesForProject(project)
-                    deleted.removeAll(deletedfiles.values()*.id)
-                    if (deleted) {
-                        log.debug("detected deleted jobs: ${deleted}...")
+                def deletedfiles = scmService.deletedExportFilesForProject(project)
+                List<String> knownDeletedIds = []
+                knownDeletedIds.addAll(deletedfiles.values()*.id.collect{it.toString()})
+                state.detectDeletedJobs(jobs, knownDeletedIds) { List<JobRevReference> newDeletedRefs ->
+                    if (newDeletedRefs) {
                         //emit fake job change event
                         eventBus.notify(
                             'multiJobChanged',
-                            deleted.collect { jobid ->
-                                def cacheItem = state.scannedJobs.remove(jobid)
+                            newDeletedRefs.collect { cacheItem ->
                                 new StoredJobChangeEvent(
                                     eventType: JobChangeEvent.JobChangeEventType.DELETE,
                                     jobReference: cacheItem,
@@ -237,8 +262,6 @@ class ScmLoaderService implements EventBusAware {
                         )
                     }
                 }
-                state.scannedJobs.clear()
-                state.addJobs(jobids.collect { id -> jobs.find { it.extid == id } })
             }
 
             Map<String, Map> jobPluginMeta = scmService.getJobsPluginMeta(project)
@@ -269,7 +292,7 @@ class ScmLoaderService implements EventBusAware {
     }
 
     @Transactional
-    def processScmImportLoader(String project, ScmPluginConfigData pluginConfig){
+    def processScmImportLoader(String project, ScmPluginConfigData pluginConfig, ScmLoaderState state){
         log.debug("processing SCM import Loader ${project} / ${pluginConfig.type}")
 
         if (!scmService.projectHasConfiguredImportPlugin(project)) {
@@ -283,8 +306,6 @@ class ScmLoaderService implements EventBusAware {
         def plugin = scmService.getLoadedImportPluginFor(project)
 
         if(plugin){
-            log.debug("import plugin found")
-
             def username = pluginConfig.getSetting("username")
             def roles = pluginConfig.getSettingList("roles")
             ScmOperationContext context = scmService.scmOperationContext(username, roles, project)
@@ -304,6 +325,27 @@ class ScmLoaderService implements EventBusAware {
                 plugin.refreshJobsStatus(joblist)
 
                 scmProjectInitLoaded.put(key, true)
+            }
+            if(!state.inited){
+                state.inited=true
+                state.addJobs(jobs)
+            }else{
+                //detect deleted jobs
+                state.detectDeletedJobs(jobs, []) { List<JobRevReference> newDeletedIds ->
+                    if (newDeletedIds) {
+                        //emit fake job change event
+                        eventBus.notify(
+                            'multiJobChanged',
+                            newDeletedIds.collect { cacheItem ->
+                                new StoredJobChangeEvent(
+                                    eventType: JobChangeEvent.JobChangeEventType.DELETE,
+                                    jobReference: cacheItem,
+                                    originalJobReference: cacheItem
+                                )
+                            }
+                        )
+                    }
+                }
             }
 
             if(frameworkService.isClusterModeEnabled()){

--- a/rundeckapp/src/test/groovy/rundeck/services/scm/ScmLoaderServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/scm/ScmLoaderServiceSpec.groovy
@@ -1,5 +1,6 @@
 package rundeck.services.scm
 
+import com.dtolabs.rundeck.core.jobs.JobRevReference
 import com.dtolabs.rundeck.plugins.scm.JobChangeEvent
 import com.dtolabs.rundeck.plugins.scm.JobScmReference
 import com.dtolabs.rundeck.plugins.scm.ScmExportPlugin
@@ -10,10 +11,10 @@ import grails.test.hibernate.HibernateSpec
 import grails.testing.services.ServiceUnitTest
 import rundeck.ScheduledExecution
 import rundeck.services.FrameworkService
-import rundeck.services.JobReferenceImpl
 import rundeck.services.JobRevReferenceImpl
 import rundeck.services.ScheduledExecutionService
 import rundeck.services.ScmService
+import spock.lang.Unroll
 
 class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmLoaderService> {
 
@@ -29,7 +30,7 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
         def scmPluginConfigData = Mock(ScmPluginConfigData)
         when:
 
-        service.processScmExportLoader(project, scmPluginConfigData, new ScmLoaderService.ScmExportLoaderStateImpl())
+        service.processScmExportLoader(project, scmPluginConfigData, new ScmLoaderService.ScmLoaderStateImpl())
 
         then:
         0 * service.scmService.getLoadedExportPluginFor(project)
@@ -48,7 +49,7 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
         def scmPluginConfigData = Mock(ScmPluginConfigData)
         when:
 
-        service.processScmImportLoader(project, scmPluginConfigData)
+        service.processScmImportLoader(project, scmPluginConfigData, new ScmLoaderService.ScmLoaderStateImpl())
 
         then:
         0 * service.scmService.getLoadedImportPluginFor(project)
@@ -81,7 +82,7 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
 
         when:
 
-        service.processScmExportLoader(project, scmPluginConfigData, new ScmLoaderService.ScmExportLoaderStateImpl())
+        service.processScmExportLoader(project, scmPluginConfigData, new ScmLoaderService.ScmLoaderStateImpl())
 
         then:
         1 * service.scmService.getLoadedExportPluginFor(project)  >> plugin
@@ -117,7 +118,7 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
 
         when:
 
-        service.processScmImportLoader(project, scmPluginConfigData)
+        service.processScmImportLoader(project, scmPluginConfigData, new ScmLoaderService.ScmLoaderStateImpl())
 
         then:
         1 * service.scmService.getLoadedImportPluginFor(project)  >> plugin
@@ -171,7 +172,7 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
         def jobList = [jobExportReference]
         when:
 
-        service.processScmExportLoader(project, scmPluginConfigData, new ScmLoaderService.ScmExportLoaderStateImpl())
+        service.processScmExportLoader(project, scmPluginConfigData, new ScmLoaderService.ScmLoaderStateImpl())
 
         then:
         1 * service.scmService.getLoadedExportPluginFor(project)  >> plugin
@@ -229,7 +230,7 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
             jobName: 'ajob',
             id: 'asdf'
         )
-        def oldstate = new ScmLoaderService.ScmExportLoaderStateImpl(
+        def oldstate = new ScmLoaderService.ScmLoaderStateImpl(
             inited: true,
             scannedJobs: ['asdf': oldReference]
         )
@@ -301,7 +302,7 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
         def jobList = [jobExportReference]
         when:
 
-        service.processScmImportLoader(project, scmPluginConfigData)
+        service.processScmImportLoader(project, scmPluginConfigData, new ScmLoaderService.ScmLoaderStateImpl())
 
         then:
         1 * service.scmService.getLoadedImportPluginFor(project)  >> plugin
@@ -313,6 +314,104 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
         1 * plugin.clusterFixJobs(_,_,_)
         service.scmProjectInitLoaded.containsKey(project+"-import")
 
+    }
+
+    def "processScmImportLoader externally deleted jobs"() {
+        given:
+            def project = "test"
+
+            service.frameworkService = Mock(FrameworkService) {
+                isClusterModeEnabled() >> true
+            }
+
+            def job = new ScheduledExecution()
+            job.id = 123
+            job.uuid = "123-123"
+            job.jobName = "test"
+            job.groupPath = "demo"
+            job.project = project
+
+            def jobs = [job]
+
+            def listWorkflow = [
+                "schedlist": jobs
+            ]
+            service.scheduledExecutionService = Mock(ScheduledExecutionService) {
+                listWorkflows(_) >> listWorkflow
+            }
+            def username = "admin"
+            def roles = ["admin"]
+
+            def plugin = Mock(ScmImportPlugin)
+            def scmPluginConfigData = Mock(ScmPluginConfigData) {
+                getSetting("username") >> username
+                getSettingList("roles") >> roles
+            }
+            service.scmService = Mock(ScmService) {
+                projectHasConfiguredImportPlugin(project) >> true
+            }
+            def jobExportReference = Mock(JobScmReference) {
+                getId() >> job.id
+                getProject() >> job.project
+            }
+            def oldReference = new JobRevReferenceImpl(
+                jobName: 'ajob',
+                id: 'asdf'
+            )
+
+            def oldstate = new ScmLoaderService.ScmLoaderStateImpl(
+                inited: true,
+                scannedJobs: ['asdf': oldReference]
+            )
+            def jobList = [jobExportReference]
+            service.targetEventBus = Mock(EventBus)
+        when:
+
+            service.processScmImportLoader(project, scmPluginConfigData, oldstate)
+
+        then:
+            1 * service.scmService.getLoadedImportPluginFor(project) >> plugin
+            1 * service.scmService.scmJobRefsForJobs(jobs, _) >> jobList
+            1 * plugin.initJobsStatus(_)
+            1 * plugin.refreshJobsStatus(_)
+            1 * service.scmService.scmOperationContext(username, roles, project) >> Mock(ScmOperationContext)
+            jobs.size() * service.scmService.getRenamedPathForJobId(project, _)
+            1 * plugin.clusterFixJobs(_, _, _)
+            service.scmProjectInitLoaded.containsKey(project + "-import")
+            1 * service.eventBus.notify('multiJobChanged',{
+                it[0].size()==1
+                it[0][0].eventType == JobChangeEvent.JobChangeEventType.DELETE
+                it[0][0].jobReference == oldReference
+                it[0][0].originalJobReference == oldReference
+            })
+            oldstate.scannedJobs.keySet().contains '123-123'
+
+    }
+
+    @Unroll
+    def "scanner state detects deleted jobs"(){
+        given:
+            def state = new ScmLoaderService.ScmLoaderStateImpl()
+
+            def job1 = new ScheduledExecution(uuid:'uuid1',jobName:'ajob',project:'aproj',groupPath: 'test1')
+            def job2 = new ScheduledExecution(uuid:'uuid2',jobName:'bjob',project:'aproj',groupPath: 'test1')
+            def job3 = new ScheduledExecution(uuid:'uuid3',jobName:'cjob',project:'bproj',groupPath: 'test2')
+            def job4 = new ScheduledExecution(uuid:'uuid4',jobName:'cjob',project:'bproj',groupPath: 'test2')
+            def job5 = new ScheduledExecution(uuid:'uuid5',jobName:'cjob',project:'bproj',groupPath: 'test2')
+
+            state.addJobs([job1, job2, job3, job4, job5])
+            List<JobRevReference> found=[]
+        when:
+            state.detectDeletedJobs([job2, job3], known, found.&addAll)
+        then:
+            found.size() == expected.size()
+            found*.id.containsAll expected
+        where:
+            known                       | expected
+            []                          | ['uuid1', 'uuid4', 'uuid5']
+            ['uuid1']                   | ['uuid4', 'uuid5']
+            ['uuid1', 'uuid4']          | ['uuid5']
+            ['uuid1', 'uuid4', 'uuid5'] | []
     }
 
     def "SCM export project config changed" (){
@@ -356,7 +455,8 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
         service.scmPluginMeta.put(project + "-export", scmPluginConfigDataCached)
         when:
 
-        service.processScmExportLoader(project, (ScmPluginConfigData)scmPluginConfigData, new ScmLoaderService.ScmExportLoaderStateImpl())
+        service.processScmExportLoader(project, (ScmPluginConfigData)scmPluginConfigData, new ScmLoaderService
+            .ScmLoaderStateImpl())
 
         then:
         1 * service.scmService.getLoadedExportPluginFor(project)  >> plugin
@@ -407,7 +507,7 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
 
         when:
 
-        service.processScmImportLoader(project, (ScmPluginConfigData)scmPluginConfigData)
+        service.processScmImportLoader(project, (ScmPluginConfigData)scmPluginConfigData, new ScmLoaderService.ScmLoaderStateImpl())
 
         then:
         1 * service.scmService.getLoadedImportPluginFor(project)  >> plugin


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Fixes https://github.com/rundeckpro/rundeckpro/issues/1730

* if a job is deleted in another cluster member, the scm import status is not reflected

**Describe the solution you've implemented**
detect jobs that were deleted and emit an event so that the scm plugin listeners are notified of deleted jobs

* does not fix issue with hibernate cache causing 500 error

**Additional context**
There may be two events emitted for deleted jobs, if both import and export plugins are configured for a project. In that case both import and export loader tasks will emit a DELETED job change event, but the handlers of those events are idempotent, and so it will not affect the behavior. a future refactor could consolidate the loader code for import/export plugins and emit a single event