### PR TITLE
RUN-374: Fix SCM/Node Sources configuration auth checks to be less restrictive

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -1504,7 +1504,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
 
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                         rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
                         rundeckAuthContextProcessor.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -1555,7 +1555,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             return renderErrorView("configPrefix parameter is required")
         }
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                         rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
                         rundeckAuthContextProcessor.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -1628,7 +1628,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
 
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                         rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
                         rundeckAuthContextProcessor.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -1747,7 +1747,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         def project = params.project
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                         rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
                         rundeckAuthContextProcessor.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -2666,7 +2666,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         }
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project)
         if (!apiService.requireAuthorized(
-            rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+            rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                 authContext,
                 rundeckAuthContextProcessor.authResourceForProject(project),
                 [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -2866,7 +2866,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         }
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project)
         if (!apiService.requireAuthorized(
-            rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+            rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                 authContext,
                 rundeckAuthContextProcessor.authResourceForProject(project),
                 [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -2965,7 +2965,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         }
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project)
         if (!apiService.requireAuthorized(
-            rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+            rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                 authContext,
                 rundeckAuthContextProcessor.authResourceForProject(project),
                 [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3366,7 +3366,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     def projectToggleSCM(){
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, params.project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                         authContext,
                         rundeckAuthContextProcessor.authResourceForProject(params.project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
@@ -1821,7 +1821,7 @@ class ProjectController extends ControllerBase{
         if (archiveParams.importScm && request.api_version >= ApiVersions.V28) {
             //verify scm access requirement
             if (archiveParams.importScm &&
-                    !rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+                    !rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                             appContext,
                             rundeckAuthContextProcessor.authResourceForProject(project.name),
                             [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -174,7 +174,7 @@ class ScmController extends ControllerBase {
     def index(String project) {
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                         authContext,
                         rundeckAuthContextProcessor.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -210,7 +210,7 @@ class ScmController extends ControllerBase {
 
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                         authContext,
                         rundeckAuthContextProcessor.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -244,7 +244,7 @@ class ScmController extends ControllerBase {
                 project
         )
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                         authContext,
                         rundeckAuthContextProcessor.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -462,7 +462,7 @@ class ScmController extends ControllerBase {
 
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                         authContext,
                         rundeckAuthContextProcessor.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -498,7 +498,7 @@ class ScmController extends ControllerBase {
     def clean(String integration, String project, String type) {
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                         authContext,
                         rundeckAuthContextProcessor.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -540,7 +540,7 @@ class ScmController extends ControllerBase {
                 project
         )
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                         authContext,
                         rundeckAuthContextProcessor.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
@@ -1759,7 +1759,7 @@ class ScmController extends ControllerBase {
     def deletePluginConfig(String project, String integration, String type){
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAll(
+                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
                         authContext,
                         rundeckAuthContextProcessor.authResourceForProject(project),
                         [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -1763,7 +1763,7 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
     }
 
     boolean hasScmConfigure(AuthContext authContext, String project) {
-        rundeckAuthContextEvaluator.authorizeApplicationResourceAll(
+        rundeckAuthContextEvaluator.authorizeApplicationResourceAny(
             authContext,
             rundeckAuthContextEvaluator.authResourceForProject(project),
             [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -1770,7 +1770,7 @@ project.label=A Label
         when:
             controller.projectPluginsAjax(project, serviceName, configPrefix)
         then:
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAll(_, _, ['configure', 'admin']) >> true
+            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, ['configure', 'admin']) >> true
             1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
             1 * controller.rundeckAuthContextProcessor.authResourceForProject(project)
             1 * controller.frameworkService.getRundeckFramework() >> Mock(IFramework) {
@@ -1862,7 +1862,7 @@ project.label=A Label
 
         then:
             response.status == 200
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAll(_, _, ['configure', 'admin']) >> true
+            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, ['configure', 'admin']) >> true
             1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
             1 * controller.rundeckAuthContextProcessor.authResourceForProject(project)
             1 * controller.pluginService.getPluginDescriptor('1type', serviceName) >>
@@ -1926,7 +1926,7 @@ project.label=A Label
 
         then:
             response.status == 422
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAll(_, _, ['configure', 'admin']) >> true
+            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, ['configure', 'admin']) >> true
             1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
             1 * controller.rundeckAuthContextProcessor.authResourceForProject(project)
 
@@ -1991,7 +1991,7 @@ project.label=A Label
 
         then:
             response.status == 422
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAll(_, _, ['configure', 'admin']) >> true
+            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, ['configure', 'admin']) >> true
             1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
             1 * controller.rundeckAuthContextProcessor.authResourceForProject(project)
 
@@ -2056,7 +2056,7 @@ project.label=A Label
 
         then:
             response.status == 422
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAll(_, _, ['configure', 'admin']) >> true
+            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, ['configure', 'admin']) >> true
             1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
             1 * controller.rundeckAuthContextProcessor.authResourceForProject(project)
 
@@ -2123,7 +2123,7 @@ project.label=A Label
 
         then:
             response.status == 422
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAll(_, _, ['configure', 'admin']) >> true
+            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, ['configure', 'admin']) >> true
             1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
             1 * controller.rundeckAuthContextProcessor.authResourceForProject(project)
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1513,7 +1513,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         params.project = project
         controller.projectToggleSCM()
         then:
-        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAll(_, _, [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]) >> true
+        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]) >> true
         1 * controller.scmService.loadScmConfig(project, 'export') >> econfig
         1 * controller.scmService.loadScmConfig(project, 'import')
 
@@ -1548,7 +1548,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         params.project = project
         controller.projectToggleSCM()
         then:
-        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAll(_, _, [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]) >> true
+        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]) >> true
         1 * controller.scmService.loadScmConfig(project, 'export') >> econfig
         1 * controller.scmService.loadScmConfig(project, 'import')
 
@@ -1582,7 +1582,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         params.project = project
         controller.projectToggleSCM()
         then:
-        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAll(_, _, [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]) >> true
+        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]) >> true
         1 * controller.scmService.loadScmConfig(project, 'export')
         1 * controller.scmService.loadScmConfig(project, 'import')
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectController2Spec.groovy
@@ -2324,7 +2324,7 @@ class ProjectController2Spec extends HibernateSpec implements ControllerUnitTest
                 _ * getAuthContextForSubjectAndProject(_,_)
                 _ * authResourceForProject('test1')
                 authorizeApplicationResourceAny(_, _, ['import', AuthConstants.ACTION_ADMIN]) >> true
-                authorizeApplicationResourceAll(_, _, [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]) >> true
+                authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]) >> true
                 0*_(*_)
             }
         request.api_version = 28

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
@@ -609,7 +609,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
         controller.scmService = Mock(ScmService)
         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
             1 * getAuthContextForSubjectAndProject(_, projectName) >> Mock(UserAndRolesAuthContext)
-            1 * authorizeApplicationResourceAll(*_) >> true
+            1 * authorizeApplicationResourceAny(*_) >> true
         }
 
         when:
@@ -632,7 +632,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
         controller.scmService = Mock(ScmService)
         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
             1 * getAuthContextForSubjectAndProject(_, projectName) >> Mock(UserAndRolesAuthContext)
-            1 * authorizeApplicationResourceAll(*_) >> true
+            1 * authorizeApplicationResourceAny(*_) >> true
         }
         setupFormTokens(session)
         when:
@@ -654,7 +654,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
         controller.scmService = Mock(ScmService)
         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
             1 * getAuthContextForSubjectAndProject(_, projectName) >> Mock(UserAndRolesAuthContext)
-            1 * authorizeApplicationResourceAll(*_) >> true
+            1 * authorizeApplicationResourceAny(*_) >> true
         }
         setupFormTokens(session)
         when:
@@ -676,7 +676,7 @@ class ScmControllerSpec extends HibernateSpec implements ControllerUnitTest<ScmC
         controller.scmService = Mock(ScmService)
         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
             1 * getAuthContextForSubjectAndProject(_, projectName) >> Mock(UserAndRolesAuthContext)
-            1 * authorizeApplicationResourceAll(*_) >> true
+            1 * authorizeApplicationResourceAny(*_) >> true
         }
         setupFormTokens(session)
         when:

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
@@ -1506,7 +1506,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
             (count) * listener.inc('export', 1)
             1 * listener.done()
             _ * service.rundeckAuthContextEvaluator.authResourceForProject('aProject') >> [test: 'resource']
-            1 * service.rundeckAuthContextEvaluator.authorizeApplicationResourceAll(auth, [test: 'resource'], ['configure','admin'])>>scmAuth
+            1 * service.rundeckAuthContextEvaluator.authorizeApplicationResourceAny(auth, [test: 'resource'], ['configure','admin'])>>scmAuth
             (count)*service.scmService.loadScmConfig('aProject','export')>>Mock(ScmPluginConfigData)
             (count)*service.scmService.loadScmConfig('aProject','import')>>Mock(ScmPluginConfigData)
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Fix #7238 

**Describe the solution you've implemented**
Update auth checks to check `configure` or `admin`, and not require both.
