### PR TITLE
Fix rundeckpro-1824 ent logstorage config [RUN-78]

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -490,7 +490,9 @@ beans={
     /**
      * Define groovy-based plugins as Spring beans, registered in a hash map
      */
-    pluginCustomizer(PluginCustomizer)
+    pluginCustomizer(PluginCustomizer){
+        pluginRegistry = ref("rundeckPluginRegistryMap")
+    }
     xmlns lang: 'http://www.springframework.org/schema/lang'
 
     appContextEmbeddedPluginFileSource(ApplicationContextPluginFileSource, '/WEB-INF/rundeck/plugins/')
@@ -507,7 +509,6 @@ beans={
                     'refresh-check-delay': application.config.plugin.refreshDelay ?: -1,
                     'customizer-ref':'pluginCustomizer'
             )
-            pluginRegistry[beanName]=beanName
         }
     }
     dbStoragePluginFactory(DbStoragePluginFactory)

--- a/rundeckapp/grails-app/services/rundeck/services/PluginService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/PluginService.groovy
@@ -475,8 +475,12 @@ class PluginService implements ResourceFormats {
     private void logValidationErrors(String svcName, String pluginName,Validator.Report report) {
         def sb = new StringBuilder()
         sb<< "${svcName}: configuration was not valid for plugin '${pluginName}': "
-        report?.errors.each { k, v ->
-            sb<<"${k}: ${v}\n"
+        if(report?.errors){
+            report?.errors?.each { k, v ->
+                sb<<"${k}: ${v}\n"
+            }
+        }else{
+            sb<<'(Unknown reason)'
         }
         log.error(sb.toString())
     }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/PluginCustomizer.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/PluginCustomizer.groovy
@@ -27,7 +27,7 @@ import org.springframework.scripting.groovy.GroovyObjectCustomizer
  * Time: 3:19 PM
  */
 class PluginCustomizer implements GroovyObjectCustomizer {
-
+    Map pluginRegistry
     public void customize(GroovyObject goo) {
         if (goo instanceof Script) {
             goo.metaClass.rundeckPlugin = { Class clazz, Closure clos ->
@@ -36,6 +36,7 @@ class PluginCustomizer implements GroovyObjectCustomizer {
                     clos.delegate = builder
                     clos.resolveStrategy = Closure.DELEGATE_FIRST
                     clos.call()
+                    pluginRegistry[goo.class.name] = goo.class.name
                     return builder
                 }
                 return goo;

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
@@ -432,8 +432,14 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
             def beanName = pluginRegistryMap["${type}:${name}"] ?: pluginRegistryMap[name]
             if (beanName) {
                 def bean = findBean(beanName)
+                if(!bean){
+                    return null
+                }
                 if (bean instanceof PluginBuilder) {
                     bean = ((PluginBuilder) bean).buildPlugin()
+                }
+                if(!bean){
+                    return null
                 }
 
                 final Plugin annotation1 = bean.getClass().getAnnotation(Plugin.class);
@@ -446,6 +452,9 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
                     desc = ((Describable) bean).description
                 } else if (PluginAdapterUtility.canBuildDescription(bean)) {
                     desc = PluginAdapterUtility.buildDescription(bean, DescriptionBuilder.builder())
+                }
+                if(!desc){
+                    return null
                 }
                 return new DescribedPlugin<T>(bean, desc, name, new File(pluginDirectory, name + ".groovy"))
             }

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistrySpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistrySpec.groovy
@@ -21,6 +21,7 @@ import com.dtolabs.rundeck.plugins.util.PropertyBuilder
 import com.dtolabs.rundeck.server.plugins.services.PluginBuilder
 import org.grails.spring.beans.factory.InstanceFactoryBean
 import org.grails.testing.GrailsUnitTest
+import org.springframework.context.ApplicationContext
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -184,6 +185,87 @@ class RundeckPluginRegistrySpec extends Specification implements GrailsUnitTest 
         'plugin1'  | 'aservicename'     | 'plugin1'
         'plugin2'  | 'otherservicename' | 'plugin2'
         'plugin1'  | 'otherservice'     | 'plugin3'
+
+    }
+    @Unroll
+    def "loadBeanDescriptor not describable"() {
+        given:
+
+        defineBeans{
+            SomeBean(InstanceFactoryBean, 'test')
+        }
+        def sut = new RundeckPluginRegistry()
+        sut.pluginDirectory = File.createTempDir('test', 'dir')
+        sut.applicationContext = applicationContext
+        sut.pluginRegistryMap = [(pluginname):'SomeBean']
+        sut.rundeckServerServiceProviderLoader = Mock(ServiceProviderLoader)
+
+
+        when:
+        def result = sut.loadBeanDescriptor(pluginname, servicename)
+
+        then:
+        result==null
+
+        where:
+
+        pluginname | servicename
+        'plugin1'  | 'aservicename'
+
+    }
+    @Unroll
+    def "loadBeanDescriptor builder returns null"() {
+        given:
+
+            def builder = Mock(PluginBuilder){
+
+            }
+        defineBeans{
+            SomeBean(InstanceFactoryBean, builder)
+        }
+        def sut = new RundeckPluginRegistry()
+        sut.pluginDirectory = File.createTempDir('test', 'dir')
+        sut.applicationContext = applicationContext
+        sut.pluginRegistryMap = [(pluginname):'SomeBean']
+        sut.rundeckServerServiceProviderLoader = Mock(ServiceProviderLoader)
+
+
+        when:
+        def result = sut.loadBeanDescriptor(pluginname, servicename)
+
+        then:
+        result==null
+
+        where:
+
+        pluginname | servicename
+        'plugin1'  | 'aservicename'
+
+    }
+    @Unroll
+    def "loadBeanDescriptor null from subcontext"() {
+        given:
+
+        def sut = new RundeckPluginRegistry()
+        sut.pluginDirectory = File.createTempDir('test', 'dir')
+        sut.applicationContext = applicationContext
+        sut.pluginRegistryMap = [(pluginname):'SomeBean']
+        sut.rundeckServerServiceProviderLoader = Mock(ServiceProviderLoader)
+        sut.subContexts['SomeBean']=Mock(ApplicationContext){
+            getBean('SomeBean')>>null
+        }
+
+
+        when:
+        def result = sut.loadBeanDescriptor(pluginname, servicename)
+
+        then:
+        result==null
+
+        where:
+
+        pluginname | servicename
+        'plugin1'  | 'aservicename'
 
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/services/PluginServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/PluginServiceSpec.groovy
@@ -74,6 +74,25 @@ class PluginServiceSpec extends Specification implements ServiceUnitTest<PluginS
 
 
     }
+    def "configure plugin invalid no errors"() {
+        given:
+        service.rundeckPluginRegistry = Mock(PluginRegistry)
+        def name = 'atest'
+        def config = [:]
+        def project = 'aproject'
+        def framework = null
+        def providerservice = Mock(PluggableProviderService)
+
+        when:
+        def result = service.configurePlugin(name, config, project, framework, providerservice)
+
+        then:
+        result == null
+        1 * service.rundeckPluginRegistry.validatePluginByName('atest', providerservice, null, 'aproject', config) >>
+                new ValidatedPlugin(valid:false,report: null)
+
+
+    }
 
     def "get plugin"() {
         given:


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fixes https://github.com/rundeckpro/rundeckpro/issues/1824

* A groovy plugin containing no definition would be registered but later cause NPE loading the plugin

**Describe the solution you've implemented**
* prevent NPE when loading spring bean plugins
* avoid registering groovy script plugins until after they are constructed

