### PR TITLE
RUN-832: Add tests for loadOptionsRemoteValues timeout config

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3930,7 +3930,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
         try {
             def framework = frameworkService.getRundeckFramework()
-            def projectConfig = framework.projectManager.loadProjectConfig(scheduledExecution.project)
+            def projectConfig = framework.frameworkProjectMgr.loadProjectConfig(scheduledExecution.project)
             boolean disableRemoteOptionJsonCheck = projectConfig.hasProperty(REMOTE_OPTION_DISABLE_JSON_CHECK)
 
             remoteResult = ScheduledExecutionController.getRemoteJSON(srcUrl, timeout, contimeout, retryCount, disableRemoteOptionJsonCheck)


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Follow up to #7641 to add tests for timeout config
