### PR TITLE
RUN-236: Make official ubuntu 20.04 image the base image of rundeck ubuntu-base 

### DIFF
--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -1,4 +1,4 @@
-FROM rundeck/ubuntu-base@sha256:4c2bf3da1b01cbfae43a17b9e7967895166ef90133adc02ea2cb177eee1fab6c
+FROM rundeck/ubuntu-base:20.04@sha256:f91fea48e850964001e1307546611f004ce0adc789fa62f6da7101b36f8068b8
 
 COPY --chown=rundeck:root .build .
 RUN java -jar rundeck.war --installonly \
@@ -14,6 +14,7 @@ COPY --chown=rundeck:root etc etc
 RUN chmod -R 0775 etc
 
 VOLUME ["/home/rundeck/server/data"]
+
 
 EXPOSE 4440
 ENTRYPOINT [ "/tini", "--", "docker-lib/entry.sh" ]

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -41,8 +41,11 @@ RUN set -euxo pipefail \
     && chmod g+w /etc/passwd
 
 # Add Tini
-ENV TINI_VERSION v0.18.0
+ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
+RUN gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+ && gpg --batch --verify /tini.asc /tini
 RUN chmod +x /tini
 
 COPY --from=0 /go/bin/remco /usr/local/bin/remco

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -9,7 +9,7 @@ RUN go install github.com/HeavyHorst/remco/cmd/remco
 
 # Build base container
 ######################
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV LANG C.UTF-8
@@ -42,12 +42,8 @@ RUN set -euxo pipefail \
 
 # Add Tini
 ENV TINI_VERSION v0.18.0
-RUN wget -O /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
-    && wget -O /tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc \
-    && export GNUPGHOME="$(mktemp -d)" &&  echo "disable-ipv6" >> "${GNUPGHOME}/dirmngr.conf" \
-    && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
-    && gpg --batch --verify /tini.asc /tini \
-    && chmod +x /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
 
 COPY --from=0 /go/bin/remco /usr/local/bin/remco
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is an enhancement as required by 
[RUN-236 Upgrade rundeck unbuntu image to version 20.04](https://pagerduty.atlassian.net/browse/RUN-236)

**Describe the solution you've implemented**
Update the docker/ubuntu-base/Dockerfile to use ubuntu:20.04 official image as its base


Milestone: 4.0.0

Rundeck offical image Built and Verified:

![Screen Shot 2022-01-18 at 12 52 30 PM](https://user-images.githubusercontent.com/96143000/150017124-d9e20c4d-81f5-48ad-90b9-942b361607a4.png)

![Screen Shot 2022-01-18 at 12 52 42 PM](https://user-images.githubusercontent.com/96143000/150017149-28cc0a2d-6475-455b-8f0f-e300018442de.png)


