### PR TITLE
Fix: bundled groovy plugins should be overwritten when extracted

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckEmbeddedPluginExtractor.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckEmbeddedPluginExtractor.groovy
@@ -76,7 +76,7 @@ class RundeckEmbeddedPluginExtractor implements ApplicationContextAware, Initial
 
             pluginList.each { PluginFileManifest pluginmf ->
                 try {
-                    if (installPlugin(pluginTargetDir, loader, pluginmf, false)) {
+                    if (installPlugin(pluginTargetDir, loader, pluginmf, pluginmf.fileName.endsWith('.groovy'))) {
                         result.logs << "Extracted bundled plugin ${pluginmf.fileName}"
                     } else {
                         result.logs << "Skipped existing plugin: ${pluginmf.fileName}"


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Fix: bundled groovy plugins are not named with version number in the name, so should overwrite previous versions if they exist.

**Describe the solution you've implemented**
Set overwrite flag to true when extracting groovy plugins

**Additional context**

For https://github.com/rundeckpro/rundeckpro/issues/1798
