### PR TITLE
RUN-384: Fix duplicated node filter after save a job

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -675,6 +675,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             return renderErrorView([:])
         }
         withForm{
+        g.refreshFormTokensHeader()
         def User u = userService.findOrCreateUser(session.user)
         def NodeFilter filter
         def boolean saveuser=false
@@ -706,6 +707,12 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                 return renderErrorView(u.errors.allErrors.collect { g.message(error: it) }.join("\n"))
             }
         }
+        if(params.isJobEdit){
+            return render(contentType: 'application/json'){
+                success true
+            }
+        }
+
         redirect(controller:'framework',action:'nodes',params:[filterName:filter.name,project:params.project])
         }.invalidToken{
             response.status=HttpServletResponse.SC_BAD_REQUEST

--- a/rundeckapp/grails-app/views/common/_queryFilterManagerModal.gsp
+++ b/rundeckapp/grails-app/views/common/_queryFilterManagerModal.gsp
@@ -175,14 +175,16 @@
     //<!CDATA[
     function _saveFiltersAjax(){
         var tokendataid = 'ajaxSaveFilterTokens';
-        var filterName = jQuery('input[name=newFilterName]').val()
+        var filterNameInput = jQuery('input[name=newFilterName]')
+        var filterName = filterNameInput.val()
         var filter = nodeFilter.filter()
 
         jQuery.ajax({
-            url:_genUrl(appLinks.frameworkStoreFilterAjax, {newFilterName:filterName, filter: filter}),
+            url:_genUrl(appLinks.frameworkStoreFilterAjax, {newFilterName:filterName, filter: filter, isJobEdit: true}),
             type:'POST',
             beforeSend: _createAjaxSendTokensHandler(tokendataid),
             error: function (jqxhr, status, err) {
+                filterNameInput.val("")
                 if (jqxhr.responseJSON && jqxhr.responseJSON.message) {
                     self.error(jqxhr.responseJSON.message)
                 } else if (jqxhr.status === 403) {
@@ -190,6 +192,7 @@
                 }
             },
             success: function(data){
+                filterNameInput.val("")
                 nodeFilter.nodeSummary().reload()
             }
         }).success(_createAjaxReceiveTokensHandler('ajaxSaveFilterTokens'));

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -336,10 +336,9 @@
                                 model="[filterset: filterset, filtvalue: filtvalue, filterName: filterName]"/>
 
 
-                      <g:hiddenField name="project" value="${params.project}"/>
-                      <g:render template="/framework/nodeFiltersHidden"/>
-                      <g:render template="/common/queryFilterManagerModal"
-                                model="${[rkey: ukey, filterName: filterName, filterset: filterset, filterLinks: true, formId: '${ukey}filter', ko: true, deleteActionSubmit: 'deleteNodeFilter', storeActionSubmitAjax: true]}"/>
+                        <g:hiddenField name="project" value="${params.project}"/>
+                        <g:render template="/common/queryFilterManagerModal"
+                                  model="${[rkey: ukey, filterName: filterName, filterset: filterset, filterLinks: true, formId: '${ukey}filter', ko: true, deleteActionSubmit: 'deleteNodeFilter', storeActionSubmitAjax: true]}"/>
                   </span>
 
           <div class=" collapse" id="queryFilterHelp">


### PR DESCRIPTION
fixes #7249 

**Is this a bugfix, or an enhancement? Please describe.**
When creating a job and setting up the node filter, the node filter value gets duplicated

**Describe the solution you've implemented**
Removed a template that include hidden fields that duplicated the filter string. Also, this PR fix an issue that doesn't allow saving more than one filter