### PR TITLE
RUN-233: Allow instrumentation DNS

### DIFF
--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -184,9 +184,9 @@ rundeck:
                     comment: the following policy definition should work in default rundeck install
                     config:
                         default-src: 'none'
-                        connect-src: 'self https://api.rundeck.com'
+                        connect-src: 'self https://api.rundeck.com https://data.analytics.rundeck.com'
                         style-src: 'self unsafe-inline'
-                        script-src: 'self unsafe-inline unsafe-eval'
+                        script-src: 'self https://content.analytics.rundeck.com unsafe-inline unsafe-eval'
                         font-src: 'self data:'
                         img-src: '* data:'
                         form-action: 'self'


### PR DESCRIPTION
This PR changes the default CSP to allow communication with our analytics DNS, to be implemented later in certain Enterprise installations.