### PR TITLE
RUN-232: Job import does not preserve option value ordering

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Option.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Option.groovy
@@ -270,6 +270,7 @@ public class Option implements Comparable{
             }else{
                 opt.valuesListDelimiter=DEFAULT_DELIMITER
             }
+            opt.optionValues=new ArrayList<String>(data.values);
             opt.valuesList = opt.produceValuesList()
             opt.values = null
         }
@@ -302,10 +303,13 @@ public class Option implements Comparable{
      * Return the string equivalent of the values set member
      */
     public String produceValuesList(){
-        if(values){
-            if(valuesListDelimiter==null){
-                valuesListDelimiter = DEFAULT_DELIMITER
-            }
+        if (valuesListDelimiter == null) {
+            valuesListDelimiter = DEFAULT_DELIMITER
+        }
+
+        if(optionValues) {
+            valuesList = optionValues.join(valuesListDelimiter)
+        } else if(values) {
             valuesList = values.join(valuesListDelimiter)
             values = null
             return valuesList


### PR DESCRIPTION
Fixes #6364 

**Is this a bugfix, or an enhancement? Please describe.**

A potential bugfix for #6364 - I thought it would be simpler and clearer to submit a PR with the proposed changes.

**Describe the solution you've implemented**

I've revised my solution as I realised that it wasn't simple to change `values` from Set to List without unintended consequences.

I've updated the code to assign `data.values` to `optionValues` at the same time as the assignment to `values`.

I've also updated public method `productValuesList()` to use `optionValues` to populate the `valuesList` if `optionValues` is set, otherwise it drops back to the default functionality of using `values` if it is set.

**Additional context**

I'm unsure if this change will have unintended consequences due to my lack of experience with Java and the size of the Rundeck codebase.  Please be gentle!