### PR TITLE
RUN-285: Fix navbar overflow during zoom

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/navbar/NavBar.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/navbar/NavBar.vue
@@ -64,16 +64,17 @@ export default class NavigationBar extends Vue {
 
         const mainGroup = this.$refs['group-main'] as HTMLElement
 
-        if (el.offsetHeight != el.scrollHeight) {
+        if (el.offsetHeight - el.scrollHeight < 0) {
             this.navBar.overflowOne()
-            /** 
+            /**
              * Continue to force layout until no longer overflowing.
              * This provides for the least amount of flicker on page load.
              **/
             this.$forceUpdate()
-            this.overflow()
-        } else if (mainGroup.offsetTop + mainGroup.offsetHeight + 230 < el.offsetHeight) {
+            window.requestAnimationFrame(this.overflow)
+        } else if (mainGroup.offsetTop + mainGroup.offsetHeight + 240 < el.offsetHeight) {
             this.navBar.showOne()
+            window.requestAnimationFrame(this.overflow)
         }
     }
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/navbar/NavBar.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/navbar/NavBar.vue
@@ -64,6 +64,11 @@ export default class NavigationBar extends Vue {
 
         const mainGroup = this.$refs['group-main'] as HTMLElement
 
+        /**
+         * Check for overflow. At different zoom levels this could be off by one in the positive
+         * even though no overflow is occuring. Testing indicates checking for negative difference
+         * works at all zoom levels.
+         */
         if (el.offsetHeight - el.scrollHeight < 0) {
             this.navBar.overflowOne()
             /**


### PR DESCRIPTION
Fixes #7188 

At various zoom levels `offsetHeight` and `scrollHeight` on the Nav Bar would be off by one in the positive even though no overflow was occurring. This would cause the overflow logic to place all items in the overflow container.

* The overflow check has been changed to look at the difference between the two and react if it becomes negative. In testing this appears to work at all zoom levels.

When removing an item from the overflow container no further overflow checks were made. In various circumstances this could cause one to be moved and no more even though there was more room for them.

* After moving an item out of the overflow container the overflow check is scheduled again on the next animation frame

## Testing

The NavBar story in Storybook can be used reproduce this and check the fix.

* Start up UI Trellis Storybook `npm run storybook`
* Go to the NavBar story and hit the button in the upper-right to open it in its own tab(without the Storybook UI)
* Give the browser a good vertical size and start messing with the zoom level (ctrl+mousewheel)

In `main` it should be possible to get the items "stuck" per #7188. With this branch I was not able to reproduce the error.