### PR TITLE
Add ops_admin where missing from auth resources definition

### DIFF
--- a/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/AuthResources.java
+++ b/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/AuthResources.java
@@ -213,6 +213,7 @@ public class AuthResources {
         projResActionsByType.put(AuthConstants.TYPE_JOB, projectJobActions);
         projResActionsByType.put(AuthConstants.TYPE_ADHOC, projectAdhocActions);
         projResActionsByType.put(AuthConstants.TYPE_NODE, projectNodeActions);
+        projResActionsByType.put(AuthConstants.TYPE_STORAGE, storageActions);
     }
 
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Updates internal authZ catalog with additional information.
