### PR TITLE
RUN-373: Change font fill to solid white

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/paper/_variables.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/paper/_variables.scss
@@ -156,7 +156,7 @@ Theme colors
     --default-background-color: var(--grey-200);
 
     --font-color:                 var(--grey-700);
-    --fill-font-color:            #{rgba($white, 0.85)};
+    --fill-font-color:            var(--white);
 
     // TODO: Is this necessary?
     --none:                       0;


### PR DESCRIPTION
Font fill was white with an alpha causing a colored "haze" effect on colored buttons and reducing contrast on black buttons.

**Before**
![image](https://user-images.githubusercontent.com/271965/131897303-432264f6-50b4-4398-b8d9-0de538015934.png)


**After**
![image](https://user-images.githubusercontent.com/271965/131897375-0a9ca14f-360b-4ac0-9c85-54a7cb32f208.png)
