### PR TITLE
RUN-427: Revert tabs to use same bg colors as default card

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/containers/tabs/tabs-rounded.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/containers/tabs/tabs-rounded.scss
@@ -29,7 +29,7 @@
         padding-top: 10px;
 
         // Rounded
-        background-color: var(--background-color-accent-lvl3);
+        background-color: var(--background-color-accent-lvl2);
     }
 
     .rdtabs__rightendcap {
@@ -41,14 +41,14 @@
     }
 
     .rdtabs__tab--active {
-        background-color: var(--background-color-lvl3);;
-        border-bottom: var(--line-width) solid var(--background-color-lvl3);;
+        background-color: var(--background-color-lvl2);;
+        border-bottom: var(--line-width) solid var(--background-color-lvl2);;
         border-top-left-radius: var(--radius);
         border-top-right-radius: var(--radius);
 
         .rdtabs__tab-inner {
             clip-path: inset(0 0 8px 0);
-            background-color: var(--background-color-lvl3);
+            background-color: var(--background-color-lvl2);
             border-top: var(--line-width) solid #D3DBE5;
             border-left: var(--line-width) solid #D3DBE5;
             border-right: var(--line-width) solid #D3DBE5;
@@ -75,11 +75,11 @@
 
     .rdtabs__tab-component:not(.rdtabs__tab--active) {
         .rdtabs__tab-inner {
-            border-left: var(--line-width) solid var(--background-color-accent-lvl3);
-            border-right: var(--line-width) solid var(--background-color-accent-lvl3);
+            border-left: var(--line-width) solid var(--background-color-accent-lvl2);
+            border-right: var(--line-width) solid var(--background-color-accent-lvl2);
             border-top: var(--line-width) solid transparent;
             border-bottom: var(--line-width) solid #D3DBE5;
-            background-color: var(--background-color-accent-lvl3);
+            background-color: var(--background-color-accent-lvl2);
         }
 
         .rdtabs__tab-inner:after {
@@ -97,7 +97,7 @@
 
 
     .rdtabs__tab-previous {
-        background-color: var(--background-color-lvl3);
+        background-color: var(--background-color-lvl2);
         .rdtabs__tab-inner {
             clip-path: inset(0 8px 0 0);
         }
@@ -108,13 +108,13 @@
         height: 100%;
         width: var(--radius);
         right:0;
-        background-color: var(--background-color-accent-lvl3);
+        background-color: var(--background-color-accent-lvl2);
         border-bottom-right-radius: var(--radius);
         position: absolute;
     }
 
     .rdtabs__tab--active + .rdtabs__tab-component {
-        background-color: var(--background-color-lvl3);
+        background-color: var(--background-color-lvl2);
         .rdtabs__tab-inner {
             clip-path: inset(0 0 0 8px);
         }
@@ -125,7 +125,7 @@
         height: 100%;
         width: var(--radius);
         left:0;
-        background-color: var(--background-color-accent-lvl3);
+        background-color: var(--background-color-accent-lvl2);
         border-bottom-left-radius: var(--radius);
         position: absolute;
     }


### PR DESCRIPTION
In the pursuit of dark-mode perfect the rounded(card) tabs style became whack in the light(default) theme:
![image](https://user-images.githubusercontent.com/271965/136843811-a621825a-6e8c-45b8-b8f9-4ef1ff8c0d7f.png)

Quick fix for `3.4.5`:
![tabs-fix](https://user-images.githubusercontent.com/271965/136843667-0fbf315e-cbe1-4877-bda1-c4b521543771.gif)
