### PR TITLE
RUN-707: Use-Client-Side-FileReader-API-Load-Content-From-File

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/storageBrowseKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/storageBrowseKO.js
@@ -118,10 +118,10 @@ function StorageUpload(storage){
     self.password=ko.observable('');
     self.fileName=ko.observable('');
 
-    //Observer triggerred when select a file
-    self.fileInputName = ko.computed(function(){
+
+    self.file.subscribe(() => {
         const [fileObj] = document.querySelector('#storageuploadfile').files;
-        if (fileObj) {
+        if (fileObj && self.inputType() === 'file') {
             reader.readAsText(fileObj)
             if(!self.modifyMode()) {
                 self.fileName(fileObj.name)
@@ -129,7 +129,10 @@ function StorageUpload(storage){
         } else {
             self.textArea("")
         }
+    })
 
+    //Observer triggerred when select a file
+    self.fileInputName = ko.computed(function(){
         const file = self.file();
         if(file){
             return file.lastIndexOf('/')>=0 ? file.substring(file.lastIndexOf('/')+1)
@@ -164,7 +167,7 @@ function StorageUpload(storage){
 
     //subscriptions to clear values when one input type is selected
     self.inputType.subscribe(function(newvalue){
-       if(newvalue=='text' || newvalue=='file'){
+       if(newvalue == 'text' || newvalue== 'file'){
            self.file('');
            self.textArea('');
        } else{
@@ -173,7 +176,7 @@ function StorageUpload(storage){
     });
     //subscriptions to clear values when one input type is selected
     self.keyType.subscribe(function(newvalue){
-       if(newvalue=='password'){
+       if(newvalue == 'password'){
            self.textArea('');
            self.inputType('text');
        } else{

--- a/rundeckapp/grails-app/assets/javascripts/storageBrowseKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/storageBrowseKO.js
@@ -119,7 +119,8 @@ function StorageUpload(storage){
     self.fileName=ko.observable('');
 
     //computed
-    self.fileInputName=ko.computed(function(){
+    // TODO: Refactor this method. It's purpose is just to get the filename which can be implemented by File object
+    self.fileInputName = ko.computed(function(){
         var file = self.file();
         if(file){
             return file.lastIndexOf('/')>=0 ? file.substring(file.lastIndexOf('/')+1)
@@ -131,21 +132,30 @@ function StorageUpload(storage){
         }
     });
     self.validInput = ko.computed(function(){
-        var intype = self.inputType();
-        var file = self.file();
         var textarea=self.textArea();
         var pass=self.password();
-        if(intype=='text'){
-            return (textarea || pass )? true:false;
-        }else{
-            return file?true:false;
-        }
+        return (textarea || pass ) ? true : false
     });
+
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+        // this will then display a text file
+        console.log(reader.result)
+        // document.querySelector('#storageuploadtext').value = reader.result
+        self.textArea(reader.result)
+    }, false);
+
     /**
      * Returns the full path for the inputPath (dir) and inputFilename
      * @type {*}
      */
     self.inputFullpath = ko.computed(function () {
+        const [fileObj] = document.querySelector('#storageuploadfile').files;
+        if (fileObj) {
+            reader.readAsText(fileObj);
+            self.fileName(fileObj.name)
+        }
+
         var name = self.fileName();
         var file = self.fileInputName();
         var path = self.storage.absolutePath(self.storage.inputBasePath());
@@ -154,10 +164,10 @@ function StorageUpload(storage){
 
     //subscriptions to clear values when one input type is selected
     self.inputType.subscribe(function(newvalue){
-       if(newvalue=='text'){
+       if(newvalue=='text' || newvalue=='file'){
            self.file('');
-       } else{
            self.textArea('');
+       } else{
            self.password('');
        }
     });
@@ -516,6 +526,5 @@ function StorageBrowser(baseUrl, rootPath) {
     });
 
     //upload link
-
     self.upload = new StorageUpload(self);
 }

--- a/rundeckapp/grails-app/assets/javascripts/storageBrowseKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/storageBrowseKO.js
@@ -119,7 +119,6 @@ function StorageUpload(storage){
     self.fileName=ko.observable('');
 
     //computed
-    // TODO: Refactor this method. It's purpose is just to get the filename which can be implemented by File object
     self.fileInputName = ko.computed(function(){
         var file = self.file();
         if(file){
@@ -139,9 +138,6 @@ function StorageUpload(storage){
 
     const reader = new FileReader();
     reader.addEventListener("load", () => {
-        // this will then display a text file
-        console.log(reader.result)
-        // document.querySelector('#storageuploadtext').value = reader.result
         self.textArea(reader.result)
     }, false);
 
@@ -150,10 +146,16 @@ function StorageUpload(storage){
      * @type {*}
      */
     self.inputFullpath = ko.computed(function () {
-        const [fileObj] = document.querySelector('#storageuploadfile').files;
-        if (fileObj) {
-            reader.readAsText(fileObj);
-            self.fileName(fileObj.name)
+        if(self.inputType() === 'file') {
+            const [fileObj] = document.querySelector('#storageuploadfile').files;
+            if (fileObj) {
+                reader.readAsText(fileObj)
+                if(!self.modifyMode()) {
+                    self.fileName(fileObj.name)
+                }
+            } else {
+                self.textArea("")
+            }
         }
 
         var name = self.fileName();

--- a/rundeckapp/grails-app/assets/javascripts/storageBrowseKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/storageBrowseKO.js
@@ -118,18 +118,28 @@ function StorageUpload(storage){
     self.password=ko.observable('');
     self.fileName=ko.observable('');
 
-    //computed
+    //Observer triggerred when select a file
     self.fileInputName = ko.computed(function(){
-        var file = self.file();
+        const [fileObj] = document.querySelector('#storageuploadfile').files;
+        if (fileObj) {
+            reader.readAsText(fileObj)
+            if(!self.modifyMode()) {
+                self.fileName(fileObj.name)
+            }
+        } else {
+            self.textArea("")
+        }
+
+        const file = self.file();
         if(file){
             return file.lastIndexOf('/')>=0 ? file.substring(file.lastIndexOf('/')+1)
                 : file.lastIndexOf('\\')>=0 ? file.substring(file.lastIndexOf('\\')+1)
                 : file;
-
         }else{
             return '';
         }
     });
+
     self.validInput = ko.computed(function(){
         var textarea=self.textArea();
         var pass=self.password();
@@ -146,22 +156,10 @@ function StorageUpload(storage){
      * @type {*}
      */
     self.inputFullpath = ko.computed(function () {
-        if(self.inputType() === 'file') {
-            const [fileObj] = document.querySelector('#storageuploadfile').files;
-            if (fileObj) {
-                reader.readAsText(fileObj)
-                if(!self.modifyMode()) {
-                    self.fileName(fileObj.name)
-                }
-            } else {
-                self.textArea("")
-            }
-        }
-
-        var name = self.fileName();
-        var file = self.fileInputName();
-        var path = self.storage.absolutePath(self.storage.inputBasePath());
-        return (path ? (path.lastIndexOf('/') == path.length - 1 ? path : path + '/') : '') + (name?name: file);
+        const fileInputName = self.fileInputName();
+        const name = self.fileName();
+        const path = self.storage.absolutePath(self.storage.inputBasePath());
+        return (path ? (path.lastIndexOf('/') == path.length - 1 ? path : path + '/') : '') + (name ? name : fileInputName);
     });
 
     //subscriptions to clear values when one input type is selected

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/StorageController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/StorageController.groovy
@@ -260,6 +260,8 @@ class StorageController extends ControllerBase{
      *
      */
     def keyStorageUpload(StorageParams storageParams){
+        if(!requestHasValidToken()) return
+
         if (storageParams.hasErrors()) {
             flash.errors=storageParams.errors
             return redirect(controller: 'menu',action: 'storage',params: [project:params.project])
@@ -269,11 +271,6 @@ class StorageController extends ControllerBase{
         }
         AuthContext authContext = getAuthContextForPath(session.subject, storageParams.resourcePath)
         def resourcePath = storageParams.resourcePath
-
-        withForm { }.invalidToken{
-            flash.errorCode= 'request.error.invalidtoken.message'
-            return redirect(controller: 'menu', action: 'storage', params: [project: params.project])
-        }
 
         def contentType= null
 
@@ -307,23 +304,21 @@ class StorageController extends ControllerBase{
         }
 
         def uploadText = params.uploadText
-        if(storageParams.uploadKeyType in ['public', 'private'] && !uploadText){
-            if(!uploadText){
+        if(storageParams.uploadKeyType in ['public', 'private']){
+            if(!uploadText) {
                 flash.errorCode = 'api.error.parameter.required'
                 flash.errorArgs = ['uploadText']
 
-                return redirect(controller: 'menu', action: 'storage',
-                        params: [project: params.project])
+                return redirect(controller: 'menu', action: 'storage', params: [project: params.project])
             }
-        } else if(storageParams.uploadKeyType == 'password' ){  // Password input type is always text
+        } else if(storageParams.uploadKeyType == 'password'){  // Password input type is always text
             //store a password
             if (!params.uploadPassword) {
                 //invalid
                 flash.errorCode = 'api.error.parameter.required'
                 flash.errorArgs = ['uploadPassword']
 
-                return redirect(controller: 'menu', action: 'storage',
-                        params: [project: params.project])
+                return redirect(controller: 'menu', action: 'storage', params: [project: params.project])
             }
             uploadText = params.uploadPassword
         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/StorageController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/StorageController.groovy
@@ -270,121 +270,121 @@ class StorageController extends ControllerBase{
         AuthContext authContext = getAuthContextForPath(session.subject, storageParams.resourcePath)
         def resourcePath = storageParams.resourcePath
 
-        withForm {
-            def contentType= null
-
-            if (storageParams.uploadKeyType == 'public') {
-                contentType = KeyStorageLayer.PUBLIC_KEY_MIME_TYPE
-            } else if (storageParams.uploadKeyType == 'private') {
-                contentType = KeyStorageLayer.PRIVATE_KEY_MIME_TYPE
-            } else if (storageParams.uploadKeyType == 'password') {
-                contentType = KeyStorageLayer.PASSWORD_MIME_TYPE
-            } else {
-                //invalid
-                flash.errorCode = 'api.error.parameter.invalid'
-                flash.errorArgs = [storageParams.uploadKeyType, 'uploadKeyType']
-                return redirect(controller: 'menu', action: 'storage',
-                        params: [project: params.project])
-            }
-            if( !(storageParams.inputType in ['file', 'text'])){
-                flash.errorCode = 'api.error.parameter.not.inList'
-                flash.errorArgs = [storageParams.inputType, 'inputType']
-                return redirect(controller: 'menu', action: 'storage',
-                        params: [project: params.project])
-            }
-
-            def filename = storageParams.fileName
-
-            if (!filename) {
-                flash.errorCode = 'api.error.upload.missing'
-                flash.errorArgs = ['fileName']
-                return redirect(controller: 'menu', action: 'storage',
-                        params: [project: params.project])
-            }
-
-            def uploadText = params.uploadText
-            if(storageParams.uploadKeyType in ['public', 'private'] && !uploadText){
-                if(!uploadText){
-                    flash.errorCode = 'api.error.parameter.required'
-                    flash.errorArgs = ['uploadText']
-
-                    return redirect(controller: 'menu', action: 'storage',
-                            params: [project: params.project])
-                }
-            } else if(storageParams.uploadKeyType == 'password' ){  // Password input type is always text
-                //store a password
-                if (!params.uploadPassword) {
-                    //invalid
-                    flash.errorCode = 'api.error.parameter.required'
-                    flash.errorArgs = ['uploadPassword']
-
-                    return redirect(controller: 'menu', action: 'storage',
-                            params: [project: params.project])
-                }
-                uploadText = params.uploadPassword
-            }
-
-            resourcePath = PathUtil.cleanPath(resourcePath + '/' + filename)
-
-            def newparams = new StorageParams(resourcePath: resourcePath)
-            newparams.validate()
-
-            if(newparams.hasErrors()){
-                flash.errors=newparams.errors
-                return redirect(controller: 'menu', action: 'storage',
-                        params: [project: params.project])
-            }
-
-            boolean dontOverwrite = params.dontOverwrite in [true, 'true']
-
-            def hasResource = storageService.hasResource(authContext, resourcePath)
-
-            if (dontOverwrite && hasResource) {
-                flash.error = g.message(code: 'api.error.item.alreadyexists',
-                        args: ['Storage file', resourcePath])
-
-                return redirect(controller: 'menu', action: 'storage',
-                        params: [project: params.project])
-            } else if (!hasResource && storageService.hasPath(authContext, resourcePath)) {
-                flash.error = g.message(code: 'api.error.item.alreadyexists',
-                        args: ['Storage directory path', resourcePath])
-
-                return redirect(controller: 'menu', action: 'storage',
-                        params: [project: params.project])
-            }
-
-            def inputBytes = uploadText.bytes
-
-            Map<String, String> map = [
-                    (StorageUtil.RES_META_RUNDECK_CONTENT_TYPE): contentType,
-                    (StorageUtil.RES_META_RUNDECK_CONTENT_LENGTH): inputBytes.length.toString() //if the value of content length is not cast to a string here,
-                                                                                                // Groovy allows the value into the map as an int or long
-                                                                                                // which will cause a type cast exception later if the contentLength
-                                                                                                // is accessed later in the storage chain
-            ]
-            try {
-                def inputStream = new ByteArrayInputStream(inputBytes)
-
-                if(hasResource){
-                    storageService.updateResource(authContext, resourcePath, map, inputStream)
-                }else{
-                    storageService.createResource(authContext, resourcePath, map, inputStream)
-                }
-                return redirect(controller: 'menu', action: 'storage', params: [resourcePath:resourcePath]+(params.project?[project:params.project]:[:]))
-            } catch (StorageAuthorizationException e) {
-                log.error("Unauthorized: resource ${resourcePath}: ${e.message}")
-                flash.errorCode = 'api.error.item.unauthorized'
-                flash.errorArgs = [e.event.toString(), 'Path', e.path.toString()]
-                return redirect(controller: 'menu', action: 'storage',params: [resourcePath:resourcePath]+(params.project?[project:params.project]:[:]))
-            } catch (StorageException e) {
-                log.error("Error creating resource ${resourcePath}: ${e.message}")
-                log.debug("Error creating resource ${resourcePath}", e)
-                flash.error= e.message
-                return redirect(controller: 'menu', action: 'storage',params: [resourcePath:resourcePath]+(params.project?[project:params.project]:[:]))
-            }
-        }.invalidToken{
+        withForm { }.invalidToken{
             flash.errorCode= 'request.error.invalidtoken.message'
             return redirect(controller: 'menu', action: 'storage', params: [project: params.project])
+        }
+
+        def contentType= null
+
+        if (storageParams.uploadKeyType == 'public') {
+            contentType = KeyStorageLayer.PUBLIC_KEY_MIME_TYPE
+        } else if (storageParams.uploadKeyType == 'private') {
+            contentType = KeyStorageLayer.PRIVATE_KEY_MIME_TYPE
+        } else if (storageParams.uploadKeyType == 'password') {
+            contentType = KeyStorageLayer.PASSWORD_MIME_TYPE
+        } else {
+            //invalid
+            flash.errorCode = 'api.error.parameter.invalid'
+            flash.errorArgs = [storageParams.uploadKeyType, 'uploadKeyType']
+            return redirect(controller: 'menu', action: 'storage',
+                    params: [project: params.project])
+        }
+        if( !(storageParams.inputType in ['file', 'text'])){
+            flash.errorCode = 'api.error.parameter.not.inList'
+            flash.errorArgs = [storageParams.inputType, 'inputType']
+            return redirect(controller: 'menu', action: 'storage',
+                    params: [project: params.project])
+        }
+
+        def filename = storageParams.fileName
+
+        if (!filename) {
+            flash.errorCode = 'api.error.upload.missing'
+            flash.errorArgs = ['fileName']
+            return redirect(controller: 'menu', action: 'storage',
+                    params: [project: params.project])
+        }
+
+        def uploadText = params.uploadText
+        if(storageParams.uploadKeyType in ['public', 'private'] && !uploadText){
+            if(!uploadText){
+                flash.errorCode = 'api.error.parameter.required'
+                flash.errorArgs = ['uploadText']
+
+                return redirect(controller: 'menu', action: 'storage',
+                        params: [project: params.project])
+            }
+        } else if(storageParams.uploadKeyType == 'password' ){  // Password input type is always text
+            //store a password
+            if (!params.uploadPassword) {
+                //invalid
+                flash.errorCode = 'api.error.parameter.required'
+                flash.errorArgs = ['uploadPassword']
+
+                return redirect(controller: 'menu', action: 'storage',
+                        params: [project: params.project])
+            }
+            uploadText = params.uploadPassword
+        }
+
+        resourcePath = PathUtil.cleanPath(resourcePath + '/' + filename)
+
+        def newparams = new StorageParams(resourcePath: resourcePath)
+        newparams.validate()
+
+        if(newparams.hasErrors()){
+            flash.errors=newparams.errors
+            return redirect(controller: 'menu', action: 'storage',
+                    params: [project: params.project])
+        }
+
+        boolean dontOverwrite = params.dontOverwrite in [true, 'true']
+
+        def hasResource = storageService.hasResource(authContext, resourcePath)
+
+        if (dontOverwrite && hasResource) {
+            flash.error = g.message(code: 'api.error.item.alreadyexists',
+                    args: ['Storage file', resourcePath])
+
+            return redirect(controller: 'menu', action: 'storage',
+                    params: [project: params.project])
+        } else if (!hasResource && storageService.hasPath(authContext, resourcePath)) {
+            flash.error = g.message(code: 'api.error.item.alreadyexists',
+                    args: ['Storage directory path', resourcePath])
+
+            return redirect(controller: 'menu', action: 'storage',
+                    params: [project: params.project])
+        }
+
+        def inputBytes = uploadText.bytes
+
+        Map<String, String> map = [
+                (StorageUtil.RES_META_RUNDECK_CONTENT_TYPE): contentType,
+                (StorageUtil.RES_META_RUNDECK_CONTENT_LENGTH): inputBytes.length.toString() //if the value of content length is not cast to a string here,
+                // Groovy allows the value into the map as an int or long
+                // which will cause a type cast exception later if the contentLength
+                // is accessed later in the storage chain
+        ]
+        try {
+            def inputStream = new ByteArrayInputStream(inputBytes)
+
+            if(hasResource){
+                storageService.updateResource(authContext, resourcePath, map, inputStream)
+            }else{
+                storageService.createResource(authContext, resourcePath, map, inputStream)
+            }
+            return redirect(controller: 'menu', action: 'storage', params: [resourcePath:resourcePath]+(params.project?[project:params.project]:[:]))
+        } catch (StorageAuthorizationException e) {
+            log.error("Unauthorized: resource ${resourcePath}: ${e.message}")
+            flash.errorCode = 'api.error.item.unauthorized'
+            flash.errorArgs = [e.event.toString(), 'Path', e.path.toString()]
+            return redirect(controller: 'menu', action: 'storage',params: [resourcePath:resourcePath]+(params.project?[project:params.project]:[:]))
+        } catch (StorageException e) {
+            log.error("Error creating resource ${resourcePath}: ${e.message}")
+            log.debug("Error creating resource ${resourcePath}", e)
+            flash.error= e.message
+            return redirect(controller: 'menu', action: 'storage',params: [resourcePath:resourcePath]+(params.project?[project:params.project]:[:]))
         }
     }
     /**

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/StorageController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/StorageController.groovy
@@ -258,7 +258,6 @@ class StorageController extends ControllerBase{
     /**
      * non-api action wrapper for apiKeys method
      *
-     * TODO: handle public key client side upload
      */
     def keyStorageUpload(StorageParams storageParams){
         if (storageParams.hasErrors()) {
@@ -359,9 +358,9 @@ class StorageController extends ControllerBase{
             Map<String, String> map = [
                     (StorageUtil.RES_META_RUNDECK_CONTENT_TYPE): contentType,
                     (StorageUtil.RES_META_RUNDECK_CONTENT_LENGTH): inputBytes.length.toString() //if the value of content length is not cast to a string here,
-                    // Groovy allows the value into the map as an int or long
-                    // which will cause a type cast exception later if the contentLength
-                    // is accessed later in the storage chain
+                                                                                                // Groovy allows the value into the map as an int or long
+                                                                                                // which will cause a type cast exception later if the contentLength
+                                                                                                // is accessed later in the storage chain
             ]
             try {
                 def inputStream = new ByteArrayInputStream(inputBytes)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/StorageController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/StorageController.groovy
@@ -366,9 +366,9 @@ class StorageController extends ControllerBase{
                 def inputStream = new ByteArrayInputStream(inputBytes)
 
                 if(hasResource){
-                    def resource = storageService.updateResource(authContext, resourcePath, map, inputStream)
+                    storageService.updateResource(authContext, resourcePath, map, inputStream)
                 }else{
-                    def resource = storageService.createResource(authContext, resourcePath, map, inputStream)
+                    storageService.createResource(authContext, resourcePath, map, inputStream)
                 }
                 return redirect(controller: 'menu', action: 'storage', params: [resourcePath:resourcePath]+(params.project?[project:params.project]:[:]))
             } catch (StorageAuthorizationException e) {

--- a/rundeckapp/grails-app/views/menu/storage.gsp
+++ b/rundeckapp/grails-app/views/menu/storage.gsp
@@ -80,7 +80,7 @@ implied. - See the License for the specific language governing permissions and -
           <div class="modal-dialog">
               %{--modal storage key upload/input form--}%
               <div class="modal-content">
-                <g:form controller="storage" action="keyStorageUpload" id="uploadKeyForm" useToken="true" class="form-horizontal" role="form"
+                <g:uploadForm controller="storage" action="keyStorageUpload" id="uploadKeyForm" useToken="true" class="form-horizontal" role="form"
                 params="[project:params.project]">
                 <div class="modal-header">
                   <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
@@ -123,8 +123,8 @@ implied. - See the License for the specific language governing permissions and -
                       <div data-bind="visible: upload.inputType()=='file' ">
                         <input type="file" name="storagefile" id="storageuploadfile" data-bind="value: upload.file"/>
                       </div>
-                      <div data-bind="if: (upload.inputType()=='text' || upload.inputType()=='file') && upload.keyType()!='password' ">
-                        <textarea class="form-control" rows="5" id="storageuploadtext" data-bind="value: upload.textArea" name="uploadText"></textarea>
+                      <div data-bind="if: (upload.inputType()=='text' || upload.inputType()=='file') && upload.keyType() != 'password'" >
+                        <textarea class="form-control" rows="5" id="storageuploadtext" data-bind="value: upload.textArea, visible: upload.inputType() != 'file'" name="uploadText"></textarea>
                       </div>
                       <div data-bind="if: upload.inputType()=='text' && upload.keyType()=='password' ">
                         <input name="uploadPassword" type="password" placeholder="Enter a password" autocomplete="new-password" data-bind="value: upload.password" id="uploadpasswordfield" class="form-control"/>
@@ -190,7 +190,7 @@ implied. - See the License for the specific language governing permissions and -
                   <button type="button" class="btn btn-sm btn-default" data-dismiss="modal"><g:message code="cancel"/></button>
                   <input type="submit" class="btn btn-sm btn-cta obs-storageupload-select" data-bind="attr: { disabled: !upload.validInput() }" value="Save"/>
                 </div>
-              </g:form>
+              </g:uploadForm>
               </div>
           </div>
         </div>

--- a/rundeckapp/grails-app/views/menu/storage.gsp
+++ b/rundeckapp/grails-app/views/menu/storage.gsp
@@ -80,7 +80,7 @@ implied. - See the License for the specific language governing permissions and -
           <div class="modal-dialog">
               %{--modal storage key upload/input form--}%
               <div class="modal-content">
-                <g:uploadForm controller="storage" action="keyStorageUpload" id="uploadKeyForm" useToken="true" class="form-horizontal" role="form"
+                <g:form controller="storage" action="keyStorageUpload" id="uploadKeyForm" useToken="true" class="form-horizontal" role="form"
                 params="[project:params.project]">
                 <div class="modal-header">
                   <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
@@ -120,15 +120,12 @@ implied. - See the License for the specific language governing permissions and -
                       <g:message code="enter.text"/>
                     </label>
                     <div class="col-sm-9">
-
-                      <div data-bind="if: upload.inputType()=='text' && upload.keyType()!='password' ">
-                        <textarea class="form-control" rows="5" id="storageuploadtext" data-bind="value: upload.textArea" name="uploadText"></textarea>
-                      </div>
-
                       <div data-bind="visible: upload.inputType()=='file' ">
                         <input type="file" name="storagefile" id="storageuploadfile" data-bind="value: upload.file"/>
                       </div>
-
+                      <div data-bind="if: (upload.inputType()=='text' || upload.inputType()=='file') && upload.keyType()!='password' ">
+                        <textarea class="form-control" rows="5" id="storageuploadtext" data-bind="value: upload.textArea" name="uploadText"></textarea>
+                      </div>
                       <div data-bind="if: upload.inputType()=='text' && upload.keyType()=='password' ">
                         <input name="uploadPassword" type="password" placeholder="Enter a password" autocomplete="new-password" data-bind="value: upload.password" id="uploadpasswordfield" class="form-control"/>
                       </div>
@@ -193,7 +190,7 @@ implied. - See the License for the specific language governing permissions and -
                   <button type="button" class="btn btn-sm btn-default" data-dismiss="modal"><g:message code="cancel"/></button>
                   <input type="submit" class="btn btn-sm btn-cta obs-storageupload-select" data-bind="attr: { disabled: !upload.validInput() }" value="Save"/>
                 </div>
-              </g:uploadForm>
+              </g:form>
               </div>
           </div>
         </div>

--- a/rundeckapp/src/test/groovy/rundeck/controllers/StorageControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/StorageControllerSpec.groovy
@@ -199,18 +199,17 @@ class StorageControllerSpec extends Specification implements ControllerUnitTest<
         0 * controller.apiService._(*_)
     }
 
-    def "key storage upload without relativePath"() {
+    def "add new key storage without relativePath"() {
         given:
         grailsApplication.config.clear()
         grailsApplication.config.rundeck.security.useHMacRequestTokens = 'false'
-        def assetTaglib = mockTagLib(UtilityTagLib)
         controller.storageService = Mock(StorageService)
         controller.frameworkService = Mock(FrameworkService)
             controller.rundeckAuthContextProvider=Mock(AuthContextProvider)
         controller.apiService = Mock(ApiService)
         when:
-        params.uploadKeyType = 'public'
-        params.inputType = 'text'
+        params.uploadKeyType = uploadKeyType
+        params.inputType = inputType
         params.fileName = 'monkey'
         params.uploadText = 'abc'
         params.project = project
@@ -224,13 +223,58 @@ class StorageControllerSpec extends Specification implements ControllerUnitTest<
         1 * controller.rundeckAuthContextProvider.getAuthContextForSubject(_)
         1 * controller.storageService.hasResource(_, 'keys/monkey') >> false
         1 * controller.storageService.hasPath(_, 'keys/monkey') >> false
-        1 * controller.storageService.createResource(_, 'keys/monkey',_,_) >> true
+        1 * controller.storageService.createResource(_, 'keys/monkey',_,_)
         1 * controller.storageService._(*_)
         0 * controller.apiService._(*_)
         where:
-            project | expect
-            null    | '/menu/storage/keys/monkey'
-            'disco' | '/menu/storage/keys/monkey?project=disco'
+            project | uploadKeyType | inputType     | expect
+            null    | 'public'      | 'text'        | '/menu/storage/keys/monkey'
+            null    | 'public'      | 'file'        | '/menu/storage/keys/monkey'
+            'disco' | 'public'      | 'text'        | '/menu/storage/keys/monkey?project=disco'
+            'disco' | 'public'      | 'file'        |'/menu/storage/keys/monkey?project=disco'
+            null    | 'private'     | 'text'        | '/menu/storage/keys/monkey'
+            null    | 'private'     | 'file'        | '/menu/storage/keys/monkey'
+            'disco' | 'private'     | 'text'        | '/menu/storage/keys/monkey?project=disco'
+            'disco' | 'private'     | 'file'        |'/menu/storage/keys/monkey?project=disco'
+    }
+
+    def "override existing key storage without relativePath"() {
+        given:
+        grailsApplication.config.clear()
+        grailsApplication.config.rundeck.security.useHMacRequestTokens = 'false'
+        controller.storageService = Mock(StorageService)
+        controller.frameworkService = Mock(FrameworkService)
+        controller.rundeckAuthContextProvider=Mock(AuthContextProvider)
+        controller.apiService = Mock(ApiService)
+        when:
+        params.dontOverwrite = false
+        params.uploadKeyType = uploadKeyType
+        params.inputType = inputType
+        params.fileName = 'monkey'
+        params.uploadText = 'abc'
+        params.project = project
+        setupFormTokens(controller)
+        request.method = 'POST'
+        def result = controller.keyStorageUpload()
+
+        then:
+        response.status == 302
+        response.redirectedUrl==expect
+        1 * controller.rundeckAuthContextProvider.getAuthContextForSubject(_)
+        1 * controller.storageService.hasResource(_, 'keys/monkey') >> true
+        1 * controller.storageService.updateResource(_, 'keys/monkey',_,_)
+        1 * controller.storageService._(*_)
+        0 * controller.apiService._(*_)
+        where:
+        project | uploadKeyType | inputType     | expect
+        null    | 'public'      | 'text'        | '/menu/storage/keys/monkey'
+        null    | 'public'      | 'file'        | '/menu/storage/keys/monkey'
+        'disco' | 'public'      | 'text'        | '/menu/storage/keys/monkey?project=disco'
+        'disco' | 'public'      | 'file'        |'/menu/storage/keys/monkey?project=disco'
+        null    | 'private'     | 'text'        | '/menu/storage/keys/monkey'
+        null    | 'private'     | 'file'        | '/menu/storage/keys/monkey'
+        'disco' | 'private'     | 'text'        | '/menu/storage/keys/monkey?project=disco'
+        'disco' | 'private'     | 'file'        |'/menu/storage/keys/monkey?project=disco'
     }
 
     @Unroll


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
- Fixes RUN-707. It's an security enhancement by obsolete file upload feature for import storage key. 

**Describe the solution you've implemented**
- The uploading file feature is replaced by read the file content in the client-side through FileReader API so there is no file uploaded to the server. 

**Describe alternatives you've considered**
- We considered obsolete the file upload feature completely. But it will change the user experience significantly. To avoid confusing user we choose the way with minimum impact to the user experience.

**Additional context**
There is no noticeable UI change.
