### PR TITLE
RUN-688: Handling special characters in user:password

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -850,7 +850,6 @@ class ScheduledExecutionController  extends ControllerBase{
             String cleanUrl = url.replaceAll("^(https?://)([^:@/]+):[^@/]*@", '$1$2:****@');
             try{
                 urlo = new URL(url)
-                client.setUri(new URL(cleanUrl).toURI())
                 if(urlo.userInfo){
                     client.setUri(new URL(cleanUrl).toURI())
                     UsernamePasswordCredentials cred = new UsernamePasswordCredentials(urlo.userInfo)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -850,10 +850,10 @@ class ScheduledExecutionController  extends ControllerBase{
             String cleanUrl = url.replaceAll("^(https?://)([^:@/]+):[^@/]*@", '$1$2:****@');
             try{
                 urlo = new URL(url)
-                client.setUri(urlo.toURI())
+                client.setUri(new URL(cleanUrl).toURI())
                 if(urlo.userInfo){
                     UsernamePasswordCredentials cred = new UsernamePasswordCredentials(urlo.userInfo)
-                    client.setBasicAuthCredentials(cred.userName,cred.password)
+                    client.setBasicAuthCredentials(cred.userName, cred.password)
                 }
             }catch(MalformedURLException e){
                 throw new Exception("Failed to configure base URL for authentication: "+e.getMessage(),e)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -852,8 +852,11 @@ class ScheduledExecutionController  extends ControllerBase{
                 urlo = new URL(url)
                 client.setUri(new URL(cleanUrl).toURI())
                 if(urlo.userInfo){
+                    client.setUri(new URL(cleanUrl).toURI())
                     UsernamePasswordCredentials cred = new UsernamePasswordCredentials(urlo.userInfo)
                     client.setBasicAuthCredentials(cred.userName, cred.password)
+                } else {
+                    client.setUri(urlo.toURI())
                 }
             }catch(MalformedURLException e){
                 throw new Exception("Failed to configure base URL for authentication: "+e.getMessage(),e)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -3735,4 +3735,24 @@ class ScheduledExecutionControllerSpec extends RundeckHibernateSpec implements C
         controller.response.redirectedUrl == null
         flash.message != null
     }
+
+    def "test special chars in URL user-password"() {
+        given:
+        controller.apiService = Mock(ApiService)
+        controller.frameworkService = Mock(FrameworkService)
+
+        when:
+        controller.getRemoteJSON(url, 100, 100, 5,false)
+
+        then:
+        def e = thrown(UnknownHostException)
+        e.message.contains("web.server")
+
+        where:
+        url                                                         |_
+        'https://admin:my^$!pass1@web.server/option.json'           |_
+        'https://admin:m^^y^^$!pass1@web.server/option.json'        |_
+        'https://web.server/geto'                                   |_
+        'http://web.server/geto'                                    |_
+    }
 }


### PR DESCRIPTION
Handling special chars when loading remote URL option.
Using clean URL when assembling the URI object and use parsed credentials (URL object) when assembling the basic auth header
Fix: https://github.com/rundeckpro/rundeckpro/issues/2188