### PR TITLE
Allow to customize rundeck.gui.startpage when using Docker image

### DIFF
--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -61,7 +61,7 @@ rundeck.api.tokens.duration.max={{ getv("/rundeck/api/tokens/duration/max", "30d
 
 rundeck.log4j.config.file={{ rundeckHome }}/server/config/log4j.properties
 
-rundeck.gui.startpage=projectHome
+rundeck.gui.startpage={{ getv("/rundeck/gui/startpage", "projectHome") }}
 
 rundeck.clusterMode.enabled=true
 


### PR DESCRIPTION
In Docker image `rundeck.gui.startpage` configuration option is hardcoded to `projectHome`. This PR allows to modify it using environment variables, identically to all the other options.