### PR TITLE
Add Style for Fixed Table and Word Breaks

### DIFF
--- a/rundeckapp/grails-app/views/execution/_execDetails.gsp
+++ b/rundeckapp/grails-app/views/execution/_execDetails.gsp
@@ -18,7 +18,7 @@
 <g:set var="rkey" value="${g.rkey()}"/>
 <div class="row">
 <div class="col-sm-12 table-responsive">
-<table class="table item_details">
+<table class="table item_details table-fixed">
     <g:if test="${execdata!=null && execdata.id && execdata instanceof ScheduledExecution && !execdata.hasExecutionEnabled()}">
         <tr>
             <td></td>

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/paper/_tables.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/paper/_tables.scss
@@ -9,6 +9,7 @@
     tr > th,
     tr > td{
       border-top: 1px solid $table-line-color;
+      word-break: break-word;
     }
     tr.success{
       th,td{
@@ -230,5 +231,12 @@
   background-color: transparent;
   tr {
     background-color: transparent;
+  }
+}
+
+.table.table-fixed {
+  table-layout: fixed;
+  > tbody > tr > td:first-child{
+      width: 145px !important;
   }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Bugfix: Table style breaks out of Modal width

**Describe the solution you've implemented**
Add fixed table layout class to constrain table into modal as well as adding `break words` to collapse long strings
