### PR TITLE
Fix token management delete and create modals

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/user/profile.js
+++ b/rundeckapp/grails-app/assets/javascripts/user/profile.js
@@ -139,6 +139,7 @@ function TokenTableHandler(ctx) {
         var table = tokenTable.getTableBody();
         table.prepend(rowContent);
         var row = $('token-' + tokenid);
+        jQuery(row).find('.modal-container').appendTo('body')
         row.style.opacity = 0;
         jQuery($(row)).fadeTo(1000, 1);
 
@@ -227,8 +228,8 @@ function removeTokenRow(elem, data) {
     tokenTable.removeRow(elem);
 }
 
-function clearToken(elem) {
-    var dom = jQuery(elem);
+function clearToken(form, row) {
+    var dom = jQuery(form);
     var login = dom.find('input[name="login"]').val();
     var params = {login: login};
     if (dom.find('input[name="tokenid"]').length > 0) {
@@ -246,13 +247,13 @@ function clearToken(elem) {
                 tokenAjaxError(data.error);
             } else if (data.result) {
                 //remove row element
-                removeTokenRow(elem, data);
+                removeTokenRow(jQuery(`#token-${row}`)[0], data);
             }
         },
         error: function (jqxhr, status, error) {
             tokenAjaxError(jqxhr.responseJSON && jqxhr.responseJSON.error ? jqxhr.responseJSON.error : error);
         }, complete: function () {
-            jQuery('#' + elem.identify() + ' .modal').modal('hide');
+            jQuery(form).find('.modal').modal('hide');
         }
     }).success(_createAjaxReceiveTokensHandler('api_req_tokens'));
 }
@@ -317,7 +318,7 @@ jQuery(function () {
     });
     jQuery(document).on('click', '.clearconfirm input.yes', function (e) {
         e.preventDefault();
-        clearToken(jQuery(e.target).closest('.apitokenform')[0]);
+        clearToken(jQuery(e.target).closest('form')[0], e.target.dataset.tokenId);
         return false;
     });
 
@@ -325,7 +326,7 @@ jQuery(function () {
     tokenDispModal.on("hide.bs.modal", function (e) {
         jQuery("#createdTokenViewer").text("--")
     })
-    var dom = jQuery('#gentokensection');
+    var dom = jQuery('#gentokenmodal');
     if (dom.length == 1) {
         var roleset = new RoleSet(data.roles);
         window.tokencreator = new TokenCreator({

--- a/rundeckapp/grails-app/views/user/_token.gsp
+++ b/rundeckapp/grails-app/views/user/_token.gsp
@@ -58,7 +58,7 @@
 
         <!-- Modal -->
 
-        <g:form controller="user" action="clearApiToken" useToken="true">
+        <g:form class="modal-container" controller="user" action="clearApiToken" useToken="true">
             <div class="modal fade clearconfirm" id="myModal${enc(attr: ukey)}" tabindex="-1" role="dialog"
                  aria-labelledby="myModalLabel"
                  aria-hidden="true">
@@ -86,7 +86,7 @@
                             </g:else>
                             <button type="button" class="btn btn-default" data-dismiss="modal"><g:message
                                     code="button.action.Cancel"/></button>
-                            <input type="submit" class="btn btn-danger yes" value="Delete"
+                            <input type="submit" class="btn btn-danger yes" value="Delete" data-token-id="${token.uuid}"
                                    name="${message(code: 'button.action.Delete')}">
 
                         </div>


### PR DESCRIPTION
All modals are now attached to the `body` in `base.gsp` so that they will always display above other site content correctly.

The user token JS code was using jQuery DOM traversal to associate the modal data with the row. This has been replaced by keying both with the token UUID.