### PR TITLE
Enhancements and fixes in support of workflow editing

### DIFF
--- a/rundeckapp/grails-app/views/execution/_wflistitemContent.gsp
+++ b/rundeckapp/grails-app/views/execution/_wflistitemContent.gsp
@@ -175,8 +175,11 @@
                 <g:embedJSON id="logFilterData_${enc(attr:i)}" data="${[
                         num:i,
                         description:item.description,
-                        filters:item?.getPluginConfigForType('LogFilter')?:[]]
-                }"/>
+                        filters:item?.getPluginConfigForType('LogFilter')?:[]
+                ]}"/>
+                <script id="wfItemData_${enc(attr:i)}" data-json-type="wfItem" type="text/json">
+                        ${raw(enc(json:[num:i,item:item]))}
+                </script>
                 <script type="text/javascript">
                 fireWhenReady("pfctrls_${enc(attr:i)}",function(){
                     var step=workflowEditor.bindStepFilters('logfilter_${i}','logFilter_${enc(attr:i)}',loadJsonData('logFilterData_${enc(attr:i)}'));

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/utils/AceEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/utils/AceEditor.vue
@@ -27,6 +27,7 @@
     </div>
     <ace v-model="valueInternal"
          @init="aceEditorInit"
+         :identifier="identifier"
          :lang="modeInternal"
          :theme="theme"
          :height="height"
@@ -66,6 +67,7 @@ export default Vue.extend({
   name: 'ace-editor',
   components: {Ace},
   props: {
+    identifier: String,
     value: String,
     height: String,
     width: String,

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/utils/AceEditorVue.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/utils/AceEditorVue.ts
@@ -13,11 +13,13 @@ export default Vue.extend({
 
         return h('div', {
             attrs: {
-                style: `height: ${height}; width: ${width};`
+                style: `height: ${height}; width: ${width};`,
+                id: this.identifier,
             }
         })
     },
     props: {
+        identifier: String,
         value: String,
         height: String,
         width: String,

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/stores/Plugins.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/stores/Plugins.ts
@@ -13,7 +13,7 @@ export class PluginStore {
 
     constructor(readonly root: RootStore, readonly client: RundeckClient) {
         this.pluginsByService = new ObservableGroupMap(this.plugins, (p) => `${p.service}`)
-        this.pluginsById = new ObservableGroupMap(this.plugins, (p) => p.id)
+        this.pluginsById = new ObservableGroupMap(this.plugins, (p) => p.name)
     }
 
     @Serial
@@ -28,7 +28,7 @@ export class PluginStore {
         }))
 
         plugins.parsedBody.forEach((p: any) => {
-            if (this.pluginsById.has(p.id))
+            if (this.pluginsById.has(p.name))
                 return
             else
                 this.plugins.push(p)

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/custom/rundeck-icon.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/custom/rundeck-icon.scss
@@ -47,139 +47,86 @@
   &.icon-small {
     width: 16px;
     height: 16px;
+    background-size: 16px;
 
     &.command,
     &.shell {
-      background-image: url("../images/icon-small-shell.png");
+      background-image: url("../images/icon-small-shell@2x.png");
     }
 
     &.script {
-      background-image: url("../images/icon-small-script.png");
+      background-image: url("../images/icon-small-script@2x.png");
     }
 
     &.scriptfile,
     &.scripturl {
-      background-image: url("../images/icon-small-scriptfile.png");
+      background-image: url("../images/icon-small-scriptfile@2x.png");
     }
 
     &.plugin {
-      background-image: url("../images/icon-small-plugin.png");
+      background-image: url("../images/icon-small-plugin@2x.png");
     }
 
     &.node {
       height: 10px;
-      background-image: url("../images/icon-small-Node.png");
+      background-image: url("../images/icon-small-Node@2x.png");
     }
 
     &.node.node-runnable {
-      background-image: url("../images/icon-small-Node-run.png");
+      background-image: url("../images/icon-small-Node-run@2x.png");
     }
   }
 
   &.icon {
     width: 32px;
     height: 32px;
+    background-size: 32x;
 
     &.command,
     &.shell {
-      background-image: url("../images/icon-shell.png");
+      background-image: url("../images/icon-shell@2x.png");
     }
 
     &.script {
-      background-image: url("../images/icon-script.png");
+      background-image: url("../images/icon-script@2x.png");
     }
 
-    &.scriptfile {
-      background-image: url("../images/icon-scriptfile.png");
+    &.scriptfile,
+    &.scripturl {
+      background-image: url("../images/icon-scriptfile@2x.png");
+    }
+
+    &.plugin {
+      background-image: url("../images/icon-small-plugin@2x.png");
     }
   }
 
   &.icon-med {
     width: 24px;
     height: 24px;
+    background-size: 24px;
 
     &.command,
     &.shell {
-      background-image: url("../images/icon-med-shell.png");
+      background-image: url("../images/icon-med-shell@2x.png");
     }
 
     &.script {
-      background-image: url("../images/icon-med-script.png");
+      background-image: url("../images/icon-med-script@2x.png");
     }
 
-    &.scriptfile {
-      background-image: url("../images/icon-med-scriptfile.png");
+    &.scriptfile,
+    &.scripturl {
+      background-image: url("../images/icon-med-scriptfile@2x.png");
+    }
+
+    &.plugin {
+      background-image: url("../images/icon-small-plugin@2x.png");
     }
   }
 
   &.app-logo.middle {
     vertical-align: middle;
-  }
-  //retina/@2x images
-  @media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 2/1), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
-    &.icon-small {
-      background-size: 16px 16px;
-
-      &.node {
-        background-size: 16px 10px;
-        background-image: url("../images/icon-small-Node@2x.png");
-      }
-
-      &.node.node-runnable {
-        background-image: url("../images/icon-small-Node-run@2x.png");
-      }
-
-      &.command,
-      &.shell {
-        background-image: url("../images/icon-small-shell@2x.png");
-      }
-
-      &.script {
-        background-image: url("../images/icon-small-script@2x.png");
-      }
-
-      &.scriptfile {
-        background-image: url("../images/icon-small-scriptfile@2x.png");
-      }
-
-      &.plugin {
-        background-image: url("../images/icon-small-plugin@2x.png");
-      }
-    }
-
-    &.icon {
-      background-size: 32px 32px;
-
-      &.command,
-      &.shell {
-        background-image: url("../images/icon-shell@2x.png");
-      }
-
-      &.script {
-        background-image: url("../images/icon-script@2x.png");
-      }
-
-      &.scriptfile {
-        background-image: url("../images/icon-scriptfile@2x.png");
-      }
-    }
-
-    &.icon-med {
-      background-size: 24px 24px;
-
-      &.command,
-      &.shell {
-        background-image: url("../images/icon-med-shell@2x.png");
-      }
-
-      &.script {
-        background-image: url("../images/icon-med-script@2x.png");
-      }
-
-      &.scriptfile {
-        background-image: url("../images/icon-med-scriptfile@2x.png");
-      }
-    }
   }
 }
 
@@ -190,19 +137,7 @@
 }
 
 .nodedetail.server .nodedesc, .node_entry.server .nodedesc {
-    background-image: url("../images/logos/rundeck2-icon-16.png");
+    background-size: 16px;
+    background-image: url("../images/logos/rundeck2-icon-32.png");
     background-repeat: no-repeat;
-}
-
-@media
-only screen and (-webkit-min-device-pixel-ratio: 2),
-only screen and (   min--moz-device-pixel-ratio: 2),
-only screen and (     -o-min-device-pixel-ratio: 2/1),
-only screen and (        min-device-pixel-ratio: 2),
-only screen and (                min-resolution: 192dpi),
-only screen and (                min-resolution: 2dppx) {
-    .nodedetail.server .nodedesc, .node_entry.server .nodedesc {
-        background-image: url("../images/logos/rundeck2-icon-32.png");
-        background-size: 16px 16px;
-    }
 }


### PR DESCRIPTION
Changes in support of rundeckpro/rundeckpro#1996

**Updates plugin store to use provider name as id key**
The previously used `id` field is not unique for all provider types.

**Add fuller workflow item JSON to workflow editor steps in GSP**
This makes it easier to get step information without scraping or hitting the internal ajax editor API.

**Remove media query for icons**
Pixel ratios between 1 and 2(like 1.5) were not getting the hi-res icon images. This update lets the browser scaling handle it so the icons are always crisp.

**Optional AceEditor identifier**
Sets the id on the main div. Allows attaching to the editor session by externally by id.
