### PR TITLE
RUN-456: Increase Memory settings in default profile templates

### DIFF
--- a/core/src/main/resources/com/dtolabs/launcher/setup/templates/profile.bat.template
+++ b/core/src/main/resources/com/dtolabs/launcher/setup/templates/profile.bat.template
@@ -9,5 +9,5 @@ set JAVA_HOME=@user.java_home.win@
 set Path=%JAVA_HOME%\bin;%RDECK_BASE%\tools\bin;%Path%
 
 set RDECK_SSL_OPTS="-Djavax.net.ssl.trustStore=%RDECK_BASE%\etc\truststore -Djavax.net.ssl.trustStoreType=jks -Djava.protocol.handler.pkgs=com.sun.net.ssl.internal.www.protocol"
-set RDECK_CLI_OPTS=-Xms64m -Xmx128m
+set RDECK_CLI_OPTS=-Xms256m -Xmx4096m
 set RD_LIBDIR=%RDECK_BASE%\tools\lib

--- a/core/src/main/resources/com/dtolabs/launcher/setup/templates/profile.template
+++ b/core/src/main/resources/com/dtolabs/launcher/setup/templates/profile.template
@@ -17,7 +17,7 @@ fi
 #
 # Set min/max heap size
 #
-export RDECK_JVM="$RDECK_JVM -Xmx1024m -Xms256m -XX:MaxMetaspaceSize=256m -server"
+export RDECK_JVM="$RDECK_JVM -Xmx4096m -Xms256m -XX:MaxMetaspaceSize=256m -server"
 
 export RDECK_SSL_OPTS="-Djavax.net.ssl.trustStore=$RDECK_BASE/etc/truststore -Djavax.net.ssl.trustStoreType=jks -Djava.protocol.handler.pkgs=com.sun.net.ssl.internal.www.protocol"
 


### PR DESCRIPTION
Fix: https://github.com/rundeck/rundeck/issues/6305

Description:
Add more memory to Linux and Windows configuration in profile template files by default to avoid a lack of memory on Rundeck first run.