### PR TITLE
RUN-586: Expand and optimize Job Edit Details tests

### DIFF
--- a/test/selenium/src/__tests__/selenium/edit-job.test.ts
+++ b/test/selenium/src/__tests__/selenium/edit-job.test.ts
@@ -80,4 +80,7 @@ describe('edit job', () => {
         expect(optionRunInput2).toBeDefined()
 
     })
+    it('correctly opens the group choose modal and picks an option', async () => {
+
+    })
 })

--- a/test/selenium/src/__tests__/selenium/edit-job.test.ts
+++ b/test/selenium/src/__tests__/selenium/edit-job.test.ts
@@ -41,17 +41,6 @@ describe('editing a job', () => {
         const save = await jobCreatePage.editSaveButton()
         await save.click()
     })
-    it('adds tags correctly', async () => {
-        const tagsField = await jobCreatePage.tagsInputArea()
-        await ctx.driver.wait(until.elementIsVisible(tagsField), 10000)
-        expect(tagsField).toBeDefined()
-        tagsField.clear()
-        tagsField.sendKeys(testVars.tags)
-
-        //ensure they were tag-ified
-        const pilledTagsField = await jobCreatePage.tagsPillsArea()
-        expect(pilledTagsField).toBeDefined()
-    })
     it('edits and saves job description correctly', async () => {
         const descriptionTextField = await jobCreatePage.descriptionTextarea()
         expect(descriptionTextField).toBeDefined()
@@ -78,10 +67,6 @@ describe('showing the edited job', () => {
     it('verifies job group', async () => {
         const groupLabel = await jobShowPage.jobGroupText()
         expect(groupLabel).toEqual(testVars.group)
-    })
-    it('verifies job tags', async () => {
-        const showTags = await jobShowPage.jobTags()
-        expect(showTags).toHaveLength(testVars.tagsCount)
     })
     it('verifies job description', async () => {
         const foundText = await jobShowPage.jobDescriptionText()

--- a/test/selenium/src/__tests__/selenium/edit-job.test.ts
+++ b/test/selenium/src/__tests__/selenium/edit-job.test.ts
@@ -35,6 +35,7 @@ describe('editing a job', () => {
     beforeAll(async () => {
         await jobCreatePage.getEditPage('b7b68386-3a52-46dc-a28b-1a4bf6ed87de')
         await ctx.driver.wait(until.urlContains('/job/edit'), 30000)
+        await ctx.driver.wait(until.elementLocated(By.css('div#schedJobNameLabel')), 10000)
     })
     afterAll(async () => {
         const save = await jobCreatePage.editSaveButton()
@@ -42,7 +43,7 @@ describe('editing a job', () => {
     })
     it('adds tags correctly', async () => {
         const tagsField = await jobCreatePage.tagsInputArea()
-        await ctx.driver.wait(until.elementIsVisible(tagsField))
+        await ctx.driver.wait(until.elementIsVisible(tagsField), 10000)
         expect(tagsField).toBeDefined()
         tagsField.clear()
         tagsField.sendKeys(testVars.tags)

--- a/test/selenium/src/pages/jobCreate.page.ts
+++ b/test/selenium/src/pages/jobCreate.page.ts
@@ -21,6 +21,7 @@ export const Elems = {
     tagsInputArea  : By.css('div.tag-input-wrapper > input.form-control'),
     tagsPillsArea : By.css('ul.tags-list'),
     groupChooseButton: By.css('span.btn[data-target="#groupChooseModal"]'),
+    groupChooseInput : By.css('input#schedJobGroup'),
     groupChooseModal : By.css('div#groupChooseModal_content'),
     modalGroupEntry : By.css('span.groupname.jobgroupexpand'),
     modalCancel : By.css('button.btn[data-dismiss="modal"]'),
@@ -126,6 +127,15 @@ export class JobCreatePage extends Page {
     }
     async tagsPillsArea() {
         return await this.ctx.driver.findElement(Elems.tagsPillsArea)
+    }
+    async groupChooseButton() {
+        return await this.ctx.driver.findElement(Elems.groupChooseButton)
+    }
+    async groupChooseInput() {
+        return await this.ctx.driver.findElement(Elems.groupChooseInput)
+    }
+    async groupChooseModal() {
+        return await this.ctx.driver.findElement(Elems.groupChooseModal)
     }
     async saveButton() {
         return this.ctx.driver.findElement(Elems.saveButton)

--- a/test/selenium/src/pages/jobCreate.page.ts
+++ b/test/selenium/src/pages/jobCreate.page.ts
@@ -3,10 +3,12 @@ import {By, until, WebElementPromise} from 'selenium-webdriver'
 import {Page} from '@rundeck/testdeck/page'
 import {Context} from '@rundeck/testdeck/context'
 
-export const Elems= {
+export const Elems = {
     jobNameInput  : By.css('form input[name="jobName"]'),
     groupPathInput  : By.css('form input[name="groupPath"]'),
     descriptionTextarea  : By.css('form textarea[name="description"]'),
+    tagsInputArea  : By.css('div.tag-input-wrapper > input.form-control'),
+    tagsPillsArea : By.css('ul.tags-list'),
     saveButton  : By.css('#Create'),
     updateButton  : By.css('#jobUpdateSaveButton'),
     cancelButton  : By.css('#createFormCancelButton'),
@@ -102,14 +104,20 @@ export class JobCreatePage extends Page {
         await driver.get(this.ctx.urlFor(this.editPagePath(jobId)))
     }
 
-    async jobNameInput(){
+    async jobNameInput() {
         return await this.ctx.driver.findElement(Elems.jobNameInput)
     }
-    async groupPathInput(){
+    async groupPathInput() {
         return await this.ctx.driver.findElement(Elems.groupPathInput)
     }
-    async descriptionTextarea(){
+    async descriptionTextarea() {
         return await this.ctx.driver.findElement(Elems.descriptionTextarea)
+    }
+    async tagsInputArea() {
+        return await this.ctx.driver.findElement(Elems.tagsInputArea)
+    }
+    async tagsPillsArea() {
+        return await this.ctx.driver.findElement(Elems.tagsPillsArea)
     }
     async saveButton() {
         return this.ctx.driver.findElement(Elems.saveButton)

--- a/test/selenium/src/pages/jobCreate.page.ts
+++ b/test/selenium/src/pages/jobCreate.page.ts
@@ -20,6 +20,10 @@ export const Elems = {
     descriptionTextarea  : By.css('form textarea[name="description"]'),
     tagsInputArea  : By.css('div.tag-input-wrapper > input.form-control'),
     tagsPillsArea : By.css('ul.tags-list'),
+    groupChooseButton: By.css('span.btn[data-target="#groupChooseModal"]'),
+    groupChooseModal : By.css('div#groupChooseModal_content'),
+    modalGroupEntry : By.css('span.groupname.jobgroupexpand'),
+    modalCancel : By.css('button.btn[data-dismiss="modal"]'),
     // Workflow tab
     tabWorkflow  : By.css('#job_edit_tabs > li > a[href=\'#tab_workflow\']'),
     addNewWfStepButton: By.xpath('//*[@id="wfnewbutton"]/span'),

--- a/test/selenium/src/pages/jobCreate.page.ts
+++ b/test/selenium/src/pages/jobCreate.page.ts
@@ -18,8 +18,6 @@ export const Elems = {
     jobNameInput  : By.css('form input[name="jobName"]'),
     groupPathInput  : By.css('form input[name="groupPath"]'),
     descriptionTextarea  : By.css('form textarea[name="description"]'),
-    tagsInputArea  : By.css('div.tag-input-wrapper > input.form-control'),
-    tagsPillsArea : By.css('ul.tags-list'),
     groupChooseButton: By.css('span.btn[data-target="#groupChooseModal"]'),
     groupChooseInput : By.css('input#schedJobGroup'),
     groupChooseModal : By.css('div#groupChooseModal_content'),
@@ -121,12 +119,6 @@ export class JobCreatePage extends Page {
     }
     async descriptionTextarea() {
         return await this.ctx.driver.findElement(Elems.descriptionTextarea)
-    }
-    async tagsInputArea() {
-        return await this.ctx.driver.findElement(Elems.tagsInputArea)
-    }
-    async tagsPillsArea() {
-        return await this.ctx.driver.findElement(Elems.tagsPillsArea)
     }
     async groupChooseButton() {
         return await this.ctx.driver.findElement(Elems.groupChooseButton)

--- a/test/selenium/src/pages/jobCreate.page.ts
+++ b/test/selenium/src/pages/jobCreate.page.ts
@@ -4,11 +4,7 @@ import {Page} from '@rundeck/testdeck/page'
 import {Context} from '@rundeck/testdeck/context'
 
 export const Elems = {
-    jobNameInput  : By.css('form input[name="jobName"]'),
-    groupPathInput  : By.css('form input[name="groupPath"]'),
-    descriptionTextarea  : By.css('form textarea[name="description"]'),
-    tagsInputArea  : By.css('div.tag-input-wrapper > input.form-control'),
-    tagsPillsArea : By.css('ul.tags-list'),
+    // Common elements
     saveButton  : By.css('#Create'),
     updateButton  : By.css('#jobUpdateSaveButton'),
     cancelButton  : By.css('#createFormCancelButton'),
@@ -16,7 +12,15 @@ export const Elems = {
     editSaveButton: By.css('#editForm div.card-footer input.btn.btn-primary[type=submit][value=Save]'),
     errorAlert  : By.css('#error'),
     formValidationAlert: By.css('#page_job_edit > div.list-group-item > div.alert.alert-danger'),
-
+    storagebrowse: By.xpath('//*[starts-with(@id,"storagebrowse")]'),
+    storagebrowseClose: By.xpath('//*[@id="storagebrowse"]/div/div/div[3]/button[1]'),
+    // Details tab
+    jobNameInput  : By.css('form input[name="jobName"]'),
+    groupPathInput  : By.css('form input[name="groupPath"]'),
+    descriptionTextarea  : By.css('form textarea[name="description"]'),
+    tagsInputArea  : By.css('div.tag-input-wrapper > input.form-control'),
+    tagsPillsArea : By.css('ul.tags-list'),
+    // Workflow tab
     tabWorkflow  : By.css('#job_edit_tabs > li > a[href=\'#tab_workflow\']'),
     addNewWfStepButton: By.xpath('//*[@id="wfnewbutton"]/span'),
     addNewWfStepCommand: By.css('#wfnewtypes #addnodestep > div > a.add_node_step_type[data-node-step-type=command]'),
@@ -32,40 +36,6 @@ export const Elems = {
     option0KeySelector: By.xpath('//*[starts-with(@id,"defaultStoragePath")]'),
     option0OpenKeyStorage: By.css('.btn.btn-default.obs-select-storage-path'),
     option0li: By.css('#optli_0'),
-
-    storagebrowse: By.xpath('//*[starts-with(@id,"storagebrowse")]'),
-    storagebrowseClose: By.xpath('//*[@id="storagebrowse"]/div/div/div[3]/button[1]'),
-
-    notificationsTab: By.css("#job_edit_tabs > li > a[href=\'#tab_notifications\']"),
-    notificationsTabContent: By.css("#tab_notifications"),
-    enableNotifications: By.css('#notifiedTrue'),
-    notifyOnsuccessEmail: By.css('#notifyOnsuccessEmail'),
-    vueNotificationEditSection: By.css('#job-editor-notifications-vue'),
-    vueAddSuccessButton: By.css('#job-notifications-onstart > .list-group-item:first-child > button'),
-    vueEditNotificationModal: By.css('#job-notifications-edit-modal'),
-    vueEditNotificationModalSaveBtn: By.css('#job-notifications-edit-modal-btn-save'),
-    vueEditNotificationModalCancelBtn: By.css('#job-notifications-edit-modal-btn-cancel'),
-    vueEditNotificationPluginTypeDropdownButton: By.css('#notification-edit-type-dropdown > button'),
-    vueEditNotificationPluginTypeDropdownMenu: By.css('#notification-edit-type-dropdown > ul'),
-    vueNotificationConfig: By.css('#notification-edit-config'),
-    notifySuccessRecipients: By.css('#notifySuccessRecipients'),
-    tabNodes  : By.css('#job_edit_tabs > li > a[href=\'#tab_nodes\']'),
-    doNodedispatchTrue  : By.xpath('//*[@id="doNodedispatchTrue"]'),
-    nodeFilter  : By.xpath('//*[@id="schedJobNodeFilter"]'),
-    nodeFilterButton  : By.css('#job_edit__node_filter_include button.node_filter__dosearch'),
-    nodeFilterSelectAllLink  : By.css('#job_edit__node_filter_include .job_edit__node_filter__filter_select_all'),
-    nodeFilterMenuLink  : By.css('#job_edit__node_filter_include .job_edit__node_filter__filter_select_dropdown'),
-    matchedNodesText  : By.css('#nodegroupitem .node_filter_results__matched_nodes .node_filter_results__matched_nodes_count'),
-    showExcludedNodesRadioYes  : By.css('#nodegroupitem #excludeFilterTrue'),
-    editableFilterYes  : By.css('#nodegroupitem #editableTrue'),
-    schedJobnodeThreadcount: By.css('#nodegroupitem #schedJobnodeThreadcount'),
-    schedJobnodeRankAttribute: By.css('#nodegroupitem #schedJobnodeRankAttribute'),
-    nodeRankOrderDescending: By.css('#nodegroupitem #nodeRankOrderDescending'),
-    nodeKeepgoingTrue: By.css('#nodegroupitem #nodeKeepgoingTrue'),
-    successOnEmptyNodeFilterTrue: By.css('#nodegroupitem #successOnEmptyNodeFilterTrue'),
-    nodesSelectedByDefaultFalse: By.css('#nodegroupitem #nodesSelectedByDefaultFalse'),
-    orchestratorDropdown: By.css('#orchestrator-edit-type-dropdown'),
-    orchestratorDropdownButton: By.css('#orchestrator-edit-type-dropdown > button'),
     workflowStrategy  : By.xpath('//*[@id="workflow.strategy"]'),
     strategyPluginparallel: By.xpath('//*[@id="strategyPluginparallel"]'),
     strategyPluginparallelMsg: By.xpath('//*[@id="strategyPluginparallel"]/span/span'),
@@ -78,22 +48,56 @@ export const Elems = {
     revertOptionsConfirm: By.xpath('//*[starts-with(@id,"popover")]/div[2]/span[2]'),
 
     wfUndoButton: By.xpath('//*[@id="wfundoredo"]/div/span[1]'),
-    //wfUndoButton: By.css('#wfundoredo > div > span.btn.btn-xs.btn-default.act_undo.flash_undo'),
+    // wfUndoButton: By.css('#wfundoredo > div > span.btn.btn-xs.btn-default.act_undo.flash_undo'),
     wfRedoButton: By.xpath('//*[@id="wfundoredo"]/div/span[2]'),
-    //wfRedoButton: By.css('#wfundoredo > div > span.btn.btn-xs.btn-default.act_redo.flash_undo'),
+    // wfRedoButton: By.css('#wfundoredo > div > span.btn.btn-xs.btn-default.act_redo.flash_undo'),
     revertWfButton: By.xpath('//*[@id="wfundoredo"]/div/span[3]'),
-    revertWfConfirm: By.xpath('//*[starts-with(@id,"popover")]/div[2]/span[2]')
-
+    revertWfConfirm: By.xpath('//*[starts-with(@id,"popover")]/div[2]/span[2]'),
+    // Notifications Tab
+    notificationsTab: By.css('#job_edit_tabs > li > a[href=\'#tab_notifications\']'),
+    notificationsTabContent: By.css('#tab_notifications'),
+    enableNotifications: By.css('#notifiedTrue'),
+    notifyOnsuccessEmail: By.css('#notifyOnsuccessEmail'),
+    vueNotificationEditSection: By.css('#job-editor-notifications-vue'),
+    vueAddSuccessButton: By.css('#job-notifications-onstart > .list-group-item:first-child > button'),
+    vueEditNotificationModal: By.css('#job-notifications-edit-modal'),
+    vueEditNotificationModalSaveBtn: By.css('#job-notifications-edit-modal-btn-save'),
+    vueEditNotificationModalCancelBtn: By.css('#job-notifications-edit-modal-btn-cancel'),
+    vueEditNotificationPluginTypeDropdownButton: By.css('#notification-edit-type-dropdown > button'),
+    vueEditNotificationPluginTypeDropdownMenu: By.css('#notification-edit-type-dropdown > ul'),
+    vueNotificationConfig: By.css('#notification-edit-config'),
+    notifySuccessRecipients: By.css('#notifySuccessRecipients'),
+    // Nodes tab
+    tabNodes  : By.css('#job_edit_tabs > li > a[href=\'#tab_nodes\']'),
+    doNodedispatchTrue  : By.xpath('//*[@id="doNodedispatchTrue"]'),
+    nodeFilter  : By.xpath('//*[@id="schedJobNodeFilter"]'),
+    nodeFilterButton  : By.css('#job_edit__node_filter_include button.node_filter__dosearch'),
+    nodeFilterSelectAllLink  : By.css('#job_edit__node_filter_include .job_edit__node_filter__filter_select_all'),
+    nodeFilterMenuLink  : By.css('#job_edit__node_filter_include .job_edit__node_filter__filter_select_dropdown'),
+    matchedNodesText  : By.css('#nodegroupitem .node_filter_results__matched_nodes .node_filter_results__matched_nodes_count'),
+    showExcludedNodesRadioYes  : By.css('#nodegroupitem #excludeFilterTrue'),
+    editableFilterYes  : By.css('#nodegroupitem #editableTrue'),
+    nodeRankOrderDescending: By.css('#nodegroupitem #nodeRankOrderDescending'),
+    nodeKeepgoingTrue: By.css('#nodegroupitem #nodeKeepgoingTrue'),
+    successOnEmptyNodeFilterTrue: By.css('#nodegroupitem #successOnEmptyNodeFilterTrue'),
+    nodesSelectedByDefaultFalse: By.css('#nodegroupitem #nodesSelectedByDefaultFalse'),
+    orchestratorDropdown: By.css('#orchestrator-edit-type-dropdown'),
+    orchestratorDropdownButton: By.css('#orchestrator-edit-type-dropdown > button'),
+    // Schedule tab
+    schedJobnodeThreadcount: By.css('#nodegroupitem #schedJobnodeThreadcount'),
+    schedJobnodeRankAttribute: By.css('#nodegroupitem #schedJobnodeRankAttribute')
+    // Execution Plugins tab
+    // Other tab
+    // Job Queue tab
 }
-
 
 export class JobCreatePage extends Page {
     path = '/resources/createProject'
-    projectName=''
+    projectName = ''
 
     constructor(readonly ctx: Context, readonly project: string) {
         super(ctx)
-        this.projectName=project
+        this.projectName = project
         this.path = `/project/${project}/job/create`
     }
     editPagePath(jobId: string){

--- a/test/selenium/src/pages/jobShow.page.ts
+++ b/test/selenium/src/pages/jobShow.page.ts
@@ -5,6 +5,7 @@ import { Context } from '@rundeck/testdeck/context'
 
 export const Elems = {
   jobTitleLink: By.css('#jobInfo_ > span > a.job-header-link'),
+  jobTags: By.css('ul#tagsList > li.tag-pill-li'),
   jobUuidText: By.css('#subtitlebar.job-page > div > div > section > small.uuid'),
   jobDescription: By.css('#subtitlebar.job-page > div > div > div.jobInfoSection > section > span.h5'),
   optionInput: By.css('#8f95c8d5_seleniumOption1'),
@@ -37,6 +38,9 @@ export class JobShowPage extends Page {
   }
   async jobEditButton(){
     return await this.ctx.driver.findElement(Elems.jobEditButton)
+  }
+  async jobTags(){
+    return await this.ctx.driver.findElements(Elems.jobTags)
   }
   async jobActionDropdown(){
     return await this.ctx.driver.findElement(Elems.jobActionDropdown)

--- a/test/selenium/src/pages/jobShow.page.ts
+++ b/test/selenium/src/pages/jobShow.page.ts
@@ -4,6 +4,7 @@ import {Page} from '@rundeck/testdeck/page'
 import { Context } from '@rundeck/testdeck/context'
 
 export const Elems = {
+  jobGroup : By.css('div.jobInfoSection a.text-secondary'),
   jobTitleLink: By.css('#jobInfo_ > span > a.job-header-link'),
   jobTags: By.css('ul#tagsList > li.tag-pill-li'),
   jobUuidText: By.css('#subtitlebar.job-page > div > div > section > small.uuid'),
@@ -33,6 +34,13 @@ export class JobShowPage extends Page {
   }
 
 
+  async jobGroup() {
+    return await this.ctx.driver.findElement(Elems.jobGroup)
+  }
+  async jobGroupText() {
+    const jobGroup = await this.jobGroup()
+    return await jobGroup.getText()
+  }
   async jobTitleLink(){
     return await this.ctx.driver.findElement(Elems.jobTitleLink)
   }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
A clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing.

**Describe the solution you've implemented**
This expands the test suites and selectors to test everything on the Details pane of the Job Edit page. It also changes the order and method of checking the changes on the Job Show page. It does this reliant on the synchronous execution of `describe` blocks, which causes need for only one load of the edit page, and one of the show page.

**Describe alternatives you've considered**
I considered not adding the optimizations, but I didn't want to continue down the path of going between edit and show pages for each individual test.

**Additional context**
Add any other context or screenshots about the change here.
