### PR TITLE
Fix: Dark mode nested table bg colors

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/stories/theme.stories.tsx
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/stories/theme.stories.tsx
@@ -1,7 +1,9 @@
 import Vue from 'vue'
+import {withKnobs, object,select} from '@storybook/addon-knobs'
 
 export default {
-    title: 'Class Components'
+    title: 'Class Components',
+    decorators: [withKnobs]
 }
 
 export const typography = () => (Vue.extend({
@@ -143,6 +145,126 @@ export const buttons = () => (Vue.extend({
         )
     }
 }))
+export const table = () => (Vue.extend({
+  props: {
+    rowStyle: {
+      default: select('Table Style', {bordered: 'table-bordered', striped: 'table-striped'}, 'table-bordered')
+    }
+  },
+  template:`
+            <div >
+              <table class="table table-condensed  table-embed table-data-embed " :class="rowStyle">
+                <tbody>
+                <tr>
+                  <th colSpan="2" class="table-header">global</th>
+                </tr>
+                <tr>
+                  <th class="table-header">Key</th>
+                  <th class="table-header">Value</th>
+                </tr>
+                <tr>
+                  <td>globals</td>
+                  <td><span class="text-muted">Empty Map</span></td>
+                </tr>
+                <tr>
+                  <td>job</td>
+                  <td>
+                    <table class="table table-condensed table-embed table-data-embed "  :class="rowStyle">
+                      <tbody>
+                      <tr>
+                        <th class="table-header">Key</th>
+     <th class="table-header">Value</th>
+                      </tr>
+                      <tr>
+                        <td>successOnEmptyNodeFilter</td>
+                        <td>false</td>
+                      </tr>
+                      <tr>
+                        <td>executionType</td>
+                        <td>user</td>
+                      </tr>
+                      <tr>
+                        <td>wasRetry</td>
+                        <td>false</td>
+                      </tr>
+                      <tr>
+                        <td>user.name</td>
+                        <td>admin</td>
+                      </tr>
+                      <tr>
+                        <td>project</td>
+                        <td>test1</td>
+                      </tr>
+                      <tr>
+                        <td>threadcount</td>
+                        <td>1</td>
+                      </tr>
+                      <tr>
+                        <td>url</td>
+                        <td>http://artorias.local:4440/rundeckpro/project/test1/execution/follow/91</td>
+                      </tr>
+                      <tr>
+                        <td>execid</td>
+                        <td>91</td>
+                      </tr>
+                      <tr>
+                        <td>filter</td>
+                        <td>name: outatime.local</td>
+                      </tr>
+                      <tr>
+                        <td>retryPrevExecId</td>
+                        <td>0</td>
+                      </tr>
+                      <tr>
+                        <td>serverUUID</td>
+                        <td>a3de6030-2b7a-47e3-b46f-3e46a11a85d9</td>
+                      </tr>
+                      <tr>
+                        <td>serverUrl</td>
+                        <td>http://artorias.local:4440/rundeckpro/</td>
+                      </tr>
+                      <tr>
+                        <td>loglevel</td>
+                        <td>NORMAL</td>
+                      </tr>
+                      <tr>
+                        <td>name</td>
+                        <td>test echo</td>
+                      </tr>
+                      <tr>
+                        <td>retryInitialExecId</td>
+                        <td>0</td>
+                      </tr>
+                      <tr>
+                        <td>id</td>
+ <td>a616e247-8000-45b0-bce8-4cf8b5712e62</td>
+                      </tr>
+                      <tr>
+                        <td>retryAttempt</td>
+                        <td>0</td>
+                      </tr>
+                      <tr>
+                        <td>group</td>
+                        <td><span class="text-muted">Null Value</span></td>
+                      </tr>
+                      <tr>
+                        <td>username</td>
+                        <td>admin</td>
+                      </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td>option</td>
+                  <td><span class="text-muted">Empty Map</span></td>
+                </tr>
+                </tbody>
+              </table>
+            </div>
+        `
+}))
+
 
 export const pagination = () => (Vue.extend({
     render(h) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_tables.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_tables.scss
@@ -79,10 +79,6 @@ th {
     border-top: 2px solid $table-border-color;
   }
 
-  // Nesting
-  .table {
-    background-color: $body-bg;
-  }
 }
 
 
@@ -133,7 +129,7 @@ th {
 
 .table-striped {
   > tbody > tr:nth-of-type(odd) {
-    background-color: $table-bg-accent;
+    background-color: var(--table-stripe-color);
   }
 }
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

* Fix darkmode nested tables bg colors.
* add storybook


E.g.
![Screen Shot 2021-10-22 at 2 44 10 PM](https://user-images.githubusercontent.com/55603/138526744-1c2cf383-0a0a-48da-b990-801137880223.png)
![Screen Shot 2021-10-22 at 2 44 17 PM](https://user-images.githubusercontent.com/55603/138526746-b44d7920-534d-4774-b6c5-b66f26ddefc7.png)


**Describe the solution you've implemented**
fix css with nested bg color

**Additional context**
Fixed:

![Screen Shot 2021-10-22 at 2 44 46 PM](https://user-images.githubusercontent.com/55603/138526786-b8625eb2-4cce-4108-9730-06d493a05781.png)
![Screen Shot 2021-10-22 at 2 44 40 PM](https://user-images.githubusercontent.com/55603/138526788-99b18295-fdd3-497c-aebd-4fa5193334fa.png)

