### PR TITLE
RUN-63 and RUN-155: Fixes Sort list of plugins by key order.

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
@@ -116,7 +116,7 @@ class EditOptsController extends ControllerBase{
                 newoption                  : params['newoption'],
                 edit                       : true,
                 fileUploadPluginDescription: fileUploadService.pluginDescription,
-                optionValuesPlugins        : optionValuesService.listOptionValuesPlugins()
+                optionValuesPlugins        : optionValuesService.listOptionValuesPlugins()?.sort{a,b->a.key<=>b.key}
         ]
         return render(template: "/scheduledExecution/optEdit", model: model + outparams)
     }
@@ -216,7 +216,7 @@ class EditOptsController extends ControllerBase{
                     regexError                 : result.regexError,
                     configMapValidate          : result.configMapValidate,
                     fileUploadPluginDescription: fileUploadService.pluginDescription,
-                    optionValuesPlugins        : optionValuesService.listOptionValuesPlugins()
+                    optionValuesPlugins        : optionValuesService.listOptionValuesPlugins()?.sort{a,b->a.key<=>b.key}
             ]
             return render(template: "/scheduledExecution/optEdit", model: model
             )

--- a/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
@@ -388,7 +388,7 @@
                         </div>
                 <feature:enabled name="optionValuesPlugin">
                     <!--List OptionValuesPlugins here -->
-                    <g:each in="${optionValuesPlugins?.sort{a,b->a.key<=>b.key}}" var="optionValPlugin">
+                    <g:each in="${optionValuesPlugins}" var="optionValPlugin">
                         <div class="radio">
                             <g:radio name="valuesType" value="${optionValPlugin.key}"
                                      checked="${option?.optionValuesPluginType == optionValPlugin.key}"

--- a/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
@@ -388,7 +388,7 @@
                         </div>
                 <feature:enabled name="optionValuesPlugin">
                     <!--List OptionValuesPlugins here -->
-                    <g:each in="${optionValuesPlugins}" var="optionValPlugin">
+                    <g:each in="${optionValuesPlugins?.sort{a,b->a.key<=>b.key}}" var="optionValPlugin">
                         <div class="radio">
                             <g:radio name="valuesType" value="${optionValPlugin.key}"
                                      checked="${option?.optionValuesPluginType == optionValPlugin.key}"

--- a/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
@@ -28,6 +28,7 @@ import rundeck.*
 import rundeck.codecs.URIComponentCodec
 import rundeck.services.FileUploadService
 import rundeck.services.FrameworkService
+import rundeck.services.optionvalues.OptionValuesService
 import spock.lang.Unroll
 
 /**
@@ -413,6 +414,34 @@ class EditOptsControllerSpec extends HibernateSpec implements ControllerUnitTest
         result.error == 'Invalid'
         result.option != null
     }
+    
+    def "invalid save returns fields in map"() {
+        given:
+        request.method = 'POST'
+        controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)
+        setupFormTokens(session)
+
+        params.scheduledExecutionId = null
+        params.name='test1'
+        params.newoption = 'insert'
+        params.num = 'testNum'
+        controller.fileUploadService = Mock(FileUploadService)
+        controller.optionValuesService = Mock(OptionValuesService)
+
+        when:
+        views['/scheduledExecution/_optEdit.gsp'] = 'mock template contents'
+        controller.save()
+
+        then:
+        model.edit == true
+        model.name == params.num
+        model.newoption == params.newoption
+        model.scheduledExecutionId == params.scheduledExecutionId
+        model.origName == null
+        1* controller.fileUploadService.getPluginDescription()
+        1* controller.optionValuesService.listOptionValuesPlugins()
+    }
+
 
     def "apply option action remove not found"() {
         given:


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
enh, sort list of plugins by key in order for easy readability.  Add a test for the controller method
**Describe the solution you've implemented**
add groovy sort closure to collection used to display plugin list
