### PR TITLE
RUN-255: Enable Cookie name and domain customization

### DIFF
--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -13,7 +13,7 @@ server.servlet.context-path={{ getv("/rundeck/server/contextpath", "/") }}
 grails.serverURL={{ getv("/rundeck/grails/url", "http://127.0.0.1:4440") }}
 rundeck.multiURL.enabled={{ getv("/rundeck/multiurl/enabled", "false") }}
 rundeck.security.cookie.name={{ getv("/rundeck/security/cookie/name", "") }}
-rundeck.security.cookie.domainNamePattern={{ getv("/rundeck/security/cookie/domainNamePattern", "") }}
+rundeck.security.cookie.domainNamePattern={{ getv("/rundeck/security/cookie/domainnamepattern", "") }}
 
 server.servlet.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
 

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -12,6 +12,8 @@ server.address={{ getv("/rundeck/server/address", "0.0.0.0") }}
 server.servlet.context-path={{ getv("/rundeck/server/contextpath", "/") }}
 grails.serverURL={{ getv("/rundeck/grails/url", "http://127.0.0.1:4440") }}
 rundeck.multiURL.enabled={{ getv("/rundeck/multiurl/enabled", "false") }}
+rundeck.security.cookie.name={{ getv("/rundeck/security/cookie/name", "") }}
+rundeck.security.cookie.domainNamePattern={{ getv("/rundeck/security/cookie/domainNamePattern", "") }}
 
 server.servlet.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
 

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -109,6 +109,7 @@ dependencies {
 
     compile "org.springframework.boot:spring-boot-starter-log4j2"
     compile "org.springframework.boot:spring-boot-autoconfigure"
+    compile 'org.springframework.session:spring-session-core'
 
     compile "org.grails:grails-core"
     compile "org.springframework.boot:spring-boot-starter-actuator"

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -152,13 +152,12 @@ beans={
 
     def defaultCookieSerializer = new DefaultCookieSerializer()
 
-    if (application.config.rundeck.security?.cookie?.domainNamePattern && !"".equals(application.config.rundeck.security.cookie.domainNamePattern)) {
-        defaultCookieSerializer.setDomainNamePattern(application.config.rundeck.security.cookie.domainNamePattern);
+    if (application.config.rundeck.security?.cookie?.domainNamePattern?.trim()) {
+        defaultCookieSerializer.setDomainNamePattern(application.config.rundeck.security.cookie.domainNamePattern.toString().trim());
     }
 
-    if (application.config.rundeck.security?.cookie?.name && !"".equals(application.config.rundeck.security.cookie.name)) {
-        defaultCookieSerializer.setCookieName(application.config.rundeck.security?.cookie?.name ? application.config.rundeck.security.cookie.name : "JSESSIONID")
-    }
+    def cookieName = application.config.rundeck.security?.cookie?.name?.trim() ?: "JSESSIONID"
+    defaultCookieSerializer.setCookieName(cookieName)
 
     def sessionFilter = new MapSessionRepository(new ConcurrentHashMap<>())
     def sessionIdResolver = new CookieHttpSessionIdResolver()


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
It's an enhancement. With `rundeck.multiURL.enabled` (https://github.com/rundeck/rundeck/pull/6760) we can use multiple url's, but we still need to login on each of them.

**Describe the solution you've implemented**
The code basically externalize two cookie properties: `name` and `domainNamePattern` ([spring docs](https://docs.spring.io/spring-session/docs/current/reference/html5/guides/java-custom-cookie.html#custom-cookie-options))

**Describe alternatives you've considered**
No other solutions.

**Additional context**
Example:

```
rundeck.multiURL.enabled=true
rundeck.security.cookie.name=RDK_SESSION
rundeck.security.cookie.domainNamePattern=^.+?\\.(\\w+\\.[a-z]+)\$
```

![rdk_cookies](https://user-images.githubusercontent.com/457100/126038691-2d6933d1-3578-4838-a251-65c854f8a880.gif)
