### PR TITLE
RUN-194: Fix errors from 1000+ Executions on Oracle Database

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
@@ -293,7 +293,17 @@ class ReportService  {
 
                 if (query.execIdFilter) {
                     or {
-                        'in'('jcExecId', query.execIdFilter)
+                        if(isOracleDatasource()){
+                            //Hack to avoid error: ORA-01795: maximum number of expressions in a list is 1000
+                            or {
+                                List execIdFilterPartioned = Lists.partition(query.execIdFilter, 1000)
+                                execIdFilterPartioned.each { List partition ->
+                                    'in'('jcExecId', partition)
+                                }
+                            }
+                        } else {
+                            'in'('jcExecId', query.execIdFilter)
+                        }
                         and{
                                     jobfilters.each { key, val ->
                                         if (query["${key}Filter"] == 'null') {

--- a/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.app.support.ExecQuery
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.Decision
 import com.dtolabs.rundeck.core.authorization.Explanation
+import com.google.common.collect.Lists
 import groovy.sql.Sql
 import org.rundeck.app.authorization.AppAuthContextEvaluator
 import org.rundeck.core.auth.AuthConstants


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/1873

**Is this a bugfix, or an enhancement? Please describe.**
Fix ORA-01795 error when using oracle database if there are more than 1000 executions for a referenced job

**Describe the solution you've implemented**
The executions id list should be partitioned if there are more than 1000 ids to be included on the query. This issue happens only if using oracle database
