### PR TITLE
RUN-830: Add Ellipses to Long Titles in Project Picker

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/widgets/project-select/ProjectSelect.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/widgets/project-select/ProjectSelect.vue
@@ -25,7 +25,7 @@
                     <div role="button" tabindex="0" class="scroller__item" :title="item.name" 
                         @click="itemClicked(item)"
                         @keypress.enter="itemClicked(item)">
-                        <span>{{item.label || item.name}}</span>
+                        <span class="text-ellipsis">{{item.label || item.name}}</span>
                     </div>
                 </RecycleScroller>
             </Skeleton>
@@ -179,5 +179,9 @@ export default class ProjectSelect extends Vue {
     --skel-color: #eeeeee !important;
     margin: 0 10px 0 10px;
 }
-
+.text-ellipsis{
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+}
 </style>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Bugfix: Titles were breaking in project picker if they exceeded the amount of space allotted in the project picker. 

**Describe the solution you've implemented**
Hide the overflow and cap the end of the line with an ellipses 