### PR TITLE
Fix: dismissible alert x button too far right

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/bootstrap/stylesheets/bootstrap/_alerts.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/bootstrap/stylesheets/bootstrap/_alerts.scss
@@ -47,7 +47,6 @@
   .close {
     position: relative;
     top: -2px;
-    right: -21px;
     color: inherit;
   }
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Fix css issue; the close button on dismissible alerts is positioned wrongly and overlaps the border.

**Describe the solution you've implemented**
Remove the -21px right positioning. 

**Additional context**
Before:
![Screen Shot 2021-09-03 at 4 18 50 PM](https://user-images.githubusercontent.com/55603/132073692-4db99a74-4467-4dd9-9e03-00b1bb0abf34.png)

After:

![Screen Shot 2021-09-03 at 4 18 41 PM](https://user-images.githubusercontent.com/55603/132073701-496a0b5f-5143-4839-8bcf-3c69023e307c.png)

