### PR TITLE
Bump rundeck client version to 0.2.3

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
@@ -1592,9 +1592,9 @@
       }
     },
     "@rundeck/client": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@rundeck/client/-/client-0.2.1.tgz",
-      "integrity": "sha512-NZq5m6jMoCHFLVjX2f4S0wmqFgEZy551kkSHRogaj5Al2wWnnjhf+U/RYWDYvjn68cwSK6cAZwBIj567zESi6A==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@rundeck/client/-/client-0.2.3.tgz",
+      "integrity": "sha512-gpi+7MTiRKecF9VdtC+2g7sp8H+QVoAVTqPLoRYO1+UHdugyz6OHeDRLLYRKSQZFAGymaD7SrDGFi5TsSICxtw==",
       "dev": true,
       "requires": {
         "@azure/ms-rest-js": "2.0.7",
@@ -3072,9 +3072,9 @@
           "dev": true
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3296,9 +3296,9 @@
           }
         },
         "vue-loader-v16": {
-          "version": "npm:vue-loader@16.1.2",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
-          "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
+          "version": "npm:vue-loader@16.2.0",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.2.0.tgz",
+          "integrity": "sha512-TitGhqSQ61RJljMmhIGvfWzJ2zk9m1Qug049Ugml6QP3t0e95o0XJjk29roNEiPKJQBEi8Ord5hFuSuELzSp8Q==",
           "dev": true,
           "optional": true,
           "requires": {

--- a/rundeckapp/grails-spa/packages/ui-trellis/package.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@azure/ms-rest-js": "^2.0.7",
     "@babel/core": "^7.10.2",
-    "@rundeck/client": "0.2.1",
+    "@rundeck/client": "0.2.3",
     "@types/node": "14.0.13",
     "@vue/cli-plugin-babel": "4.5.8",
     "@vue/cli-plugin-typescript": "4.5.8",

--- a/rundeckapp/grails-spa/packages/ui/package-lock.json
+++ b/rundeckapp/grails-spa/packages/ui/package-lock.json
@@ -4280,9 +4280,9 @@
       }
     },
     "@rundeck/client": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@rundeck/client/-/client-0.2.1.tgz",
-      "integrity": "sha512-NZq5m6jMoCHFLVjX2f4S0wmqFgEZy551kkSHRogaj5Al2wWnnjhf+U/RYWDYvjn68cwSK6cAZwBIj567zESi6A==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@rundeck/client/-/client-0.2.3.tgz",
+      "integrity": "sha512-gpi+7MTiRKecF9VdtC+2g7sp8H+QVoAVTqPLoRYO1+UHdugyz6OHeDRLLYRKSQZFAGymaD7SrDGFi5TsSICxtw==",
       "requires": {
         "@azure/ms-rest-js": "2.0.7",
         "@types/promise-queue": "^2.2.0",
@@ -23645,18 +23645,18 @@
       "integrity": "sha512-ASH8OPHMNlkdjrEdmoILmzFfsJICvhBsFfAum4aKZ/9U4B6M6tTmTPh+f3ttWdD74CEGV5XvXWkbyfSdXaTd7g=="
     },
     "@types/node-fetch": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.10.tgz",
+      "integrity": "sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
       },
       "dependencies": {
         "form-data": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",

--- a/rundeckapp/grails-spa/packages/ui/package.json
+++ b/rundeckapp/grails-spa/packages/ui/package.json
@@ -18,7 +18,7 @@
     "ci:test": "npm ci && npm run test"
   },
   "dependencies": {
-    "@rundeck/client": "0.2.1",
+    "@rundeck/client": "0.2.3",
     "ace-builds": "1.4.12",
     "ant-design-vue": "1.6.2",
     "axios": "^0.18.0",


### PR DESCRIPTION
Related to rundeckpro/rundeckpro#1783

Bumps `@rundeck/client` to a version with a fix to `apiRequest` so that it calls the subclass implementation of `sendRequest` instead of super.

This method sets the base URL for you and in the browser based on `rdBase`. A small convenience and an explicit method for making raw API calls that doesn't rely on overloaded infrastructure method(`sendRequest`).