### PR TITLE
RUN-222: SCM Loader enhancement: avoid failed plugin will be init on background iteration

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
@@ -7,7 +7,6 @@ import com.dtolabs.rundeck.plugins.scm.JobExportReference
 import com.dtolabs.rundeck.plugins.scm.JobScmReference
 import com.dtolabs.rundeck.plugins.scm.ScmOperationContext
 import grails.events.annotation.Subscriber
-import grails.events.bus.EventBus
 import grails.events.bus.EventBusAware
 import grails.gorm.transactions.Transactional
 import groovy.transform.CompileDynamic
@@ -43,6 +42,7 @@ class ScmLoaderService implements EventBusAware {
     final Map<String, ScheduledFuture> scmProjectLoaderProcess = Collections.synchronizedMap([:])
     final Map<String, Boolean> scmProjectInitLoaded = Collections.synchronizedMap([:])
     final Map<String, ScmPluginConfigData> scmPluginMeta = Collections.synchronizedMap([:])
+    final Map<String, ScmPluginConfigData> scmFailedProjectInit = Collections.synchronizedMap([:])
 
     @Subscriber("rundeck.bootstrap")
     @CompileDynamic
@@ -54,19 +54,21 @@ class ScmLoaderService implements EventBusAware {
                     {
                         for (String project : frameworkService.projectNames()) {
                             for (String integration : scmService.INTEGRATIONS) {
-                                String projectIntegration = project + "-" + integration
+                                String projectIntegration = getProjectIntegration(project, integration)
                                 ScmPluginConfigData pluginConfigData = scmService.loadScmConfig(project, integration)
-                                if(!scmProjectLoaderProcess.get(projectIntegration)){
+                                if(projectIntegrationEnabled(project, integration, pluginConfigData)){
                                     if(pluginConfigData && pluginConfigData.enabled) {
                                         scmProjectLoaderProcess.put(projectIntegration, startScmLoader(project, integration))
                                     }
                                 }else{
                                     //cleanup: if scm was disabled or the project was deleted
                                     if(pluginConfigData && !pluginConfigData.enabled || !pluginConfigData) {
-                                        ScheduledFuture scheduler = scmProjectLoaderProcess.get(projectIntegration)
-                                        scheduler.cancel(true)
-                                        scmProjectLoaderProcess.remove(projectIntegration)
-                                        cleanUpScmPlugin(project, integration)
+                                        if(scmProjectLoaderProcess.get(projectIntegration)){
+                                            ScheduledFuture scheduler = scmProjectLoaderProcess.get(projectIntegration)
+                                            scheduler.cancel(true)
+                                            scmProjectLoaderProcess.remove(projectIntegration)
+                                            cleanUpScmPlugin(project, integration)
+                                        }
                                     }
                                 }
                             }
@@ -79,13 +81,35 @@ class ScmLoaderService implements EventBusAware {
         }
     }
 
+    String getProjectIntegration(String project, String integration){
+        project + "-" + integration
+    }
+
+    boolean projectIntegrationEnabled(String project, String integration,  ScmPluginConfigData pluginConfigData){
+        String projectIntegration = getProjectIntegration(project, integration)
+        if(!scmProjectLoaderProcess.get(projectIntegration) && !scmFailedProjectInit.get(projectIntegration)){
+            if(pluginConfigData && pluginConfigData.enabled) {
+                return true
+            }
+        }else{
+            if(scmFailedProjectInit.get(projectIntegration)){
+                if(reloadPlugin(project, integration, pluginConfigData)){
+                    scmFailedProjectInit.remove(projectIntegration)
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+
     def startScmLoader(String project, String integration){
 
         def state = new ScmLoaderStateImpl()
         //enable project integration cache loader
         def scheduler = scheduledExecutor.scheduleAtFixedRate(
                 {
-                    String projectIntegration = project + "-" + integration
+                    String projectIntegration = getProjectIntegration(project, integration)
                     ScmPluginConfigData pluginConfigData = scmService.loadScmConfig(project, integration)
                     if(!scmPluginMeta.get(projectIntegration)){
                         scmPluginMeta.put(projectIntegration, pluginConfigData)
@@ -100,13 +124,11 @@ class ScmLoaderService implements EventBusAware {
 
                         } catch (Throwable t) {
                             log.error("processMessages error: $project/$integration: ${t.message}")
+                            scmFailedProjectInit.put(projectIntegration, pluginConfigData)
+                            removingLoaderProcess(project, integration)
                         }
                     }else{
-                        //removing task
-                        log.debug("removing thread ${projectIntegration}")
-                        scmProjectLoaderProcess.remove(projectIntegration)
-                        cleanUpScmPlugin(project, integration)
-                        throw new RuntimeException("SCM disabled or project removed");
+                        removingLoaderProcess(project, integration)
                     }
                 },
                 scmLoaderInitialDelaySeconds,
@@ -114,6 +136,16 @@ class ScmLoaderService implements EventBusAware {
                 TimeUnit.SECONDS
         )
         scheduler
+    }
+
+    def removingLoaderProcess(String project, String integration){
+        String projectIntegration = getProjectIntegration(project, integration)
+
+        //removing task
+        log.debug("removing thread ${projectIntegration}")
+        scmProjectLoaderProcess.remove(projectIntegration)
+        cleanUpScmPlugin(project, integration)
+        throw new RuntimeException("SCM disabled or project removed");
     }
 
     long getScmLoaderInitialDelaySeconds() {
@@ -219,6 +251,15 @@ class ScmLoaderService implements EventBusAware {
     @Transactional
     def processScmExportLoader(String project, ScmPluginConfigData pluginConfig, ScmLoaderState state) {
 
+        def username = pluginConfig.getSetting("username")
+        def roles = pluginConfig.getSettingList("roles")
+        ScmOperationContext context = scmService.scmOperationContext(username, roles, project)
+        def loaded = scmService.loadPluginWithConfig(scmService.EXPORT, context, pluginConfig.type, pluginConfig.config)
+
+        if(!loaded){
+            return
+        }
+
         if (!scmService.projectHasConfiguredExportPlugin(project)) {
             return
         }
@@ -233,9 +274,7 @@ class ScmLoaderService implements EventBusAware {
         def plugin = scmService.getLoadedExportPluginFor(project)
 
         if (plugin) {
-            def username = pluginConfig.getSetting("username")
-            def roles = pluginConfig.getSettingList("roles")
-            ScmOperationContext context = scmService.scmOperationContext(username, roles, project)
+            log.debug("export plugin found")
 
             List<ScheduledExecution> jobs = getJobs(project)
             log.debug("processing ${jobs.size()} jobs")
@@ -294,6 +333,15 @@ class ScmLoaderService implements EventBusAware {
     @Transactional
     def processScmImportLoader(String project, ScmPluginConfigData pluginConfig, ScmLoaderState state){
         log.debug("processing SCM import Loader ${project} / ${pluginConfig.type}")
+        def username = pluginConfig.getSetting("username")
+        def roles = pluginConfig.getSettingList("roles")
+        ScmOperationContext context = scmService.scmOperationContext(username, roles, project)
+
+        def loaded = scmService.loadPluginWithConfig(scmService.IMPORT, context, pluginConfig.type, pluginConfig.config)
+
+        if(!loaded){
+            return
+        }
 
         if (!scmService.projectHasConfiguredImportPlugin(project)) {
             return
@@ -306,9 +354,7 @@ class ScmLoaderService implements EventBusAware {
         def plugin = scmService.getLoadedImportPluginFor(project)
 
         if(plugin){
-            def username = pluginConfig.getSetting("username")
-            def roles = pluginConfig.getSettingList("roles")
-            ScmOperationContext context = scmService.scmOperationContext(username, roles, project)
+            log.debug("import plugin found")
 
             List<ScheduledExecution> jobs = getJobs(project)
             log.debug("processing ${jobs.size()} jobs")
@@ -360,13 +406,17 @@ class ScmLoaderService implements EventBusAware {
     }
 
     boolean reloadPlugin(String project, String integration, ScmPluginConfigData pluginConfig){
-        String key = project + "-" + integration
-        def pluginConfigCache = scmPluginMeta.get(key)
-        if(pluginConfigCache && pluginConfig.getProperties() != pluginConfigCache.getProperties()){
-            scmService.unregisterPlugin(integration, project)
-            scmService.initProject(project, integration)
-            scmPluginMeta.remove(key)
-            return true
+        String key = getProjectIntegration(project, integration)
+        try{
+            def pluginConfigCache = scmPluginMeta.get(key)
+            if(pluginConfigCache && pluginConfig.getProperties() != pluginConfigCache.getProperties()){
+                scmService.unregisterPlugin(integration, project)
+                scmService.initProject(project, integration)
+                scmPluginMeta.remove(key)
+                return true
+            }
+        }catch(Exception e){
+            return false
         }
 
         return false

--- a/rundeckapp/src/test/groovy/rundeck/services/scm/ScmLoaderServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/scm/ScmLoaderServiceSpec.groovy
@@ -1,6 +1,8 @@
 package rundeck.services.scm
 
 import com.dtolabs.rundeck.core.jobs.JobRevReference
+import com.dtolabs.rundeck.core.plugins.CloseableProvider
+import com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException
 import com.dtolabs.rundeck.plugins.scm.JobChangeEvent
 import com.dtolabs.rundeck.plugins.scm.JobScmReference
 import com.dtolabs.rundeck.plugins.scm.ScmExportPlugin
@@ -9,6 +11,7 @@ import com.dtolabs.rundeck.plugins.scm.ScmOperationContext
 import grails.events.bus.EventBus
 import grails.test.hibernate.HibernateSpec
 import grails.testing.services.ServiceUnitTest
+import org.rundeck.storage.api.StorageException
 import rundeck.ScheduledExecution
 import rundeck.services.FrameworkService
 import rundeck.services.JobRevReferenceImpl
@@ -16,7 +19,7 @@ import rundeck.services.ScheduledExecutionService
 import rundeck.services.ScmService
 import spock.lang.Unroll
 
-class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmLoaderService> {
+class  ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmLoaderService> {
 
     def "loaded export plugin not configured"(){
 
@@ -71,6 +74,8 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
         def listWorkflow = [
                 "schedlist": jobs
         ]
+        def username = "admin"
+        def roles = ["admin"]
         service.scheduledExecutionService = Mock(ScheduledExecutionService){
             listWorkflows(_)>>listWorkflow
         }
@@ -78,13 +83,17 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
             projectHasConfiguredExportPlugin(project)>>true
         }
         def plugin  = Mock(ScmExportPlugin)
-        def scmPluginConfigData = Mock(ScmPluginConfigData)
+        def scmPluginConfigData = Mock(ScmPluginConfigData){
+            getSetting("username")>>username
+            getSettingList("roles")>>roles
+        }
 
         when:
 
         service.processScmExportLoader(project, scmPluginConfigData, new ScmLoaderService.ScmLoaderStateImpl())
-
         then:
+        1 * service.scmService.scmOperationContext(username,roles,project) >> Mock(ScmOperationContext)
+        1 * service.scmService.loadPluginWithConfig(_, _, _, _) >> Mock(CloseableProvider)
         1 * service.scmService.getLoadedExportPluginFor(project)  >> plugin
         1 * service.scmService.exportjobRefsForJobs(jobs,_)
         1 * plugin.initJobsStatus(_)
@@ -93,7 +102,7 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
 
     }
 
-    def "loaded import plugin load without"(){
+    def "loaded import plugin load without cluster fix"(){
 
         given:
         def project = "test"
@@ -107,6 +116,8 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
         def listWorkflow = [
                 "schedlist": jobs
         ]
+        def username = "admin"
+        def roles = ["admin"]
         service.scheduledExecutionService = Mock(ScheduledExecutionService){
             listWorkflows(_)>>listWorkflow
         }
@@ -114,13 +125,18 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
             projectHasConfiguredImportPlugin(project)>>true
         }
         def plugin  = Mock(ScmImportPlugin)
-        def scmPluginConfigData = Mock(ScmPluginConfigData)
+        def scmPluginConfigData = Mock(ScmPluginConfigData){
+            getSetting("username")>>username
+            getSettingList("roles")>>roles
+        }
 
         when:
 
         service.processScmImportLoader(project, scmPluginConfigData, new ScmLoaderService.ScmLoaderStateImpl())
 
         then:
+        1 * service.scmService.scmOperationContext(username,roles,project) >> Mock(ScmOperationContext)
+        1 * service.scmService.loadPluginWithConfig(_, _, _, _) >> Mock(CloseableProvider)
         1 * service.scmService.getLoadedImportPluginFor(project)  >> plugin
         1 * service.scmService.scmJobRefsForJobs(jobs,_)
         1 * plugin.initJobsStatus(_)
@@ -175,11 +191,12 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
         service.processScmExportLoader(project, scmPluginConfigData, new ScmLoaderService.ScmLoaderStateImpl())
 
         then:
+        1 * service.scmService.scmOperationContext(username,roles,project) >> Mock(ScmOperationContext)
+        1 * service.scmService.loadPluginWithConfig(_, _, _, _) >> Mock(CloseableProvider)
         1 * service.scmService.getLoadedExportPluginFor(project)  >> plugin
         1 * service.scmService.exportjobRefsForJobs(jobs,_)>>jobList
         1 * plugin.initJobsStatus(_)
         1 * plugin.refreshJobsStatus(_)
-        1 * service.scmService.scmOperationContext(username,roles,project)>>Mock(ScmOperationContext)
         jobs.size()*service.scmService.getRenamedPathForJobId(_,_)
         1 * plugin.clusterFixJobs(_,_,_)
         service.scmProjectInitLoaded.containsKey(project+"-export")
@@ -240,12 +257,13 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
         service.processScmExportLoader(project, scmPluginConfigData, oldstate)
 
         then:
+        1 * service.scmService.scmOperationContext(username,roles,project) >> Mock(ScmOperationContext)
+        1 * service.scmService.loadPluginWithConfig(_, _, _, _) >> Mock(CloseableProvider)
         1 * service.scmService.getLoadedExportPluginFor(project)  >> plugin
         1 * service.scmService.exportjobRefsForJobs(jobs,_)>>jobList
         1 * service.scmService.deletedExportFilesForProject(project)>>[:]
         1 * plugin.initJobsStatus(_)
         1 * plugin.refreshJobsStatus(_)
-        1 * service.scmService.scmOperationContext(username,roles,project)>>Mock(ScmOperationContext)
         jobs.size()*service.scmService.getRenamedPathForJobId(_,_)
         0 * service.scmService.recordDeletedJob(project,'/old/job/path',_)
         1 * plugin.clusterFixJobs(_,_,_)
@@ -305,11 +323,12 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
         service.processScmImportLoader(project, scmPluginConfigData, new ScmLoaderService.ScmLoaderStateImpl())
 
         then:
+        1 * service.scmService.scmOperationContext(username,roles,project) >> Mock(ScmOperationContext)
+        1 * service.scmService.loadPluginWithConfig(_, _, _, _) >> Mock(CloseableProvider)
         1 * service.scmService.getLoadedImportPluginFor(project)  >> plugin
         1 * service.scmService.scmJobRefsForJobs(jobs,_) >> jobList
         1 * plugin.initJobsStatus(_)
         1 * plugin.refreshJobsStatus(_)
-        1 * service.scmService.scmOperationContext(username,roles,project)>>Mock(ScmOperationContext)
         jobs.size()*service.scmService.getRenamedPathForJobId(project,_)
         1 * plugin.clusterFixJobs(_,_,_)
         service.scmProjectInitLoaded.containsKey(project+"-import")
@@ -370,11 +389,12 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
             service.processScmImportLoader(project, scmPluginConfigData, oldstate)
 
         then:
+            1 * service.scmService.scmOperationContext(username,roles,project) >> Mock(ScmOperationContext)
+            1 * service.scmService.loadPluginWithConfig(_, _, _, _) >> Mock(CloseableProvider)
             1 * service.scmService.getLoadedImportPluginFor(project) >> plugin
             1 * service.scmService.scmJobRefsForJobs(jobs, _) >> jobList
             1 * plugin.initJobsStatus(_)
             1 * plugin.refreshJobsStatus(_)
-            1 * service.scmService.scmOperationContext(username, roles, project) >> Mock(ScmOperationContext)
             jobs.size() * service.scmService.getRenamedPathForJobId(project, _)
             1 * plugin.clusterFixJobs(_, _, _)
             service.scmProjectInitLoaded.containsKey(project + "-import")
@@ -459,6 +479,8 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
             .ScmLoaderStateImpl())
 
         then:
+        1 * service.scmService.scmOperationContext(username,roles,project) >> Mock(ScmOperationContext)
+        1 * service.scmService.loadPluginWithConfig(_, _, _, _) >> Mock(CloseableProvider)
         1 * service.scmService.getLoadedExportPluginFor(project)  >> plugin
         1 * service.scmService.exportjobRefsForJobs(_,_)>>jobList
         1 * service.scmService.unregisterPlugin("export", project)
@@ -510,11 +532,82 @@ class ScmLoaderServiceSpec extends HibernateSpec implements ServiceUnitTest<ScmL
         service.processScmImportLoader(project, (ScmPluginConfigData)scmPluginConfigData, new ScmLoaderService.ScmLoaderStateImpl())
 
         then:
+        1 * service.scmService.scmOperationContext(username,roles,project) >> Mock(ScmOperationContext)
+        1 * service.scmService.loadPluginWithConfig(_, _, _, _) >> Mock(CloseableProvider)
         1 * service.scmService.getLoadedImportPluginFor(project)  >> plugin
         1 * service.scmService.scmJobRefsForJobs(jobs,_) >> jobList
         1 * service.scmService.unregisterPlugin("import", project)
         1 * service.scmService.initProject(project, "import")
         service.scmProjectInitLoaded.containsKey(project+"-import")
+
+    }
+
+    def "SCM export project bad plugin config" (){
+        given:
+        def project = "test"
+        def username = "admin"
+        def roles = ["admin"]
+        def config = ["url":"http://localhost","branch": "dev"]
+        def configCached = ["url":"http://localhost","branch": "main"]
+
+        def plugin  = Mock(ScmExportPlugin)
+        def scmPluginConfigData = Mock(ScmPluginConfig){
+            getSetting("username")>>username
+            getSettingList("roles")>>roles
+            getProperties() >> config
+        }
+
+        service.scmService = Mock(ScmService){
+            projectHasConfiguredExportPlugin(project)>>true
+        }
+
+        service.scmService.scmOperationContext(username,roles,project) >> Mock(ScmOperationContext)
+        service.scmService.loadPluginWithConfig(_, _, _, _) >> { throw new Exception("fail plugin config")  }
+
+        when:
+
+        service.processScmExportLoader(project, (ScmPluginConfigData)scmPluginConfigData, new ScmLoaderService
+                .ScmLoaderStateImpl())
+
+        then:
+        Exception e = thrown()
+        0 * service.scmService.getLoadedExportPluginFor(project)  >> plugin
+        0 * service.scmService.exportjobRefsForJobs(_,_)
+        0 * service.scmService.unregisterPlugin("export", project)
+        0 * service.scmService.initProject(project, "export")
+    }
+
+    def "SCM import bad plugin config"(){
+        given:
+        def project = "test"
+        def username = "admin"
+        def roles = ["admin"]
+        def config = ["url":"http://localhost","branch": "dev"]
+        def configCached = ["url":"http://localhost","branch": "main"]
+
+        def plugin  = Mock(ScmImportPlugin)
+        def scmPluginConfigData = Mock(ScmPluginConfig){
+            getSetting("username")>>username
+            getSettingList("roles")>>roles
+            getProperties() >> config
+        }
+
+        service.scmService = Mock(ScmService){
+            projectHasConfiguredImportPlugin(project)>>true
+        }
+        service.scmService.scmOperationContext(username,roles,project) >> Mock(ScmOperationContext)
+        service.scmService.loadPluginWithConfig(_, _, _, _) >> { throw new Exception("fail plugin config")  }
+
+        when:
+
+        service.processScmImportLoader(project, (ScmPluginConfigData)scmPluginConfigData, new ScmLoaderService.ScmLoaderStateImpl())
+
+        then:
+        Exception e = thrown()
+        0 * service.scmService.getLoadedExportPluginFor(project)  >> plugin
+        0 * service.scmService.exportjobRefsForJobs(_,_)
+        0 * service.scmService.unregisterPlugin("import", project)
+        0 * service.scmService.initProject(project, "import")
 
     }
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
enhancement:
avoid SCM Loader try to load a failed plugin integration in each iteration (for example because the SCM folder is wrong or for authentication issues)

**Describe the solution you've implemented**
- add a list that saves failed plugins 
- each time the SCM background process fails to init an SCM plugin, that failed plugin is storage in the list
- if the plugin changes and it doesn't fail, it will be removed from the list.

**Describe alternatives you've considered**

**Additional context**
