### PR TITLE
fix to include payload format and http method on notification importing

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Notification.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Notification.groovy
@@ -139,7 +139,7 @@ public class Notification {
             n.type='url'
             n.format=data.format
             n.content=data.urls
-            n.configuration=[urls: data.urls, httpMethod: data.method]
+            n.configuration=[urls: data.urls, httpMethod: data.httpMethod]
         }else if(data.type){
             n.type=data.type
             if(data.configuration && data.configuration instanceof Map){
@@ -209,7 +209,7 @@ public class Notification {
         }else if(data.type=='url'){
             n.format=data.config.format
             n.content=data.config.urls
-            n.configuration=[urls: data.config.urls, httpMethod: data.config.method]
+            n.configuration=[urls: data.config.urls, httpMethod: data.config.httpMethod]
         }else if(data.type){
             if(data.config && data.config instanceof Map){
                 n.configuration=data.config

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -566,7 +566,13 @@ class ScheduledExecution extends ExecutionContext implements EmbeddedJsonData {
                         //support for built-in notification types
                     ['urls','email'].each{ subkey->
                         if(data.notification[name][subkey]){
-                            nots << Notification.fromMap(name, [(subkey):data.notification[name][subkey]])
+                            Map notificationData = [
+                                    format    : data.notification[name]["format"],
+                                    httpMethod: data.notification[name]["httpMethod"],
+                                    (subkey)  : data.notification[name][subkey]
+                            ]
+
+                            nots << Notification.fromMap(name, notificationData)
                         }
                     }
                     if(data.notification[name]['plugin']){

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/notification/DummyWebhookNotificationPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/notification/DummyWebhookNotificationPlugin.groovy
@@ -88,7 +88,7 @@ class DummyWebhookNotificationPlugin implements NotificationPlugin {
     )
     @SelectValues(values = ['get','post'])
     @SelectLabels(values = ['GET','POST'])
-    String method
+    String httpMethod
 
     @Override
     boolean postNotification(final String trigger, final Map executionData, final Map config) {

--- a/rundeckapp/src/test/groovy/rundeck/NotificationSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/NotificationSpec.groovy
@@ -102,11 +102,12 @@ class NotificationSpec extends Specification {
             result.eventTrigger == trigger
             result.type == type
             result.urlConfiguration().urls == expect
+            result.urlConfiguration().httpMethod == expectMethod
             result.format == expectformat
         where:
-            trigger     | config                        | expect | expectformat
-            'onsuccess' | [urls: 'blah', format: 'xml'] | 'blah' | 'xml'
-            'onsuccess' | [urls: 'blah', format: 'json'] | 'blah' | 'json'
+            trigger     | config                                             | expect | expectformat | expectMethod
+            'onsuccess' | [urls: 'blah', format: 'xml', httpMethod: 'post']  | 'blah' | 'xml'        | 'post'
+            'onsuccess' | [urls: 'blah', format: 'json', httpMethod: 'get']  | 'blah' | 'json'       | 'get'
 
     }
     @Unroll

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionSpec.groovy
@@ -17,6 +17,7 @@
 package rundeck
 
 import grails.test.hibernate.HibernateSpec
+import org.eclipse.jetty.util.ajax.JSON
 
 import static org.junit.Assert.*
 
@@ -59,6 +60,25 @@ class ScheduledExecutionSpec extends HibernateSpec
             se.options
             se.options.size() == 2
             se.options.every { it.scheduledExecution == se }
+    }
+
+    def "from map notifications urls should include httpMethod and format"() {
+        given:
+            def map = [
+                    jobName: 'abc',
+                    notification: [
+                            onFailure: [urls:"url1", format: "JSON", httpMethod: "POST"]
+                    ]
+            ]
+        when:
+            def se = ScheduledExecution.fromMap(map)
+
+        then:
+            se.notifications.size() == 1
+            Notification notification = se.notifications.first()
+            notification.type == "url"
+            notification.format == "JSON"
+            notification.content == '{"urls":"url1","httpMethod":"POST"}'
     }
 
     void testGenerateJobScheduledName() {


### PR DESCRIPTION
fixes https://github.com/rundeckpro/rundeckpro/issues/1830

**Is this a bugfix, or an enhancement? Please describe.**
The payload format and http method was not being included when importing a job

**Describe the solution you've implemented**
Correction in property name and adjustments in imported data for notification creation
