### PR TITLE
Fix: 404 page when clicking on referenced execution from a different parent

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
@@ -363,7 +363,7 @@ class ReportsController extends ControllerBase{
                 map.executionId= map.remove('jcExecId')
                 try {
                     map.execution = Execution.get(Long.parseLong(map.executionId)).toMap()
-                    map.executionHref = createLink(controller: 'execution', action: 'show', absolute: false, id: map.executionId, params: [project: params.project])
+                    map.executionHref = createLink(controller: 'execution', action: 'show', absolute: false, id: map.executionId, params: [project: (map?.ctxProject != null)? map.ctxProject : params.project])
                 } catch (Exception e) {
 
                 }


### PR DESCRIPTION
Fix: https://github.com/rundeck/rundeck/issues/7670
Case Tested in: https://github.com/rundeckpro/rundeck-tester/pull/149

Solution:
Generate report items using the report's ctxProject value instead of the received params.project.