### PR TITLE
Job tags not copied when duplicating job 

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -1786,6 +1786,8 @@ class ScheduledExecutionController  extends ControllerBase{
             EditOptsController.getSessionOptions(session,null,editopts)
         }
         def model = scheduledExecutionService.prepareCreateEditJob(params, newScheduledExecution , AuthConstants.ACTION_CREATE, authContext)
+        def jobComponentValues=rundeckJobDefinitionManager.getJobDefinitionComponentValues(scheduledExecution)
+        model["jobComponentValues"] = jobComponentValues
         model["iscopy"] = true
 
         render(


### PR DESCRIPTION
Retrieve JobComponent values when copying job and add it to the model. fix rundeckpro/rundeckpro#1764 fix run-260

**Is this a bugfix, or an enhancement? Please describe.**
bugfix.  Copy Job did not copy values for JobComponents.  
**Describe the solution you've implemented**
In the copy method, Job Component Values are retrieved from job being copied from and set in model returned to view
**Describe alternatives you've considered**
N/A
**Additional context**
Add any other context or screenshots about the change here.
