### PR TITLE
RUN-799: Fix: GUI always displays "nodes" view ignoring set default value

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2634,7 +2634,7 @@ class ScheduledExecutionController  extends ControllerBase{
             if(params.followdetail=='html'){
                 redirect(controller: "execution", action: "renderOutput", id: results.id, params:[convertContent:'on', loglevels:'on', ansicolor:'on', project:params.project, reload:'true'])
             }else{
-                redirect(controller: "execution", action: "show", id: results.id, params:[outdetails: params.followdetail])
+                redirect(controller: "execution", action: "show", id: results.id, fragment: params.followdetail)
             }
         } else {
             redirect(controller: "scheduledExecution", action: "show", id: params.id)


### PR DESCRIPTION
Fix: https://github.com/rundeckpro/rundeckpro/issues/2338

ExecutionController was setting default view value in the url using a query parameter instead of a fragment reference (what the `/execution/show` page expects)