### PR TITLE
RUN-482: Bump to spring-security 5.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ bouncyCastleVersion=1.68
 # https://github.com/spring-projects/spring-boot/blob/1.5.x/spring-boot-dependencies/pom.xml
 #
 jetty.version=9.4.39.v20210325
-spring.version=5.1.18.RELEASE
+spring.version=5.2.0.RELEASE
 spring-security.version=5.2.0.RELEASE
 log4j2.version=2.13.2
 jackson.version=2.10.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ bouncyCastleVersion=1.68
 #
 jetty.version=9.4.39.v20210325
 spring.version=5.1.18.RELEASE
-spring-security.version=5.1.11.RELEASE
+spring-security.version=5.2.0.RELEASE
 log4j2.version=2.13.2
 jackson.version=2.10.5
 assetPluginVersion=3.1.0


### PR DESCRIPTION
Our current version of spring-security (5.1.11) uses an old version of nimbus-jose-jwt (6.0.2) which has a critical CVE. We need to go to spring-security 5.2 to get to the patched version of nimbus (7.9)

This change builds, tests, and runs locally successfully.