### PR TITLE
RUN-493 Add warning message if changing job scheduling on a cluster

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -1740,7 +1740,7 @@ class ScheduledExecutionController  extends ControllerBase{
             flash.savedJobMessage="Saved changes to Job"
 
             if(result.remoteSchedulingChanged){
-                flash.info = "INFO: The schedule change will take effect after a few seconds."
+                flash.info = "INFO: Any scheduling changes will take effect after a few seconds."
             }
             scheduledExecutionService.logJobChange(changeinfo,scheduledExecution.properties)
             redirect(controller: 'scheduledExecution', action: 'show', params: [id: scheduledExecution.extid])

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -438,6 +438,7 @@ class ScheduledExecutionController  extends ControllerBase{
     }
     def show () {
         log.debug("ScheduledExecutionController: show : params: " + params)
+        def infoMessage = flash.info
         def crontab = [:]
         def framework = frameworkService.getRundeckFramework()
         def ScheduledExecution scheduledExecution = scheduledExecutionService.getByIDorUUID( params.id )
@@ -461,6 +462,7 @@ class ScheduledExecutionController  extends ControllerBase{
         }
 
         if (!params.project || params.project != scheduledExecution.project) {
+            flash.info = infoMessage
             return redirect(controller: 'scheduledExecution', action: 'show',
                     params: [id: params.id, project: scheduledExecution.project])
         }
@@ -1736,6 +1738,10 @@ class ScheduledExecutionController  extends ControllerBase{
             clearEditSession(scheduledExecution.id.toString())
             flash.savedJob=scheduledExecution
             flash.savedJobMessage="Saved changes to Job"
+
+            if(result.remoteSchedulingChanged){
+                flash.info = "INFO: The schedule change will take effect after a few seconds."
+            }
             scheduledExecutionService.logJobChange(changeinfo,scheduledExecution.properties)
             redirect(controller: 'scheduledExecution', action: 'show', params: [id: scheduledExecution.extid])
         }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -696,16 +696,16 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
      */
     def rescheduleJob(ScheduledExecution scheduledExecution, wasScheduled, oldJobName, oldJobGroup, boolean forceLocal, boolean remoteAssigned = false) {
         if (jobSchedulesService.shouldScheduleExecution(scheduledExecution.uuid) && shouldScheduleInThisProject(scheduledExecution.project)) {
-            def nextdate = null
-            def nextExecNode = null
             try {
-                (nextdate, nextExecNode) = scheduleJob(scheduledExecution, oldJobName, oldJobGroup, forceLocal, remoteAssigned)
+                return scheduleJob(scheduledExecution, oldJobName, oldJobGroup, forceLocal, remoteAssigned)
             } catch (SchedulerException e) {
                 log.error("Unable to schedule job: ${scheduledExecution.extid}: ${e.message}")
             }
         } else if (wasScheduled && oldJobName && oldJobGroup) {
-            deleteJob(oldJobName, oldJobGroup)
+            return deleteJob(oldJobName, oldJobGroup)
         }
+
+        return false
     }
 
     /**
@@ -3432,7 +3432,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             false, !schedulingWasChanged || !modify
         )
 
-        boolean remoteSchedulingChanged = schedulingWasChanged && (scheduleResult == [null, null])
+        boolean remoteSchedulingChanged = scheduleResult == null || scheduleResult == [null, null]
+
         def eventType=JobChangeEvent.JobChangeEventType.MODIFY
         if (renamed) {
             eventType = JobChangeEvent.JobChangeEventType.MODIFY_RENAME

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1143,7 +1143,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                   "oldQuartzJobName": oldJobName,
                   "oldQuartzGroupName": oldGroupName]
 
-        if(!forceLocal){
+        if(!forceLocal && frameworkService.isClusterModeEnabled()){
             boolean remoteAssign = remoteAssigned ?: jobSchedulerService.scheduleRemoteJob(data)
 
             if(remoteAssign){
@@ -3424,7 +3424,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                     .save(flush: true)
         }
 
-        rescheduleJob(
+        def scheduleResult = rescheduleJob(
             scheduledExecution,
             oldjob.isScheduled,
             renamed ? oldjob.oldjobname : scheduledExecution.generateJobScheduledName(),
@@ -3432,12 +3432,13 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             false, !schedulingWasChanged || !modify
         )
 
+        boolean remoteSchedulingChanged = schedulingWasChanged && (scheduleResult == [null, null])
         def eventType=JobChangeEvent.JobChangeEventType.MODIFY
         if (renamed) {
             eventType = JobChangeEvent.JobChangeEventType.MODIFY_RENAME
         }
         def event = createJobChangeEvent(eventType, scheduledExecution, oldjob.originalRef)
-        return [success: true, scheduledExecution: scheduledExecution, jobChangeEvent: event]
+        return [success: true, scheduledExecution: scheduledExecution, jobChangeEvent: event, remoteSchedulingChanged: remoteSchedulingChanged]
 
 
     }

--- a/rundeckapp/grails-app/views/scheduledExecution/show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/show.gsp
@@ -193,6 +193,13 @@ search
 <body>
 <div class="content">
 <div id="layoutBody">
+    <g:if test="${flash.info}">
+        <div class="list-group-item">
+            <div class="alert alert-info">
+                <g:enc>${flash.info}</g:enc>
+            </div>
+        </div>
+    </g:if>
 <tmpl:show scheduledExecution="${scheduledExecution}" crontab="${crontab}"/>
 <g:render template="/menu/copyModal"
           model="[projectNames: projectNames]"/>


### PR DESCRIPTION
fixes https://github.com/rundeckpro/rundeckpro/issues/1895

**Is this a bugfix, or an enhancement? Please describe.**
When changing the scheduling and saving the job very close the next execution of the old scheduling (like 2 or 3 seconds), the job  will execute considering the old scheduling until the take over message is handled.

**Describe the solution you've implemented**
Since the scheduling changes takes effect after the job take over message is processed (if cluster mode is enabled), a message is shown on the Gui to warn user that the scheduling will take effect after few seconds.
