### PR TITLE
Update Javadoc in ExecutionLogger.java

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionLogger.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionLogger.java
@@ -27,7 +27,7 @@ public interface ExecutionLogger {
     /**
      * Log a message at a given level
      *
-     * @param level   the log level, from 0 to 5, where 0 is "error" and 5 is "debug"
+     * @param level   the log level, from 0 to 4, where 0 is "error" and 4 is "debug"
      * @param message Message being logged. <code>null</code> messages are not logged, however, zero-length strings
      *                are.
      */
@@ -36,7 +36,7 @@ public interface ExecutionLogger {
     /**
      * Log a message at a given level, with additional metadata
      *
-     * @param level     the log level, from 0 to 5, where 0 is "error" and 5 is "debug"
+     * @param level     the log level, from 0 to 4, where 0 is "error" and 4 is "debug"
      * @param message   Message being logged. <code>null</code> messages are not logged, however, zero-length strings
      *                  are.
      * @param eventMeta metadata


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Typo fix

**Describe the solution you've implemented**
Log level debug is equal to 4 according to the [CONSTANTS.DEBUG_LEVEL](https://github.com/rundeck/rundeck/blob/8ea3bc0f019c0ad9fddeac3550639465d139d3f8/core/src/main/java/com/dtolabs/rundeck/core/Constants.java#L39).

