### PR TITLE
feat(docker): add RDECK_JVM_SETTINGS params

### DIFF
--- a/docker/official/README.md
+++ b/docker/official/README.md
@@ -219,3 +219,6 @@ Set to a space-separated list of environment variables to unset before starting 
 
 ### `RUNDECK_QUARTZ_THREADPOOL_THREADCOUNT`
 Set the threadCount value to the max number of threads you want to run concurrently. If not set, default to 10.
+
+### `RDECK_JVM_SETTINGS`
+Set extra java command line arguments.

--- a/docker/official/lib/entry.sh
+++ b/docker/official/lib/entry.sh
@@ -71,6 +71,7 @@ if [[ -n "${EXEC_CMD}" ]] ; then
 fi
 
 exec java \
+    "${RDECK_JVM_SETTINGS}" \
     -XX:+UnlockExperimentalVMOptions \
     -XX:MaxRAMPercentage="${JVM_MAX_RAM_PERCENTAGE}" \
     -Dlog4j.configurationFile="${HOME}/server/config/log4j2.properties" \


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Enhancement, extra java command line arguments cannot be set in the Rundeck Docker image.

**Describe the solution you've implemented**
Add the param RDECK_JVM_SETTINGS in the Rundeck Docker image entrypoint

**Additional context**
https://docs.rundeck.com/docs/administration/maintenance/tuning-rundeck.html#jmx-instrumentation