### PR TITLE
change oracle text type from CLOB to varchar2(4000).

### DIFF
--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -17,7 +17,7 @@ databaseChangeLog = {
 
         property name: "text.type", global: "true", value: "longtext", dbms: "mysql,mariadb"
         property name: "text.type", global: "true", value: "text", dbms: "postgresql"
-        property name: "text.type", global: "true", value: "CLOB", dbms: "oracle"
+        property name: "text.type", global: "true", value: "VARCHAR2(4000)", dbms: "oracle"
         property name: "text.type", global: "true", value: "varchar(max)", dbms: "mssql,h2"
 
         property name: "timestamp.type", global: "true", value: "datetime(6)", dbms: "mysql,mariadb"


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Bugfix.  Cannot modify clob fields after creation.

**Describe the solution you've implemented**
Initialze text.type to varchar(4000) in oracle.  In oracle, a clob field cannot be modified to a varchar when needed.  In order to have a field converted to a varchar, a new field column needs to be created, the data from the old field copied over to the new field, and the old field dropped.  Even though liquibase diff changesets mark a field with a text type to an oracle clob, gorm sets this field as varchar2(4000).  Making a grails domain object text field as varchar2(4000) makes conversion to other types easy if ever needed.
