### PR TITLE
RUN-190: Script for automating release steps

### DIFF
--- a/auto_release.rb
+++ b/auto_release.rb
@@ -8,7 +8,7 @@ class AutoRelease
     }
     
     def initialize(mode: ARGV[0])
-        sanitized_arg = mode.match(/^--(.*)$/i).captures
+        sanitized_arg = mode.match(/^(--)?(.*)$/i).captures
 
         @app_url = nil
         @version = nil
@@ -16,7 +16,7 @@ class AutoRelease
         @full_version = nil
         @release_tag = nil
         @release_branch = nil
-        @mode = sanitized_arg[0].downcase || "live"
+        @mode = sanitized_arg[1].downcase || "live"
         @debug = @mode == "test" ? true : false
     end
 
@@ -25,9 +25,16 @@ class AutoRelease
         pass_count = 0
 
         puts "---Auto-Releaser Power On Self Test---"
-        if @mode == "test"
+        case @mode
+        when "test"
             puts "✓ TEST MODE ACTIVE"
             @mode = "auto_release_test"
+        when "help", "noop", "live"
+            puts "✓ Valid mode selected"
+        else
+            puts @mode
+            puts "Invalid mode selected! Please try again using a valid argument. Launch using --help for details."
+            user_exit(1)
         end
 
         if GH_URLS.key?(current_dir.downcase.to_sym)
@@ -45,7 +52,7 @@ class AutoRelease
             puts "✓ No uncommitted changes"
         end
 
-        if pass_count <= 3
+        if pass_count >= 3
             @app_url = GH_URLS[current_dir]
             puts "Mode is #{@mode}"
             puts "Startup check complete!"
@@ -72,6 +79,7 @@ class AutoRelease
         Usage:
         "./auto_release.rb --noop" - Steps you through the prompts and flow of the script and shows you the commands that are run, but makes no actual changes.
         "./auto_release.rb --help" - Brings up this dialog.
+        "./auto_release.rb --test" - Will make changes to a test repo when run from there ('git clone git@github.com:rundeck/auto_release_test.git').
         TEXT
     end
 

--- a/auto_release.rb
+++ b/auto_release.rb
@@ -1,47 +1,265 @@
 #!/usr/bin/env ruby
 
-@version = ""
-@type = ""
+class AutoRelease
+    GH_URLS  = {
+        "rundeck": "https://github.com/rundeck/rundeck",
+        "rundeckpro": "https://github.com/rundeckpro/rundeckpro",
+        "auto_release_test": "https://github.com/rundeck/auto_release_test"
+    }
+    
+    def initialize(mode: ARGV[0])
+        sanitized_arg = mode.match(/^--(.*)$/i).captures
 
-def confirm_dir
-    return false unless File.exist?("./setversion.sh")
+        @app_url = nil
+        @version = nil
+        @rc = nil
+        @full_version = nil
+        @release_tag = nil
+        @release_branch = nil
+        @mode = sanitized_arg[0].downcase || "live"
+        @debug = @mode == "test" ? true : false
+    end
+
+    def power_on_self_test
+        current_dir = File.basename(Dir.pwd).to_sym
+        pass_count = 0
+
+        puts "---Auto-Releaser Power On Self Test---"
+        if @mode == "test"
+            puts "✓ TEST MODE ACTIVE"
+            @mode = "auto_release_test"
+        end
+
+        if GH_URLS.key?(current_dir.downcase.to_sym)
+            pass_count += 1
+            puts "✓ In a supported directory (#{current_dir})"
+        end
+
+        if File.exist?("./setversion.sh")
+            pass_count += 1
+            puts "✓ setversion.sh exists"
+        end
+
+        if @mode == "auto_release_test" || system("git diff --exit-code")
+            pass_count += 1
+            puts "✓ No uncommitted changes"
+        end
+
+        if pass_count <= 3
+            @app_url = GH_URLS[current_dir]
+            puts "Mode is #{@mode}"
+            puts "Startup check complete!"
+        else
+            puts "Startup check failed! Please ensure you are running in the main directory of rundeck or rundeckpro and" +
+            "you have no uncommitted changes ('git stash'), and try again."
+            user_exit(1)
+        end
+    end
+
+    def help
+        puts <<~TEXT
+        Intro:
+        This is a small utility to automate the manual portions of cutting a GA or RC release of Rundeck.
+        It is written off of the documented instructions at https://pagerduty.atlassian.net/wiki/spaces/RUNDECK/pages/2304901608/Rundeck+Enterprise+Release+Process.
+        The script is verbose on purpose. It will step you through each area of input, vocalize what it is doing, and allow you to quit one last time before changes actually occur.
+
+        Prerequisites:
+        * Any version of Ruby 2 or greater should be on your machine.
+        * You should be on a clean copy of main, with no uncommitted changes.
+        * The setversion.sh script must be present
+        * You will need to be in the main directory of rundeck or rundeckpro
+
+        Usage:
+        "./auto_release.rb --noop" - Steps you through the prompts and flow of the script and shows you the commands that are run, but makes no actual changes.
+        "./auto_release.rb --help" - Brings up this dialog.
+        TEXT
+    end
+
+    def run
+        power_on_self_test unless @mode == "help"
+        header
+        if @mode == "help"
+            help
+            user_exit
+        end
+        get_user_data
+        progress_check
+        prepare_release
+        run_setversion
+        commit_new_version
+        wrap_up
+    end
+
+
+    def get_user_data
+        puts "Will this be a release candidate or GA release (r, g)?"
+        handle_input(prompt_type: "release_type", input: STDIN.gets.chomp)
+
+        if @rc
+            puts "What will be the RC Number?"
+            @rc = "RC" + STDIN.gets.chomp
+        end
+
+        puts "What will be the version number for the release?:"
+        handle_input(prompt_type: "release_version", input: STDIN.gets.chomp)
+        prep_git_details
+    end
+
+    def progress_check
+        puts <<~TEXT
+            You're ready to go with the following details:
+            Version: #{@full_version}
+            Release Tag: #{@release_tag}
+            Release Branch: #{@release_branch}
+        TEXT
+
+        puts "The script will now setup the release branch and tag, and push it to GitHub. Are you ready to continue? (y/n)"
+        handle_input(prompt_type: "boolean", input: STDIN.gets.chomp)
+    end
+
+    def prepare_release
+        puts "Checking out main and pulling latest changes..."
+        system_overlord(['git', 'checkout', 'main'])
+        system_overlord(['git', 'pull'])
+        branch_exists = system_overlord(['git', 'checkout', '-b', "release/#{@version}"], ignore_errors: true)
+        system_overlord(['git', 'checkout', "release/#{@version}"]) if branch_exists
+        system_overlord(['git', 'merge', 'main'])
+    end
+
+    def run_setversion
+        puts "Running ./setversion.sh and confirming changes..."
+        type = @rc || "GA"
+        system_overlord(['./setversion.sh', @version, type])
+        version_file = IO.read("./version.properties")
+
+        puts <<~TEXT
+            This is how we've set version.properties based on your input:
+
+            ===./version.properties===
+            #{version_file}
+            ===./version.properties===
+
+            Ready to proceed with pushing this version to GitHub? (y/n)
+        TEXT
+        handle_input(prompt_type: "boolean", input: STDIN.gets.chomp)
+    end
+
+    def commit_new_version
+        puts "Committing changes and pushing tag and branch to origin..."
+        system_overlord(['git', 'add', 'version.properties'])
+        system_overlord(['git', 'commit', '-m', "Release #{@version}"])
+        system_overlord(['git', 'tag', '-a', "v#{@version}", '-m', "Release #{@version}"])
+        system_overlord(['git', 'push', '-u', 'origin', "release/#{@version}"])
+        system_overlord(['git', 'push', 'origin', "v#{@version}"])
+    end
+
+    def wrap_up
+        puts <<~TEXT
+            DONE!
+
+            At this point, your code should be correctly released and available on GitHub!
+            You can verify by visiting your release: #{@app_url}/tree/#{@release_branch}
+
+        TEXT
+        user_exit
+    end
+
+    private
+
+    def system_overlord(command, ignore_errors: false)
+        if @mode == "noop"
+            puts "Skipping command '#{command}' since noop flag is enabled"
+            return
+        end
+
+        debug("system_overlord > command: #{command}")
+
+        if command_status = system(*command)
+            puts "Ran '#{command}'"
+        else
+            if ignore_errors
+                return false
+            else
+                fail_out("running '#{command}'")
+            end
+        end
+    end
+
+    def header
+        puts "\n---Auto-Releaser for Rundeck/Rundeck Pro---"
+        case @mode
+        when "noop"
+            puts "NOOP SESSION: No changes will be made to the system or GitHub."
+        when "live"
+            puts "LIVE SESSION: All changes will be saved to the system and committed to GitHub!"
+        when "help"
+            ""
+        end
+        puts "Ctrl-C to quit at any time.\n\n"
+    end
+
+    def handle_input(prompt_type:, input:)
+        case prompt_type
+        when "boolean"
+            boolean_handler(input)
+        when "release_type"
+            type_handler(input)
+        when "release_version"
+            debug("handle_input > release_version > input: #{input}") 
+            version_handler(input)
+        end
+    end
+
+    def type_handler(input)
+        puts "type_handler: #{input}"
+        case input
+        when /^g(a)?$/i
+            true
+        when /^r(c)?(\d+)?$/i
+            @rc = "RC"
+        else
+            fail_out("validating type")
+        end
+    end
+
+    def version_handler(input)
+        fail_out("validating version") unless /^(\d+\.)?(\d+\.)?(\*|\d+)$/.match?(input)
+        @version = input
+    end
+
+    def boolean_handler(input)
+        case input
+        when "y"
+            true
+        when "n"
+            puts "Ok, aborting... No changes to Git were made"
+            exit(0)
+        else
+            fail_out("validating confirmation")
+        end
+    end
+
+    def prep_git_details
+        @full_version = @version
+        @full_version += "-#{@rc}" if @rc
+
+        @release_tag = "v#{@full_version}"
+        @release_branch = "release/#{@full_version}"
+    end
+
+    def user_exit(exit_code = 0)
+        puts "Press any key to exit..."
+        STDIN.getc
+        exit(exit_code)
+    end
+
+    def fail_out(message)
+        abort("There was an issue #{message}! Please try again. Aborting...")
+    end
+
+    def debug(message)
+        puts "DEBUG> #{message}" if @debug
+    end
 end
 
-def get_user_data
-    puts "What version are you releasing?:"
-    version = gets.chomp
-
-    puts "Is this a GA release or an RC (if RC add RC number):"
-    type = gets.chomp
-end
-
-def validate_and_store_input(version:, type:)
-    return false unless version && type
-    return false unless version == /^(\d+\.)?(\d+\.)?(\*|\d+)$/
-    return false unless type == /^ga$/i || type == /^rc\d+$/i
-
-    @version = version
-    @type = type
-
-    return true
-end
-
-def update_git
-    puts "Checking out main and pulling latest changes..."
-    system('git checkout main')
-    system('git pull')
-    branch_exists? = system("git checkout -b release/", @version)
-    system("git checkout release/", @version) if branch_exists?
-end
-
-def run_setversion
-    system("./setversion.sh", @version, "1", @type)
-end
-
-def commit_new_version
-    system('git add version.properties')
-    system("git commit -m 'Release ", @version, "'")
-    system("git tag -a v", @version, " -m 'Release ", @version, "'")
-    system("git push -u origin release/", @version)
-    system("git push origin v", @version)
-end
+AutoRelease.new.run

--- a/auto_release.rb
+++ b/auto_release.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+
+@version = ""
+@type = ""
+
+def confirm_dir
+    return false unless File.exist?("./setversion.sh")
+end
+
+def get_user_data
+    puts "What version are you releasing?:"
+    version = gets.chomp
+
+    puts "Is this a GA release or an RC (if RC add RC number):"
+    type = gets.chomp
+end
+
+def validate_and_store_input(version:, type:)
+    return false unless version && type
+    return false unless version == /^(\d+\.)?(\d+\.)?(\*|\d+)$/
+    return false unless type == /^ga$/i || type == /^rc\d+$/i
+
+    @version = version
+    @type = type
+
+    return true
+end
+
+def update_git
+    puts "Checking out main and pulling latest changes..."
+    system('git checkout main')
+    system('git pull')
+    branch_exists? = system("git checkout -b release/", @version)
+    system("git checkout release/", @version) if branch_exists?
+end
+
+def run_setversion
+    system("./setversion.sh", @version, "1", @type)
+end
+
+def commit_new_version
+    system('git add version.properties')
+    system("git commit -m 'Release ", @version, "'")
+    system("git tag -a v", @version, " -m 'Release ", @version, "'")
+    system("git push -u origin release/", @version)
+    system("git push origin v", @version)
+end

--- a/setversion.sh
+++ b/setversion.sh
@@ -1,29 +1,19 @@
 #!/bin/bash
 
 CUR_VERSION="$(grep version.number= "$PWD/version.properties" | cut -d= -f 2)"
-CUR_RELEASE="$(grep version.release.number= "$PWD/version.properties" | cut -d= -f 2)"
 CUR_TAG="$(grep version.tag= "$PWD/version.properties" | cut -d= -f 2)"
 
 echo "current NUMBER: $CUR_VERSION"
-echo "current RELEASE: $CUR_RELEASE"
 echo "current TAG: $CUR_TAG"
 
 if [ -z "$1" ] ; then
-echo "usage: setversion.sh <version> [release] [GA]"
+echo "usage: setversion.sh <version> [GA]"
 exit 2
 fi
 
 VNUM="$1"
-
-shift
-if [ -z "$1" ]; then
-    RELEASE="$CUR_RELEASE"
-else
-    RELEASE="$1"
-fi
 shift
 VTAG="${1:-GA}"
-
 
 VDATE="$(date +%Y%m%d)"
 
@@ -34,13 +24,11 @@ else
 fi
 
 echo "new NUMBER: $VNUM"
-echo "new RELEASE: $RELEASE"
 echo "new DATE: $VDATE"
 echo "new VERSION: $VNAME"
 
 #alter version.properties
 perl  -i'.orig' -p -e "s#^version\\.number\\s*=.*\$#version.number=$VNUM#" "$PWD/version.properties"
-perl  -i'.orig' -p -e "s#^version\\.release\\.number\\s*=.*\$#version.release.number=$RELEASE#" "$PWD/version.properties"
 perl  -i'.orig' -p -e "s#^version\\.tag\\s*=.*\$#version.tag=$VTAG#" "$PWD/version.properties"
 perl  -i'.orig' -p -e "s#^version\\.date\\s*=.*\$#version.date=$VDATE#" "$PWD/version.properties"
 perl  -i'.orig' -p -e "s#^version\\.version\\s*=.*\$#version.version=$VNAME#" "$PWD/version.properties"
@@ -48,4 +36,3 @@ perl  -i'.orig' -p -e "s#^version\\.version\\s*=.*\$#version.version=$VNAME#" "$
 perl  -i'.orig' -p -e "s#^currentVersion\\s*=.*\$#currentVersion = $VNUM#" "$PWD"/gradle.properties
 
 echo MODIFIED: "$(pwd)"/version.properties
-


### PR DESCRIPTION
This script automates the official rundeck release process. Previously, there were a number of steps to copy and paste from a Confluence readme.

Now, you can simply launch this script, follow the step-by-step instructions, and end with a proper release branch and tag, which should kick off other parts of the build and release process.

Upon merge, I will also PR this file for rundeckpro.

### To test:
```
git clone git@github.com:rundeck/auto_release_test.git
cd auto_release_test
./auto_release.rb --test
# You can put in any combination of release info--the changes will be sent back to the auto_release_test repo, so they are totally safe.
```
