### PR TITLE
RUN-89 Add UI profile and search to plugin list endpoint

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
@@ -1,5 +1,6 @@
 package rundeck.controllers
 
+import com.dtolabs.rundeck.app.api.plugins.ApiPluginListProvider
 import com.dtolabs.rundeck.app.support.PluginResourceReq
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
@@ -8,7 +9,6 @@ import org.rundeck.app.spi.AuthorizedServicesProvider
 import org.rundeck.core.auth.AuthConstants
 import com.dtolabs.rundeck.core.plugins.PluginValidator
 import com.dtolabs.rundeck.core.plugins.configuration.PluginAdapterUtility
-import com.dtolabs.rundeck.server.plugins.services.UIPluginProviderService
 import grails.converters.JSON
 import groovy.transform.CompileStatic
 import org.springframework.web.multipart.MultipartFile
@@ -146,22 +146,27 @@ class PluginController extends ControllerBase {
                 return
 
             svc.providers.each { p ->
-                def provider = [:]
-                provider.service = svc.service
-                provider.artifactName = p.pluginName
-                provider.name = p.name
-                provider.id = p.pluginId
-                provider.builtin = p.builtin
-                provider.pluginVersion = p.pluginVersion
-                provider.title = p.title
-                provider.description = p.description
-                provider.author = p.pluginAuthor
-                provider.iconUrl = p.iconUrl
-                provider.providerMetadata = p.providerMetadata
+                ApiPluginListProvider provider = new ApiPluginListProvider([
+                        service: svc.service,
+                        artifactName: p.pluginName,
+                        name: p.name,
+                        id: p.pluginId,
+                        builtin: p.builtin,
+                        pluginVersion: p.pluginVersion,
+                        title: p.title,
+                        description: p.description,
+                        author: p.pluginAuthor,
+                        iconUrl: p.iconUrl,
+                        providerMetadata: p.providerMetadata,
+                ])
+
                 providers.add(provider)
             }
         }
-        render(providers as JSON)
+        respond(
+                providers,
+                [formats: ['json']]
+        )
     }
 
     def listPluginsByService() {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
@@ -138,10 +138,15 @@ class PluginController extends ControllerBase {
     }
 
     def listPlugins() {
+        String service = params.service
+
         def providers = []
         pluginApiService.listPlugins().each { svc ->
+            if (service && service != svc.service)
+                return
+
             svc.providers.each { p ->
-                 def provider = [:]
+                def provider = [:]
                 provider.service = svc.service
                 provider.artifactName = p.pluginName
                 provider.name = p.name
@@ -151,6 +156,8 @@ class PluginController extends ControllerBase {
                 provider.title = p.title
                 provider.description = p.description
                 provider.author = p.pluginAuthor
+                provider.iconUrl = p.iconUrl
+                provider.providerMetadata = p.providerMetadata
                 providers.add(provider)
             }
         }

--- a/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
@@ -274,7 +274,7 @@ class PluginApiService {
                  pluginDate   : toEpoch(dte),
                  enabled      : true] as LinkedHashMap<Object, Object>
 
-                if(service != "UI") {
+                if(service != ServiceNameConstants.UI) {
                     def uiDesc = uiPluginService.getProfileFor(service, provider.name)
                     if (uiDesc.icon)
                         pluginDesc.iconUrl = grailsLinkGenerator.link(

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
@@ -30,16 +30,19 @@ class ApiVersions {
     public static final int V37 = 37
     public static final int V38 = 38
     public static final int V39 = 39
+    public static final int V40 = 40
     public static final Map VersionMap = [:]
     public static final List Versions = [V11, V12, V13, V14, V15, V16, V17, V18,
-                                         V19, V20, V21, V22, V23, V24, V25, V26, V27, V28, V29, V30, V31, V32,V33,V34,V35,V36, V37, V38, V39]
+                                         V19, V20, V21, V22, V23, V24, V25, V26,
+                                         V27, V28, V29, V30, V31, V32,V33,V34,V35,
+                                         V36, V37, V38, V39, V40]
     static {
         Versions.each { VersionMap[it.toString()] = it }
     }
     public static final Set VersionStrings = new HashSet(VersionMap.values())
 
     public final static int API_EARLIEST_VERSION = V11
-    public final static int API_CURRENT_VERSION = V39
+    public final static int API_CURRENT_VERSION = V40
     public final static int API_MIN_VERSION = API_EARLIEST_VERSION
     public final static int API_MAX_VERSION = API_CURRENT_VERSION
 }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/plugins/ApiPluginListProvider.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/plugins/ApiPluginListProvider.groovy
@@ -1,0 +1,21 @@
+package com.dtolabs.rundeck.app.api.plugins
+
+import com.dtolabs.rundeck.app.api.marshall.ApiResource
+import com.dtolabs.rundeck.app.api.marshall.ApiVersion
+
+@ApiResource
+class ApiPluginListProvider {
+        String service
+        String artifactName
+        String name
+        String id
+        Boolean builtin
+        String pluginVersion
+        String title
+        String description
+        String author
+        @ApiVersion(40)
+        String iconUrl
+        @ApiVersion(40)
+        LinkedHashMap<Object, Object> providerMetadata
+}

--- a/rundeckapp/src/test/groovy/rundeck/controllers/PluginControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/PluginControllerSpec.groovy
@@ -205,6 +205,38 @@ class PluginControllerSpec extends Specification implements ControllerUnitTest<P
 
     }
 
+    def "plugin list filters by service"() {
+        given:
+            params.service = a
+            controller.pluginService = Mock(PluginService)
+            controller.pluginApiService = Mock(PluginApiService)
+            controller.uiPluginService = Mock(UiPluginService)
+
+            def plugins = [
+                    [
+                        service: 'WebhookEvent',
+                        providers: [
+                                [:],
+                                [:]],
+                    ],
+                    [
+                        service: 'Foo',
+                        providers: [[:]]
+                    ]
+            ]
+
+        when:
+            def result = controller.listPlugins()
+        then:
+            1 * controller.pluginApiService.listPlugins() >> plugins
+            response.json.size() == b
+
+        where:
+            a                | b
+            null             | 3
+            'WebhookEvent'   | 2
+    }
+
     def "plugin service descriptions"() {
         given:
         controller.pluginService = Mock(PluginService)

--- a/rundeckapp/src/test/groovy/rundeck/services/PluginApiServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/PluginApiServiceSpec.groovy
@@ -27,6 +27,7 @@ import com.dtolabs.rundeck.plugins.rundeck.UIPlugin
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder
 import com.dtolabs.rundeck.server.plugins.RundeckPluginRegistry
 import grails.testing.services.ServiceUnitTest
+import grails.web.mapping.LinkGenerator
 import spock.lang.Specification
 
 import java.text.SimpleDateFormat
@@ -43,6 +44,8 @@ class PluginApiServiceSpec extends Specification implements ServiceUnitTest<Plug
         fwk.getPluginManager() >> Mock(ServiceProviderLoader)
         service.frameworkService = fwksvc
         service.rundeckPluginRegistry = Mock(RundeckPluginRegistry)
+        service.uiPluginService = Mock(UiPluginService)
+        service.grailsLinkGenerator = Mock(LinkGenerator)
 
         def pluginDescs = [
                 "Notification": [new FakePluginDescription()]
@@ -63,6 +66,8 @@ class PluginApiServiceSpec extends Specification implements ServiceUnitTest<Plug
 
         when:
         1 * service.rundeckPluginRegistry.getPluginMetadata(_,_) >> fakeMeta
+        1 * service.uiPluginService.getProfileFor(_, _) >> [icon: 'foo']
+        1 * service.grailsLinkGenerator.link(_) >> 'http://localhost:8080/icon'
         def response = service.listPlugins()
         def service = response[0]
         def entry = service.providers[0]
@@ -80,7 +85,7 @@ class PluginApiServiceSpec extends Specification implements ServiceUnitTest<Plug
         entry.pluginVersion == "1.0"
         entry.pluginDate == 1534253342000
         entry.enabled == true
-
+        entry.iconUrl == 'http://localhost:8080/icon'
     }
 
     def "list installed plugin ids"() {
@@ -93,6 +98,8 @@ class PluginApiServiceSpec extends Specification implements ServiceUnitTest<Plug
         service.frameworkService = fwksvc
         service.pluginService = Mock(PluginService)
         service.rundeckPluginRegistry = Mock(RundeckPluginRegistry)
+        service.uiPluginService = Mock(UiPluginService)
+        service.grailsLinkGenerator = Mock(LinkGenerator)
 
         def pluginDescs = [
                 "Notification": [new FakePluginDescription()]
@@ -119,6 +126,8 @@ class PluginApiServiceSpec extends Specification implements ServiceUnitTest<Plug
             getPluginId() >> uipluginid
         }
         1 * service.pluginService.listPlugins(_,_) >> ["oneuiplugin":new FakeUIDescribedPlugin(uiplugin,uiplugindesc,"oneuiplugin")]
+        1 * service.uiPluginService.getProfileFor(_, _) >> [icon: 'foo']
+        1 * service.grailsLinkGenerator.link(_) >> 'http://localhost:8080/icon'
         1 * service.rundeckPluginRegistry.getPluginMetadata('Notification',_) >> fakeMeta
         1 * service.rundeckPluginRegistry.getPluginMetadata('UI',_) >> uiMeta
         def idList = service.listInstalledPluginIds()
@@ -337,4 +346,3 @@ class PluginApiServiceSpec extends Specification implements ServiceUnitTest<Plug
         }
     }
 }
-

--- a/test/api/include.sh
+++ b/test/api/include.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # common header for test scripts
-API_CURRENT_VERSION=39
+API_CURRENT_VERSION=40
 
 SRC_DIR=$(cd `dirname $0` && pwd)
 DIR=${TMP_DIR:-$SRC_DIR}

--- a/test/api/test-project-resources.sh
+++ b/test/api/test-project-resources.sh
@@ -91,7 +91,7 @@ APIURL2="${RDURL}/api/${API_VERSION2}"
 runurl2="${APIURL2}/project/${proj}/resources"
 
 docurl ${runurl2}?${params} > ${file} || fail "ERROR: failed request"
-$SHELL $SRC_DIR/api-test-error.sh ${file} "Unsupported API Version \"2\". API Request: $API_BASE/api/2/project/${proj}/resources. Reason: Current version: 39" || fail "ERROR: failed request"
+$SHELL $SRC_DIR/api-test-error.sh ${file} "Unsupported API Version \"2\". API Request: $API_BASE/api/2/project/${proj}/resources. Reason: Current version: ${API_CURRENT_VERSION}" || fail "ERROR: failed request"
 
 echo "OK"
 

--- a/test/selenium/src/__tests__/api/plugins.test.ts
+++ b/test/selenium/src/__tests__/api/plugins.test.ts
@@ -1,0 +1,45 @@
+import {CreateTestContext} from '@rundeck/testdeck/test/api'
+
+import '@rundeck/testdeck/test/rundeck'
+
+
+/** Fetch context which will be initialized before the tests run */
+let context = CreateTestContext({})
+
+describe('Plugins API', () => {
+    it('Does not return v40 fields on older versions', async () => {
+        /* {
+          iconUrl?: String
+          providerMetadata?: any
+        }
+        */
+
+        const {cluster} = context
+
+        const resp = await cluster.client.apiRequest({
+            method: 'GET',
+            pathTemplate: 'api/39/plugin/list'
+        });
+
+        const found = (<Array<any>>resp.parsedBody).find(i => i.iconUrl || i.providerMetadata)
+        expect(found).toBeFalsy()
+    })
+
+    it('Returns v40 fieldd', async () => {
+        /* {
+          iconUrl?: String
+          providerMetadata?: any
+        }
+        */
+
+        const {cluster} = context
+
+        const resp = await cluster.client.apiRequest({
+            method: 'GET',
+            pathTemplate: 'api/40/plugin/list'
+        });
+
+        const found = (<Array<any>>resp.parsedBody).find(i => i.iconUrl || i.providerMetadata)
+        expect(found).toBeTruthy()
+    })
+})

--- a/test/selenium/src/__tests__/api/plugins.test.ts
+++ b/test/selenium/src/__tests__/api/plugins.test.ts
@@ -25,7 +25,7 @@ describe('Plugins API', () => {
         expect(found).toBeFalsy()
     })
 
-    it('Returns v40 fieldd', async () => {
+    it('Returns v40 field', async () => {
         /* {
           iconUrl?: String
           providerMetadata?: any


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This enhancement adds UI profile(`iconUrl`, `providerMetadata`) to the public `plugin/list` API endpoint along with the query parameter `service` to filter the results by provider.

**Additional Context**
This is part of ongoing efforts to move functionality out of UI specific endpoints and into the public API.