### PR TITLE
Fix issue serving user assets

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/DefaultInterceptorHelper.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/DefaultInterceptorHelper.groovy
@@ -28,22 +28,25 @@ import javax.servlet.http.HttpServletRequest
 class DefaultInterceptorHelper implements InterceptorHelper, InitializingBean {
     private List<String> allowedControllers = []
     private List<String> allowedPaths = []
+    private boolean checkUserAssetsPrefix = false;
 
     @Autowired
     ConfigurationService configurationService
 
     @Override
     boolean matchesAllowedAsset(String controllerName, HttpServletRequest request) {
-        return allowedControllers.contains(controllerName) || matchesStaticServletPath(request.servletPath)
+        return allowedControllers.contains(controllerName) || matchesStaticServletPath(request.pathInfo)
     }
 
-    boolean matchesStaticServletPath(String servletPath) {
-        return allowedPaths.contains(servletPath)
+    boolean matchesStaticServletPath(String pathInfo) {
+        if(checkUserAssetsPrefix && pathInfo.startsWith("/user-assets")) return true
+        return allowedPaths.contains(pathInfo)
     }
 
     @Override
     void afterPropertiesSet() throws Exception {
         allowedControllers = (List<String>)configurationService.getValue("security.interceptor.allowed.controllers",[])
         allowedPaths = (List<String>)configurationService.getValue("security.interceptor.allowed.paths",[])
+        checkUserAssetsPrefix = configurationService.getBoolean("gui.staticUserResources.enabled", false)
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/DefaultInterceptorHelperSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/DefaultInterceptorHelperSpec.groovy
@@ -1,0 +1,40 @@
+package rundeck.interceptors
+
+import org.grails.plugins.testing.GrailsMockHttpServletRequest
+import rundeck.services.ConfigurationService
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DefaultInterceptorHelperSpec extends Specification {
+
+    @Unroll
+    def "MatchesAllowedAsset"() {
+        given:
+        DefaultInterceptorHelper interceptorHelper = new DefaultInterceptorHelper()
+        interceptorHelper.configurationService = Mock(ConfigurationService) {
+            getValue("security.interceptor.allowed.controllers",[]) >> controllerList
+            getValue("security.interceptor.allowed.paths",[]) >> pathList
+            getBoolean("gui.staticUserResources.enabled", false) >> statusUserResEnabled
+        }
+        def rq = new GrailsMockHttpServletRequest()
+        rq.setPathInfo(pathInfo)
+
+        when:
+        interceptorHelper.afterPropertiesSet()
+        def actual = interceptorHelper.matchesAllowedAsset(controllerName, rq)
+
+
+        then:
+        expected == actual
+
+        where:
+        expected | controllerName | pathInfo                     | statusUserResEnabled  | controllerList               | pathList
+        false    | "user"         | "/user/123"                  | false                 | ["static", "user-assets"]    | ["/error","/favicon.ico","/health"]
+        false    | "project"      | "/user/proj1"                | false                 | ["static", "user-assets"]    | ["/error","/favicon.ico","/health"]
+        true     | null           | "/favicon.ico"               | false                 | ["static", "user-assets"]    | ["/error","/favicon.ico","/health"]
+        true     | "user-assets"  | "/user-assets/fav-icon.png"  | false                 | ["static", "user-assets"]    | ["/error","/favicon.ico","/health"]
+        false    | null           | "/user-assets/sub1/res.png"  | false                 | ["static", "user-assets"]    | ["/error","/favicon.ico","/health"]
+        true     | null           | "/user-assets/sub1/res.png"  | true                  | ["static", "user-assets"]    | ["/error","/favicon.ico","/health"]
+    }
+
+}


### PR DESCRIPTION
When attempting to access users assets in a sub directory eg /user-assets/sub1/asset1.png

Grails does not populate the controllerName correctly so the interceptor helper is
blocking the attempt with a 403. This changes works around the problem by
adding a prefix check for /user-assets if they have been enabled by the user.
