### PR TITLE
Fix #7424 update log4j dependency

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -159,7 +159,11 @@ dependencies {
     }
 //    runtime "org.springframework:spring-test:5.0.3.RELEASE"
     runtime "com.h2database:h2:1.4.199"
-    runtime 'org.apache.logging.log4j:log4j-web:2.13.3'
+    runtime 'org.apache.logging.log4j:log4j-web:2.15.0'
+    compile('org.apache.logging.log4j:log4j-core:2.15.0')
+    compile('org.apache.logging.log4j:log4j-api:2.15.0')
+    compile('org.apache.logging.log4j:log4j-jul:2.15.0')
+    compile('org.apache.logging.log4j:log4j-slf4j-impl:2.15.0')
 
     // Database drivers
     runtime 'com.microsoft.sqlserver:mssql-jdbc:6.4.0.jre8'

--- a/testbuild.groovy
+++ b/testbuild.groovy
@@ -47,7 +47,7 @@ def debug=Boolean.getBoolean('debug')?:("-debug" in args)
 def versions=[
         jetty:'9.4.39.v20210325',
         servlet:'api-3.1.0',
-        log4j:'2.13.2'
+        log4j:'2.15.0'
 ]
 
 def warFile= "rundeckapp/${target}/rundeck-${version}.war"


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Update log4j dependency to 2.15.0 to prevent CVE-2021-44228
**Describe the solution you've implemented**
update version
