### PR TITLE
RUN-715: CI updates 2

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/AuthorizationInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/AuthorizationInterceptor.groovy
@@ -18,37 +18,30 @@ class AuthorizationInterceptor {
 
     boolean before() {
         if(interceptorHelper.matchesAllowedAsset(controllerName, request)) return true
-        if (request.invalidApiAuthentication) {
+        if(request.apiVersionStatusNotReady){
+            response.status = HttpServletResponse.SC_SERVICE_UNAVAILABLE
+            return false
+        }else if (request.invalidApiAuthentication) {
             response.setStatus(403)
             def authid = session.user ?: "(${request.invalidAuthToken ?: 'unauthenticated'})"
             log.error("${authid} UNAUTHORIZED for ${controllerName}/${actionName}");
-            if (request.api_version) {
-                //api request
-                if (response.format in ['json']) {
-                    render(contentType: "application/json", encoding: "UTF-8") {
-                        error true
-                        apiversion ApiVersions.API_CURRENT_VERSION
-                        errorCode "unauthorized"
-                        message ("${authid} is not authorized for: ${request.forwardURI}")
-                    }
-                } else {
-                    render(contentType: "text/xml", encoding: "UTF-8") {
-                        result(error: "true", apiversion: ApiVersions.API_CURRENT_VERSION) {
-                            delegate.'error'(code: "unauthorized") {
-                                message("${authid} is not authorized for: ${request.forwardURI}")
-                            }
+            //api request
+            if (response.format in ['xml']) {
+                render(contentType: "text/xml", encoding: "UTF-8") {
+                    result(error: "true", apiversion: ApiVersions.API_CURRENT_VERSION) {
+                        delegate.'error'(code: "unauthorized") {
+                            message("${authid} is not authorized for: ${request.forwardURI}")
                         }
                     }
                 }
-                return false
+            } else {
+                render(contentType: "application/json", encoding: "UTF-8") {
+                    error true
+                    apiversion ApiVersions.API_CURRENT_VERSION
+                    errorCode "unauthorized"
+                    message ("${authid} is not authorized for: ${request.forwardURI}")
+                }
             }
-            flash.title = "Unauthorized"
-            flash.error = "${authid} is not authorized"
-            response.setHeader(Constants.X_RUNDECK_ACTION_UNAUTHORIZED_HEADER, flash.error)
-            redirect(controller: 'user', action: actionName ==~ /^.*(Fragment|Inline)$/ ? 'deniedFragment' : 'denied', params: params.xmlreq ? params.subMap(['xmlreq']) : null)
-            return false;
-        }else if(request.apiVersionStatusNotReady){
-            response.status = HttpServletResponse.SC_SERVICE_UNAVAILABLE
             return false
         }
         return true

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
@@ -56,6 +56,8 @@ class SetUserInterceptor {
             request.invalidApiAuthentication=true
             return false
         }
+        def authtoken = params.authtoken? Webhook.cleanAuthToken(params.authtoken) : request.getHeader('X-RunDeck-Auth-Token')
+
         if (request.userPrincipal && session.user!=request.userPrincipal.name) {
             session.user = request.userPrincipal.name
 
@@ -72,9 +74,8 @@ class SetUserInterceptor {
         } else if(request.remoteUser && session.subject &&
                 !configurationService.getBoolean("security.authorization.preauthenticated.enabled",false)) {
             request.subject = session.subject
-        } else if (request.api_version && !session.user ) {
+        } else if (request.api_version && !session.user && authtoken) {
             //allow authentication token to be used
-            def authtoken = params.authtoken? Webhook.cleanAuthToken(params.authtoken) : request.getHeader('X-RunDeck-Auth-Token')
             boolean webhookType = controllerName == "webhook" && actionName == "post"
 
             AuthenticationToken foundToken = lookupToken(authtoken, servletContext, webhookType)

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
@@ -116,10 +116,15 @@ class SetUserInterceptor {
             }
         } else if (!request.remoteUser) {
             //unauthenticated request to an action
-            response.status = 403
-            request.errorCode = 'request.authentication.required'
-            render view: '/common/error.gsp'
-            return false
+            if(request.api_version) {
+                //api unauth response handled by AuthorizationInterceptor
+                request.invalidApiAuthentication = true
+            }else{
+                response.status = 403
+                request.errorCode = 'request.authentication.required'
+                render view: '/common/error.gsp'
+                return false
+            }
         }
         def requiredRole = configurationService.getString("security.requiredRole","")
         if(!requiredRole.isEmpty()) {

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/AuthorizationInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/AuthorizationInterceptorSpec.groovy
@@ -14,20 +14,24 @@ class AuthorizationInterceptorSpec extends Specification implements InterceptorU
     }
 
     void "Test authorization interceptor matching"() {
-        when:"A request matches the interceptor"
-            withRequest(controller:"authorization")
+        when: "A request matches the interceptor"
+            withRequest(controller: "authorization")
 
-        then:"The interceptor does match"
+        then: "The interceptor does match"
             interceptor.doesMatch()
     }
-    def "apiVersionStatusNotReady causes 503 response"(){
+
+    def "apiVersionStatusNotReady causes 503 response"() {
         given:
-            request.apiVersionStatusNotReady=true
-            interceptor.interceptorHelper=Mock(InterceptorHelper)
+            request.apiVersionStatusNotReady = true
+            request.invalidApiAuthentication = invalidApiAuthentication
+            interceptor.interceptorHelper = Mock(InterceptorHelper)
         when:
-            def result=interceptor.before()
+            def result = interceptor.before()
         then:
             !result
-            response.status==503
+            response.status == 503
+        where:
+            invalidApiAuthentication << [true, false]
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/AuthorizationInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/AuthorizationInterceptorSpec.groovy
@@ -34,4 +34,30 @@ class AuthorizationInterceptorSpec extends Specification implements InterceptorU
         where:
             invalidApiAuthentication << [true, false]
     }
+
+    def "invalidApiAuthentication causes API error response"() {
+        given:
+            request.invalidApiAuthentication = true
+            interceptor.interceptorHelper = Mock(InterceptorHelper)
+        when:
+            response.format=format
+            def result = interceptor.before()
+        then:
+            !result
+            response.status == 403
+            if (xmlresp) {
+                def xml = response.xml
+
+                xml.'@error'.text() == 'true'
+                xml.'error'.'@code'.text() == 'unauthorized'
+            } else {
+                response.json.error == true
+                response.json.errorCode == 'unauthorized'
+            }
+        where:
+            format | xmlresp | jsonresp
+            'xml'  | true    | false
+            'json' | false   | true
+            null   | false   | true
+    }
 }

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
@@ -175,4 +175,15 @@ class SetUserInterceptorSpec extends Specification implements InterceptorUnitTes
         "RN1" | false        | true     | "admin"
     }
 
+    def "request without remote auth info will be invalid"(){
+        given:
+            request.api_version=12
+            interceptor.interceptorHelper=Mock(InterceptorHelper)
+        when:
+            def result=interceptor.before()
+        then:
+            result
+            request.invalidApiAuthentication
+    }
+
 }

--- a/test/api/unauthorized-test-xml.sh
+++ b/test/api/unauthorized-test-xml.sh
@@ -10,12 +10,12 @@ runurl="${APIURL}/projects"
 #remove any existing cookies
 test -f $DIR/cookies && rm $DIR/cookies
 
-echo "TEST: unauthorized simple request"
+echo "TEST: unauthorized simple request (XML)"
 
 params=""
 
 # get listing
-$CURL  -D $DIR/headers.out ${runurl}?${params} > $DIR/curl.out
+$CURL  -D $DIR/headers.out -H 'accept:application/xml'  ${runurl}?${params} > $DIR/curl.out
 if [ 0 != $? ] ; then
     errorMsg "ERROR: failed query request"
     exit 2
@@ -38,13 +38,13 @@ rm $DIR/curl.out
 rm $DIR/headers.out
 
 
-echo "TEST: unauthorized token request (header)"
+echo "TEST: unauthorized token request (header) XML"
 
 params=""
 FAKEAUTH="abc123badtoken"
 
 # get listing
-$CURL -H "X-RunDeck-Auth-Token: $FAKEAUTH" -D $DIR/headers.out ${runurl}?${params} > $DIR/curl.out
+$CURL -H "X-RunDeck-Auth-Token: $FAKEAUTH" -D $DIR/headers.out -H 'accept:application/xml'  ${runurl}?${params} > $DIR/curl.out
 if [ 0 != $? ] ; then
     errorMsg "ERROR: failed query request"
     exit 2
@@ -66,12 +66,12 @@ fi
 rm $DIR/curl.out
 rm $DIR/headers.out
 
-echo "TEST: unauthorized token request (param)"
+echo "TEST: unauthorized token request (param) XML"
 
 params="authtoken=$FAKEAUTH"
 
 # get listing
-$CURL  -D $DIR/headers.out ${runurl}?${params} > $DIR/curl.out
+$CURL  -D $DIR/headers.out -H 'accept:application/xml'  ${runurl}?${params} > $DIR/curl.out
 if [ 0 != $? ] ; then
     errorMsg "ERROR: failed query request"
     exit 2

--- a/test/testdeck/src/commands/TestCommand.ts
+++ b/test/testdeck/src/commands/TestCommand.ts
@@ -4,7 +4,7 @@ import { Rundeck, PasswordCredentialProvider } from 'ts-rundeck'
 
 import {spawn} from '../async/child-process'
 import { ProjectImporter } from '../projectImporter'
-import { waitForRundeckReady } from '../util/RundeckAPI'
+import { createWaitForRundeckReady } from '../util/RundeckAPI'
 import { ClusterFactory, IClusterManager } from '../ClusterManager'
 import { Config } from '../Config';
 
@@ -149,9 +149,10 @@ class TestCommand {
 
         console.log(cmdString)
 
-        const client = new Rundeck(new PasswordCredentialProvider(opts.url, 'admin', 'admin'), {baseUri: opts.url})
-
-        await waitForRundeckReady(client,5*60*1000)
+        await createWaitForRundeckReady(
+          () => new Rundeck(new PasswordCredentialProvider(opts.url, 'admin', 'admin'), {noRetryPolicy: true, baseUri: opts.url}),
+          5 * 60 * 1000
+        )
 
         const ret = await spawn('/bin/sh', ['-c', cmdString], {
             stdio: 'inherit',

--- a/test/testdeck/src/commands/TestCommand.ts
+++ b/test/testdeck/src/commands/TestCommand.ts
@@ -147,12 +147,15 @@ class TestCommand {
         /** Drop the null entries and construct command string */
         const cmdString = cmdArgs.filter(a => a != null).join(' ')
 
-        console.log(cmdString)
-
+        console.info(`Waiting for server to accept requests...`)
+        const reqstart = Date.now()
         await createWaitForRundeckReady(
           () => new Rundeck(new PasswordCredentialProvider(opts.url, 'admin', 'admin'), {noRetryPolicy: true, baseUri: opts.url}),
           5 * 60 * 1000
         )
+        console.info(`Client connected. (${Date.now() - reqstart}ms)`)
+
+        console.log(cmdString)
 
         const ret = await spawn('/bin/sh', ['-c', cmdString], {
             stdio: 'inherit',

--- a/test/testdeck/src/util/RundeckAPI.ts
+++ b/test/testdeck/src/util/RundeckAPI.ts
@@ -13,12 +13,10 @@ export async function createWaitForRundeckReady(factory: ()=>Rundeck, timeout = 
     const unauthMax=10
     const sleepTime=2000
     let unauthCount=0
-    console.info(`Waiting for server to accept requests...`)
     while (Date.now() - start < timeout) {
         try {
             const reqstart=Date.now()
             let resp = await factory().systemInfoGet()
-            console.info(`Client connected: ${resp.system?.rundeckProperty?.version} (${Date.now() - reqstart}ms)`)
             return
         } catch  (e) {
             if (e.statusCode === 403) {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Some more updates to API responses and testdeck wait for server startup

* `request.apiVersionStatusNotReady` state should be processed before unauthorized response
    *  reason: otherwise the 503 service unavailable response is not sent correctly just 403
* SetUserInterceptor: clause checking auth token should only be applied if a token is in the request
    * reason: request state without auth and without a token still falls into that clause
    * for api requests which are unauthenticated and have no token, use the `request.invalidApiAuthentication` to indicate invalid auth state via the AuthorizationInterceptor
* AuthorizationInterceptor: default response format was changed to json, xml will be used if Accept header is present
    * update unauthorized-test-xml.sh to specify Accept header for xml 
*  Change behavior of TestCommand.ts and and RundeckApi.ts - create a new Rundeck client instance for each attempt, and disable internal retries.  This solves the issue where the client cookie is reused with an invalid "unauthenticated" state on the server side and retries never progress to a 200 response.  The client will now create a new session each time, and handles all retries with the RundeckApi code.  Special case of repeated 403 responses will fail faster.