### PR TITLE
RUN-513: option default value bad parsing

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
@@ -779,7 +779,7 @@
           bashVarPrefix:'${DataContextUtils.ENV_VAR_PREFIX}',
           optionType:"${option?.optionType}",
           enforceType:currentEnforceType,
-          defaultValue:"${enc(attr:option?.defaultValue)}",
+          defaultValue:"${option?.defaultValue}",
           showDefaultValue:"${!option?.secureInput && !option?.isDate}",
           valuesList:"${listvalue ? listvalue : listjoin ? listjoin.join(',') : ''}",
           valuesUrl:"${option?.getRealValuesUrl()?.toString()}"});


### PR DESCRIPTION
editOption gsp template was doing an unnecesary html-encoding to the option default value so it was removed.

Fixes:
[Job Option default value bad parsing #2104](https://github.com/rundeckpro/rundeckpro/issues/2104)
[rundeckpro/rundeckpro #2112](https://github.com/rundeckpro/rundeckpro/issues/2112)

Test:
A test will be added to the qa framework to check that the option data is rendered corretly.