### PR TITLE
RUN-831 Improve Name Label Size in Mainbar

### DIFF
--- a/rundeckapp/grails-app/views/common/_mainbar.gsp
+++ b/rundeckapp/grails-app/views/common/_mainbar.gsp
@@ -115,7 +115,7 @@
         <g:set var="userDefinedInstanceName" value="${cfg.getString(config: "gui.instanceName")}"/>
         <g:if test="${userDefinedInstanceName}">
           <li>
-            <span class="label label-default instance-label" style="float:left;font-size: 20px;margin: 10px 15px 0 0;">
+            <span class="label label-default instance-label" style="float:left;font-size: 14px;margin-right: 15px;border-radius: 3px;padding-left: 15px;padding-right: 15px">
                 ${enc(sanitize:userDefinedInstanceName)}
             </span>
           </li>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Enhancement for name label in mainbar. 
Label design was discussed with Miguel.

<img width="1435" alt="Screen Shot 2022-04-13 at 1 15 55 PM" src="https://user-images.githubusercontent.com/90348123/163263110-8eee922d-93ec-4103-9312-3c8b8962d1f3.png">



