### PR TITLE
Fix auth constant

### DIFF
--- a/grails-webhooks/grails-app/controllers/webhooks/WebhookController.groovy
+++ b/grails-webhooks/grails-app/controllers/webhooks/WebhookController.groovy
@@ -62,7 +62,7 @@ class WebhookController {
         }
 
         UserAndRolesAuthContext authContext = rundeckAuthContextProvider.getAuthContextForSubjectAndProject(session.subject, params.project)
-        if (!authorized(authContext, webhook.project, ACTION_DELETE)) {
+        if (!authorized(authContext, webhook.project, AuthConstants.ACTION_DELETE)) {
             sendJsonError("You are not authorized to perform this action")
             return
         }


### PR DESCRIPTION
Fixes rundeckpro/rundeckpro#2074

`DELETE` auth constant was not being accessed through the correct object causing deletes to fail.