### PR TITLE
RUN-465 Fixes duplicated job scheduling after renaming job/group

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobReference.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobReference.java
@@ -50,4 +50,14 @@ public interface JobReference {
      * @return server UUID
      */
     String getServerUUID();
+
+    /**
+     * @return original job name in case of renaming
+     */
+    default String getOriginalJobName(){ return null; }
+
+    /**
+     * @return original group name in case of renaming
+     */
+    default String getOriginalGroupName(){ return null; }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobReference.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobReference.java
@@ -54,10 +54,10 @@ public interface JobReference {
     /**
      * @return original job name in case of renaming
      */
-    default String getOriginalJobName(){ return null; }
+    default String getOriginalQuartzJobName(){ return null; }
 
     /**
      * @return original group name in case of renaming
      */
-    default String getOriginalGroupName(){ return null; }
+    default String getOriginalQuartzGroupName(){ return null; }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/JobReferenceImpl.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobReferenceImpl.groovy
@@ -27,8 +27,8 @@ class JobReferenceImpl implements JobReference {
     String jobName
     String groupPath
     String serverUUID
-    String originalJobName
-    String originalGroupName
+    String originalQuartzJobName
+    String originalQuartzGroupName
 
     @Override
     String getJobAndGroup() {

--- a/rundeckapp/grails-app/services/rundeck/services/JobReferenceImpl.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobReferenceImpl.groovy
@@ -27,6 +27,8 @@ class JobReferenceImpl implements JobReference {
     String jobName
     String groupPath
     String serverUUID
+    String originalJobName
+    String originalGroupName
 
     @Override
     String getJobAndGroup() {

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3364,8 +3364,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         if(frameworkService.isClusterModeEnabled()){
             if (schedulingWasChanged) {
                 JobReferenceImpl jobReference = scheduledExecution.asReference()
-                jobReference.setOriginalJobName(oldjob.oldjobname)
-                jobReference.setOriginalGroupName(oldjob.oldjobgroup)
+                jobReference.setOriginalQuartzJobName(oldjob.oldjobname)
+                jobReference.setOriginalQuartzGroupName(oldjob.oldjobgroup)
                 modify = jobSchedulerService.updateScheduleOwner(jobReference)
                 if (modify) {
                     scheduledExecution.serverNodeUUID = frameworkService.serverUUID

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1140,8 +1140,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
         def data=["project": se.project,
                   "jobId":se.uuid,
-                  "oldJobName": oldJobName,
-                  "oldGroupName": oldGroupName]
+                  "oldQuartzJobName": oldJobName,
+                  "oldQuartzGroupName": oldGroupName]
 
         if(!forceLocal){
             boolean remoteAssign = remoteAssigned ?: jobSchedulerService.scheduleRemoteJob(data)

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1139,7 +1139,9 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
 
         def data=["project": se.project,
-                  "jobId":se.uuid, "oldServerNodeUUID": se.serverNodeUUID]
+                  "jobId":se.uuid,
+                  "oldJobName": oldJobName,
+                  "oldGroupName": oldGroupName]
 
         if(!forceLocal){
             boolean remoteAssign = remoteAssigned ?: jobSchedulerService.scheduleRemoteJob(data)
@@ -3361,7 +3363,10 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         boolean schedulingWasChanged = oldjob.schedulingWasChanged(scheduledExecution)
         if(frameworkService.isClusterModeEnabled()){
             if (schedulingWasChanged) {
-                modify = jobSchedulerService.updateScheduleOwner(scheduledExecution.asReference())
+                JobReferenceImpl jobReference = scheduledExecution.asReference()
+                jobReference.setOriginalJobName(oldjob.oldjobname)
+                jobReference.setOriginalGroupName(oldjob.oldjobgroup)
+                modify = jobSchedulerService.updateScheduleOwner(jobReference)
                 if (modify) {
                     scheduledExecution.serverNodeUUID = frameworkService.serverUUID
                 }

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -230,12 +230,7 @@ class ScheduledExecutionServiceSpec extends HibernateSpec implements ServiceUnit
             getServerUUID() >> 'uuid'
             isClusterModeEnabled() >> clusterEnabled
         }
-        service.jobSchedulerService=Mock(JobSchedulerService){
-            determineExecNode(*_)>>{args->
-                return serverNodeUUID
-            }
-            scheduleRemoteJob(_)>>false
-        }
+
         def job = new ScheduledExecution(
                 createJobParams(
                         scheduled: hasSchedule,
@@ -245,9 +240,20 @@ class ScheduledExecutionServiceSpec extends HibernateSpec implements ServiceUnit
                 )
         ).save()
 //        def scheduleDate = new Date()
+        def data=["project": job.project,
+                  "jobId":job.uuid,
+                  "oldJobName": originalJobName,
+                  "oldGroupName": originalGroupName]
+
+        service.jobSchedulerService=Mock(JobSchedulerService){
+            determineExecNode(*_)>>{args->
+                return serverNodeUUID
+            }
+            scheduleRemoteJob(data)>>false
+        }
 
         when:
-        def result = service.scheduleJob(job, null, null, false, remoteAssgined)
+        def result = service.scheduleJob(job, originalJobName, originalGroupName, false, remoteAssgined)
 
         then:
         1 * service.executionServiceBean.getExecutionsAreActive() >> executionsAreActive
@@ -255,11 +261,13 @@ class ScheduledExecutionServiceSpec extends HibernateSpec implements ServiceUnit
         result == [scheduleDate, serverNodeUUID]
 
         where:
-        executionsAreActive | scheduleEnabled | executionEnabled | hasSchedule | expectScheduled | clusterEnabled | serverNodeUUID | remoteAssgined | scheduleDate
-        true                | true            | true             | true        | true            | false          | null           | false          | new Date()
-        true                | true            | true             | true        | true            | true           | 'uuid'         | false          | new Date()
-        true                | true            | true             | true        | true            | false          | null           | true           | null
-        true                | true            | true             | true        | true            | true           | null           | true           | null
+        executionsAreActive | scheduleEnabled | executionEnabled | hasSchedule | expectScheduled | clusterEnabled | serverNodeUUID | remoteAssgined | scheduleDate | originalJobName | originalGroupName
+        true                | true            | true             | true        | true            | false          | null           | false          | new Date()   | null            | null
+        true                | true            | true             | true        | true            | true           | 'uuid'         | false          | new Date()   | null            | null
+        true                | true            | true             | true        | true            | false          | null           | false          | new Date()   | "aJobName"      | "aGroupName"
+        true                | true            | true             | true        | true            | true           | 'uuid'         | false          | new Date()   | "aJobName"      | "aGroupName"
+        true                | true            | true             | true        | true            | false          | null           | true           | null         | null            | null
+        true                | true            | true             | true        | true            | true           | null           | true           | null         | null            | null
     }
 
     @Unroll
@@ -3617,6 +3625,83 @@ class ScheduledExecutionServiceSpec extends HibernateSpec implements ServiceUnit
         then: "validation error results in failure"
             !results.success
             results.error.contains('Validation failed')
+    }
+
+    @Unroll
+    def "do save updated job, renaming a job with cluster enabled should keep original job name on job reference"() {
+        def params = [:]
+        def job = new ScheduledExecution(createJobParams())
+        def oldJob = new OldJob(oldjobname: 'blue', originalRef: ScheduledExecutionService.jobEventRevRef(job))
+        job.jobName = 'other name'
+        def auth = Mock(UserAndRolesAuthContext){
+            getUsername()>>'bob'
+            getRoles()>>['a']
+        }
+        setupDoUpdateJob()
+        service.frameworkService = Mock(FrameworkService) {
+            _ * existsFrameworkProject('AProject') >> true
+            _ * getFrameworkProject('AProject') >> Mock(IRundeckProject) {
+                getProperties() >> [:]
+                getProjectProperties() >> [:]
+            }
+            _ * existsFrameworkProject('BProject') >> true
+
+            _ * projectNames(_ as AuthContext) >> ['AProject', 'BProject']
+            _ * isClusterModeEnabled() >> true
+            _ * getServerUUID() >> null
+            _ * getRundeckFramework() >> Mock(Framework) {
+                _ * getWorkflowStrategyService() >> Mock(WorkflowStrategyService) {
+                    _ * getStrategyForWorkflow(*_) >> Mock(WorkflowStrategy) {
+                        _ * validate(_)
+                    }
+                }
+            }
+            _ * frameworkNodeName () >> null
+            _ * getFrameworkPropertyResolverWithProps(_, _)
+            _ * filterNodeSet(*_) >> null
+        }
+
+        service.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
+            1 * authorizeProjectJobAll(_,_,_,_) >> true
+            _ * authorizeProjectResourceAll(*_) >> true
+            _ * authorizeProjectJobAny(*_) >> true
+            _ * filterAuthorizedNodes(*_) >> null
+            _ * getAuthContextWithProject(_, _) >> { args ->
+                return args[0]
+            }
+        }
+
+
+        JobReferenceImpl jobReferenceImpl = new JobReferenceImpl(
+                id: job.extid,
+                jobName: job.jobName,
+                groupPath: job.groupPath,
+                project: job.project,
+                serverUUID: job.serverNodeUUID,
+                originalJobName: oldJob.oldjobname,
+                originalGroupName: oldJob.oldjobgroup
+        )
+
+        service.jobSchedulerService = Mock(JobSchedulerService){
+            1 * updateScheduleOwner(_) >> { arguments ->
+                JobReferenceImpl jobReference = arguments[0];
+                jobReference.getOriginalJobName() == jobReferenceImpl.getOriginalJobName()
+                jobReference.getOriginalGroupName() == jobReferenceImpl.getOriginalGroupName()
+                return false
+            }
+        }
+
+        service.jobSchedulesService=Mock(SchedulesManager){
+            1 * shouldScheduleExecution(_) >> false
+        }
+
+        def importedJob = RundeckJobDefinitionManager.importedJob(job, [:])
+
+        when: "save the updated the job"
+            def results = service._dosaveupdated(params, importedJob, oldJob, auth)
+
+        then: "validation error results in failure"
+            results.success
     }
     @Unroll
     def "do update job, disabled execution should delete quartz"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -242,8 +242,8 @@ class ScheduledExecutionServiceSpec extends HibernateSpec implements ServiceUnit
 //        def scheduleDate = new Date()
         def data=["project": job.project,
                   "jobId":job.uuid,
-                  "oldJobName": originalJobName,
-                  "oldGroupName": originalGroupName]
+                  "oldQuartzJobName": originalJobName,
+                  "oldQuartzGroupName": originalGroupName]
 
         service.jobSchedulerService=Mock(JobSchedulerService){
             determineExecNode(*_)>>{args->

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -3678,15 +3678,15 @@ class ScheduledExecutionServiceSpec extends HibernateSpec implements ServiceUnit
                 groupPath: job.groupPath,
                 project: job.project,
                 serverUUID: job.serverNodeUUID,
-                originalJobName: oldJob.oldjobname,
-                originalGroupName: oldJob.oldjobgroup
+                originalQuartzJobName: oldJob.oldjobname,
+                originalQuartzGroupName: oldJob.oldjobgroup
         )
 
         service.jobSchedulerService = Mock(JobSchedulerService){
             1 * updateScheduleOwner(_) >> { arguments ->
                 JobReferenceImpl jobReference = arguments[0];
-                jobReference.getOriginalJobName() == jobReferenceImpl.getOriginalJobName()
-                jobReference.getOriginalGroupName() == jobReferenceImpl.getOriginalGroupName()
+                jobReference.getOriginalQuartzJobName() == jobReferenceImpl.getOriginalQuartzJobName()
+                jobReference.getOriginalQuartzGroupName() == jobReferenceImpl.getOriginalQuartzGroupName()
                 return false
             }
         }


### PR DESCRIPTION
fixes https://github.com/rundeckpro/rundeckpro/issues/2093

**Is this a bugfix, or an enhancement? Please describe.**
Rundeck is not able to handle scheduling after renaming job making the job run multiple times for the same schedule

**Describe the solution you've implemented**
Was included the original job/group name on the job take over message in order to handle scheduling after renaming a job

