### PR TITLE
RUN-631: Remove execution 'follow' action which duplicates 'show'

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -92,13 +92,10 @@ class ExecutionController extends ControllerBase{
         redirect(controller:'menu',action:'index')
     }
 
-    @RdAuthorizeExecution(RundeckAccess.Execution.AUTH_APP_READ_OR_VIEW)
     def follow() {
-        def m = show()
-        if(response.status != 302) {
-            render(view:'show',model:m)
-        }
+        return redirect(action: 'show', controller: 'execution', params: params)
     }
+
     @RdAuthorizeExecution(RundeckAccess.Execution.AUTH_APP_READ_OR_VIEW)
     def followFragment() {
         return render(view:'showFragment',model:show())

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2525,10 +2525,10 @@ class ScheduledExecutionController  extends ControllerBase{
                 link =createLink(controller: "execution", action: "renderOutput", id: results.id,
                         params:[convertContent:'on', loglevels:'on', ansicolor:'on', project:params.project, reload:'true'])
             }else{
-                link =createLink(controller: "execution",action: "follow",id: results.id, fragment: params.followdetail)
+                link =createLink(controller: "execution",action: "show",id: results.id, fragment: params.followdetail)
             }
         } else {
-            link = createLink(controller: "execution", action: "follow", id: results.id)
+            link = createLink(controller: "execution", action: "show", id: results.id)
         }
         boolean follow_ = params.follow == 'true'
         return render(contentType:'application/json'){
@@ -2572,10 +2572,10 @@ class ScheduledExecutionController  extends ControllerBase{
             if(params.followdetail=='html'){
                 link =createLink(controller: "execution", action: "renderOutput", id: results.id, params:[convertContent:'on', loglevels:'on', ansicolor:'on', project:params.project, reload:'true'])
             }else{
-                link =createLink(controller: "execution",action: "follow",id: results.id, fragment: params.followdetail)
+                link =createLink(controller: "execution",action: "show",id: results.id, fragment: params.followdetail)
             }
         }else {
-            link = createLink(controller: "execution", action: "follow", id: results.id)
+            link = createLink(controller: "execution", action: "show", id: results.id)
         }
         boolean follow_ = params.follow == 'true'
 
@@ -2633,7 +2633,7 @@ class ScheduledExecutionController  extends ControllerBase{
             if(params.followdetail=='html'){
                 redirect(controller: "execution", action: "renderOutput", id: results.id, params:[convertContent:'on', loglevels:'on', ansicolor:'on', project:params.project, reload:'true'])
             }else{
-                redirect(controller: "execution", action: "follow", id: results.id, params:[outdetails: params.followdetail])
+                redirect(controller: "execution", action: "show", id: results.id, params:[outdetails: params.followdetail])
             }
         } else {
             redirect(controller: "scheduledExecution", action: "show", id: params.id)

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1000,7 +1000,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     }
 
     static String generateExecutionURL(Execution execution,LinkGenerator grailsLinkGenerator) {
-        grailsLinkGenerator.link(controller: 'execution', action: 'follow', id: execution.id, absolute: true,
+        grailsLinkGenerator.link(controller: 'execution', action: 'show', id: execution.id, absolute: true,
                 params: [project: execution.project])
     }
     static String generateServerURL(LinkGenerator grailsLinkGenerator) {

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -609,7 +609,7 @@ public class NotificationService implements ApplicationContextAware{
         apiService.renderExecutionsXml(execlist.collect{ Execution e->
             [
                 execution:e,
-                href: grailsLinkGenerator.link(controller: 'execution', action: 'follow', id: e.id, absolute: true,
+                href: grailsLinkGenerator.link(controller: 'execution', action: 'show', id: e.id, absolute: true,
                         params: [project: e.project]),
                 status: e.executionState,
                 summary: executionService.summarizeJob(e.scheduledExecution, e)
@@ -623,7 +623,7 @@ public class NotificationService implements ApplicationContextAware{
         apiService.renderExecutionsJson(execlist.collect{ Execution e->
             [
                     execution:e,
-                    href: grailsLinkGenerator.link(controller: 'execution', action: 'follow', id: e.id, absolute: true,
+                    href: grailsLinkGenerator.link(controller: 'execution', action: 'show', id: e.id, absolute: true,
                                                    params: [project: e.project]),
                     status: e.executionState,
                     summary: executionService.summarizeJob(e.scheduledExecution, e)
@@ -688,7 +688,7 @@ public class NotificationService implements ApplicationContextAware{
         def modifiedSuccessNodeList = executionService.getEffectiveSuccessNodeList(e)
         def emap = [
             id: e.id,
-            href: grailsLinkGenerator.link(controller: 'execution', action: 'follow', id: e.id, absolute: true,
+            href: grailsLinkGenerator.link(controller: 'execution', action: 'show', id: e.id, absolute: true,
                     params: [project: e.project]),
             status: e.executionState,
             user: e.user,

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -1074,7 +1074,6 @@ class ExecutionControllerSpec extends HibernateSpec implements ControllerUnitTes
             'downloadOutput'         | RundeckAccess.Execution.AUTH_APP_READ_OR_VIEW
             'renderOutput'           | RundeckAccess.Execution.AUTH_APP_READ_OR_VIEW
             'show'                   | RundeckAccess.Execution.AUTH_APP_READ_OR_VIEW
-            'follow'                 | RundeckAccess.Execution.AUTH_APP_READ_OR_VIEW
             'followFragment'         | RundeckAccess.Execution.AUTH_APP_READ_OR_VIEW
             'ajaxExecNodeState'      | RundeckAccess.Execution.AUTH_APP_READ_OR_VIEW
             'apiExecution'           | RundeckAccess.Execution.AUTH_APP_READ_OR_VIEW

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -910,7 +910,7 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         response.status == 200
         response.contentType.contains 'application/json'
         response.json == [
-                href   : "/execution/follow/${exec.id}",
+                href   : "/execution/show/${exec.id}",
                 success: true,
                 id     : exec.id,
                 follow : false
@@ -976,7 +976,7 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         response.status == 200
         response.contentType.contains 'application/json'
         response.json == [
-                href   : "/execution/follow/${exec.id}",
+                href   : "/execution/show/${exec.id}",
                 success: true,
                 id     : exec.id,
                 follow : false
@@ -1049,7 +1049,7 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         response.status == 200
         response.contentType.contains 'application/json'
         response.json == [
-                href   : "/execution/follow/${exec.id}",
+                href   : "/execution/show/${exec.id}",
                 success: true,
                 id     : exec.id,
                 follow : false
@@ -1120,7 +1120,7 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         response.contentType.contains 'application/json'
         if(follow != 'html'){
             response.json == [
-                    href   : "/execution/follow/${exec.id}#"+follow,
+                    href   : "/execution/show/${exec.id}#"+follow,
                     success: true,
                     id     : exec.id,
                     follow : false
@@ -1206,7 +1206,7 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         response.status == 200
         response.contentType.contains 'application/json'
         response.json == [
-                href   : "/execution/follow/${exec.id}",
+                href   : "/execution/show/${exec.id}",
                 success: true,
                 id     : exec.id,
                 follow : false
@@ -1279,7 +1279,7 @@ class ScheduledExecutionControllerSpec extends HibernateSpec implements Controll
         response.contentType.contains 'application/json'
         if(follow != 'html') {
             response.json == [
-                    href   : "/execution/follow/${exec.id}#" + follow,
+                    href   : "/execution/show/${exec.id}#" + follow,
                     success: true,
                     id     : exec.id,
                     follow : false


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fix an issue where `execution/follow` URL might be used instead of `execution/show`, but some UI code expects to see `execution/show` to drive certain behaviors.

**Describe the solution you've implemented**

* Replace all cases where URL generation uses 'follow' and use 'show' instead
* Update 'follow' action to redirect to 'show'
* Remove authZ check on 'follow' since it will redirect to authorized 'show' action

**Additional context**

Some UI plugins were not working correctly on execution show page, because they were not detecting the correct route due to use of 'follow' instead of 'show'.
