### PR TITLE
RUN-648: Add some ENV variables to Docker Remco mapping

### DIFF
--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -62,6 +62,12 @@ rundeck.api.tokens.duration.max={{ getv("/rundeck/api/tokens/duration/max", "30d
 rundeck.log4j.config.file={{ rundeckHome }}/server/config/log4j.properties
 
 rundeck.gui.startpage={{ getv("/rundeck/gui/startpage", "projectHome") }}
+{% if exists("/rundeck/gui/helplink") %}
+rundeck.gui.helpLink={{ getv("/rundeck/gui/helplink") }}
+{% endif %}
+{% if exists("/rundeck/gui/login/welcomehtml") %}
+rundeck.gui.login.welcomeHtml={{ getv("/rundeck/gui/login/welcomehtml") }}
+{% endif %}
 
 rundeck.clusterMode.enabled=true
 
@@ -76,3 +82,6 @@ rundeck.applyFix.workflowConfigFix973={{ getv("/rundeck/applyfix/workflowconfigf
 {% if exists("/rundeck/primaryserverid") %}
 rundeck.primaryServerId={{ getv("/rundeck/primaryserverid") }}
 {% endif %}
+
+rundeck.metrics.enabled={{ getv("/rundeck/metrics/enabled", "false") }}
+rundeck.metrics.jmxEnabled={{ getv("/rundeck/metrics/jmxenabled", "false") }}


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

This is a small enhancement to add a few ENV vars as described here https://docs.rundeck.com/docs/administration/configuration/docker.html#environment-variables

Let me know if anything else is needed!