### PR TITLE
Added quotes to the nodeFilter before getting it

### DIFF
--- a/rundeckapp/grails-spa/packages/ui/src/components/job/resources/NodeFilterLink.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/resources/NodeFilterLink.vue
@@ -51,7 +51,11 @@ export default class NodeFilterLink extends Vue {
 
   getFilter() {
     if (this.nodeFilter) {
-      return this.nodeFilter
+      let nodeFilterCpy = this.nodeFilter.trim() + "\""
+      let idxKey = nodeFilterCpy.indexOf(": ") + 2
+      nodeFilterCpy = nodeFilterCpy.slice(0, idxKey) + "\"" + nodeFilterCpy.slice(idxKey)
+
+      return nodeFilterCpy
     } else if (this.filterKey && this.filterVal) {
       return `${this.filterKey}: ${this.filterVal}`
     }


### PR DESCRIPTION
This issue appeared after migrating to vue. When getting the node filter from the component, it didn't add quotes to the filter value if if has spaces in it.
Fix: https://github.com/rundeckpro/rundeckpro/issues/2172