### PR TITLE
RUN-671: Ansible plugin moved to `rundeck-plugins` GitHub Org

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 rundeck:
   plugins: # Extra plugins to bundle
-  - "com.github.Batix:rundeck-ansible-plugin:3.1.0"
+  - "com.github.rundeck-plugins:ansible-plugin:3.2.0"
   - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.7"
   - "com.github.rundeck-plugins:py-winrm-plugin:2.0.15"
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.1"

--- a/cve-suppress.xml
+++ b/cve-suppress.xml
@@ -2,9 +2,9 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
    <suppress>
       <notes><![CDATA[
-      file name: rundeck-ansible-plugin-3.1.0.jar
+      file name: ansible-plugin-3.2.0.jar
       ]]></notes>
-<!--      <packageUrl regex="true">^pkg:maven/com\.github\.Batix/rundeck\-ansible\-plugin@.*$</packageUrl>-->
+<!--      <packageUrl regex="true">^pkg:maven/com\.github\.rundeck\-plugins/ansible\-plugin@.*$</packageUrl>-->
       <cve>CVE-2020-11009</cve>
    </suppress>
    <suppress>

--- a/test/docker/dockers/rundeck/data/blocklist.yaml
+++ b/test/docker/dockers/rundeck/data/blocklist.yaml
@@ -1,5 +1,5 @@
 fileNameEntries:
-  - rundeck-ansible
+  - ansible
   - rundeckpro-cyberark
   - openssh-node-execution
   - rundeck-copyfile-plugin

--- a/testbuild.groovy
+++ b/testbuild.groovy
@@ -56,7 +56,7 @@ def coreJarFile = "core/${target}/rundeck-core-${version}.jar"
 
 //the list of bundled plugins to verify in the war and jar
 def plugins=['script','stub','localexec','copyfile','job-state','flow-control','jasypt-encryption','git','object-store','azure-object-store','orchestrator', 'source-refresh','upvar']
-def externalPlugins=['rundeck-ansible-plugin','aws-s3-model-source','py-winrm-plugin','openssh-node-execution','multiline-regex-datacapture-filter', 'attribute-match-node-enhancer','sshj-plugin']
+def externalPlugins=['ansible-plugin','aws-s3-model-source','py-winrm-plugin','openssh-node-execution','multiline-regex-datacapture-filter', 'attribute-match-node-enhancer','sshj-plugin']
 
 //manifest describing expected build results
 def manifest=[


### PR DESCRIPTION
### Do not merge this until the [ansible-plugin PR](https://github.com/rundeck-plugins/ansible-plugin/pull/310) is merged (tests will fail until it can find the new artifact)

**Is this a bugfix, or an enhancement? Please describe.**
This is an enhancement to use the new [Rundeck-published ansible-plugin](https://github.com/rundeck-plugins/ansible-plugin/pull/310)

**Describe the solution you've implemented**
Simply points at the new paths, and uses 3.2.0, under which we will publish the changes

**Describe alternatives you've considered**
N/a

**Additional context**
* The release that contains this code should have release notes or otherwise inform the user that they will need to update to the new migrated ansible plugin.
