### PR TITLE
RUN-64: Fix: optionValuePlugins list disappears when when a validation errors

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
@@ -215,7 +215,8 @@ class EditOptsController extends ControllerBase{
                     edit                       : true,
                     regexError                 : result.regexError,
                     configMapValidate          : result.configMapValidate,
-                    fileUploadPluginDescription: fileUploadService.pluginDescription
+                    fileUploadPluginDescription: fileUploadService.pluginDescription,
+                    optionValuesPlugins        : optionValuesService.listOptionValuesPlugins()
             ]
             return render(template: "/scheduledExecution/optEdit", model: model
             )


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
bugfix, optionListValue was not sent back to opsEdit view on validation error
**Describe the solution you've implemented**
return the optionValuesPlugins to the view on validation error exactly as it's sent during the initial edit
