### PR TITLE
RUN-716: Fix the crontab update issue

### DIFF
--- a/rundeckapp/grails-spa/packages/ui/src/components/job/schedule/ScheduleEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/schedule/ScheduleEditor.vue
@@ -145,6 +145,7 @@
                                       @blur="validateCronExpression"
                                       v-model="modelData.crontabString"
                                     >
+                                    <input type="hidden" name="useCrontabString" v-model="modelData.useCrontabString">
                                   </div>
                                 </div>
                                 <div class="col-sm-6">
@@ -272,7 +273,6 @@
 </div>
 </template>
 <script lang="ts">
-import {_genUrl} from '@/utilities/genUrl'
 import axios from 'axios'
 import InlineValidationErrors from '../../form/InlineValidationErrors.vue'
 import Vue from 'vue'
@@ -284,10 +284,7 @@ import {
   getMonths,
   getSimpleDecomposition,
 } from "./services/scheduleDefinition"
-import {
-  getRundeckContext,
-  getAppLinks
-} from '@rundeck/ui-trellis'
+
 
 @Component({components: {InlineValidationErrors}})
 export default class ScheduleEditor extends Vue {
@@ -364,7 +361,7 @@ export default class ScheduleEditor extends Vue {
         project: window._rundeck.projectName,
         crontabString: this.modelData.crontabString
       },
-      url: `/scheduledExecution/checkCrontab`,
+      url: new URL(`scheduledExecution/checkCrontab`, window._rundeck.rdBase).toString(),
       withCredentials: true
     }).then(response => {
       this.errors = response.request.response


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is a bug fix for (https://github.com/rundeckpro/rundeckpro/issues/2271) and RUN-716

**Describe the solution you've implemented**

1. The root cause of the bug:

When updating the crontab with the formatted string, a parameter useCrontabString must also be provided to indicate the crontab string should be used to set the schedule. But this parameter is missing so the server-side program always gets a NULL value.
```
// ScheduledExecution.groovy
// Line #816
if(params.crontabString && 'true'==params.useCrontabString){
    //parse the crontabString
    crontabString = params.crontabString
    parseCrontabString(crontabString)
    return
}
```

Adding a hidden field of useCrontabString can solve the problem with minimum impact.

2. Another hidden bug found during the investigation:

The client-side javascript ajax call to validateCronExpression will fail with a 404 error if a custom context path was set because the URL composition logic didn't consider the context path.

Refactor the URL composition logic can fix the issue:

```
url: new URL(`scheduledExecution/checkCrontab`, window._rundeck.rdBase).toString()
```



**Describe alternatives you've considered**
Remove the server-side check on `params.useCrontabString` can be a solution but the side-effect is not easy to identify. A client-side fix is safer.


