### PR TITLE
RUN-794: Putting back config attribute useForwardHeaders to avoid https redirecting back to HTTP

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -757,6 +757,8 @@ beans={
         initParams = configParams?.toProperties()?.collectEntries {
             [it.key.toString(), it.value.toString()]
         }
+
+        useForwardHeaders = Boolean.getBoolean('rundeck.jetty.connector.forwarded')
     }
 
     rundeckAuthSuccessEventListener(RundeckAuthSuccessEventListener) {

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -753,12 +753,13 @@ beans={
 
     jettyServletCustomizer(JettyServletContainerCustomizer) {
         def configParams = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.initParams", String.class)
+        def useForwardHeadersConfig = grailsApplication.config.getProperty("server.useForwardHeaders")
 
         initParams = configParams?.toProperties()?.collectEntries {
             [it.key.toString(), it.value.toString()]
         }
 
-        useForwardHeaders = Boolean.getBoolean('rundeck.jetty.connector.forwarded')
+        useForwardHeaders = ["true", true].contains(useForwardHeadersConfig) ?: Boolean.getBoolean('rundeck.jetty.connector.forwarded')
     }
 
     rundeckAuthSuccessEventListener(RundeckAuthSuccessEventListener) {

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -753,13 +753,13 @@ beans={
 
     jettyServletCustomizer(JettyServletContainerCustomizer) {
         def configParams = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.initParams", String.class)
-        def useForwardHeadersConfig = grailsApplication.config.getProperty("server.useForwardHeaders")
+        def useForwardHeadersConfig = grailsApplication.config.getProperty("server.useForwardHeaders",Boolean.class)
 
         initParams = configParams?.toProperties()?.collectEntries {
             [it.key.toString(), it.value.toString()]
         }
 
-        useForwardHeaders = ["true", true].contains(useForwardHeadersConfig) ?: Boolean.getBoolean('rundeck.jetty.connector.forwarded')
+        useForwardHeaders = useForwardHeadersConfig ?: Boolean.getBoolean('rundeck.jetty.connector.forwarded')
     }
 
     rundeckAuthSuccessEventListener(RundeckAuthSuccessEventListener) {

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -35,6 +35,7 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
      * Set of init parameters to set in the web app context
      */
     Map<String, String> initParams = [:]
+    Boolean useForwardHeaders
 
     @Override
     void customize(final JettyServletWebServerFactory factory) {
@@ -49,6 +50,7 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
             }
         })
         factory.addConfigurations(new JettyConfigPropsInitParameterConfiguration(initParams))
+        factory.useForwardHeaders=useForwardHeaders
     }
 }
 


### PR DESCRIPTION
fixes #7605

**Is this a bugfix, or an enhancement? Please describe.**
This PR fixes redirecting to http if config property `server.useForwardHeaders` or sys config `rundeck.jetty.connector.forwarded` is true

**Describe the solution you've implemented**
The useForwardHeaders attribute on JettyServletWebServerFactory was not being configured as apparently part of the code had been removed

**Describe alternatives you've considered**
Looks like this code was removed a long time ago so I was trying to figure out why it seems to be working in 3.4.x versions