### PR TITLE
RUN-7: dropdown context menu to be shown on the notification edit modal

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/jobedit.js
+++ b/rundeckapp/grails-app/assets/javascripts/jobedit.js
@@ -319,6 +319,12 @@ function addWfAutocomplete(liitem, iseh, isnodestepfunc, istextareatemplatemode,
 
 }
 
+function setupNotificationAutocomplete(idcompenent){
+  jQuery('#' + idcompenent).each(function (i, elem) {
+    addNotificationAutocomplete(jQuery(elem));
+  });
+}
+
 function addNotificationAutocomplete(liitem, iseh, isnodestepfunc, istextareatemplatemode, acetexteditorcallback, gettextfieldenvmode) {
   var baseVarData = [].concat(_jobVarData());
   baseVarData = baseVarData.concat(_jobGlobalVarData());

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
@@ -65,6 +65,8 @@
                 <plugin-prop-edit v-model="inputValues[prop.name]"
                                 :prop="prop"
                                 :input-values="inputValues"
+                                :context-autocomplete="inputContextAutocomplete"
+                                @pluginPropsMounted="notifyHandleAutoComplete"
                                 :validation="validation"
                                 :rkey="'g_'+gindex+'_'+rkey"
                                 :pindex="pindex"/>
@@ -150,7 +152,8 @@ export default Vue.extend({
     'validation',
     'validationWarningText',
     'scope',
-    'defaultScope'
+    'defaultScope',
+    'contextAutocomplete',
   ],
   data () {
     return {
@@ -166,7 +169,8 @@ export default Vue.extend({
       inputSavedProps: (typeof this.savedProps !== 'undefined') ? this.savedProps : ['type'],
       rkey: 'r_' + Math.floor(Math.random() * Math.floor(1024)).toString(16) + '_',
       groupExpand:{} as {[name:string]:boolean},
-      inputLoaded: false
+      inputLoaded: false,
+      inputContextAutocomplete: this.contextAutocomplete !== null ? this.contextAutocomplete : false
     }
   },
   methods: {
@@ -323,6 +327,9 @@ export default Vue.extend({
     },
     notifyHasKeyStorageAccess(){
       this.$emit("hasKeyStorageAccess", this.provider)
+    },
+    notifyHandleAutoComplete(){
+      this.$emit("handleAutocomplete")
     },
     loadForMode(){
       if (this.serviceName && this.provider) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginPropEdit.vue
@@ -122,6 +122,7 @@
           size="100"
           type="number"
           class="form-control input-sm"
+          v-bind:class="contextAutocomplete ? 'context_var_autocomplete' : ''"
           v-if="['Integer','Long'].indexOf(prop.type)>=0"
         >
         <template v-else-if="prop.options && prop.options['displayType']==='MULTI_LINE'">
@@ -132,6 +133,7 @@
             rows="10"
             cols="100"
             class="form-control input-sm"
+            v-bind:class="contextAutocomplete ? 'context_var_autocomplete' : ''"
           ></textarea>
         </template>
         <template v-else-if="prop.options && prop.options['displayType']==='CODE'">
@@ -172,6 +174,7 @@
             readonly
             size="100"
             class="form-control input-sm"
+            v-bind:class="contextAutocomplete ? 'context_var_autocomplete' : ''"
             v-bind:title="currentValue"
             v-bind:value="jobName"
           >
@@ -183,6 +186,7 @@
           size="100"
           type="text"
           class="form-control input-sm"
+          v-bind:class="contextAutocomplete ? 'context_var_autocomplete' : ''"
           v-else
         >
       </div>
@@ -294,6 +298,11 @@ export default Vue.extend({
         default:'',
         required:false
     },
+    'contextAutocomplete':{
+        type:Boolean,
+        default:false,
+        required:false
+    },
   },
   methods:{
     inputColSize(prop: any) {
@@ -357,6 +366,7 @@ export default Vue.extend({
     }
   },
   mounted(){
+    this.$emit("pluginPropsMounted")
     this.setJobName(this.value)
     if (window._rundeck && window._rundeck.projectName) {
       this.keyPath = 'keys/project/' + window._rundeck.projectName +'/'

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/notifications/NotificationsEditor.vue
@@ -202,6 +202,8 @@
             :key="'edit_config'+editIndex+'/'+editNotification.type"
             :show-title="false"
             :show-description="false"
+            :context-autocomplete="true"
+            @handleAutocomplete="handleAutoComplete"
             :validation="editValidation"
             scope="Instance"
             default-scope="Instance"
@@ -445,6 +447,9 @@ export default {
     },
     doRedo(change){
       this.perform(change.operation,change)
+    },
+    handleAutoComplete(){
+      window.setupNotificationAutocomplete("notification-edit-config")
     },
     async perform(operation,change){
       if(operation==='create'){


### PR DESCRIPTION
fixes https://github.com/rundeckpro/rundeckpro/issues/1406

**Is this a bugfix, or an enhancement? Please describe.**
The fields of the notification plugins is not showing the dropdown context menu

**Describe the solution you've implemented**
It include the class on the fields that should have the dropdown and call the function to inclute this component when the plugin property fields is mounted on the modal
