### PR TITLE
Fix small issue in Rundeck boot lifecycle

### DIFF
--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -562,7 +562,7 @@ class BootStrap {
     }
 
      def destroy = {
-         metricRegistry.removeMatching(MetricFilter.ALL)
+         metricRegistry?.removeMatching(MetricFilter.ALL)
          log.info("Rundeck Shutdown detected")
      }
 }


### PR DESCRIPTION
If Rundeck doesn't boot properly the metricRegistry will never be created
and the destroy method will throw an NPE when it tries to remove the metrics.
