### PR TITLE
RUN-617: Fix/2207 import job with many same type notif

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -389,8 +389,8 @@ class ScheduledExecution extends ExecutionContext implements EmbeddedJsonData {
                     trigger.add(map1)
                 }
             }
-            map.keySet().findAll{it.startsWith('on')}.each { trigger ->
-                map.notification[trigger].find({ notif -> notif.plugin }).plugin.sort{ a, b -> a.type <=> b.type }
+            map.notification.keySet().findAll{it.startsWith('on')}.each { trigger ->
+                map.notification[trigger].find{ notif -> notif.plugin }.plugin.sort{ a, b -> a.type <=> b.type }
             }
             map.notifyAvgDurationThreshold = notifyAvgDurationThreshold
         }

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -390,7 +390,7 @@ class ScheduledExecution extends ExecutionContext implements EmbeddedJsonData {
                 }
             }
             map.notification.keySet().findAll{it.startsWith('on')}.each { trigger ->
-                map.notification[trigger].find{ notif -> notif.plugin }.plugin.sort{ a, b -> a.type <=> b.type }
+                map.notification[trigger].find{ notif -> notif.plugin }?.plugin?.sort{ a, b -> a.type <=> b.type }
             }
             map.notifyAvgDurationThreshold = notifyAvgDurationThreshold
         }

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -205,6 +205,7 @@ class ScheduledExecution extends ExecutionContext implements EmbeddedJsonData {
         groupPath type: 'string'
 //        orchestrator type: 'text'
         //options lazy: false
+        notifications sort: 'id', order: 'asc'
         timeout(type: 'text')
         retry(type: 'text')
         retryDelay(type: 'text')

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -2952,7 +2952,6 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 n.scheduledExecution = scheduledExecution
                 scheduledExecution.addToNotifications(n)
             }
-
             addedNotifications << n
         }
         //delete notifications that are not part of the modified set

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -2936,38 +2936,19 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
             }.findAll{it}
         }
-        def addedNotifications=[]
-        if(!scheduledExecution.notifications) replaceAll = true
-        notificationSet.each{Notification n->
-            //modify existing notification
-            Notification oldn = replaceAll?null:scheduledExecution.findNotification(n.eventTrigger,n.type)//TODO: WHY DO WE DELETE EXISTING NOTIFICATIONS
-            if(oldn){
-                oldn.content=n.content
-                oldn.format=n.format
-                def x=n
-                n=oldn
-                n.scheduledExecution = scheduledExecution
-                x.discard()
-            }else{
-                n.scheduledExecution = scheduledExecution
-                scheduledExecution.addToNotifications(n)
-            }
-            addedNotifications << n
-        }
-        //delete notifications that are not part of the modified set
+
         if (scheduledExecution.notifications) {
-            List<Notification> todelete = []
-            scheduledExecution.notifications.each { Notification note ->
-                if(!(note in addedNotifications)){
-                    todelete << note
-                }
-            }
-            todelete.each {
+            List<Notification> toDelete = []
+            scheduledExecution.notifications.each { Notification notif -> toDelete << notif }
+            toDelete.each {
                 it.delete()
                 scheduledExecution.removeFromNotifications(it)
-//                todiscard << it
             }
+        }
 
+        notificationSet.each{Notification notif->
+            notif.scheduledExecution = scheduledExecution
+            scheduledExecution.addToNotifications(notif)
         }
     }
 

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -2937,9 +2937,10 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             }.findAll{it}
         }
         def addedNotifications=[]
+        if(!scheduledExecution.notifications) replaceAll = true
         notificationSet.each{Notification n->
             //modify existing notification
-            Notification oldn = replaceAll?null:scheduledExecution.findNotification(n.eventTrigger,n.type)
+            Notification oldn = replaceAll?null:scheduledExecution.findNotification(n.eventTrigger,n.type)//TODO: WHY DO WE DELETE EXISTING NOTIFICATIONS
             if(oldn){
                 oldn.content=n.content
                 oldn.format=n.format
@@ -2949,11 +2950,9 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 x.discard()
             }else{
                 n.scheduledExecution = scheduledExecution
-            }
-
-            if(!oldn){
                 scheduledExecution.addToNotifications(n)
             }
+
             addedNotifications << n
         }
         //delete notifications that are not part of the modified set

--- a/rundeckapp/grails-app/utils/rundeck/codecs/JobsXMLCodec.groovy
+++ b/rundeckapp/grails-app/utils/rundeck/codecs/JobsXMLCodec.groovy
@@ -283,17 +283,17 @@ class JobsXMLCodec {
                 plugin['configuration']=confMap
             }
 
-            def setValidNotifData = { Map notifData, String notifType, String trigger ->
+            def setValidNotifData = { notifData, String notifType, String trigger ->
                 if(!notifType.equals('plugin')){
                     Map notifItem = [:]
                     if(notifType.equals('webhook')){
-                        if(!notifData.urls){
+                        if(notifData.urls==null){
                             throw new JobXMLException("${trigger} webhook had blank or missing 'urls' attribute")
                         }
                         notifItem = notifData
                     }
                     else if(notifType.equals('email')){
-                        if(!notifData.recipients){
+                        if(notifData.size() < 1 || notifData.recipients==null || notifData.recipients.size() < 1){
                             throw new JobXMLException("${trigger} email had blank or missing 'recipients' attribute")
                         }
                         notifItem[notifType] = notifData
@@ -303,10 +303,10 @@ class JobsXMLCodec {
                     if (notifData.size() < 1) {
                         throw new JobXMLException("${trigger} plugin element was empty")
                     }
-                    if (!notifData.type) {
+                    if (notifData.type==null) {
                         throw new JobXMLException("${trigger} plugin had blank or missing 'type' attribute")
                     }
-                    if (!notifData.configuration) {
+                    if (notifData.configuration==null) {
                         throw new JobXMLException("${trigger} plugin had blank or missing 'configuration' element")
                     }
                     convertPluginToMap(notifData)
@@ -317,7 +317,7 @@ class JobsXMLCodec {
             }
 
             triggers.each{trigger->
-                if(!map.notification[trigger].email && !map.notification[trigger].webhook && !map.notification[trigger].plugin){
+                if((map.notification[trigger].size() < 1) || (map.notification[trigger].email==null && map.notification[trigger].webhook==null && map.notification[trigger].plugin==null)){
                     throw new JobXMLException("notification '${trigger}' element had missing 'email' or 'webhook' or 'plugin' element")
                 }
                 final def xmlNotif = map.notification[trigger]

--- a/rundeckapp/grails-app/utils/rundeck/codecs/JobsXMLCodec.groovy
+++ b/rundeckapp/grails-app/utils/rundeck/codecs/JobsXMLCodec.groovy
@@ -356,8 +356,10 @@ class JobsXMLCodec {
                 final def xmlNotif = map.notification[trigger]
                 map.notification[trigger] = []
                 if(isOldFormat && xmlNotif['webhook']){
-                    xmlNotif['webhook']['format'] = xmlNotif.remove('format')
-                    xmlNotif['webhook']['httpMethod'] = xmlNotif.remove('httpMethod')
+                    if(xmlNotif['format'] && xmlNotif['httpMethod']){
+                        xmlNotif['webhook']['format'] = xmlNotif.remove('format')
+                        xmlNotif['webhook']['httpMethod'] = xmlNotif.remove('httpMethod')
+                    }
                 }
 
                 xmlNotif.each { notifEntry ->

--- a/rundeckapp/grails-app/utils/rundeck/codecs/JobsXMLCodec.groovy
+++ b/rundeckapp/grails-app/utils/rundeck/codecs/JobsXMLCodec.groovy
@@ -297,7 +297,7 @@ class JobsXMLCodec {
             if(!map.notification || !(map.notification instanceof Map)){
                 throw new JobXMLException("notification section had no trigger elements")
             }
-            def triggers = map.notification?.keySet().findAll { it.startsWith('on') }
+            def triggers = map.notification?.keySet()
             if( !triggers){
                 throw new JobXMLException("notification section had no trigger elements")
             }
@@ -660,7 +660,7 @@ class JobsXMLCodec {
                 }
             }
             boolean useOldWebhookFormat = useOldFormat(map.notification, true)
-            map.notification.keySet().sort().findAll { it.startsWith('on') }.each { trigger ->
+            map.notification.keySet().sort()?.each { trigger ->
                 ArrayList triggerNotifs = map.notification[trigger]
                 map.notification[trigger] = [:]
                 triggerNotifs?.each {notif ->

--- a/rundeckapp/grails-app/utils/rundeck/codecs/JobsXMLCodec.groovy
+++ b/rundeckapp/grails-app/utils/rundeck/codecs/JobsXMLCodec.groovy
@@ -109,10 +109,13 @@ class JobsXMLCodec {
 
     /**
      * Checks if the given notification map follows or should follow the old format
+     * @param notificationMap
+     * @param isCanonicalJobMap true if the given map is a canonical scheduled execution map
+     * @return false if notificationMap has more than one notification of the same type in any trigger
      */
-    static boolean useOldFormat(Map notificationMap, boolean isScheduleMap){
+    static boolean useOldFormat(Map notificationMap, boolean isCanonicalJobMap){
         boolean useOld
-        if(isScheduleMap) {
+        if(isCanonicalJobMap) {
             def hasMany = notificationMap.find { Map.Entry triggerEntry ->
                 Map notifsAmount = [:]
                 return triggerEntry.value.find{ Map notifEntry ->
@@ -694,7 +697,6 @@ class JobsXMLCodec {
                             xmlNotif = [:]
                             map.notification[trigger][entry.key] = entry.value
                         }
-
                     }else{
                         if(!map.notification[trigger][xmlNotifType]) map.notification[trigger][xmlNotifType] = []
                         if(notif.xmlNotif instanceof Collection)

--- a/rundeckapp/src/integration-test/groovy/rundeck/codecs/JobsYAMLCodecIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/codecs/JobsYAMLCodecIntegrationSpec.groovy
@@ -17,7 +17,6 @@
 package rundeck.codecs
 
 import grails.testing.mixin.integration.Integration
-import org.junit.Test
 import org.yaml.snakeyaml.Yaml
 import rundeck.CommandExec
 import rundeck.JobExec

--- a/rundeckapp/src/main/groovy/org/rundeck/app/components/JobYAMLFormat.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/components/JobYAMLFormat.groovy
@@ -43,7 +43,7 @@ class JobYAMLFormat implements JobFormat {
     @CompileStatic(TypeCheckingMode.SKIP)
     List<Map> decode(final Reader reader) throws JobDefinitionException {
         Yaml yaml = new Yaml(new SafeConstructor())
-        Collection<Map> data = yaml.load(reader)
+        def data = yaml.load(reader)
         if (!(data instanceof List)) {
             throw new JobDefinitionException("Yaml: Expected list data")
         }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/components/JobYAMLFormat.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/components/JobYAMLFormat.groovy
@@ -128,6 +128,8 @@ class JobYAMLFormat implements JobFormat {
 
     /**
      * Checks if the given notification map follows or should follow the old format
+     * @param notificationMap canonical job map
+     * @return false if notificationMap has more than one notification of the same type in any trigger
      */
     static boolean useOldFormat(Map notificationMap){
         boolean useOld

--- a/rundeckapp/src/test/groovy/org/rundeck/app/components/JobXMLFormatSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/components/JobXMLFormatSpec.groovy
@@ -1,0 +1,101 @@
+package org.rundeck.app.components
+
+import org.rundeck.app.components.jobs.JobFormat
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class JobXMLFormatSpec extends Specification {
+    @Unroll
+    def "should return a notification map with email and webhook notifs"() {
+        given:
+        def input = "" +
+        "<joblist>\n" +
+        "  <job>\n" +
+        "    <defaultTab>nodes</defaultTab>\n" +
+        "    <description></description>\n" +
+        "    <loglevel>INFO</loglevel>\n" +
+        "    <name>a</name>\n" +
+        "    <nodeFilterEditable>false</nodeFilterEditable>\n" +
+        "    <notification>\n" +
+        "      <onsuccess>\n" +
+        "        <email attachLog='true' attachLogInFile='true' recipients='leojesus.juarez@gmail.com' subject='RD-SUCCESS' />\n" +
+        "        <webhook format='xml' httpMethod='get' urls='http://localhost:4440/project' />\n" +
+        "        <webhook format='json' httpMethod='post' urls='http://localhost:4440/project' />\n" +
+        "        <email attachLog='true' attachLogInline='true' recipients='2@gmail.com' subject='RD-SUCCESS' />\n" +
+        "      </onsuccess>\n" +
+        "    </notification>\n" +
+        "    <notifyAvgDurationThreshold />\n" +
+        "    <plugins />\n" +
+        "    <scheduleEnabled>true</scheduleEnabled>\n" +
+        "    <schedules />\n" +
+        "    <sequence keepgoing='false' strategy='node-first'>\n" +
+        "      <command>\n" +
+        "        <exec>asd</exec>\n" +
+        "      </command>\n" +
+        "    </sequence>\n" +
+        "  </job>\n" +
+        "</joblist>"
+        def sut = new JobXMLFormat()
+        when:
+        def result = sut.decode(new StringReader(input))
+        then:
+        result[0].notification['onsuccess'].size() == 4
+        result[0].notification['onsuccess'].findAll{ it['email'] != null }.size() == 2
+        result[0].notification['onsuccess'].findAll{ it['urls'] != null }.size() == 2
+    }
+
+    @Unroll
+    def "should return an xml str with email and webhook tags"() {
+        given:
+        List<Map> input = [[
+                id: 0,
+                defaultTab: "nodes",
+                description: "",
+                loglevel: "INFO",
+                name: "a",
+                nodeFilterEditable: false,
+                notification: [
+                        onsuccess: [
+                                [email: [recipients: "mail@example.com"]],
+                                [email: [recipients: "mail2@example.com"]],
+                                [
+                                        format: "xml",
+                                        httpMethod: "get",
+                                        urls: "http://example1.com/1"
+                                ],
+                                [
+                                        format: "json",
+                                        httpMethod: "post",
+                                        urls: "https://example2.com/2"
+                                ]
+                        ]
+                ],
+                notifyAvgDurationThreshold: "",
+                plugins: "",
+                scheduledEnabled: "true",
+                schedules: "",
+                sequence: [
+                        keepgoing: false,
+                        strategy: "node-first",
+                        commands: [[exec:"asd"]]
+                ],
+                executionEnabled: true,
+                multipleExecutions: false
+        ]]
+        def sut = new JobXMLFormat()
+        def writer = new StringWriter()
+        def options = JobFormat.options(true, [:], (String) null)
+
+        when:
+        sut.encode(input, options, writer)
+        String notifStr = writer.toString()
+        notifStr = notifStr.substring(notifStr.indexOf("<onsuccess>") + "<onsuccess>".length())
+        notifStr = notifStr.substring(0,notifStr.indexOf("</onsuccess>")).replaceAll("\\s","")
+
+        then:
+        notifStr.contains("<emailrecipients='mail@example.com'/>")
+        notifStr.contains("<emailrecipients='mail2@example.com'/>")
+        notifStr.contains("<webhookformat='xml'httpMethod='get'urls='http://example1.com/1'/>")
+        notifStr.contains("<webhookformat='json'httpMethod='post'urls='https://example2.com/2'/>")
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/JobsXMLCodecTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobsXMLCodecTests.groovy
@@ -1,8 +1,5 @@
 package rundeck
 
-import grails.test.mixin.TestFor
-import grails.test.mixin.TestMixin
-import grails.test.mixin.web.ControllerUnitTestMixin
 import groovy.xml.MarkupBuilder
 
 /*

--- a/rundeckapp/src/test/groovy/rundeck/JobsYAMLCodecTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobsYAMLCodecTests.groovy
@@ -245,7 +245,7 @@ public class JobsYAMLCodecTests  {
         assertNotNull doc
         assertEquals(1,doc[0].notification.size())
         assertEquals(1,doc[0].notification.onsuccess.size())
-        assertEquals([type:'test1', configuration:['blah':'blee']],doc[0].notification.onsuccess.plugin[0][0])
+        assertEquals([type:'test1', configuration:['blah':'blee']],doc[0].notification.onsuccess.plugin)
 
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/JobsYAMLCodecTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobsYAMLCodecTests.groovy
@@ -245,7 +245,7 @@ public class JobsYAMLCodecTests  {
         assertNotNull doc
         assertEquals(1,doc[0].notification.size())
         assertEquals(1,doc[0].notification.onsuccess.size())
-        assertEquals([type:'test1', configuration:['blah':'blee']],doc[0].notification.onsuccess.plugin)
+        assertEquals([type:'test1', configuration:['blah':'blee']],doc[0].notification.onsuccess.plugin[0][0])
 
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionSpec.groovy
@@ -19,7 +19,6 @@ package rundeck
 import grails.test.hibernate.HibernateSpec
 import org.eclipse.jetty.util.ajax.JSON
 import testhelper.RundeckHibernateSpec
-
 import static org.junit.Assert.*
 
 /**

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionSpec.groovy
@@ -67,7 +67,9 @@ class ScheduledExecutionSpec extends RundeckHibernateSpec
             def map = [
                     jobName: 'abc',
                     notification: [
-                            onFailure: [urls:"url1", format: "JSON", httpMethod: "POST"]
+                            onFailure: [
+                                [urls:"url1", format: "JSON", httpMethod: "POST"]
+                            ]
                     ]
             ]
         when:

--- a/rundeckapp/src/test/groovy/rundeck/codecs/JobsYAMLCodecSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/codecs/JobsYAMLCodecSpec.groovy
@@ -78,13 +78,15 @@ class JobsYAMLCodecSpec extends Specification {
         doc.size() == 1
         doc[0].name == 'test job 1'
         doc[0].notification.onsuccess.size() == 1
-        doc[0].notification.onsuccess.plugin.size() == 3
+        doc[0].notification.onsuccess.plugin[0].size() == 3
         def expectorder = ['aplugin', 'bplugin', 'zplugin']
         def conforder = ['a', 'c', 'z']
-        doc[0].notification.onsuccess.plugin.collect { it.type } == expectorder
+        doc[0].notification.onsuccess.plugin.collect { it.type }[0] == expectorder
+
+        doc[0].notification.onsuccess.plugin
         (0..2).each { i ->
-            doc[0].notification.onsuccess.plugin[i].type == expectorder[i]
-            doc[0].notification.onsuccess.plugin[i].configuration.keySet().toList() == conforder
+            doc[0].notification.onsuccess.plugin[0][i].type == expectorder[i]
+            doc[0].notification.onsuccess.plugin[0][i].configuration.keySet().toList() == conforder
         }
 
         where:


### PR DESCRIPTION
Rundeck never supported export/import of multiple notifications of the same type in the same trigger (same code since 2014).

Fix: https://github.com/rundeckpro/rundeckpro/issues/2207
Fix: https://github.com/rundeck/rundeck/issues/7496
Fix: https://github.com/rundeck/rundeck/issues/7642

## NOTE
It now supports import/export multiple notifications in the same trigger:
 * Compatibility with previous versions is kept. 
 * xml webhook element now has all its attributes inside `<webhook format='xml' httpMethod='post' urls='http://asdfasdfas.com' />`
 * In yaml, use list of objects when having more than one notification of some type in a trigger.
 * **If there are not 2 or more notifications of the same type in the same trigger in the job, IT WILL BE EXPORTED USING PREVIOUS VERSIONS OF YAML/XML FORMAT**
#### 

Some examples of valid job definitions:
```
<notification>
      <onsuccess>
        <email attachLog='true' attachLogInFile='true' recipients='9xmpl@xmpl.com' subject='9xmpl' />
        <plugin type='splunk-json-collector'>
          <configuration>
            <entry key='hostname' value='https://localhost234.com' />
          </configuration>
        </plugin>
        <webhook format='xml' httpMethod='post' urls='http://asdfasdfas.com' />
      </onsuccess>
    </notification>
```
```
notification:
    onsuccess:
    - format: xml
      httpMethod: post
      urls: http://asdfasdfas.com
    - email:
        attachLog: true
        attachLogInFile: true
        recipients: 9xmpl@xmpl.com
        subject: 9xmpl
    - plugin:
      - configuration:
          some-key: some-value
        type: splunk-json-collector
```
```
<notification>
      <onsuccess>
        <email attachLog='true' attachLogInline='true' recipients='0xmpl@xmpl.com' subject='0xmpl' />
        <email attachLog='true' attachLogInFile='true' recipients='9xmpl@xmpl.com' subject='9xmpl' />
        <plugin type='splunk-json-collector'>
          <configuration>
            <entry key='hostname' value='https://localhost234.com' />
          </configuration>
        </plugin>
        <plugin type='splunk-json-collector'>
          <configuration>
            <entry key='hostname' value='https://localhost234.com' />
          </configuration>
        </plugin>
        <webhook format='xml' httpMethod='post' urls='http://asdfasdfas.com' />
      </onsuccess>
    </notification>
```
```
notification:
    onfailure:
    - email:
        recipients: 'tom@example.com,shirley@example.com'
    - email:
        attachLog: 'true'
        attachLogInline: true
        recipients: manager@example.com
        subject: JOB-FAILURE
    onretryablefailure:
      plugin:
      - type: splunk-raw-collector
        configuration:
          somekey: somevalue
      - type: splunk-raw-collector
        configuration:
          somekey: somevalue
    onstart:
      email:
        attachLog: true
        attachLogInFile: true
        recipients: tom@example.com
        subject: JOB-STARTED
```