### PR TITLE
[RUN-61]fix rundeckpro/rundeckpro#1823 check if sequences

### DIFF
--- a/rundeckapp/grails-app/migrations/core/ConstraintsIndexesKeys.groovy
+++ b/rundeckapp/grails-app/migrations/core/ConstraintsIndexesKeys.groovy
@@ -14,6 +14,11 @@ databaseChangeLog = {
     }
 //////////////////////////////////////// Oracle Specific ///////////////////////////////////////////////////////////////
     changeSet(author: "rundeckuser (generated)", id: "1613961122706-29", dbms: "oracle") {
+        preConditions(onFail: "MARK_RAN"){
+            not{
+                indexExists (tableName:"auth_token", indexName: "IDX_TOKEN")
+            }
+        }
         createIndex(indexName: "IDX_TOKEN", tableName: "auth_token", unique: "true") {
             column(name: "token")
         }
@@ -29,6 +34,11 @@ databaseChangeLog = {
     }
 
     changeSet(author: "rundeckuser (generated)", id: "1613961122706-32", dbms: "oracle") {
+        preConditions(onFail: "MARK_RAN"){
+            not{
+                indexExists (tableName:"project", indexName: "PROJECT_IDX_NAME")
+            }
+        }
         createIndex(indexName: "PROJECT_IDX_NAME", tableName: "project", unique: "true") {
             column(name: "name")
         }
@@ -64,7 +74,7 @@ databaseChangeLog = {
             column(name: "date_started")
         }
     }
-    
+
     changeSet(author: "rundeckuser (generated)", id: "3.4.0-36") {
         preConditions(onFail: "MARK_RAN"){
             not{

--- a/rundeckapp/grails-app/migrations/core/HibernateIndex.groovy
+++ b/rundeckapp/grails-app/migrations/core/HibernateIndex.groovy
@@ -1,5 +1,10 @@
 databaseChangeLog = {
     changeSet(author: "rundeckuser (generated)", id: "3.4.0-1", dbms: "oracle,postgresql") {
+        preConditions(onFail: "MARK_RAN"){
+            not{
+                sequenceExists (sequenceName:"hibernate_sequence")
+            }
+        }
         createSequence(incrementBy: "1", sequenceName: "hibernate_sequence", startValue: "1")
     }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Bugfix.  When upgrading from rundeck 3.3.x to 3.4.0 and the database used is Oracle, the hibernate_sequence, IDX_TOKEN and PROJECT_IDX_TOKEN exist and should be checked with a precondition before trying to add them.
**Describe the solution you've implemented**
Update changesets to apply a precondition which checks to see if these indexes and sequence already exist
**Describe alternatives you've considered**
None