### PR TITLE
RUN-565: Fix/issue 5780 api gui pagination

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -66,7 +66,7 @@ public class RundeckConfigBase {
     @Data
     public static class RundeckApiConfig {
         ApiTokensConfig tokens;
-        PaginateJobs paginateJobs;
+        PaginateJobs paginatejobs;
 
         @Data
         public static class PaginateJobs {

--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -554,7 +554,7 @@ public class RundeckConfigBase {
                 Per per;
                 @Data
                 public static class Per {
-                    String page;
+                    Integer page;
                 }
             }
         }

--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -66,6 +66,12 @@ public class RundeckConfigBase {
     @Data
     public static class RundeckApiConfig {
         ApiTokensConfig tokens;
+        PaginateJobs paginateJobs;
+
+        @Data
+        public static class PaginateJobs {
+            Boolean enabled;
+        }
 
         @Data
         public static class ApiTokensConfig {
@@ -542,7 +548,15 @@ public class RundeckConfigBase {
         @Data
         public static class PaginateJobs {
             Boolean enabled;
-            String maxPerPage;
+            Max max;
+            @Data
+            public static class Max {
+                Per per;
+                @Data
+                public static class Per {
+                    String page;
+                }
+            }
         }
 
         @Data

--- a/core/src/main/java/org/rundeck/app/components/jobs/JobQueryInput.java
+++ b/core/src/main/java/org/rundeck/app/components/jobs/JobQueryInput.java
@@ -49,5 +49,5 @@ public interface JobQueryInput extends BaseQueryInput {
 
     Boolean getRunJobLaterFilter();
 
-    default Boolean getApiCall(){return false;};
+    default Boolean getPaginatedRequired(){return false;};
 }

--- a/core/src/main/java/org/rundeck/app/components/jobs/JobQueryInput.java
+++ b/core/src/main/java/org/rundeck/app/components/jobs/JobQueryInput.java
@@ -48,4 +48,6 @@ public interface JobQueryInput extends BaseQueryInput {
     Integer getDaysAhead();
 
     Boolean getRunJobLaterFilter();
+
+    default Boolean getApiCall(){return false;};
 }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2921,6 +2921,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
 
         }
 
+        query.apiCall = true
         query.projFilter = params.project
         //test valid project
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -303,9 +303,10 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             }
         }
 
-        if(guiPaginationEnabled)
+        if(configurationService.getBoolean('gui.paginatejobs.enabled',false)) {
             query.paginatedRequired = true
-        else{
+            query.max = configurationService.getInteger('gui.paginatejobs.max.per.page', 10)
+        }else{
             query.max = null
             query.offset = null
         }
@@ -360,9 +361,10 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                                         code: 'api.error.parameter.required', args: ['project']])
         }
 
-        if(guiPaginationEnabled)
+        if(configurationService.getBoolean('gui.paginatejobs.enabled',false)){
             query.paginatedRequired = true
-        else{
+            query.max = configurationService.getInteger('gui.paginatejobs.max.per.page', 10)
+        }else{
             query.max = null
             query.offset = null
         }
@@ -594,31 +596,12 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         )
     }
 
-    private def getConfiguredMaxPerPage(int defaultMax) {
-        if(guiPaginationEnabled) {
-            return grailsApplication.config.rundeck.gui.paginatejobs.max.per.page.isEmpty() ? defaultMax : grailsApplication.config.rundeck.gui.paginatejobs.max.per.page.toInteger()
-        }
-        return null
-    }
-
-    private boolean getGuiPaginationEnabled() {
-        grailsApplication.config.rundeck.gui.paginatejobs.enabled in ["true",true]
-    }
-
-    private boolean getApiPaginationEnabled() {
-        if(grailsApplication.config.rundeck.api.paginatejobs.enabled != null)
-            return grailsApplication.config.rundeck.api.paginatejobs.enabled in ["false",false]
-        
-        return true
-    }
-
     private def listWorkflows(ScheduledExecutionQuery query,AuthContext authContext,String user) {
         long start=System.currentTimeMillis()
         if(null!=query){
             query.configureFilter()
         }
 
-        query.max = getConfiguredMaxPerPage(10)
         def qres = scheduledExecutionService.listWorkflows(query, params)
         log.debug("service.listWorkflows: "+(System.currentTimeMillis()-start));
         long rest=System.currentTimeMillis()
@@ -2950,7 +2933,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
      */
     def apiJobsListv2 (ScheduledExecutionQuery query) {
 
-        if (!apiPaginationEnabled){
+        if (!configurationService.getBoolean('api.paginatejobs.enable',true)){
             query.max = null
             query.offset = null
         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -639,7 +639,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 AuthConstants.ACTION_CREATE, query.projFilter)
 
 
-        def Map jobauthorizations=[:]
+        Map jobauthorizations=[:]
 
         //produce map: [actionName:[id1,id2,...],actionName2:[...]] for all allowed actions for jobs
         decisions=decisions.findAll { it.authorized}

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -606,10 +606,10 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     }
 
     private boolean getApiPaginationEnabled() {
-        if(grailsApplication.config.rundeck.api.paginatejobs.enabled)
+        if(grailsApplication.config.rundeck.api.paginatejobs.enabled != null)
             return grailsApplication.config.rundeck.api.paginatejobs.enabled in ["false",false]
-        else
-            return true
+        
+        return true
     }
 
     private def listWorkflows(ScheduledExecutionQuery query,AuthContext authContext,String user) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -302,6 +302,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 return redirect(jobListLinkHandler.generateRedirectMap([project:params.project]))
             }
         }
+
+        query.paginatedRequired = paginationEnabled
         def results = jobsFragment(query, JobsScmInfo.MINIMAL)
         results.execQueryParams=query.asExecQueryParams()
         results.reportQueryParams=query.asReportQueryParams()
@@ -351,6 +353,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             return apiService.renderErrorXml(response, [status: HttpServletResponse.SC_BAD_REQUEST,
                                                         code: 'api.error.parameter.required', args: ['project']])
         }
+
+        query.paginatedRequired = paginationEnabled
         query.projFilter = params.project
         //test valid project
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2921,7 +2921,6 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
 
         }
 
-        query.apiCall = true
         query.projFilter = params.project
         //test valid project
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2933,7 +2933,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
      */
     def apiJobsListv2 (ScheduledExecutionQuery query) {
 
-        if (!configurationService.getBoolean('api.paginatejobs.enable',true)){
+        if (!configurationService.getBoolean('api.paginatejobs.enabled',true)){
             query.max = null
             query.offset = null
         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -586,7 +586,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         if(paginationEnabled) {
             return grailsApplication.config.rundeck.gui.paginatejobs.max.per.page.isEmpty() ? defaultMax : grailsApplication.config.rundeck.gui.paginatejobs.max.per.page.toInteger()
         }
-        return defaultMax
+        return null
     }
 
     private boolean getPaginationEnabled() {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -577,11 +577,25 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 formatted
         )
     }
+
+    private def getConfiguredMaxPerPage(int defaultMax) {
+        if(paginationEnabled) {
+            return grailsApplication.config.rundeck.gui.paginatejobs.max.per.page.isEmpty() ? defaultMax : grailsApplication.config.rundeck.gui.paginatejobs.max.per.page.toInteger()
+        }
+        return defaultMax
+    }
+
+    private boolean getPaginationEnabled() {
+        grailsApplication.config.rundeck.gui.paginatejobs.enabled in ["true",true]
+    }
+
     private def listWorkflows(ScheduledExecutionQuery query,AuthContext authContext,String user) {
         long start=System.currentTimeMillis()
         if(null!=query){
             query.configureFilter()
         }
+
+        query.max = getConfiguredMaxPerPage(10)
         def qres = scheduledExecutionService.listWorkflows(query, params)
         log.debug("service.listWorkflows: "+(System.currentTimeMillis()-start));
         long rest=System.currentTimeMillis()

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -303,7 +303,13 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             }
         }
 
-        query.paginatedRequired = paginationEnabled
+        if(paginationEnabled)
+            query.paginatedRequired = true
+        else{
+            query.max = null
+            query.offset = null
+        }
+
         def results = jobsFragment(query, JobsScmInfo.MINIMAL)
         results.execQueryParams=query.asExecQueryParams()
         results.reportQueryParams=query.asReportQueryParams()
@@ -354,7 +360,13 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                                         code: 'api.error.parameter.required', args: ['project']])
         }
 
-        query.paginatedRequired = paginationEnabled
+        if(paginationEnabled)
+            query.paginatedRequired = true
+        else{
+            query.max = null
+            query.offset = null
+        }
+
         query.projFilter = params.project
         //test valid project
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -303,7 +303,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             }
         }
 
-        if(paginationEnabled)
+        if(guiPaginationEnabled)
             query.paginatedRequired = true
         else{
             query.max = null
@@ -360,7 +360,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                                         code: 'api.error.parameter.required', args: ['project']])
         }
 
-        if(paginationEnabled)
+        if(guiPaginationEnabled)
             query.paginatedRequired = true
         else{
             query.max = null
@@ -595,14 +595,21 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     }
 
     private def getConfiguredMaxPerPage(int defaultMax) {
-        if(paginationEnabled) {
+        if(guiPaginationEnabled) {
             return grailsApplication.config.rundeck.gui.paginatejobs.max.per.page.isEmpty() ? defaultMax : grailsApplication.config.rundeck.gui.paginatejobs.max.per.page.toInteger()
         }
         return null
     }
 
-    private boolean getPaginationEnabled() {
+    private boolean getGuiPaginationEnabled() {
         grailsApplication.config.rundeck.gui.paginatejobs.enabled in ["true",true]
+    }
+
+    private boolean getApiPaginationEnabled() {
+        if(grailsApplication.config.rundeck.api.paginatejobs.enabled)
+            return grailsApplication.config.rundeck.api.paginatejobs.enabled in ["false",false]
+        else
+            return true
     }
 
     private def listWorkflows(ScheduledExecutionQuery query,AuthContext authContext,String user) {
@@ -2942,6 +2949,12 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
      * API: /api/2/project/NAME/jobs, version 2
      */
     def apiJobsListv2 (ScheduledExecutionQuery query) {
+
+        if (!apiPaginationEnabled){
+            query.max = null
+            query.offset = null
+        }
+
         if (!apiService.requireApi(request, response)) {
             return
         }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -240,7 +240,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         !grailsApplication.config.rundeck.gui.matchedNodesMaxCount?.isEmpty() ? grailsApplication.config.rundeck.gui.matchedNodesMaxCount?.toInteger() : null
     }
 
-    def Map finishquery ( query,params,model){
+    Map finishquery ( query,params,model){
 
         if(!params.max){
             params.max=query.max
@@ -495,7 +495,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     /**
      * return a map of defined group path to count of the number of jobs with that exact path
      */
-    def Map getGroups(project, AuthContext authContext){
+    Map getGroups(project, AuthContext authContext){
         def groupMap=[:]
 
         //collect all jobs and authorize the user for the set of available Job actions
@@ -586,7 +586,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
      *
      * @return Map of job ID to boolean, indicating whether the job was claimed
      */
-    def Map claimScheduledJobs(
+    Map claimScheduledJobs(
             String toServerUUID,
             String fromServerUUID = null,
             boolean selectAll = false,
@@ -865,7 +865,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
           ]
      * </pre>
      */
-    def Map getGroupTree(project, AuthContext authContext){
+    Map getGroupTree(project, AuthContext authContext){
         def groupMap = getGroups(project, authContext)
         def tree=[:]
         groupMap.keySet().each{
@@ -1403,7 +1403,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     /**
      * Schedule a temp job to execute immediately.
      */
-    def Map scheduleTempJob(AuthContext authContext, Execution e) {
+    Map scheduleTempJob(AuthContext authContext, Execution e) {
         if(!executionService.getExecutionsAreActive()){
             def msg=g.message(code:'disabled.execution.run')
             return [success:false,failed:true,error:'disabled',message:msg]
@@ -1519,7 +1519,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
      * @param scheduledExecutions
      * @return
      */
-    def Map clusterScheduledJobs(Collection<ScheduledExecution> scheduledExecutions) {
+    Map clusterScheduledJobs(Collection<ScheduledExecution> scheduledExecutions) {
         def map = [ : ]
         if(frameworkService.isClusterModeEnabled()) {
             def serverUUID = frameworkService.getServerUUID()
@@ -3034,8 +3034,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
             } else if (params.options instanceof Map) {
                 while (params.options["options[${i}]"]) {
-                    def Map optdefparams = params.options["options[${i}]"]
-                    def Option theopt = new Option(optdefparams)
+                    Map optdefparams = params.options["options[${i}]"]
+                    Option theopt = new Option(optdefparams)
                     scheduledExecution.addToOptions(theopt)
                     theopt.scheduledExecution = scheduledExecution
                     i++
@@ -3847,7 +3847,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
      * @param mapConfig
      * @return option remote
      */
-    def Map loadOptionsRemoteValues(ScheduledExecution scheduledExecution, Map mapConfig, def username) {
+    Map loadOptionsRemoteValues(ScheduledExecution scheduledExecution, Map mapConfig, def username) {
         //load expand variables in URL source
         Option opt = scheduledExecution.options.find { it.name == mapConfig.option }
         def realUrl = opt.realValuesUrl.toExternalForm()

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -308,9 +308,6 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             if (!queryOffset) {
                 queryOffset = 0
             }
-        }else{ //ignore pagination controls
-            queryMax=null
-            queryOffset=null
         }
 
         def idlist=[]

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -279,7 +279,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
 
 
-        def tmod=[max: query?.max?query.max:getConfiguredMaxPerPage(10),
+        def tmod=[max: query?query.max:null,
             offset:query?.offset?query.offset:0,
             paginateParams:paginateParams,
             displayParams:displayParams]
@@ -308,6 +308,9 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             if (!queryOffset) {
                 queryOffset = 0
             }
+        }else{ //ignore pagination controls
+            queryMax=null
+            queryOffset=null
         }
 
         def idlist=[]
@@ -329,8 +332,6 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         def scheduled = crit.list{
             if(queryMax && queryMax>0){
                 maxResults(queryMax)
-            }else{
-//                maxResults(10)
             }
             if(queryOffset){
                 firstResult(queryOffset.toInteger())

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -315,7 +315,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         Integer queryMax=query.max
         Integer queryOffset=query.offset
 
-        if(paginationEnabled && !query.apiCall) {
+        if(paginationEnabled) {
             if (!queryMax) {
                 queryMax = getConfiguredMaxPerPage(10)
             }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -315,7 +315,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         Integer queryMax=query.max
         Integer queryOffset=query.offset
 
-        if(paginationEnabled) {
+        if(paginationEnabled && !query.apiCall) {
             if (!queryMax) {
                 queryMax = getConfiguredMaxPerPage(10)
             }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -236,25 +236,14 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }.sort { a, b -> a.name <=> b.name }
     }
 
-    boolean getPaginationEnabled() {
-        grailsApplication.config.rundeck.gui.paginatejobs.enabled in ["true",true]
-    }
-
     def getMatchedNodesMaxCount() {
         !grailsApplication.config.rundeck.gui.matchedNodesMaxCount?.isEmpty() ? grailsApplication.config.rundeck.gui.matchedNodesMaxCount?.toInteger() : null
-    }
-
-    def getConfiguredMaxPerPage(int defaultMax) {
-        if(paginationEnabled) {
-            return grailsApplication.config.rundeck.gui.paginatejobs.max.per.page.isEmpty() ? defaultMax : grailsApplication.config.rundeck.gui.paginatejobs.max.per.page.toInteger()
-        }
-        return defaultMax
     }
 
     def Map finishquery ( query,params,model){
 
         if(!params.max){
-            params.max=getConfiguredMaxPerPage(10)
+            params.max=query.max
         }
         if(!params.offset){
             params.offset=0
@@ -315,10 +304,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         Integer queryMax=query.max
         Integer queryOffset=query.offset
 
-        if(paginationEnabled) {
-            if (!queryMax) {
-                queryMax = getConfiguredMaxPerPage(10)
-            }
+        if(query.paginatedRequired) {
             if (!queryOffset) {
                 queryOffset = 0
             }
@@ -422,7 +408,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             if(query && query.sortBy && xfilters[query.sortBy]){
                 order(xfilters[query.sortBy],query.sortOrder=='ascending'?'asc':'desc')
             }else{
-                if(paginationEnabled) {
+                if(query.paginatedRequired) {
                     order("groupPath","asc")
                 }
                 order("jobName","asc")

--- a/rundeckapp/src/integration-test/groovy/rundeck/services/ScheduledExecutionServiceIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/services/ScheduledExecutionServiceIntegrationSpec.groovy
@@ -1,12 +1,10 @@
 package rundeck.services
 
-import com.dtolabs.rundeck.core.authorization.AuthContextProvider
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.IRundeckProject
 import grails.gorm.transactions.Rollback
 import grails.testing.mixin.integration.Integration
 import org.hibernate.StaleObjectStateException
-import org.hibernate.criterion.CriteriaSpecification
 import org.quartz.JobDetail
 import org.quartz.Scheduler
 import org.quartz.SimpleTrigger

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ScheduledExecutionQuery.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ScheduledExecutionQuery.groovy
@@ -44,7 +44,7 @@ public class ScheduledExecutionQuery extends BaseQuery implements JobQueryInput,
 
     Integer daysAhead
     Boolean runJobLaterFilter
-    Boolean apiCall
+    Boolean paginatedRequired
 
     /**
      * text filters
@@ -118,7 +118,7 @@ public class ScheduledExecutionQuery extends BaseQuery implements JobQueryInput,
         })
         daysAhead(nullable: true)
         runJobLaterFilter(nullable: true)
-        apiCall(nullable: true)
+        paginatedRequired(nullable: true)
     }
 
 

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ScheduledExecutionQuery.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ScheduledExecutionQuery.groovy
@@ -44,6 +44,7 @@ public class ScheduledExecutionQuery extends BaseQuery implements JobQueryInput,
 
     Integer daysAhead
     Boolean runJobLaterFilter
+    Boolean apiCall
 
     /**
      * text filters
@@ -117,6 +118,7 @@ public class ScheduledExecutionQuery extends BaseQuery implements JobQueryInput,
         })
         daysAhead(nullable: true)
         runJobLaterFilter(nullable: true)
+        apiCall(nullable: true)
     }
 
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -299,6 +299,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         given:
         def testUUID = UUID.randomUUID().toString()
         def testUUID2 = UUID.randomUUID().toString()
+        controller.configurationService = Mock(ConfigurationService)
         controller.apiService = Mock(ApiService)
         controller.frameworkService = Mock(FrameworkService)
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)
@@ -343,6 +344,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         given:
         def testUUID = UUID.randomUUID().toString()
         def testUUID2 = UUID.randomUUID().toString()
+        controller.configurationService = Mock(ConfigurationService)
         controller.apiService = Mock(ApiService)
         controller.frameworkService = Mock(FrameworkService)
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)
@@ -392,6 +394,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         given:
         def testUUID = UUID.randomUUID().toString()
         def testUUID2 = UUID.randomUUID().toString()
+        controller.configurationService = Mock(ConfigurationService)
         controller.apiService = Mock(ApiService)
         controller.frameworkService = Mock(FrameworkService)
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)
@@ -439,6 +442,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         given:
         def testUUID = UUID.randomUUID().toString()
         def testUUID2 = UUID.randomUUID().toString()
+        controller.configurationService = Mock(ConfigurationService)
         controller.apiService = Mock(ApiService)
         controller.frameworkService = Mock(FrameworkService)
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)
@@ -1635,6 +1639,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
 
     def "jobs jobListIds"() {
         given:
+        controller.configurationService = Mock(ConfigurationService)
         controller.jobListLinkHandlerRegistry = Mock(JobListLinkHandlerRegistry) {
             getJobListLinkHandlerForProject(_) >> new GroupedJobListLinkHandler()
         }
@@ -1676,6 +1681,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
     @Unroll
     def "jobs scheduledJobListIds"() {
         given:
+        controller.configurationService = Mock(ConfigurationService)
         controller.jobListLinkHandlerRegistry = Mock(JobListLinkHandlerRegistry) {
             getJobListLinkHandlerForProject(_) >> new GroupedJobListLinkHandler()
         }
@@ -1746,6 +1752,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
         def job6 = new ScheduledExecution(createJobParams(jobName:'another job6',groupPath:'', project: params.project)).save()
         def job7 = new ScheduledExecution(createJobParams(jobName:'another job7',groupPath:'', project: params.project)).save()
 
+        controller.configurationService = new ConfigurationService()
         controller.aclFileManagerService = Mock(AclFileManagerService)
         controller.scheduledExecutionService = new ScheduledExecutionService()
         controller.scmService = Mock(ScmService)
@@ -1795,8 +1802,10 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
 
 
         def query = new ScheduledExecutionQuery()
+
         grailsApplication.config.rundeck.gui.paginatejobs.enabled = requirePagination
         grailsApplication.config.rundeck.gui.paginatejobs.max.per.page = maxPerPage
+        controller.configurationService.setAppConfig(grailsApplication.config.rundeck)
         query.offset = offset
 
         when:
@@ -1819,6 +1828,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
 
     def "jobs list next execution times"() {
         given:
+        controller.configurationService = Mock(ConfigurationService)
         controller.jobListLinkHandlerRegistry = Mock(JobListLinkHandlerRegistry) {
             getJobListLinkHandlerForProject(_) >> new GroupedJobListLinkHandler()
         }
@@ -2165,6 +2175,7 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
 
     def "test project job list handler"() {
         given:
+        controller.configurationService = Mock(ConfigurationService)
         controller.scmService = Mock(ScmService)
         controller.frameworkService = Mock(FrameworkService) {
             getRundeckFramework() >> Mock(Framework) {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -24,7 +24,6 @@ import com.dtolabs.rundeck.app.support.SaveProjAclFile
 import com.dtolabs.rundeck.app.support.SaveSysAclFile
 import com.dtolabs.rundeck.app.support.ScheduledExecutionQuery
 import com.dtolabs.rundeck.app.support.SysAclFile
-import com.dtolabs.rundeck.core.authorization.AuthContextProvider
 import com.dtolabs.rundeck.core.authorization.AuthorizationUtil
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.authorization.ValidationSet
@@ -38,7 +37,6 @@ import grails.test.hibernate.HibernateSpec
 import grails.testing.web.controllers.ControllerUnitTest
 import grails.web.Action
 import org.rundeck.app.acl.AppACLContext
-import org.rundeck.app.authorization.AppAuthContextEvaluator
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.app.gui.JobListLinkHandler
 import org.rundeck.core.auth.AuthConstants

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1735,6 +1735,90 @@ class MenuControllerSpec extends HibernateSpec implements ControllerUnitTest<Men
             false      | false      | 0
     }
 
+    @Unroll
+    def "next scheduled jobs pagination"() {
+        given:
+
+        params.project='test'
+        def job1 = new ScheduledExecution(createJobParams(jobName:'another job1',groupPath: '', project: params.project)).save()
+        def job2 = new ScheduledExecution(createJobParams(jobName:'another job2',groupPath:'', project: params.project)).save()
+        def job3 = new ScheduledExecution(createJobParams(jobName:'another job3',groupPath:'', project: params.project)).save()
+        def job4 = new ScheduledExecution(createJobParams(jobName:'another job4',groupPath:'', project: params.project)).save()
+        def job5 = new ScheduledExecution(createJobParams(jobName:'another job5',groupPath:'', project: params.project)).save()
+        def job6 = new ScheduledExecution(createJobParams(jobName:'another job6',groupPath:'', project: params.project)).save()
+        def job7 = new ScheduledExecution(createJobParams(jobName:'another job7',groupPath:'', project: params.project)).save()
+
+        controller.aclFileManagerService = Mock(AclFileManagerService)
+        controller.scheduledExecutionService = new ScheduledExecutionService()
+        controller.scmService = Mock(ScmService)
+        controller.userService = Mock(UserService)
+        controller.jobSchedulesService = Mock(JobSchedulesService)
+        controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
+        controller.scheduledExecutionService.applicationContext = applicationContext
+
+        controller.jobListLinkHandlerRegistry = Mock(JobListLinkHandlerRegistry) {
+            getJobListLinkHandlerForProject(_) >> new GroupedJobListLinkHandler()
+        }
+
+        controller.frameworkService = Mock(FrameworkService){
+            getRundeckFramework() >> Mock(Framework) {
+                getProjectManager() >> Mock(ProjectManager)
+                isClusterModeEnabled() >> false
+            }
+
+        }
+        controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
+            getAuthContextForUserAndRolesAndProject(_,_,_)>>Mock(UserAndRolesAuthContext)
+            authorizeProjectResource(_, _, _, _) >> true
+            authorizeProjectResources(_, _, _, _) >> [[authorized: true,
+                                                       action    : AuthConstants.ACTION_READ,
+                                                       resource  : [group: job1.groupPath, name: job1.jobName]],
+                                                      [authorized: true,
+                                                       action    : AuthConstants.ACTION_READ,
+                                                       resource  : [group: job2.groupPath, name: job2.jobName]],
+                                                      [authorized: true,
+                                                       action    : AuthConstants.ACTION_READ,
+                                                       resource  : [group: job3.groupPath, name: job3.jobName]],
+                                                      [authorized: true,
+                                                       action    : AuthConstants.ACTION_READ,
+                                                       resource  : [group: job4.groupPath, name: job4.jobName]],
+                                                      [authorized: true,
+                                                       action    : AuthConstants.ACTION_READ,
+                                                       resource  : [group: job5.groupPath, name: job5.jobName]],
+                                                      [authorized: true,
+                                                       action    : AuthConstants.ACTION_READ,
+                                                       resource  : [group: job6.groupPath, name: job6.jobName]],
+                                                      [authorized: true,
+                                                       action    : AuthConstants.ACTION_READ,
+                                                       resource  : [group: job7.groupPath, name: job7.jobName]]]
+        }
+
+        controller.scheduledExecutionService.frameworkService = controller.frameworkService
+
+
+        def query = new ScheduledExecutionQuery()
+        grailsApplication.config.rundeck.gui.paginatejobs.enabled = requirePagination
+        grailsApplication.config.rundeck.gui.paginatejobs.max.per.page = maxPerPage
+        query.offset = offset
+
+        when:
+        def model = controller.jobs(query)
+
+        then:
+        model.nextScheduled.size() == count
+
+        where:
+        requirePagination | offset | maxPerPage | count
+        true              | 5      | "3"        | 2
+        false             | 3      | "3"        | 7
+        true              | 0      | "3"        | 3
+        true              | 7      | "3"        | 0
+        false             | 5      | "5"        | 7
+        true              | 4      | "3"        | 3
+        true              | 6      | "3"        | 1
+
+    }
+
     def "jobs list next execution times"() {
         given:
         controller.jobListLinkHandlerRegistry = Mock(JobListLinkHandlerRegistry) {

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -16,7 +16,7 @@
 
 package rundeck.services
 
-import com.dtolabs.rundeck.core.authorization.AuthContextProvider
+
 import com.dtolabs.rundeck.core.jobs.JobLifecycleStatus
 import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException
 import com.dtolabs.rundeck.core.schedule.SchedulesManager
@@ -26,11 +26,9 @@ import grails.test.hibernate.HibernateSpec
 import grails.testing.services.ServiceUnitTest
 import org.grails.spring.beans.factory.InstanceFactoryBean
 import org.quartz.SchedulerException
-import org.rundeck.app.authorization.AppAuthContextEvaluator
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.app.components.RundeckJobDefinitionManager
 import org.rundeck.app.components.jobs.ImportedJob
-import org.quartz.Trigger
 import org.rundeck.app.components.jobs.JobQuery
 import org.rundeck.app.components.jobs.JobQueryInput
 import org.rundeck.app.components.schedule.TriggerBuilderHelper
@@ -49,7 +47,6 @@ import rundeck.ScheduledExecutionStats
 import static org.junit.Assert.*
 
 import com.dtolabs.rundeck.core.authorization.AuthContext
-import com.dtolabs.rundeck.core.authorization.UserAndRoles
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.IRundeckProject
@@ -61,8 +58,6 @@ import com.dtolabs.rundeck.core.plugins.configuration.Description
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolver
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
-import grails.test.mixin.Mock
-import grails.test.mixin.TestFor
 import org.quartz.ListenerManager
 import org.quartz.Scheduler
 import org.springframework.context.MessageSource
@@ -78,7 +73,6 @@ import rundeck.WorkflowStep
 import rundeck.ReferencedExecution
 import rundeck.controllers.ScheduledExecutionController
 import spock.lang.Issue
-import spock.lang.Specification
 import spock.lang.Unroll
 
 /**
@@ -5424,7 +5418,7 @@ class ScheduledExecutionServiceSpec extends HibernateSpec implements ServiceUnit
             getMax()>>queryMax
             getProjFilter()>>'AProject'
             getGroupPath()>>groupPath
-            getApiCall()>>true
+            getPaginatedRequired()>>true
         }
         service.applicationContext = applicationContext
         when:

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -5399,43 +5399,6 @@ class ScheduledExecutionServiceSpec extends HibernateSpec implements ServiceUnit
         output[3].workflow == [[script:"script"]]
 
     }
-
-    def "list workflows by api call with pagination enabled"() {
-        given:
-        grailsApplication.config.rundeck.gui.paginatejobs.enabled = true
-        def job1 = new ScheduledExecution(createJobParams()).save()
-        def job2 = new ScheduledExecution(createJobParams(jobName:'another job',groupPath: '')).save()
-        def job3 = new ScheduledExecution(createJobParams(jobName:'another job3',groupPath:'')).save()
-        def job4 = new ScheduledExecution(createJobParams(jobName:'another job4',groupPath:'')).save()
-        def job5 = new ScheduledExecution(createJobParams(jobName:'another job5',groupPath:'')).save()
-        def job6 = new ScheduledExecution(createJobParams(jobName:'another job6',groupPath:'')).save()
-        def job7 = new ScheduledExecution(createJobParams(jobName:'another job7',groupPath:'')).save()
-        def job8 = new ScheduledExecution(createJobParams(jobName:'another job8',groupPath:'')).save()
-        def job9 = new ScheduledExecution(createJobParams(jobName:'another job9',groupPath:'')).save()
-        def job10 = new ScheduledExecution(createJobParams(jobName:'another job10',groupPath:'')).save()
-        def job11 = new ScheduledExecution(createJobParams(jobName:'another job11',groupPath:'')).save()
-        def input = Mock(JobQueryInput){
-            getMax()>>queryMax
-            getProjFilter()>>'AProject'
-            getGroupPath()>>groupPath
-            getPaginatedRequired()>>true
-        }
-        service.applicationContext = applicationContext
-        when:
-        def result = service.listWorkflows(input, [:])
-        then:
-        result != null
-        result.schedlist.size()==count
-        result.total == total
-
-        where:
-        queryMax |  groupPath    | total | count
-        0        |  'some/where' | 1     | 1
-        0        |  '-'          | 10    | 10
-        1        |  '-'          | 10    | 1
-        null     |  '-'          | 10    | 10
-    }
-
 }
 
 class TriggersExtenderImpl implements TriggersExtender {

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -5405,6 +5405,43 @@ class ScheduledExecutionServiceSpec extends HibernateSpec implements ServiceUnit
         output[3].workflow == [[script:"script"]]
 
     }
+
+    def "list workflows by api call with pagination enabled"() {
+        given:
+        grailsApplication.config.rundeck.gui.paginatejobs.enabled = true
+        def job1 = new ScheduledExecution(createJobParams()).save()
+        def job2 = new ScheduledExecution(createJobParams(jobName:'another job',groupPath: '')).save()
+        def job3 = new ScheduledExecution(createJobParams(jobName:'another job3',groupPath:'')).save()
+        def job4 = new ScheduledExecution(createJobParams(jobName:'another job4',groupPath:'')).save()
+        def job5 = new ScheduledExecution(createJobParams(jobName:'another job5',groupPath:'')).save()
+        def job6 = new ScheduledExecution(createJobParams(jobName:'another job6',groupPath:'')).save()
+        def job7 = new ScheduledExecution(createJobParams(jobName:'another job7',groupPath:'')).save()
+        def job8 = new ScheduledExecution(createJobParams(jobName:'another job8',groupPath:'')).save()
+        def job9 = new ScheduledExecution(createJobParams(jobName:'another job9',groupPath:'')).save()
+        def job10 = new ScheduledExecution(createJobParams(jobName:'another job10',groupPath:'')).save()
+        def job11 = new ScheduledExecution(createJobParams(jobName:'another job11',groupPath:'')).save()
+        def input = Mock(JobQueryInput){
+            getMax()>>queryMax
+            getProjFilter()>>'AProject'
+            getGroupPath()>>groupPath
+            getApiCall()>>true
+        }
+        service.applicationContext = applicationContext
+        when:
+        def result = service.listWorkflows(input, [:])
+        then:
+        result != null
+        result.schedlist.size()==count
+        result.total == total
+
+        where:
+        queryMax |  groupPath    | total | count
+        0        |  'some/where' | 1     | 1
+        0        |  '-'          | 10    | 10
+        1        |  '-'          | 10    | 1
+        null     |  '-'          | 10    | 10
+    }
+
 }
 
 class TriggersExtenderImpl implements TriggersExtender {


### PR DESCRIPTION
fixes https://github.com/rundeck/rundeck/issues/5780

ScheduledExecutionService was decoupled from its consumers:
* The pagination setup was moved from ScheduledExecutionService to MenuController _(excepting the offset=0 for compatibility)_.
* Added a new test for pagination on MenuController.jobs() endpoint.
* Added the alternative to disable pagination for api _(it will ignore pagination parameters if the `rundeck.api.paginatejobs.enabled` property is set to false explicitly)_
* Cleaned just a little some old code.

Examples:

With rundeck GUI pagination config:
rundeck.gui.paginatejobs.enabled=true
rundeck.gui.paginatejobs.max.per.page=3

(All the 7 jobs are returned)
<img width="667" alt="Screen Shot 2022-01-03 at 11 02 27" src="https://user-images.githubusercontent.com/50217398/147939540-2f852edb-d3cb-4775-8d9d-44bfaf288903.png">

Pagination parameters work perfectly fine (decoupled from others configuration), unless `rundeck.api.paginatejobs.enabled` exists and is false
![image](https://user-images.githubusercontent.com/49494423/150396228-beea53d2-d79f-4eae-8787-04321782967b.png)



