### PR TITLE
Fixes Project Nav Remains when View All Projects link is clicked #RUN-405 

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/widgets/project-select/ProjectSelect.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/widgets/project-select/ProjectSelect.vue
@@ -31,7 +31,7 @@
             </Skeleton>
         </div>
         <div class="widget-section" style="height: 40px; flex-grow: 0; flex-shrink: 0;border-top: solid 1px grey; padding-left: 10px">
-            <a class="text-info" :href="allProjectsLink" @click.prevent="allClickekd" @keypress.enter.prevent="allClickekd">View All Projects</a>
+            <a class="text-info" :href="allProjectsLink" @click.prevent="allClicked" @keypress.enter.prevent="allClicked">View All Projects</a>
         </div>
     </div>
 </template>
@@ -108,7 +108,7 @@ export default class ProjectSelect extends Vue {
         this.$emit('project:selected', project)
     }
 
-    allClickekd() {
+    allClicked() {
         this.$emit('project:select-all')
     }
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/widgets/project-select/ProjectSelect.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/widgets/project-select/ProjectSelect.vue
@@ -31,7 +31,7 @@
             </Skeleton>
         </div>
         <div class="widget-section" style="height: 40px; flex-grow: 0; flex-shrink: 0;border-top: solid 1px grey; padding-left: 10px">
-            <a class="text-info" :href="allProjectsLink" @click@keypress.enter="handleSelect">View All Projects</a>
+            <a class="text-info" :href="allProjectsLink" @click.prevent="allClickekd" @keypress.enter.prevent="allClickekd">View All Projects</a>
         </div>
     </div>
 </template>


### PR DESCRIPTION
Fixes RUN-405

Root cause:
- The `View All Projects` is rendered as an <a> element with the attribute `href` set to the URL of the current project. When clicked the default behavior of <a> tag got triggered instead of executing the registered javascript handler. This causes the page to always be rendered with an active project so the sidebar is always displayed.
- There is another issue with the ProjectSelect Vue template definition. The allProjectsLink `eventHandler` used a non-existent handler name `handleSelectAll`. Since this event never got triggered due to the above issue, so it was undetected until this fix was applied.

Solution:
- Prevent the default behavior of the <a> tag by using Vue modifier e.g. change `@click` to `@click.prevent`.
- Change the select all projects event handler to the right name `allClicked`


Milestone: 3.4.10