### PR TITLE
Allow absolute redirectUrl in preauthenticated

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -71,7 +71,12 @@ class UserController extends ControllerBase{
 
     def loggedout(){
         if(grailsApplication.config.rundeck.security.authorization.preauthenticated.redirectLogout in ['true',true]) {
-            return redirect(url: grailsApplication.config.grails.serverURL + grailsApplication.config.rundeck.security.authorization.preauthenticated.redirectUrl)
+            final URI redirectUrl = new URI(grailsApplication.config.rundeck.security.authorization.preauthenticated.redirectUrl)
+            if (redirectUrl.isAbsolute()) {
+                return redirect(url: redirectUrl)
+            } else {
+                return redirect(url: grailsApplication.config.grails.serverURL + redirectUrl)
+            }
         }
     }
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
https://docs.rundeck.com/docs/administration/configuration/config-file-reference.html#logout-behaviors talks about being able to use both a relative and absolute URL.

I therefore expected to be able to use an absolute redirectUrl in preauthenticated too. However, it just appended the URL in a slightly broken fashion.

As an example, given you are on https://rundeck.example.com/ and `rundeck-config.properties` contained the following properties:
```
rundeck.security.authorization.preauthenticated.redirectLogout=true
rundeck.security.authorization.preauthenticated.redirectUrl=https://auth.example.com/logout
```

When clicking logout in the top right menu of Rundeck, you would be redirected to https://rundeck.example.comhttps//auth.example.com/logout (note the missing `:`) instead of https://auth.example.com/logout.

**Describe the solution you've implemented**
I have added a check to use the redirectUrl directly if it is an absolute Url. I have manually tested this to make sure it works correctly in both cases.

**Describe alternatives you've considered**
I have not considered any alternative, as the behaviour simply did not seem like intended to me. 

**Additional context**
This fix makes it possible to use Rundeck behind something like Authelia, which prefers to run on another domain than the applications it is handling authentication for.
