### PR TITLE
RUN-252: Optional BindDN in JAAS login module template for Docker Image

### DIFF
--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -5,7 +5,9 @@
         debug="{{ getv("/rundeck/jaas/ldap/debug", "true") }}"
         contextFactory="{{ getv("/rundeck/jaas/ldap/contextfactory", "com.sun.jndi.ldap.LdapCtxFactory") }}"
         providerUrl="{{ getv("/rundeck/jaas/ldap/providerurl") }}"
+    {% if exists("/rundeck/jaas/ldap/binddn") -%}
         bindDn="{{ getv("/rundeck/jaas/ldap/binddn") }}"
+    {% endif %}
     {% if exists("/rundeck/jaas/ldap/bindpassword") -%}
         bindPassword="{{ getv("/rundeck/jaas/ldap/bindpassword") }}"
     {% endif %}


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
For issue https://github.com/rundeck/rundeck/issues/7160

**Describe the solution you've implemented**
skip bindDn setting if the env var is not set for jass login module template

**Describe alternatives you've considered**

**Additional context**
