### PR TITLE
Make ScmService#pathForConfigFile behave like before (Fix #6646)

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -301,12 +301,6 @@ class ScmService {
     }
 
     private String pathForConfigFile(String integration) {
-        if(frameworkService.isClusterModeEnabled()){ //universal config for cluster
-            return "etc/scm-${integration}.properties"
-        }
-        if (frameworkService.serverUUID) {
-            return "${frameworkService.serverUUID}/etc/scm-${integration}.properties"
-        }
         "etc/scm-${integration}.properties"
     }
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This PR resolves https://github.com/rundeck/rundeck/issues/6646.

**Describe the solution you've implemented**
As described on https://github.com/rundeck/rundeck/issues/6646#issuecomment-930416577, `FrameworkService#getServerUUID` used to return null if the cluster mode was disabled, that is, `ScmService#pathForConfigFile` used to return the same value "etc/scm-${integration}.properties" whether or not the cluster mode is enabled.
So, I made the method `ScmService#pathForConfigFile` behave like before.

**Describe alternatives you've considered**
none

**Additional context**
This change is a breaking change for users who use Rundeck 3.3.4 or later with the cluster mode disabled and a fixed server UUID.
The upgrade guide should mention it.
