### PR TITLE
RCLOUD-181: Add the ability to authenticate webhooks using the Authorization header

### DIFF
--- a/grails-webhooks/grails-app/domain/webhooks/Webhook.groovy
+++ b/grails-webhooks/grails-app/domain/webhooks/Webhook.groovy
@@ -21,7 +21,7 @@ class Webhook {
     String name
     String project
     String authToken
-    String secret
+    String authConfigJson
     String eventPlugin
     String pluginConfigurationJson = '{}'
     boolean enabled = true
@@ -29,13 +29,14 @@ class Webhook {
     static constraints = {
         uuid(nullable: true)
         name(nullable: false)
-        secret(nullable: true)
+        authConfigJson(nullable: true)
         project(nullable: false)
         authToken(nullable: false)
         eventPlugin(nullable: false)
     }
 
     static mapping = {
+        authConfigJson type: 'text'
         pluginConfigurationJson type: 'text'
     }
 

--- a/grails-webhooks/grails-app/domain/webhooks/Webhook.groovy
+++ b/grails-webhooks/grails-app/domain/webhooks/Webhook.groovy
@@ -21,6 +21,7 @@ class Webhook {
     String name
     String project
     String authToken
+    String secret
     String eventPlugin
     String pluginConfigurationJson = '{}'
     boolean enabled = true
@@ -28,6 +29,7 @@ class Webhook {
     static constraints = {
         uuid(nullable: true)
         name(nullable: false)
+        secret(nullable: true)
         project(nullable: false)
         authToken(nullable: false)
         eventPlugin(nullable: false)

--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -23,6 +23,7 @@ import com.dtolabs.rundeck.plugins.webhook.WebhookEventPlugin
 import com.fasterxml.jackson.databind.ObjectMapper
 import grails.gorm.transactions.Transactional
 import groovy.transform.PackageScope
+import org.apache.commons.lang.RandomStringUtils
 import org.rundeck.app.spi.Services
 import org.rundeck.app.spi.SimpleServiceProvider
 import org.slf4j.Logger
@@ -160,11 +161,14 @@ class WebhookService {
         hook.uuid = hookData.uuid ?: hook.uuid
         hook.name = hookData.name ?: hook.name
         hook.project = hookData.project ?: hook.project
-        if(hookData.authString != null && !hookData.authString.isEmpty()) {
-            hook.authConfigJson = mapper.writeValueAsString(new AuthorizationHeaderAuthenticator.Config(secret:hookData.authString.toString().sha256()))
-        } else if(hookData.authString == '') {
+        String generatedSecureString = null
+        if(hookData.useAuth == true && hookData.regenAuth == true) {
+            generatedSecureString = RandomStringUtils.random(32, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+            hook.authConfigJson = mapper.writeValueAsString(new AuthorizationHeaderAuthenticator.Config(secret:generatedSecureString.sha256()))
+        } else if(hookData.useAuth == false) {
             hook.authConfigJson = null
         }
+
         if(hookData.enabled != null) hook.enabled = hookData.enabled
         if(hookData.eventPlugin && !pluginService.listPlugins(WebhookEventPlugin).any { it.key == hookData.eventPlugin}){
             hook.discard()
@@ -213,7 +217,9 @@ class WebhookService {
 
         if(hook.validate()) {
             hook.save(failOnError:true, flush:true)
-            return [msg: "Saved webhook"]
+            def responsePayload = [msg: "Saved webhook"]
+            if(generatedSecureString) responsePayload.generatedSecurityString = generatedSecureString
+            return responsePayload
         } else {
             if(!hook.id && hook.authToken){
                 //delete the created token
@@ -306,7 +312,7 @@ class WebhookService {
 
     private Map getWebhookWithAuthAsMap(Webhook hook) {
         AuthenticationToken authToken = rundeckAuthTokenManagerService.getToken(hook.authToken)
-        return [id:hook.id, uuid:hook.uuid, name:hook.name, project: hook.project, enabled: hook.enabled, user:authToken.ownerName, creator:authToken.creator, roles: authToken.authRolesSet().join(","), authToken:hook.authToken, authString: hook.authConfigJson ? "***********" : null, eventPlugin:hook.eventPlugin, config:mapper.readValue(hook.pluginConfigurationJson, HashMap)]
+        return [id:hook.id, uuid:hook.uuid, name:hook.name, project: hook.project, enabled: hook.enabled, user:authToken.ownerName, creator:authToken.creator, roles: authToken.authRolesSet().join(","), authToken:hook.authToken, useAuth: hook.authConfigJson != null, regenAuth: false, eventPlugin:hook.eventPlugin, config:mapper.readValue(hook.pluginConfigurationJson, HashMap)]
     }
 
     Webhook getWebhook(Long id) {

--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -27,6 +27,7 @@ import org.rundeck.app.spi.Services
 import org.rundeck.app.spi.SimpleServiceProvider
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import webhooks.authenticator.AuthorizationHeaderAuthenticator
 
 import javax.servlet.http.HttpServletRequest
 
@@ -159,7 +160,11 @@ class WebhookService {
         hook.uuid = hookData.uuid ?: hook.uuid
         hook.name = hookData.name ?: hook.name
         hook.project = hookData.project ?: hook.project
-        if(hookData.secret != null) hook.secret = hookData.secret
+        if(hookData.authString != null && !hookData.authString.isEmpty()) {
+            hook.authConfigJson = mapper.writeValueAsString(new AuthorizationHeaderAuthenticator.Config(secret:hookData.authString.toString().sha256()))
+        } else if(hookData.authString == '') {
+            hook.authConfigJson = null
+        }
         if(hookData.enabled != null) hook.enabled = hookData.enabled
         if(hookData.eventPlugin && !pluginService.listPlugins(WebhookEventPlugin).any { it.key == hookData.eventPlugin}){
             hook.discard()
@@ -301,7 +306,7 @@ class WebhookService {
 
     private Map getWebhookWithAuthAsMap(Webhook hook) {
         AuthenticationToken authToken = rundeckAuthTokenManagerService.getToken(hook.authToken)
-        return [id:hook.id, uuid:hook.uuid, name:hook.name, project: hook.project, enabled: hook.enabled, user:authToken.ownerName, creator:authToken.creator, roles: authToken.authRolesSet().join(","), authToken:hook.authToken, secret: hook.secret, eventPlugin:hook.eventPlugin, config:mapper.readValue(hook.pluginConfigurationJson, HashMap)]
+        return [id:hook.id, uuid:hook.uuid, name:hook.name, project: hook.project, enabled: hook.enabled, user:authToken.ownerName, creator:authToken.creator, roles: authToken.authRolesSet().join(","), authToken:hook.authToken, authString: hook.authConfigJson ? "***********" : null, eventPlugin:hook.eventPlugin, config:mapper.readValue(hook.pluginConfigurationJson, HashMap)]
     }
 
     Webhook getWebhook(Long id) {

--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -159,6 +159,7 @@ class WebhookService {
         hook.uuid = hookData.uuid ?: hook.uuid
         hook.name = hookData.name ?: hook.name
         hook.project = hookData.project ?: hook.project
+        if(hookData.secret != null) hook.secret = hookData.secret
         if(hookData.enabled != null) hook.enabled = hookData.enabled
         if(hookData.eventPlugin && !pluginService.listPlugins(WebhookEventPlugin).any { it.key == hookData.eventPlugin}){
             hook.discard()
@@ -300,7 +301,7 @@ class WebhookService {
 
     private Map getWebhookWithAuthAsMap(Webhook hook) {
         AuthenticationToken authToken = rundeckAuthTokenManagerService.getToken(hook.authToken)
-        return [id:hook.id, uuid:hook.uuid, name:hook.name, project: hook.project, enabled: hook.enabled, user:authToken.ownerName, creator:authToken.creator, roles: authToken.authRolesSet().join(","), authToken:hook.authToken, eventPlugin:hook.eventPlugin, config:mapper.readValue(hook.pluginConfigurationJson, HashMap)]
+        return [id:hook.id, uuid:hook.uuid, name:hook.name, project: hook.project, enabled: hook.enabled, user:authToken.ownerName, creator:authToken.creator, roles: authToken.authRolesSet().join(","), authToken:hook.authToken, secret: hook.secret, eventPlugin:hook.eventPlugin, config:mapper.readValue(hook.pluginConfigurationJson, HashMap)]
     }
 
     Webhook getWebhook(Long id) {

--- a/grails-webhooks/src/main/groovy/webhooks/WebhooksGrailsPlugin.groovy
+++ b/grails-webhooks/src/main/groovy/webhooks/WebhooksGrailsPlugin.groovy
@@ -2,6 +2,7 @@ package webhooks
 
 import grails.plugins.*
 import grails.util.Environment
+import webhooks.authenticator.AuthorizationHeaderAuthenticator
 import webhooks.component.project.WebhooksProjectComponent
 import webhooks.exporter.WebhooksProjectExporter
 import webhooks.importer.WebhooksProjectImporter

--- a/grails-webhooks/src/main/groovy/webhooks/authenticator/AuthorizationHeaderAuthenticator.groovy
+++ b/grails-webhooks/src/main/groovy/webhooks/authenticator/AuthorizationHeaderAuthenticator.groovy
@@ -1,0 +1,20 @@
+package webhooks.authenticator
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import webhooks.Webhook
+import javax.servlet.http.HttpServletRequest
+
+class AuthorizationHeaderAuthenticator implements WebhookAuthenticator {
+    static final ObjectMapper mapper = new ObjectMapper()
+    @Override
+    boolean authenticate(Webhook webhook, HttpServletRequest request) {
+        String hdrValue = request.getHeader("Authorization")
+        if(!hdrValue) return false
+        Config config = mapper.readValue(webhook.authConfigJson, Config)
+        return config.secret == hdrValue.sha256()
+    }
+
+    static class Config {
+        String secret
+    }
+}

--- a/grails-webhooks/src/main/groovy/webhooks/authenticator/WebhookAuthenticator.groovy
+++ b/grails-webhooks/src/main/groovy/webhooks/authenticator/WebhookAuthenticator.groovy
@@ -1,0 +1,8 @@
+package webhooks.authenticator
+
+import webhooks.Webhook
+import javax.servlet.http.HttpServletRequest
+
+interface WebhookAuthenticator {
+    boolean authenticate(Webhook webhook, HttpServletRequest request)
+}

--- a/grails-webhooks/src/test/groovy/webhooks/WebhookControllerSpec.groovy
+++ b/grails-webhooks/src/test/groovy/webhooks/WebhookControllerSpec.groovy
@@ -19,14 +19,18 @@ import com.dtolabs.rundeck.core.authorization.AuthContextEvaluator
 import com.dtolabs.rundeck.core.authorization.AuthContextProvider
 import com.dtolabs.rundeck.core.authorization.SubjectAuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import com.dtolabs.rundeck.core.storage.ResourceMeta
 import com.dtolabs.rundeck.plugins.webhook.DefaultJsonWebhookResponder
 import com.dtolabs.rundeck.plugins.webhook.DefaultWebhookResponder
 import com.dtolabs.rundeck.plugins.webhook.WebhookDataImpl
 import com.dtolabs.rundeck.plugins.webhook.WebhookResponder
 import grails.testing.web.controllers.ControllerUnitTest
 import org.rundeck.core.auth.AuthConstants
+import org.rundeck.storage.api.Resource
 import spock.lang.Specification
+import spock.lang.Unroll
 
+import javax.rmi.CORBA.Stub
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
@@ -77,6 +81,51 @@ class WebhookControllerSpec extends Specification implements ControllerUnitTest<
         1 * controller.webhookService.getWebhookByToken(_) >> { new Webhook(name:"test",authToken: "1234")}
         0 * controller.webhookService.processWebhook(_,_,_,_)
         response.text == '{"err":"You are not authorized to perform this action"}'
+    }
+
+    @Unroll
+    def "test post Authorization header and secret"() {
+        given:
+        controller.rundeckAuthContextProvider = Mock(AuthContextProvider)
+        controller.rundeckAuthContextEvaluator = Mock(AuthContextEvaluator)
+        controller.webhookService = Mock(MockWebhookService)
+        def mockResourceMeta = Mock(ResourceMeta) {
+            writeContent(_ as OutputStream) >> {
+                OutputStream out = it[0]
+                out.write(keystorevalue.bytes)
+                return keystorevalue.bytes.size()
+            }
+        }
+        def mockResource = Mock(Resource) {
+            getContents() >> mockResourceMeta
+        }
+        def mockTree = Mock(MockStorageTree) {
+            getResource(_) >> mockResource
+        }
+        controller.storageService = Mock(MockStorageService)
+
+        when:
+        request.addHeader(WebhookController.AUTH_HEADER, secretHeader)
+        params.authtoken = "1234"
+        request.method = 'POST'
+        controller.post()
+
+        then:
+        1 * controller.webhookService.getWebhookByToken(_) >> { new Webhook(name:"test",authToken: "1234", secret: secret)}
+        1 * controller.rundeckAuthContextProvider.getAuthContextForSubjectAndProject(_, _) >> { new SubjectAuthContext(null, null) }
+        1 * controller.rundeckAuthContextEvaluator.authorizeProjectResourceAny(_,_,_,_) >> { return true }
+        ssCount * controller.storageService.storageTreeWithContext(_) >> { mockTree }
+        phCount * controller.webhookService.processWebhook(_,_,_,_,_) >> { new DefaultWebhookResponder() }
+        response.text == expectedMsg
+
+        where:
+        secret              | secretHeader   | keystorevalue | ssCount   | expectedMsg                              | phCount
+        "AuthMe!!"          | "AuthMe!!"     | null          | 0         | 'ok'                                     |    1
+        "AuthMe!!"          | "something"    | null          | 0         | '{"err":"Failed webhook authorization"}' |    0
+        "keys/hooks/hk1"    | "AuthMe!!"     | 'AuthMe!!'    | 1         | 'ok'                                     |    1
+        "keys/hooks/hk1"    | "AuthMe!!"     | 'wonmatch'    | 1         | '{"err":"Failed webhook authorization"}' |    0
+        "keys/hooks/hk1"    | "wrongval"     | 'AuthMe!!'    | 1         | '{"err":"Failed webhook authorization"}' |    0
+        "wontmatch"         | "AuthMe!!"     | null          | 0         | '{"err":"Failed webhook authorization"}' |    0
     }
 
     def "remove webhook should fail when project params is not present"() {
@@ -163,6 +212,13 @@ class WebhookControllerSpec extends Specification implements ControllerUnitTest<
         'GET'       | 405        | 0
         'PUT'       | 405        | 0
         'DELETE'    | 405        | 0
+    }
+
+    interface MockStorageService {
+        Object storageTreeWithContext(Object obj)
+    }
+    interface MockStorageTree {
+        Resource getResource(String path)
     }
 
     interface MockWebhookService {

--- a/rundeckapp/grails-app/migrations/core/Webhook.groovy
+++ b/rundeckapp/grails-app/migrations/core/Webhook.groovy
@@ -41,14 +41,14 @@ databaseChangeLog = {
             }
         }
     }
-    changeSet(author: "Stephen Joyner", id: "3.4.11-webhook-secret") {
+    changeSet(author: "Stephen Joyner", id: "3.4.11-webhook-auth_config_json") {
         preConditions(onFail: "MARK_RAN") {
             not {
-                columnExists(tableName: "webhook", columnName: 'secret')
+                columnExists(tableName: "webhook", columnName: 'auth_config_json')
             }
         }
         addColumn(tableName: "webhook") {
-            column(name: 'secret', type: '${varchar255.type}')
+            column(name: 'auth_config_json', type: '${text.type}')
         }
     }
 }

--- a/rundeckapp/grails-app/migrations/core/Webhook.groovy
+++ b/rundeckapp/grails-app/migrations/core/Webhook.groovy
@@ -41,4 +41,14 @@ databaseChangeLog = {
             }
         }
     }
+    changeSet(author: "Stephen Joyner", id: "3.4.11-webhook-secret") {
+        preConditions(onFail: "MARK_RAN") {
+            not {
+                columnExists(tableName: "webhook", columnName: 'secret')
+            }
+        }
+        addColumn(tableName: "webhook") {
+            column(name: 'secret', type: '${varchar255.type}')
+        }
+    }
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/help/HelpIcon.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/help/HelpIcon.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="help-icon">
         <i :id="`help-${this._uid}`" class="fas fa-sm fa-question-circle text-muted" style="cursor:pointer;margin-left:5px"/>
-        <popover :title="title" :target="`#help-${this._uid}`" custom-class="popover-wide" viewport="#main-panel">
+        <popover :title="title" :target="`#help-${this._uid}`" custom-class="popover-wide" viewport="#section-main">
         <template slot="popover">
             <slot></slot>
         </template>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/help/HelpIcon.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/help/HelpIcon.vue
@@ -1,0 +1,34 @@
+<template>
+    <div class="help-icon">
+        <i :id="`help-${this._uid}`" class="fas fa-sm fa-question-circle text-muted" style="cursor:pointer;margin-left:5px"/>
+        <popover :title="title" :target="`#help-${this._uid}`" custom-class="popover-wide" viewport="#main-panel">
+        <template slot="popover">
+            <slot></slot>
+        </template>
+        </popover>
+    </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+    name: 'HelpIcon',
+    props: {
+        title: String
+    }
+})
+</script>
+
+<style>
+.popover-content {
+    max-height: 50vh;
+    overflow-y: auto;
+}
+</style>
+
+<style scoped>
+.help-icon {
+    display: inline;
+}
+</style>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/stores/Webhooks.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/stores/Webhooks.ts
@@ -150,6 +150,7 @@ export class Webhook {
     @observable project!: string
     @observable roles!: string
     @observable user!: string
+    @observable secret!: string
     @observable eventPluginName!: string
     @observable eventPlugin?: Plugin
 
@@ -174,6 +175,7 @@ export class Webhook {
         this.project = json.project
         this.roles = json.roles
         this.user = json.user
+        this.secret = json.secret
         this.eventPluginName = json.eventPlugin
     }
 
@@ -191,6 +193,7 @@ export class Webhook {
             project: this.project,
             roles: this.roles,
             user: this.user,
+            secret: this.secret,
             eventPlugin: this.eventPlugin?.name
         }
     }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/stores/Webhooks.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/stores/Webhooks.ts
@@ -150,6 +150,8 @@ export class Webhook {
     @observable project!: string
     @observable roles!: string
     @observable user!: string
+    @observable useAuth!: boolean
+    @observable regenAuth!: boolean
     @observable authString!: string
     @observable eventPluginName!: string
     @observable eventPlugin?: Plugin
@@ -175,6 +177,8 @@ export class Webhook {
         this.project = json.project
         this.roles = json.roles
         this.user = json.user
+        this.useAuth = json.useAuth
+        this.regenAuth = json.regenAuth
         this.authString = json.authString
         this.eventPluginName = json.eventPlugin
     }
@@ -193,6 +197,8 @@ export class Webhook {
             project: this.project,
             roles: this.roles,
             user: this.user,
+            useAuth: this.useAuth,
+            regenAuth: this.regenAuth,
             authString: this.authString,
             eventPlugin: this.eventPlugin?.name
         }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/stores/Webhooks.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/stores/Webhooks.ts
@@ -150,7 +150,7 @@ export class Webhook {
     @observable project!: string
     @observable roles!: string
     @observable user!: string
-    @observable secret!: string
+    @observable authString!: string
     @observable eventPluginName!: string
     @observable eventPlugin?: Plugin
 
@@ -175,7 +175,7 @@ export class Webhook {
         this.project = json.project
         this.roles = json.roles
         this.user = json.user
-        this.secret = json.secret
+        this.authString = json.authString
         this.eventPluginName = json.eventPlugin
     }
 
@@ -193,7 +193,7 @@ export class Webhook {
             project: this.project,
             roles: this.roles,
             user: this.user,
-            secret: this.secret,
+            authString: this.authString,
             eventPlugin: this.eventPlugin?.name
         }
     }

--- a/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/i18n.js
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/i18n.js
@@ -21,10 +21,10 @@ const translationStrings = {
       webhookRolesLabel:'Roles',
       webhookRolesHelp:'The authorization roles assumed when running this webhook (comma separated). All ACL policies matching these roles will apply.',
       webhookAuthLabel: 'HTTP Authorization String',
-      webhookGenerateSecurityLabel: "Use Authorization String",
-      webhookGenerateSecretCheckboxHelp: "[Optional] A Webhook Authentication string can be generated to increase security of this webhook. All posts will need to include the generated string in the Authorization header.",
+      webhookGenerateSecurityLabel: "Use Authorization Header",
+      webhookGenerateSecretCheckboxHelp: "[Optional] A Webhook authorization string can be generated to increase security of this webhook. All posts will need to include the generated string in the Authorization header.",
       webhookSecretMessageHelp: "Copy this authorization string now. After you navigate away from this webhook you will no longer be able to see the string.",
-      webhookRegenClicked:'A new Authorization string will be generated and displayed when the webhook is saved.',
+      webhookRegenClicked:'A new authorization string will be generated and displayed when the webhook is saved.',
       webhookPluginLabel:'Choose Webhook Plugin'
     }
   }

--- a/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/i18n.js
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/i18n.js
@@ -20,8 +20,8 @@ const translationStrings = {
       webhookUserHelp:'The authorization username assumed when running this webhook. All ACL policies matching this username will apply.',
       webhookRolesLabel:'Roles',
       webhookRolesHelp:'The authorization roles assumed when running this webhook (comma separated). All ACL policies matching these roles will apply.',
-      webhookSecretLabel:'Secret',
-      webhookSecretHelp:'If you want to authenticate the webhook, put a value in this field or store the value in the key store. All posts to this webhook must have the secret in the Authorization header.',
+      webhookSecretLabel:'Authorization String',
+      webhookSecretHelp:'[Optional] A Webhook Authentication string can be generated to increase security of this webhook. All posts will need to include the generated string in the Authorization header. NOTE: The generated string is only shown once! Make sure you save the string or you will need to generate it again.',
       webhookPluginLabel:'Choose Webhook Plugin'
     }
   }

--- a/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/i18n.js
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/i18n.js
@@ -20,8 +20,11 @@ const translationStrings = {
       webhookUserHelp:'The authorization username assumed when running this webhook. All ACL policies matching this username will apply.',
       webhookRolesLabel:'Roles',
       webhookRolesHelp:'The authorization roles assumed when running this webhook (comma separated). All ACL policies matching these roles will apply.',
-      webhookSecretLabel:'Authorization String',
-      webhookSecretHelp:'[Optional] A Webhook Authentication string can be generated to increase security of this webhook. All posts will need to include the generated string in the Authorization header. NOTE: The generated string is only shown once! Make sure you save the string or you will need to generate it again.',
+      webhookAuthLabel: 'HTTP Authorization String',
+      webhookGenerateSecurityLabel: "Use Authorization String",
+      webhookGenerateSecretCheckboxHelp: "[Optional] A Webhook Authentication string can be generated to increase security of this webhook. All posts will need to include the generated string in the Authorization header.",
+      webhookSecretMessageHelp: "Copy this authorization string now. After you navigate away from this webhook you will no longer be able to see the string.",
+      webhookRegenClicked:'A new Authorization string will be generated and displayed when the webhook is saved.',
       webhookPluginLabel:'Choose Webhook Plugin'
     }
   }

--- a/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/i18n.js
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/i18n.js
@@ -20,6 +20,8 @@ const translationStrings = {
       webhookUserHelp:'The authorization username assumed when running this webhook. All ACL policies matching this username will apply.',
       webhookRolesLabel:'Roles',
       webhookRolesHelp:'The authorization roles assumed when running this webhook (comma separated). All ACL policies matching these roles will apply.',
+      webhookSecretLabel:'Secret',
+      webhookSecretHelp:'If you want to authenticate the webhook, put a value in this field or store the value in the key store. All posts to this webhook must have the secret in the Authorization header.',
       webhookPluginLabel:'Choose Webhook Plugin'
     }
   }

--- a/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/views/WebhooksView.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/views/WebhooksView.vue
@@ -10,7 +10,7 @@
         @click="handleAddNew"><i class="fas fa-plus-circle"/> {{ $t('message.webhookCreateBtn') }}</a>
     </div>
   </div>
-  
+
   <div style="display: flex; height: 100%;overflow: hidden;">
     <div id="wh-list" style="flex-basis: 250px;flex-grow: 0; padding: 20px;overflow-x: hidden;overflow-y: auto;">
       <WebhookPicker :selected="curHook ? curHook.uuid : ''" :project="projectName" @item:selected="(item) => handleSelect(item)"/>
@@ -72,6 +72,14 @@
                   <div class="form-group"><label>{{ $t('message.webhookRolesLabel') }}</label><input v-model="curHook.roles" class="form-control">
                     <div class="help-block">
                       {{$t('message.webhookRolesHelp')}}
+                    </div>
+                  </div>
+                  <div class="form-group"><label>{{ $t('message.webhookSecretLabel') }}</label><input v-model="curHook.secret" class="form-control">
+                    <key-storage-selector :value="secretInput"
+                                          :allow-upload="true"
+                                          v-on:input="handleKeyStorage($event)"/>
+                    <div class="help-block">
+                      {{$t('message.webhookSecretHelp')}}
                     </div>
                   </div>
                   <div class="form-group">
@@ -159,6 +167,7 @@ import CopyBox from '@rundeck/ui-trellis/lib/components/containers/copybox/CopyB
 import Tabs from '@rundeck/ui-trellis/lib/components/containers/tabs/Tabs'
 import Tab from '@rundeck/ui-trellis/lib/components/containers/tabs/Tab'
 import WebhookPicker from '@rundeck/ui-trellis/lib/components/widgets/webhook-select/WebhookSelect.vue'
+import KeyStorageSelector from '@rundeck/ui-trellis/lib/components/plugins/KeyStorageSelector.vue'
 
 import {getServiceProviderDescription,
   getPluginProvidersForService} from '@rundeck/ui-trellis/lib/modules/pluginService'
@@ -199,7 +208,8 @@ export default observer(Vue.extend({
     Tabs,
     Tab,
     WebhookPicker,
-    WebhookTitle
+    WebhookTitle,
+    KeyStorageSelector
   },
   inject: ["rootStore"],
   data() {
@@ -218,7 +228,15 @@ export default observer(Vue.extend({
       dirty: false
     }
   },
+  computed: {
+    secretInput() {
+      return this.curHook.secret ? this.curHook.secret : ''
+    }
+  },
   methods: {
+    handleKeyStorage(val) {
+      Vue.set(this.curHook, "secret", val)
+    },
     input() {
       this.dirty = true
     },
@@ -280,7 +298,7 @@ export default observer(Vue.extend({
       }, (data) => {
         this.dirty = true
       })
-      
+
       this.setValidation(true)
       this.setSelectedPlugin(true)
     },

--- a/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/views/WebhooksView.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/views/WebhooksView.vue
@@ -223,7 +223,6 @@ export default observer(Vue.extend({
       webhookPlugins: [],
       curHook: null,
       hkSecret: null,
-      inSaveCall: false,
       origUseAuthVal: false,
       config: null,
       errors: {},
@@ -311,7 +310,9 @@ export default observer(Vue.extend({
       this.cleanAction(() => this.select(selected))
     },
     select(selected) {
-      if(!this.inSaveCall) this.hkSecret = null
+      if (!this.curHook || this.curHook.uuid !== selected.uuid) {
+          this.hkSecret = null
+      }
       this.curHook = this.rootStore.webhooks.clone(selected)
       this.origUseAuthVal = this.curHook.useAuth
 
@@ -356,7 +357,6 @@ export default observer(Vue.extend({
         return
       }
       webhook.config = this.selectedPlugin.config
-      this.inSaveCall = true
       let resp
       if (webhook.new)
         resp = await this.rootStore.webhooks.create(webhook)
@@ -378,7 +378,6 @@ export default observer(Vue.extend({
         await this.rootStore.webhooks.refresh(this.projectName)
         this.select(this.rootStore.webhooks.webhooksByUuid.get(webhook.uuid))
       }
-      this.inSaveCall = false
     },
     handleCancel() {
       this.cleanAction(this.cancel)


### PR DESCRIPTION
POSTs to webhooks can now be authenticated, by a value specified in the Webhook data or a value from the key store.
