### PR TITLE
fix:  project ACL change is not refreshed in cluster

### DIFF
--- a/core/src/main/java/org/rundeck/app/acl/ACLCacheControl.java
+++ b/core/src/main/java/org/rundeck/app/acl/ACLCacheControl.java
@@ -1,0 +1,11 @@
+package org.rundeck.app.acl;
+
+/**
+ * Cache cleanup methods
+ */
+public interface ACLCacheControl {
+    /**
+     * Clean acl cache for supplied context and path
+     */
+    void cleanAclCache(AppACLContext context, String path);
+}


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

fix an issue where project acl modification was not communicated to cluster members.

fixes https://github.com/rundeckpro/rundeckpro/issues/1763

* adds interface to enable cache cleanup