### PR TITLE
RUN-137: Fix 3.4.0 UI regressions

### DIFF
--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -420,7 +420,13 @@ search
         <div class="subtitle-head-item flex-container flex-align-items-baseline">
             <div class="flex-item-auto text-h3">
 
-                <span class="label label-secondary has_tooltip" title="${totalauthorized} Jobs Found"><g:enc>${totalauthorized}</g:enc></span>
+                <span
+                    class="label label-secondary has_tooltip"
+                    data-container="#section-content"
+                    data-placement="auto bottom"
+                    title="${totalauthorized} Jobs Found">
+                        <g:enc>${totalauthorized}</g:enc>
+                </span>
 
 
                 <g:if test="${wasfiltered && wasfiltered.contains('groupPath') && !filterName}">

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/paper/_tables.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/paper/_tables.scss
@@ -9,7 +9,6 @@
     tr > th,
     tr > td{
       border-top: 1px solid $table-line-color;
-      word-break: break-word;
     }
     tr.success{
       th,td{
@@ -238,5 +237,12 @@
   table-layout: fixed;
   > tbody > tr > td:first-child{
       width: 145px !important;
+  }
+
+  tfoot{
+    tr > th,
+    tr > td{
+      word-break: break-word;
+    }
   }
 }


### PR DESCRIPTION
Addresses #7125

### Search modal freeze
This is not a regression in `3.4.x` and needs some further discussion. I have split this issue off into its own: #7141

### Job number tooltip
Adjusted positioning:
![image](https://user-images.githubusercontent.com/271965/123494360-292d6500-d5e5-11eb-84e4-43c937beefc2.png)


### Commands node info modal
A change was introduced to the `.table` class for a specific screen that caused the table columns to collapse on all work break opportunities. I moved this change to the `.table-fixed` class that was applied to the table from the previous fix to scope it more narrowly. This table needs some work but the previous, more usable display is restored:

![image](https://user-images.githubusercontent.com/271965/123494274-db186180-d5e4-11eb-9a59-530653334907.png)
