### PR TITLE
Add Copy Box for job id

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_show.gsp
@@ -41,7 +41,9 @@
                       ]"/>
 
             <section class="section-space">
-                <small class="uuid">${scheduledExecution.extid}</small>
+                <div class="vue-copybox">
+                    <copy-box content="${scheduledExecution.extid}" style="max-width: 375px;"/>
+                </div>
             </section>
         </div>
 

--- a/rundeckapp/grails-app/views/scheduledExecution/show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/show.gsp
@@ -187,6 +187,7 @@ search
 })
     </g:javascript>
     <asset:javascript src="static/pages/project-activity.js" defer="defer"/>
+    <asset:javascript src="static/components/copybox.js"/>
 </head>
 
 <body>

--- a/rundeckapp/grails-spa/packages/ui/src/components/copybox/main.ts
+++ b/rundeckapp/grails-spa/packages/ui/src/components/copybox/main.ts
@@ -1,0 +1,22 @@
+import Vue from 'vue'
+import copyBox from '@rundeck/ui-trellis/lib/components/containers/copybox/CopyBox.vue'
+// The Vue build version to load with the `import` command
+// (runtime-only or standalone) has been set in webpack.base.conf with an alias.
+
+
+window.addEventListener('DOMContentLoaded', init)
+function init(){
+    const els = document.body.getElementsByClassName('vue-copybox')
+    if (!els)
+        return
+
+    for (var i = 0; i < els.length; i++) {
+        const e = els[i]
+        /* eslint-disable no-new */
+        new Vue({
+            el: e,
+            components: { copyBox }
+        })
+    }
+}
+

--- a/rundeckapp/grails-spa/packages/ui/vue.config.js
+++ b/rundeckapp/grails-spa/packages/ui/vue.config.js
@@ -3,6 +3,7 @@ const webpack = require('webpack')
 
 module.exports = {
   pages: {
+    'components/copybox': { entry: './src/components/copybox/main.ts' },
     'components/central': { entry: './src/components/central/main.ts'},
     'components/ko-paginator': { entry: './src/components/ko-paginator/main.ts'},
     'components/motd': { entry: './src/components/motd/main.js'},


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Enhancement: Provides user the ability to click to copy job id

**Describe the solution you've implemented**
Include Copy Box Vue  component to Job page
