### PR TITLE
enable project node.install property usage for vendorAssetDeps

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -360,6 +360,11 @@ task copySpa(type: Copy) {
 assetPluginPackage.dependsOn copySpa
 assetCompile.dependsOn copySpa
 
+node{
+    download = project.hasProperty('node.install')
+    version = project.hasProperty('node.install') ? project.getProperty('node.install') : null
+}
+
 task vendorAssetDeps(type: NpmTask) { it ->
     def baseDir = "${projectDir}/grails-app/assets/javascripts"
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Enables the `node.install=12.16.3` project property to properly install node when building 
