### PR TITLE
OpenAPI documentation generator - RUN-668

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,6 +42,7 @@ spring-jcl=5.3.15
 log4j2.version=2.17.1
 assetPluginVersion=3.4.3
 dbMigrationPluginVersion=4.0.0-RC2
+micronautVersion=3.2.6
 node.install=12.16.3
 org.gradle.daemon=true
 org.gradle.parallel=true

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -176,11 +176,15 @@ dependencies {
         exclude(group:"org.grails.profiles",module:"web")
     }
 
-    //openapi dependencies
-    annotationProcessor "io.micronaut.configuration:micronaut-openapi:1.4.0"
-    compile "io.swagger.core.v3:swagger-annotations:2.1.1"
-    compileOnly "io.micronaut.configuration:micronaut-openapi:1.4.0"
-    compile 'io.micronaut:micronaut-http-client'
+    // OpenApi Dependencies
+    annotationProcessor "io.micronaut.openapi:micronaut-openapi:4.0.0"
+    implementation "io.swagger.core.v3:swagger-annotations:2.1.1"
+    compileOnly    "io.micronaut.openapi:micronaut-openapi:4.0.0"
+    implementation "io.micronaut:micronaut-http-server:${micronautVersion}"
+    implementation "io.micronaut:micronaut-inject:${micronautVersion}"
+    implementation "io.micronaut:micronaut-inject-java:${micronautVersion}"
+    implementation "io.micronaut:micronaut-inject-groovy:${micronautVersion}"
+    implementation "io.micronaut:micronaut-core:${micronautVersion}"
 
 
     runtimeOnly 'org.aspectj:aspectjweaver:1.9.7'

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -293,8 +293,12 @@ bootRun {
 }
 
 tasks.withType(GroovyCompile) {
+    def additionalSpecDir = new File(project.buildDir, 'openapi')
+    doFirst {
+        additionalSpecDir.mkdirs()
+    }
     configure(groovyOptions) {
-        forkOptions.jvmArgs = ['-Xmx1024m']
+        forkOptions.jvmArgs = ['-Xmx1024m',"-Dmicronaut.openapi.additional.files=${additionalSpecDir.absolutePath}".toString()]
     }
 }
 

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -176,6 +176,13 @@ dependencies {
         exclude(group:"org.grails.profiles",module:"web")
     }
 
+    //openapi dependencies
+    annotationProcessor "io.micronaut.configuration:micronaut-openapi:1.4.0"
+    compile "io.swagger.core.v3:swagger-annotations:2.1.1"
+    compileOnly "io.micronaut.configuration:micronaut-openapi:1.4.0"
+    compile 'io.micronaut:micronaut-http-client'
+
+
     runtimeOnly 'org.aspectj:aspectjweaver:1.9.7'
     runtimeOnly "com.h2database:h2:1.4.199"
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -34,10 +34,19 @@ import javax.servlet.http.HttpServletResponse
 import java.lang.management.ManagementFactory
 
 import com.dtolabs.rundeck.app.api.ApiVersions
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 
 /**
  * Contains utility actions for API access and responses
  */
+@Controller("/api/{apiversion}")
 class ApiController extends ControllerBase{
     def defaultAction = "invalid"
     def quartzScheduler
@@ -465,6 +474,13 @@ class ApiController extends ControllerBase{
         value = RundeckAccess.System.AUTH_READ_OR_OPS_ADMIN,
         description = 'Read System Info'
     )
+    @Get(uri="/system/info", produces = MediaType.APPLICATION_JSON)
+    @Operation(method = "GET", summary = "Get Rundeck server information and stats",
+            description = "Display stats and info about the server"
+    )
+    @ApiResponse(responseCode = "200", description = "System info response", content = @Content(mediaType = "application/json",
+            schema = @Schema(type="string")))
+    @Tag(name = "system")
     def apiSystemInfo(){
         if (!apiService.requireApi(request, response)) {
             return

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -50,7 +50,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 /**
  * Contains utility actions for API access and responses
  */
-@Controller("/api/{apiversion}")
+@Controller()
 class ApiController extends ControllerBase{
     def defaultAction = "invalid"
     def quartzScheduler

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -526,6 +526,7 @@ class ApiController extends ControllerBase{
             extMeta[it.name] = it.infoMetadata
         }
         SystemInfoModel systemInfoModel = new SystemInfoModel(
+            system:[
                 timestamp: [ epoch:nowDate.getTime(), unit:'ms', datetime:g.w3cDateValue(date:nowDate)],
                 rundeck: [ version: appVersion,
                            build: grailsApplication.metadata['build.ident'],
@@ -550,11 +551,10 @@ class ApiController extends ControllerBase{
                 metrics: [href:metricsJsonUrl,contentType:'application/json'],
                 threadDump: [href:metricsThreadDumpUrl,contentType:'text/plain'],
                 healthcheck: [href:metricsHealthcheckUrl,contentType:'application/json'],
-                ping: [href:metricsPingUrl, contentType:'text/plain']
-
+                ping: [href:metricsPingUrl, contentType:'text/plain'],
+                extended:extMeta?:null
+            ]
         )
-        if (extMeta)
-            systemInfoModel.extended = extMeta
         withFormat{
             xml{
                 return apiService.renderSuccessXml(request,response){

--- a/rundeckapp/grails-app/init/rundeckapp/Application.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/Application.groovy
@@ -26,9 +26,9 @@ import java.nio.file.Paths
 @OpenAPIDefinition(
         info = @Info(
                 title = "Rundeck",
-                version = "39",
+                version = "40",
                 description = "Rundeck provides a Web API for use with your applications.",
-                license = @License(name = "MIT", url = "")
+                license = @License(name = "Apache 2.0", url = "")
         )
 )
 

--- a/rundeckapp/grails-app/init/rundeckapp/Application.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/Application.groovy
@@ -2,6 +2,9 @@ package rundeckapp
 
 import grails.boot.GrailsApp
 import grails.boot.config.GrailsAutoConfiguration
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.info.Info
+import io.swagger.v3.oas.annotations.info.License
 import org.rundeck.app.bootstrap.PreBootstrap
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -19,6 +22,15 @@ import rundeckapp.init.prebootstrap.InitializeRundeckPreboostrap
 
 import java.nio.file.Files
 import java.nio.file.Paths
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Rundeck",
+                version = "39",
+                description = "Rundeck provides a Web API for use with your applications.",
+                license = @License(name = "MIT", url = "")
+        )
+)
 
 @EnableAutoConfiguration(exclude = [SecurityFilterAutoConfiguration])
 class Application extends GrailsAutoConfiguration implements EnvironmentAware {

--- a/rundeckapp/grails-app/init/rundeckapp/Application.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/Application.groovy
@@ -1,10 +1,13 @@
 package rundeckapp
 
+import com.dtolabs.rundeck.app.api.ApiVersions
 import grails.boot.GrailsApp
 import grails.boot.config.GrailsAutoConfiguration
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.info.Info
 import io.swagger.v3.oas.annotations.info.License
+import io.swagger.v3.oas.annotations.servers.Server
+import io.swagger.v3.oas.annotations.servers.ServerVariable
 import org.rundeck.app.bootstrap.PreBootstrap
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -24,12 +27,25 @@ import java.nio.file.Files
 import java.nio.file.Paths
 
 @OpenAPIDefinition(
-        info = @Info(
-                title = "Rundeck",
-                version = "40",
-                description = "Rundeck provides a Web API for use with your applications.",
-                license = @License(name = "Apache 2.0", url = "")
-        )
+    info = @Info(
+        title = "Rundeck",
+        version = ApiVersions.API_CURRENT_VERSION_STR,
+        description = "Rundeck provides a Web API for use with your applications.",
+        license = @License(name = "Apache 2.0", url = "https://www.apache.org/licenses/LICENSE-2.0.html")
+    ),
+    servers = @Server(
+        url = '{host}/api/{apiversion}',
+        variables = [
+            @ServerVariable(
+                name = 'apiversion',
+                defaultValue = '40' //NB: spec generation doesn't seem to accept a constant string :(
+            ),
+            @ServerVariable(
+                name = 'host',
+                defaultValue = 'http://localhost:4440'
+            )
+        ]
+    )
 )
 
 @EnableAutoConfiguration(exclude = [SecurityFilterAutoConfiguration])

--- a/rundeckapp/grails-app/init/rundeckapp/Application.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/Application.groovy
@@ -38,7 +38,7 @@ import java.nio.file.Paths
         variables = [
             @ServerVariable(
                 name = 'apiversion',
-                defaultValue = '40' //NB: spec generation doesn't seem to accept a constant string :(
+                defaultValue = '41' //NB: spec generation doesn't seem to accept a constant string :(
             ),
             @ServerVariable(
                 name = 'host',

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
@@ -45,6 +45,7 @@ class ApiVersions {
     public final static int API_EARLIEST_VERSION = V11
     public final static int API_DEPRECATION_VERSION = V14
     public final static int API_CURRENT_VERSION = V41
+    public final static String API_CURRENT_VERSION_STR = '41'
     public final static int API_MIN_VERSION = API_EARLIEST_VERSION
     public final static int API_MAX_VERSION = API_CURRENT_VERSION
 }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/api/model/SystemInfoModel.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/api/model/SystemInfoModel.groovy
@@ -4,123 +4,127 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 import java.lang.management.ThreadInfo;
 
-@Schema(name="system", description="System Information")
+@Schema(description="System Information")
 class SystemInfoModel {
-    TimestampInfoModel timestamp
-    RundeckInfoModel rundeck
-    ExecutionsInfoModel executions
-    OsInfoModel os
-    JvmInfoModel jvm
-    StatInfoModel stats
-    MetricsInfoModel metrics
-    ThreadDumpInfoModel threadDump
-    HealthCheckInfoModel healthcheck
-    PingInfoModel ping
-    def extended
+    @Schema(name="system", description="System Information")
+    SystemInfoSystem system
+    static class SystemInfoSystem{
+        TimestampInfoModel timestamp
+        RundeckInfoModel rundeck
+        ExecutionsInfoModel executions
+        OsInfoModel os
+        JvmInfoModel jvm
+        StatInfoModel stats
+        MetricsInfoModel metrics
+        ThreadDumpInfoModel threadDump
+        HealthCheckInfoModel healthcheck
+        PingInfoModel ping
+        Map extended
 
-    @Schema(name="timestamp", description="Timestamp Information")
-    static class TimestampInfoModel {
-        long epoch
-        String unit
-        String datetime
-    }
-    @Schema(name="executions", description="Executions Information")
-    static class ExecutionsInfoModel {
-        String active
-        String executionMode
-    }
-    @Schema(name="os", description="Operating System Information")
-    static class OsInfoModel {
-        String arch
-        String name
-        String version
-    }
-    @Schema(name="jvm", description="Jvm System Information")
-    static class JvmInfoModel {
-        String name
-        String vendor
-        String version
-        String implementationVersion
-    }
+        @Schema(name="timestamp", description="Timestamp Information")
+        static class TimestampInfoModel {
+            long epoch
+            String unit
+            String datetime
+        }
+        @Schema(name="executions", description="Executions Information")
+        static class ExecutionsInfoModel {
+            String active
+            String executionMode
+        }
+        @Schema(name="os", description="Operating System Information")
+        static class OsInfoModel {
+            String arch
+            String name
+            String version
+        }
+        @Schema(name="jvm", description="Jvm System Information")
+        static class JvmInfoModel {
+            String name
+            String vendor
+            String version
+            String implementationVersion
+        }
 
-    @Schema(name="rundeck", description="Rundeck Information")
-    static class RundeckInfoModel {
-        String version
-        String build
-        String buildGit
-        String node
-        String base
-        String apiversion
-        String serverUUID
-    }
-    @Schema(name="stats", description="Stat Information")
-    static class StatInfoModel {
+        @Schema(name="rundeck", description="Rundeck Information")
+        static class RundeckInfoModel {
+            String version
+            String build
+            String buildGit
+            String node
+            String base
+            String apiversion
+            String serverUUID
+        }
+        @Schema(name="stats", description="Stat Information")
+        static class StatInfoModel {
 
-        UptimeInfoModel uptime
-        CpuInfoModel cpu
-        MemoryInfoModel memory
-        SchedulerInfoModel scheduler
-        ThreadInfoModel threads
-    }
-    @Schema(name="uptime", description="Uptime Information")
-    static class UptimeInfoModel {
-        int duration
-        String unit
-        SinceInfoModel since
-    }
-    @Schema(name="since", description="Since Uptime Information")
-    static class SinceInfoModel {
-        long epoch
-        String unit
-        String datetime
-    }
-    @Schema(name="cpu", description="Cpu Information")
-    static class CpuInfoModel {
-        LoadAverageInfoModel loadAverage
-        int processors
-    }
-    @Schema(name="loadAverage", description="Cpu Load Average Information")
-    static class LoadAverageInfoModel {
-        String unit
-        int average
-    }
-    @Schema(name="memory", description="Memory Information")
-    static class MemoryInfoModel {
-        String unit
-        int max
-        int free
-        int total
-    }
-    @Schema(name="scheduler", description="Scheduler Information")
-    static class SchedulerInfoModel {
-        int running
-        int threadPoolSize
-    }
-    @Schema(name="threads", description="Thread Information")
-    static class ThreadInfoModel {
-        int active
-    }
+            UptimeInfoModel uptime
+            CpuInfoModel cpu
+            MemoryInfoModel memory
+            SchedulerInfoModel scheduler
+            ThreadInfoModel threads
+        }
+        @Schema(name="uptime", description="Uptime Information")
+        static class UptimeInfoModel {
+            int duration
+            String unit
+            SinceInfoModel since
+        }
+        @Schema(name="since", description="Since Uptime Information")
+        static class SinceInfoModel {
+            long epoch
+            String unit
+            String datetime
+        }
+        @Schema(name="cpu", description="Cpu Information")
+        static class CpuInfoModel {
+            LoadAverageInfoModel loadAverage
+            int processors
+        }
+        @Schema(name="loadAverage", description="Cpu Load Average Information")
+        static class LoadAverageInfoModel {
+            String unit
+            int average
+        }
+        @Schema(name="memory", description="Memory Information")
+        static class MemoryInfoModel {
+            String unit
+            int max
+            int free
+            int total
+        }
+        @Schema(name="scheduler", description="Scheduler Information")
+        static class SchedulerInfoModel {
+            int running
+            int threadPoolSize
+        }
+        @Schema(name="threads", description="Thread Information")
+        static class ThreadInfoModel {
+            int active
+        }
 
-    @Schema(name="metrics", description="Metrics Information")
-    static class MetricsInfoModel {
-        String href
-        String contentType
-    }
-    @Schema(name="threadDump", description="Thread Dump Information")
-    static class ThreadDumpInfoModel {
-        String href
-        String contentType
-    }
+        @Schema(name="metrics", description="Metrics Information")
+        static class MetricsInfoModel {
+            String href
+            String contentType
+        }
+        @Schema(name="threadDump", description="Thread Dump Information")
+        static class ThreadDumpInfoModel {
+            String href
+            String contentType
+        }
 
-    @Schema(name="healthcheck", description="Health Check Information")
-    static class HealthCheckInfoModel {
-        String href
-        String contentType
-    }
-    @Schema(name="ping", description="Ping Information")
-    static class PingInfoModel {
-        String href
-        String contentType
+        @Schema(name="healthcheck", description="Health Check Information")
+        static class HealthCheckInfoModel {
+            String href
+            String contentType
+        }
+        @Schema(name="ping", description="Ping Information")
+        static class PingInfoModel {
+            String href
+            String contentType
+        }
     }
 }
 

--- a/rundeckapp/src/main/groovy/org/rundeck/app/api/model/SystemInfoModel.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/api/model/SystemInfoModel.groovy
@@ -1,0 +1,127 @@
+package org.rundeck.app.api.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+import java.lang.management.ThreadInfo;
+
+@Schema(name="system", description="System Information")
+class SystemInfoModel {
+    TimestampInfoModel timestamp
+    RundeckInfoModel rundeck
+    ExecutionsInfoModel executions
+    OsInfoModel os
+    JvmInfoModel jvm
+    StatInfoModel stats
+    MetricsInfoModel metrics
+    ThreadDumpInfoModel threadDump
+    HealthCheckInfoModel healthcheck
+    PingInfoModel ping
+    def extended
+
+    @Schema(name="timestamp", description="Timestamp Information")
+    static class TimestampInfoModel {
+        long epoch
+        String unit
+        String datetime
+    }
+    @Schema(name="executions", description="Executions Information")
+    static class ExecutionsInfoModel {
+        String active
+        String executionMode
+    }
+    @Schema(name="os", description="Operating System Information")
+    static class OsInfoModel {
+        String arch
+        String name
+        String version
+    }
+    @Schema(name="jvm", description="Jvm System Information")
+    static class JvmInfoModel {
+        String name
+        String vendor
+        String version
+        String implementationVersion
+    }
+
+    @Schema(name="rundeck", description="Rundeck Information")
+    static class RundeckInfoModel {
+        String version
+        String build
+        String buildGit
+        String node
+        String base
+        String apiversion
+        String serverUUID
+    }
+    @Schema(name="stats", description="Stat Information")
+    static class StatInfoModel {
+
+        UptimeInfoModel uptime
+        CpuInfoModel cpu
+        MemoryInfoModel memory
+        SchedulerInfoModel scheduler
+        ThreadInfoModel threads
+    }
+    @Schema(name="uptime", description="Uptime Information")
+    static class UptimeInfoModel {
+        int duration
+        String unit
+        SinceInfoModel since
+    }
+    @Schema(name="since", description="Since Uptime Information")
+    static class SinceInfoModel {
+        long epoch
+        String unit
+        String datetime
+    }
+    @Schema(name="cpu", description="Cpu Information")
+    static class CpuInfoModel {
+        LoadAverageInfoModel loadAverage
+        int processors
+    }
+    @Schema(name="loadAverage", description="Cpu Load Average Information")
+    static class LoadAverageInfoModel {
+        String unit
+        int average
+    }
+    @Schema(name="memory", description="Memory Information")
+    static class MemoryInfoModel {
+        String unit
+        int max
+        int free
+        int total
+    }
+    @Schema(name="scheduler", description="Scheduler Information")
+    static class SchedulerInfoModel {
+        int running
+        int threadPoolSize
+    }
+    @Schema(name="threads", description="Thread Information")
+    static class ThreadInfoModel {
+        int active
+    }
+
+    @Schema(name="metrics", description="Metrics Information")
+    static class MetricsInfoModel {
+        String href
+        String contentType
+    }
+    @Schema(name="threadDump", description="Thread Dump Information")
+    static class ThreadDumpInfoModel {
+        String href
+        String contentType
+    }
+
+    @Schema(name="healthcheck", description="Health Check Information")
+    static class HealthCheckInfoModel {
+        String href
+        String contentType
+    }
+    @Schema(name="ping", description="Ping Information")
+    static class PingInfoModel {
+        String href
+        String contentType
+    }
+}
+
+


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
enhancement.  Introducing generation of openapi documentation automatically through build process.  

**Describe the solution you've implemented**
Using  micronaut-openapi to generate documentation for rundeck open api methods.  Requires use of Micronaut and Swagger annotations.  Grails urls defined in UrlMappings.groovy takes precedence.  Documentation currently created in the {rundeck_home}/rundeckapp/build/classes/groovy/main/META-INF/swagger
**Describe alternatives you've considered**
spring-fox.  Micronaut is cleaner
**Additional context**
Current api documented in this pull request
<img width="738" alt="Screen Shot 2021-11-01 at 4 42 42 PM" src="https://user-images.githubusercontent.com/69808856/139739430-266eba3f-585a-4a87-9105-04ef99c9712a.png">
:
