### PR TITLE
RUN-541: Fix: Job options misbehaviors when reordering/duplicating

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
@@ -531,6 +531,10 @@ class EditOptsController extends ControllerBase{
                 return result
             }
 
+            //if it was a dupplicate then shift right all next items
+            if(option.sortIndex != null)
+                editopts.forEach({ nameKey, opVal -> if (opVal.sortIndex >= option.sortIndex) opVal.sortIndex++ })
+
             editopts[name] = option
             result['undo'] = [action: 'remove', name: name]
         }  else if ('reorder' == input.action) {
@@ -998,6 +1002,9 @@ class EditOptsController extends ControllerBase{
         }
         def newName = duplicateName(params.name, 1, editopts)
         newOption.name = newName
+
+        if(newOption.sortIndex != null)
+            newOption.sortIndex++
 
         def result = _applyOptionAction(editopts, [action: 'insert', name: newName, params: _getParamsFromOption(newOption)])
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
@@ -724,9 +724,9 @@ class EditOptsControllerSpec extends HibernateSpec implements ControllerUnitTest
 
     def "duplicate options"(){
         given:
-        Option opt1 = new Option(name: 'abc')
-        Option opt2 = new Option(name: 'def')
-        Option opt3 = new Option(name: 'ghi')
+        Option opt2 = new Option(name: 'def', sortIndex: 1)
+        Option opt1 = new Option(name: 'abc', sortIndex: 2)
+        Option opt3 = new Option(name: 'ghi', sortIndex: 3)
         def opts = [opt1, opt2, opt3]
         def editopts = opts.collectEntries { [it.name, it] }
         controller.fileUploadService = Mock(FileUploadService)
@@ -747,9 +747,11 @@ class EditOptsControllerSpec extends HibernateSpec implements ControllerUnitTest
         result1.actions.undo.action == "remove"
         result1.actions.undo.name == "abc_2"
 
+        editopts[opt1.name].sortIndex == 2
+        editopts[opt2.name].sortIndex == 1
+        editopts[opt3.name].sortIndex == 5
+
         editopts.size() == 5
-
-
     }
     def "duplicate options secure"(){
         given:


### PR DESCRIPTION
Now we do a shift right before inserting the duplicated option.

Fix:
https://github.com/rundeckpro/rundeckpro/issues/2037