### PR TITLE
RUN-766: fix schedule crontab string should be shown in job editor

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -295,7 +295,7 @@
   <section class="section-space-lg">
 
       <div class="job-editor-schedules-vue" id="job-editor-schedules-vue">
-          <schedules-editor-section :event-bus="EventBus" />
+          <schedules-editor-section :event-bus="EventBus" :use-crontab-string="${scheduledExecution?.shouldUseCrontabString()?:false}"/>
       </div>
 
       <g:render template="jobComponentProperties"

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/schedule/ScheduleEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/schedule/ScheduleEditor.vue
@@ -27,7 +27,7 @@
         </div>
       </div>
     </div>
-    <div class="form-group" id="scheduledExecutionEditTZ" name="scheduledExecutionEditTZ">
+    <div class="form-group" id="scheduledExecutionEditTZ">
     <template v-if="modelData.scheduled">
       <div class="form-group">
         <div class="col-sm-10 col-sm-offset-2">
@@ -38,13 +38,13 @@
                   <div class="col-xs-10">
                     <div class="vue-tabs"><div class="nav-tabs-navigation">
                       <ul class="nav nav-tabs ">
-                        <li id="simpleLi" v-bind:class="{active: !modelData.useCrontabString? true: false}">
+                        <li id="simpleLi" v-bind:class="{active: !modelData.useCrontabString}">
                           <a data-crontabstring="false"
                              href="#cronsimple"
                              @click="showSimpleCron"
                           >Simple</a>
                         </li>
-                        <li id="cronLi" v-bind:class="{active: modelData.useCrontabString? true: false}">
+                        <li id="cronLi" v-bind:class="{active: !!modelData.useCrontabString}">
                           <a data-crontabstring="true"
                              href="#cronstrtab"
                              @click="showCronExpression"
@@ -186,7 +186,6 @@
         </div>
       </div>
       <!--------------------------->
-     <!-- <div class="form-group" id="scheduledExecutionEditTZ" name="scheduledExecutionEditTZ">-->
       <div class="form-group">
         <div class="col-sm-2 control-label text-form-label">
           {{$t('scheduledExecution.property.timezone.prompt')}}

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/schedule/ScheduleEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/schedule/ScheduleEditor.vue
@@ -299,6 +299,9 @@ export default class ScheduleEditor extends Vue {
   @Prop({required: true})
   eventBus!: Vue
 
+  @Prop({required: false, default: false})
+  useCrontabString!: boolean
+
   labelColClass = 'col-sm-2 control-label'
   fieldColSize = 'col-sm-10'
 
@@ -330,10 +333,9 @@ export default class ScheduleEditor extends Vue {
   async mounted() {
     this.modelData = Object.assign({
       selectedDays: [],
-      selectedMonths: []
+      selectedMonths: [],
+      useCrontabString: this.useCrontabString
     }, this.value)
-
-    this.showSimpleCron()
   }
 
   loadScheduleIntoSimpleTab (decomposedSchedule:any){

--- a/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/SchedulesEditorSection.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/SchedulesEditorSection.vue
@@ -1,6 +1,6 @@
 <template>
   <div >
-    <schedule-editor v-model="updatedData" :event-bus="eventBus" v-if="updatedData"/>
+    <schedule-editor v-model="updatedData" :event-bus="eventBus" v-if="updatedData" :use-crontab-string="useCrontabString"/>
     <json-embed :output-data="updatedData" field-name="schedulesJsonData"/>
   </div>
 </template>
@@ -16,7 +16,7 @@ import {
 
 export default {
   name: 'App',
-  props:['eventBus' ],
+  props:['eventBus','useCrontabString' ],
   components: {
     ScheduleEditor,
     JsonEmbed


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
fix: missing check for heuristic about whether crontab string should be shown by default on Job edit page
