### PR TITLE
[internal enhancement] execution views cleanup on execution show page

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -928,6 +928,8 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
     self.activeTab = self.activeView;
 
     self.views = ko.observableArray(data.views)
+    /** synonym for compatibility */
+    self.tabs = self.views
     /**
      * returns the tabs that have showButton flag enabled
      */

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -921,19 +921,30 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
     self.endTime=ko.observable();
     self.executionId = ko.observable(data.executionId);
     self.outputScrollOffset=0;
-    self.activeTab = ko.observable("nodes");
+    self.activeView = ko.observable("nodes");
+    /**
+     * synonym with activeView, to maintain compatibility
+     */
+    self.activeTab = self.activeView;
 
-    let tabs = [
-        {id: 'nodes', title: 'Nodes'},
-        {id: 'output', title: 'Log Output'},
-    ];
-
-    self.tabs = ko.observableArray(data.tabs || tabs)
+    self.views = ko.observableArray(data.views)
+    /**
+     * returns the tabs that have showButton flag enabled
+     */
+    self.viewButtons = ko.pureComputed(function () {
+        return ko.utils.arrayFilter(self.views(), (e) => e.showButton)
+    })
+    /**
+     * Returns the tabs that have hasContent flag enabled
+     */
+    self.contentViews = ko.pureComputed(function () {
+        return ko.utils.arrayFilter(self.views(), (e) => e.hasContent)
+    })
     self.humanizedDisplay=ko.observable(false);
     self.logoutput = ko.observable(data.logoutput);
     self.activeTabData = ko.pureComputed(function () {
         const theTab = self.activeTab()
-        return self.tabs().find((e) => e.id === theTab)
+        return self.views().find((e) => e.id === theTab)
     })
     self.scheduled = ko.pureComputed(function () {
         return self.executionState() === 'SCHEDULED';

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -576,6 +576,7 @@ search
                       <div class="card card-plain " data-ko-bind="nodeflow">
                           <div class="btn-group " data-bind="if: views().length>2">
                               <button class="btn btn-default btn-sm dropdown-toggle "
+                                      id="views_dropdown_button"
                                       data-target="#"
                                       data-toggle="dropdown">
                                   <span class="colon-after"><g:message code="view"/></span>
@@ -601,7 +602,7 @@ search
                           </div>
                           <!-- ko foreach: viewButtons -->
                           <a href="#"
-                             data-bind="click:function(){$root.activeTab(id)}, attr: {href: '#'+id }, visible: $root.activeTab()!==id"
+                             data-bind="click:function(){$root.activeTab(id)}, attr: {href: '#'+id, id: 'btn_view_'+id }, visible: $root.activeTab()!==id"
                              class="btn btn-sm">
                               <span data-bind="text: title"></span> &raquo;
                           </a>

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -574,7 +574,7 @@ search
               <div class="row">
                   <div class="col-sm-12">
                       <div class="card card-plain " data-ko-bind="nodeflow">
-                          <div class="btn-group " data-bind="if: tabs().length>2">
+                          <div class="btn-group " data-bind="if: views().length>2">
                               <button class="btn btn-default btn-sm dropdown-toggle "
                                       data-target="#"
                                       data-toggle="dropdown">
@@ -584,33 +584,29 @@ search
                                   </span>
                                   <i class="caret"></i>
                               </button>
-                              <ul class="dropdown-menu pull-left" role="menu" data-bind="foreach: tabs">
+                              <ul class="dropdown-menu pull-left" role="menu" data-bind="foreach: views">
 
                                   <li data-bind="attr: {id: 'tab_link_'+id }">
                                       <a href="#"
-                                         data-bind="click: function(){$root.activeTab(id)}, attr: {href: '#'+id }, text: title">
+                                         data-bind="click: function(){$root.activeTab(id)}, attr: {href: '#'+id }">
+                                          <span data-bind="text: title"></span>
+                                          <!-- ko if: $root.activeTab()===id -->
+                                          <i class="fas fa-check" style="margin-left:1em"></i>
+                                          <!-- /ko -->
                                       </a>
                                   </li>
 
                               </ul>
 
                           </div>
-                          <a href="#state"
-                             data-bind="click: function(){activeTab('nodes')}, visible: activeTab()!=='nodes'"
+                          <!-- ko foreach: viewButtons -->
+                          <a href="#"
+                             data-bind="click:function(){$root.activeTab(id)}, attr: {href: '#'+id }, visible: $root.activeTab()!==id"
                              class="btn btn-sm">
-                              <g:message code="execution.page.show.tab.Nodes.title"/>  &raquo;
+                              <span data-bind="text: title"></span> &raquo;
                           </a>
-                          <a href="#output"
-                             data-bind="click: function(){activeTab('output')}, visible: activeTab()!=='output'"
-                             class="btn btn-sm">
-                              <g:message code="execution.show.mode.Log.title"/> &raquo;
-                          </a>
+                          <!-- /ko -->
 
-%{--                          <a href="#output-plus"--}%
-%{--                             data-bind="click: function(){activeTab('output-plus')}, visible: activeTab()!=='output-plus'"--}%
-%{--                             class="btn btn-sm">--}%
-%{--                              <g:message code="execution.show.mode.LogPlus.title"/> &raquo;--}%
-%{--                          </a>--}%
 
                           <span data-bind="visible: activeTab().startsWith('output')">
 
@@ -837,6 +833,11 @@ search
 
                               <div class="tab-content" id="exec-main-view">
 
+                                  <!-- ko foreach: contentViews -->
+                                  <div class="tab-pane" data-bind="css: {active: $root.activeTab()===id}, attr: {id:id}">
+                                      <span data-bind="attr: {id:id+'_content'}, html:content"></span>
+                                  </div>
+                                  <!-- /ko -->
                                   <div class="tab-pane " id="nodes" data-bind="css: {active: activeTab()==='nodes'}">
                                       <div class="flowstate ansicolor ansicolor-on" id="nodeflowstate">
                                           <g:render template="wfstateNodeModelDisplay" bean="${workflowState}"
@@ -1149,7 +1150,11 @@ search
                     showStep:${enc(js: !isAdhoc)},
                     showNodeCol:false,
                 }
-            } )
+            } ),
+            views: [
+                {id: 'nodes', title: message('execution.page.show.tab.Nodes.title'), showButton: true},
+                {id: 'output', title: message('execution.show.mode.Log.title'), showButton: true}
+            ]
         }
         );
         flowState = new FlowState('${enc(js: execution?.id)}','flowstate',{
@@ -1158,10 +1163,6 @@ search
         outputUrl:"${g.enc(js:createLink(controller: 'execution', action: 'tailExecutionOutput', id: execution.id,params:[format:'json']))}",
         selectedOutputStatusId:'selectedoutputview',
         reloadInterval:1500,
-            tabs:[
-                {id: 'nodes', title: message('execution.page.show.tab.Nodes.title')},
-                {id: 'output', title: message('execution.show.mode.Log.title')}
-            ]
      });
 
       nodeflowvm.followFlowState(flowState,true);

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -1329,6 +1329,10 @@ function getCurSEID(){
             jobeditor.addError('plugins');
 </g:if>
             initKoBind(null,{jobeditor:jobeditor})
+
+            jQuery('textarea.form-control.apply_ace').each(function () {
+                _setupAceTextareaEditor(this);
+            });
         }
 
         jQuery(pageinit);

--- a/test/selenium/src/__tests__/selenium/execution/execution-show-page-views.test.ts
+++ b/test/selenium/src/__tests__/selenium/execution/execution-show-page-views.test.ts
@@ -52,11 +52,6 @@ describe('execution', () => {
     const displayed = await viewContent.isDisplayed()
     expect(displayed).toBeTruthy()
 
-    // expect view dropdown to show nodes
-    const viewDropdown = await execShowPage.viewDropdown()
-    const viewDropdownText = await viewDropdown.getText()
-    expect(viewDropdownText).toBe('View Nodes')
-
     // expect nodes button to be hidden
     const nodesButton = await execShowPage.viewButton('nodes')
     const btnDisplayed = await nodesButton.isDisplayed()
@@ -88,11 +83,6 @@ describe('execution', () => {
 
     const displayed = await viewContent.isDisplayed()
     expect(displayed).toBeTruthy()
-
-    // expect view dropdown to show correct text
-    const viewDropdown = await execShowPage.viewDropdown()
-    const viewDropdownText = await viewDropdown.getText()
-    expect(viewDropdownText).toBe('View Log Output')
 
     // expect output button to be hidden
     const viewButton = await execShowPage.viewButton('output')
@@ -126,11 +116,6 @@ describe('execution', () => {
     const displayed = await viewContent.isDisplayed()
     expect(displayed).toBeTruthy()
 
-    // expect view dropdown to show nodes
-    const viewDropdown = await execShowPage.viewDropdown()
-    const viewDropdownText = await viewDropdown.getText()
-    expect(viewDropdownText).toBe('View Nodes')
-
     // expect nodes button to be hidden
     const nodesButton = await execShowPage.viewButton('nodes')
     const btnDisplayed = await nodesButton.isDisplayed()
@@ -163,11 +148,6 @@ describe('execution', () => {
 
     const displayed = await viewContent.isDisplayed()
     expect(displayed).toBeTruthy()
-
-    // expect view dropdown to show correct text
-    const viewDropdown = await execShowPage.viewDropdown()
-    const viewDropdownText = await viewDropdown.getText()
-    expect(viewDropdownText).toBe('View Log Output')
 
     // expect output button to be hidden
     const viewButton = await execShowPage.viewButton('output')

--- a/test/selenium/src/__tests__/selenium/execution/execution-show-page-views.test.ts
+++ b/test/selenium/src/__tests__/selenium/execution/execution-show-page-views.test.ts
@@ -1,0 +1,182 @@
+import {sleep} from '@rundeck/testdeck/async/util'
+import {Context} from '@rundeck/testdeck/context'
+import '@rundeck/testdeck/test/rundeck'
+import {CreateContext} from '@rundeck/testdeck/test/selenium'
+import {AdhocCommandPage, Elems} from 'pages/adhocCommand.page'
+import {ExecutionShowPage} from 'pages/executionShow.page'
+import {LoginPage} from 'pages/login.page'
+import {ProjectCreatePage} from 'pages/projectCreate.page'
+import {By, Key, until} from 'selenium-webdriver'
+import {NavigationPage} from '../../../pages/navigation.page'
+
+// We will initialize and cleanup in the before/after methods
+const ctx = CreateContext({projects: ['SeleniumBasic']})
+let loginPage: LoginPage
+let adhocPage: AdhocCommandPage
+let execPageHref: string
+let navigation: NavigationPage
+
+beforeAll(async () => {
+  loginPage = new LoginPage(ctx)
+  navigation = new NavigationPage(ctx)
+  adhocPage = new AdhocCommandPage(ctx, 'SeleniumBasic')
+})
+
+beforeAll(async () => {
+  await loginPage.login('admin', 'admin')
+})
+beforeAll(async () => {
+  // @ts-ignore
+  let path = expect.getState().testPath
+  path = path.substring(path.lastIndexOf('/') + 1)
+  const execPageLink = await adhocPage.runBasicCommand('echo running test "' + path + '"', '.*')
+  execPageHref = await execPageLink.getAttribute('href')
+})
+
+describe('execution', () => {
+  it('default page load shows nodes view', async () => {
+    await ctx.driver.get(execPageHref)
+
+    await ctx.driver.wait(until.urlContains('/execution/show'), 25000)
+    const execShowPage = new ExecutionShowPage(ctx, 'SeleniumBasic', '')
+
+    // expect an execution state
+    const display = await execShowPage.executionStateDisplay()
+    const val = await display.getAttribute('data-execstate')
+    expect(val.toUpperCase()).toBeDefined()
+
+    // expect 'nodes' view to be active
+    const viewContent = await execShowPage.viewContent('nodes')
+    await ctx.driver.wait(until.elementIsVisible(viewContent))
+
+    const displayed = await viewContent.isDisplayed()
+    expect(displayed).toBeTruthy()
+
+    // expect view dropdown to show nodes
+    const viewDropdown = await execShowPage.viewDropdown()
+    const viewDropdownText = await viewDropdown.getText()
+    expect(viewDropdownText).toBe('View Nodes')
+
+    // expect nodes button to be hidden
+    const nodesButton = await execShowPage.viewButton('nodes')
+    const btnDisplayed = await nodesButton.isDisplayed()
+    expect(btnDisplayed).toBeFalsy()
+    // expect other button to be shown
+    const viewButton2 = await execShowPage.viewButton('output')
+    const btnDisplayed2 = await viewButton2.isDisplayed()
+    expect(btnDisplayed2).toBeTruthy()
+
+  })
+
+  it('fragment #output page load shows output view', async () => {
+    await navigation.gotoProject('SeleniumBasic')
+    await ctx.driver.wait(until.urlContains('/home'), 5000)
+
+    await ctx.driver.get(execPageHref + '#output')
+
+    await ctx.driver.wait(until.urlContains('/execution/show'), 25000)
+    const execShowPage = new ExecutionShowPage(ctx, 'SeleniumBasic', '')
+
+    // expect an execution state
+    const display = await execShowPage.executionStateDisplay()
+    const val = await display.getAttribute('data-execstate')
+    expect(val.toUpperCase()).toBeDefined()
+
+    // expect 'output' view to be active
+    const viewContent = await execShowPage.viewContent('output')
+    await ctx.driver.wait(until.elementIsVisible(viewContent))
+
+    const displayed = await viewContent.isDisplayed()
+    expect(displayed).toBeTruthy()
+
+    // expect view dropdown to show correct text
+    const viewDropdown = await execShowPage.viewDropdown()
+    const viewDropdownText = await viewDropdown.getText()
+    expect(viewDropdownText).toBe('View Log Output')
+
+    // expect output button to be hidden
+    const viewButton = await execShowPage.viewButton('output')
+    const btnDisplayed = await viewButton.isDisplayed()
+    expect(btnDisplayed).toBeFalsy()
+    // expect other button to be shown
+    const viewButton2 = await execShowPage.viewButton('nodes')
+    const btnDisplayed2 = await viewButton2.isDisplayed()
+    expect(btnDisplayed2).toBeTruthy()
+  })
+
+  it('output view toggle to nodes view with button', async () => {
+    await navigation.gotoProject('SeleniumBasic')
+    await ctx.driver.wait(until.urlContains('/home'), 5000)
+
+    await ctx.driver.get(execPageHref + '#output')
+
+    await ctx.driver.wait(until.urlContains('/execution/show'), 25000)
+    const execShowPage = new ExecutionShowPage(ctx, 'SeleniumBasic', '')
+
+    const toggleButton = await execShowPage.viewButton('nodes')
+    const toggleBtnDisplayed = await toggleButton.isDisplayed()
+    expect(toggleBtnDisplayed).toBeTruthy()
+
+    await toggleButton.click()
+
+    // expect 'nodes' view to be active
+    const viewContent = await execShowPage.viewContent('nodes')
+    await ctx.driver.wait(until.elementIsVisible(viewContent))
+
+    const displayed = await viewContent.isDisplayed()
+    expect(displayed).toBeTruthy()
+
+    // expect view dropdown to show nodes
+    const viewDropdown = await execShowPage.viewDropdown()
+    const viewDropdownText = await viewDropdown.getText()
+    expect(viewDropdownText).toBe('View Nodes')
+
+    // expect nodes button to be hidden
+    const nodesButton = await execShowPage.viewButton('nodes')
+    const btnDisplayed = await nodesButton.isDisplayed()
+    expect(btnDisplayed).toBeFalsy()
+    // expect other button to be shown
+    const viewButton2 = await execShowPage.viewButton('output')
+    const btnDisplayed2 = await viewButton2.isDisplayed()
+    expect(btnDisplayed2).toBeTruthy()
+
+  })
+
+  it('nodes view toggle to output view with button', async () => {
+    await navigation.gotoProject('SeleniumBasic')
+    await ctx.driver.wait(until.urlContains('/home'), 5000)
+
+    await ctx.driver.get(execPageHref)
+
+    await ctx.driver.wait(until.urlContains('/execution/show'), 25000)
+    const execShowPage = new ExecutionShowPage(ctx, 'SeleniumBasic', '')
+
+    const toggleButton = await execShowPage.viewButton('output')
+    const toggleBtnDisplayed = await toggleButton.isDisplayed()
+    expect(toggleBtnDisplayed).toBeTruthy()
+
+    await toggleButton.click()
+
+    // expect 'output' view to be active
+    const viewContent = await execShowPage.viewContent('output')
+    await ctx.driver.wait(until.elementIsVisible(viewContent))
+
+    const displayed = await viewContent.isDisplayed()
+    expect(displayed).toBeTruthy()
+
+    // expect view dropdown to show correct text
+    const viewDropdown = await execShowPage.viewDropdown()
+    const viewDropdownText = await viewDropdown.getText()
+    expect(viewDropdownText).toBe('View Log Output')
+
+    // expect output button to be hidden
+    const viewButton = await execShowPage.viewButton('output')
+    const btnDisplayed = await viewButton.isDisplayed()
+    expect(btnDisplayed).toBeFalsy()
+    // expect other button to be shown
+    const viewButton2 = await execShowPage.viewButton('nodes')
+    const btnDisplayed2 = await viewButton2.isDisplayed()
+    expect(btnDisplayed2).toBeTruthy()
+  })
+
+})

--- a/test/selenium/src/pages/adhocCommand.page.ts
+++ b/test/selenium/src/pages/adhocCommand.page.ts
@@ -1,4 +1,4 @@
-import {By, WebElementPromise} from 'selenium-webdriver'
+import {By, until, WebElementPromise} from 'selenium-webdriver'
 
 import {Context} from '@rundeck/testdeck/context'
 import {Page} from '@rundeck/testdeck/page'
@@ -46,5 +46,30 @@ export class AdhocCommandPage extends Page {
   }
   async abortButton() {
     return await this.ctx.driver.findElement(Elems.abortButton)
+  }
+
+  /**
+   * Load adhoc commands page, run a basic command on a node filter, and return the link to the execution
+   * @param command
+   */
+  async runBasicCommand(command: string, nodefilter: string) {
+    const {driver} = this.ctx
+    await this.get()
+    await driver.wait(until.urlContains('/command/run'), 25000)
+    const nodeFilter = await this.nodeFilterInput()
+    await nodeFilter.sendKeys(nodefilter)
+
+    const nodeFilterBtn = await this.filterNodesButton()
+    await nodeFilterBtn.click()
+
+    const commandInput = await this.commandInput()
+    await commandInput.sendKeys(command)
+
+    const commandButton = await this.runCommandButton()
+    await commandButton.click()
+
+    // find execution id and get link
+    await driver.wait(until.elementLocated(Elems.runningExecutionState), 25000)
+    return this.runningExecutionLink()
   }
 }

--- a/test/selenium/src/pages/executionShow.page.ts
+++ b/test/selenium/src/pages/executionShow.page.ts
@@ -5,7 +5,9 @@ import {Page} from '@rundeck/testdeck/page'
 
 export const Elems = {
   abortButton: By.css('#subtitlebar section.execution-action-links span.btn-danger[data-bind=\'click: killExecAction\''),
+  execOutputCard: By.css('card.exec-output'),
   executionStateDisplay: By.css('#subtitlebar summary > span.execution-summary-status > span.execstate.execstatedisplay.overall'),
+  viewsDropdownButton: By.css('#views_dropdown_button'),
 }
 
 export class ExecutionShowPage extends Page {
@@ -22,5 +24,21 @@ export class ExecutionShowPage extends Page {
 
   async abortButton() {
     return await this.ctx.driver.findElement(Elems.abortButton)
+  }
+
+  async viewDropdown() {
+    return await this.ctx.driver.findElement(Elems.viewsDropdownButton)
+  }
+
+  async viewContent(view: string) {
+    return await this.ctx.driver.findElement(By.css('#' + view))
+  }
+
+  async viewButton(view: string) {
+    return await this.ctx.driver.findElement(By.css('#btn_view_' + view))
+  }
+
+  async execOutputCard() {
+    return await this.ctx.driver.findElement(Elems.execOutputCard)
   }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Enhances the Execution View page to enable UI plugin code to add new Views for an execution.

**Describe the solution you've implemented**

Updates NodeFlowViewModel js type with:
* renames `tabs` to `views`
* renames `activeTab` to `activeView` but retains `activeTab` for compatibility
* each view object can have `showButton: true` which enables a separate toggle button in addition to entry in the View selection dropdown
* each view object can have `hasContent: true` to enable generation of a dom element containing the content, which is revealed when the view is selected.  the `content` value can contain HTML to put in the view.



**Additional context**
Also fixes an issue: Ace syntax editor was not working for Execution Lifecycle plugin properties.
