### PR TITLE
RUN-603: Enhance UserController to support more flexible error message

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -59,8 +59,18 @@ class UserController extends ControllerBase{
         redirect(action:"login")
     }
 
+    /**
+     * Error action can accept an URL query parameter: message
+     * If there is a NonEmpty message then this message instead of the default `invalid.username.and.password`
+     * message will be displayed in the login form.
+     *
+     * If there is no message parameter provided in URL, then the default `invalid.username.and.password` will be displayed
+     */
     def error = {
-        flash.loginerror = message(code: "invalid.username.and.password")
+        flash.loginerror = request.getParameter("message")?.trim() ?
+                request.getParameter("message").trim() :
+                message(code:  "invalid.username.and.password")
+
         return render(view:'login')
     }
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -67,9 +67,10 @@ class UserController extends ControllerBase{
      * If there is no message parameter provided in URL, then the default `invalid.username.and.password` will be displayed
      */
     def error = {
-        flash.loginerror = request.getParameter("message")?.trim() ?
-                request.getParameter("message").trim() :
-                message(code:  "invalid.username.and.password")
+        def errorCode = request.getParameter("code")?.trim() ?
+                request.getParameter("code").trim() : "invalid.username.and.password"
+
+        flash.loginerror = message(code:  errorCode)
 
         return render(view:'login')
     }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -59,19 +59,10 @@ class UserController extends ControllerBase{
         redirect(action:"login")
     }
 
-    /**
-     * Error action can accept an URL query parameter: message
-     * If there is a NonEmpty message then this message instead of the default `invalid.username.and.password`
-     * message will be displayed in the login form.
-     *
-     * If there is no message parameter provided in URL, then the default `invalid.username.and.password` will be displayed
-     */
-    def error = {
-        def errorCode = request.getParameter("code")?.trim() ?
-                request.getParameter("code").trim() : "invalid.username.and.password"
-
-        flash.loginerror = message(code:  errorCode)
-
+    def error() {
+        if(!flash.loginErrorCode){
+            flash.loginErrorCode = 'invalid.username.and.password'
+        }
         return render(view:'login')
     }
 

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
@@ -32,7 +32,6 @@ class SetUserInterceptor {
     ApiService apiService
     ConfigurationService configurationService
 
-    def messageSource
     int order = HIGHEST_PRECEDENCE + 30
 
     SetUserInterceptor() {
@@ -128,7 +127,7 @@ class SetUserInterceptor {
                 SecurityContextHolder.clearContext()
                 request.logout()
                 response.status = 403
-                flash.loginerror = messageSource.getMessage("user.not.allowed",null,null)
+                flash.loginErrorCode = 'user.not.allowed'
                 render view: '/user/login.gsp'
                 return false
             }

--- a/rundeckapp/grails-app/views/user/login.gsp
+++ b/rundeckapp/grails-app/views/user/login.gsp
@@ -179,9 +179,9 @@
                     </g:showLocalLogin>
                   </div>
                   <div class="card-footer text-center">
-                    <g:if test="${flash.loginerror}">
+                    <g:if test="${flash.loginErrorCode}">
                       <div class="alert alert-danger">
-                          <span><g:enc>${flash.loginerror}</g:enc></span>
+                          <span><g:message code="${flash.loginErrorCode}" default="Login failed."/></span>
                       </div>
                     </g:if>
                   <div class="alert alert-danger" style="display:none;" id="empty-username-msg">

--- a/rundeckapp/src/test/groovy/rundeck/controllers/UserControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/UserControllerSpec.groovy
@@ -839,4 +839,20 @@ class UserControllerSpec extends Specification implements ControllerUnitTest<Use
         then:
             response.status == 403
     }
+
+    def "error sets loginErrorCode flash "(){
+        given:
+            if(code){
+                flash.loginErrorCode=code
+            }
+        when:
+            controller.error()
+        then:
+            flash.loginErrorCode!=null
+            flash.loginErrorCode==expected
+        where:
+            code              | expected
+            null              | 'invalid.username.and.password'
+            'some.other.code' | 'some.other.code'
+    }
 }

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
@@ -107,7 +107,6 @@ class SetUserInterceptorSpec extends Specification implements InterceptorUnitTes
             getString(_,_)>>""
             getString(_)>>""
         }
-        messageSource.addMessage("user.not.allowed",Locale.default,"User Not Allowed")
 
         when:
         interceptor.userService = userServiceMock
@@ -118,12 +117,13 @@ class SetUserInterceptorSpec extends Specification implements InterceptorUnitTes
 
         then:
         allowed == expected
+        flash.loginErrorCode==code
 
         where:
-        requiredRole | username | groups           | expected
-        "enter"      | "auser"  | ["grp1"]         | false
-        "enter"      | "auser"  | ["grp1","enter"] | true
-        ""           | "auser"  | ["grp1"]         | true
+        requiredRole | username | groups            | expected | code
+        "enter"      | "auser"  | ["grp1"]          | false    | 'user.not.allowed'
+        "enter"      | "auser"  | ["grp1", "enter"] | true     | null
+        ""           | "auser"  | ["grp1"]          | true     | null
 
 
     }


### PR DESCRIPTION

**Is this a bug fix or an enhancement? Please describe.**
Enhancement for RUN-603

**Describe the solution you've implemented**
The original design of the Error action only displays a fixed message for any user login failure. By adding logic to retrieve error messages from query parameters we can make the error page display custom error messages. It provides a better user experience e.g. for RUN-603 we can display the specific rate-limiting error to end-users. 


**Additional context**
Currently, this enhancement is only used by the enterprise version for the feature of login rate-limiting. 


