### PR TITLE
[MERGE AFTER #7498] RUN-629: Improve Job Edit Nodes Tests

### DIFF
--- a/test/selenium/src/__tests__/selenium/edit-job.test.ts
+++ b/test/selenium/src/__tests__/selenium/edit-job.test.ts
@@ -80,4 +80,7 @@ describe('edit job', () => {
         expect(optionRunInput2).toBeDefined()
 
     })
+    it('correctly opens the group choose modal and picks an option', async () => {
+
+    })
 })

--- a/test/selenium/src/__tests__/selenium/edit-job.test.ts
+++ b/test/selenium/src/__tests__/selenium/edit-job.test.ts
@@ -41,17 +41,6 @@ describe('editing a job', () => {
         const save = await jobCreatePage.editSaveButton()
         await save.click()
     })
-    it('adds tags correctly', async () => {
-        const tagsField = await jobCreatePage.tagsInputArea()
-        await ctx.driver.wait(until.elementIsVisible(tagsField), 10000)
-        expect(tagsField).toBeDefined()
-        tagsField.clear()
-        tagsField.sendKeys(testVars.tags)
-
-        //ensure they were tag-ified
-        const pilledTagsField = await jobCreatePage.tagsPillsArea()
-        expect(pilledTagsField).toBeDefined()
-    })
     it('edits and saves job description correctly', async () => {
         const descriptionTextField = await jobCreatePage.descriptionTextarea()
         expect(descriptionTextField).toBeDefined()
@@ -78,10 +67,6 @@ describe('showing the edited job', () => {
     it('verifies job group', async () => {
         const groupLabel = await jobShowPage.jobGroupText()
         expect(groupLabel).toEqual(testVars.group)
-    })
-    it('verifies job tags', async () => {
-        const showTags = await jobShowPage.jobTags()
-        expect(showTags).toHaveLength(testVars.tagsCount)
     })
     it('verifies job description', async () => {
         const foundText = await jobShowPage.jobDescriptionText()

--- a/test/selenium/src/__tests__/selenium/edit-job.test.ts
+++ b/test/selenium/src/__tests__/selenium/edit-job.test.ts
@@ -35,6 +35,7 @@ describe('editing a job', () => {
     beforeAll(async () => {
         await jobCreatePage.getEditPage('b7b68386-3a52-46dc-a28b-1a4bf6ed87de')
         await ctx.driver.wait(until.urlContains('/job/edit'), 30000)
+        await ctx.driver.wait(until.elementLocated(By.css('div#schedJobNameLabel')), 10000)
     })
     afterAll(async () => {
         const save = await jobCreatePage.editSaveButton()
@@ -42,7 +43,7 @@ describe('editing a job', () => {
     })
     it('adds tags correctly', async () => {
         const tagsField = await jobCreatePage.tagsInputArea()
-        await ctx.driver.wait(until.elementIsVisible(tagsField))
+        await ctx.driver.wait(until.elementIsVisible(tagsField), 10000)
         expect(tagsField).toBeDefined()
         tagsField.clear()
         tagsField.sendKeys(testVars.tags)

--- a/test/selenium/src/pages/jobCreate.page.ts
+++ b/test/selenium/src/pages/jobCreate.page.ts
@@ -21,6 +21,7 @@ export const Elems = {
     tagsInputArea  : By.css('div.tag-input-wrapper > input.form-control'),
     tagsPillsArea : By.css('ul.tags-list'),
     groupChooseButton: By.css('span.btn[data-target="#groupChooseModal"]'),
+    groupChooseInput : By.css('input#schedJobGroup'),
     groupChooseModal : By.css('div#groupChooseModal_content'),
     modalGroupEntry : By.css('span.groupname.jobgroupexpand'),
     modalCancel : By.css('button.btn[data-dismiss="modal"]'),
@@ -126,6 +127,15 @@ export class JobCreatePage extends Page {
     }
     async tagsPillsArea() {
         return await this.ctx.driver.findElement(Elems.tagsPillsArea)
+    }
+    async groupChooseButton() {
+        return await this.ctx.driver.findElement(Elems.groupChooseButton)
+    }
+    async groupChooseInput() {
+        return await this.ctx.driver.findElement(Elems.groupChooseInput)
+    }
+    async groupChooseModal() {
+        return await this.ctx.driver.findElement(Elems.groupChooseModal)
     }
     async saveButton() {
         return this.ctx.driver.findElement(Elems.saveButton)

--- a/test/selenium/src/pages/jobCreate.page.ts
+++ b/test/selenium/src/pages/jobCreate.page.ts
@@ -72,23 +72,36 @@ export const Elems = {
     notifySuccessRecipients: By.css('#notifySuccessRecipients'),
     // Nodes tab
     tabNodes  : By.css('#job_edit_tabs > li > a[href=\'#tab_nodes\']'),
-    doNodedispatchTrue  : By.xpath('//*[@id="doNodedispatchTrue"]'),
-    nodeFilter  : By.xpath('//*[@id="schedJobNodeFilter"]'),
-    nodeFilterButton  : By.css('#job_edit__node_filter_include button.node_filter__dosearch'),
-    nodeFilterSelectAllLink  : By.css('#job_edit__node_filter_include .job_edit__node_filter__filter_select_all'),
+    doNodedispatchTrue  : By.css('input#doNodedispatchTrue'),
+    doNodedispatchFalse  : By.css('input#doNodedispatchFalse'),
     nodeFilterMenuLink  : By.css('#job_edit__node_filter_include .job_edit__node_filter__filter_select_dropdown'),
+    nodeFilterSelectAllLink  : By.css('#job_edit__node_filter_include .job_edit__node_filter__filter_select_all'),
+    nodeFilterInput  : By.css('input#schedJobNodeFilter'),
+    nodeFilterHelp : By.css('button#filterSearchHelpBtn'),
+    nodeFilterSearch  : By.css('#job_edit__node_filter_include button.node_filter__dosearch'),
+    excludeFilterMenuLink  : By.css('#job_edit__node_filter_exclude .job_edit__node_filter__filter_select_dropdown'),
+    excludeFilterSelectAllLink  : By.css('#job_edit__node_filter_exclude .job_edit__node_filter__filter_select_all'),
+    excludeFilterInput: By.css('input#schedJobNodeFilterExclude'),
+    excludeFilterSearch : By.css('#job_edit__node_filter_exclude button.node_filter__dosearch'),
     matchedNodesText  : By.css('#nodegroupitem .node_filter_results__matched_nodes .node_filter_results__matched_nodes_count'),
+    matchedNodesRefresh : By.css('button.refresh_nodes'),
     showExcludedNodesRadioYes  : By.css('#nodegroupitem #excludeFilterTrue'),
+    showExcludedNodesRadioNo  : By.css('#nodegroupitem #excludeFilterFalse'),
     editableFilterYes  : By.css('#nodegroupitem #editableTrue'),
+    editableFilterNo  : By.css('#nodegroupitem #editableFalse'),
+    schedJobnodeThreadcount: By.css('#nodegroupitem #schedJobnodeThreadcount'),
+    schedJobnodeRankAttribute: By.css('#nodegroupitem #schedJobnodeRankAttribute'),
+    nodeRankOrderAscending: By.css('#nodegroupitem #nodeRankOrderAscending'),
     nodeRankOrderDescending: By.css('#nodegroupitem #nodeRankOrderDescending'),
-    nodeKeepgoingTrue: By.css('#nodegroupitem #nodeKeepgoingTrue'),
-    successOnEmptyNodeFilterTrue: By.css('#nodegroupitem #successOnEmptyNodeFilterTrue'),
+    nodeFailsKeepgoingTrue: By.css('#nodegroupitem #nodeKeepgoingTrue'),
+    nodeFailsKeepgoingFalse: By.css('#nodegroupitem #nodeKeepgoingFalse'),
+    emptyNodeSetFailTrue: By.css('#nodegroupitem #successOnEmptyNodeFilterTrue'),
+    emptyNodeSetFailFalse: By.css('#nodegroupitem #successOnEmptyNodeFilterFalse'),
+    nodesSelectedByDefaultTrue: By.css('#nodegroupitem #nodesSelectedByDefaultTrue'),
     nodesSelectedByDefaultFalse: By.css('#nodegroupitem #nodesSelectedByDefaultFalse'),
     orchestratorDropdown: By.css('#orchestrator-edit-type-dropdown'),
     orchestratorDropdownButton: By.css('#orchestrator-edit-type-dropdown > button'),
     // Schedule tab
-    schedJobnodeThreadcount: By.css('#nodegroupitem #schedJobnodeThreadcount'),
-    schedJobnodeRankAttribute: By.css('#nodegroupitem #schedJobnodeRankAttribute')
     // Execution Plugins tab
     // Other tab
     // Job Queue tab
@@ -264,39 +277,48 @@ export class JobCreatePage extends Page {
         return this.ctx.driver.wait(until.elementLocated(Elems.doNodedispatchTrue),15000)
     }
     async nodeFilter(){
-        return this.ctx.driver.wait(until.elementLocated(Elems.nodeFilter),15000)
+        return this.ctx.driver.wait(until.elementLocated(Elems.nodeFilterInput),15000)
     }
     async nodeFilterButton(){
-        return this.ctx.driver.wait(until.elementLocated(Elems.nodeFilterButton),15000)
+        return this.ctx.driver.wait(until.elementLocated(Elems.nodeFilterSearch),15000)
+    }
+    async excludeFilterSearch() {
+        return this.ctx.driver.wait(until.elementLocated(Elems.excludeFilterSearch),15000)
     }
     async nodeFilterMenuLink(){
         return this.ctx.driver.wait(until.elementLocated(Elems.nodeFilterMenuLink),15000)
     }
-    async showExcludedNodesRadioYes(){
+    async showExcludedNodesRadioYes() {
         return this.ctx.driver.wait(until.elementLocated(Elems.showExcludedNodesRadioYes),15000)
     }
-    async editableFilterYes(){
+    async editableFilterYes() {
         return this.ctx.driver.wait(until.elementLocated(Elems.editableFilterYes),15000)
     }
-    async schedJobnodeThreadcount(){
+    async schedJobnodeThreadcount() {
         return this.ctx.driver.wait(until.elementLocated(Elems.schedJobnodeThreadcount),15000)
     }
-    async schedJobnodeRankAttribute(){
+    async schedJobnodeRankAttribute() {
         return this.ctx.driver.wait(until.elementLocated(Elems.schedJobnodeRankAttribute),15000)
     }
-    async nodeRankOrderDescending(){
+    async nodeRankOrderDescending() {
         return this.ctx.driver.wait(until.elementLocated(Elems.nodeRankOrderDescending),15000)
     }
-    async nodeKeepgoingTrue(){
-        return this.ctx.driver.wait(until.elementLocated(Elems.nodeKeepgoingTrue),15000)
+    async nodeKeepgoingTrue() {
+        return this.ctx.driver.wait(until.elementLocated(Elems.nodeFailsKeepgoingTrue),15000)
     }
-    async successOnEmptyNodeFilterTrue(){
-        return this.ctx.driver.wait(until.elementLocated(Elems.successOnEmptyNodeFilterTrue),15000)
+    async nodeKeepgoingFalse() {
+        return this.ctx.driver.wait(until.elementLocated(Elems.nodeFailsKeepgoingFalse),15000)
     }
-    async nodesSelectedByDefaultFalse(){
+    async successOnEmptyNodeFilterTrue() {
+        return this.ctx.driver.wait(until.elementLocated(Elems.emptyNodeSetFailTrue),15000)
+    }
+    async successOnEmptyNodeFilterFalse() {
+        return this.ctx.driver.wait(until.elementLocated(Elems.emptyNodeSetFailFalse),15000)
+    }
+    async nodesSelectedByDefaultFalse() {
         return this.ctx.driver.wait(until.elementLocated(Elems.nodesSelectedByDefaultFalse),15000)
     }
-    async nodeFilterSelectAllLink(){
+    async nodeFilterSelectAllLink() {
         return this.ctx.driver.wait(until.elementLocated(Elems.nodeFilterSelectAllLink),15000)
     }
     async matchedNodes(){
@@ -307,6 +329,9 @@ export class JobCreatePage extends Page {
         await matchedNodeElem.isDisplayed()
         return await matchedNodeElem.getText()
     }
+    async orchestratorDropdown() {
+        return this.ctx.driver.findElement(Elems.orchestratorDropdown)
+    }
     async orchestratorDropdownButton() {
         return this.ctx.driver.wait(until.elementLocated(Elems.orchestratorDropdownButton),15000)
     }
@@ -315,6 +340,10 @@ export class JobCreatePage extends Page {
           '#orchestrator-edit-type-dropdown > ul > li > a[role=button][data-plugin-type=' + val + ']'
         )
         return this.ctx.driver.findElement(orchChoiceLink)
+    }
+    async orchestratorOptions() {
+        const dropdown = await this.orchestratorDropdown()
+        return dropdown.findElements(By.css('ul.dropdown-menu li'));
     }
     async workflowStrategy(){
         return this.ctx.driver.wait(until.elementLocated(Elems.workflowStrategy),15000)

--- a/test/selenium/src/pages/jobCreate.page.ts
+++ b/test/selenium/src/pages/jobCreate.page.ts
@@ -3,10 +3,12 @@ import {By, until, WebElementPromise} from 'selenium-webdriver'
 import {Page} from '@rundeck/testdeck/page'
 import {Context} from '@rundeck/testdeck/context'
 
-export const Elems= {
+export const Elems = {
     jobNameInput  : By.css('form input[name="jobName"]'),
     groupPathInput  : By.css('form input[name="groupPath"]'),
     descriptionTextarea  : By.css('form textarea[name="description"]'),
+    tagsInputArea  : By.css('div.tag-input-wrapper > input.form-control'),
+    tagsPillsArea : By.css('ul.tags-list'),
     saveButton  : By.css('#Create'),
     updateButton  : By.css('#jobUpdateSaveButton'),
     cancelButton  : By.css('#createFormCancelButton'),
@@ -102,14 +104,20 @@ export class JobCreatePage extends Page {
         await driver.get(this.ctx.urlFor(this.editPagePath(jobId)))
     }
 
-    async jobNameInput(){
+    async jobNameInput() {
         return await this.ctx.driver.findElement(Elems.jobNameInput)
     }
-    async groupPathInput(){
+    async groupPathInput() {
         return await this.ctx.driver.findElement(Elems.groupPathInput)
     }
-    async descriptionTextarea(){
+    async descriptionTextarea() {
         return await this.ctx.driver.findElement(Elems.descriptionTextarea)
+    }
+    async tagsInputArea() {
+        return await this.ctx.driver.findElement(Elems.tagsInputArea)
+    }
+    async tagsPillsArea() {
+        return await this.ctx.driver.findElement(Elems.tagsPillsArea)
     }
     async saveButton() {
         return this.ctx.driver.findElement(Elems.saveButton)

--- a/test/selenium/src/pages/jobCreate.page.ts
+++ b/test/selenium/src/pages/jobCreate.page.ts
@@ -20,6 +20,10 @@ export const Elems = {
     descriptionTextarea  : By.css('form textarea[name="description"]'),
     tagsInputArea  : By.css('div.tag-input-wrapper > input.form-control'),
     tagsPillsArea : By.css('ul.tags-list'),
+    groupChooseButton: By.css('span.btn[data-target="#groupChooseModal"]'),
+    groupChooseModal : By.css('div#groupChooseModal_content'),
+    modalGroupEntry : By.css('span.groupname.jobgroupexpand'),
+    modalCancel : By.css('button.btn[data-dismiss="modal"]'),
     // Workflow tab
     tabWorkflow  : By.css('#job_edit_tabs > li > a[href=\'#tab_workflow\']'),
     addNewWfStepButton: By.xpath('//*[@id="wfnewbutton"]/span'),

--- a/test/selenium/src/pages/jobCreate.page.ts
+++ b/test/selenium/src/pages/jobCreate.page.ts
@@ -18,8 +18,6 @@ export const Elems = {
     jobNameInput  : By.css('form input[name="jobName"]'),
     groupPathInput  : By.css('form input[name="groupPath"]'),
     descriptionTextarea  : By.css('form textarea[name="description"]'),
-    tagsInputArea  : By.css('div.tag-input-wrapper > input.form-control'),
-    tagsPillsArea : By.css('ul.tags-list'),
     groupChooseButton: By.css('span.btn[data-target="#groupChooseModal"]'),
     groupChooseInput : By.css('input#schedJobGroup'),
     groupChooseModal : By.css('div#groupChooseModal_content'),
@@ -121,12 +119,6 @@ export class JobCreatePage extends Page {
     }
     async descriptionTextarea() {
         return await this.ctx.driver.findElement(Elems.descriptionTextarea)
-    }
-    async tagsInputArea() {
-        return await this.ctx.driver.findElement(Elems.tagsInputArea)
-    }
-    async tagsPillsArea() {
-        return await this.ctx.driver.findElement(Elems.tagsPillsArea)
     }
     async groupChooseButton() {
         return await this.ctx.driver.findElement(Elems.groupChooseButton)

--- a/test/selenium/src/pages/jobCreate.page.ts
+++ b/test/selenium/src/pages/jobCreate.page.ts
@@ -4,11 +4,7 @@ import {Page} from '@rundeck/testdeck/page'
 import {Context} from '@rundeck/testdeck/context'
 
 export const Elems = {
-    jobNameInput  : By.css('form input[name="jobName"]'),
-    groupPathInput  : By.css('form input[name="groupPath"]'),
-    descriptionTextarea  : By.css('form textarea[name="description"]'),
-    tagsInputArea  : By.css('div.tag-input-wrapper > input.form-control'),
-    tagsPillsArea : By.css('ul.tags-list'),
+    // Common elements
     saveButton  : By.css('#Create'),
     updateButton  : By.css('#jobUpdateSaveButton'),
     cancelButton  : By.css('#createFormCancelButton'),
@@ -16,7 +12,15 @@ export const Elems = {
     editSaveButton: By.css('#editForm div.card-footer input.btn.btn-primary[type=submit][value=Save]'),
     errorAlert  : By.css('#error'),
     formValidationAlert: By.css('#page_job_edit > div.list-group-item > div.alert.alert-danger'),
-
+    storagebrowse: By.xpath('//*[starts-with(@id,"storagebrowse")]'),
+    storagebrowseClose: By.xpath('//*[@id="storagebrowse"]/div/div/div[3]/button[1]'),
+    // Details tab
+    jobNameInput  : By.css('form input[name="jobName"]'),
+    groupPathInput  : By.css('form input[name="groupPath"]'),
+    descriptionTextarea  : By.css('form textarea[name="description"]'),
+    tagsInputArea  : By.css('div.tag-input-wrapper > input.form-control'),
+    tagsPillsArea : By.css('ul.tags-list'),
+    // Workflow tab
     tabWorkflow  : By.css('#job_edit_tabs > li > a[href=\'#tab_workflow\']'),
     addNewWfStepButton: By.xpath('//*[@id="wfnewbutton"]/span'),
     addNewWfStepCommand: By.css('#wfnewtypes #addnodestep > div > a.add_node_step_type[data-node-step-type=command]'),
@@ -32,40 +36,6 @@ export const Elems = {
     option0KeySelector: By.xpath('//*[starts-with(@id,"defaultStoragePath")]'),
     option0OpenKeyStorage: By.css('.btn.btn-default.obs-select-storage-path'),
     option0li: By.css('#optli_0'),
-
-    storagebrowse: By.xpath('//*[starts-with(@id,"storagebrowse")]'),
-    storagebrowseClose: By.xpath('//*[@id="storagebrowse"]/div/div/div[3]/button[1]'),
-
-    notificationsTab: By.css("#job_edit_tabs > li > a[href=\'#tab_notifications\']"),
-    notificationsTabContent: By.css("#tab_notifications"),
-    enableNotifications: By.css('#notifiedTrue'),
-    notifyOnsuccessEmail: By.css('#notifyOnsuccessEmail'),
-    vueNotificationEditSection: By.css('#job-editor-notifications-vue'),
-    vueAddSuccessButton: By.css('#job-notifications-onstart > .list-group-item:first-child > button'),
-    vueEditNotificationModal: By.css('#job-notifications-edit-modal'),
-    vueEditNotificationModalSaveBtn: By.css('#job-notifications-edit-modal-btn-save'),
-    vueEditNotificationModalCancelBtn: By.css('#job-notifications-edit-modal-btn-cancel'),
-    vueEditNotificationPluginTypeDropdownButton: By.css('#notification-edit-type-dropdown > button'),
-    vueEditNotificationPluginTypeDropdownMenu: By.css('#notification-edit-type-dropdown > ul'),
-    vueNotificationConfig: By.css('#notification-edit-config'),
-    notifySuccessRecipients: By.css('#notifySuccessRecipients'),
-    tabNodes  : By.css('#job_edit_tabs > li > a[href=\'#tab_nodes\']'),
-    doNodedispatchTrue  : By.xpath('//*[@id="doNodedispatchTrue"]'),
-    nodeFilter  : By.xpath('//*[@id="schedJobNodeFilter"]'),
-    nodeFilterButton  : By.css('#job_edit__node_filter_include button.node_filter__dosearch'),
-    nodeFilterSelectAllLink  : By.css('#job_edit__node_filter_include .job_edit__node_filter__filter_select_all'),
-    nodeFilterMenuLink  : By.css('#job_edit__node_filter_include .job_edit__node_filter__filter_select_dropdown'),
-    matchedNodesText  : By.css('#nodegroupitem .node_filter_results__matched_nodes .node_filter_results__matched_nodes_count'),
-    showExcludedNodesRadioYes  : By.css('#nodegroupitem #excludeFilterTrue'),
-    editableFilterYes  : By.css('#nodegroupitem #editableTrue'),
-    schedJobnodeThreadcount: By.css('#nodegroupitem #schedJobnodeThreadcount'),
-    schedJobnodeRankAttribute: By.css('#nodegroupitem #schedJobnodeRankAttribute'),
-    nodeRankOrderDescending: By.css('#nodegroupitem #nodeRankOrderDescending'),
-    nodeKeepgoingTrue: By.css('#nodegroupitem #nodeKeepgoingTrue'),
-    successOnEmptyNodeFilterTrue: By.css('#nodegroupitem #successOnEmptyNodeFilterTrue'),
-    nodesSelectedByDefaultFalse: By.css('#nodegroupitem #nodesSelectedByDefaultFalse'),
-    orchestratorDropdown: By.css('#orchestrator-edit-type-dropdown'),
-    orchestratorDropdownButton: By.css('#orchestrator-edit-type-dropdown > button'),
     workflowStrategy  : By.xpath('//*[@id="workflow.strategy"]'),
     strategyPluginparallel: By.xpath('//*[@id="strategyPluginparallel"]'),
     strategyPluginparallelMsg: By.xpath('//*[@id="strategyPluginparallel"]/span/span'),
@@ -78,22 +48,56 @@ export const Elems = {
     revertOptionsConfirm: By.xpath('//*[starts-with(@id,"popover")]/div[2]/span[2]'),
 
     wfUndoButton: By.xpath('//*[@id="wfundoredo"]/div/span[1]'),
-    //wfUndoButton: By.css('#wfundoredo > div > span.btn.btn-xs.btn-default.act_undo.flash_undo'),
+    // wfUndoButton: By.css('#wfundoredo > div > span.btn.btn-xs.btn-default.act_undo.flash_undo'),
     wfRedoButton: By.xpath('//*[@id="wfundoredo"]/div/span[2]'),
-    //wfRedoButton: By.css('#wfundoredo > div > span.btn.btn-xs.btn-default.act_redo.flash_undo'),
+    // wfRedoButton: By.css('#wfundoredo > div > span.btn.btn-xs.btn-default.act_redo.flash_undo'),
     revertWfButton: By.xpath('//*[@id="wfundoredo"]/div/span[3]'),
-    revertWfConfirm: By.xpath('//*[starts-with(@id,"popover")]/div[2]/span[2]')
-
+    revertWfConfirm: By.xpath('//*[starts-with(@id,"popover")]/div[2]/span[2]'),
+    // Notifications Tab
+    notificationsTab: By.css('#job_edit_tabs > li > a[href=\'#tab_notifications\']'),
+    notificationsTabContent: By.css('#tab_notifications'),
+    enableNotifications: By.css('#notifiedTrue'),
+    notifyOnsuccessEmail: By.css('#notifyOnsuccessEmail'),
+    vueNotificationEditSection: By.css('#job-editor-notifications-vue'),
+    vueAddSuccessButton: By.css('#job-notifications-onstart > .list-group-item:first-child > button'),
+    vueEditNotificationModal: By.css('#job-notifications-edit-modal'),
+    vueEditNotificationModalSaveBtn: By.css('#job-notifications-edit-modal-btn-save'),
+    vueEditNotificationModalCancelBtn: By.css('#job-notifications-edit-modal-btn-cancel'),
+    vueEditNotificationPluginTypeDropdownButton: By.css('#notification-edit-type-dropdown > button'),
+    vueEditNotificationPluginTypeDropdownMenu: By.css('#notification-edit-type-dropdown > ul'),
+    vueNotificationConfig: By.css('#notification-edit-config'),
+    notifySuccessRecipients: By.css('#notifySuccessRecipients'),
+    // Nodes tab
+    tabNodes  : By.css('#job_edit_tabs > li > a[href=\'#tab_nodes\']'),
+    doNodedispatchTrue  : By.xpath('//*[@id="doNodedispatchTrue"]'),
+    nodeFilter  : By.xpath('//*[@id="schedJobNodeFilter"]'),
+    nodeFilterButton  : By.css('#job_edit__node_filter_include button.node_filter__dosearch'),
+    nodeFilterSelectAllLink  : By.css('#job_edit__node_filter_include .job_edit__node_filter__filter_select_all'),
+    nodeFilterMenuLink  : By.css('#job_edit__node_filter_include .job_edit__node_filter__filter_select_dropdown'),
+    matchedNodesText  : By.css('#nodegroupitem .node_filter_results__matched_nodes .node_filter_results__matched_nodes_count'),
+    showExcludedNodesRadioYes  : By.css('#nodegroupitem #excludeFilterTrue'),
+    editableFilterYes  : By.css('#nodegroupitem #editableTrue'),
+    nodeRankOrderDescending: By.css('#nodegroupitem #nodeRankOrderDescending'),
+    nodeKeepgoingTrue: By.css('#nodegroupitem #nodeKeepgoingTrue'),
+    successOnEmptyNodeFilterTrue: By.css('#nodegroupitem #successOnEmptyNodeFilterTrue'),
+    nodesSelectedByDefaultFalse: By.css('#nodegroupitem #nodesSelectedByDefaultFalse'),
+    orchestratorDropdown: By.css('#orchestrator-edit-type-dropdown'),
+    orchestratorDropdownButton: By.css('#orchestrator-edit-type-dropdown > button'),
+    // Schedule tab
+    schedJobnodeThreadcount: By.css('#nodegroupitem #schedJobnodeThreadcount'),
+    schedJobnodeRankAttribute: By.css('#nodegroupitem #schedJobnodeRankAttribute')
+    // Execution Plugins tab
+    // Other tab
+    // Job Queue tab
 }
-
 
 export class JobCreatePage extends Page {
     path = '/resources/createProject'
-    projectName=''
+    projectName = ''
 
     constructor(readonly ctx: Context, readonly project: string) {
         super(ctx)
-        this.projectName=project
+        this.projectName = project
         this.path = `/project/${project}/job/create`
     }
     editPagePath(jobId: string){

--- a/test/selenium/src/pages/jobShow.page.ts
+++ b/test/selenium/src/pages/jobShow.page.ts
@@ -5,6 +5,7 @@ import { Context } from '@rundeck/testdeck/context'
 
 export const Elems = {
   jobTitleLink: By.css('#jobInfo_ > span > a.job-header-link'),
+  jobTags: By.css('ul#tagsList > li.tag-pill-li'),
   jobUuidText: By.css('#subtitlebar.job-page > div > div > section > small.uuid'),
   jobDescription: By.css('#subtitlebar.job-page > div > div > div.jobInfoSection > section > span.h5'),
   optionInput: By.css('#8f95c8d5_seleniumOption1'),
@@ -37,6 +38,9 @@ export class JobShowPage extends Page {
   }
   async jobEditButton(){
     return await this.ctx.driver.findElement(Elems.jobEditButton)
+  }
+  async jobTags(){
+    return await this.ctx.driver.findElements(Elems.jobTags)
   }
   async jobActionDropdown(){
     return await this.ctx.driver.findElement(Elems.jobActionDropdown)

--- a/test/selenium/src/pages/jobShow.page.ts
+++ b/test/selenium/src/pages/jobShow.page.ts
@@ -4,6 +4,7 @@ import {Page} from '@rundeck/testdeck/page'
 import { Context } from '@rundeck/testdeck/context'
 
 export const Elems = {
+  jobGroup : By.css('div.jobInfoSection a.text-secondary'),
   jobTitleLink: By.css('#jobInfo_ > span > a.job-header-link'),
   jobTags: By.css('ul#tagsList > li.tag-pill-li'),
   jobUuidText: By.css('#subtitlebar.job-page > div > div > section > small.uuid'),
@@ -33,6 +34,13 @@ export class JobShowPage extends Page {
   }
 
 
+  async jobGroup() {
+    return await this.ctx.driver.findElement(Elems.jobGroup)
+  }
+  async jobGroupText() {
+    const jobGroup = await this.jobGroup()
+    return await jobGroup.getText()
+  }
   async jobTitleLink(){
     return await this.ctx.driver.findElement(Elems.jobTitleLink)
   }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This PR adds additional selectors for elements on the Job Edit Nodes tab, to improve the ability to add tests later.

**Describe the solution you've implemented**
Simply added additional selectors

**Describe alternatives you've considered**
N/a

**Additional context**
This change was forked from work in RUN-585, so it should not be merged until that PR, #7498, is merged.
