### PR TITLE
RUN-190: Remove old release version arg from setversion.sh

### DIFF
--- a/setversion.sh
+++ b/setversion.sh
@@ -1,29 +1,19 @@
 #!/bin/bash
 
 CUR_VERSION="$(grep version.number= "$PWD/version.properties" | cut -d= -f 2)"
-CUR_RELEASE="$(grep version.release.number= "$PWD/version.properties" | cut -d= -f 2)"
 CUR_TAG="$(grep version.tag= "$PWD/version.properties" | cut -d= -f 2)"
 
 echo "current NUMBER: $CUR_VERSION"
-echo "current RELEASE: $CUR_RELEASE"
 echo "current TAG: $CUR_TAG"
 
 if [ -z "$1" ] ; then
-echo "usage: setversion.sh <version> [release] [GA]"
+echo "usage: setversion.sh <version> [GA]"
 exit 2
 fi
 
 VNUM="$1"
-
-shift
-if [ -z "$1" ]; then
-    RELEASE="$CUR_RELEASE"
-else
-    RELEASE="$1"
-fi
 shift
 VTAG="${1:-GA}"
-
 
 VDATE="$(date +%Y%m%d)"
 
@@ -34,13 +24,11 @@ else
 fi
 
 echo "new NUMBER: $VNUM"
-echo "new RELEASE: $RELEASE"
 echo "new DATE: $VDATE"
 echo "new VERSION: $VNAME"
 
 #alter version.properties
 perl  -i'.orig' -p -e "s#^version\\.number\\s*=.*\$#version.number=$VNUM#" "$PWD/version.properties"
-perl  -i'.orig' -p -e "s#^version\\.release\\.number\\s*=.*\$#version.release.number=$RELEASE#" "$PWD/version.properties"
 perl  -i'.orig' -p -e "s#^version\\.tag\\s*=.*\$#version.tag=$VTAG#" "$PWD/version.properties"
 perl  -i'.orig' -p -e "s#^version\\.date\\s*=.*\$#version.date=$VDATE#" "$PWD/version.properties"
 perl  -i'.orig' -p -e "s#^version\\.version\\s*=.*\$#version.version=$VNAME#" "$PWD/version.properties"
@@ -48,4 +36,3 @@ perl  -i'.orig' -p -e "s#^version\\.version\\s*=.*\$#version.version=$VNAME#" "$
 perl  -i'.orig' -p -e "s#^currentVersion\\s*=.*\$#currentVersion = $VNUM#" "$PWD"/gradle.properties
 
 echo MODIFIED: "$(pwd)"/version.properties
-


### PR DESCRIPTION
Checked in with @gschueler and it seems like we no longer need to use this old release number argument. I removed it, so as to simplify script usage.