### PR TITLE
RUN-478: add found Token principal to subject when used for API requests

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/authentication/Token.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/authentication/Token.java
@@ -1,0 +1,38 @@
+package com.dtolabs.rundeck.core.authentication;
+
+import com.dtolabs.rundeck.core.authentication.tokens.AuthTokenType;
+
+import java.io.Serializable;
+import java.security.Principal;
+
+public class Token
+        implements Principal, Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    public Token(String tokenId, AuthTokenType type) {
+        super();
+        this.tokenId = tokenId;
+        this.type = type;
+    }
+
+    private final String tokenId;
+    private final AuthTokenType type;
+
+    /**
+     * @see java.security.Principal#getName()
+     */
+    public String getName() {
+        return tokenId;
+    }
+
+    public AuthTokenType getType() {
+        return type;
+    }
+
+    @Override
+    public String toString() {
+        return "Auth Token: " + this.tokenId + ", " + type;
+    }
+
+}

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
@@ -1,6 +1,7 @@
 package rundeck.interceptors
 
 import com.dtolabs.rundeck.core.authentication.Group
+import com.dtolabs.rundeck.core.authentication.Token
 import com.dtolabs.rundeck.core.authentication.Username
 import com.dtolabs.rundeck.core.authentication.tokens.AuthTokenType
 import com.dtolabs.rundeck.core.authentication.tokens.AuthenticationToken
@@ -83,6 +84,9 @@ class SetUserInterceptor {
 
                 roles.each{role->
                     subject.principals << new Group(role.trim());
+                }
+                if(foundToken){
+                    subject.principals.add(new Token(foundToken.uuid, foundToken.type))
                 }
 
                 request.subject = subject


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Adds a Token principal to auth Subject to enable behaviors based on token type.

