### PR TITLE
Dev environment error when logging encodeAsJSON() objects

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
@@ -253,8 +253,8 @@ class WorkflowService implements ApplicationContextAware,ExecutionFileProducer{
             log.error(name + ": " + e.message, e)
             if (Environment.getCurrent() == Environment.DEVELOPMENT) {
                 //print state change list in dev mode
-                log.error(logstate.stateChanges.encodeAsJSON())
-                log.error(stateMapping.mapOf(id, state).encodeAsJSON())
+                log.error(logstate.stateChanges.encodeAsJSON().toString())
+                log.error(stateMapping.mapOf(id, state).encodeAsJSON().toString())
             }
         }
 
@@ -273,7 +273,7 @@ class WorkflowService implements ApplicationContextAware,ExecutionFileProducer{
             chain << new WorkflowStateListenerAction(onWorkflowExecutionStateChanged: {
                 ExecutionState executionState, Date timestamp, List<String> nodeSet ->
                     if (executionState.completedState) {
-                        log.debug(logstate.stateChanges.encodeAsJSON())
+                        log.debug(logstate.stateChanges.encodeAsJSON().toString())
                     }
             })
         }


### PR DESCRIPTION
The logging system needs encodeAsJSON to be toString() before passing to a log method.

We only appear to be doing this running in a development environment so the impact of this bug is low.