### PR TITLE
RUN-695: fix issue with API access before server fully starts

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/ApiAccessInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/ApiAccessInterceptor.groovy
@@ -19,6 +19,7 @@ class ApiAccessInterceptor {
     def allowed_pre_api_reqs=[
             'user':['login','loggedout'],
             'menu':['index','home'],
+            error:['fiveHundred']
     ]
 
     ApiAccessInterceptor() {

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/ApiVersionInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/ApiVersionInterceptor.groovy
@@ -136,9 +136,9 @@ class ApiVersionInterceptor {
             XML.use('v' + request.api_version)
             JSON.use('v' + request.api_version)
         } catch (ConverterException e) {
-            //API request may have happened before named converter configs have been registered at startup, send service unavailable
-            response.status = HttpServletResponse.SC_SERVICE_UNAVAILABLE
-            return false
+            //API request may have happened before named converter configs have been registered at startup
+            //the response will be handled in AuthorizationInterceptor after the SetUserInterceptor completes
+            request.apiVersionStatusNotReady=true
         }
         return true
     }

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/AuthorizationInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/AuthorizationInterceptor.groovy
@@ -4,6 +4,8 @@ import com.dtolabs.client.utils.Constants
 import com.dtolabs.rundeck.app.api.ApiVersions
 import org.rundeck.app.access.InterceptorHelper
 
+import javax.servlet.http.HttpServletResponse
+
 class AuthorizationInterceptor {
 
     int order = HIGHEST_PRECEDENCE + 50
@@ -45,6 +47,9 @@ class AuthorizationInterceptor {
             response.setHeader(Constants.X_RUNDECK_ACTION_UNAUTHORIZED_HEADER, flash.error)
             redirect(controller: 'user', action: actionName ==~ /^.*(Fragment|Inline)$/ ? 'deniedFragment' : 'denied', params: params.xmlreq ? params.subMap(['xmlreq']) : null)
             return false;
+        }else if(request.apiVersionStatusNotReady){
+            response.status = HttpServletResponse.SC_SERVICE_UNAVAILABLE
+            return false
         }
         return true
     }

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/ApiAccessInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/ApiAccessInterceptorSpec.groovy
@@ -1,22 +1,79 @@
 package rundeck.interceptors
 
 import grails.testing.web.interceptor.InterceptorUnitTest
+import org.grails.spring.beans.factory.InstanceFactoryBean
+import org.grails.web.util.GrailsApplicationAttributes
+import org.rundeck.app.access.InterceptorHelper
 import spock.lang.Specification
 
 class ApiAccessInterceptorSpec extends Specification implements InterceptorUnitTest<ApiAccessInterceptor> {
 
     def setup() {
+        def helperMock = Mock(InterceptorHelper)
+        defineBeans {
+            interceptorHelper(InstanceFactoryBean, helperMock)
+        }
     }
 
     def cleanup() {
 
     }
 
-    void "Test apiRequest interceptor matching"() {
-        when:"A request matches the interceptor"
-            withRequest(controller:"apiRequest")
+    void "Test apiAccess interceptor matching"() {
+        when: "A request matches the interceptor"
+            withRequest(controller: "something")
 
-        then:"The interceptor does match"
+        then: "The interceptor does match"
             interceptor.doesMatch()
+    }
+
+    void "Test apiAccess interceptor does not match api "() {
+        when: "A request matches the api"
+            withRequest(uri: "/api/apiVersion")
+
+        then: "The interceptor does not match"
+            !interceptor.doesMatch()
+    }
+
+    void "Test apiAccess before disables api access "() {
+        given:
+            session.api_access_allowed = preset
+        when: "A request matches the api"
+            withRequest(controller: 'something', action: 'other')
+            interceptor.before()
+
+        then: "api_access_allowed set to false"
+            session.api_access_allowed == expect
+        where:
+            preset | expect
+            true   | true
+            false  | false
+            null   | false
+    }
+
+    void "Test apiAccess before allowed actions "() {
+        given:
+            session.api_access_allowed = null
+            withRequest(controller: ctrl, action: action)
+            request.setAttribute(GrailsApplicationAttributes.CONTROLLER_NAME_ATTRIBUTE, ctrl)
+            request.setAttribute(GrailsApplicationAttributes.ACTION_NAME_ATTRIBUTE, action)
+        when: "A request matches the api"
+
+            def result = interceptor.before()
+
+        then: "api_access_allowed unset"
+            session.api_access_allowed == expect
+            result
+        where:
+            ctrl    | action        | expect
+            'menu'  | 'index'       | null
+            'menu'  | 'home'        | null
+            'menu'  | 'other'       | false
+            'user'  | 'login'       | null
+            'user'  | 'loggedout'   | null
+            'user'  | 'other'       | false
+            'error' | 'fiveHundred' | null
+            'error' | 'other'       | false
+
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/ApiVersionInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/ApiVersionInterceptorSpec.groovy
@@ -79,8 +79,8 @@ class ApiVersionInterceptorSpec extends Specification implements InterceptorUnit
             boolean allowed = interceptor.before()
 
         then:
-            !allowed
-            response.status==503
+            allowed
+            request.apiVersionStatusNotReady
 
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/ApiVersionInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/ApiVersionInterceptorSpec.groovy
@@ -69,6 +69,21 @@ class ApiVersionInterceptorSpec extends Specification implements InterceptorUnit
 
     }
 
+    void "api access before marshallers registered causes 503"() {
+        given:
+            ConvertersConfigurationHolder.clear()
+
+        when:
+            request.method = "GET"
+            params.api_version = ApiVersions.API_CURRENT_VERSION.toString()
+            boolean allowed = interceptor.before()
+
+        then:
+            !allowed
+            response.status==503
+
+    }
+
     void "Invalid sync tokens do not allow api access"() {
         given:
 

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/ApiVersionInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/ApiVersionInterceptorSpec.groovy
@@ -1,16 +1,15 @@
 package rundeck.interceptors
 
 import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.Timer
 import com.dtolabs.rundeck.app.api.ApiMarshallerRegistrar
 import com.dtolabs.rundeck.app.api.ApiVersions
 import grails.testing.web.interceptor.InterceptorUnitTest
-import org.grails.plugins.web.servlet.mvc.InvalidResponseHandler
 import org.grails.plugins.web.servlet.mvc.ValidResponseHandler
+import org.grails.spring.beans.factory.InstanceFactoryBean
+import org.grails.web.converters.configuration.ConvertersConfigurationHolder
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
-import org.grails.web.servlet.mvc.TokenResponseHandler
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.MessageSource
-import rundeck.controllers.ProjectController
 import rundeck.controllers.TokenVerifierController
 import rundeck.services.ApiService
 import spock.lang.Specification
@@ -18,6 +17,20 @@ import spock.lang.Specification
 class ApiVersionInterceptorSpec extends Specification implements InterceptorUnitTest<ApiVersionInterceptor> {
 
     def setup() {
+        def mockMetric = Mock(MetricRegistry){
+            _ * timer(_)>>Mock(Timer){
+
+            }
+        }
+        def mockToken = Mock(TokenVerifierController)
+        def apiServiceMock = Mock(ApiService)
+        def msgSrc = Mock(MessageSource)
+        defineBeans {
+            metricRegistry(InstanceFactoryBean,mockMetric)
+            tokenVerifierController(InstanceFactoryBean,mockToken)
+            apiService(InstanceFactoryBean, apiServiceMock)
+            delegate.'messageSource'(InstanceFactoryBean, msgSrc)
+        }
     }
 
     def cleanup() {
@@ -25,15 +38,6 @@ class ApiVersionInterceptorSpec extends Specification implements InterceptorUnit
     }
 
     void "Test apiVersion interceptor matching"() {
-        given:
-        def service = Mock(ApiService)
-        def msgSrc = Mock(MessageSource)
-        defineBeans {
-            metricRegistry(MetricRegistry)
-            tokenVerifierController(TokenVerifierController)
-            apiService(service)
-            messageSource(msgSrc)
-        }
         when:"A request matches the interceptor"
             withRequest(uri:"/api/apiVersion")
 
@@ -43,16 +47,9 @@ class ApiVersionInterceptorSpec extends Specification implements InterceptorUnit
 
     void "Valid sync tokens allow api access"() {
         given:
-        def service = Mock(ApiService)
-        def msgSrc = Mock(MessageSource)
         def tkController = Mock(TokenVerifierController)
+        interceptor.tokenVerifierController = tkController
 
-        defineBeans {
-            metricRegistry(MetricRegistry)
-            tokenVerifierController(tkController)
-            apiService(service)
-            messageSource(msgSrc)
-        }
 
         ApiMarshallerRegistrar apiMarshallerRegistrar = new ApiMarshallerRegistrar()
         apiMarshallerRegistrar.registerApiMarshallers()
@@ -61,7 +58,6 @@ class ApiVersionInterceptorSpec extends Specification implements InterceptorUnit
             params[SynchronizerTokensHolder.TOKEN_URI] = "/"
             request.method = "POST"
             params.api_version = ApiVersions.API_CURRENT_VERSION.toString()
-            interceptor.tokenVerifierController = tkController
             boolean allowed = interceptor.before()
 
         then:
@@ -75,15 +71,6 @@ class ApiVersionInterceptorSpec extends Specification implements InterceptorUnit
 
     void "Invalid sync tokens do not allow api access"() {
         given:
-        def service = Mock(ApiService)
-        def msgSrc = Mock(MessageSource)
-
-        defineBeans {
-            metricRegistry(MetricRegistry)
-            tokenVerifierController(TokenVerifierController)
-            apiService(service)
-            messageSource(msgSrc)
-        }
 
         ApiMarshallerRegistrar apiMarshallerRegistrar = new ApiMarshallerRegistrar()
         apiMarshallerRegistrar.registerApiMarshallers()

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/AuthorizationInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/AuthorizationInterceptorSpec.groovy
@@ -1,6 +1,7 @@
 package rundeck.interceptors
 
 import grails.testing.web.interceptor.InterceptorUnitTest
+import org.rundeck.app.access.InterceptorHelper
 import spock.lang.Specification
 
 class AuthorizationInterceptorSpec extends Specification implements InterceptorUnitTest<AuthorizationInterceptor> {
@@ -18,5 +19,15 @@ class AuthorizationInterceptorSpec extends Specification implements InterceptorU
 
         then:"The interceptor does match"
             interceptor.doesMatch()
+    }
+    def "apiVersionStatusNotReady causes 503 response"(){
+        given:
+            request.apiVersionStatusNotReady=true
+            interceptor.interceptorHelper=Mock(InterceptorHelper)
+        when:
+            def result=interceptor.before()
+        then:
+            !result
+            response.status==503
     }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Fix an issue (seen in CI) where API requests before server fully starts prevent all API requests in the session, when using username/password API login.

**Describe the solution you've implemented**
* Handle exception caused by missing API response marshaller configuration before server has completed startup by responding with 503 (Service Unavailable)
* Fix issue where "error/fiveHundred" response caused by exception would block API access for the session when using username/password login
* Additional change was necessary, due to order of Interceptors: ApiVersionInterceptor should not return false immediately, but adds a request attribute, so that the SetUserInterceptor executes cleanly and sets up appropriate session data about authenticated user. The AuthorizationInterceptor then handles the 503 response based on request attribute