### PR TITLE
Refactor: auth success user profile updates decoupled from UserService

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -688,8 +688,7 @@ beans={
 
     if(grailsApplication.config.rundeck.security.syncLdapUser in [true,'true']) {
         rundeckJaasAuthenticationSuccessEventListener(RundeckJaasAuthenticationSuccessEventListener) {
-            userService = ref("userService")
-            grailsApplication = grailsApplication
+            configurationService = ref('configurationService')
         }
     }
     rundeckConfig(RundeckConfig)

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -629,7 +629,6 @@ beans={
     if(grailsApplication.config.rundeck.security.authorization.preauthenticated.enabled in [true,'true']) {
         rundeckPreauthSuccessEventHandler(RundeckPreauthSuccessEventHandler) {
             configurationService = ref('configurationService')
-            userService = ref("userService")
         }
         rundeckPreauthFilter(RundeckPreauthenticationRequestHeaderFilter) {
             enabled = grailsApplication.config.rundeck?.security?.authorization?.preauthenticated?.enabled in [true, 'true']

--- a/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
@@ -19,7 +19,9 @@ package rundeck.services
 import com.dtolabs.rundeck.core.plugins.PluggableProviderService
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
 import com.dtolabs.rundeck.plugins.user.groups.UserGroupSourcePlugin
+import grails.events.annotation.Subscriber
 import grails.gorm.transactions.Transactional
+import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import org.hibernate.StaleStateException
 import org.springframework.dao.OptimisticLockingFailureException
@@ -29,6 +31,7 @@ import rundeck.User
 
 @Transactional
 class UserService {
+    public static final String G_EVENT_LOGIN_PROFILE_CHANGE = 'user.login.profile.change'
     ConfigurationService configurationService
     FrameworkService frameworkService
     public static final int DEFAULT_TIMEOUT = 30
@@ -167,6 +170,23 @@ class UserService {
         return [user:u,storedpref:storedpref]
     }
 
+    @CompileStatic
+    @Subscriber(G_EVENT_LOGIN_PROFILE_CHANGE)
+    def userLoginProfileChange(UserProfileData data){
+        updateUserProfile(
+            data.username,
+            data.lastName,
+            data.firstName,
+            data.email
+        )
+    }
+    @CompileStatic
+    static class UserProfileData{
+        String username
+        String lastName
+        String firstName
+        String email
+    }
     void updateUserProfile(String username, String lastName, String firstName, String email) {
         User u = findOrCreateUser(username)
         u.firstName = firstName


### PR DESCRIPTION
* Use grails event to trigger user profile updates instead of directly calling UserService
* Fix spring dependency chain issue

**Is this a bugfix, or an enhancement? Please describe.**

Fixes https://github.com/rundeckpro/rundeckpro/issues/1796

**Describe the solution you've implemented**

Instead of depending on UserClass directly, change `RundeckPreauthSuccessEventHandler` and `RundeckJaasAuthenticationSuccessEventListener` to send a grails event with user detail for updating user profile. Modify UserService to react to the event.

**Describe alternatives you've considered**
Attempt to alter spring dependency chain to be less strict at load time did not work.
