### PR TITLE
RUN-492: Project import including all but executions via GUI/RDCLI/API

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -1614,7 +1614,7 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
                     log.error("[${execxmlmap[exml]}] Unable to save workflow for execution: ${e.workflow.errors}")
                     return
                 }
-                if (!e.save()) {
+                if (!e.save(flush: true)) {
                     execerrors<<"[${execxmlmap[exml]}] Unable to save new execution: ${e.errors}"
                     log.error("[${execxmlmap[exml]}] Unable to save new execution: ${e.errors}")
                     return


### PR DESCRIPTION
Issue:
https://github.com/rundeckpro/rundeckpro/issues/2121

Fix description:
Added flush true to save the execution at the end of the transaction.