### PR TITLE
RUN-121: Remove 1 second timeout for request

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/stores/News.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/stores/News.ts
@@ -23,7 +23,6 @@ export class NewsStore {
         resp.data.objects.forEach( (o: any) => {
            this.articles.push(Article.FromApi(o))
         })
-        // yield new Promise(res => setTimeout(res, 5000))
         this.loaded = true
     })
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/stores/Projects.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/stores/Projects.ts
@@ -17,7 +17,6 @@ export class ProjectStore {
 
         this.projects = []
         const resp = (yield this.client.projectList()) as ProjectListResponse
-        yield new Promise(res => {setTimeout(res, 0)})
         resp.forEach(p => {
             this.projects.push(Project.FromApi(p))
         })

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/stores/Projects.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/stores/Projects.ts
@@ -17,7 +17,7 @@ export class ProjectStore {
 
         this.projects = []
         const resp = (yield this.client.projectList()) as ProjectListResponse
-        yield new Promise(res => {setTimeout(res, 1000)})
+        yield new Promise(res => {setTimeout(res, 0)})
         resp.forEach(p => {
             this.projects.push(Project.FromApi(p))
         })


### PR DESCRIPTION
Fixes #7116 

**Is this a bugfix, or an enhancement? Please describe.**
Bugfix: Project Picker always took 1 sec to load 

**Describe the solution you've implemented**
Remove the timeout that cause the project picked to be forced to load after 1 sec


