### PR TITLE
RUN-310 Fixing modal to save node filter when editing/creating a job. Adding config property to define max number of matched nodes.

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/framework/adhoc.js
+++ b/rundeckapp/grails-app/assets/javascripts/framework/adhoc.js
@@ -280,7 +280,7 @@ function init() {
         jQuery.extend(filterParams, {
             nodeSummary:nodeSummary,
             view: 'embed',
-            maxShown: 50,
+            maxShown: filterParams.matchedNodesMaxCount,
             emptyMode: 'blank',
             project: pageParams.project,
             nodesTitleSingular: message('Node'),

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -306,7 +306,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         if (usedFilter) {
             model['filterName'] = usedFilter
         }
-        return model + [runCommand: runCommand, emptyQuery: query.nodeFilterIsEmpty()]
+        return model + [runCommand: runCommand, emptyQuery: query.nodeFilterIsEmpty(), matchedNodesMaxCount: scheduledExecutionService.getMatchedNodesMaxCount()]
     }
 
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -239,6 +239,10 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         grailsApplication.config.rundeck.gui.paginatejobs.enabled in ["true",true]
     }
 
+    def getMatchedNodesMaxCount() {
+        !grailsApplication.config.rundeck.gui.matchedNodesMaxCount?.isEmpty() ? grailsApplication.config.rundeck.gui.matchedNodesMaxCount?.toInteger() : null
+    }
+
     def getConfiguredMaxPerPage(int defaultMax) {
         if(paginationEnabled) {
             return grailsApplication.config.rundeck.gui.paginatejobs.max.per.page.isEmpty() ? defaultMax : grailsApplication.config.rundeck.gui.paginatejobs.max.per.page.toInteger()
@@ -4445,6 +4449,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                      orchestratorPlugins         : orchestratorPlugins,
                      strategyPlugins             : strategyPlugins,
                      params                      : params,
+                     matchedNodesMaxCount        : getMatchedNodesMaxCount(),
                      nodeStepDescriptions        : nodeStepTypes,
                      stepDescriptions            : stepTypes,
                      timeZones                   : timeZones,

--- a/rundeckapp/grails-app/views/common/_js.gsp
+++ b/rundeckapp/grails-app/views/common/_js.gsp
@@ -46,6 +46,7 @@
         frameworkAdhoc: "${createLink(controller:"framework",action:"adhoc",params:projParams)}",
         frameworkReloadNodes: "${createLink(controller:"framework",action:"reloadNodes",params:projParams)}",
         frameworkNodeSummaryAjax: "${createLink(controller:"framework",action:"nodeSummaryAjax",params:projParams)}",
+        frameworkStoreFilterAjax: "${createLink(controller:"framework",action:"storeNodeFilter",params:projParams)}",
         frameworkDeleteNodeFilterAjax: "${createLink(controller:"framework",action:"deleteNodeFilterAjax",params:projParams)}",
         frameworkCreateProject: "${createLink(controller:"framework",action:"createProject")}",
         authProjectsToCreateAjax: "${g.createLink(controller: 'menu', action: 'authProjectsToCreateAjax',params:projParams)}",

--- a/rundeckapp/grails-app/views/common/_queryFilterManagerModal.gsp
+++ b/rundeckapp/grails-app/views/common/_queryFilterManagerModal.gsp
@@ -128,7 +128,7 @@
     </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
 
-
+<g:jsonToken id="ajaxSaveFilterTokens" />
 <div class="modal fade" id="saveFilterModal" role="dialog" aria-labelledby="saveFilterModalLabel" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
@@ -163,7 +163,37 @@
                 <g:elseif test="${storeActionSubmitRemote}">
                     <g:submitToRemote value="Save Filter" url="${storeActionSubmitRemote}" update="${update}" class="btn btn-primary"/>
                 </g:elseif>
+                <g:elseif test="${storeActionSubmitAjax}">
+                    <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="_saveFiltersAjax()">Save Filter</button>
+                </g:elseif>
             </div>
         </div><!-- /.modal-content -->
     </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
+
+<script type="text/javascript">
+    //<!CDATA[
+    function _saveFiltersAjax(){
+        var tokendataid = 'ajaxSaveFilterTokens';
+        var filterName = jQuery('input[name=newFilterName]').val()
+        var filter = nodeFilter.filter()
+
+        jQuery.ajax({
+            url:_genUrl(appLinks.frameworkStoreFilterAjax, {newFilterName:filterName, filter: filter}),
+            type:'POST',
+            beforeSend: _createAjaxSendTokensHandler(tokendataid),
+            error: function (jqxhr, status, err) {
+                if (jqxhr.responseJSON && jqxhr.responseJSON.message) {
+                    self.error(jqxhr.responseJSON.message)
+                } else if (jqxhr.status === 403) {
+                    self.error('Not authorized')
+                }
+            },
+            success: function(data){
+                nodeFilter.nodeSummary().reload()
+            }
+        }).success(_createAjaxReceiveTokensHandler('ajaxSaveFilterTokens'));
+
+    }
+    //]>
+</script>

--- a/rundeckapp/grails-app/views/framework/adhoc.gsp
+++ b/rundeckapp/grails-app/views/framework/adhoc.gsp
@@ -42,7 +42,7 @@
     <asset:javascript src="framework/adhoc.js"/>
     <g:set var="defaultLastLines" value="${grailsApplication.config.rundeck.gui.execution.tail.lines.default}"/>
     <g:set var="maxLastLines" value="${grailsApplication.config.rundeck.gui.execution.tail.lines.max}"/>
-    <g:embedJSON id="filterParamsJSON" data="${[filterName: params.filterName, filter: query?.filter, filterAll: params.showall in ['true', true]]}"/>
+    <g:embedJSON id="filterParamsJSON" data="${[filterName: params.filterName, matchedNodesMaxCount: matchedNodesMaxCount?:50, filter: query?.filter, filterAll: params.showall in ['true', true]]}"/>
     <g:embedJSON id="pageParams" data="${[
             disableMarkdown: params.boolean('disableMarkdown') ? '&disableMarkdown=true' :'',
             smallIconUrl:resource(dir: 'images', file: 'icon-small'),

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -17,7 +17,7 @@
 <%@ page import="com.dtolabs.rundeck.plugins.ServiceNameConstants; rundeck.ScheduledExecution; rundeck.User; org.rundeck.core.auth.AuthConstants" %>
 
 <g:jsonToken id="job_edit_tokens" url="${request.forwardURI}"/>
-
+<g:set var="ukey" value="${g.rkey()}" />
 <g:if test="${flash.message}">
     <div class="list-group-item">
       <div class="alert alert-info">
@@ -44,7 +44,7 @@
 
 <g:set var="project" value="${scheduledExecution?.project ?: params.project?:request.project?: projects?.size() == 1 ? projects[0].name : ''}"/>
 <g:embedJSON id="filterParamsJSON"
-             data="${[filterName: params.filterName, filter: scheduledExecution?.asFilter(),filterExcludeName: params.filterExcludeName, filterExclude: scheduledExecution?.asExcludeFilter(),nodeExcludePrecedence: scheduledExecution?.nodeExcludePrecedence, excludeFilterUncheck: scheduledExecution?.excludeFilterUncheck]}"/>
+             data="${[filterName: params.filterName, matchedNodesMaxCount: matchedNodesMaxCount?:100, filter: scheduledExecution?.asFilter(),filterExcludeName: params.filterExcludeName, filterExclude: scheduledExecution?.asExcludeFilter(),nodeExcludePrecedence: scheduledExecution?.nodeExcludePrecedence, excludeFilterUncheck: scheduledExecution?.excludeFilterUncheck]}"/>
 <g:embedJSON id="jobDefinitionJSON"
              data="${[jobName:scheduledExecution?.jobName,groupPath:scheduledExecution?.groupPath, uuid: scheduledExecution?.uuid,
                      href:scheduledExecution?.id?createLink(controller:'scheduledExecution',action:'show',params:[project:scheduledExecution.project,id:scheduledExecution.extid]):null
@@ -334,6 +334,14 @@
                       </g:if>
                       <g:render template="/framework/nodeFilterInputGroup"
                                 model="[filterset: filterset, filtvalue: filtvalue, filterName: filterName]"/>
+
+                      %{--  Form for saving/deleting node filters--}%
+                      <g:form class="form form-horizontal" useToken="true">
+                          <g:hiddenField name="project" value="${params.project}"/>
+                      %{--          <g:render template="/framework/nodeFiltersHidden"/>--}%
+                          <g:render template="/common/queryFilterManagerModal"
+                                    model="${[rkey: ukey, filterName: filterName, filterset: filterset, filterLinks: true, formId: '${ukey}filter', ko: true, deleteActionSubmit: 'deleteNodeFilter', storeActionSubmitAjax: true]}"/>
+                      </g:form>
                   </span>
 
           <div class=" collapse" id="queryFilterHelp">
@@ -1297,7 +1305,7 @@ function getCurSEID(){
                     appLinks.frameworkNodes,
                     Object.assign(filterParams, {
                         nodeSummary:nodeSummary,
-                        maxShown:100,
+                        maxShown:filterParams.matchedNodesMaxCount,
                         nodefilterLinkId: '#nodegroupitem',
                          project: selFrameworkProject,
                          view:'embed',


### PR DESCRIPTION
fixes https://github.com/rundeckpro/rundeckpro/issues/1894

**Is this a bugfix, or an enhancement? Please describe.**
The modal to save a node filter when editing a job was not being displayed. Another issue was that the maximum matched nodes on filter results was 100 and it was not possible to change this value (Job editing page)

**Describe the solution you've implemented**
The modal was included on page to be shown and was included a new config property on rundeck-config.properties to define the max count of matched nodes (default is 100)