### PR TITLE
RUN-288: Fix copybox to work if connection is insecure

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/containers/copybox/CopyBox.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/containers/copybox/CopyBox.vue
@@ -14,6 +14,8 @@
 <script lang="ts">
 import Vue, { VNode } from 'vue'
 
+import {CopyToClipboard} from '../../../utilities/Clipboard'
+
 export default Vue.extend({
     name: 'rd-copybox',
     props: {
@@ -26,7 +28,7 @@ export default Vue.extend({
         title() {
             return this.content
         },
-        handleClick() {
+        async handleClick() {
             const content = (<HTMLElement>this.$refs['content'])
 
             const range = document.createRange()
@@ -35,7 +37,7 @@ export default Vue.extend({
             const sel = window.getSelection()
             sel?.removeAllRanges()
 
-            navigator.clipboard.writeText(this.content)
+            await CopyToClipboard(this.content)
             this.active = true
             setTimeout(() => this.active = false, 400)
             setTimeout(() => {sel?.addRange(range)}, 700)

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/inputs/Switch.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/inputs/Switch.vue
@@ -17,7 +17,7 @@
             v-model="value"
             v-on:input="$emit('input', $event.target.value)"
             type="checkbox"
-            style="height: 0;width: 0;"/>
+            style="height: 0;width: 0;appearance: none;"/>
         <span 
             class="switch__slider"
             :class="{'switch__slider--checked': value}"/>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/utilities/Clipboard.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/utilities/Clipboard.ts
@@ -1,0 +1,25 @@
+
+/**
+ * Copies supplied text to clipboard. Falls back on text area
+ * if navitagor clipboard or writeText is missing. This can
+ * occur if the host is not local and/or is not secure(https).
+ */
+export async function CopyToClipboard(text: string) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(text)
+    } else {
+        let textArea = document.createElement("textarea")
+        textArea.value = text
+        // make the textarea out of viewport
+        textArea.style.position = "fixed"
+        textArea.style.left = "-999999px"
+        textArea.style.top = "-999999px"
+        document.body.appendChild(textArea)
+        textArea.focus()
+        textArea.select()
+        return new Promise((res, rej) => {
+            document.execCommand('copy') ? res(void(0)) : rej();
+            textArea.remove();
+        });
+    }
+}


### PR DESCRIPTION
Fixes #7195

[RUN-288]

If the connection is insecure(not https) and not local in FireFox the navigator clipboard will not be present or `writeText` will not be present.

* Moves copying to clipboard to a utility method and adds a fallback method.

In FireFox the OS style for the checkbox input in our Switch component is still rendered on screen.

* Adds `appearance: none;` to hide the OS styles.

## Testing

Storybook in UI Trellis can be used to verify both fixes:

* Containers -> Copy Box
Access Storybook via a host other than `localhost` over an insecure connection.

* Inputs -> Switch
View with FireFox.

[RUN-288]: https://pagerduty.atlassian.net/browse/RUN-288