### PR TITLE
RUN-138: Fix: High CPU usage with large log outputs without any log warning

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1045,7 +1045,11 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         String outputLimit = scheduledExecution?.logOutputThreshold ?: frameworkService.getProjectLogOutputLimit()
         executionStatusLogger.info("Logging output limit: ${outputLimit}")
         def thresholdMap = ScheduledExecution.parseLogOutputThreshold(outputLimit)
-        def threshold = LoggingThreshold.fromMap(thresholdMap,scheduledExecution?.logOutputThresholdAction)
+
+        String limitAction = frameworkService.getProjectLogOutputLimit() ?
+                frameworkService.getProjectLogLimitAction() : scheduledExecution?.logOutputThresholdAction
+        executionStatusLogger.info("Logging limit action: ${limitAction}")
+        def threshold = LoggingThreshold.fromMap(thresholdMap, limitAction)
 
         def ExecutionLogWriter loghandler= loggingService.openLogWriter(
                 execution,

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1042,7 +1042,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 //
 
         //set up log output threshold
-        def thresholdMap = ScheduledExecution.parseLogOutputThreshold(scheduledExecution?.logOutputThreshold)
+        String outputLimit = scheduledExecution?.logOutputThreshold ?: frameworkService.getProjectLogOutputLimit()
+        executionStatusLogger.info("Logging output limit: ${outputLimit}")
+        def thresholdMap = ScheduledExecution.parseLogOutputThreshold(outputLimit)
         def threshold = LoggingThreshold.fromMap(thresholdMap,scheduledExecution?.logOutputThresholdAction)
 
         def ExecutionLogWriter loghandler= loggingService.openLogWriter(

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1051,6 +1051,10 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         executionStatusLogger.info("Logging limit action: ${limitAction}")
         def threshold = LoggingThreshold.fromMap(thresholdMap, limitAction)
 
+        String warnSize = frameworkService.getProjectLogSizeWarning() ?: LoggingThreshold.WARN_SIZE_DEFAULT
+        Map<String, Long> warnSizeMap = ScheduledExecution.parseLogOutputThreshold(warnSize)
+        threshold.warningSize = warnSizeMap.values()[0]
+
         def ExecutionLogWriter loghandler= loggingService.openLogWriter(
                 execution,
                 logLevelForString(execution.loglevel),

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -75,13 +75,13 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
     public static final String FIRST_LOGIN_FILE  = ".firstLogin"
     static final String SYS_PROP_SERVER_ID       = "rundeck.server.uuid"
     /**
-     * Log output limit key applied over all projects
+     * Log output limit applied over all projects
      */
-    static final String PROJECT_LOG_OUTPUT_LIMIT = "rundeck.project.log.output.limit"
+    static final String PROJECT_LOG_OUTPUT_LIMIT = "framework.project.log.output.limit"
     /**
-     * Default log output limit expressed as bytes (3MB)
+     *
      */
-    static final String DEFAULT_LOG_OUTPUT_LIMIT = "3145728"
+    static final String PROJECT_LOG_LIMIT_ACTION = "framework.project.log.limit.action"
 
     def ApplicationContext applicationContext
     def gormEventStoreService
@@ -139,12 +139,21 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
     }
 
     /**
-     * @return the log output limit number from framework.properties file
+     * @return the log output limit size from framework.properties file
      */
     String getProjectLogOutputLimit() {
         return rundeckFramework
                 .getPropertyRetriever()
-                .getProperty(PROJECT_LOG_OUTPUT_LIMIT) ?: DEFAULT_LOG_OUTPUT_LIMIT
+                .getProperty(PROJECT_LOG_OUTPUT_LIMIT)
+    }
+
+    /**
+     * @return the log limit action from framework.properties file
+     */
+    String getProjectLogLimitAction() {
+        return rundeckFramework
+                .getPropertyRetriever()
+                .getProperty(PROJECT_LOG_LIMIT_ACTION)
     }
 
     String getServerHostname() {

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -79,9 +79,14 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
      */
     static final String PROJECT_LOG_OUTPUT_LIMIT = "framework.project.log.output.limit"
     /**
-     *
+     * Log limit action applied over all projects
      */
     static final String PROJECT_LOG_LIMIT_ACTION = "framework.project.log.limit.action"
+    /**
+     * Log size warning
+     */
+    static final String PROJECT_LOG_SIZE_WARNING = "framework.project.log.output.warning.size"
+
 
     def ApplicationContext applicationContext
     def gormEventStoreService
@@ -154,6 +159,15 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
         return rundeckFramework
                 .getPropertyRetriever()
                 .getProperty(PROJECT_LOG_LIMIT_ACTION)
+    }
+
+    /**
+     * @return the log size warning from framework.properties file
+     */
+    String getProjectLogSizeWarning() {
+        return rundeckFramework
+                .getPropertyRetriever()
+                .getProperty(PROJECT_LOG_SIZE_WARNING)
     }
 
     String getServerHostname() {

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -71,9 +71,17 @@ import java.util.function.Predicate
 @GrailsCompileStatic
 class FrameworkService implements ApplicationContextAware, ClusterInfoService {
     static transactional = false
-    public static final String REMOTE_CHARSET = 'remote.charset.default'
-    public static final String FIRST_LOGIN_FILE = ".firstLogin"
-    static final String SYS_PROP_SERVER_ID = "rundeck.server.uuid"
+    public static final String REMOTE_CHARSET    = 'remote.charset.default'
+    public static final String FIRST_LOGIN_FILE  = ".firstLogin"
+    static final String SYS_PROP_SERVER_ID       = "rundeck.server.uuid"
+    /**
+     * Log output limit key applied over all projects
+     */
+    static final String PROJECT_LOG_OUTPUT_LIMIT = "rundeck.project.log.output.limit"
+    /**
+     * Default log output limit expressed as bytes (3MB)
+     */
+    static final String DEFAULT_LOG_OUTPUT_LIMIT = "3145728"
 
     def ApplicationContext applicationContext
     def gormEventStoreService
@@ -128,6 +136,15 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
 
     String getServerUUID() {
         System.getProperty(SYS_PROP_SERVER_ID)
+    }
+
+    /**
+     * @return the log output limit number from framework.properties file
+     */
+    String getProjectLogOutputLimit() {
+        return rundeckFramework
+                .getPropertyRetriever()
+                .getProperty(PROJECT_LOG_OUTPUT_LIMIT) ?: DEFAULT_LOG_OUTPUT_LIMIT
     }
 
     String getServerHostname() {

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -77,15 +77,19 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
     /**
      * Log output limit applied over all projects
      */
-    static final String PROJECT_LOG_OUTPUT_LIMIT = "framework.project.log.output.limit"
+    static final String PROJECT_LOG_OUTPUT_LIMIT = "framework.projects.log.output.limit"
     /**
      * Log limit action applied over all projects
      */
-    static final String PROJECT_LOG_LIMIT_ACTION = "framework.project.log.limit.action"
+    static final String PROJECT_LOG_LIMIT_ACTION = "framework.projects.log.limit.action"
     /**
      * Log size warning
      */
-    static final String PROJECT_LOG_SIZE_WARNING = "framework.project.log.output.warning.size"
+    static final String PROJECT_LOG_SIZE_WARNING = "framework.projects.log.output.warning.size"
+    /**
+     * Log global config
+     */
+    static final String PROJECT_LOG_GLOBAL_CONFIG = "framework.projects.log.global.config"
 
 
     def ApplicationContext applicationContext
@@ -141,6 +145,16 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
 
     String getServerUUID() {
         System.getProperty(SYS_PROP_SERVER_ID)
+    }
+
+    /**
+     * @return the log global config from framework.properties file
+     */
+    boolean getProjectLogGlobalConfig() {
+        String res = rundeckFramework
+                .getPropertyRetriever()
+                .getProperty(PROJECT_LOG_GLOBAL_CONFIG) ?: Boolean.toString(false)
+        return res.toBoolean()
     }
 
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/logging/LoggingThreshold.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/logging/LoggingThreshold.groovy
@@ -32,9 +32,10 @@ class LoggingThreshold implements ThresholdValue<Long>, ValueWatcher<Long> {
     /**
      * Warning log file size value in bytes (300MB)
      */
-    public static final Long   WARNING_SIZE    = 1024//314572800
+    public static final Long WARN_SIZE_DEFAULT = 314572800
 
     Long maxValue
+    Long warningSize
     ValueHolder<Long> valueHolder
     String action
     String description
@@ -114,6 +115,6 @@ class LoggingThreshold implements ThresholdValue<Long>, ValueWatcher<Long> {
      * @return true if log file size is over a warning size alert
      */
     boolean isWarningSizeReached() {
-        return getValue() > WARNING_SIZE
+        return getValue() > warningSize
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/logging/LoggingThreshold.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/logging/LoggingThreshold.groovy
@@ -24,11 +24,16 @@ import rundeck.services.execution.ValueWatcher
  * Defines a threshold for some logging statistic
  */
 class LoggingThreshold implements ThresholdValue<Long>, ValueWatcher<Long> {
-    public static final String TOTAL_LINES = "lines"
-    public static final String LINES_PER_NODE = "linesPerNode"
+    public static final String TOTAL_LINES     = "lines"
+    public static final String LINES_PER_NODE  = "linesPerNode"
     public static final String TOTAL_FILE_SIZE = "size"
-    public static final String ACTION_HALT = "halt"
+    public static final String ACTION_HALT     = "halt"
     public static final String ACTION_TRUNCATE = "truncate"
+    /**
+     * Warning log file size value in bytes (300MB)
+     */
+    public static final Long   WARNING_SIZE    = 1024//314572800
+
     Long maxValue
     ValueHolder<Long> valueHolder
     String action
@@ -103,5 +108,12 @@ class LoggingThreshold implements ThresholdValue<Long>, ValueWatcher<Long> {
      */
     boolean isTruncateOnLimitReached() {
         action == ACTION_TRUNCATE
+    }
+
+    /**
+     * @return true if log file size is over a warning size alert
+     */
+    boolean isWarningSizeReached() {
+        return getValue() > WARNING_SIZE
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/logging/ThresholdLogWriter.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/logging/ThresholdLogWriter.groovy
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 class ThresholdLogWriter extends FilterStreamingLogWriter {
     static final Logger LOG = LoggerFactory.getLogger(ThresholdLogWriter.class)
 
-    static final String MSG_WARN_SIZE = "The log file size achieved more than 300MB - current size in bytes: {}"
+    static final String MSG_WARN_SIZE = "The log file size achieved more than {} bytes - current size: {} bytes"
 
     LoggingThreshold threshold
     final boolean truncate
@@ -54,7 +54,7 @@ class ThresholdLogWriter extends FilterStreamingLogWriter {
         getWriter().addEvent(event)
 
         if (!warning && threshold.isWarningSizeReached() && warningReached.compareAndSet(false, true)) {
-            LOG.warn(MSG_WARN_SIZE  , threshold.getValue())
+            LOG.warn(MSG_WARN_SIZE  , threshold.warningSize, threshold.getValue())
         }
 
         if (!limit && threshold.isThresholdExceeded() && limitReached.compareAndSet(false, true)) {

--- a/rundeckapp/grails-app/services/rundeck/services/logging/ThresholdLogWriter.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/logging/ThresholdLogWriter.groovy
@@ -20,6 +20,8 @@ import com.dtolabs.rundeck.core.logging.FilterStreamingLogWriter
 import com.dtolabs.rundeck.core.logging.LogEvent
 import com.dtolabs.rundeck.core.logging.LogUtil
 import com.dtolabs.rundeck.core.logging.StreamingLogWriter
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -27,6 +29,8 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Used to log that a threshold was reached, and optionally truncate further output
  */
 class ThresholdLogWriter extends FilterStreamingLogWriter {
+    static final Logger LOG = LoggerFactory.getLogger(ThresholdLogWriter.class)
+
     LoggingThreshold threshold
     final boolean truncate
     AtomicBoolean limitReached = new AtomicBoolean(false)
@@ -46,7 +50,9 @@ class ThresholdLogWriter extends FilterStreamingLogWriter {
         getWriter().addEvent(event)
 
         if (!limit && threshold.isThresholdExceeded() && limitReached.compareAndSet(false, true)) {
-            getWriter().addEvent(LogUtil.logError("Log output limit exceeded: " + threshold.description))
+            String msgError = "Log output limit exceeded: ${threshold.description}"
+            LOG.error(msgError)
+            getWriter().addEvent(LogUtil.logError(msgError))
         }
     }
 }


### PR DESCRIPTION
Issue:
https://github.com/rundeckpro/rundeckpro/issues/1753

Fix description:
Added four new parameters at framework.properties applied over all projects.

## framework.properties

framework.projects.log.global.config = true
framework.projects.log.output.warning.size = 1KB
framework.projects.log.output.limit = 5MB
framework.projects.log.limit.action = truncate

- `framework.projects.log.global.config`: Overwrite output limit and limit action configured in jobs. 
- `framework.projects.log.output.warning.size`: Indicates the log size where is triggered a warning message at log file.
- `framework.projects.log.output.limit` - Show an error when that limit is exceeded. Could be entered either maximum total line-count (e.g. "100"), maximum per-node line-count ("100/node"), or maximum log file size ("100MB", "100KB", etc.), using "GB","MB","KB","B" as Giga- Mega- Kilo- and bytes.
- `framework.project.log.limit.action`: Is the action applied when the limit is achieved. It is triggered only if there is a value at framework.project.log.output.limit. The values accepted are ‘truncate' or 'halt’.