### PR TITLE
RUN-189: Upgrade pywinrm plugin. Excluded RD_EXEC_COMMAND from environment var…

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ rundeck:
   plugins: # Extra plugins to bundle
   - "com.github.Batix:rundeck-ansible-plugin:3.1.0"
   - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.6"
-  - "com.github.rundeck-plugins:py-winrm-plugin:2.0.12"
+  - "com.github.rundeck-plugins:py-winrm-plugin:2.0.13"
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.1"
   - "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.0.0"
   - "com.github.rundeck-plugins:attribute-match-node-enhancer:v0.1.5"


### PR DESCRIPTION
Issue:
#1869

PR:
rundeck-plugins/py-winrm-plugin#77

Bugfix description:
Excluded RD_EXEC_COMMAND from environment variables due to it presents an issue when the command is a special character like %.