### PR TITLE
Post main branch generated artifacts to a latest bucket in S3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,7 @@ jobs:
             source .circleci/circle-shim.sh
             copy_artifacts
             sync_to_s3
+            sync_to_latest_s3
             seal_artifacts
       - save-gradle-cache
       - when:

--- a/scripts/circle-helpers.sh
+++ b/scripts/circle-helpers.sh
@@ -100,7 +100,7 @@ sync_to_s3() {
 }
 
 sync_to_latest_s3() {
-    if [[ "${RUNDECK_BRANCH}" = "latest_artifacts_s3" ]]; then
+    if [[ "${RUNDECK_BRANCH}" = "main" ]]; then
         aws s3 rm "${S3_LATEST_ARTIFACT_PATH}" --recursive --include "latest/*"
         aws s3 sync --delete ./artifacts "${S3_LATEST_ARTIFACT_PATH}"
     else

--- a/scripts/circle-helpers.sh
+++ b/scripts/circle-helpers.sh
@@ -101,7 +101,7 @@ sync_to_s3() {
 
 sync_to_latest_s3() {
     if [[ "${RUNDECK_BRANCH}" = "latest_artifacts_s3" ]]; then
-        aws rm "${S3_LATEST_ARTIFACT_PATH}" --recursive --dryrun --include "latest/*"
+        aws s3 rm "${S3_LATEST_ARTIFACT_PATH}" --recursive --dryrun --include "latest/*"
         aws s3 sync --delete ./artifacts "${S3_LATEST_ARTIFACT_PATH}"
     else
         echo "not main branch, not posting to latest"

--- a/scripts/circle-helpers.sh
+++ b/scripts/circle-helpers.sh
@@ -101,6 +101,7 @@ sync_to_s3() {
 
 sync_to_latest_s3() {
     if [[ "${RUNDECK_BRANCH}" = "latest_artifacts_s3" ]]; then
+        aws rm "${S3_LATEST_ARTIFACT_PATH}" --recursive --dryrun --include "latest/*"
         aws s3 sync --delete ./artifacts "${S3_LATEST_ARTIFACT_PATH}"
     else
         echo "not main branch, not posting to latest"

--- a/scripts/circle-helpers.sh
+++ b/scripts/circle-helpers.sh
@@ -52,6 +52,7 @@ S3_BUILD_ARTIFACT_PATH="${S3_ARTIFACT_BASE}/branch/${RUNDECK_BRANCH}/build/${RUN
 S3_BUILD_ARTIFACT_SEAL="${S3_ARTIFACT_BASE}/branch/${RUNDECK_BRANCH}/build-seal/${RUNDECK_BUILD_NUMBER}"
 S3_COMMIT_ARTIFACT_PATH="${S3_ARTIFACT_BASE}/branch/${RUNDECK_BRANCH}/commit/${RUNDECK_COMMIT}/artifacts"
 S3_TAG_ARTIFACT_PATH="${S3_ARTIFACT_BASE}/tag/${RUNDECK_TAG}/artifacts"
+S3_LATEST_ARTIFACT_PATH="${S3_ARTIFACT_BASE}/latest/artifacts"
 
 # Store artifacts in a predictable location in the case of version tags.
 # This will allow us to locate them across repos without passing information explicitly.
@@ -96,6 +97,14 @@ sync_from_s3() {
 
 sync_to_s3() {
     aws s3 sync --delete ./artifacts "${S3_ARTIFACT_PATH}"
+}
+
+sync_to_latest_s3() {
+    if [[ "${RUNDECK_BRANCH}" = "latest_artifacts_s3" ]]; then
+        aws s3 sync --delete ./artifacts "${S3_LATEST_ARTIFACT_PATH}"
+    else
+        echo "not main branch, not posting to latest"
+    fi
 }
 
 sync_commit_from_s3() {

--- a/scripts/circle-helpers.sh
+++ b/scripts/circle-helpers.sh
@@ -52,7 +52,7 @@ S3_BUILD_ARTIFACT_PATH="${S3_ARTIFACT_BASE}/branch/${RUNDECK_BRANCH}/build/${RUN
 S3_BUILD_ARTIFACT_SEAL="${S3_ARTIFACT_BASE}/branch/${RUNDECK_BRANCH}/build-seal/${RUNDECK_BUILD_NUMBER}"
 S3_COMMIT_ARTIFACT_PATH="${S3_ARTIFACT_BASE}/branch/${RUNDECK_BRANCH}/commit/${RUNDECK_COMMIT}/artifacts"
 S3_TAG_ARTIFACT_PATH="${S3_ARTIFACT_BASE}/tag/${RUNDECK_TAG}/artifacts"
-S3_LATEST_ARTIFACT_PATH="${S3_ARTIFACT_BASE}/latest/artifacts"
+S3_LATEST_ARTIFACT_PATH="s3://rundeck-ci-artifacts/oss/circle/latest/artifacts"
 
 # Store artifacts in a predictable location in the case of version tags.
 # This will allow us to locate them across repos without passing information explicitly.

--- a/scripts/circle-helpers.sh
+++ b/scripts/circle-helpers.sh
@@ -101,7 +101,7 @@ sync_to_s3() {
 
 sync_to_latest_s3() {
     if [[ "${RUNDECK_BRANCH}" = "latest_artifacts_s3" ]]; then
-        aws s3 rm "${S3_LATEST_ARTIFACT_PATH}" --recursive --dryrun --include "latest/*"
+        aws s3 rm "${S3_LATEST_ARTIFACT_PATH}" --recursive --include "latest/*"
         aws s3 sync --delete ./artifacts "${S3_LATEST_ARTIFACT_PATH}"
     else
         echo "not main branch, not posting to latest"


### PR DESCRIPTION
there will always be a latest set of artifacts so that packaging-core and packaging-pro can successfully build without rundeck context
