### PR TITLE
RUN-220: FIX: npe if execution fails to start

### DIFF
--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -548,10 +548,10 @@ class ExecutionJob implements InterruptableJob {
         ExecutionService.AsyncStarted execmap
     )
     {
-        Map<String, NodeStepResult> failedNodes = execmap.noderecorder?.getFailedNodes()
-        Set<String> succeededNodes = execmap.noderecorder?.getSuccessfulNodes()
+        Map<String, NodeStepResult> failedNodes = execmap?.noderecorder?.getFailedNodes()
+        Set<String> succeededNodes = execmap?.noderecorder?.getSuccessfulNodes()
 
-        if(wasThreshold && execmap.threshold?.action==LoggingThreshold.ACTION_HALT){
+        if(wasThreshold && execmap?.threshold?.action==LoggingThreshold.ACTION_HALT){
             //use custom status or fail
             success=false
             statusString = initMap.scheduledExecution?.logOutputThresholdStatus?:'failed'


### PR DESCRIPTION
ref #7127 
**Is this a bugfix, or an enhancement? Please describe.**

Fixes handling of null result due to execution failing to start.


**Additional context**
Original cause of #7127 was not determined