### PR TITLE
Add plugin security feature check to installPlugin endpoint

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
@@ -485,9 +485,16 @@ class PluginController extends ControllerBase {
     }
 
     def installPlugin() {
+
         if(!requireAjaxFormToken()){
             return
         }
+
+        if(featureService.featurePresent(Features.PLUGIN_SECURITY)){
+            renderErrorCodeAsJson("plugin.error.unauthorized.upload")
+            return
+        }
+
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         boolean authorized = rundeckAuthContextProcessor.authorizeApplicationResourceType(authContext,
                                                                                "system",

--- a/rundeckapp/src/test/groovy/rundeck/controllers/PluginControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/PluginControllerSpec.groovy
@@ -605,12 +605,15 @@ class PluginControllerSpec extends Specification implements ControllerUnitTest<P
     void "pluginSecurity install plugin fails"() {
         setup:
         controller.frameworkService = Mock(FrameworkService)
+        controller.apiService=Mock(ApiService)
         controller.featureService = Mock(FeatureService)
 
         controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor)
         messageSource.addMessage("plugin.error.unauthorized.upload",Locale.ENGLISH,"Plugin Security Enabled")
 
         when:
+        request.method='POST'
+        setupFormTokens(params)
         def pluginUrl = Thread.currentThread().getContextClassLoader().getResource(PLUGIN_FILE)
         params.pluginUrl = pluginUrl.toString()
         controller.installPlugin()


### PR DESCRIPTION
Updated the PluginController.installPlugin() action to fail and return an error if the feature flag is enabled