### PR TITLE
RUN-786: Fix: CPU usage showing negative value

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -22,6 +22,7 @@ import com.dtolabs.rundeck.app.api.tokens.Token
 import com.dtolabs.rundeck.core.authentication.tokens.AuthTokenType
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.extension.ApplicationExtension
+import com.sun.management.OperatingSystemMXBean
 import grails.web.mapping.LinkGenerator
 import org.rundeck.core.auth.AuthConstants
 import org.rundeck.core.auth.app.RundeckAccess
@@ -474,7 +475,7 @@ class ApiController extends ControllerBase{
         String nodeName= servletContext.getAttribute("FRAMEWORK_NODE")
         String appVersion= grailsApplication.metadata['info.app.version']
         String sUUID= frameworkService.getServerUUID()
-        double load= ManagementFactory.getOperatingSystemMXBean().systemLoadAverage
+        double load= ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class).getSystemCpuLoad()
         int processorsCount= ManagementFactory.getOperatingSystemMXBean().availableProcessors
         String osName= ManagementFactory.getOperatingSystemMXBean().name
         String osVersion= ManagementFactory.getOperatingSystemMXBean().version


### PR DESCRIPTION
Fix: https://github.com/rundeckpro/rundeckpro/issues/2273

Used to use systemLoadAverage but this always return a negative value in windows.
Now changed this to work with getSystemCpuLoad() which works perfectly on windows and linux. 

![image](https://user-images.githubusercontent.com/49494423/159978207-278177bd-2237-4b86-8dc9-8b519d38c95e.png)
