### PR TITLE
RUN-366: Migration to change adhoc_local_string column type from VARCHAR to NVARCHAR on SQL Server database.

### DIFF
--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -105,5 +105,7 @@ databaseChangeLog = {
         include file: 'core/ConstraintsIndexesKeys.groovy'
         include file: 'core/WorkflowStep.groovy'
         include file: 'core/Tag-3.4.0.groovy'
+        include file: 'core/WorkflowStepVARCHARtoNVARCHAR.groovy'
+        include file: 'core/Tag-3.4.4.groovy'
 
 }

--- a/rundeckapp/grails-app/migrations/core/Tag-3.4.4.groovy
+++ b/rundeckapp/grails-app/migrations/core/Tag-3.4.4.groovy
@@ -1,0 +1,7 @@
+databaseChangeLog = {
+    changeSet(author: "rundeckuser (generated)", id: "tag-3.4.4") {
+        tagDatabase(tag: "3.4.4")
+        empty()
+        rollback()
+    }
+}

--- a/rundeckapp/grails-app/migrations/core/WorkflowStepVARCHARtoNVARCHAR.groovy
+++ b/rundeckapp/grails-app/migrations/core/WorkflowStepVARCHARtoNVARCHAR.groovy
@@ -1,0 +1,20 @@
+databaseChangeLog = {
+    changeSet(author: "rundeckuser (generated)", id: "1630329719623", dbms: "mssql") {
+        comment { 'change column type to nvarchar' }
+        preConditions(onFail: 'MARK_RAN') {
+            grailsPrecondition {
+                check {
+                    def ran = sql.firstRow("SELECT count(*) as num FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'workflow_step' AND COLUMN_NAME = 'adhoc_local_string' AND DATA_TYPE = 'varchar'").num
+                    if (ran == 0) fail('precondition is not satisfied')
+                }
+            }
+        }
+        grailsChange {
+            change {
+                sql.execute("ALTER TABLE \"workflow_step\" ALTER COLUMN \"adhoc_local_string\" nvarchar(max) null;")
+            }
+            rollback {
+            }
+        }
+    }
+}


### PR DESCRIPTION
fixes https://github.com/rundeckpro/rundeckpro/issues/1970

**Is this a bugfix, or an enhancement? Please describe.**
Cannot use Unicode Characters on Rundeck using MSSQL database. (see description [here](https://github.com/rundeckpro/rundeckpro/issues/1970) )

**Describe the solution you've implemented**
This PR include a migration to change the column type of `adhoc_local_string` from `VARCHAR` to `NVARCHAR` to accept Unicode characters.
