### PR TITLE
RUN-127: Fix: Unable to edit a job after removing a plugin used in that job

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -60,6 +60,7 @@ import org.grails.web.json.JSONElement
 import org.quartz.CronExpression
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.app.components.RundeckJobDefinitionManager
+import org.rundeck.app.components.jobs.ImportedJob
 import org.rundeck.app.spi.AuthorizedServicesProvider
 import org.rundeck.core.auth.AuthConstants
 import org.rundeck.util.Toposort
@@ -1660,6 +1661,14 @@ class ScheduledExecutionController  extends ControllerBase{
             session.removeAttribute('redoOPTS');
         }
         def result = scheduledExecutionService.prepareCreateEditJob(params, scheduledExecution, AuthConstants.ACTION_UPDATE, authContext)
+
+        ImportedJob<ScheduledExecution> importedJob = RundeckJobDefinitionManager.importedJob(scheduledExecution, [:])
+        def validation=[:]
+        boolean failed  = !scheduledExecutionService.validateJobDefinition(importedJob, authContext, params, validation, false)
+        if (failed) {
+            flash.message = g.message(code:'scheduledExecution.invalid.message', args: [scheduledExecution.jobName])
+        }
+
         return result
     }
 

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -160,6 +160,7 @@ commandExec.jobName.strict.validation.message=The referenced job does not exist
 Workflow.stepErrorHandler.nodeStep.invalid=The Error Handler for Step {0} is of the wrong type. Error Handlers for Node Steps must also be Node Steps when the Workflow is Node-oriented.
 WorkflowStep.errorHandler.nodeStep.invalid=The Error Handler must be a Node Step.
 scheduledExecution.adhocString.duplicate.message=Please specify only one of Local script or Remote command or Script file
+scheduledExecution.invalid.message=The Job "{0}" has a definition problem. Correct or remove the definition before editing.
 scheduledExecution.options.invalid.message=Invalid Option definition: {0}
 scheduledExecution.notifications.invalid.message=Invalid Notification definition: {0}
 scheduledExecution.notifications.email.blank.message=Email address cannot be blank

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -155,6 +155,7 @@ commandExec.jobName.strict.validation.message=El trabajo referenciado no existe.
 Workflow.stepErrorHandler.nodeStep.invalid=El Gestor de Error para el Paso {0} es del tipo errado. Los Gestores de Errores para los Pasos de Nodos deben ser también Pasos de Nodos cuando el Flujo de Trabajo esté otientado por el Nodo.
 WorkflowStep.errorHandler.nodeStep.invalid=El Gestor de Error debe ser un Paso de Nodo.
 scheduledExecution.adhocString.duplicate.message=Por favor, especifique solo uno del sript local o Comando Remoto o un archivo de script
+scheduledExecution.invalid.message=El Trabajo "{0}" tiene un problema en su definición. Corrija o remueva la definición antes de editar.
 scheduledExecution.options.invalid.message=Definición de Opción Inválida: {0}
 scheduledExecution.notifications.invalid.message=Definición de Notificación Inválida: {0}
 scheduledExecution.notifications.email.blank.message=El email no puede estar en blanco


### PR DESCRIPTION
Issue:
fixes: rundeckpro/rundeckpro#1714

Fix description:
When a user try to edit a job and there is a broken or deleted plugin bound to this, is shown a warning message explaining the plugin must be removed before editing.