### PR TITLE
RUN-354: Update project picker to respect GUI startpage setting

### DIFF
--- a/rundeckapp/grails-spa/packages/ui/src/components/project-picker/main.ts
+++ b/rundeckapp/grails-spa/packages/ui/src/components/project-picker/main.ts
@@ -22,7 +22,7 @@ function init() {
         template: `<ProjectPicker projectLabel="${el.dataset.projectLabel}" @project:selected="handleSelect" @project:select-all="handleSelectAll"/>`,
         methods: {
             handleSelect(project: Project) {
-                window.location.assign(url(`project/${project.name}/home`).href)
+                window.location.assign(url(`?project=${project.name}`).href)
             },
             handleSelectAll() {
                 window.location.assign(url('').href)


### PR DESCRIPTION
Fixes #7214

**Is this a bugfix, or an enhancement? Please describe.**
The new project picker introduced in `3.4.0` does not take advantage of the `gui.startpage` setting which controls the project's homepage.

**Describe the solution you've implemented**
Updated to use the special endpoint `/?projectName=`. This endpoint will `302` redirect to the appropriate project page.

### Testing
This setting can be set to `jobs` to test: https://docs.rundeck.com/docs/administration/configuration/gui-customization.html#rundeck-gui-startpage . A new Docker config option was recently merged `RUNDECK_GUI_STARTPAGE` which drives this.

After changing the setting to `jobs` selecting a project from the picker should land you on the Jobs screen.