### PR TITLE
Remove margin on text color in card

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/theme-next/scss/paper/_cards.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme-next/scss/paper/_cards.scss
@@ -163,9 +163,6 @@
         margin-top: 10px;
     }
 
-    .text-warning, .text-success{
-        margin: 0 10px;
-    }
     .map {
         height: 280px;
         border-radius: $border-radius-base;


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Fix too broad css style 


**Additional context**
![Screen Shot 2021-05-07 at 10 22 57 AM](https://user-images.githubusercontent.com/55603/117486789-f0470d00-af1e-11eb-9e65-b23a40555d9e.png)
