### PR TITLE
RUN-767: restore crontab section hint information in editor

### DIFF
--- a/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/i18n.js
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/job/editor/i18n.js
@@ -12,6 +12,17 @@ const translationStrings = {
                 cancel: "Cancel",
                 ok: "OK"
             }
+        },
+        cron:{
+            section:{
+                0:'Seconds',
+                1:'Minutes',
+                2:'Hours',
+                3:'Day of Month',
+                4:'Month',
+                5:'Day of Week',
+                6:'Year'
+            }
         }
     }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Restores a user affordance that provides information about what crontab section is selected.

![screencast 2022-03-17 17-42-11](https://user-images.githubusercontent.com/55603/158916322-311aac52-655e-4426-9ede-bff68d961893.gif)


