### PR TITLE
RUN-626: Allow several tokens per user for API authentication

### DIFF
--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -556,22 +556,28 @@ class BootStrap {
 
     /**
      * Convert to a map whose keys are tokens.
-     * @param userMap a map "user" -> "token[,role,...]"
+     * @param userMap a map "user" -> "token[;...][role,...]"
      * @return a map "token" -> "user,role[,...]"
      */
     static Properties convertToTokenMap(Properties userMap) {
         def tokenMap = new Properties()
-        def splitRegex = " *, *"
+        def splitTokensAndRolesRegex = " *, *"
+        def splitTokensRegex = " *; *"
         userMap.each { k, v ->
-            def roles='api_token_group'
-            def tokenTmp=v
-            def split = v.toString().split(splitRegex)
+            def user = k.toString()
+            def tokensAndRoles = v.toString()
+            def split = tokensAndRoles.split(splitTokensAndRolesRegex)
+            def tokens = split[0]
+            def roles
             if (split.length > 1) {
-                tokenTmp = split[0]
                 def groupList = split.drop(1)
                 roles = groupList.join(',')
+            } else {
+                roles = 'api_token_group'
             }
-            tokenMap[tokenTmp]=k+','+roles
+            tokens.split(splitTokensRegex).each { token ->
+                tokenMap[token] = user + ',' + roles
+            }
         }
         return tokenMap
     }

--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -231,23 +231,11 @@ class BootStrap {
                 } catch (IOException e) {
                     log.error("Unable to load static tokens file: "+e.getMessage())
                 }
-                Properties tokens = new Properties()
-                def splitRegex = " *, *"
-                userTokens.each { k, v ->
-                    def roles='api_token_group'
-                    def tokenTmp=v
-                    def split = v.toString().split(splitRegex)
-                    if (split.length > 1) {
-                        tokenTmp = split[0]
-                        def groupList = split.drop(1)
-                        roles = groupList.join(',')
-                    }
-                    tokens[tokenTmp]=k+','+roles
-                }
+                Properties tokenMap = convertToTokenMap(userTokens)
                 servletContext.setAttribute("TOKENS_FILE_PATH", new File(tokensfile).absolutePath)
-                servletContext.setAttribute("TOKENS_FILE_PROPS", tokens)
-                if (tokens) {
-                    log.debug("Loaded ${tokens.size()} tokens from tokens file: ${tokensfile}...")
+                servletContext.setAttribute("TOKENS_FILE_PROPS", tokenMap)
+                if (tokenMap) {
+                    log.debug("Loaded ${tokenMap.size()} tokens from tokens file: ${tokensfile}...")
                 }
             }
             //begin import at bootstrap time
@@ -565,6 +553,28 @@ class BootStrap {
          metricRegistry?.removeMatching(MetricFilter.ALL)
          log.info("Rundeck Shutdown detected")
      }
+
+    /**
+     * Convert to a map whose keys are tokens.
+     * @param userMap a map "user" -> "token[,role,...]"
+     * @return a map "token" -> "user,role[,...]"
+     */
+    static Properties convertToTokenMap(Properties userMap) {
+        def tokenMap = new Properties()
+        def splitRegex = " *, *"
+        userMap.each { k, v ->
+            def roles='api_token_group'
+            def tokenTmp=v
+            def split = v.toString().split(splitRegex)
+            if (split.length > 1) {
+                tokenTmp = split[0]
+                def groupList = split.drop(1)
+                roles = groupList.join(',')
+            }
+            tokenMap[tokenTmp]=k+','+roles
+        }
+        return tokenMap
+    }
 }
 
 

--- a/rundeckapp/src/test/groovy/rundeckapp/BootStrapTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/BootStrapTest.groovy
@@ -1,0 +1,21 @@
+package rundeckapp
+
+import spock.lang.Specification
+
+class BootStrapTest  extends Specification {
+    def "Test convertToTokenMap"() {
+        given:
+        Properties userMap = new Properties().tap {
+            load(new StringReader("""\
+                |user1=01234567012345670123456700000000
+                |user2=01234567012345670123456700000001,role1
+                """.stripMargin()))
+        }
+        when:
+        Properties tokenMap = BootStrap.convertToTokenMap(userMap)
+
+        then:
+        tokenMap.getProperty("01234567012345670123456700000000") == "user1,api_token_group"
+        tokenMap.getProperty("01234567012345670123456700000001") == "user2,role1"
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeckapp/BootStrapTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/BootStrapTest.groovy
@@ -7,15 +7,24 @@ class BootStrapTest  extends Specification {
         given:
         Properties userMap = new Properties().tap {
             load(new StringReader("""\
-                |user1=01234567012345670123456700000000
-                |user2=01234567012345670123456700000001,role1
+                |user1=${token("0")}
+                |user2=${token("1")},role1
+                |user3=${token("2")},role1,role2
+                |user4=${token("3")};${token("4")},role1
                 """.stripMargin()))
         }
         when:
         Properties tokenMap = BootStrap.convertToTokenMap(userMap)
 
         then:
-        tokenMap.getProperty("01234567012345670123456700000000") == "user1,api_token_group"
-        tokenMap.getProperty("01234567012345670123456700000001") == "user2,role1"
+        tokenMap.getProperty(token("0")) == "user1,api_token_group"
+        tokenMap.getProperty(token("1")) == "user2,role1"
+        tokenMap.getProperty(token("2")) == "user3,role1,role2"
+        tokenMap.getProperty(token("3")) == "user4,role1"
+        tokenMap.getProperty(token("4")) == "user4,role1"
+    }
+
+    private String token(String suffix) {
+        return "0123456701234567012345670000000${suffix}"
     }
 }


### PR DESCRIPTION
This PR will ease the rotation of tokens used to authenticate to
the Rundeck API.

Currently, the token used by the clients of the Rundeck API must be in
sync with the one configured in the static file of Rundeck, which
creates a service disruption.  With this commit, the clients will be
able to switch to a new token without disruption.

A later commit in rundeck/docs will mention this feature in the
documentation.