### PR TITLE
Tweak task definition to work if environment is undefined

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/build.gradle
+++ b/rundeckapp/grails-spa/packages/ui-trellis/build.gradle
@@ -201,14 +201,15 @@ tasks.register('runNpmPublish', NpmTask) {t ->
 
     def dryRun = (findProperty('dryRun') as String ?: 'true').toBoolean()
 
-    args = ['publish', '--dry-run']
+    def myargs = ['publish', '--dry-run']
 
     if (!dryRun)
-        args = args - '--dry-run'
+        myargs = myargs - '--dry-run'
 
-    if (project.environment != 'release') {
-        args += ['--tag', 'snapshot']
+    if (project.findProperty('environment') != 'release') {
+        myargs += ['--tag', 'snapshot']
     }
+    args=myargs
 
     t.execOverrides {
         it.workingDir = 'build/pack'


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Fixing an issue that sometimes happens with IntelliJ in debug mode - it fails to evaluate this gradle file.
* fix issue with `+=` 
* fix evaluating `project.environment` if environment property is not defined
