### PR TITLE
RUN-698: execution mode change should allow app_admin authorization

### DIFF
--- a/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/app/RundeckAccess.java
+++ b/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/app/RundeckAccess.java
@@ -92,21 +92,21 @@ public class RundeckAccess {
                 APP_CONFIGURE =
                 action(AuthConstants.ACTION_CONFIGURE).or(RundeckAccess.General.ALL_ADMIN);
 
-        public static final String AUTH_OPS_ENABLE_EXECUTION = "opsEnableExecution";
+        public static final String AUTH_ADMIN_ENABLE_EXECUTION = "adminEnableExecution";
         /**
-         * Enable executions or ops admin
+         * Enable executions or any admin
          */
         public static final AuthActions
-                OPS_ENABLE_EXECUTION =
-                action(AuthConstants.ACTION_ENABLE_EXECUTIONS).or(RundeckAccess.General.OPS_ADMIN);
+                ADMIN_ENABLE_EXECUTION =
+                action(AuthConstants.ACTION_ENABLE_EXECUTIONS).or(General.ALL_ADMIN);
 
-        public static final String AUTH_OPS_DISABLE_EXECUTION = "opsDisableExecution";
+        public static final String AUTH_ADMIN_DISABLE_EXECUTION = "adminDisableExecution";
         /**
-         * Disable execution or ops admin
+         * Disable execution or any admin
          */
         public static final AuthActions
-                OPS_DISABLE_EXECUTION =
-                action(AuthConstants.ACTION_DISABLE_EXECUTIONS).or(RundeckAccess.General.OPS_ADMIN);
+                ADMIN_DISABLE_EXECUTION =
+                action(AuthConstants.ACTION_DISABLE_EXECUTIONS).or(General.ALL_ADMIN);
 
         public static final String AUTH_READ_OR_ANY_ADMIN = "readOrAnyAdmin";
         /**
@@ -129,8 +129,8 @@ public class RundeckAccess {
         static {
             NAMED_AUTH_ACTIONS = Collections.unmodifiableMap(new HashMap<String, AuthActions>() {{
                 put(AUTH_CONFIGURE, APP_CONFIGURE);
-                put(AUTH_OPS_DISABLE_EXECUTION, OPS_DISABLE_EXECUTION);
-                put(AUTH_OPS_ENABLE_EXECUTION, OPS_ENABLE_EXECUTION);
+                put(AUTH_ADMIN_DISABLE_EXECUTION, ADMIN_DISABLE_EXECUTION);
+                put(AUTH_ADMIN_ENABLE_EXECUTION, ADMIN_ENABLE_EXECUTION);
                 put(AUTH_READ_OR_ANY_ADMIN, READ_OR_ANY_ADMIN);
                 put(AUTH_READ_OR_OPS_ADMIN, READ_OR_OPS_ADMIN);
                 putAll(General.NAMED_AUTH_ACTIONS);

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -485,8 +485,8 @@ class ExecutionController extends ControllerBase{
             def requestActive=params.mode == 'active'
 
             authorizingSystem.authorize(
-                requestActive ? RundeckAccess.System.OPS_ENABLE_EXECUTION :
-                RundeckAccess.System.OPS_DISABLE_EXECUTION
+                requestActive ? RundeckAccess.System.ADMIN_ENABLE_EXECUTION :
+                RundeckAccess.System.ADMIN_DISABLE_EXECUTION
             )
 
             if(requestActive == executionService.executionsAreActive){
@@ -2150,7 +2150,7 @@ setTimeout(function(){
      */
 
     @RdAuthorizeSystem(
-        RundeckAccess.System.AUTH_OPS_ENABLE_EXECUTION
+        RundeckAccess.System.AUTH_ADMIN_ENABLE_EXECUTION
     )
     def apiExecutionModeActive() {
         apiExecutionMode(true)
@@ -2160,7 +2160,7 @@ setTimeout(function(){
      * @return
      */
     @RdAuthorizeSystem(
-        RundeckAccess.System.AUTH_OPS_DISABLE_EXECUTION
+        RundeckAccess.System.AUTH_ADMIN_DISABLE_EXECUTION
     )
     def apiExecutionModePassive() {
         apiExecutionMode(false)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -893,9 +893,9 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
     def executionMode(){
         def executionModeActive=configurationService.executionModeActive
         authorizingSystem.authorize(
-            executionModeActive?
-                RundeckAccess.System.OPS_DISABLE_EXECUTION:
-                RundeckAccess.System.OPS_ENABLE_EXECUTION
+            executionModeActive ?
+                RundeckAccess.System.ADMIN_DISABLE_EXECUTION :
+                RundeckAccess.System.ADMIN_ENABLE_EXECUTION
         )
     }
     def storage(){

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -42,7 +42,6 @@ import org.rundeck.core.auth.access.NotFound
 import org.rundeck.app.authorization.domain.execution.AuthorizingExecution
 import org.rundeck.app.authorization.domain.AppAuthorizer
 import org.rundeck.core.auth.AuthConstants
-import org.rundeck.core.auth.access.UnauthorizedAccess
 import org.rundeck.core.auth.app.RundeckAccess
 import org.rundeck.core.auth.web.RdAuthorizeAdhoc
 import org.rundeck.core.auth.web.RdAuthorizeExecution
@@ -1114,8 +1113,8 @@ class ExecutionControllerSpec extends HibernateSpec implements ControllerUnitTes
             result.value() == access
         where:
             endpoint                  | access
-            'apiExecutionModeActive'  | RundeckAccess.System.AUTH_OPS_ENABLE_EXECUTION
-            'apiExecutionModePassive' | RundeckAccess.System.AUTH_OPS_DISABLE_EXECUTION
+            'apiExecutionModeActive'  | RundeckAccess.System.AUTH_ADMIN_ENABLE_EXECUTION
+            'apiExecutionModePassive' | RundeckAccess.System.AUTH_ADMIN_DISABLE_EXECUTION
             'apiExecutionModeStatus'  | RundeckAccess.System.AUTH_READ_OR_ANY_ADMIN
     }
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Change auth required for execution mode toggle, to allow `app_admin` as well as `ops_admin` and `admin`.
