### PR TITLE
RUN-262: Possibility to use redis to store sessions

### DIFF
--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -12,10 +12,24 @@ server.address={{ getv("/rundeck/server/address", "0.0.0.0") }}
 server.servlet.context-path={{ getv("/rundeck/server/contextpath", "/") }}
 grails.serverURL={{ getv("/rundeck/grails/url", "http://127.0.0.1:4440") }}
 rundeck.multiURL.enabled={{ getv("/rundeck/multiurl/enabled", "false") }}
+
+server.servlet.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
+
+# session cookie configuration
 rundeck.security.cookie.name={{ getv("/rundeck/security/cookie/name", "") }}
 rundeck.security.cookie.domainNamePattern={{ getv("/rundeck/security/cookie/domainnamepattern", "") }}
 
-server.servlet.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
+# memory or redis
+rundeck.session.storeType={{ getv("/rundeck/session/storetype", "") }}
+
+{% if getv("/rundeck/session/storetype", "") == "redis" %}
+# redis session configuration if rundeck.session.storeType is "redis"
+rundeck.session.redis.host={{ getv("/rundeck/session/redis/host", "") }}
+rundeck.session.redis.port={{ getv("/rundeck/session/redis/port", "") }}
+rundeck.session.redis.maxTotal={{ getv("/rundeck/session/redis/maxtotal", "100") }}
+rundeck.session.redis.maxIdle={{ getv("/rundeck/session/redis/maxidle", "100") }}
+rundeck.session.redis.minIdle={{ getv("/rundeck/session/redis/minidle", "10") }}
+{% endif %}
 
 {% if exists("/rundeck/database/create") %}
 dataSource.dbCreate = {{ getv("/rundeck/database/create", "") }}

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -13,7 +13,7 @@ server.servlet.context-path={{ getv("/rundeck/server/contextpath", "/") }}
 grails.serverURL={{ getv("/rundeck/grails/url", "http://127.0.0.1:4440") }}
 rundeck.multiURL.enabled={{ getv("/rundeck/multiurl/enabled", "false") }}
 rundeck.security.cookie.name={{ getv("/rundeck/security/cookie/name", "") }}
-rundeck.security.cookie.domainNamePattern={{ getv("/rundeck/security/cookie/domainNamePattern", "") }}
+rundeck.security.cookie.domainNamePattern={{ getv("/rundeck/security/cookie/domainnamepattern", "") }}
 
 server.servlet.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
 

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -26,6 +26,8 @@ rundeck.session.storeType={{ getv("/rundeck/session/storetype", "") }}
 # redis session configuration if rundeck.session.storeType is "redis"
 rundeck.session.redis.host={{ getv("/rundeck/session/redis/host", "") }}
 rundeck.session.redis.port={{ getv("/rundeck/session/redis/port", "") }}
+rundeck.session.redis.password={{ getv("/rundeck/session/redis/password", "") }}
+rundeck.session.redis.database={{ getv("/rundeck/session/redis/database", "") }}
 rundeck.session.redis.maxTotal={{ getv("/rundeck/session/redis/maxtotal", "100") }}
 rundeck.session.redis.maxIdle={{ getv("/rundeck/session/redis/maxidle", "100") }}
 rundeck.session.redis.minIdle={{ getv("/rundeck/session/redis/minidle", "10") }}

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -12,6 +12,8 @@ server.address={{ getv("/rundeck/server/address", "0.0.0.0") }}
 server.servlet.context-path={{ getv("/rundeck/server/contextpath", "/") }}
 grails.serverURL={{ getv("/rundeck/grails/url", "http://127.0.0.1:4440") }}
 rundeck.multiURL.enabled={{ getv("/rundeck/multiurl/enabled", "false") }}
+rundeck.security.cookie.name={{ getv("/rundeck/security/cookie/name", "") }}
+rundeck.security.cookie.domainNamePattern={{ getv("/rundeck/security/cookie/domainNamePattern", "") }}
 
 server.servlet.session.timeout={{ getv("/rundeck/server/session/timeout", "3600") }}
 

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -111,7 +111,8 @@ dependencies {
     compile "org.springframework.boot:spring-boot-autoconfigure"
     compile 'org.springframework.session:spring-session-core'
     compile 'org.springframework.session:spring-session-data-redis'
-    compile 'redis.clients:jedis'
+    compile 'io.lettuce:lettuce-core'
+    compile 'org.apache.commons:commons-pool2'
 
     compile "org.grails:grails-core"
     compile "org.springframework.boot:spring-boot-starter-actuator"
@@ -138,6 +139,10 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-core"
     compile "com.fasterxml.jackson.core:jackson-annotations"
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.5"
+
+    // redis xml de/serialization
+    compile 'com.thoughtworks.xstream:xstream:1.4.10'
+
     compile "org.eclipse.jetty:jetty-jaas"
     compile "org.eclipse.jetty:jetty-util"
     compile "org.eclipse.jetty:jetty-security"

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -110,6 +110,8 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-log4j2"
     compile "org.springframework.boot:spring-boot-autoconfigure"
     compile 'org.springframework.session:spring-session-core'
+    compile 'org.springframework.session:spring-session-data-redis'
+    compile 'redis.clients:jedis'
 
     compile "org.grails:grails-core"
     compile "org.springframework.boot:spring-boot-starter-actuator"

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -109,6 +109,7 @@ dependencies {
 
     compile "org.springframework.boot:spring-boot-starter-log4j2"
     compile "org.springframework.boot:spring-boot-autoconfigure"
+    compile 'org.springframework.session:spring-session-core'
 
     compile "org.grails:grails-core"
     compile "org.springframework.boot:spring-boot-starter-actuator"

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -50,6 +50,7 @@ import com.dtolabs.rundeck.core.storage.TreeStorageManager
 import com.dtolabs.rundeck.core.utils.GrailsServiceInjectorJobListener
 import com.dtolabs.rundeck.core.utils.RequestAwareLinkGenerator
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
+import com.dtolabs.rundeck.server.SynchronizerTokensHolderFilter
 import com.dtolabs.rundeck.server.plugins.PluginCustomizer
 import com.dtolabs.rundeck.server.plugins.RundeckEmbeddedPluginExtractor
 import com.dtolabs.rundeck.server.plugins.RundeckPluginRegistry
@@ -186,6 +187,9 @@ beans={
                 database = application.config.rundeck.session.redis.database.toString().toInteger()
             }
         }
+
+        // deals with withForm tokens
+        synchronizerTokensHolderFilter(SynchronizerTokensHolderFilter) { }
 
         def redisPoolConfig = new GenericObjectPoolConfig()
         redisPoolConfig.setMaxTotal(application.config.rundeck.session?.redis?.maxTotal?.toString()?.isInteger() ? application.config.rundeck.session.redis.maxTotal.toInteger() : 100)

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -152,13 +152,12 @@ beans={
 
     def defaultCookieSerializer = new DefaultCookieSerializer()
 
-    if (application.config.rundeck.security?.cookie?.domainNamePattern && !"".equals(application.config.rundeck.security.cookie.domainNamePattern)) {
-        defaultCookieSerializer.setDomainNamePattern(application.config.rundeck.security.cookie.domainNamePattern);
+    if (application.config.rundeck.security?.cookie?.domainNamePattern?.trim()) {
+        defaultCookieSerializer.setDomainNamePattern(application.config.rundeck.security.cookie.domainNamePattern.toString().trim());
     }
 
-    if (application.config.rundeck.security?.cookie?.name && !"".equals(application.config.rundeck.security.cookie.name)) {
-        defaultCookieSerializer.setCookieName(application.config.rundeck.security?.cookie?.name ? application.config.rundeck.security.cookie.name : "JSESSIONID")
-    }
+    def cookieName = application.config.rundeck.security?.cookie?.name?.trim() ?: "JSESSIONID"
+    defaultCookieSerializer.setCookieName(cookieName)
 
     def sessionFilter = new MapSessionRepository(new ConcurrentHashMap<>())
     def sessionIdResolver = new CookieHttpSessionIdResolver()

--- a/rundeckapp/grails-app/init/rundeckapp/Application.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/Application.groovy
@@ -6,21 +6,21 @@ import org.rundeck.app.bootstrap.PreBootstrap
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration
+import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.EnvironmentAware
 import org.springframework.core.env.Environment
 import org.springframework.core.env.MapPropertySource
 import org.springframework.core.env.PropertiesPropertySource
 import rundeckapp.init.ReloadableRundeckPropertySource
+import rundeckapp.init.RundeckDbMigration
 import rundeckapp.init.RundeckInitConfig
 import rundeckapp.init.RundeckInitializer
-import rundeckapp.init.RundeckDbMigration
-import rundeckapp.init.prebootstrap.InitializeRundeckPreboostrap
 
 import java.nio.file.Files
 import java.nio.file.Paths
 
-@EnableAutoConfiguration(exclude = [SecurityFilterAutoConfiguration])
+@EnableAutoConfiguration(exclude = [SecurityFilterAutoConfiguration, SessionAutoConfiguration])
 class Application extends GrailsAutoConfiguration implements EnvironmentAware {
     static final String SYS_PROP_RUNDECK_CONFIG_INITTED = "rundeck.config.initted"
     static RundeckInitConfig rundeckConfig = null

--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -220,6 +220,17 @@ class BootStrap {
 
                 if(!primaryServerId) log.warn("Running in cluster mode without rundeck.primaryServerId set. Please set rundeck.primaryServerId to the UUID of the primary server in the cluster")
             }
+
+            if (grailsApplication.config.rundeck.session?.storeType in ['redis']) {
+                def redisHost = grailsApplication.config.rundeck.session?.redis?.host?.trim()
+                def redisPort = grailsApplication.config.rundeck.session?.redis?.port?.isInteger() ? grailsApplication.config.rundeck.session.redis.port.toInteger() : 6379
+                if (!redisHost) {
+                    log.warn("Redis session not enabled. Please set rundeck.session.redis.host.")
+                } else {
+                    log.warn("Redis session enabled: ${redisHost}:${redisPort}")
+                }
+            }
+
             //auth tokens stored in file
             def tokensfile = properties.getProperty("rundeck.tokens.file")
             if (tokensfile) {

--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -227,7 +227,9 @@ class BootStrap {
                 if (!redisHost) {
                     log.warn("Redis session not enabled. Please set rundeck.session.redis.host.")
                 } else {
-                    log.warn("Redis session enabled: ${redisHost}:${redisPort}")
+                    def redisPassword = grailsApplication.config.rundeck.session?.redis?.password ? "yes" : "no"
+                    def redisDatabase = grailsApplication.config.rundeck.session?.redis?.database ?: "0"
+                    log.warn("Redis session enabled: ${redisHost}:${redisPort} - using password: ${redisPassword} - database: ${redisDatabase}")
                 }
             }
 

--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -222,8 +222,8 @@ class BootStrap {
             }
 
             if (grailsApplication.config.rundeck.session?.storeType in ['redis']) {
-                def redisHost = grailsApplication.config.rundeck.session?.redis?.host?.trim()
-                def redisPort = grailsApplication.config.rundeck.session?.redis?.port?.isInteger() ? grailsApplication.config.rundeck.session.redis.port.toInteger() : 6379
+                def redisHost = grailsApplication.config.rundeck.session?.redis?.host?.toString()?.trim()
+                def redisPort = grailsApplication.config.rundeck.session?.redis?.port?.toString()?.isInteger() ? grailsApplication.config.rundeck.session.redis.port.toInteger() : 6379
                 if (!redisHost) {
                     log.warn("Redis session not enabled. Please set rundeck.session.redis.host.")
                 } else {

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/SynchronizerTokensHolderFilter.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/SynchronizerTokensHolderFilter.groovy
@@ -1,0 +1,59 @@
+package com.dtolabs.rundeck.server
+
+import grails.web.mvc.FlashScope
+import org.grails.web.util.GrailsApplicationAttributes
+import org.springframework.web.filter.OncePerRequestFilter
+
+import javax.servlet.FilterChain
+import javax.servlet.ServletException
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import javax.servlet.http.HttpSession
+
+class SynchronizerTokensHolderFilter extends OncePerRequestFilter {
+    private final String SYNCHRONIZER_TOKENS_HOLDER = "SYNCHRONIZER_TOKENS_HOLDER"
+
+    @Override
+    void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain)
+            throws IOException, ServletException {
+        def isFlashScopeEmpty = true;
+        def isFlashScopeNull = false;
+
+        HttpSession session = request.getSession(false);
+
+        if (session != null) {
+            FlashScope flashScope = getFlashScope(session);
+            if (flashScope != null) {
+                isFlashScopeEmpty = flashScope.isEmpty();
+            } else {
+                isFlashScopeNull = true;
+            }
+        }
+
+        chain.doFilter(request, response);
+
+        if (session == null) return;
+
+        FlashScope flashScope = getFlashScope(session);
+        if ((flashScope != null && (isFlashScopeNull || !isFlashScopeEmpty || !flashScope.isEmpty())) || (flashScope == null && !isFlashScopeNull)) {
+            session.setAttribute(GrailsApplicationAttributes.FLASH_SCOPE, flashScope);
+        }
+
+        updateSessionVariable(session, SYNCHRONIZER_TOKENS_HOLDER);
+    }
+
+    FlashScope getFlashScope(HttpSession session) {
+        if (session != null) {
+            Object flashScope = session.getAttribute(GrailsApplicationAttributes.FLASH_SCOPE);
+            if (flashScope instanceof FlashScope) {
+                return (FlashScope) flashScope;
+            }
+        }
+        return null;
+    }
+
+    void updateSessionVariable(HttpSession session, String attributeName) {
+        Object attributeValue = session.getAttribute(attributeName);
+        session.setAttribute(attributeName, attributeValue);
+    }
+}


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
It's an enhancement. While working on #7166 I realized that distributed sessions can be a useful feature to the community.

**Describe the solution you've implemented**
This implementation introduces 8 new options:

- rundeck.session.storeType - at this moment, only `redis` will change session storage behavior.
- rundeck.session.redis.host - redis host. If not specified, a warning will be logged (`Redis session not enabled. Please set rundeck.session.redis.host.`) and store type goes to default (memory).
- rundeck.session.redis.port - redis port. Default: 6379
- rundeck.session.redis.password - redis password.
- rundeck.session.redis.database - redis database. Default: 0
- rundeck.session.redis.maxTotal - redis pool max total connections. Default: 100
- rundeck.session.redis.maxIdle - redis pool max idle connections. Default: 100
- rundeck.session.redis.minIdle - redis pool min idle connections. Default: 10

**Describe alternatives you've considered**
No other solutions.

**Additional context**
