### PR TITLE
RUN-749: Correct the parameter name of minute

### DIFF
--- a/rundeckapp/grails-spa/packages/ui/src/components/job/schedule/ScheduleEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/schedule/ScheduleEditor.vue
@@ -74,7 +74,7 @@
                               <label for="minuteNumber" aria-hidden="false" style="display: none;">Minute</label>
                               <select
                                 id="minuteNumber"
-                                name="minutes"
+                                name="minute"
                                 v-model="modelData.minuteSelected"
                                 class="form-control"
                                 style="width:auto;"


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is a bugfix. The simple schedule editing form used a wrong form input parameter name for `minute` so the change won't be updated on the server-side

**Describe the solution you've implemented**
Correct wrong form input field name from `minutes` to `minute`


