### PR TITLE
RUN-165: Fix issue when scheduled jobs runs twice in a cluster

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -690,12 +690,12 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
      * @param forceLocal true to reschedule locally always
      * @return
      */
-    def rescheduleJob(ScheduledExecution scheduledExecution, wasScheduled, oldJobName, oldJobGroup, boolean forceLocal) {
+    def rescheduleJob(ScheduledExecution scheduledExecution, wasScheduled, oldJobName, oldJobGroup, boolean forceLocal, boolean remoteAssigned = false) {
         if (jobSchedulesService.shouldScheduleExecution(scheduledExecution.uuid) && shouldScheduleInThisProject(scheduledExecution.project)) {
             def nextdate = null
             def nextExecNode = null
             try {
-                (nextdate, nextExecNode) = scheduleJob(scheduledExecution, oldJobName, oldJobGroup, forceLocal);
+                (nextdate, nextExecNode) = scheduleJob(scheduledExecution, oldJobName, oldJobGroup, forceLocal, remoteAssigned)
             } catch (SchedulerException e) {
                 log.error("Unable to schedule job: ${scheduledExecution.extid}: ${e.message}")
             }
@@ -1114,7 +1114,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 AuthConstants.ACTION_RUN,se.project)
     }
 
-    def scheduleJob(ScheduledExecution se, String oldJobName, String oldGroupName, boolean forceLocal=false) {
+    def scheduleJob(ScheduledExecution se, String oldJobName, String oldGroupName, boolean forceLocal=false, boolean remoteAssigned = false) {
         def jobid = "${se.generateFullName()} [${se.extid}]"
         def jobDesc = "Attempt to schedule job $jobid in project $se.project"
         if (!executionService.executionsAreActive) {
@@ -1135,10 +1135,10 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
 
         def data=["project": se.project,
-                  "jobId":se.uuid]
+                  "jobId":se.uuid, "oldServerNodeUUID": se.serverNodeUUID]
 
         if(!forceLocal){
-            boolean remoteAssign = jobSchedulerService.scheduleRemoteJob(data)
+            boolean remoteAssign = remoteAssigned ?: jobSchedulerService.scheduleRemoteJob(data)
 
             if(remoteAssign){
                 return [null, null]
@@ -3352,7 +3352,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
 
 
-
+        def modify = true
         if(frameworkService.isClusterModeEnabled()){
 
             if (oldjob.originalCron != scheduledExecution.generateCrontabExression() ||
@@ -3362,7 +3362,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 oldjob.oldsched != scheduledExecution.scheduled ||
                 renamed
             ) {
-                def modify = jobSchedulerService.updateScheduleOwner(scheduledExecution.asReference())
+                modify = jobSchedulerService.updateScheduleOwner(scheduledExecution.asReference())
                 if (modify) {
                     scheduledExecution.serverNodeUUID = frameworkService.serverUUID
                 }
@@ -3425,7 +3425,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             oldjob.oldsched,
             renamed ? oldjob.oldjobname : scheduledExecution.generateJobScheduledName(),
             renamed ? oldjob.oldjobgroup : scheduledExecution.generateJobGroupName(),
-            false
+            false, !modify
         )
 
         def eventType=JobChangeEvent.JobChangeEventType.MODIFY

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -2480,14 +2480,15 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
 
         def oldJob = new OldJob(
-                oldjobname: scheduledExecution.generateJobScheduledName(),
-                oldjobgroup: scheduledExecution.generateJobGroupName(),
-                oldsched: jobSchedulesService.isScheduled(scheduledExecution.uuid),
-                originalCron: scheduledExecution.generateCrontabExression(),
-                originalSchedule: scheduledExecution.scheduleEnabled,
-                originalExecution: scheduledExecution.executionEnabled,
-                originalTz: scheduledExecution.timeZone,
-                originalRef: jobEventRevRef(scheduledExecution)
+            oldjobname: scheduledExecution.generateJobScheduledName(),
+            oldjobgroup: scheduledExecution.generateJobGroupName(),
+            isScheduled: jobSchedulesService.isScheduled(scheduledExecution.uuid),
+            localScheduled: scheduledExecution.scheduled,
+            originalCron: scheduledExecution.generateCrontabExression(),
+            originalSchedule: scheduledExecution.scheduleEnabled,
+            originalExecution: scheduledExecution.executionEnabled,
+            originalTz: scheduledExecution.timeZone,
+            originalRef: jobEventRevRef(scheduledExecution)
         )
         ImportedJob<ScheduledExecution> importedJob2 = updateJobDefinition(importedJob, params, authContext, scheduledExecution)
 
@@ -3359,7 +3360,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 oldjob.originalSchedule != scheduledExecution.scheduleEnabled ||
                 oldjob.originalExecution != scheduledExecution.executionEnabled ||
                 oldjob.originalTz != scheduledExecution.timeZone ||
-                oldjob.oldsched != scheduledExecution.scheduled ||
+                oldjob.localScheduled != scheduledExecution.scheduled ||
                 renamed
             ) {
                 modify = jobSchedulerService.updateScheduleOwner(scheduledExecution.asReference())
@@ -3422,7 +3423,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
         rescheduleJob(
             scheduledExecution,
-            oldjob.oldsched,
+            oldjob.isScheduled,
             renamed ? oldjob.oldjobname : scheduledExecution.generateJobScheduledName(),
             renamed ? oldjob.oldjobgroup : scheduledExecution.generateJobGroupName(),
             false, !modify
@@ -4476,7 +4477,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 class OldJob{
     String oldjobname
     String oldjobgroup
-    Boolean oldsched
+    Boolean isScheduled
+    Boolean localScheduled
     String originalCron
     Boolean originalSchedule
     Boolean originalExecution

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -244,20 +244,22 @@ class ScheduledExecutionServiceSpec extends HibernateSpec implements ServiceUnit
                         userRoleList: 'a,b'
                 )
         ).save()
-        def scheduleDate = new Date()
+//        def scheduleDate = new Date()
 
         when:
-        def result = service.scheduleJob(job, null, null)
+        def result = service.scheduleJob(job, null, null, false, remoteAssgined)
 
         then:
         1 * service.executionServiceBean.getExecutionsAreActive() >> executionsAreActive
-        1 * service.jobSchedulesService.handleScheduleDefinitions(_, _) >> [nextTime: scheduleDate]
+        (remoteAssgined ? 0 : 1) * service.jobSchedulesService.handleScheduleDefinitions(_, _) >> [nextTime: scheduleDate]
         result == [scheduleDate, serverNodeUUID]
 
         where:
-        executionsAreActive | scheduleEnabled | executionEnabled | hasSchedule | expectScheduled | clusterEnabled | serverNodeUUID
-        true                | true            | true             | true        | true            | false          | null
-        true                | true            | true             | true        | true            | true           | 'uuid'
+        executionsAreActive | scheduleEnabled | executionEnabled | hasSchedule | expectScheduled | clusterEnabled | serverNodeUUID | remoteAssgined | scheduleDate
+        true                | true            | true             | true        | true            | false          | null           | false          | new Date()
+        true                | true            | true             | true        | true            | true           | 'uuid'         | false          | new Date()
+        true                | true            | true             | true        | true            | false          | null           | true           | null
+        true                | true            | true             | true        | true            | true           | null           | true           | null
     }
 
     @Unroll


### PR DESCRIPTION
fixes https://github.com/rundeckpro/rundeckpro/issues/1678

**Is this a bugfix, or an enhancement? Please describe.**
When a job is edited using the instance of the cluster that does not own the job and this instance becomes the owner after editing, the takeout message is sent to itself, then the owner never removes it from the schedule in quartz. 

Also, after a job is edited and saved, the remote execution node is assigned twice and then, two takeout messages are sent.

Another problem found was that, when unassigning the job from a schedule, the schedule was not being removed because scheduling at the project level does not change the `scheduled` attribute of ScheduledExecution to `true`. Therefore, if another instance of the cluster unassignee the job, the instance that owns it will not know that this job was previously scheduled and does not delete the scheduling in quartz.

**Describe the solution you've implemented**
The job will assign the remote node only once after being edited and then a new attribute has been added to the message to inform who was the last owner of the job. Thus, all instances that are not the destination of the takeout message will check if it should remove any quartz triggers and remove the message if it was the last owner.

The case when unassigning the job from a schedule was fixed checking if the local instance has any trigger scheduled for itself in addition to checking if the `scheduled` attribute in ScheduledExecution was `true` previously

**Additional context**
PR related: https://github.com/rundeckpro/rundeckpro/pull/1919
