### PR TITLE
RUN-124: Scope Ace setup to execution plugin tab

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -1330,7 +1330,7 @@ function getCurSEID(){
 </g:if>
             initKoBind(null,{jobeditor:jobeditor})
 
-            jQuery('textarea.form-control.apply_ace').each(function () {
+            jQuery('#tab_execution_plugins .textarea.form-control.apply_ace').each(function () {
                 _setupAceTextareaEditor(this);
             });
         }


### PR DESCRIPTION
fixes rundeckpro/rundeckpro#1846
[RUN-124]

**Is this a bugfix, or an enhancement? Please describe.**
**Bug**: This Ace setup was introduced in #7082 to attach the editor to lifecycle plugin property fields. It caused duplicate editors in at least one case.

**Describe the solution you've implemented**
I scoped the jQuery selector to the `#tab_execution_plugins` element so it would not apply to other DOM locations. I'm actually unsure if this satisfies the original intent.



[RUN-123]: https://pagerduty.atlassian.net/browse/RUN-123

[RUN-124]: https://pagerduty.atlassian.net/browse/RUN-124