### PR TITLE
fix: default label colors

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/stories/theme.stories.tsx
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/stories/theme.stories.tsx
@@ -57,7 +57,22 @@ export const typography = () => (Vue.extend({
         )
     }
 }))
-
+export const labels = () => (Vue.extend({
+  render(h) {
+    return (
+      <div>
+        <h3>H3 Text <span class="label label-default">default</span></h3>
+        <h3>H3 Text <span class="label label-secondary">secondary</span></h3>
+        <h3>H3 Text <span class="label label-muted">muted</span></h3>
+        <h3>H3 Text <span class="label label-danger">danger</span></h3>
+        <h3>H3 Text <span class="label label-warning">warning</span></h3>
+        <h3>H3 Text <span class="label label-success">success</span></h3>
+        <h3>H3 Text <span class="label label-info">info</span></h3>
+        <h3>H3 Text <span class="label label-white">white</span></h3>
+      </div>
+    )
+  }
+}))
 export const buttons = () => (Vue.extend({
     render(h) {
         return (

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/custom/labels.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/custom/labels.scss
@@ -1,14 +1,13 @@
 @import "../runstrap/variables";
 
 .label{
-  // &.label-default{
-    // a{
-    //   color: var(--white-color);
-    // }
-  // }
+  &.label-default {
+    color: var(--default-color);
+    background-color: var(--font-color);
+  }
   &.label-white{
-    background-color: white;
-    color: black;
+    background-color: var(--white-color);
+    color: var(--black-color);
   }
 
   &.label-muted {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Fix: default label colors are incorrect

examples:

![Screen Shot 2021-10-22 at 2 30 17 PM](https://user-images.githubusercontent.com/55603/138525270-95946fe9-0320-47d5-9d79-65a465278ab2.png)
![Screen Shot 2021-10-22 at 2 30 12 PM](https://user-images.githubusercontent.com/55603/138525282-3f42eaf7-48c8-4bc5-b8dd-b2cc9fb68c76.png)


**Describe the solution you've implemented**
Update style to fix colors for default and white labels.
added storybook for labels

**Additional context**

fixed:
![screencast 2021-10-22 14-26-12](https://user-images.githubusercontent.com/55603/138525313-f9557b50-d638-4329-8faf-743d1af39cb4.gif)

