### PR TITLE
RUN-403: Auth check cleanup

### DIFF
--- a/grails-repository/grails-app/controllers/repository/RepositoryController.groovy
+++ b/grails-repository/grails-app/controllers/repository/RepositoryController.groovy
@@ -13,6 +13,7 @@ import com.rundeck.repository.definition.RepositoryDefinition
 import com.rundeck.repository.manifest.search.ManifestSearch
 import grails.converters.JSON
 import groovy.transform.PackageScope
+import org.rundeck.core.auth.AuthConstants
 
 class RepositoryController {
 
@@ -36,7 +37,7 @@ class RepositoryController {
         }
 
         def listArtifacts() {
-            if (!authorized(PLUGIN_RESOURCE,"read")) {
+            if (!authorized(AuthConstants.RESOURCE_TYPE_PLUGIN,AuthConstants.ACTION_READ)) {
                 specifyUnauthorizedError()
                 return
             }
@@ -59,7 +60,7 @@ class RepositoryController {
         }
 
         def searchArtifacts() {
-            if (!authorized(PLUGIN_RESOURCE,"read")) {
+            if (!authorized(AuthConstants.RESOURCE_TYPE_PLUGIN,AuthConstants.ACTION_READ)) {
                 specifyUnauthorizedError()
                 return
             }
@@ -91,7 +92,7 @@ class RepositoryController {
         }
 
         def listInstalledArtifacts() {
-            if (!authorized(PLUGIN_RESOURCE,"read")) {
+            if (!authorized(AuthConstants.RESOURCE_TYPE_PLUGIN,AuthConstants.ACTION_READ)) {
                 specifyUnauthorizedError()
                 return
             }
@@ -123,7 +124,7 @@ class RepositoryController {
                 return
             }
 
-            if (!authorized(PLUGIN_RESOURCE,"install")) {
+            if (!authorized(AuthConstants.RESOURCE_TYPE_PLUGIN,AuthConstants.ACTION_INSTALL)) {
                 specifyUnauthorizedError()
                 return
             }
@@ -152,7 +153,7 @@ class RepositoryController {
 
 
         def installArtifact() {
-            if (!authorized(PLUGIN_RESOURCE,"install")) {
+            if (!authorized(AuthConstants.RESOURCE_TYPE_PLUGIN,AuthConstants.ACTION_INSTALL)) {
                 specifyUnauthorizedError()
                 return
             }
@@ -180,7 +181,7 @@ class RepositoryController {
         }
 
         def uninstallArtifact() {
-            if (!authorized(PLUGIN_RESOURCE,"uninstall")) {
+            if (!authorized(AuthConstants.RESOURCE_TYPE_PLUGIN,AuthConstants.ACTION_UNINSTALL)) {
                 specifyUnauthorizedError()
                 return
             }
@@ -256,7 +257,7 @@ class RepositoryController {
         }
 
         def syncInstalledArtifactsToRundeck() {
-            if (!authorized(PLUGIN_RESOURCE,"install")) {
+            if (!authorized(AuthConstants.RESOURCE_TYPE_PLUGIN,AuthConstants.ACTION_INSTALL)) {
                 specifyUnauthorizedError()
                 return
             }
@@ -309,14 +310,11 @@ class RepositoryController {
         }
 
         @PackageScope
-        boolean authorized(Map resourceType = ADMIN_RESOURCE,String action = "admin") {
-            List authorizedActions = ["admin"]
-            if(action != "admin") authorizedActions.add(action)
+        boolean authorized(Map resourceType = AuthConstants.RESOURCE_TYPE_SYSTEM, String action = AuthConstants.ACTION_ADMIN) {
+            List authorizedActions = [AuthConstants.ACTION_ADMIN]
+            if(action != AuthConstants.ACTION_ADMIN) authorizedActions.add(action)
             AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
             rundeckAuthContextProcessor.authorizeApplicationResourceAny(authContext,resourceType,authorizedActions)
 
         }
-
-        private static Map PLUGIN_RESOURCE = Collections.unmodifiableMap(AuthorizationUtil.resourceType("plugin"))
-        private static Map ADMIN_RESOURCE = Collections.unmodifiableMap(AuthorizationUtil.resourceType("admin"))
 }

--- a/grails-repository/grails-app/views/artifact/index.gsp
+++ b/grails-repository/grails-app/views/artifact/index.gsp
@@ -1,3 +1,4 @@
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 %{--
   - Copyright 2018 Rundeck, Inc. (http://rundeck.com)
   -
@@ -27,11 +28,11 @@
 <div class="content">
 <div id="layoutBody">
 <g:set var="pluginInstall" value="${auth.resourceAllowedTest(
-        type: 'resource',
-        kind: 'plugin',
-        action: ["install","admin"],
+        type: AuthConstants.TYPE_RESOURCE,
+        kind: AuthConstants.TYPE_PLUGIN,
+        action: [AuthConstants.ACTION_INSTALL, AuthConstants.ACTION_ADMIN],
         any: true,
-        context: 'application'
+        context: AuthConstants.CTX_APPLICATION
 )}"/>
 <script type="text/javascript">
     window.repocaninstall = ${pluginInstall ?: false};

--- a/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/AuthConstants.java
+++ b/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/AuthConstants.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.Map;
 
 public class AuthConstants {
-
+    public static final String CTX_APPLICATION = "application";
     public static final String ACTION_CREATE = "create";
     public static final String ACTION_READ = "read";
     public static final String ACTION_VIEW = "view";
@@ -68,6 +68,7 @@ public class AuthConstants {
     public static final String TYPE_USER = "user";
     public static final String TYPE_STORAGE = "storage";
     public static final String TYPE_WEBHOOK = "webhook";
+    public static final String TYPE_RESOURCE = "resource";
 
     private static Map<String, String> resType(String type) {
         return Collections.unmodifiableMap(AuthorizationUtil.resourceType(type));

--- a/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/AuthConstants.java
+++ b/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/AuthConstants.java
@@ -80,6 +80,7 @@ public class AuthConstants {
     public static final Map<String, String> RESOURCE_TYPE_JOB = resType(TYPE_JOB);
     public static final Map<String, String> RESOURCE_TYPE_EVENT = resType(TYPE_EVENT);
     public static final Map<String, String> RESOURCE_TYPE_WEBHOOK = resType(TYPE_WEBHOOK);
+    public static final Map<String, String> RESOURCE_TYPE_PLUGIN = resType(TYPE_PLUGIN);
     public static final Map<String, String> RESOURCE_ADHOC = Collections.unmodifiableMap(AuthorizationUtil
             .resource(TYPE_ADHOC));
 }

--- a/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/AuthResources.java
+++ b/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/AuthResources.java
@@ -8,7 +8,8 @@ public class AuthResources {
             Arrays.asList(
                     AuthConstants.TYPE_ADHOC,
                     AuthConstants.TYPE_JOB,
-                    AuthConstants.TYPE_NODE
+                    AuthConstants.TYPE_NODE,
+                    AuthConstants.TYPE_STORAGE
             )
     );
     public static final Set<String> projectKinds = new HashSet<>(

--- a/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/AuthResources.java
+++ b/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/AuthResources.java
@@ -15,7 +15,8 @@ public class AuthResources {
             Arrays.asList(
                     AuthConstants.TYPE_JOB,
                     AuthConstants.TYPE_NODE,
-                    AuthConstants.TYPE_EVENT
+                    AuthConstants.TYPE_EVENT,
+                    AuthConstants.TYPE_WEBHOOK
             )
     );
     public static final Set<String> appTypes = new HashSet<>(
@@ -34,7 +35,8 @@ public class AuthResources {
                     AuthConstants.TYPE_USER,
                     AuthConstants.TYPE_JOB,
                     AuthConstants.TYPE_APITOKEN,
-                    AuthConstants.TYPE_PLUGIN
+                    AuthConstants.TYPE_PLUGIN,
+                    AuthConstants.TYPE_WEBHOOK
             )
     );
 
@@ -58,7 +60,7 @@ public class AuthResources {
                     AuthConstants.ACTION_DELETE,
                     AuthConstants.ACTION_ADMIN
             );
-    public static final List<String> appStorageActions =
+    public static final List<String> storageActions =
             Arrays.asList(
                     AuthConstants.ACTION_CREATE,
                     AuthConstants.ACTION_READ,
@@ -111,12 +113,20 @@ public class AuthResources {
             AuthConstants.ACTION_UNINSTALL,
             AuthConstants.ACTION_ADMIN
     );
+    public static final List<String> appWebhookKindActions = Arrays.asList(
+            AuthConstants.ACTION_READ,
+            AuthConstants.ACTION_CREATE,
+            AuthConstants.ACTION_UPDATE,
+            AuthConstants.ACTION_DELETE,
+            AuthConstants.ACTION_POST,
+            AuthConstants.ACTION_ADMIN
+    );
 
     static {
         appResActionsByType = new HashMap<>();
         appResActionsByType.put(AuthConstants.TYPE_PROJECT, appProjectActions);
         appResActionsByType.put(AuthConstants.TYPE_PROJECT_ACL, appProjectAclActions);
-        appResActionsByType.put(AuthConstants.TYPE_STORAGE, appStorageActions);
+        appResActionsByType.put(AuthConstants.TYPE_STORAGE, storageActions);
         appResActionsByType.put(AuthConstants.TYPE_APITOKEN, appApitokenActions);
     }
 
@@ -141,6 +151,7 @@ public class AuthResources {
         appKindActionsByType.put(AuthConstants.TYPE_JOB, appJobKindActions);
         appKindActionsByType.put(AuthConstants.TYPE_APITOKEN, appApitokenKindActions);
         appKindActionsByType.put(AuthConstants.TYPE_PLUGIN, appPluginActions);
+        appKindActionsByType.put(AuthConstants.TYPE_WEBHOOK, appWebhookKindActions);
     }
 
 
@@ -206,6 +217,7 @@ public class AuthResources {
                 "(etc. any node attribute)"
         );
         projResAttrsByType.put(AuthConstants.TYPE_NODE, nodeAttributeNames);
+        projResAttrsByType.put(AuthConstants.TYPE_STORAGE, Arrays.asList("path", "name"));
     }
 
     public static final List<String> projectNodeKindActions =
@@ -221,6 +233,12 @@ public class AuthResources {
                     AuthConstants.ACTION_CREATE
             );
     public static final Map<String, List<String>> projKindActionsByType;
+    static final List<String> projectWebhookKindActions = Arrays.asList(AuthConstants.ACTION_READ,
+                                                                        AuthConstants.ACTION_CREATE,
+                                                                        AuthConstants.ACTION_UPDATE,
+                                                                        AuthConstants.ACTION_DELETE,
+                                                                        AuthConstants.ACTION_ADMIN,
+                                                                        AuthConstants.ACTION_POST);
 
     static {
 
@@ -228,5 +246,7 @@ public class AuthResources {
         projKindActionsByType.put(AuthConstants.TYPE_JOB, projectJobKindActions);
         projKindActionsByType.put(AuthConstants.TYPE_NODE, projectNodeKindActions);
         projKindActionsByType.put(AuthConstants.TYPE_EVENT, projectEventKindActions);
+        projKindActionsByType.put(AuthConstants.TYPE_WEBHOOK, projectWebhookKindActions);
+        projKindActionsByType.put(AuthConstants.TYPE_STORAGE, storageActions);
     }
 }

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -76,6 +76,7 @@ import org.rundeck.app.authorization.BaseAuthContextProvider
 import org.rundeck.app.authorization.ContextACLStorageFileManagerFactory
 import org.rundeck.app.authorization.RundeckAuthorizedServicesProvider
 import org.rundeck.app.authorization.TimedAuthContextEvaluator
+import org.rundeck.app.authorization.WebAuthContextProcessor
 import org.rundeck.app.cluster.ClusterInfo
 import org.rundeck.app.components.RundeckJobDefinitionManager
 import org.rundeck.app.components.JobXMLFormat
@@ -267,6 +268,9 @@ beans={
     rundeckAuthContextProcessor(BaseAuthContextProcessor){
         rundeckAuthContextProvider=ref('rundeckAuthContextProvider')
         rundeckAuthContextEvaluator=ref('rundeckAuthContextEvaluator')
+    }
+    rundeckWebAuthContextProcessor(WebAuthContextProcessor){
+        authContextProcessor = ref('rundeckAuthContextProcessor')
     }
 
     aclStorageFileManager(ContextACLStorageFileManagerFactory){

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -52,8 +52,7 @@ class ApiController extends ControllerBase{
             apiTokenRemoveExpired: ['POST']
     ]
     def info () {
-        respond((Object)
-            [
+        respond((Object) [
                 apiversion: ApiVersions.API_CURRENT_VERSION,
                 href: grailsLinkGenerator.link(uri: "/api/${ApiVersions.API_CURRENT_VERSION}", absolute: true)
             ], formats: ['json']

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -41,7 +41,6 @@ class ApiController extends ControllerBase{
     def quartzScheduler
     def frameworkService
     AppAuthContextProcessor rundeckAuthContextProcessor
-    def apiService
     def userService
     def configurationService
     LinkGenerator grailsLinkGenerator

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -65,7 +65,6 @@ class ExecutionController extends ControllerBase{
     LoggingService loggingService
     ScheduledExecutionService scheduledExecutionService
     OrchestratorPluginService orchestratorPluginService
-    ApiService apiService
     WorkflowService workflowService
     FileUploadService fileUploadService
     PluginService pluginService

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -342,8 +342,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         }
         AuthContext authContext=rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,query.project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeProjectResourceAll(authContext, AuthConstants.RESOURCE_TYPE_NODE,
-                        [AuthConstants.ACTION_READ], query.project),
+                rundeckAuthContextProcessor.authorizeProjectResource(authContext, AuthConstants.RESOURCE_TYPE_NODE,
+                        AuthConstants.ACTION_READ, query.project),
                 AuthConstants.ACTION_READ, 'Project', 'nodes')) {
             return
         }
@@ -483,8 +483,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
     def nodeSummaryAjax(String project){
 
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
-        if (!rundeckAuthContextProcessor.authorizeProjectResourceAll(authContext, AuthConstants.RESOURCE_TYPE_NODE,
-                                                          [AuthConstants.ACTION_READ],
+        if (!rundeckAuthContextProcessor.authorizeProjectResource(authContext, AuthConstants.RESOURCE_TYPE_NODE,
+                                                          AuthConstants.ACTION_READ,
                                                           project
         )) {
 
@@ -531,8 +531,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         Framework framework = frameworkService.getRundeckFramework()
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, params.project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeProjectResourceAll(authContext, AuthConstants.RESOURCE_TYPE_NODE,
-                                                             [AuthConstants.ACTION_READ],
+                rundeckAuthContextProcessor.authorizeProjectResource(authContext, AuthConstants.RESOURCE_TYPE_NODE,
+                                                             AuthConstants.ACTION_READ,
                                                              query.project
                 ),
                 AuthConstants.ACTION_READ, 'Project', 'nodes', true
@@ -621,8 +621,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             return
         }
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, params.project)
-        if (!rundeckAuthContextProcessor.authorizeProjectResourceAll(authContext, AuthConstants.RESOURCE_TYPE_NODE,
-                                                             [AuthConstants.ACTION_READ],
+        if (!rundeckAuthContextProcessor.authorizeProjectResource(authContext, AuthConstants.RESOURCE_TYPE_NODE,
+                                                             AuthConstants.ACTION_READ,
                                                              query.project
                 )) {
 
@@ -2521,8 +2521,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         if(notFoundResponse(frameworkService.existsFrameworkProject(project),'Project',project,true)){
             return
         }
-        if(unauthorizedResponse(rundeckAuthContextProcessor.authorizeApplicationResourceAll(authContext,
-                rundeckAuthContextProcessor.authResourceForProject(project), [AuthConstants.ACTION_READ]),
+        if(unauthorizedResponse(rundeckAuthContextProcessor.authorizeApplicationResource(authContext,
+                rundeckAuthContextProcessor.authResourceForProject(project), AuthConstants.ACTION_READ),
                 AuthConstants.ACTION_READ,'Project',project,true)){
             return
         }
@@ -2556,8 +2556,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         if (notFoundResponse(frameworkService.existsFrameworkProject(project), 'Project', project, true)) {
             return
         }
-        if (unauthorizedResponse(rundeckAuthContextProcessor.authorizeApplicationResourceAll(authContext,
-                rundeckAuthContextProcessor.authResourceForProject(project), [AuthConstants.ACTION_READ]),
+        if (unauthorizedResponse(rundeckAuthContextProcessor.authorizeApplicationResource(authContext,
+                rundeckAuthContextProcessor.authResourceForProject(project), AuthConstants.ACTION_READ),
                 AuthConstants.ACTION_READ, 'Project', project, true)) {
             return
         }
@@ -3028,8 +3028,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                     code: 'api.error.item.doesnotexist', args: ['project',params.project]])
         }
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,params.project)
-        if (!rundeckAuthContextProcessor.authorizeProjectResourceAll(authContext, AuthConstants.RESOURCE_TYPE_NODE,
-                [AuthConstants.ACTION_READ], params.project)) {
+        if (!rundeckAuthContextProcessor.authorizeProjectResource(authContext, AuthConstants.RESOURCE_TYPE_NODE,
+                AuthConstants.ACTION_READ, params.project)) {
             return apiService.renderErrorXml(response, [status: HttpServletResponse.SC_FORBIDDEN,
                     code: 'api.error.item.unauthorized', args: ['Read Nodes', 'Project', params.project]])
         }
@@ -3075,8 +3075,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         }
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,params.project)
-        if (!rundeckAuthContextProcessor.authorizeProjectResourceAll(authContext, AuthConstants.RESOURCE_TYPE_NODE,
-                [AuthConstants.ACTION_READ], params.project)) {
+        if (!rundeckAuthContextProcessor.authorizeProjectResource(authContext, AuthConstants.RESOURCE_TYPE_NODE,
+                AuthConstants.ACTION_READ, params.project)) {
             return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_FORBIDDEN,
                                                            code: 'api.error.item.unauthorized', args: ['Read Nodes', 'Project', params.project]])
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -1018,7 +1018,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             return redirect(controller: 'menu', action: 'index', params: [project: project])
         }
 
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -1245,7 +1245,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             return redirect(controller: 'menu', action: 'index', params: [project: project])
         }
 
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -1503,7 +1503,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def project = params.project
 
 
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -1550,7 +1550,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         if (!configPrefix) {
             return renderErrorView("configPrefix parameter is required")
         }
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -1619,7 +1619,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def plugins = request.JSON.plugins
 
 
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -1734,7 +1734,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         }
 
         def project = params.project
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -1778,7 +1778,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             return redirect(controller: 'framework', action: 'projectNodeSources', params: [project: project])
         }
 
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -1842,7 +1842,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         }
 
         def project = params.project
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -1884,7 +1884,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def project = params.project
 
 
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -1948,7 +1948,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def project = params.project
         def index = params.index.toInteger()
 
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -2022,7 +2022,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         def project = params.project
 
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -2112,7 +2112,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         def project = params.project
 
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -2163,7 +2163,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         def project = params.project
 
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -2199,7 +2199,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         def project = params.project
 
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -2619,7 +2619,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         )) {
             return
         }
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -2692,7 +2692,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             return
         }
         final IRundeckProject fwkProject = frameworkService.getFrameworkProject(project)
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (!apiService.requireAuthorized(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             response,
@@ -2809,7 +2809,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         )) {
             return
         }
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
@@ -2902,7 +2902,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         )) {
             return
         }
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
         if (unauthorizedResponse(
             rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             AuthConstants.ACTION_CONFIGURE, 'Project',project)) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -115,7 +115,6 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
     PasswordFieldsService fcopyPasswordFieldsService
 
     def metricService
-    def ApiService apiService
     def ContextACLManager<AppACLContext> aclFileManagerService
     def ApplicationContext applicationContext
     def MenuService menuService

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -1019,15 +1019,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             return redirect(controller: 'menu', action: 'index', params: [project: project])
         }
 
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                        authContext,
-                        rundeckAuthContextProcessor.authResourceForProject(project),
-                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-                ),
-                AuthConstants.ACTION_CONFIGURE, 'Project',project
-        )) {
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
 
@@ -1251,11 +1246,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             return redirect(controller: 'menu', action: 'index', params: [project: project])
         }
 
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAny(authContext,
-                        rundeckAuthContextProcessor.authResourceForProject(project), [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]),
-                AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
 
@@ -1510,14 +1504,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def project = params.project
 
 
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                        rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
-                        rundeckAuthContextProcessor.authResourceForProject(project),
-                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-                ),
-                AuthConstants.ACTION_CONFIGURE, 'Project', project
-        )) {
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
 
@@ -1561,14 +1551,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         if (!configPrefix) {
             return renderErrorView("configPrefix parameter is required")
         }
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                        rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
-                        rundeckAuthContextProcessor.authResourceForProject(project),
-                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-                ),
-                AuthConstants.ACTION_CONFIGURE, 'Project', project
-        )) {
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
 
@@ -1634,14 +1620,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def plugins = request.JSON.plugins
 
 
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                        rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
-                        rundeckAuthContextProcessor.authResourceForProject(project),
-                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-                ),
-                AuthConstants.ACTION_CONFIGURE, 'Project', project
-        )) {
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
 
@@ -1753,14 +1735,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         }
 
         def project = params.project
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                        rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
-                        rundeckAuthContextProcessor.authResourceForProject(project),
-                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-                ),
-                AuthConstants.ACTION_CONFIGURE, 'Project', project
-        )) {
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
 
@@ -1801,15 +1779,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             return redirect(controller: 'framework', action: 'projectNodeSources', params: [project: project])
         }
 
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                        authContext,
-                        rundeckAuthContextProcessor.authResourceForProject(project),
-                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-                ),
-                AuthConstants.ACTION_CONFIGURE, 'Project', project
-        )) {
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
 
@@ -1870,14 +1843,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         }
 
         def project = params.project
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                        rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
-                        rundeckAuthContextProcessor.authResourceForProject(project),
-                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-                ),
-                AuthConstants.ACTION_CONFIGURE, 'Project', project
-        )) {
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
 
@@ -1916,14 +1885,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def project = params.project
 
 
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                        rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
-                        rundeckAuthContextProcessor.authResourceForProject(project),
-                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-                ),
-                AuthConstants.ACTION_CONFIGURE, 'Project', project
-        )) {
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
         final def fwkProject = frameworkService.getFrameworkProject(project)
@@ -1984,14 +1949,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         def project = params.project
         def index = params.index.toInteger()
 
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                        rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
-                        rundeckAuthContextProcessor.authResourceForProject(project),
-                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-                ),
-                AuthConstants.ACTION_CONFIGURE, 'Project', project
-        )) {
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
 
@@ -2062,14 +2023,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         def project = params.project
 
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                        rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
-                        rundeckAuthContextProcessor.authResourceForProject(project),
-                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-                ),
-                AuthConstants.ACTION_CONFIGURE, 'Project', project
-        )) {
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
 
@@ -2156,14 +2113,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         def project = params.project
 
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                        rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
-                        rundeckAuthContextProcessor.authResourceForProject(project),
-                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-                ),
-                AuthConstants.ACTION_CONFIGURE, 'Project', project
-        )) {
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
 
@@ -2211,12 +2164,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         def project = params.project
 
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                        rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
-                        rundeckAuthContextProcessor.authResourceForProject(project),
-                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]),
-                AuthConstants.ACTION_CONFIGURE, 'Project', project)) {
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
 
@@ -2249,12 +2200,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         def project = params.project
 
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                rundeckAuthContextProcessor.getAuthContextForSubject(session.subject),
-                rundeckAuthContextProcessor.authResourceForProject(project),
-                        [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]),
-                AuthConstants.ACTION_CONFIGURE, 'Project', project)) {
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
 
@@ -2671,16 +2620,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         )) {
             return
         }
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project)
-        if (!apiService.requireAuthorized(
-            rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                authContext,
-                rundeckAuthContextProcessor.authResourceForProject(project),
-                [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-            ),
-            response,
-            [AuthConstants.ACTION_CONFIGURE, 'Project', project]
-        )) {
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        if (unauthorizedResponse(
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
         final IRundeckProject fwkProject = frameworkService.getFrameworkProject(project)
@@ -2750,13 +2693,9 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             return
         }
         final IRundeckProject fwkProject = frameworkService.getFrameworkProject(project)
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project)
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
         if (!apiService.requireAuthorized(
-            rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                authContext,
-                rundeckAuthContextProcessor.authResourceForProject(project),
-                [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-            ),
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
             response,
             [AuthConstants.ACTION_CONFIGURE, 'Project', project]
         )) {
@@ -2871,16 +2810,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         )) {
             return
         }
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project)
-        if (!apiService.requireAuthorized(
-            rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                authContext,
-                rundeckAuthContextProcessor.authResourceForProject(project),
-                [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-            ),
-            response,
-            [AuthConstants.ACTION_CONFIGURE, 'Project', project]
-        )) {
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        if (unauthorizedResponse(
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
         def index = params.int('index')
@@ -2970,16 +2903,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         )) {
             return
         }
-        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project)
-        if (!apiService.requireAuthorized(
-            rundeckAuthContextProcessor.authorizeApplicationResourceAny(
-                authContext,
-                rundeckAuthContextProcessor.authResourceForProject(project),
-                [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
-            ),
-            response,
-            [AuthConstants.ACTION_CONFIGURE, 'Project', project]
-        )) {
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
+        if (unauthorizedResponse(
+            rundeckAuthContextProcessor.authorizeProjectConfigure(authContext, project),
+            AuthConstants.ACTION_CONFIGURE, 'Project',project)) {
             return
         }
         def index = params.int('index')

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -81,7 +81,6 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     def configurationService
     ScmService scmService
     def quartzScheduler
-    def ApiService apiService
     ContextACLManager<AppACLContext> aclFileManagerService
     def ApplicationContext applicationContext
     static allowedMethods = [

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2483,10 +2483,10 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             summary[project.name].description= description
             def projectAuth = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project.name)
             def eventAuth = rundeckAuthContextProcessor.
-                authorizeProjectResourceAll(
+                authorizeProjectResource(
                     projectAuth,
                     AuthConstants.RESOURCE_TYPE_EVENT,
-                    [AuthConstants.ACTION_READ],
+                    AuthConstants.ACTION_READ,
                     project.name
                 )
             if(!eventAuth){

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
@@ -37,7 +37,6 @@ class PluginController extends ControllerBase {
     PluginService pluginService
     PluginApiService pluginApiService
     FrameworkService frameworkService
-    ApiService apiService
     def featureService
     AppAuthContextProcessor rundeckAuthContextProcessor
     AuthorizedServicesProvider rundeckAuthorizedServicesProvider

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
@@ -55,7 +55,6 @@ class ProjectController extends ControllerBase{
     def projectService
     def scheduledExecutionService
     AppAuthContextProcessor rundeckAuthContextProcessor
-    ApiService apiService
     ContextACLManager<AppACLContext> aclFileManagerService
     def static allowedMethods = [
             apiProjectConfigKeyDelete:['DELETE'],

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
@@ -65,10 +65,10 @@ class ReportsController extends ControllerBase{
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, params.project)
 
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeProjectResourceAll(
+                rundeckAuthContextProcessor.authorizeProjectResource(
                         authContext,
-                        AuthorizationUtil.resourceType('event'),
-                        [AuthConstants.ACTION_READ],
+                        AuthConstants.RESOURCE_TYPE_EVENT,
+                        AuthConstants.ACTION_READ,
                         params.project
                 ),
                 AuthConstants.ACTION_READ,
@@ -93,9 +93,17 @@ class ReportsController extends ControllerBase{
         def usedFilter
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,params.project)
 
-        if(unauthorizedResponse(rundeckAuthContextProcessor.authorizeProjectResourceAll(authContext, AuthorizationUtil
-                .resourceType('event'), [AuthConstants.ACTION_READ],
-                params.project), AuthConstants.ACTION_READ,'Events in project',params.project)){
+        if(unauthorizedResponse(
+            rundeckAuthContextProcessor.authorizeProjectResource(
+                authContext,
+                AuthConstants.RESOURCE_TYPE_EVENT,
+                AuthConstants.ACTION_READ,
+                params.project
+            ),
+            AuthConstants.ACTION_READ,
+            'Events in project',
+            params.project)
+        ){
             return
         }
         def User u = userService.findOrCreateUser(session.user)
@@ -156,8 +164,7 @@ class ReportsController extends ControllerBase{
                 list.each {refex ->
                     boolean add = true
                     if(refex.project != params.project){
-                        if(unauthorizedResponse(rundeckAuthContextProcessor.authorizeProjectResourceAll(authContext, AuthorizationUtil
-                                .resourceType('event'), [AuthConstants.ACTION_READ],
+                        if(unauthorizedResponse(rundeckAuthContextProcessor.authorizeProjectResource(authContext, AuthConstants.RESOURCE_TYPE_EVENT, AuthConstants.ACTION_READ,
                                 params.project), AuthConstants.ACTION_READ,'Events in project',refex.project)){
                             log.debug('Cant read executions on project '+refex.project)
                         }else{
@@ -211,9 +218,12 @@ class ReportsController extends ControllerBase{
         def usedFilter
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,params.project)
 
-        if (unauthorizedResponse(rundeckAuthContextProcessor.authorizeProjectResourceAll(authContext, AuthorizationUtil
-                .resourceType('event'), [AuthConstants.ACTION_READ],
-                params.project), AuthConstants.ACTION_READ, 'Events for project', params.project)) {
+        if (unauthorizedResponse(rundeckAuthContextProcessor.authorizeProjectResource(
+            authContext,
+            AuthConstants.RESOURCE_TYPE_EVENT,
+            AuthConstants.ACTION_READ,
+            params.project
+        ), AuthConstants.ACTION_READ, 'Events for project', params.project)) {
             return
         }
         if (params.max != null && params.max != query.max.toString()) {
@@ -318,9 +328,12 @@ class ReportsController extends ControllerBase{
     def eventsFragment={ ExecQuery query ->
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,params.project)
 
-        if (unauthorizedResponse(rundeckAuthContextProcessor.authorizeProjectResourceAll(authContext, AuthorizationUtil
-                .resourceType('event'), [AuthConstants.ACTION_READ],
-                params.project), AuthConstants.ACTION_READ, 'Events for project', params.project)) {
+        if (unauthorizedResponse(rundeckAuthContextProcessor.authorizeProjectResource(
+            authContext,
+            AuthConstants.RESOURCE_TYPE_EVENT,
+            AuthConstants.ACTION_READ,
+            params.project
+        ), AuthConstants.ACTION_READ, 'Events for project', params.project)) {
             return
         }
         def results = index_old(query)
@@ -331,9 +344,12 @@ class ReportsController extends ControllerBase{
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,params.project)
 
 
-        if (unauthorizedResponse(rundeckAuthContextProcessor.authorizeProjectResourceAll(authContext, AuthorizationUtil
-                .resourceType('event'), [AuthConstants.ACTION_READ],
-                params.project), AuthConstants.ACTION_READ, 'Events for project', params.project)) {
+        if (unauthorizedResponse(rundeckAuthContextProcessor.authorizeProjectResource(
+            authContext,
+            AuthConstants.RESOURCE_TYPE_EVENT,
+            AuthConstants.ACTION_READ,
+            params.project
+        ), AuthConstants.ACTION_READ, 'Events for project', params.project)) {
             return
         }
 
@@ -631,8 +647,12 @@ class ReportsController extends ControllerBase{
 
         }
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,params.project)
-        if (!rundeckAuthContextProcessor.authorizeProjectResourceAll(authContext, AuthConstants.RESOURCE_TYPE_EVENT,
-                [AuthConstants.ACTION_READ], params.project)) {
+        if (!rundeckAuthContextProcessor.authorizeProjectResource(
+            authContext,
+            AuthConstants.RESOURCE_TYPE_EVENT,
+            AuthConstants.ACTION_READ,
+            params.project
+        )) {
             return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_FORBIDDEN,
                     code: 'api.error.item.unauthorized', args: ['Read Events', 'Project', params.project]])
         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
@@ -51,7 +51,6 @@ class ReportsController extends ControllerBase{
     def FrameworkService frameworkService
     AppAuthContextProcessor rundeckAuthContextProcessor
     def scheduledExecutionService
-    def ApiService apiService
     def MetricService metricService
     static allowedMethods = [
             deleteFilter    : 'POST',

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -1754,8 +1754,8 @@ class ScheduledExecutionController  extends ControllerBase{
         }
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,scheduledExecution.project)
         //authorize
-        if(unauthorizedResponse(rundeckAuthContextProcessor.authorizeProjectResourceAll(authContext,
-                AuthConstants.RESOURCE_TYPE_JOB, [AuthConstants.ACTION_CREATE], params.project),
+        if(unauthorizedResponse(rundeckAuthContextProcessor.authorizeProjectResource(authContext,
+                AuthConstants.RESOURCE_TYPE_JOB, AuthConstants.ACTION_CREATE, params.project),
                 AuthConstants.ACTION_CREATE,
                 'New Job'
         )){
@@ -1811,12 +1811,11 @@ class ScheduledExecutionController  extends ControllerBase{
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,execution.project)
 
         if (unauthorizedResponse(
-                rundeckAuthContextProcessor.authorizeProjectResourceAll(
-                        authContext,
-                        AuthConstants.RESOURCE_TYPE_JOB,
-                        [AuthConstants.ACTION_CREATE],
-                        params.project
-                ),
+            rundeckAuthContextProcessor.authorizeProjectResource(
+                authContext,
+                AuthConstants.RESOURCE_TYPE_JOB,
+                AuthConstants.ACTION_CREATE,
+                params.project),
                 AuthConstants.ACTION_CREATE,
                 'New Job'
         )) {
@@ -1862,9 +1861,11 @@ class ScheduledExecutionController  extends ControllerBase{
 
         UserAndRolesAuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,params.project)
         //authorize
-        if (unauthorizedResponse(rundeckAuthContextProcessor.authorizeProjectResourceAll(authContext,
-                AuthConstants.RESOURCE_TYPE_JOB, [AuthConstants.ACTION_CREATE],
-                params.project),
+        if (unauthorizedResponse(rundeckAuthContextProcessor.authorizeProjectResource(
+            authContext,
+            AuthConstants.RESOURCE_TYPE_JOB,
+            AuthConstants.ACTION_CREATE,
+            params.project),
                 AuthConstants.ACTION_CREATE, 'New Job')) {
             return
         }
@@ -3939,11 +3940,11 @@ class ScheduledExecutionController  extends ControllerBase{
                     ]
             )
         }
-        if (!rundeckAuthContextProcessor.authorizeProjectResourceAll(
-                authContext,
-                AuthConstants.RESOURCE_TYPE_EVENT,
-                [AuthConstants.ACTION_READ],
-                scheduledExecution.project
+        if (!rundeckAuthContextProcessor.authorizeProjectResource(
+            authContext,
+            AuthConstants.RESOURCE_TYPE_EVENT,
+            AuthConstants.ACTION_READ,
+            scheduledExecution.project
         )
         ) {
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -147,7 +147,6 @@ class ScheduledExecutionController  extends ControllerBase{
     def ScheduledExecutionService scheduledExecutionService
     def OrchestratorPluginService orchestratorPluginService
 	def NotificationService notificationService
-    def ApiService apiService
     def UserService userService
     def ScmService scmService
     def PluginService pluginService

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -38,7 +38,6 @@ class ScmController extends ControllerBase {
     def scmService
     def frameworkService
     AppAuthContextProcessor rundeckAuthContextProcessor
-    def apiService
     def scheduledExecutionService
 
     def static allowedMethods = [

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/StorageController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/StorageController.groovy
@@ -57,7 +57,6 @@ class StorageController extends ControllerBase{
      */
     public static final Set<String> RES_META_MASKED = [StorageUtil.RES_META_RUNDECK_CONTENT_LENGTH]
     StorageService storageService
-    ApiService apiService
     FrameworkService frameworkService
     AuthContextProvider rundeckAuthContextProvider
     static allowedMethods = [

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -221,8 +221,7 @@ class UserController extends ControllerBase{
         }
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
 
-        if (unauthorizedResponse(user.login == session.user || rundeckAuthContextProcessor.authorizeApplicationResourceType
-                (authContext, AuthConstants.TYPE_USER, AuthConstants.ACTION_ADMIN), AuthConstants.ACTION_ADMIN, 'Users',
+        if (unauthorizedResponse(user.login == session.user || rundeckAuthContextProcessor.authorizeApplicationResourceType(authContext, AuthConstants.TYPE_USER, AuthConstants.ACTION_ADMIN), AuthConstants.ACTION_ADMIN, 'Users',
                 user.login)) {
             return
         }
@@ -599,8 +598,7 @@ class UserController extends ControllerBase{
         //check auth to view profile
         //default to current user profile
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
-        if(unauthorizedResponse(params.login == session.user || rundeckAuthContextProcessor.authorizeApplicationResourceType
-                (authContext, AuthConstants.TYPE_USER,
+        if(unauthorizedResponse(params.login == session.user || rundeckAuthContextProcessor.authorizeApplicationResourceType(authContext, AuthConstants.TYPE_USER,
                 AuthConstants.ACTION_ADMIN), AuthConstants.ACTION_ADMIN,'User',params.login)){
             return
         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -40,7 +40,6 @@ class UserController extends ControllerBase{
     UserService userService
     AppAuthContextProcessor rundeckAuthContextProcessor
     GrailsApplication grailsApplication
-    def apiService
     def configurationService
 
     static allowedMethods = [

--- a/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
@@ -227,7 +227,7 @@ class JobStateService implements AuthorizingJobService {
                 se.project
             )
         }else if(!se){
-            isAuth=rundeckAuthContextEvaluator.authorizeProjectResourceAll(auth, AuthConstants.RESOURCE_ADHOC, [AuthConstants.ACTION_READ],
+            isAuth=rundeckAuthContextEvaluator.authorizeProjectResource(auth, AuthConstants.RESOURCE_ADHOC, AuthConstants.ACTION_READ,
                     exec.project)
         }
         if(!isAuth){

--- a/rundeckapp/grails-app/views/common/_navBarProjectSettingsData.gsp
+++ b/rundeckapp/grails-app/views/common/_navBarProjectSettingsData.gsp
@@ -19,37 +19,37 @@
         action: AuthConstants.ACTION_ADMIN,
         type: AuthConstants.TYPE_PROJECT,
         name: (params.project ?: request.project),
-        context: "application"
+        context: AuthConstants.CTX_APPLICATION
 )}"/>
 <g:set var="authDelete"
        value="${authAdmin || auth.resourceAllowedTest(
                action: AuthConstants.ACTION_DELETE,
                type: AuthConstants.TYPE_PROJECT,
-               name: (params.project ?: request.project), context: "application"
+               name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION
        )}"/>
 <g:set var="authExport"
        value="${authAdmin || auth.resourceAllowedTest(
                action: AuthConstants.ACTION_EXPORT,
                type: AuthConstants.TYPE_PROJECT,
-               name: (params.project ?: request.project), context: "application"
+               name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION
        )}"/>
 <g:set var="authImport"
        value="${authAdmin || auth.resourceAllowedTest(
                action: AuthConstants.ACTION_IMPORT,
                type: AuthConstants.TYPE_PROJECT,
-               name: (params.project ?: request.project), context: "application"
+               name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION
        )}"/>
 <g:set var="authConfigure"
        value="${authAdmin || auth.resourceAllowedTest(
                action: AuthConstants.ACTION_CONFIGURE,
                type: AuthConstants.TYPE_PROJECT,
-               name: (params.project ?: request.project), context: "application"
+               name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION
        )}"/>
 <g:set var="authReadAcl"
        value="${auth.resourceAllowedTest(action: [AuthConstants.ACTION_READ, AuthConstants.ACTION_ADMIN],
                any: true,
                type: AuthConstants.TYPE_PROJECT_ACL,
-               name: (params.project ?: request.project), context: "application"
+               name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION
        )}"/>
 <g:set var="projectKeyStorageEnabled"
        value="${!(grailsApplication.config.rundeck?.feature?.projectKeyStorage?.enabled in [false,'false'])}"/>

--- a/rundeckapp/grails-app/views/common/_navData.gsp
+++ b/rundeckapp/grails-app/views/common/_navData.gsp
@@ -45,7 +45,7 @@
                             AuthConstants.ACTION_EXPORT,
                             AuthConstants.ACTION_DELETE],
                    any: true,
-                   context: 'application'
+                   context: AuthConstants.CTX_APPLICATION
            )}"/>
     <g:set var="projACLAuth"
            value="${auth.resourceAllowedTest(
@@ -54,7 +54,7 @@
                    action: [AuthConstants.ACTION_READ,
                             AuthConstants.ACTION_ADMIN],
                    any: true,
-                   context: 'application'
+                   context: AuthConstants.CTX_APPLICATION
            )}"/>
 </g:if>
 
@@ -104,7 +104,7 @@
                 </g:if>
 
 
-                <auth:resourceAllowed project="${projectName}" action="${[AuthConstants.ACTION_READ]}" kind="event">
+                <auth:resourceAllowed project="${projectName}" action="${[AuthConstants.ACTION_READ]}" kind="${AuthConstants.TYPE_EVENT}">
                 {
                     type: 'link',
                     id: 'nav-activity-link',

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -46,8 +46,8 @@
       </g:else>
       </g:each>
       <g:set var="adhocRunAllowed" value="${auth.adhocAllowedTest(action: AuthConstants.ACTION_RUN,project:execution.project)}"/>
-      <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(context: 'application', type: 'project', name: params.project, action: AuthConstants.ACTION_ADMIN)}"/>
-      <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: 'application', type: 'project', name: params.project, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
+      <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: params.project, action: AuthConstants.ACTION_ADMIN)}"/>
+      <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: params.project, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
 
       <g:set var="defaultLastLines" value="${grailsApplication.config.rundeck.gui.execution.tail.lines.default}"/>
       <g:set var="maxLastLines" value="${grailsApplication.config.rundeck.gui.execution.tail.lines.max}"/>
@@ -893,7 +893,7 @@ search
               <g:set var="hasEventReadAuth" value="${auth.resourceAllowedTest(
                       project: scheduledExecution.project,
                       action: AuthConstants.ACTION_READ,
-                      kind: 'event'
+                      kind: AuthConstants.TYPE_EVENT
               )}"/>
               <div class="col-sm-12">
 

--- a/rundeckapp/grails-app/views/execution/showFragment.gsp
+++ b/rundeckapp/grails-app/views/execution/showFragment.gsp
@@ -33,7 +33,7 @@
     </g:else>
 </g:each>
 <g:set var="adhocRunAllowed" value="${auth.adhocAllowedTest(action: AuthConstants.ACTION_RUN,project:execution.project)}"/>
-<g:set var="jobCreateAllowed" value="${auth.resourceAllowedTest(kind: 'job', action: [AuthConstants.ACTION_CREATE],project:execution.project)}"/>
+<g:set var="jobCreateAllowed" value="${auth.resourceAllowedTest(kind: AuthConstants.TYPE_JOB, action: [AuthConstants.ACTION_CREATE],project:execution.project)}"/>
 
 
 

--- a/rundeckapp/grails-app/views/framework/_createProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_createProjectForm.gsp
@@ -14,7 +14,7 @@
   - limitations under the License.
   --}%
 
-<%@ page import="com.dtolabs.rundeck.plugins.ServiceNameConstants" contentType="text/html;charset=UTF-8" %>
+<%@ page import="org.rundeck.core.auth.AuthConstants; com.dtolabs.rundeck.plugins.ServiceNameConstants" contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <g:set var="rkey" value="${g.rkey()}"/>
@@ -99,7 +99,7 @@
 
 <body>
 <g:set var="adminauth"
-       value="${auth.resourceAllowedTest(type: 'resource', kind: 'project', action: ['create'], context: 'application')}"/>
+       value="${auth.resourceAllowedTest(type: AuthConstants.TYPE_RESOURCE, kind: AuthConstants.TYPE_PROJECT, action: [AuthConstants.ACTION_CREATE], context: AuthConstants.CTX_APPLICATION)}"/>
 <g:if test="${adminauth}">
 <div class="content">
 <div id="layoutBody">

--- a/rundeckapp/grails-app/views/framework/_projectSelect.gsp
+++ b/rundeckapp/grails-app/views/framework/_projectSelect.gsp
@@ -1,3 +1,4 @@
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 %{--
   - Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
   -
@@ -30,7 +31,7 @@
     <li class="dropdown-header">
       <g:message code="Project.plural"/>
     </li>
-    <auth:resourceAllowed action="create" kind="project" context="application">
+    <auth:resourceAllowed action="${AuthConstants.ACTION_CREATE}" kind="${AuthConstants.TYPE_PROJECT}" context="${AuthConstants.CTX_APPLICATION}">
       <g:if test="${!params.nocreate}">
         <li>
           <g:link controller="framework" action="createProject">

--- a/rundeckapp/grails-app/views/framework/_projectSelectSidebar.gsp
+++ b/rundeckapp/grails-app/views/framework/_projectSelectSidebar.gsp
@@ -1,3 +1,4 @@
+<%@ page import="org.rundeck.core.auth.AuthConstants" %>
 %{--
   - Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
   -
@@ -19,7 +20,7 @@
 
 <div class="subnav" style="display:none">
   <ul class="nav" style="" data-old-padding-top="" data-old-padding-bottom="" data-old-overflow="">
-    <auth:resourceAllowed action="create" kind="project" context="application">
+    <auth:resourceAllowed action="${AuthConstants.ACTION_CREATE}" kind="${AuthConstants.TYPE_PROJECT}" context="${AuthConstants.CTX_APPLICATION}">
       <g:if test="${!params.nocreate}">
         <li>
           <g:link controller="framework" action="createProject">

--- a/rundeckapp/grails-app/views/framework/adhoc.gsp
+++ b/rundeckapp/grails-app/views/framework/adhoc.gsp
@@ -25,13 +25,13 @@
     <g:set var="projectLabel" value="${session.frameworkLabels?session.frameworkLabels[projectName]:projectName}"/>
     <title><g:message code="gui.menu.Adhoc"/> - <g:enc>${projectLabel}</g:enc></title>
 
-  <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(context: 'application', type: 'project', name: projectName, action: AuthConstants.ACTION_ADMIN)}"/>
-  <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: 'application', type: 'project', name: projectName, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
+  <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: AuthConstants.ACTION_ADMIN)}"/>
+  <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
 
   <g:set var="eventReadAuth" value="${auth.resourceAllowedTest(
           project: projectName,
           action: AuthConstants.ACTION_READ,
-          kind: 'event'
+          kind: AuthConstants.TYPE_EVENT
   )}"/>
 
     <asset:javascript src="static/css/pages/command.css"/>

--- a/rundeckapp/grails-app/views/framework/editProjectFile.gsp
+++ b/rundeckapp/grails-app/views/framework/editProjectFile.gsp
@@ -83,7 +83,7 @@
               <g:submitButton name="save" value="${g.message(code: 'button.action.Save', default: 'Save')}" class="btn btn-cta reset_page_confirm"/>
               <g:if test="${displayConfig?.contains('none')}">
                 <span class="text-warning text-right">
-                  <g:set var="authAdmin" value="${auth.resourceAllowedTest( action: AuthConstants.ACTION_ADMIN, type: "project", name: (params.project ?: request.project), context: "application" )}"/>
+                  <g:set var="authAdmin" value="${auth.resourceAllowedTest( action: AuthConstants.ACTION_ADMIN, type: AuthConstants.TYPE_PROJECT, name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION )}"/>
                   <g:if test="${authAdmin}">
                     <g:message code="project.edit.readme.warning.not.displayed.admin.message" />
                       <g:link controller="framework" action="editProject" params="[project: params.project]">

--- a/rundeckapp/grails-app/views/framework/nodes.gsp
+++ b/rundeckapp/grails-app/views/framework/nodes.gsp
@@ -41,7 +41,7 @@
 </g:if>
 
 <g:set var="run_authorized" value="${auth.adhocAllowedTest( action:AuthConstants.ACTION_RUN,project: params.project ?: request.project)}"/>
-<g:set var="job_create_authorized" value="${auth.resourceAllowedTest(kind:'job', action: AuthConstants.ACTION_CREATE,project: params.project ?: request.project)}"/>
+<g:set var="job_create_authorized" value="${auth.resourceAllowedTest(kind:AuthConstants.TYPE_JOB, action: AuthConstants.ACTION_CREATE,project: params.project ?: request.project)}"/>
 <div class="content">
 <div id="layoutBody">
 <div class="row" style="margin-bottom: 20px;">

--- a/rundeckapp/grails-app/views/menu/_configExecutionMode.gsp
+++ b/rundeckapp/grails-app/views/menu/_configExecutionMode.gsp
@@ -36,7 +36,7 @@
 <g:if test="${selected != 'changeexecmode'}">
 
     <g:set var="authAction" value="${g.executionMode(active:true)?AuthConstants.ACTION_DISABLE_EXECUTIONS:AuthConstants.ACTION_ENABLE_EXECUTIONS}"/>
-    <auth:resourceAllowed action="${[authAction,AuthConstants.ACTION_ADMIN]}" any="true" context="application" kind="system">
+    <auth:resourceAllowed action="${[authAction,AuthConstants.ACTION_ADMIN]}" any="true" context="${AuthConstants.CTX_APPLICATION}" kind="${AuthConstants.TYPE_SYSTEM}">
         <g:ifExecutionMode active="true">
             <g:link action="executionMode" controller="menu" class="btn btn-default btn-sm">
                 <g:message code="change.execution.mode" />

--- a/rundeckapp/grails-app/views/menu/_projectConfigNavMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_projectConfigNavMenu.gsp
@@ -20,37 +20,37 @@
         action: AuthConstants.ACTION_ADMIN,
         type: AuthConstants.TYPE_PROJECT,
         name: (params.project ?: request.project),
-        context: "application"
+        context: AuthConstants.CTX_APPLICATION
 )}"/>
 <g:set var="authDelete"
        value="${authAdmin || auth.resourceAllowedTest(
                action: AuthConstants.ACTION_DELETE,
                type: AuthConstants.TYPE_PROJECT,
-               name: (params.project ?: request.project), context: "application"
+               name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION
        )}"/>
 <g:set var="authExport"
        value="${authAdmin || auth.resourceAllowedTest(
                action: AuthConstants.ACTION_EXPORT,
                type: AuthConstants.TYPE_PROJECT,
-               name: (params.project ?: request.project), context: "application"
+               name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION
        )}"/>
 <g:set var="authImport"
        value="${authAdmin || auth.resourceAllowedTest(
                action: AuthConstants.ACTION_IMPORT,
                type: AuthConstants.TYPE_PROJECT,
-               name: (params.project ?: request.project), context: "application"
+               name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION
        )}"/>
 <g:set var="authConfigure"
        value="${authAdmin || auth.resourceAllowedTest(
                action: AuthConstants.ACTION_CONFIGURE,
                type: AuthConstants.TYPE_PROJECT,
-               name: (params.project ?: request.project), context: "application"
+               name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION
        )}"/>
 <g:set var="authReadAcl"
        value="${auth.resourceAllowedTest(action: [AuthConstants.ACTION_READ, AuthConstants.ACTION_ADMIN],
                                          any: true,
                                          type: AuthConstants.TYPE_PROJECT_ACL,
-                                         name: (params.project ?: request.project), context: "application"
+                                         name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION
        )}"/>
 
 <bs:dropdown>

--- a/rundeckapp/grails-app/views/menu/_projectExportForm.gsp
+++ b/rundeckapp/grails-app/views/menu/_projectExportForm.gsp
@@ -84,24 +84,24 @@
                   <g:checkBox name="exportReadmes" value="true"/>
                   <label for="exportReadmes">Readme/Motd</label>
                 </div>
-                <auth:resourceAllowed action="${[AuthConstants.ACTION_READ, AuthConstants.ACTION_ADMIN]}" any="true" context='application' type="project_acl" name="${params.project}">
+                <auth:resourceAllowed action="${[AuthConstants.ACTION_READ, AuthConstants.ACTION_ADMIN]}" any="true" context="${AuthConstants.CTX_APPLICATION}" type="${AuthConstants.TYPE_PROJECT_ACL}" name="${params.project}">
                   <div class="checkbox">
                     <g:checkBox name="exportAcls" value="true"/>
                     <label for="exportAcls">ACL Policies</label>
                   </div>
                 </auth:resourceAllowed>
-                <auth:resourceAllowed action="${[AuthConstants.ACTION_READ, AuthConstants.ACTION_ADMIN]}" any="true" context='application' type="project_acl" has="false" name="${params.project}">
+                <auth:resourceAllowed action="${[AuthConstants.ACTION_READ, AuthConstants.ACTION_ADMIN]}" any="true" context="${AuthConstants.CTX_APPLICATION}" type="${AuthConstants.TYPE_PROJECT_ACL}" has="false" name="${params.project}">
                   <div class="checkbox disabled text-strong">
                     <i class="glyphicon glyphicon-ban-circle"></i> ACL Policies (Unauthorized)
                   </div>
                 </auth:resourceAllowed>
-                <auth:resourceAllowed action="${[AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]}" context='application' type="project" name="${params.project}">
+                <auth:resourceAllowed action="${[AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]}" context="${AuthConstants.CTX_APPLICATION}" type="${AuthConstants.TYPE_PROJECT}" name="${params.project}">
                 <div class="checkbox">
                   <g:checkBox name="exportScm" value="true"/>
                   <label for="exportScm">SCM configuration</label>
                 </div>
                 </auth:resourceAllowed>
-                <auth:resourceAllowed action="${[AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]}" context='application' type="project" has="false" name="${params.project}">
+                <auth:resourceAllowed action="${[AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]}" context="${AuthConstants.CTX_APPLICATION}" type="${AuthConstants.TYPE_PROJECT}" has="false" name="${params.project}">
                   <div class="checkbox disabled text-strong">
                     <i class="glyphicon glyphicon-ban-circle"></i> SCM Configuration (Unauthorized)
                   </div>
@@ -127,10 +127,10 @@
                         </div>
                     </g:set>
                     <g:if test="${projectComponent.exportAuthRequiredActions}">
-                       <auth:resourceAllowed action="${projectComponent.exportAuthRequiredActions}" context='application' type="project" name="${params.project}">
+                       <auth:resourceAllowed action="${projectComponent.exportAuthRequiredActions}" context="${AuthConstants.CTX_APPLICATION}" type="${AuthConstants.TYPE_PROJECT}" name="${params.project}">
                           ${raw(projectComponentCheckboxTemplate)}
                         </auth:resourceAllowed>
-                        <auth:resourceAllowed action="${projectComponent.exportAuthRequiredActions}" context='application' type="project" name="${params.project}" has="false">
+                        <auth:resourceAllowed action="${projectComponent.exportAuthRequiredActions}" context="${AuthConstants.CTX_APPLICATION}" type="${AuthConstants.TYPE_PROJECT}" name="${params.project}" has="false">
                           <div class="checkbox disabled text-strong">
                             <i class="glyphicon glyphicon-ban-circle"></i> ${projectComponentTitle} (Unauthorized)
                           </div>
@@ -206,7 +206,7 @@
       <div class="card-footer">
         <g:submitButton name="cancel" value="${g.message(code:'button.action.Cancel',default:'Cancel')}" class="btn btn-default  btn-sm"/>
         <button type="submit" class="btn btn-cta btn-sm"><g:message code="export.archive"/> <g:icon name="download"/></button>
-        <auth:resourceAllowed action="${[AuthConstants.ACTION_PROMOTE, AuthConstants.ACTION_ADMIN]}" context='application' type="project" name="${params.project}">
+        <auth:resourceAllowed action="${[AuthConstants.ACTION_PROMOTE, AuthConstants.ACTION_ADMIN]}" context="${AuthConstants.CTX_APPLICATION}" type="${AuthConstants.TYPE_PROJECT}" name="${params.project}">
           <button type="button" data-toggle="modal" data-target="#exportModal" class="btn btn-info  btn-sm pull-right"><g:message code="export.another.instance"/></button>
         </auth:resourceAllowed>
       </div>

--- a/rundeckapp/grails-app/views/menu/_projectImportForm.gsp
+++ b/rundeckapp/grails-app/views/menu/_projectImportForm.gsp
@@ -109,7 +109,7 @@
                 </span>
               </div>
           </div>
-          <auth:resourceAllowed action="${[AuthConstants.ACTION_CREATE, AuthConstants.ACTION_ADMIN]}" any="true" context='application' type="project_acl" name="${params.project}">
+          <auth:resourceAllowed action="${[AuthConstants.ACTION_CREATE, AuthConstants.ACTION_ADMIN]}" any="true" context="${AuthConstants.CTX_APPLICATION}" type="${AuthConstants.TYPE_PROJECT_ACL}" name="${params.project}">
             <div class="list-group-item">
               <h4 class="list-group-item-heading">ACL Policies</h4>
                 <div class="radio">
@@ -132,7 +132,7 @@
                 </div>
             </div>
           </auth:resourceAllowed>
-          <auth:resourceAllowed action="${[AuthConstants.ACTION_CREATE, AuthConstants.ACTION_ADMIN]}" any="true" context='application' type="project_acl" has="false" name="${params.project}">
+          <auth:resourceAllowed action="${[AuthConstants.ACTION_CREATE, AuthConstants.ACTION_ADMIN]}" any="true" context="${AuthConstants.CTX_APPLICATION}" type="${AuthConstants.TYPE_PROJECT_ACL}" has="false" name="${params.project}">
             <div class="list-group-item">
               <h4 class="list-group-item-heading">ACL Policies</h4>
               <span class="help-block">
@@ -189,7 +189,7 @@
             <g:set var="projectComponent" value="${projectComponentMap[compName]}"/>
 
 
-            <g:if test="${!projectComponent.importAuthRequiredActions || auth.resourceAllowedTest(action: projectComponent.importAuthRequiredActions,any:true,context:'application',type:'project',name:params.project)}">
+            <g:if test="${!projectComponent.importAuthRequiredActions || auth.resourceAllowedTest(action: projectComponent.importAuthRequiredActions,any:true,context:AuthConstants.CTX_APPLICATION,type:AuthConstants.TYPE_PROJECT,name:params.project)}">
                 <g:set var="componentTitle">
                     <g:if test="${projectComponent.titleCode}">
                         <g:message code="${projectComponent.titleCode}" default="${projectComponent.title?:projectComponent.name}"/>

--- a/rundeckapp/grails-app/views/menu/_sysConfigExecutionModeNavMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_sysConfigExecutionModeNavMenu.gsp
@@ -20,8 +20,8 @@
         AuthConstants.ACTION_ENABLE_EXECUTIONS}"/>
 <auth:resourceAllowed action="${[authAction, AuthConstants.ACTION_ADMIN]}"
                       any="true"
-                      context="application"
-                      kind="system">
+                      context="${AuthConstants.CTX_APPLICATION}"
+                      kind="${AuthConstants.TYPE_SYSTEM}">
     <bs:menuitem/>
     <bs:menuitem
             action="executionMode"

--- a/rundeckapp/grails-app/views/menu/_sysConfigNavMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_sysConfigNavMenu.gsp
@@ -17,26 +17,26 @@
 <%@ page import="org.rundeck.core.auth.AuthConstants" %>
 
 <g:set var="authRead" value="${auth.resourceAllowedTest(
-        type: 'resource',
-        kind: 'system',
+        type: AuthConstants.TYPE_RESOURCE,
+        kind: AuthConstants.TYPE_SYSTEM,
         action: [AuthConstants.ACTION_READ, AuthConstants.ACTION_ADMIN],
         any: true,
-        context: 'application'
+        context: AuthConstants.CTX_APPLICATION
 )}"/>
 
 <g:set var="pluginRead" value="${auth.resourceAllowedTest(
-        type: 'resource',
-        kind: 'plugin',
+        type: AuthConstants.TYPE_RESOURCE,
+        kind: AuthConstants.TYPE_PLUGIN,
         action: [AuthConstants.ACTION_READ, AuthConstants.ACTION_ADMIN],
         any: true,
-        context: 'application'
+        context: AuthConstants.CTX_APPLICATION
 )}"/>
 <g:set var="pluginInstall" value="${auth.resourceAllowedTest(
-        type: 'resource',
-        kind: 'plugin',
-        action: ["install","admin"],
+        type: AuthConstants.TYPE_RESOURCE,
+        kind: AuthConstants.TYPE_PLUGIN,
+        action: [AuthConstants.ACTION_INSTALL, AuthConstants.ACTION_ADMIN],
         any: true,
-        context: 'application'
+        context: AuthConstants.CTX_APPLICATION
 )}"/>
 <g:set var="repoEnabled" value="${grailsApplication.config.rundeck?.feature?.repository?.enabled in [true,'true']}"/>
 

--- a/rundeckapp/grails-app/views/menu/_workflowsFull.gsp
+++ b/rundeckapp/grails-app/views/menu/_workflowsFull.gsp
@@ -46,8 +46,8 @@
 <g:set var="rkey" value="${rkey?:g.rkey()}"/>
 
 <g:set var="authProjectSCMAdmin" value="${auth.resourceAllowedTest(
-        context: 'application',
-        type: 'project',
+        context: AuthConstants.CTX_APPLICATION,
+        type: AuthConstants.TYPE_PROJECT,
         action: [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN],
         any: true,
         name: params.project
@@ -220,7 +220,7 @@
                     <span class="caret"></span>
                   </button>
                   <ul class="dropdown-menu pull-right" role="menu" id="job_action_menu" data-ko-bind="bulkeditor">
-                  <auth:resourceAllowed kind="job" action="${AuthConstants.ACTION_CREATE}" project="${params.project ?: request.project}">
+                  <auth:resourceAllowed kind="${AuthConstants.TYPE_JOB}" action="${AuthConstants.ACTION_CREATE}" project="${params.project ?: request.project}">
                     <li>
                       <g:link controller="scheduledExecution" action="create" params="[project: params.project ?: request.project]" class="">
                         <i class="glyphicon glyphicon-plus"></i>
@@ -390,7 +390,7 @@
                                         </span>
 
 
-                                        <auth:resourceAllowed kind="job" action="${AuthConstants.ACTION_DELETE  }"
+                                        <auth:resourceAllowed kind="${AuthConstants.TYPE_JOB}" action="${AuthConstants.ACTION_DELETE  }"
                                                               project="${params.project ?: request.project}">
                                         <span data-bind="if: isDelete">
                                             <g:actionSubmit action="deleteBulk"
@@ -431,7 +431,7 @@
                                         <span class="caret"></span>
                                     </button>
                                     <ul class="dropdown-menu " role="menu">
-                                        <auth:resourceAllowed kind="job" action="${AuthConstants.ACTION_DELETE  }"
+                                        <auth:resourceAllowed kind="${AuthConstants.TYPE_JOB}" action="${AuthConstants.ACTION_DELETE  }"
                                                               project="${params.project ?: request.project}">
 
 
@@ -505,7 +505,7 @@
                 <g:if test="${!jobgroups}">
                     <div class="presentation">
 
-                        <auth:resourceAllowed kind="job" action="${AuthConstants.ACTION_CREATE}" project="${params.project ?: request.project}">
+                        <auth:resourceAllowed kind="${AuthConstants.TYPE_JOB}" action="${AuthConstants.ACTION_CREATE}" project="${params.project ?: request.project}">
                           <g:link controller="scheduledExecution" action="create"
                                                             params="[project: params.project ?: request.project]"
                                class="btn btn-cta">

--- a/rundeckapp/grails-app/views/menu/acls.gsp
+++ b/rundeckapp/grails-app/views/menu/acls.gsp
@@ -28,28 +28,28 @@
 <g:set var="hasAdminAuth" value="${auth.resourceAllowedTest([
         any    : true,
         action : [AuthConstants.ACTION_ADMIN],
-        context: 'application',
+        context: AuthConstants.CTX_APPLICATION,
         kind   : AuthConstants.TYPE_SYSTEM_ACL,
 ]
 )}"/>
 <g:set var="hasEditAuth" value="${hasAdminAuth || auth.resourceAllowedTest([
         any    : true,
         action : [AuthConstants.ACTION_UPDATE],
-        context: 'application',
+        context: AuthConstants.CTX_APPLICATION,
         kind   : AuthConstants.TYPE_SYSTEM_ACL,
 ]
 )}"/>
 <g:set var="hasCreateAuth" value="${hasAdminAuth || auth.resourceAllowedTest([
         any    : true,
         action : [AuthConstants.ACTION_CREATE],
-        context: 'application',
+        context: AuthConstants.CTX_APPLICATION,
         kind   : AuthConstants.TYPE_SYSTEM_ACL,
 ]
 )}"/>
 <g:set var="hasDeleteAuth" value="${hasAdminAuth || auth.resourceAllowedTest([
         any    : true,
         action : [AuthConstants.ACTION_DELETE],
-        context: 'application',
+        context: AuthConstants.CTX_APPLICATION,
         kind   : AuthConstants.TYPE_SYSTEM_ACL,
 ]
 )}"/>

--- a/rundeckapp/grails-app/views/menu/executionMode.gsp
+++ b/rundeckapp/grails-app/views/menu/executionMode.gsp
@@ -96,7 +96,7 @@
               <g:message code="cancel"/>
             </g:link>
             <g:set var="authAction" value="${g.executionMode(active: true) ? AuthConstants.ACTION_DISABLE_EXECUTIONS : AuthConstants.ACTION_ENABLE_EXECUTIONS}"/>
-            <auth:resourceAllowed action="${[authAction, AuthConstants.ACTION_ADMIN]}" any="true" context="application" kind="system">
+            <auth:resourceAllowed action="${[authAction, AuthConstants.ACTION_ADMIN]}" any="true" context="${AuthConstants.CTX_APPLICATION}" kind="${AuthConstants.TYPE_SYSTEM}">
               <button type="submit" class="btn btn-cta">
                 <g:message code="set.execution.mode"/>
               </button>

--- a/rundeckapp/grails-app/views/menu/home.gsp
+++ b/rundeckapp/grails-app/views/menu/home.gsp
@@ -109,7 +109,7 @@
                 <b class="fas fa-spinner fa-spin loading-spinner"></b>
                 <g:message code="page.home.loading.projects" />
             </span>
-            <auth:resourceAllowed action="create" kind="project" context="application">
+            <auth:resourceAllowed action="${AuthConstants.ACTION_CREATE}" kind="${AuthConstants.TYPE_PROJECT}" context="${AuthConstants.CTX_APPLICATION}">
               <g:link controller="framework" action="createProject" class="btn  btn-success pull-right">
                 <g:message code="page.home.new.project.button.label" />
                 <b class="glyphicon glyphicon-plus"></b>
@@ -120,7 +120,7 @@
             <div class="card-footer">
               <hr>
               <div class="row">
-                <auth:resourceAllowed action="create" kind="project" context="application">
+                <auth:resourceAllowed action="${AuthConstants.ACTION_CREATE}" kind="${AuthConstants.TYPE_PROJECT}" context="${AuthConstants.CTX_APPLICATION}">
                     <div class="col-sm-4">
                         <g:link controller="framework" action="createProject" class="btn  btn-cta pull-right">
                             <g:message code="page.home.new.project.button.label" />
@@ -178,13 +178,13 @@
         </div>
       </div>
       <div class="container-fluid" data-bind="if: projectCount() == 0">
-        <auth:resourceAllowed action="create" kind="project" context="application" has="true">
+        <auth:resourceAllowed action="${AuthConstants.ACTION_CREATE}" kind="${AuthConstants.TYPE_PROJECT}" context="${AuthConstants.CTX_APPLICATION}" has="true">
           <div id="firstRun"></div>
         </auth:resourceAllowed>
       </div>
       <div class="container-fluid" data-bind="if: projectCount()<1 && loadedProjectNames()">
         <div class="row">
-          <auth:resourceAllowed action="create" kind="project" context="application" has="false">
+          <auth:resourceAllowed action="${AuthConstants.ACTION_CREATE}" kind="${AuthConstants.TYPE_PROJECT}" context="${AuthConstants.CTX_APPLICATION}" has="false">
           <div class="col-sm-12">
             <div class="card">
               <div class="card-content">
@@ -242,7 +242,7 @@
                     </div>
                   </div>
                 </div>
-  
+
                 <div data-bind="foreach: { data: pagedProjects(), as: 'project' } ">
                   %{--Template for project details--}%
                   <div class="project_list_item" data-bind="attr: { 'data-project': project }, ">
@@ -329,7 +329,7 @@
                           </span>
                         </div>
                       </div>
-            
+
                 <div class="col-sm-12 col-md-2 col-last" data-bind="if: $root.projectForName(project)">
                   <div class="pull-right">
                     <div class="dropdown-toggle-hover" >
@@ -371,7 +371,7 @@
                       </ul>
                     </div>
                   </div>
-                </div>  
+                </div>
               </div>
             </div>
             <!-- ko if: $root.projectForName(project).extra() -->
@@ -396,7 +396,7 @@
             <!-- /ko -->
             <!-- /ko -->
           </div>
-  
+
         </div>
       </div>
     </div>

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -28,8 +28,8 @@
     <g:set var="paginateJobsPerPage" value="${grailsApplication.config.rundeck.gui.paginatejobs.max.per.page}" />
     <title><g:message code="gui.menu.Workflows"/> - <g:enc>${projectLabel}</g:enc></title>
 
-    <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(context: 'application', type: 'project', name: projectName, action: AuthConstants.ACTION_ADMIN)}"/>
-    <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: 'application', type: 'project', name: projectName, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
+    <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: AuthConstants.ACTION_ADMIN)}"/>
+    <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
 
     <asset:javascript src="menu/jobs.js"/>
     <g:if test="${grails.util.Environment.current==grails.util.Environment.DEVELOPMENT}">
@@ -677,7 +677,7 @@ search
     </div>
   </div>
 
-  <auth:resourceAllowed project="${projectName}" action="${[AuthConstants.ACTION_READ]}" kind="event">
+  <auth:resourceAllowed project="${projectName}" action="${[AuthConstants.ACTION_READ]}" kind="${AuthConstants.TYPE_EVENT}">
   <div class="row">
     <div class="col-xs-12">
       <div class="card card-plain">

--- a/rundeckapp/grails-app/views/menu/plugins.gsp
+++ b/rundeckapp/grails-app/views/menu/plugins.gsp
@@ -32,11 +32,11 @@ To change this template use File | Settings | File Templates.
   <title><g:message code="page.Plugins.title"/></title>
 </head>
 <g:set var="authAdmin" value="${auth.resourceAllowedTest(
-        type: 'resource',
-        kind: 'system',
+        type: AuthConstants.TYPE_RESOURCE,
+        kind: AuthConstants.TYPE_SYSTEM,
         action: [AuthConstants.ACTION_ADMIN],
         any: true,
-        context: 'application'
+        context: AuthConstants.CTX_APPLICATION
 )}"/>
 <body>
 <div class="content">

--- a/rundeckapp/grails-app/views/menu/projectAcls.gsp
+++ b/rundeckapp/grails-app/views/menu/projectAcls.gsp
@@ -27,7 +27,7 @@
 <g:set var="hasAdminAuth" value="${auth.resourceAllowedTest([
         any       : true,
         action    : [AuthConstants.ACTION_ADMIN],
-        context   : 'application',
+        context   : AuthConstants.CTX_APPLICATION,
         type      : AuthConstants.TYPE_PROJECT_ACL,
         attributes: [name: params.project]
 ]
@@ -35,7 +35,7 @@
 <g:set var="hasEditAuth" value="${hasAdminAuth || auth.resourceAllowedTest([
         any       : true,
         action    : [AuthConstants.ACTION_UPDATE],
-        context   : 'application',
+        context   : AuthConstants.CTX_APPLICATION,
         type      : AuthConstants.TYPE_PROJECT_ACL,
         attributes: [name: params.project]
 ]
@@ -43,7 +43,7 @@
 <g:set var="hasCreateAuth" value="${hasAdminAuth || auth.resourceAllowedTest([
         any       : true,
         action    : [AuthConstants.ACTION_CREATE],
-        context   : 'application',
+        context   : AuthConstants.CTX_APPLICATION,
         type      : AuthConstants.TYPE_PROJECT_ACL,
         attributes: [name: params.project]
 ]
@@ -51,7 +51,7 @@
 <g:set var="hasDeleteAuth" value="${hasAdminAuth || auth.resourceAllowedTest([
         any       : true,
         action    : [AuthConstants.ACTION_DELETE],
-        context   : 'application',
+        context   : AuthConstants.CTX_APPLICATION,
         type      : AuthConstants.TYPE_PROJECT_ACL,
         attributes: [name: params.project]
 ]

--- a/rundeckapp/grails-app/views/menu/projectHome.gsp
+++ b/rundeckapp/grails-app/views/menu/projectHome.gsp
@@ -34,10 +34,10 @@
     <asset:stylesheet href="static/css/pages/project-dashboard.css"/>
     <g:jsMessages code="jobslist.date.format.ko,select.all,select.none,delete.selected.executions,cancel.bulk.delete,cancel,close,all"/>
     <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(
-                context: 'application', type: 'project', name: params.project, action: AuthConstants.ACTION_ADMIN)}"/>
-        <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: 'application', type: 'project', name:
+                context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: params.project, action: AuthConstants.ACTION_ADMIN)}"/>
+        <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name:
                 params.project, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
-        <g:set var="projectEventsAuth" value="${auth.resourceAllowedTest(kind: 'event', project: params.project, action: AuthConstants.ACTION_READ) || projAdminAuth}"/>
+        <g:set var="projectEventsAuth" value="${auth.resourceAllowedTest(kind: AuthConstants.TYPE_EVENT, project: params.project, action: AuthConstants.ACTION_READ) || projAdminAuth}"/>
     <g:javascript>
     window._rundeck = Object.assign(window._rundeck || {}, {
         data:{

--- a/rundeckapp/grails-app/views/reports/_activityLinks.gsp
+++ b/rundeckapp/grails-app/views/reports/_activityLinks.gsp
@@ -113,8 +113,8 @@
             </span>
 
         <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(
-                context: 'application', type: 'project', name: params.project, action: AuthConstants.ACTION_ADMIN)}"/>
-        <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: 'application', type: 'project', name:
+                context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: params.project, action: AuthConstants.ACTION_ADMIN)}"/>
+        <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name:
                 params.project, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
         <g:if test="${deleteExecAuth}">
             <button class="btn btn-xs btn-warning"

--- a/rundeckapp/grails-app/views/reports/_eventsFragment.gsp
+++ b/rundeckapp/grails-app/views/reports/_eventsFragment.gsp
@@ -173,9 +173,9 @@
                                 </span>
                             </span>
                             <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(
-                                    context: 'application', type: 'project', name: params.project, action: AuthConstants.ACTION_ADMIN)}"/>
+                                    context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: params.project, action: AuthConstants.ACTION_ADMIN)}"/>
                             <g:set var="deleteExecAuth"
-                                   value="${auth.resourceAllowedTest(context: 'application', type: 'project', name:
+                                   value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name:
                                            params.project, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
                             <g:if test="${deleteExecAuth}">
                             <span class="btn btn-xs btn-warning act_bulk_edit_enable obs_bulk_edit_disable">

--- a/rundeckapp/grails-app/views/reports/index.gsp
+++ b/rundeckapp/grails-app/views/reports/index.gsp
@@ -71,8 +71,8 @@ saved.filters
 search
 "/>
     <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(
-            context: 'application', type: 'project', name: projectName, action: AuthConstants.ACTION_ADMIN)}"/>
-    <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: 'application', type: 'project', name:
+            context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: AuthConstants.ACTION_ADMIN)}"/>
+    <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name:
             projectName, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
     <g:javascript>
     window._rundeck = Object.assign(window._rundeck || {}, {

--- a/rundeckapp/grails-app/views/scheduledExecution/_jobActionButton.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_jobActionButton.gsp
@@ -191,7 +191,7 @@
         </div>
     </div>
 </auth:jobAllowed>
-<auth:resourceAllowed kind="job" action="${AuthConstants.ACTION_DELETE}"
+<auth:resourceAllowed kind="${AuthConstants.TYPE_JOB}" action="${AuthConstants.ACTION_DELETE}"
                       project="${scheduledExecution.project ?: params.project ?: request.project}">
     <g:if test="${auth.jobAllowedTest(job: scheduledExecution, action: AuthConstants.ACTION_DELETE, project: scheduledExecution.project)}">
 <g:javascript>
@@ -225,9 +225,9 @@ jQuery(function(){
                                 </div>
                             </div>
 
-                            <auth:resourceAllowed type="project"
+                            <auth:resourceAllowed type="${AuthConstants.TYPE_PROJECT}"
                                                   name="${scheduledExecution.project}"
-                                                  context="application"
+                                                  context="${AuthConstants.CTX_APPLICATION}"
                                                   action="${[AuthConstants.ACTION_DELETE_EXECUTION, AuthConstants.ACTION_ADMIN]}"
                                                   any="true">
                                 <div class="form-group">

--- a/rundeckapp/grails-app/views/scheduledExecution/_jobActionButtonMenuContent.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_jobActionButtonMenuContent.gsp
@@ -20,12 +20,12 @@
 <g:set var="authDelete" value="${auth.jobAllowedTest(job: scheduledExecution, action: [AuthConstants.ACTION_DELETE])}"/>
 <g:set var="authEnableDisableSchedule" value="${auth.jobAllowedTest(job: scheduledExecution, action: [AuthConstants.ACTION_TOGGLE_SCHEDULE])}"/>
 <g:set var="authEnableDisableExecution" value="${auth.jobAllowedTest(job: scheduledExecution, action: [AuthConstants.ACTION_TOGGLE_EXECUTION])}"/>
-<g:set var="authJobCreate" value="${auth.resourceAllowedTest(kind: 'job', action: AuthConstants.ACTION_CREATE, project: scheduledExecution.project)}"/>
-<g:set var="authOtherProject" value="${auth.resourceAllowedTest(kind: 'job', action: AuthConstants.ACTION_CREATE, project: scheduledExecution.project, others: true)}"/>
-<g:set var="authJobDelete" value="${auth.resourceAllowedTest(kind: 'job', action: AuthConstants.ACTION_DELETE, project: scheduledExecution.project)}"/>
+<g:set var="authJobCreate" value="${auth.resourceAllowedTest(kind: AuthConstants.TYPE_JOB, action: AuthConstants.ACTION_CREATE, project: scheduledExecution.project)}"/>
+<g:set var="authOtherProject" value="${auth.resourceAllowedTest(kind: AuthConstants.TYPE_JOB, action: AuthConstants.ACTION_CREATE, project: scheduledExecution.project, others: true)}"/>
+<g:set var="authJobDelete" value="${auth.resourceAllowedTest(kind: AuthConstants.TYPE_JOB, action: AuthConstants.ACTION_DELETE, project: scheduledExecution.project)}"/>
 <g:set var="authProjectExport" value="${auth.resourceAllowedTest(
-        context: 'application',
-        type: 'project',
+        context: AuthConstants.CTX_APPLICATION,
+        type: AuthConstants.TYPE_PROJECT,
         action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT],
         any: true,
         name: scheduledExecution.project

--- a/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
@@ -142,7 +142,7 @@
     </g:if>
     <div class="row" id="_job_main_placeholder">
         <div class="col-xs-12">
-            <g:set var="hasEventReadAuth" value="${auth.resourceAllowedTest(project:scheduledExecution.project, action:AuthConstants.ACTION_READ, kind: 'event')}"/>
+            <g:set var="hasEventReadAuth" value="${auth.resourceAllowedTest(project:scheduledExecution.project, action:AuthConstants.ACTION_READ, kind: AuthConstants.TYPE_EVENT)}"/>
 
             <div class="card" id="activity_section">
                 <div class="card-content">

--- a/rundeckapp/grails-app/views/scheduledExecution/_showHead.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_showHead.gsp
@@ -24,15 +24,15 @@
     </g:if>
   <section class="${scheduledExecution.groupPath?'section-space':''}" id="jobInfo_">
     <g:set var="authProjectExport" value="${auth.resourceAllowedTest(
-            context: 'application',
-            type: 'project',
+            context: AuthConstants.CTX_APPLICATION,
+            type: AuthConstants.TYPE_PROJECT,
             action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_EXPORT],
             any: true,
             name: scheduledExecution.project
     )}"/>
     <g:set var="authProjectImport" value="${auth.resourceAllowedTest(
-            context: 'application',
-            type: 'project',
+            context: AuthConstants.CTX_APPLICATION,
+            type: AuthConstants.TYPE_PROJECT,
             action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_IMPORT],
             any: true,
             name: scheduledExecution.project

--- a/rundeckapp/grails-app/views/scheduledExecution/delete.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/delete.gsp
@@ -50,9 +50,9 @@
             </div>
         </div>
 
-        <auth:resourceAllowed type="project"
+        <auth:resourceAllowed type="${AuthConstants.TYPE_PROJECT}"
                               name="${scheduledExecution.project}"
-                              context="application"
+                              context="${AuthConstants.CTX_APPLICATION}"
                               action="${[AuthConstants.ACTION_DELETE_EXECUTION, AuthConstants.ACTION_ADMIN]}"
                               any="true">
             <div class="form-group">

--- a/rundeckapp/grails-app/views/scheduledExecution/show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/show.gsp
@@ -137,8 +137,8 @@ search
     </script>
     <g:set var="projectName" value="${scheduledExecution.project}"/>
     <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(
-            context: 'application', type: 'project', name: projectName, action: AuthConstants.ACTION_ADMIN)}"/>
-    <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: 'application', type: 'project', name:
+            context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: AuthConstants.ACTION_ADMIN)}"/>
+    <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name:
             projectName, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
     <g:set var="runAccess" value="${auth.jobAllowedTest(job: scheduledExecution, action: AuthConstants.ACTION_RUN)}"/>
     <g:set var="readAccess" value="${auth.jobAllowedTest(job: scheduledExecution, action: AuthConstants.ACTION_READ)}"/>

--- a/rundeckapp/grails-app/views/user/_userListItem.gsp
+++ b/rundeckapp/grails-app/views/user/_userListItem.gsp
@@ -53,7 +53,7 @@
             </g:if>
         </span>
 
-        <g:set var="adminauth" value="${auth.resourceAllowedTest(kind:'user',action:[AuthConstants.ACTION_ADMIN],context:'application')}"/>
+        <g:set var="adminauth" value="${auth.resourceAllowedTest(kind:AuthConstants.TYPE_USER,action:[AuthConstants.ACTION_ADMIN],context:AuthConstants.CTX_APPLICATION)}"/>
         <g:if test="${adminauth}">
         <span class="useredit">
             <g:link action="edit" params="[login:user.login]" class="textbtn textbtn-info textbtn-on-hover">

--- a/rundeckapp/grails-app/views/user/list.gsp
+++ b/rundeckapp/grails-app/views/user/list.gsp
@@ -30,7 +30,7 @@
         <div class="col-sm-10 col-sm-offset-1">
             <h3>Users
 
-            <g:if test="${auth.resourceAllowedTest(kind: 'user', action: [AuthConstants.ACTION_ADMIN], context: 'application')}">
+            <g:if test="${auth.resourceAllowedTest(kind: AuthConstants.TYPE_USER, action: [AuthConstants.ACTION_ADMIN], context: AuthConstants.CTX_APPLICATION)}">
                     <g:link action="create" class="btn btn-default btn-xs">
                         <i class="glyphicon glyphicon-plus"></i>
                         New Profile &hellip;

--- a/rundeckapp/grails-app/views/user/profile.gsp
+++ b/rundeckapp/grails-app/views/user/profile.gsp
@@ -20,14 +20,14 @@
   --}%
 
     <g:set var="selfToken" value="${auth.resourceAllowedTest(
-            kind: 'apitoken',
+            kind: AuthConstants.TYPE_APITOKEN,
             action: [AuthConstants.ACTION_GENERATE_USER_TOKEN],
-            context: 'application'
+            context: AuthConstants.CTX_APPLICATION
     )}"/>
     <g:set var="serviceToken" value="${auth.resourceAllowedTest(
-            kind: 'apitoken',
+            kind: AuthConstants.TYPE_APITOKEN,
             action: [AuthConstants.ACTION_GENERATE_SERVICE_TOKEN],
-            context: 'application'
+            context: AuthConstants.CTX_APPLICATION
     )}"/>
     <g:appTitle/> - <g:message code="userController.page.profile.title"/>: ${user.login}</title>
     <asset:javascript src="user/profile.js"/>

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/AppAuthContextEvaluator.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/AppAuthContextEvaluator.groovy
@@ -16,6 +16,13 @@ interface AppAuthContextEvaluator extends AuthContextEvaluator {
      */
     def Map authResourceForJob(ScheduledExecution se)
 
+    /**
+     * Return true if the user is authorized to configure the project
+     * @param authContext
+     * @param project project name
+     * @return true/false
+     */
+    boolean authorizeProjectConfigure(AuthContext authContext, String project)
 
     /**
      * Return true if the user is authorized for all actions for the execution

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/AppAuthContextEvaluator.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/AppAuthContextEvaluator.groovy
@@ -105,11 +105,4 @@ interface AppAuthContextEvaluator extends AuthContextEvaluator {
         final Function<T, Map<String, String>> convert,
         final String key
     )
-    def <T> boolean authorizeResourceAll(
-        AuthContext authContext,
-        final String project,
-        final Set<String> actions,
-        final T resource,
-        final Function<T, Map<String, String>> convert
-    )
 }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/BaseAuthContextEvaluator.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/BaseAuthContextEvaluator.groovy
@@ -416,4 +416,12 @@ class BaseAuthContextEvaluator implements AppAuthContextEvaluator {
         return nodeSupport.filterAuthorizedNodes(project, actions, unfiltered, authContext)
     }
 
+    @Override
+    boolean authorizeProjectConfigure(final AuthContext authContext, final String project) {
+        return authorizeApplicationResourceAny(
+            authContext,
+            authResourceForProject(project),
+            [AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN]
+        )
+    }
 }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/BaseAuthContextEvaluator.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/BaseAuthContextEvaluator.groovy
@@ -335,7 +335,6 @@ class BaseAuthContextEvaluator implements AppAuthContextEvaluator {
         return authorizeResourceAll(authContext, project, new HashSet<String> (actions), job, this.&authResourceForJob)
     }
 
-    @Override
     def <T> boolean authorizeResourceAll(
         AuthContext authContext,
         final String project,

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/TimedAuthContextEvaluator.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/TimedAuthContextEvaluator.groovy
@@ -218,17 +218,6 @@ class TimedAuthContextEvaluator implements AppAuthContextEvaluator {
     }
 
     @Override
-    def <T> boolean authorizeResourceAll(
-        final AuthContext authContext,
-        final String project,
-        final Set<String> actions,
-        final T resource,
-        final Function<T, Map<String, String>> convert
-    ) {
-        return rundeckAuthContextEvaluator.authorizeResourceAll(authContext, project, actions, resource, convert)
-    }
-
-    @Override
     def <T> Set<T> filterAuthorizedResourcesAll(
         final AuthContext authContext,
         final String project,

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/TimedAuthContextEvaluator.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/TimedAuthContextEvaluator.groovy
@@ -240,4 +240,9 @@ class TimedAuthContextEvaluator implements AppAuthContextEvaluator {
         return rundeckAuthContextEvaluator.
             filterAuthorizedResourcesAll(authContext, project, actions, resources, convert, key)
     }
+
+    @Override
+    boolean authorizeProjectConfigure(final AuthContext authContext, final String project) {
+        return rundeckAuthContextEvaluator.authorizeProjectConfigure(authContext, project)
+    }
 }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/UnauthorizedAccess.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/UnauthorizedAccess.groovy
@@ -1,0 +1,29 @@
+package org.rundeck.app.authorization
+
+import groovy.transform.CompileStatic
+
+/**
+ * Authorization check failed
+ */
+@CompileStatic
+class UnauthorizedAccess extends Exception {
+    /**
+     * Action
+     */
+    String action
+    /**
+     * Resource type
+     */
+    String type
+    /**
+     * Resource name
+     */
+    String name
+
+    UnauthorizedAccess(String action, String type, String name) {
+        super("Unauthorized for ${action} access to ${type} ${name}")
+        this.action = action
+        this.type = type
+        this.name = name
+    }
+}

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/WebAuthContextProcessor.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/WebAuthContextProcessor.groovy
@@ -1,0 +1,180 @@
+package org.rundeck.app.authorization
+
+import com.dtolabs.rundeck.core.authorization.AuthContext
+import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
+import org.rundeck.core.auth.AuthConstants
+import rundeck.Execution
+import rundeck.ScheduledExecution
+
+import java.util.function.Function
+
+/**
+ * Throws exceptions when authorization is not allowed.
+ */
+@CompileStatic
+class WebAuthContextProcessor implements AppAuthContextProcessor{
+    @Delegate
+    AppAuthContextProcessor authContextProcessor
+
+    @Override
+    boolean authorizeApplicationResourceTypeAll(
+        final AuthContext authContext,
+        final String resourceType,
+        final Collection<String> actions
+    ) {
+        if(!authContextProcessor.authorizeApplicationResourceTypeAll(authContext,resourceType,actions)) {
+            throw new UnauthorizedAccess(actions.join(', '), resourceType, "")
+        }
+        return true
+    }
+
+    @Override
+    boolean authorizeApplicationResourceType(
+        final AuthContext authContext,
+        final String resourceType,
+        final String action
+    ) {
+        if(!authContextProcessor.authorizeApplicationResourceType(authContext,resourceType,action)) {
+            throw new UnauthorizedAccess(action, resourceType, "")
+        }
+        return true
+    }
+
+    @Override
+    boolean authorizeApplicationResourceAny(
+        final AuthContext authContext,
+        final Map<String, String> resource,
+        final List<String> actions
+    ) {
+        if(!authContextProcessor.authorizeApplicationResourceAny(authContext,resource,actions)) {
+            throw new UnauthorizedAccess(actions[0], resource.get("kind")?:resource.get("type"), resource.get("name")?:'')
+        }
+        return true
+    }
+
+    @Override
+    boolean authorizeApplicationResourceAll(
+        final AuthContext authContext,
+        final Map<String, String> resource,
+        final Collection<String> actions
+    ) {
+        if(!authContextProcessor.authorizeApplicationResourceAll(authContext,resource,actions)) {
+            throw new UnauthorizedAccess(actions[0], resource.get("kind")?:resource.get("type"), resource.get("name")?:'')
+        }
+        return true
+    }
+
+
+    @Override
+    boolean authorizeApplicationResource(
+        final AuthContext authContext,
+        final Map<String, String> resource,
+        final String action
+    ) {
+        if(!authContextProcessor.authorizeApplicationResource(authContext,resource,action)) {
+            throw new UnauthorizedAccess(action, resource.get("kind")?:resource.get("type"), resource.get("name")?:'')
+        }
+        return true
+    }
+
+    @Override
+    boolean authorizeProjectResourceAny(
+        final AuthContext authContext,
+        final Map<String, String> resource,
+        final Collection<String> actions,
+        final String project
+    ) {
+        if (!authContextProcessor.authorizeProjectResourceAny(authContext, resource, actions, project)) {
+            throw new UnauthorizedAccess(actions[0], resource.get("kind")?:resource.get("type"), resource.get("name")?:'')
+        }
+        return true
+    }
+
+    @Override
+    boolean authorizeProjectResourceAll(
+        final AuthContext authContext,
+        final Map<String, String> resource,
+        final Collection<String> actions,
+        final String project
+    ) {
+        if (!authContextProcessor.authorizeProjectResourceAll(authContext, resource, actions, project)) {
+            throw new UnauthorizedAccess(actions[0], resource.get("kind")?:resource.get("type"), resource.get("name")?:'')
+        }
+        return true
+    }
+
+    @Override
+    boolean authorizeProjectResource(
+        final AuthContext authContext,
+        final Map<String, String> resource,
+        final String action,
+        final String project
+    ) {
+        if (!authContextProcessor.authorizeProjectResource(authContext, resource, action, project)) {
+            throw new UnauthorizedAccess(action, resource.get("kind")?:resource.get("type"), resource.get("name")?:'')
+        }
+        return true
+    }
+
+    @Override
+    boolean authorizeProjectConfigure(final AuthContext authContext, final String project) {
+
+        if (!authContextProcessor.authorizeProjectConfigure(authContext, project)) {
+            throw new UnauthorizedAccess(AuthConstants.ACTION_CONFIGURE, "project", project)
+        }
+        return true
+    }
+
+    @Override
+    boolean authorizeProjectExecutionAll(
+        final AuthContext authContext,
+        final Execution exec,
+        final Collection<String> actions
+    ) {
+        if (!authContextProcessor.authorizeProjectExecutionAll(authContext, exec,actions)) {
+            throw new UnauthorizedAccess(actions[0], "Execution", exec.id.toString())
+        }
+        return true
+    }
+
+    @Override
+    boolean authorizeProjectExecutionAny(
+        final AuthContext authContext,
+        final Execution exec,
+        final Collection<String> actions
+    ) {
+        if (!authContextProcessor.authorizeProjectExecutionAny(authContext, exec,actions)) {
+            throw new UnauthorizedAccess(actions[0], "Execution", exec.id.toString())
+        }
+        return true
+    }
+
+
+    @Override
+    boolean authorizeProjectJobAny(
+        final AuthContext authContext,
+        final ScheduledExecution job,
+        final Collection<String> actions,
+        final String project
+    ) {
+        if (!authContextProcessor.authorizeProjectJobAny(authContext, job, actions, project)) {
+            throw new UnauthorizedAccess(actions[0], "Job", job.generateFullName())
+        }
+        return true
+    }
+
+    @Override
+    boolean authorizeProjectJobAll(
+        final AuthContext authContext,
+        final ScheduledExecution job,
+        final Collection<String> actions,
+        final String project
+    ) {
+        if (!authContextProcessor.authorizeProjectJobAll(authContext, job, actions, project)) {
+            throw new UnauthorizedAccess(actions[0], "Job", job.generateFullName())
+        }
+        return true
+    }
+
+}

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkController2Spec.groovy
@@ -453,7 +453,7 @@ class FrameworkController2Spec extends HibernateSpec implements ControllerUnitTe
             _ * isProjectScheduledEnabled(_) >> true
         }
         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
-            1 * getAuthContextForSubjectAndProject(_,'TestSaveProject')
+            1 * getAuthContextForSubject(_)
             1 * authorizeProjectConfigure(*_)>>true
         }
         when:
@@ -719,7 +719,7 @@ class FrameworkController2Spec extends HibernateSpec implements ControllerUnitTe
                 _ * isProjectScheduledEnabled(_) >> true
             }
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
-                1 * getAuthContextForSubjectAndProject(_,'TestSaveProject')
+                1 * getAuthContextForSubject(_)
                 1 * authorizeProjectConfigure(*_)>>true
             }
         when:
@@ -836,7 +836,7 @@ class FrameworkController2Spec extends HibernateSpec implements ControllerUnitTe
                 _ * isProjectScheduledEnabled(_) >> true
             }
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
-                1 * getAuthContextForSubjectAndProject(_,'TestSaveProject')
+                1 * getAuthContextForSubject(_)
                 1 * authorizeProjectConfigure(*_)>>true
             }
 
@@ -939,7 +939,7 @@ class FrameworkController2Spec extends HibernateSpec implements ControllerUnitTe
         }
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
-                1 * getAuthContextForSubjectAndProject(_,'edit_test_project')
+                1 * getAuthContextForSubject(_)
                 1 * authorizeProjectConfigure(*_)>>true
             }
         params.project = "edit_test_project"
@@ -960,7 +960,7 @@ class FrameworkController2Spec extends HibernateSpec implements ControllerUnitTe
 
         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
             1 * authorizeProjectConfigure(*_)>>true
-            1 * getAuthContextForSubjectAndProject(_,'edit_test_project')
+            1 * getAuthContextForSubject(_)
         }
 
         def proj = Mock(IRundeckProject){

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -906,7 +906,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
                 1 * filterAuthorizedNodes(projectName, Collections.singleton('read'), !null, authCtx) >> authedNodes
-                1 * authorizeProjectResourceAll(authCtx, [type: 'resource', kind: 'node'], ['read'], projectName) >> true
+                1 * authorizeProjectResource(authCtx, [type: 'resource', kind: 'node'], 'read', projectName) >> true
 
 
                 1 * getAuthContextForSubjectAndProject(_, projectName) >> authCtx
@@ -952,7 +952,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
                 1 * filterAuthorizedNodes(projectName, Collections.singleton('read'), !null, authCtx) >> authedNodes
-                1 * authorizeProjectResourceAll(authCtx, [type: 'resource', kind: 'node'], ['read'], projectName) >> true
+                1 * authorizeProjectResource(authCtx, [type: 'resource', kind: 'node'], 'read', projectName) >> true
 
                 1 * getAuthContextForSubjectAndProject(_, projectName) >> authCtx
             }
@@ -1002,7 +1002,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
                 1 * filterAuthorizedNodes(projectName, Collections.singleton('read'), !null, authCtx) >> authedNodes
 
-                1 * authorizeProjectResourceAll(authCtx, [type: 'resource', kind: 'node'], ['read'], projectName) >> true
+                1 * authorizeProjectResource(authCtx, [type: 'resource', kind: 'node'], 'read', projectName) >> true
                 1 * getAuthContextForSubjectAndProject(_, projectName) >> authCtx
             }
         controller.apiService = Mock(ApiService) {
@@ -1049,7 +1049,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
                 1 * filterAuthorizedNodes(projectName, Collections.singleton('read'), !null, authCtx) >> authedNodes
-                1 * authorizeProjectResourceAll(authCtx, [type: 'resource', kind: 'node'], ['read'], projectName) >> true
+                1 * authorizeProjectResource(authCtx, [type: 'resource', kind: 'node'], 'read', projectName) >> true
                 1 * getAuthContextForSubjectAndProject(_, projectName) >> authCtx
             }
         controller.apiService = Mock(ApiService) {
@@ -1095,7 +1095,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
                 1 * filterAuthorizedNodes(projectName, Collections.singleton('read'), !null, authCtx) >> authedNodes
-                1 * authorizeProjectResourceAll(authCtx, [type: 'resource', kind: 'node'], ['read'], projectName) >> true
+                1 * authorizeProjectResource(authCtx, [type: 'resource', kind: 'node'], 'read', projectName) >> true
 
                 1 * getAuthContextForSubjectAndProject(_, projectName) >> authCtx
             }
@@ -1664,7 +1664,7 @@ project.label=A Label
         when:
         controller.nodeSummaryAjax(project)
         then:
-        1 * controller.rundeckAuthContextProcessor.authorizeProjectResourceAll(*_) >> true
+        1 * controller.rundeckAuthContextProcessor.authorizeProjectResource(*_) >> true
         1 * controller.userService.findOrCreateUser(_) >> testUser
         1 * controller.frameworkService.getFrameworkProject(project) >> Mock(IRundeckProject) {
             getNodeSet() >> new NodeSetImpl()

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -650,7 +650,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
         response.status==302
         request.errors == null
 
-        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
         1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
         1 * fwkService.listDescriptions() >> [null,null,null]
         1 * fwkService.updateFrameworkProjectConfig(_,{
@@ -693,7 +693,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
             ) >> [success: true]
 
 
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
             1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
             1 * fwkService.listDescriptions() >> [null, null, null]
             1 * fwkService.validateProjectConfigurableInput(_, _, { !it.test('resourceModelSource') }) >> [:]
@@ -729,7 +729,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
         response.status==302
         request.errors == null
 
-        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
         1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
         1 * fwkService.listDescriptions() >> [null,null,null]
         1 * fwkService.updateFrameworkProjectConfig(_,{
@@ -775,7 +775,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
                 it.enabled && it.maxDaysToKeep==1 && it.cronExpression=='crontab1' && it.minimumExecutionToKeep==2 && it.maximumDeletionSize==3
             })
 
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
             1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
             1 * fwkService.listDescriptions() >> [null, null, null]
             1 * fwkService.updateFrameworkProjectConfig(
@@ -826,7 +826,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
             response.status == 302
             request.errors == null
 
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
             1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
             1 * fwkService.validateServiceConfig('foobar', "${prefix}.default.config.", _, _) >> [valid: true]
             if (service == 'FileCopier') {
@@ -1128,7 +1128,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
                 1 * authorizeProjectConfigure(_,'test') >> true
-                1 * getAuthContextForSubjectAndProject(_,'test')
+                1 * getAuthContextForSubject(_)
             }
         controller.apiService = Mock(ApiService) {
             1 * requireApi(_, _, 23) >> true
@@ -1187,7 +1187,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
                 1 * authorizeProjectConfigure(_,'test') >> true
-                1 * getAuthContextForSubjectAndProject(_,'test')
+                1 * getAuthContextForSubject(_)
             }
             controller.apiService = Mock(ApiService) {
                 1 * requireApi(_, _, 23) >> true
@@ -1291,7 +1291,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
         response.status==302
         request.errors == null
 
-        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
         1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
         1 * fwkService.listDescriptions() >> [null,null,null]
         1 * fwkService.updateFrameworkProjectConfig(_,{
@@ -1355,7 +1355,7 @@ ${ScheduledExecutionService.CONF_PROJECT_DISABLE_SCHEDULE}=${disableSchedule}
         response.status==302
         request.errors == null
 
-        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
         1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
         1 * controller.frameworkService.listDescriptions() >> [null,null,null]
         2 * controller.frameworkService.validateServiceConfig(*_) >> [valid:true]
@@ -1422,7 +1422,7 @@ project.label=A Label
             response.status == 302
             request.errors == null
 
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
             1 * controller.frameworkService.getRundeckFramework()
             1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
             1 * controller.frameworkService.listDescriptions() >> [null, null, null]
@@ -1714,7 +1714,7 @@ project.label=A Label
         params.project = project
         def result = controller.saveProjectNodeSources()
         then:
-        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(*_)
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
         1 * controller.frameworkService.getRundeckFramework()
 //        1 * controller.frameworkService.listResourceModelSourceDescriptions()
         1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,project) >> true
@@ -1768,7 +1768,7 @@ project.label=A Label
             controller.projectPluginsAjax(project, serviceName, configPrefix)
         then:
             1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,project) >> true
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,project)
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
             1 * controller.frameworkService.getRundeckFramework() >> Mock(IFramework) {
                 getFrameworkProjectMgr() >> Mock(ProjectManager) {
                     loadProjectConfig(project) >> Mock(IRundeckProjectConfig) {
@@ -1859,7 +1859,7 @@ project.label=A Label
         then:
             response.status == 200
             1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_, project) >> true
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,project)
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
             1 * controller.pluginService.getPluginDescriptor('1type', serviceName) >>
             new DescribedPlugin(null, null, '1type')
             1 * controller.pluginService.validatePluginConfig(serviceName, '1type', [bongo: 'asdf']) >>
@@ -1922,7 +1922,7 @@ project.label=A Label
         then:
             response.status == 422
             1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_, project) >> true
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,project)
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
 
             0 * controller.pluginService.getPluginDescriptor('1type', serviceName) >>
             new DescribedPlugin(null, null, '1type')
@@ -1986,7 +1986,7 @@ project.label=A Label
         then:
             response.status == 422
             1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_, project) >> true
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,project)
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
 
             1 * controller.pluginService.getPluginDescriptor('1type', serviceName) >> null
             0 * controller.pluginService.validatePluginConfig(serviceName, '1type', [bongo: 'asdf'])
@@ -2050,7 +2050,7 @@ project.label=A Label
         then:
             response.status == 422
             1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_, project) >> true
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,project)
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
 
             1 * controller.pluginService.getPluginDescriptor('1type', serviceName) >>
             new DescribedPlugin(null, null, '1type')
@@ -2116,7 +2116,7 @@ project.label=A Label
         then:
             response.status == 422
             1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_, project) >> true
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,project)
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
 
             1 * controller.pluginService.getPluginDescriptor('1type', serviceName) >>
             new DescribedPlugin(null, null, '1type')
@@ -2170,7 +2170,7 @@ project.label=A Label
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
                 1 * authorizeProjectConfigure(_, 'test') >> true
-                1 * getAuthContextForSubjectAndProject(_,'test')
+                1 * getAuthContextForSubject(_)
             }
             controller.pluginService=Mock(PluginService){
                 1 * getPluginDescriptor('monkey',_)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -649,9 +649,9 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
         then:
         response.status==302
         request.errors == null
-        1 * controller.rundeckAuthContextProcessor.authResourceForProject(_)
-        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
-        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(null,null,['configure','admin']) >> true
+
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+        1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
         1 * fwkService.listDescriptions() >> [null,null,null]
         1 * fwkService.updateFrameworkProjectConfig(_,{
             it['project.description'] == 'abc'
@@ -692,9 +692,9 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
             }, _
             ) >> [success: true]
 
-            1 * controller.rundeckAuthContextProcessor.authResourceForProject(_)
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(null, null, ['configure', 'admin']) >> true
+
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+            1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
             1 * fwkService.listDescriptions() >> [null, null, null]
             1 * fwkService.validateProjectConfigurableInput(_, _, { !it.test('resourceModelSource') }) >> [:]
             1 * fwkService.getRundeckFramework()
@@ -728,9 +728,9 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
         then:
         response.status==302
         request.errors == null
-        1 * controller.rundeckAuthContextProcessor.authResourceForProject(_)
-        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
-        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(null,null,['configure','admin']) >> true
+
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+        1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
         1 * fwkService.listDescriptions() >> [null,null,null]
         1 * fwkService.updateFrameworkProjectConfig(_,{
             it['project.description'] == ''
@@ -774,9 +774,9 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
             1 * controller.frameworkService.scheduleCleanerExecutions('TestSaveProject',{
                 it.enabled && it.maxDaysToKeep==1 && it.cronExpression=='crontab1' && it.minimumExecutionToKeep==2 && it.maximumDeletionSize==3
             })
-            1 * controller.rundeckAuthContextProcessor.authResourceForProject(_)
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(null, null, ['configure', 'admin']) >> true
+
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+            1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
             1 * fwkService.listDescriptions() >> [null, null, null]
             1 * fwkService.updateFrameworkProjectConfig(
                 _, {
@@ -825,9 +825,9 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
         then:
             response.status == 302
             request.errors == null
-            1 * controller.rundeckAuthContextProcessor.authResourceForProject(_)
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(null, null, ['configure', 'admin']) >> true
+
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+            1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
             1 * fwkService.validateServiceConfig('foobar', "${prefix}.default.config.", _, _) >> [valid: true]
             if (service == 'FileCopier') {
                 controller.fcopyPasswordFieldsService.untrack(
@@ -1127,8 +1127,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
         }
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
-                1 * authResourceForProject('test')
-                1 * authorizeApplicationResourceAny(_,_,['configure','admin']) >> true
+                1 * authorizeProjectConfigure(_,'test') >> true
                 1 * getAuthContextForSubjectAndProject(_,'test')
             }
         controller.apiService = Mock(ApiService) {
@@ -1187,8 +1186,7 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
             }
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
-                1 * authResourceForProject('test')
-                1 * authorizeApplicationResourceAny(_,_,['configure','admin']) >> true
+                1 * authorizeProjectConfigure(_,'test') >> true
                 1 * getAuthContextForSubjectAndProject(_,'test')
             }
             controller.apiService = Mock(ApiService) {
@@ -1292,9 +1290,9 @@ class FrameworkControllerSpec extends HibernateSpec implements ControllerUnitTes
         then:
         response.status==302
         request.errors == null
-        1 * controller.rundeckAuthContextProcessor.authResourceForProject(_)
-        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
-        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(null,null,['configure','admin']) >> true
+
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+        1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
         1 * fwkService.listDescriptions() >> [null,null,null]
         1 * fwkService.updateFrameworkProjectConfig(_,{
             it['project.description'] == 'abc'
@@ -1356,9 +1354,9 @@ ${ScheduledExecutionService.CONF_PROJECT_DISABLE_SCHEDULE}=${disableSchedule}
         then:
         response.status==302
         request.errors == null
-        1 * controller.rundeckAuthContextProcessor.authResourceForProject(_)
-        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
-        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(null,null,['configure','admin']) >> true
+
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
+        1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
         1 * controller.frameworkService.listDescriptions() >> [null,null,null]
         2 * controller.frameworkService.validateServiceConfig(*_) >> [valid:true]
         1 * controller.frameworkService.setFrameworkProjectConfig(project,{
@@ -1423,10 +1421,10 @@ project.label=A Label
         then:
             response.status == 302
             request.errors == null
-            1 * controller.rundeckAuthContextProcessor.authResourceForProject(_)
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
+
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,'TestSaveProject')
             1 * controller.frameworkService.getRundeckFramework()
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(null, null, ['configure', 'admin']) >> true
+            1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,'TestSaveProject') >> true
             1 * controller.frameworkService.listDescriptions() >> [null, null, null]
             2 * controller.frameworkService.validateServiceConfig(*_) >> [valid: true]
 
@@ -1716,11 +1714,10 @@ project.label=A Label
         params.project = project
         def result = controller.saveProjectNodeSources()
         then:
-        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(*_)
-        1 * controller.rundeckAuthContextProcessor.authResourceForProject(project)
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(*_)
         1 * controller.frameworkService.getRundeckFramework()
 //        1 * controller.frameworkService.listResourceModelSourceDescriptions()
-        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(*_) >> true
+        1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,project) >> true
         1 * controller.frameworkService.validateProjectConfigurableInput(*_) >> [props: [:], remove: []]
         1 * controller.frameworkService.updateFrameworkProjectConfig(project, _, _) >> [success: true]
         0 * controller.frameworkService._(*_)
@@ -1770,9 +1767,8 @@ project.label=A Label
         when:
             controller.projectPluginsAjax(project, serviceName, configPrefix)
         then:
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, ['configure', 'admin']) >> true
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
-            1 * controller.rundeckAuthContextProcessor.authResourceForProject(project)
+            1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_,project) >> true
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,project)
             1 * controller.frameworkService.getRundeckFramework() >> Mock(IFramework) {
                 getFrameworkProjectMgr() >> Mock(ProjectManager) {
                     loadProjectConfig(project) >> Mock(IRundeckProjectConfig) {
@@ -1862,9 +1858,8 @@ project.label=A Label
 
         then:
             response.status == 200
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, ['configure', 'admin']) >> true
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
-            1 * controller.rundeckAuthContextProcessor.authResourceForProject(project)
+            1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_, project) >> true
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,project)
             1 * controller.pluginService.getPluginDescriptor('1type', serviceName) >>
             new DescribedPlugin(null, null, '1type')
             1 * controller.pluginService.validatePluginConfig(serviceName, '1type', [bongo: 'asdf']) >>
@@ -1926,9 +1921,8 @@ project.label=A Label
 
         then:
             response.status == 422
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, ['configure', 'admin']) >> true
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
-            1 * controller.rundeckAuthContextProcessor.authResourceForProject(project)
+            1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_, project) >> true
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,project)
 
             0 * controller.pluginService.getPluginDescriptor('1type', serviceName) >>
             new DescribedPlugin(null, null, '1type')
@@ -1991,9 +1985,8 @@ project.label=A Label
 
         then:
             response.status == 422
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, ['configure', 'admin']) >> true
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
-            1 * controller.rundeckAuthContextProcessor.authResourceForProject(project)
+            1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_, project) >> true
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,project)
 
             1 * controller.pluginService.getPluginDescriptor('1type', serviceName) >> null
             0 * controller.pluginService.validatePluginConfig(serviceName, '1type', [bongo: 'asdf'])
@@ -2056,9 +2049,8 @@ project.label=A Label
 
         then:
             response.status == 422
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, ['configure', 'admin']) >> true
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
-            1 * controller.rundeckAuthContextProcessor.authResourceForProject(project)
+            1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_, project) >> true
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,project)
 
             1 * controller.pluginService.getPluginDescriptor('1type', serviceName) >>
             new DescribedPlugin(null, null, '1type')
@@ -2123,9 +2115,8 @@ project.label=A Label
 
         then:
             response.status == 422
-            1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, ['configure', 'admin']) >> true
-            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
-            1 * controller.rundeckAuthContextProcessor.authResourceForProject(project)
+            1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_, project) >> true
+            1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_,project)
 
             1 * controller.pluginService.getPluginDescriptor('1type', serviceName) >>
             new DescribedPlugin(null, null, '1type')
@@ -2178,9 +2169,8 @@ project.label=A Label
             }
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
-                1 * authResourceForProject('test')
-                1 * authorizeApplicationResourceAny(_, _, ['configure', 'admin']) >> true
-                1 * getAuthContextForSubject(_)
+                1 * authorizeProjectConfigure(_, 'test') >> true
+                1 * getAuthContextForSubjectAndProject(_,'test')
             }
             controller.pluginService=Mock(PluginService){
                 1 * getPluginDescriptor('monkey',_)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1301,7 +1301,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_, 'proj') >> projectAuth
             1 * controller.
                 rundeckAuthContextProcessor.
-                authorizeProjectResourceAll(projectAuth, AuthorizationUtil.resourceType('event'), ['read'], 'proj')>>authEventRead
+                authorizeProjectResource(projectAuth, AuthorizationUtil.resourceType('event'), 'read', 'proj')>>authEventRead
             1 * controller.
                 rundeckAuthContextProcessor.authorizeProjectResource(
                 projectAuth,
@@ -2015,7 +2015,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         controller.nowrunningAjax()
         then:
         response.status == 403
-        1 * controller.rundeckAuthContextProcessor.authorizeProjectResourceAll(_, _, [action], 'aProject')
+        1 * controller.rundeckAuthContextProcessor.authorizeProjectResource(_, _, action, 'aProject')
         1 * controller.frameworkService.existsFrameworkProject('aProject') >> true
     }
     @Unroll
@@ -2037,7 +2037,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         controller.apiExecutionsRunningv14()
         then:
         response.status == 403
-        1 * controller.rundeckAuthContextProcessor.authorizeProjectResourceAll(_, _, [action], 'aProject')
+        1 * controller.rundeckAuthContextProcessor.authorizeProjectResource(_, _, action, 'aProject')
         1 * controller.frameworkService.existsFrameworkProject('aProject') >> true
 
     }
@@ -2062,7 +2062,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         controller.apiExecutionsRunningv14()
         then:
         response.status == 404
-        0 * controller.rundeckAuthContextProcessor.authorizeProjectResourceAll(_, _, [action], 'aProject')
+        0 * controller.rundeckAuthContextProcessor.authorizeProjectResource(_, _, action, 'aProject')
         1 * controller.frameworkService.existsFrameworkProject('aProject') >> false
 
     }
@@ -2142,7 +2142,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
 
-                authorizeProjectResourceAll(_, AuthorizationUtil.resourceType('event'),['read'], 'aProject') >> true
+                authorizeProjectResource(_, AuthorizationUtil.resourceType('event'),'read', 'aProject') >> true
 
                 1 * getAuthContextForSubject(_) >> test
             }
@@ -2192,7 +2192,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         }
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
-                authorizeProjectResourceAll(_, AuthorizationUtil.resourceType('event'),['read'], 'aProject') >> true
+                authorizeProjectResource(_, AuthorizationUtil.resourceType('event'),'read', 'aProject') >> true
 
                 1 * getAuthContextForSubject(_) >> test
             }
@@ -2244,7 +2244,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
             }
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
-                1 * authorizeProjectResourceAll(_, AuthorizationUtil.resourceType('event'), ['read'], 'aProject') >>
+                1 * authorizeProjectResource(_, AuthorizationUtil.resourceType('event'), 'read', 'aProject') >>
                 true
 
                 1 * getAuthContextForSubjectAndProject(_, 'aProject')
@@ -2297,7 +2297,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
 
         }
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
-                authorizeProjectResourceAll(_, AuthorizationUtil.resourceType('event'),['read'], 'aProject') >> false
+                authorizeProjectResource(_, AuthorizationUtil.resourceType('event'),'read', 'aProject') >> false
 
                 1 * getAuthContextForSubject(_) >> test
             }
@@ -2353,7 +2353,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
 
         }
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
-                authorizeProjectResourceAll(_, AuthorizationUtil.resourceType('event'),['read'], 'aProject') >> true
+                authorizeProjectResource(_, AuthorizationUtil.resourceType('event'),'read', 'aProject') >> true
 
                 1 * getAuthContextForSubject(_) >> test
             }
@@ -2410,7 +2410,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
 
         }
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
-                authorizeProjectResourceAll(_, AuthorizationUtil.resourceType('event'),['read'], _) >> {
+                authorizeProjectResource(_, AuthorizationUtil.resourceType('event'),'read', _) >> {
                     it[3] == 'aProject' ||  it[3] == 'bProject'||  it[3] == 'cProject'
                 }
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ReportsControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ReportsControllerSpec.groovy
@@ -61,7 +61,7 @@ class ReportsControllerSpec extends HibernateSpec implements ControllerUnitTest<
 
             controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
                 _ * getAuthContextForSubjectAndProject(*_) >> null
-                _ * authorizeProjectResourceAll(*_) >> true
+                _ * authorizeProjectResource(*_) >> true
             }
         controller.userService = Mock(UserService) {
             findOrCreateUser(*_) >> new User()
@@ -110,7 +110,7 @@ class ReportsControllerSpec extends HibernateSpec implements ControllerUnitTest<
         controller.frameworkService = Mock(FrameworkService)
         controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
             1 * getAuthContextForSubjectAndProject(_, _)
-            _ * authorizeProjectResourceAll(*_) >> true
+            _ * authorizeProjectResource(*_) >> true
         }
         controller.userService = Mock(UserService) {
             findOrCreateUser(*_) >> new User()

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionController2Spec.groovy
@@ -904,7 +904,7 @@ class ScheduledExecutionController2Spec extends HibernateSpec implements Control
         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
 
             1 * authorizeProjectJobAny(_,se,['read','view'],se.project)>>true
-            1 * authorizeProjectResourceAll(_,[type: 'resource', kind: 'event'],['read'],se.project)>>true
+            1 * authorizeProjectResource(_,[type: 'resource', kind: 'event'],'read',se.project)>>true
         }
 
         sec.executionService = mockWith(ExecutionService) {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -1607,7 +1607,7 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
             getProjectGlobals(_) >> [:]
         }
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
-                authorizeProjectResourceAll(_, _, _, _) >> true
+                authorizeProjectResource(_, _, _, _) >> true
                 authorizeProjectExecutionAny(_, exec, _) >> true
 
                 _ * getAuthContextForSubjectAndProject(_, _) >> Mock(UserAndRolesAuthContext) {
@@ -3472,7 +3472,7 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
             getAuthContextForSubjectAndProject(*_) >> auth
             authorizeProjectJobAll(_, _, ['create','view'], _) >> true
-            authorizeProjectResourceAll(_, _ , ['create'] , _ ) >> true
+            authorizeProjectResource(_, _ , 'create' , _ ) >> true
             authorizeProjectJobAll(_, _ , ['read'] , _ ) >> true
         }
 

--- a/test/api/test-metrics.sh
+++ b/test/api/test-metrics.sh
@@ -41,7 +41,7 @@ test_metrics_metrics(){
     VAL=$(jq -r '.counters | length'  "${file}" )
     [ "$VAL" -gt 0 ] || fail "Expected > 0 for .counters in $file but was $VAL"
     assert_json_value '8' '.meters | length'  "${file}"
-    assert_json_value '29' '.timers | length'  "${file}"
+    assert_json_value '28' '.timers | length'  "${file}"
 
     test_succeed
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Cleanup and updates for auth checks

* use AuthConstants in all gsp pages instead of static text
* use AuthConstants in other places 
* prefer `authorizeProjectResource` instead of `authorizeProjectResourceAll` with a single action
* cleanup event read auth checks in MenuController
* move "project configure" auth definition into AppAuthContextProcessor
* add new mechanism using declarative exception handling for unauthorized responses
* update AuthResources definitions