### PR TITLE
RUN 199: Allow including Variables or Options ( keys ) as part of the  Remote URL entry

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -760,7 +760,7 @@ class ScheduledExecutionController  extends ControllerBase{
         if (scheduledExecution.options && scheduledExecution.options.find {it.name == params.option}) {
             Option opt = scheduledExecution.options.find {it.name == params.option}
             if (opt.realValuesUrl) {
-                Map optionRemoteValues = scheduledExecutionService.loadOptionsRemoteValues(scheduledExecution, params, session.user)
+                Map optionRemoteValues = scheduledExecutionService.loadOptionsRemoteValues(scheduledExecution, params, session.user, authContext)
                 def model = [optionSelect : optionRemoteValues.optionSelect,
                              values       : optionRemoteValues.values,
                              srcUrl       : optionRemoteValues.srcUrl,

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2584,7 +2584,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             def defaultoptions=[:]
             options.each {Option opt ->
                 if(null==optparams[opt.name] && opt.enforced && !opt.optionValues){
-                    Map remoteOptions = scheduledExecutionService.loadOptionsRemoteValues(scheduledExecution, [option: opt.name, extra: [option: optparams]], authContext?.username)
+                    Map remoteOptions = scheduledExecutionService.loadOptionsRemoteValues(scheduledExecution, [option: opt.name, extra: [option: optparams]], authContext?.username, authContext)
                     if(!remoteOptions.err && remoteOptions.values){
                         Map selectedOption = remoteOptions.values.find {it instanceof Map && [true, 'true'].contains(it.selected)}
                         if(selectedOption){
@@ -2727,7 +2727,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 }
                 if(opt.enforced && !(opt.optionValues || opt.optionValuesPluginType)){
                     Map remoteOptions = scheduledExecutionService.loadOptionsRemoteValues(scheduledExecution,
-                            [option: opt.name, extra: [option: optparams]], authContext?.username)
+                            [option: opt.name, extra: [option: optparams]], authContext?.username, authContext)
                     if(!remoteOptions.err && remoteOptions.values){
                         opt.optionValues = remoteOptions.values.collect { optValue ->
                             if (optValue instanceof Map) {

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3850,7 +3850,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
      */
     void fillSecureOptionsWithStorage(ScheduledExecution scheduledExecution, Map mapConfig, def authContext){
         if(authContext){
-            def emptyValueOptions = mapConfig?.extra?.option?.findAll{it.value.isEmpty()}
+            def emptyValueOptions = mapConfig?.extra?.option?.findAll{it.value == null || it.value?.isEmpty()}
             if(emptyValueOptions){
                 def keystore = storageService.storageTreeWithContext(authContext)
                 emptyValueOptions.each{

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -1579,7 +1579,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         service.validateOptionValues(se, opts)
 
         then:
-        1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_) >> {
+        1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_,_) >> {
             [
                     optionSelect : opt,
                     values       : remoteValues,
@@ -1611,7 +1611,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         service.validateOptionValues(se, opts)
 
         then:
-        1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_) >> {
+        1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_,_) >> {
             [
                     optionSelect : opt,
                     values       : remoteValues,
@@ -1652,7 +1652,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         Option opt = new Option(name: 'test1', enforced: true, defaultValue: defaultValue, optionValues: null)
         se.addToOptions(opt)
         service.scheduledExecutionService = Mock(ScheduledExecutionService)
-        service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_) >> {
+        service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_,_) >> {
             [
                     optionSelect : opt,
                     values       : remoteValues,
@@ -1911,7 +1911,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         def validation = service.validateOptionValues(se, opts)
 
         then:
-        1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_) >> {
+        1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_,_) >> {
             [
                     optionSelect : option,
                     values       : [],
@@ -3114,7 +3114,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         when:
         def res = service.runJobRefExecutionItem(origContext,item,createFailure,createSuccess)
         then:
-        1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_) >> {
+        1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,_,_) >> {
             [
                     optionSelect : opt,
                     values       : ["A", "B", "C"],
@@ -5548,7 +5548,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
         then:
         1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,
-                ['option':'test1', 'extra':['option':['test1':'Foo']]],_) >> {
+                ['option':'test1', 'extra':['option':['test1':'Foo']]],_,_) >> {
             [
                     optionSelect : opt,
                     values       : remoteValues,
@@ -5693,8 +5693,8 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         HashMap optparams = service.parseJobOptionInput([:], se, admin)
 
         then:
-            1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,'Admin') >> [:]
-            0 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_, null) >> [:]
+            1 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_,'Admin',_) >> [:]
+            0 * service.scheduledExecutionService.loadOptionsRemoteValues(_,_, null,_) >> [:]
     }
 
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -5190,6 +5190,7 @@ class ScheduledExecutionServiceSpec extends HibernateSpec implements ServiceUnit
         true    | 'optionValue'      | 'optionValue'
         false   | ''                 | ''
         false   | 'optionValue'      | 'optionValue'
+        true    | null               | 'keyStorageValue'
     }
 }
 


### PR DESCRIPTION
Related to ER https://github.com/rundeckpro/rundeckpro/issues/1836

Option url can now reference a secure option with default storage path.
It only replaced the value when the option value is empty

EG:
<option name='var' secure='true' storagePath='keys/TEST_URL' valueExposed='true' />
<option enforcedvalues='true' name='OPT1' required='true' value='ip' values='dummy1,dummy2,ip' valuesListDelimiter=',' />
<option enforcedvalues='true' name='OPT2' required='true' valuesUrl='http://${option.var.value}/${option.OPT1.value}' />

url to get the values from would be:
http://{VALUE_FROM_STORAGE_PATH}/ip