### PR TITLE
RUN-705: nested groups are not displayed by default

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -681,7 +681,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         }
         readauthcount= newschedlist.size()
 
-        if(configurationService.getBoolean("gui.realJobTree", false)) {
+        if(configurationService.getBoolean("gui.realJobTree", true)) {
             //Adding group entries for empty hierachies to have a "real" tree
             def missinggroups = [:]
             jobgroups.each { k, v ->


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Bugfix:
nested groups are not displayed by default.

**Describe the solution you've implemented**

the check of parameter `rundeck.gui.realJobTree` must return true by default to have the same behavior than Rundeck 3.x
with the grails 5 migration that behavior was changed.

**Describe alternatives you've considered**

**Additional context**
