### PR TITLE
Fix install script for rundeck CLI

### DIFF
--- a/test/docker/dockers/rundeck/Dockerfile
+++ b/test/docker/dockers/rundeck/Dockerfile
@@ -11,7 +11,7 @@ ARG CLI_VERS
 
 #Add PAM test user
 
-RUN curl https://packagecloud.io/install/repositories/pagerduty/rundeck/script.deb.sh 2> /dev/null | bash -s rundeck \
+RUN curl -s https://packagecloud.io/install/repositories/pagerduty/rundeck/script.deb.sh | os=any dist=any bash \
     && apt-get -y install rundeck-cli=${CLI_VERS}
 
 RUN useradd -p $(echo "pampwd123" | openssl passwd -1 -stdin) -m --shell /bin/bash pamlogintest


### PR DESCRIPTION
Update the docker file to use package cloud install script, vs custom deb install script.