### PR TITLE
RUN-500: Improve dark-mode markdown table visibility

### DIFF
--- a/rundeckapp/grails-app/assets/stylesheets/github-markdown.css
+++ b/rundeckapp/grails-app/assets/stylesheets/github-markdown.css
@@ -212,7 +212,7 @@
 }
 
 .markdown-body a {
-  color: #0366d6;
+  color: var(--link-color);
   text-decoration: none;
 }
 
@@ -568,16 +568,16 @@
 .markdown-body table th,
 .markdown-body table td {
   padding: 6px 13px;
-  border: 1px solid #dfe2e5;
+  border: 1px solid var(--input-outline-color);
 }
 
 .markdown-body table tr {
-  background-color: #fff;
-  border-top: 1px solid #c6cbd1;
+  background-color: var(--background-color-lvl2);
+  border-top: 1px solid var(--input-outline-color);
 }
 
 .markdown-body table tr:nth-child(2n) {
-  background-color: #f6f8fa;
+  background-color: var(--background-color);
 }
 
 .markdown-body img {
@@ -592,7 +592,7 @@
   padding-bottom: 0.2em;
   margin: 0;
   font-size: 85%;
-  background-color: rgba(27,31,35,0.05);
+  background-color: var(--background-color);
   border-radius: 3px;
 }
 
@@ -631,8 +631,10 @@
   overflow: auto;
   font-size: 85%;
   line-height: 1.45;
-  background-color: #f6f8fa;
+  background-color: var(--background-color);
+  color: var(--font-color);
   border-radius: 3px;
+  border-color: var(--input-outline-color);
 }
 
 .markdown-body pre code {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/first-run/FirstRun.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/first-run/FirstRun.vue
@@ -19,7 +19,7 @@
              To get started, create a new project.
             </p>
             <p>
-              <a :href="links.frameworkCreateProject" class="btn  btn-cta btn-lg ">
+              <a :href="links.frameworkCreateProject" class="btn  btn-primary btn-lg ">
                   Create New Project <b class="glyphicon glyphicon-plus"></b>
               </a>
             </p>
@@ -33,7 +33,7 @@
           <div class="l3">Automation</div>
         </div>
         <div style="margin-top:12px;text-align:center;">
-          <a href="https://docs.rundeck.com/docs/learning/" target="_blank" class="btn  btn-success btn-lg">Learn Here</a>
+          <a href="https://docs.rundeck.com/docs/learning/" target="_blank" class="btn  btn-default btn-lg">Learn Here</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
this is a fix for markdown table. visibility in dark mode. [link to issue](https://github.com/rundeck/rundeck/issues/7380)

<img width="380" alt="Screen Shot 2022-03-29 at 3 31 04 PM" src="https://user-images.githubusercontent.com/90348123/160717642-440740b5-3b27-40b9-b1ca-dc5ae1f12c3b.png">

