### PR TITLE
RUN-143:  Handles null value when resource does not have the attribute filtered by rule key

### DIFF
--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
@@ -545,7 +545,7 @@ public class RuleEvaluator implements AclRuleSetAuthorization {
         static Set<String> getCollection(final String str) {
             final HashSet<String> hs = new HashSet<>();
             //treat o as comma-seperated list of strings
-            final String[] split = str.split(",");
+            final String[] split = null != str ? str.split(",") : new String[]{};
             for (final String s : split) {
                 hs.add(s.trim());
             }

--- a/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
+++ b/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
@@ -943,13 +943,11 @@ class RuleEvaluatorSpec extends Specification {
                         sourceIdentity: "test1",
                         description   : "bob job allow exec, deny delete for admin group",
                         equalsResource: [
-                                tag: 'bob'
+                                jobName: 'bob'
                         ],
                         resourceType  : 'job',
                         regexMatch    : false,
-                        containsMatch : [
-                                tag: 'bob'
-                        ],
+                        containsMatch : false,
                         equalsMatch : true,
                         username      : null,
                         group         : 'admin',

--- a/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
+++ b/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
@@ -74,7 +74,8 @@ class RuleEvaluatorSpec extends Specification {
         def result = eval.evaluate(
                 [
                         type   : 'job',
-                        jobName: 'bob'
+                        jobName: 'bob',
+                        aaa: 'sss'
                 ],
                 basicSubject("bob","admin","user"),
                 "EXECUTE",
@@ -364,7 +365,7 @@ class RuleEvaluatorSpec extends Specification {
     }
 
     @Unroll
-    def "evaluate rule #testRule - #testType - #testValue"() {
+    def "evaluate rule#testRule - #testType - #testKey : #testValue"() {
         when:
         def matchResourceName = [match: 'regexResource']
         Authorization eval = newRuleEvaluator(basicRules([
@@ -373,7 +374,7 @@ class RuleEvaluatorSpec extends Specification {
                 subsetMatch                                             : testType == 'subset',
                 equalsMatch                                             : testType == 'equals',
                 (matchResourceName[testType] ?: (testType + 'Resource')): [
-                        jobName: testRule
+                        (testKey): testRule
                 ],
                 resourceType                                            : 'job',
                 allowActions                                            : ['EXECUTE'] as Set,
@@ -396,32 +397,33 @@ class RuleEvaluatorSpec extends Specification {
         result.action == "EXECUTE"
 
         where:
-        testValue       | testRule          | testType   | isauthorized
-        'bob'           | 'bob'             | 'match'    | true
-        'boblinkious'   | 'bob.*'           | 'match'    | true
-        'abboblinkious' | 'bob.*'           | 'match'    | false
+        testKey  | testValue       | testRule          | testType   | isauthorized
+        'jobName'| 'bob'           | 'bob'             | 'match'    | true
+        'jobName'| 'boblinkious'   | 'bob.*'           | 'match'    | true
+        'jobName'| 'abboblinkious' | 'bob.*'           | 'match'    | false
 
-        'bob'           | 'bob'             | 'equals'   | true
-        'bob'           | 'bobasdf'         | 'equals'   | false
-        'asdfbob'       | 'bob'             | 'equals'   | false
+        'jobName'| 'bob'           | 'bob'             | 'equals'   | true
+        'jobName'| 'bob'           | 'bobasdf'         | 'equals'   | false
+        'jobName'| 'asdfbob'       | 'bob'             | 'equals'   | false
 
-        'val1'          | 'val1'            | 'contains' | true
-        'val1'          | ['val1']          | 'contains' | true
-        'val1,val2'     | 'val1'            | 'contains' | true
-        'val1,val2'     | 'val2'            | 'contains' | true
-        'val1,val2'     | ['val1', 'val2']  | 'contains' | true
-        'val1,val2'     | ['val2', 'val1']  | 'contains' | true
-        'val1,val2'     | ['val3', 'val1']  | 'contains' | false
-        'val1,val3'     | ['val12', 'val1'] | 'contains' | false
+        'jobName'| 'val1'          | 'val1'            | 'contains' | true
+        'jobName'| 'val1'          | ['val1']          | 'contains' | true
+        'jobName'| 'val1,val2'     | 'val1'            | 'contains' | true
+        'jobName'| 'val1,val2'     | 'val2'            | 'contains' | true
+        'jobName'| 'val1,val2'     | ['val1', 'val2']  | 'contains' | true
+        'jobName'| 'val1,val2'     | ['val2', 'val1']  | 'contains' | true
+        'jobName'| 'val1,val2'     | ['val3', 'val1']  | 'contains' | false
+        'jobName'| 'val1,val3'     | ['val12', 'val1'] | 'contains' | false
+        'tag1'   | 'val1'          | 'val1'            | 'contains' | false
 
-        'val1'          | 'val1'            | 'subset'   | true
-        'val1'          | ['val1']          | 'subset'   | true
-        'val1,val2'     | 'val1'            | 'subset'   | false
-        'val1,val2'     | 'val2'            | 'subset'   | false
-        'val1,val2'     | ['val1', 'val2']  | 'subset'   | true
-        'val1,val2'     | ['val2', 'val1']  | 'subset'   | true
-        'val1,val2'     | ['val3', 'val1']  | 'subset'   | false
-        'val1,val3'     | ['val12', 'val1'] | 'subset'   | false
+        'jobName'| 'val1'          | 'val1'            | 'subset'   | true
+        'jobName'| 'val1'          | ['val1']          | 'subset'   | true
+        'jobName'| 'val1,val2'     | 'val1'            | 'subset'   | false
+        'jobName'| 'val1,val2'     | 'val2'            | 'subset'   | false
+        'jobName'| 'val1,val2'     | ['val1', 'val2']  | 'subset'   | true
+        'jobName'| 'val1,val2'     | ['val2', 'val1']  | 'subset'   | true
+        'jobName'| 'val1,val2'     | ['val3', 'val1']  | 'subset'   | false
+        'jobName'| 'val1,val3'     | ['val12', 'val1'] | 'subset'   | false
 
     }
 
@@ -942,11 +944,13 @@ class RuleEvaluatorSpec extends Specification {
                         sourceIdentity: "test1",
                         description   : "bob job allow exec, deny delete for admin group",
                         equalsResource: [
-                                jobName: 'bob'
+                                tag: 'bob'
                         ],
                         resourceType  : 'job',
                         regexMatch    : false,
-                        containsMatch : false,
+                        containsMatch : [
+                                tag: 'bob'
+                        ],
                         equalsMatch : true,
                         username      : null,
                         group         : 'admin',

--- a/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
+++ b/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
@@ -74,8 +74,7 @@ class RuleEvaluatorSpec extends Specification {
         def result = eval.evaluate(
                 [
                         type   : 'job',
-                        jobName: 'bob',
-                        aaa: 'sss'
+                        jobName: 'bob'
                 ],
                 basicSubject("bob","admin","user"),
                 "EXECUTE",


### PR DESCRIPTION
fixes https://github.com/rundeckpro/rundeckpro/issues/1381

**Is this a bugfix, or an enhancement? Please describe.**
A NullPointerException is thrown If a node resource does not have an attribute defined on ACL policy using `contains` rule

**Describe the solution you've implemented**
Include changes to handle null value on string when applying the test for the rule
