### PR TITLE
RUN-181: add a flag to disable Local Execution and Local File Copier

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/LocalFileCopier.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/LocalFileCopier.java
@@ -30,6 +30,8 @@ import com.dtolabs.rundeck.core.execution.impl.common.BaseFileCopier;
 import com.dtolabs.rundeck.core.execution.service.FileCopier;
 import com.dtolabs.rundeck.core.execution.service.FileCopierException;
 import com.dtolabs.rundeck.core.execution.service.MultiFileCopier;
+import com.dtolabs.rundeck.core.execution.service.NodeExecutorResultImpl;
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepFailureReason;
 
 import java.io.File;
 import java.io.InputStream;
@@ -43,9 +45,22 @@ import java.util.List;
  */
 public class LocalFileCopier extends BaseFileCopier implements FileCopier {
     public static final String SERVICE_PROVIDER_TYPE = "local";
+    public static final String DISABLE_LOCAL_EXECUTOR_ENV = "RUNDECK_DISABLED_LOCAL_EXECUTOR";
+    private boolean disableLocalExecutor = false;
 
     public LocalFileCopier(Framework framework) {
         this.framework = framework;
+
+        String disableLocalExecutor = System.getenv(DISABLE_LOCAL_EXECUTOR_ENV);
+
+        if(disableLocalExecutor!=null && disableLocalExecutor.equals("true")){
+            this.disableLocalExecutor=true;
+        }
+
+    }
+
+    public void setDisableLocalExecutor(boolean disableLocalExecutor) {
+        this.disableLocalExecutor = disableLocalExecutor;
     }
 
     private Framework framework;
@@ -59,6 +74,11 @@ public class LocalFileCopier extends BaseFileCopier implements FileCopier {
             final String destination
     ) throws FileCopierException
     {
+
+        if(disableLocalExecutor){
+            throw new FileCopierException("Local Executor is disabled", StepFailureReason.ConfigurationFailure);
+        }
+
         return BaseFileCopier.writeLocalFile(
                 scriptfile,
                 input,

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/impl/local/LocalFileCopierSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/impl/local/LocalFileCopierSpec.groovy
@@ -1,0 +1,33 @@
+package com.dtolabs.rundeck.core.execution.impl.local
+
+import com.dtolabs.rundeck.core.common.Framework
+import com.dtolabs.rundeck.core.common.INodeEntry
+import com.dtolabs.rundeck.core.execution.ExecutionContext
+import com.dtolabs.rundeck.core.execution.ExecutionListener
+import com.dtolabs.rundeck.core.execution.service.FileCopierException
+import spock.lang.Specification
+
+class LocalFileCopierSpec extends Specification{
+
+    def "disable local file copier"() {
+        given:
+        def node = Mock(INodeEntry)
+        def context = Mock(ExecutionContext){
+            getExecutionListener()>> Mock(ExecutionListener)
+        }
+        def framework = Mock(Framework)
+
+        def plugin = new LocalFileCopier(framework)
+        plugin.setDisableLocalExecutor(true)
+
+        File scriptFile = File.createTempFile("test","sh");
+
+        when:
+        def result = plugin.copyFile(context, scriptFile, node, "/tmp/inlinescript.sh"  )
+
+        then:
+        FileCopierException e = thrown()
+        e.message == "Local Executor is disabled"
+
+    }
+}

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/impl/local/LocalNodeExecutorSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/impl/local/LocalNodeExecutorSpec.groovy
@@ -16,7 +16,11 @@
 
 package com.dtolabs.rundeck.core.execution.impl.local
 
+import com.dtolabs.rundeck.core.common.Framework
+import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.INodeEntry
+import com.dtolabs.rundeck.core.execution.ExecutionContext
+import com.dtolabs.rundeck.core.execution.ExecutionListener
 import com.dtolabs.rundeck.core.execution.script.ExecTaskParameterGeneratorImpl
 import org.apache.tools.ant.Project
 import org.apache.tools.ant.taskdefs.ExecTask
@@ -59,5 +63,28 @@ class LocalNodeExecutorSpec extends Specification {
         null         | _
         'UTF-8'      | _
         'ISO-8859-2' | _
+    }
+
+    def "disable local executor"() {
+        given:
+        def node = Mock(INodeEntry)
+        def context = Mock(ExecutionContext){
+            getExecutionListener()>> Mock(ExecutionListener)
+        }
+        def command = ['a', 'command'] as String[]
+        def framework = Mock(Framework)
+
+        def plugin = new LocalNodeExecutor(framework)
+        plugin.setDisableLocalExecutor(true)
+
+        when:
+        def result = plugin.executeCommand(context, command, node)
+
+        then:
+        result != null
+        !result.success
+        result.failureReason != null
+        result.failureMessage == "Local Executor is disabled"
+
     }
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
adding a flag to disable the Local Execution and Local File Copier

**Describe the solution you've implemented**
adding a system environment called  `RUNDECK_DISABLED_LOCAL_EXECUTOR`

**Describe alternatives you've considered**

**Additional context**

