### PR TITLE
RUN-141: Fix: UI Bug with Projects list that hinders display over 15 projects in a list.

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/menu/home.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/home.js
@@ -432,7 +432,7 @@ function batchInitWaypoints(arr,handler,count){
     "use strict";
     var arr2=arr.splice(0,count);
     if(arr2.length>0) {
-        jQuery(arr2).waypoint(handler, {context:'#main-panel',offset: '100%'});
+        jQuery(arr2).children('.row').waypoint(handler, {context:'#main-panel',offset: '100%'});
         if (arr.length > 0) {
             _waypointBatchTimer=setTimeout(function(){batchInitWaypoints(arr, handler,count);}, 500);
         }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Bugfix: In the default project list on the Home page, if there are more than 15 projects the remaining projects do not load
https://github.com/rundeck/rundeck/issues/7130

**Describe the solution you've implemented**
It appears that there is a conflict in the `project-list-item` selector since the data attribute is added by knockout after load. By referencing a child element of the selector that is available in the DOM on load, allows for the waypoint to trigger. 
