### PR TITLE
Fix project picker view all link

### DIFF
--- a/rundeckapp/grails-app/views/common/_js.gsp
+++ b/rundeckapp/grails-app/views/common/_js.gsp
@@ -47,6 +47,7 @@
         frameworkReloadNodes: "${createLink(controller:"framework",action:"reloadNodes",params:projParams)}",
         frameworkNodeSummaryAjax: "${createLink(controller:"framework",action:"nodeSummaryAjax",params:projParams)}",
         frameworkDeleteNodeFilterAjax: "${createLink(controller:"framework",action:"deleteNodeFilterAjax",params:projParams)}",
+        frameworkCreateProject: "${createLink(controller:"framework",action:"createProject")}",
         authProjectsToCreateAjax: "${g.createLink(controller: 'menu', action: 'authProjectsToCreateAjax',params:projParams)}",
         menuDeleteJobFilterAjax: "${createLink(controller:"menu",action:"deleteJobFilterAjax",params:projParams)}",
         menuSaveJobFilterAjax: "${createLink(controller:"menu",action:"saveJobFilterAjax",params:projParams)}",

--- a/rundeckapp/grails-app/views/common/_js.gsp
+++ b/rundeckapp/grails-app/views/common/_js.gsp
@@ -55,6 +55,7 @@
         reportsSaveFilterAjax: "${g.createLink(controller: 'reports', action: 'saveFilterAjax',params:projParams)}",
         reportsDeleteFilterAjax: "${g.createLink(controller: 'reports', action: 'deleteFilterAjax',params:projParams)}",
         menuNowrunningAjax: "${g.createLink(controller: 'menu', action: 'nowrunningAjax',params:projParams)}",
+        menuHome: "${g.createLink(controller: 'menu', action: 'home',params:projParams)}",
         menuHomeAjax: "${g.createLink(controller: 'menu', action: 'homeAjax',params:projParams)}",
         menuHomeSummaryAjax: "${g.createLink(controller: 'menu', action: 'homeSummaryAjax',params:projParams)}",
         menuProjectNamesAjax: "${g.createLink(controller: 'menu', action: 'projectNamesAjax',params:projParams)}",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/first-run/FirstRun.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/first-run/FirstRun.vue
@@ -19,7 +19,7 @@
              To get started, create a new project.
             </p>
             <p>
-              <a href="/resources/createProject" class="btn  btn-cta btn-lg ">
+              <a :href="links.frameworkCreateProject" class="btn  btn-cta btn-lg ">
                   Create New Project <b class="glyphicon glyphicon-plus"></b>
               </a>
             </p>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/widgets/project-select/ProjectSelect.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/widgets/project-select/ProjectSelect.vue
@@ -29,7 +29,7 @@
             </RecycleScroller>
         </div>
         <div class="widget-section" style="height: 40px; flex-grow: 0; flex-shrink: 0;border-top: solid 1px grey; padding-left: 10px">
-            <a class="text-info" href="/" @click@keypress.enter="handleSelect">View All Projects</a>
+            <a class="text-info" :href="allProjectsLink" @click@keypress.enter="handleSelect">View All Projects</a>
         </div>
     </div>
 </template>
@@ -37,18 +37,17 @@
 <script lang="ts">
 import Vue from 'vue'
 import {Component, Inject} from 'vue-property-decorator'
+import { autorun } from 'mobx'
 import {Observer} from 'mobx-vue'
-
+import PerfectScrollbar from 'perfect-scrollbar'
 import { RecycleScroller } from 'vue-virtual-scroller'
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
 
-import {RootStore} from '../../../stores/RootStore'
+import { getAppLinks } from '../../../rundeckService'
 
+import {RootStore} from '../../../stores/RootStore'
 import { ProjectStore, Project } from '../../../stores/Projects'
 
-import PerfectScrollbar from 'perfect-scrollbar'
-
-import { autorun } from 'mobx'
 
 
 RecycleScroller.updated = function() {
@@ -78,6 +77,10 @@ export default class ProjectSelect extends Vue {
     ps!: PerfectScrollbar
 
     searchTerm: string = ''
+
+    get allProjectsLink(): string {
+        return getAppLinks().menuHome
+    }
 
     created() {
         this.projects = this.rootStore.projects

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/interfaces/AppLinks.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/interfaces/AppLinks.ts
@@ -21,6 +21,7 @@ export interface AppLinks {
     frameworkCheckResourceModelConfig: string
     frameworkEditResourceModelConfig: string
     frameworkCreateResourceModelConfig: string
+    frameworkCreateProject: string
     frameworkNodes: string
     frameworkNodesFragment: string
     frameworkNodesQueryAjax: string

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/interfaces/AppLinks.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/interfaces/AppLinks.ts
@@ -36,6 +36,7 @@ export interface AppLinks {
     reportsSaveFilterAjax: string
     reportsDeleteFilterAjax: string
     menuNowrunningAjax: string
+    menuHome: string
     menuHomeAjax: string
     menuHomeSummaryAjax: string
     menuProjectNamesAjax: string


### PR DESCRIPTION
**Describe the solution you've implemented**
Add app link for `menuHome` and use this for the link. This should account for `rdbase`.

**Describe alternatives you've considered**
Using `rdbase` as the `href` as it redirects to the projects list. This didn't seem explicit enough..
