### PR TITLE
RUN-260: Fix/issue 1899 Wrong value after changing option type

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/optionEditKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/optionEditKO.js
@@ -20,6 +20,10 @@
 
 function OptionEditor(data) {
     var self = this;
+    self.valuesList = ko.observable(data.valuesList);
+    self.valuesUrl = ko.observable(data.valuesUrl);
+    self.showDefaultValue = ko.observable(data.showDefaultValue);
+    self.defaultValue = ko.observable(data.defaultValue);
     self.optionType = ko.observable(data.optionType);
     self.name=ko.observable(data.name);
     self.bashVarPrefix= data.bashVarPrefix? data.bashVarPrefix:'';
@@ -51,5 +55,22 @@ function OptionEditor(data) {
 
     self.isRegexEnforceType = ko.computed(function () {
         return self.enforceType() === "regex";
+    });
+    self.clearDefaultValue = function(showDefaultValueInput){
+        self.defaultValue('');
+        self.valuesList('');
+        self.valuesUrl('');
+        self.enforceType('none');
+        self.showDefaultValue(showDefaultValueInput);
+        return true;
+    };
+    self.shouldShowDefaultValue = ko.computed(function(){
+        return JSON.parse(self.showDefaultValue());
+    });
+    self.shouldShowDefaultStorage = ko.computed(function(){
+        return !JSON.parse(self.showDefaultValue());
+    });
+    self.isNonSecure = ko.computed(function(){
+        return JSON.parse(self.showDefaultValue());
     });
 }

--- a/rundeckapp/grails-app/assets/javascripts/optionEditKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/optionEditKO.js
@@ -25,9 +25,10 @@ function OptionEditor(data) {
     self.showDefaultValue = ko.observable(data.showDefaultValue);
     self.defaultValue = ko.observable(data.defaultValue);
     self.optionType = ko.observable(data.optionType);
-    self.name=ko.observable(data.name);
+    self.name = ko.observable(data.name);
     self.bashVarPrefix= data.bashVarPrefix? data.bashVarPrefix:'';
     self.enforceType = ko.observable(data.enforceType);
+    self.originalIsNonSecure = data.showDefaultValue;
     self.tofilebashvar = function (str) {
         return self.bashVarPrefix + "FILE_" + str.toUpperCase().replace(/[^a-zA-Z0-9_]/g, '_').replace(/[{}$]/, '');
     };
@@ -72,5 +73,8 @@ function OptionEditor(data) {
     });
     self.isNonSecure = ko.computed(function(){
         return JSON.parse(self.showDefaultValue());
+    });
+    var subscription = this.optionType.subscribe(function(newValue) {
+        self.showDefaultValue(self.originalIsNonSecure);
     });
 }

--- a/test/selenium/src/pages/jobCreate.page.ts
+++ b/test/selenium/src/pages/jobCreate.page.ts
@@ -26,7 +26,7 @@ export const Elems= {
     option0UsageSession: By.css('#optvis_0 > div.optEditForm > div > section.section-separator-solo'),
     option0Type: By.xpath('//*[starts-with(@id,"sectrue")]'),
     option0KeySelector: By.xpath('//*[starts-with(@id,"defaultStoragePath")]'),
-    option0OpenKeyStorage: By.xpath('//*[starts-with(@id,"optedit")]/div[7]/div/div/span[2]/a'),
+    option0OpenKeyStorage: By.css('.btn.btn-default.obs-select-storage-path'),
     option0li: By.css('#optli_0'),
 
     storagebrowse: By.xpath('//*[starts-with(@id,"storagebrowse")]'),


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/1899


- [x] When changing from plain text to secure and back, it will now use the right value for the selected option 
- [x] When changing option from text to file and back, now the form does show the accordingly to the option type selected
- [x] Allowed values list is not shown when the option is secure (is it was before, when the option was saved)