### PR TITLE
RUN-620: Fix Requirement for Restart When Key Storage Prop is Updated

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -530,12 +530,12 @@ beans={
         loggerName='org.rundeck.storage.events'
     }
     rundeckStorageTreeCreator(StorageTreeCreator){
-        storageTreeFactory=ref('rundeckStorageTreeFactory')
         frameworkPropertyLookup=ref('frameworkPropertyLookup')
         pluginRegistry=ref("rundeckPluginRegistry")
         storagePluginProviderService=ref('storagePluginProviderService')
         storageConverterPluginProviderService=ref('storageConverterPluginProviderService')
         storageConfigPrefix='provider'
+        startupConfiguration = application.config.rundeck?.storage?.toFlatConfig()
         converterConfigPrefix='converter'
         baseStorageType='file'
         baseStorageConfig=['baseDir':storageDir.getAbsolutePath()]

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -26,6 +26,8 @@ import com.dtolabs.rundeck.app.config.RundeckConfig
 import com.dtolabs.rundeck.app.internal.framework.FrameworkPropertyLookupFactory
 import com.dtolabs.rundeck.app.internal.framework.RundeckFilesystemProjectImporter
 import com.dtolabs.rundeck.app.internal.framework.RundeckFrameworkFactory
+import com.dtolabs.rundeck.app.tree.DelegateStorageTree
+import com.dtolabs.rundeck.app.tree.StorageTreeCreator
 import com.dtolabs.rundeck.core.Constants
 import com.dtolabs.rundeck.core.authorization.AclsUtil
 import com.dtolabs.rundeck.core.authorization.Log4jAuthorizationLogger
@@ -527,7 +529,22 @@ beans={
         defaultConverters=['StorageTimestamperConverter','KeyStorageLayer']
         loggerName='org.rundeck.storage.events'
     }
-    rundeckStorageTree(rundeckStorageTreeFactory:"createTree")
+    rundeckStorageTreeCreator(StorageTreeCreator){
+        storageTreeFactory=ref('rundeckStorageTreeFactory')
+        frameworkPropertyLookup=ref('frameworkPropertyLookup')
+        pluginRegistry=ref("rundeckPluginRegistry")
+        storagePluginProviderService=ref('storagePluginProviderService')
+        storageConverterPluginProviderService=ref('storageConverterPluginProviderService')
+        storageConfigPrefix='provider'
+        converterConfigPrefix='converter'
+        baseStorageType='file'
+        baseStorageConfig=['baseDir':storageDir.getAbsolutePath()]
+        defaultConverters=['StorageTimestamperConverter','KeyStorageLayer']
+        loggerName='org.rundeck.storage.events'
+    }
+    rundeckStorageTree(DelegateStorageTree){
+        creator=ref('rundeckStorageTreeCreator')
+    }
     if(grailsApplication.config.getProperty("rundeck.feature.projectKeyStorage.enabled", Boolean.class, false)) {
         rundeckKeyStorageContextProvider(ProjectKeyStorageContextProvider)
     }else{

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTree.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTree.groovy
@@ -14,15 +14,21 @@ class DelegateStorageTree implements StorageTree, InitializingBean {
     StorageTree delegate
 
     StorageTreeCreator creator
+    Map<String,String> configuration
 
     @Override
     void afterPropertiesSet() {
         delegate = creator.createOnStartup()
+        configuration=creator.configuration
     }
 
     @Subscriber('rundeck.configuration.refreshed')
     @CompileDynamic
     def updateTreeConfig(def event) {
-        delegate = creator.create()
+        Map<String, String> config = creator.getStorageConfigMap()
+        if(configuration != config){
+            delegate = creator.create()
+            configuration = config
+        }
     }
 }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTree.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTree.groovy
@@ -1,0 +1,28 @@
+package com.dtolabs.rundeck.app.tree
+
+import com.dtolabs.rundeck.core.storage.StorageTree
+import grails.events.annotation.Subscriber
+import grails.util.Holders
+import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
+import org.springframework.beans.factory.InitializingBean
+import org.springframework.beans.factory.annotation.Autowired
+
+@CompileStatic
+class DelegateStorageTree implements StorageTree, InitializingBean {
+    @Delegate
+    StorageTree delegate
+
+    StorageTreeCreator creator
+
+    @Override
+    void afterPropertiesSet() {
+        delegate = creator.createOnStartup()
+    }
+
+    @Subscriber('rundeck.configuration.refreshed')
+    @CompileDynamic
+    def updateTreeConfig(def event) {
+        delegate = creator.create()
+    }
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTree.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTree.groovy
@@ -26,7 +26,17 @@ class DelegateStorageTree implements StorageTree, InitializingBean {
     @CompileDynamic
     def updateTreeConfig(def event) {
         Map<String, String> config = creator.getStorageConfigMap()
-        if(configuration != config){
+        Boolean typeSet = false
+        Boolean pathSet = false
+        for(entry in config){
+            if(entry.getKey().toString().endsWith("path")){
+                pathSet=true
+            }
+            else if(entry.getKey().toString().endsWith("type")){
+                typeSet=true
+            }
+        }
+        if(configuration != config && typeSet && pathSet){
             delegate = creator.create(false)
             configuration = config
         }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTree.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTree.groovy
@@ -18,7 +18,7 @@ class DelegateStorageTree implements StorageTree, InitializingBean {
 
     @Override
     void afterPropertiesSet() {
-        delegate = creator.createOnStartup()
+        delegate = creator.create(true)
         configuration=creator.configuration
     }
 
@@ -27,7 +27,7 @@ class DelegateStorageTree implements StorageTree, InitializingBean {
     def updateTreeConfig(def event) {
         Map<String, String> config = creator.getStorageConfigMap()
         if(configuration != config){
-            delegate = creator.create()
+            delegate = creator.create(false)
             configuration = config
         }
     }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreator.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreator.groovy
@@ -68,9 +68,8 @@ class StorageTreeCreator {
             }
         }
         factory.configuration=finalconfigMap
-        if(finalconfigMap != configuration){
-            factory.createTree()
-        }
+        configuration=finalconfigMap
+        factory.createTree()
     }
 
     StorageTree createOnStartup(){

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreator.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreator.groovy
@@ -19,6 +19,7 @@ class StorageTreeCreator {
     StorageTreeFactory storageTreeFactory
     PluggableProviderService<StoragePlugin> storagePluginProviderService
     PluggableProviderService<StorageConverterPlugin> storageConverterPluginProviderService
+    Map<String, String> startupConfiguration
 
     @Autowired
     ConfigurationService configurationService
@@ -31,7 +32,7 @@ class StorageTreeCreator {
     def loggerName='org.rundeck.storage.events'
     Map<String, String> configuration
 
-    StorageTree create(){
+    StorageTree create(Boolean startup){
         def factory = new StorageTreeFactory()
         factory.frameworkPropertyLookup = frameworkPropertyLookup
         factory.pluginRegistry=pluginRegistry
@@ -44,10 +45,15 @@ class StorageTreeCreator {
         factory.loggerName=loggerName
         factory.defaultConverters=defaultConverters.toSet()
 
-        Map<String, String> finalconfigMap = getStorageConfigMap()
-
-        factory.configuration=finalconfigMap
-        configuration=finalconfigMap
+        if(startup){
+            factory.configuration=startupConfiguration
+            configuration=startupConfiguration
+        }
+        else{
+            Map<String, String> storageConfigMap = getStorageConfigMap()
+            factory.configuration=storageConfigMap
+            configuration=storageConfigMap
+        }
         factory.createTree()
     }
 
@@ -75,10 +81,5 @@ class StorageTreeCreator {
             }
         }
         return finalconfigMap
-    }
-
-    StorageTree createOnStartup(){
-        configuration=storageTreeFactory.configuration
-        storageTreeFactory.createTree()
     }
 }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreator.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreator.groovy
@@ -63,7 +63,7 @@ class StorageTreeCreator {
         Map<String, Map> providerMap = storageMap.get("provider") as Map<String, Map>
 
         finalconfigMap.put("default", "deleteMe")
-        providerMap.each {
+        providerMap?.each {
             if (it.key.toString().isInteger()) {
                 int index = it.key.toInteger()
                 Map<String, Map> finalMap = it.value as Map<String, Map>

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreator.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreator.groovy
@@ -44,32 +44,37 @@ class StorageTreeCreator {
         factory.loggerName=loggerName
         factory.defaultConverters=defaultConverters.toSet()
 
+        Map<String, String> finalconfigMap = getStorageConfigMap()
+
+        factory.configuration=finalconfigMap
+        configuration=finalconfigMap
+        factory.createTree()
+    }
+
+    Map<String, String> getStorageConfigMap(){
         Map<String, String> finalconfigMap = [:]
         Map<String, Map> storageMap = configurationService.getAppConfig().get("storage") as Map<String, Map>
         Map<String, Map> providerMap = storageMap.get("provider") as Map<String, Map>
 
         finalconfigMap.put("default", "deleteMe")
         providerMap.each {
-            if(it.key.toString().isInteger()){
+            if (it.key.toString().isInteger()) {
                 int index = it.key.toInteger()
                 Map<String, Map> finalMap = it.value as Map<String, Map>
                 finalMap.each {
-                    if(it.key == "config"){
-                        Map<String, String> configMap = it.value as Map<String,String>
+                    if (it.key == "config") {
+                        Map<String, String> configMap = it.value as Map<String, String>
                         configMap.each {
                             finalconfigMap.put("provider." + index + "." + "config." + it.key, it.value.toString())
                         }
-                    }
-                    else{
+                    } else {
                         finalconfigMap.put("provider." + index + "." + it.key, it.value.toString())
                     }
 
                 }
             }
         }
-        factory.configuration=finalconfigMap
-        configuration=finalconfigMap
-        factory.createTree()
+        return finalconfigMap
     }
 
     StorageTree createOnStartup(){

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreator.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreator.groovy
@@ -1,0 +1,80 @@
+package com.dtolabs.rundeck.app.tree
+
+import com.dtolabs.rundeck.core.plugins.PluggableProviderService
+import com.dtolabs.rundeck.core.plugins.PluginRegistry
+import com.dtolabs.rundeck.core.storage.StorageTree
+import com.dtolabs.rundeck.core.storage.StorageTreeFactory
+import com.dtolabs.rundeck.core.utils.IPropertyLookup
+import com.dtolabs.rundeck.plugins.storage.StorageConverterPlugin
+import com.dtolabs.rundeck.plugins.storage.StoragePlugin
+import grails.util.Holders
+import groovy.transform.CompileStatic
+import org.springframework.beans.factory.annotation.Autowired
+import rundeck.services.ConfigurationService
+
+@CompileStatic
+class StorageTreeCreator {
+    IPropertyLookup frameworkPropertyLookup
+    PluginRegistry pluginRegistry
+    StorageTreeFactory storageTreeFactory
+    PluggableProviderService<StoragePlugin> storagePluginProviderService
+    PluggableProviderService<StorageConverterPlugin> storageConverterPluginProviderService
+
+    @Autowired
+    ConfigurationService configurationService
+
+    def storageConfigPrefix='provider'
+    def converterConfigPrefix='converter'
+    def baseStorageType='file'
+    Map baseStorageConfig
+    List<String> defaultConverters=['StorageTimestamperConverter','KeyStorageLayer']
+    def loggerName='org.rundeck.storage.events'
+    Map<String, String> configuration
+
+    StorageTree create(){
+        def factory = new StorageTreeFactory()
+        factory.frameworkPropertyLookup = frameworkPropertyLookup
+        factory.pluginRegistry=pluginRegistry
+        factory.storagePluginProviderService=storagePluginProviderService
+        factory.storageConverterPluginProviderService=storageConverterPluginProviderService
+        factory.storageConfigPrefix='provider'
+        factory.converterConfigPrefix='converter'
+        factory.baseStorageType='file'
+        factory.baseStorageConfig=baseStorageConfig
+        factory.loggerName=loggerName
+        factory.defaultConverters=defaultConverters.toSet()
+
+        Map<String, String> finalconfigMap = [:]
+        Map<String, Map> storageMap = configurationService.getAppConfig().get("storage") as Map<String, Map>
+        Map<String, Map> providerMap = storageMap.get("provider") as Map<String, Map>
+
+        finalconfigMap.put("default", "deleteMe")
+        providerMap.each {
+            if(it.key.toString().isInteger()){
+                int index = it.key.toInteger()
+                Map<String, Map> finalMap = it.value as Map<String, Map>
+                finalMap.each {
+                    if(it.key == "config"){
+                        Map<String, String> configMap = it.value as Map<String,String>
+                        configMap.each {
+                            finalconfigMap.put("provider." + index + "." + "config." + it.key, it.value.toString())
+                        }
+                    }
+                    else{
+                        finalconfigMap.put("provider." + index + "." + it.key, it.value.toString())
+                    }
+
+                }
+            }
+        }
+        factory.configuration=finalconfigMap
+        if(finalconfigMap != configuration){
+            factory.createTree()
+        }
+    }
+
+    StorageTree createOnStartup(){
+        configuration=storageTreeFactory.configuration
+        storageTreeFactory.createTree()
+    }
+}

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTreeSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTreeSpec.groovy
@@ -19,25 +19,23 @@ class DelegateStorageTreeSpec extends Specification {
                 tree.updateTreeConfig(null)
 
             then:
-                tree.delegate == null
+            0 * creator.create()
+
         }
 
     def "updateTreeConfig w storage updates"(){
 
         given:
-        StorageTreeCreator creator = Mock(StorageTreeCreator){
-            getStorageConfigMap() >> ["config1": "config1Def", "config2": "config2Def"]
-            create() >> Mock(StorageTree)
-        }
         DelegateStorageTree tree = new DelegateStorageTree()
         tree.configuration = ["config1": "config1Def", "config3": "config3Def"]
-        tree.creator=creator
+        tree.creator = Mock(StorageTreeCreator)
+        1 * tree.creator.getStorageConfigMap() >> ["config1": "config1Def", "config2": "config2Def"]
 
         when:
         tree.updateTreeConfig(null)
 
         then:
-        tree.delegate != null
+        1 * tree.creator.create()
     }
 
 }

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTreeSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTreeSpec.groovy
@@ -11,9 +11,9 @@ class DelegateStorageTreeSpec extends Specification {
                 StorageTreeCreator creator = Mock(StorageTreeCreator){
                     getStorageConfigMap() >> ["config1": "config1Def", "config2": "config2Def"]
                 }
-                creator.configuration = ["config1": "config1Def", "config2": "config2Def"]
                 DelegateStorageTree tree = new DelegateStorageTree()
                 tree.configuration = ["config1": "config1Def", "config2": "config2Def"]
+                tree.creator=creator
 
             when:
                 tree.updateTreeConfig(null)
@@ -27,16 +27,17 @@ class DelegateStorageTreeSpec extends Specification {
         given:
         StorageTreeCreator creator = Mock(StorageTreeCreator){
             getStorageConfigMap() >> ["config1": "config1Def", "config2": "config2Def"]
+            create() >> Mock(StorageTree)
         }
         DelegateStorageTree tree = new DelegateStorageTree()
-        tree.creator = creator
-        tree.configuration = ["config1": "config1DefUpdate", "config2": "config2Def"]
+        tree.configuration = ["config1": "config1Def", "config3": "config3Def"]
+        tree.creator=creator
 
         when:
         tree.updateTreeConfig(null)
 
         then:
-        tree.delegate == null
+        tree.delegate != null
     }
 
 }

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTreeSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTreeSpec.groovy
@@ -29,13 +29,13 @@ class DelegateStorageTreeSpec extends Specification {
         DelegateStorageTree tree = new DelegateStorageTree()
         tree.configuration = ["config1": "config1Def", "config3": "config3Def"]
         tree.creator = Mock(StorageTreeCreator)
-        1 * tree.creator.getStorageConfigMap() >> ["config1": "config1Def", "config2": "config2Def"]
+        1 * tree.creator.getStorageConfigMap() >> ["test.path": "config1Def", "test.type": "config2Def"]
 
         when:
         tree.updateTreeConfig(null)
 
         then:
-        1 * tree.creator.create()
+        1 * tree.creator.create(false)
     }
 
 }

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTreeSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/DelegateStorageTreeSpec.groovy
@@ -1,0 +1,42 @@
+package com.dtolabs.rundeck.app.tree
+
+import com.dtolabs.rundeck.core.storage.StorageTree
+import spock.lang.Specification
+
+class DelegateStorageTreeSpec extends Specification {
+
+        def "updateTreeConfig no storage updates"(){
+
+            given:
+                StorageTreeCreator creator = Mock(StorageTreeCreator){
+                    getStorageConfigMap() >> ["config1": "config1Def", "config2": "config2Def"]
+                }
+                creator.configuration = ["config1": "config1Def", "config2": "config2Def"]
+                DelegateStorageTree tree = new DelegateStorageTree()
+                tree.configuration = ["config1": "config1Def", "config2": "config2Def"]
+
+            when:
+                tree.updateTreeConfig(null)
+
+            then:
+                tree.delegate == null
+        }
+
+    def "updateTreeConfig w storage updates"(){
+
+        given:
+        StorageTreeCreator creator = Mock(StorageTreeCreator){
+            getStorageConfigMap() >> ["config1": "config1Def", "config2": "config2Def"]
+        }
+        DelegateStorageTree tree = new DelegateStorageTree()
+        tree.creator = creator
+        tree.configuration = ["config1": "config1DefUpdate", "config2": "config2Def"]
+
+        when:
+        tree.updateTreeConfig(null)
+
+        then:
+        tree.delegate == null
+    }
+
+}

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreatorSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreatorSpec.groovy
@@ -1,0 +1,39 @@
+package com.dtolabs.rundeck.app.tree
+
+import rundeck.services.ConfigurationService
+import spock.lang.Specification
+
+class StorageTreeCreatorSpec extends Specification{
+
+    def "getStorageConfigMap"(){
+        given:
+        int index =1
+        Map<String, String> configProps = ["address":"testaddress", "prefix":"somePrefix"]
+        Map<String, Object> configMap = ["type":"test-type", "path": "testPath"]
+        configMap.put("config", configProps)
+
+        StorageTreeCreator creator = Mock(StorageTreeCreator)
+        creator.configurationService = Mock(ConfigurationService){
+            getAppConfig() >> Mock(Map){
+                get("storage") >> Mock(Map){
+                    get("provider") >> Mock(Map){
+                        each {
+                            it.key.toString().isInteger() >> true
+                            it.key.toInteger() >> index
+                            it.value >> configMap
+                        }
+                    }
+                }
+            }
+        }
+        when:
+           def result = creator.getStorageConfigMap()
+
+        then:
+            result.size()==4
+            result.containsKey("provider.1.type")
+            result.containsKey("provider.1.config.address")
+
+    }
+
+}

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreatorSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreatorSpec.groovy
@@ -8,29 +8,25 @@ class StorageTreeCreatorSpec extends Specification{
     def "getStorageConfigMap"(){
         given:
         int index =1
+
         Map<String, String> configProps = ["address":"testaddress", "prefix":"somePrefix"]
         Map<String, Object> configMap = ["type":"test-type", "path": "testPath"]
         configMap.put("config", configProps)
+        Map<String, Map> indexMap = ["1":configMap]
+        Map<String, Map> providerMap = ["provider":indexMap]
+        Map<String, Map> storageMap = ["storage":providerMap]
 
-        StorageTreeCreator creator = Mock(StorageTreeCreator)
+
+        StorageTreeCreator creator = new StorageTreeCreator()
         creator.configurationService = Mock(ConfigurationService){
-            getAppConfig() >> Mock(Map){
-                get("storage") >> Mock(Map){
-                    get("provider") >> Mock(Map){
-                        each {
-                            it.key.toString().isInteger() >> true
-                            it.key.toInteger() >> index
-                            it.value >> configMap
-                        }
-                    }
-                }
-            }
+            getAppConfig() >> storageMap
         }
+
         when:
            def result = creator.getStorageConfigMap()
 
         then:
-            result.size()==4
+            result.size()==5
             result.containsKey("provider.1.type")
             result.containsKey("provider.1.config.address")
 


### PR DESCRIPTION
add delegate storage tree that functions the same on startup, but creates a new storage tree on a config refresh event if a storage prop is changed
