### PR TITLE
RUN-533: Fixed ldap user information on profile

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
@@ -22,12 +22,9 @@ import com.dtolabs.rundeck.plugins.user.groups.UserGroupSourcePlugin
 import grails.events.annotation.Subscriber
 import grails.gorm.transactions.Transactional
 import groovy.transform.CompileStatic
-import groovy.transform.PackageScope
 import org.hibernate.StaleStateException
 import org.springframework.dao.OptimisticLockingFailureException
-import org.springframework.orm.hibernate5.HibernateOptimisticLockingFailureException
 import rundeck.User
-
 
 @Transactional
 class UserService {

--- a/rundeckapp/src/main/groovy/org/rundeck/security/RundeckJaasAuthenticationSuccessEventListener.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/RundeckJaasAuthenticationSuccessEventListener.groovy
@@ -38,7 +38,7 @@ class RundeckJaasAuthenticationSuccessEventListener implements ApplicationListen
     @Override
     void onApplicationEvent(final JaasAuthenticationSuccessEvent event) {
         try {
-            if (configurationService.getBoolean('rundeck.security.syncLdapUser', false)) {
+            if (configurationService.grailsApplication?.config?.rundeck?.security?.syncLdapUser in [true, 'true']) {
                 Subject subject = ((JaasAuthenticationToken) event.authentication).loginContext.subject
 
                 String username = event.authentication.principal.toString()

--- a/rundeckapp/src/test/groovy/org/rundeck/security/RundeckJaasAuthenticationSuccessEventListenerTest.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/security/RundeckJaasAuthenticationSuccessEventListenerTest.groovy
@@ -18,6 +18,7 @@ package org.rundeck.security
 import com.dtolabs.rundeck.jetty.jaas.LdapEmailPrincipal
 import com.dtolabs.rundeck.jetty.jaas.LdapFirstNamePrincipal
 import com.dtolabs.rundeck.jetty.jaas.LdapLastNamePrincipal
+import grails.core.GrailsApplication
 import grails.events.bus.EventBus
 import org.grails.testing.GrailsUnitTest
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -35,9 +36,10 @@ import java.security.Principal
 class RundeckJaasAuthenticationSuccessEventListenerTest extends Specification implements GrailsUnitTest {
     def "OnApplicationEvent - syncLdap disabled"() {
         setup:
+        grailsApplication.config.rundeck.security.syncLdapUser = 'false'
         RundeckJaasAuthenticationSuccessEventListener listener = new RundeckJaasAuthenticationSuccessEventListener()
-        listener.configurationService = Mock(ConfigurationService){
-            1 * getBoolean('rundeck.security.syncLdapUser', false) >> false
+        listener.configurationService = Mock(ConfigurationService) {
+            getGrailsApplication() >> grailsApplication
         }
         listener.targetEventBus = Mock(EventBus)
 
@@ -51,9 +53,10 @@ class RundeckJaasAuthenticationSuccessEventListenerTest extends Specification im
 
     def "OnApplicationEvent - syncLdap enabled"() {
         setup:
+        grailsApplication.config.rundeck.security.syncLdapUser = 'true'
         RundeckJaasAuthenticationSuccessEventListener listener = new RundeckJaasAuthenticationSuccessEventListener()
-        listener.configurationService = Mock(ConfigurationService){
-            1 * getBoolean('rundeck.security.syncLdapUser', false) >> true
+        listener.configurationService = Mock(ConfigurationService) {
+            getGrailsApplication() >> grailsApplication
         }
         listener.targetEventBus = Mock(EventBus)
         Subject subject = new Subject(true, [new LdapEmailPrincipal(email),
@@ -85,9 +88,10 @@ class RundeckJaasAuthenticationSuccessEventListenerTest extends Specification im
 
     def "OnApplicationEvent - syncLdap enabled with non ldap login"() {
         setup:
+        grailsApplication.config.rundeck.security.syncLdapUser = 'true'
         RundeckJaasAuthenticationSuccessEventListener listener = new RundeckJaasAuthenticationSuccessEventListener()
-        listener.configurationService = Mock(ConfigurationService){
-            1 * getBoolean('rundeck.security.syncLdapUser', false) >> true
+        listener.configurationService = Mock(ConfigurationService) {
+            getGrailsApplication() >> grailsApplication
         }
         listener.targetEventBus = Mock(EventBus)
 


### PR DESCRIPTION
Issue:
https://github.com/rundeckpro/rundeckpro/issues/2155

Fix description:
Fixed problem when Rundeck tried to save ldap information at the DB.