### PR TITLE
RUN-708: Cannot uncheck the "Keep going on success" option for error handler

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
@@ -800,6 +800,9 @@ class WorkflowController extends ControllerBase {
         }
         def modifyItemFromParams={moditem,params->
             if (params.pluginItem) {
+                if (!params.keepgoingOnSuccess) {
+                    params.keepgoingOnSuccess = 'false'
+                }
                 moditem.properties=params.subMap(['keepgoingOnSuccess','description'])
                 moditem.configuration = cleanLineEndings(params.pluginConfig)
             } else {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/WorkflowControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/WorkflowControllerSpec.groovy
@@ -660,7 +660,39 @@ class WorkflowControllerSpec extends HibernateSpec implements ControllerUnitTest
 
     }
 
+    def "modify step without keepgoingOnSuccess parameter"() {
+        given:
+        def pluginWorkflowStepProps = [type: 'WorkflowStep', nodeStep: true, keepgoingOnSuccess: true]
+        Workflow wf = new Workflow(
+                threadcount: 1,
+                keepgoing: true,
+                commands: [
+                        new PluginStep(pluginWorkflowStepProps)
+                ]
+        )
+        CommandExec item = new CommandExec(adhocExecution: true, adhocRemoteString: 'echo something')
+        wf.addToCommands(item)
+        controller.frameworkService = Mock(FrameworkService)
+        controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)
 
+        params.pluginItem = pItem
+        params.pluginConfig = config
+
+        when:
+        def result = controller._applyWFEditAction(
+                wf,
+                [action: 'modify', num: 0, params: params]
+        )
+
+        then:
+        result.error
+        result.item
+        result.item.keepgoingOnSuccess == keepgoingonsuccess
+
+        where:
+        pItem  | config   | keepgoingonsuccess
+        'true' | [a: 'b'] | false
+    }
 
     public ScheduledExecution createBasicJob() {
         new ScheduledExecution(


### PR DESCRIPTION
Issue:
https://github.com/rundeckpro/rundeckpro/issues/2267

Fix description:
When the property keepgoingonsuccess is not sent by the front-end this is set as false.