### PR TITLE
RUN-632: Fix vue console errors

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/navbar/NavBarDrawer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/navbar/NavBarDrawer.vue
@@ -11,9 +11,11 @@
 import Vue from 'vue'
 
 export default Vue.extend({
-    data: {
-        display: false,
-        opening: false
+    data(){
+        return  {
+            display: false,
+            opening: false
+        }
     },
     mounted() {
         const drawer = this.$refs['drawer'] as HTMLElement

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/utility-bar/Popper.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/utility-bar/Popper.vue
@@ -18,9 +18,11 @@ export default Vue.extend({
         }
     },
 
-    data: {
-        parent: null as HTMLElement | null,
-        instance: null as Instance | null
+    data(){
+        return {
+            parent: null as HTMLElement | null,
+            instance: null as Instance | null
+        }
     },
 
     mounted() {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/utils/OffsetPagination.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/utils/OffsetPagination.vue
@@ -31,7 +31,7 @@ Vue.component('pagination', Pagination)
 
 @Component
 export default class OffsetPagination extends Vue {
-  currentPage!: number
+  currentPage: number=0
 
   @Prop({required: true})
   pagination: any


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Fix some errors in browser JS console due to Vue, e.g on Execution/show page:

* error about `data` must be a function
* error about `currentPage` of OffsetPagination component

---
Console errors:

```
vue.js?compile=false:635 [Vue warn]: The "data" option should be a function that returns a per-instance value in component definitions.
```

```
vue.js?compile=false:635 [Vue warn]: Property or method "currentPage" is not defined on the instance but referenced during render. Make sure that this property is reactive, either in the data option, or for class-based components, by initializing the property. See: https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties.

found in

---> <OffsetPagination> at src/components/utils/OffsetPagination.vue
       <ActivityList> at src/components/activity/activityList.vue
         <Root>
```