### PR TITLE
RUN-136: access control did not allow to toggle execution enabled/disabled option even if allowed by ACL policy

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -1261,7 +1261,7 @@ class ScheduledExecutionController  extends ControllerBase{
 
     private def performFlipJobFlagBulk(ApiBulkJobDeleteRequest deleteRequest,String methodName,Map flags, String successCode) {
 
-        UserAndRolesAuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
+        UserAndRolesAuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, params.project)
         def ids = deleteRequest.generateIdSet()
 
         def successful = []

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -1261,23 +1261,26 @@ class ScheduledExecutionController  extends ControllerBase{
 
     private def performFlipJobFlagBulk(ApiBulkJobDeleteRequest deleteRequest,String methodName,Map flags, String successCode) {
 
-        UserAndRolesAuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, params.project)
         def ids = deleteRequest.generateIdSet()
 
         def successful = []
         def errs = []
-        def changeinfo = [method: methodName, change: 'modify', user: authContext.username]
         def framework = frameworkService.getRundeckFramework()
         ids.sort().each { jobid ->
-
-            def result = scheduledExecutionService._doUpdateExecutionFlags(
-                    [id: jobid] + flags,
-                    authContext.username,
-                    authContext.roles.join(','),
-                    framework,
-                    authContext,
-                    changeinfo
-            )
+            ScheduledExecution scheduledExecution = scheduledExecutionService.getByIDorUUID(jobid)
+            def result = [success: false]
+            if(scheduledExecution) {
+                UserAndRolesAuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, scheduledExecution.project)
+                def changeinfo = [method: methodName, change: 'modify', user: authContext.username]
+                result = scheduledExecutionService._doUpdateExecutionFlags(
+                        [id: jobid] + flags,
+                        authContext.username,
+                        authContext.roles.join(','),
+                        framework,
+                        authContext,
+                        changeinfo
+                )
+            }
             if (!result.success) {
                 if (result.unauthorized) {
                     errs << [id       : jobid,

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -182,6 +182,7 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
     def "flip execution disable bulk"() {
         given:
         def job1 = new ScheduledExecution(createJobParams())
+        job1.save()
         controller.scheduledExecutionService = Mock(ScheduledExecutionService)
         controller.frameworkService = Mock(FrameworkService)
         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)
@@ -192,8 +193,8 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
             getRoles() >> (['test'] as Set)
         }
 
-        params.idList = 'dummy1'
-        params.ids = ['dummy1']
+        params.idList = job1.id
+        params.ids = [job1.id]
         params.project = 'project'
         params.executionEnabled = false
         request.subject=new Subject()
@@ -208,8 +209,9 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         0 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_) >> auth
         1 * controller.frameworkService.getRundeckFramework()
         0 * controller.frameworkService._(*_)
+        1 * controller.scheduledExecutionService.getByIDorUUID(job1.id.toString()) >> job1
         1 * controller.scheduledExecutionService._doUpdateExecutionFlags(
-                [id: 'dummy1', executionEnabled: false],
+                [id: job1.id.toString(), executionEnabled: false],
                 _,
                 _,
                 _,
@@ -224,6 +226,7 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
     def "flip execution enable bulk"() {
         given:
         def job1 = new ScheduledExecution(createJobParams())
+        job1.save()
         controller.scheduledExecutionService = Mock(ScheduledExecutionService)
         controller.frameworkService = Mock(FrameworkService)
         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)
@@ -234,8 +237,8 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
             getRoles() >> (['test'] as Set)
         }
 
-        params.idList = 'dummy1'
-        params.ids = ['dummy1']
+        params.idList = job1.id
+        params.ids = [job1.id]
         params.project = 'project'
         params.executionEnabled = true
         request.subject=new Subject()
@@ -249,9 +252,10 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,_) >> auth
         0 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_) >> auth
         1 * controller.frameworkService.getRundeckFramework()
+        1 * controller.scheduledExecutionService.getByIDorUUID(job1.id.toString()) >> job1
         0 * controller.frameworkService._(*_)
         1 * controller.scheduledExecutionService._doUpdateExecutionFlags(
-                [id: 'dummy1', executionEnabled: true],
+                [id: job1.id.toString(), executionEnabled: true],
                 _,
                 _,
                 _,


### PR DESCRIPTION
fixes https://github.com/rundeckpro/rundeckpro/issues/1569

**Is this a bugfix, or an enhancement? Please describe.**
The auth context was not loading the ACL rules on the project context

**Describe the solution you've implemented**
Change the method to create the auth context for subject and project context
