### PR TITLE
Run 835

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/dispatcher/DataContextUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/dispatcher/DataContextUtils.java
@@ -53,7 +53,14 @@ public class DataContextUtils {
                                                                  "[^}\\s]+?" +
                                                                  Pattern.quote("}") +
                                                                  "$");
-
+    private static final Pattern optionPatterWithOtherCharacters = Pattern.compile("\\$\\{" +
+        Pattern.quote("option.") +
+                    "[^}\\s]+?" +
+                    Pattern.quote("}") + "$");                                   
+    public static boolean hasOptionsInString(String evalString){
+        Matcher matcher = optionPatterWithOtherCharacters.matcher(evalString);
+        return matcher.find();
+    }
     /**
      * A converter which replaces '${option.*}' with blank when replacing data references
      */

--- a/core/src/main/java/com/dtolabs/rundeck/core/dispatcher/DataContextUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/dispatcher/DataContextUtils.java
@@ -53,12 +53,9 @@ public class DataContextUtils {
                                                                  "[^}\\s]+?" +
                                                                  Pattern.quote("}") +
                                                                  "$");
-    private static final Pattern optionPatterWithOtherCharacters = Pattern.compile("\\$\\{" +
-        Pattern.quote("option.") +
-                    "[^}\\s]+?" +
-                    Pattern.quote("}") + "$");                                   
+    private static final Pattern optionPatternEntireString = Pattern.compile( "\\$\\{option.([^}]*?)\\}" );                                   
     public static boolean hasOptionsInString(String evalString){
-        Matcher matcher = optionPatterWithOtherCharacters.matcher(evalString);
+        Matcher matcher = optionPatternEntireString.matcher(evalString);
         return matcher.find();
     }
     /**

--- a/core/src/main/java/com/dtolabs/rundeck/core/dispatcher/DataContextUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/dispatcher/DataContextUtils.java
@@ -53,7 +53,9 @@ public class DataContextUtils {
                                                                  "[^}\\s]+?" +
                                                                  Pattern.quote("}") +
                                                                  "$");
-    private static final Pattern optionPatternEntireString = Pattern.compile( "\\$\\{option.([^}]*?)\\}" );                                   
+    //Evaluate an entire string for tokens
+    private static final Pattern optionPatternEntireString = Pattern.compile( "\\$\\{option.([^}]*?)\\}" );
+    //Uses the pattern above to return a boolean if there's a token in the given string
     public static boolean hasOptionsInString(String evalString){
         Matcher matcher = optionPatternEntireString.matcher(evalString);
         return matcher.find();

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtils.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtils.java
@@ -190,6 +190,7 @@ public class DefaultScriptFileNodeStepUtils implements ScriptFileNodeStepUtils {
                     expandTokens
             );
         } else if (null != serverScriptFilePath) {
+            // if the filepath has option tokens, they will be expanded.
             File serverScriptFile;
             if( DataContextUtils.hasOptionsInString(serverScriptFilePath) ){
                 Map<String, Map<String, String>> optionsContext = new HashMap();

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtils.java
@@ -188,7 +188,15 @@ public class DefaultScriptFileNodeStepUtils implements ScriptFileNodeStepUtils {
                     expandTokens
             );
         } else if (null != serverScriptFilePath) {
-            File serverScriptFile = new File(serverScriptFilePath);
+            File serverScriptFile;
+            if( DataContextUtils.hasOptionsInString(serverScriptFilePath) ){
+                Map<String, Map<String, String>> optionsContext = new HashMap();
+                optionsContext.put("option", context.getDataContext().get("option"));
+                String expandedVarsInURL = DataContextUtils.replaceDataReferencesInString(serverScriptFilePath, optionsContext);
+                serverScriptFile = new File(expandedVarsInURL);
+            }else{
+                serverScriptFile = new File(serverScriptFilePath);
+            }
             if(expandTokens){
                 try(InputStream inputStream = new FileInputStream(serverScriptFile)) {
                     serverScriptFile = fileCopierUtil.writeScriptTempFile(

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtils.java
@@ -29,6 +29,7 @@ import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext;
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepFailureReason;
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepException;
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepResult;
+import com.dtolabs.rundeck.core.dispatcher.DataContextUtils;
 import com.dtolabs.rundeck.core.utils.ScriptExecUtil;
 import org.apache.commons.lang.BooleanUtils;
 import org.slf4j.Logger;

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/dispatcher/DataContextUtilsSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/dispatcher/DataContextUtilsSpec.groovy
@@ -212,4 +212,36 @@ class DataContextUtilsSpec extends Specification {
         result.get('test2').get('key2') != null
         result.get('test2').get('key2') == 'value2'
     }
+
+    def testHasOptionsInString() {
+        given:
+        String urlScenario1 = '/tmp/${option.path1}/${option.path2}/file' //perfect expectation
+        //no opening braces
+        String urlScenario2 = '/tmp/$option.path1}/${option.path2}/file' //true
+        String urlScenario3 = '/tmp/$option.path1}/$option.path2}/file' //false
+        //no closing braces
+        String urlScenario4 = '/tmp/${option.path1/${option.path2}/file' //true
+        String urlScenario5 = '/tmp/${option.path1/${option.path2/file' //false
+        //no $ sign
+        String urlScenario6 = '/tmp/{option.path1}/${option.path2}/file' //true
+        String urlScenario7 = '/tmp/{option.path1}/{option.path2}/file' //false
+        //no 'option.'
+        String urlScenario8 = '/tmp/${path1}/${option.path2}/file' //true
+        String urlScenario9 = '/tmp/${path1}/${path2}/file' //false
+
+        expect:
+        DataContextUtils.hasOptionsInString(urlScenario1) == true //perfect expectation
+
+        DataContextUtils.hasOptionsInString(urlScenario2) == true //true
+        DataContextUtils.hasOptionsInString(urlScenario3) == false //false
+
+        DataContextUtils.hasOptionsInString(urlScenario4) == true //true
+        DataContextUtils.hasOptionsInString(urlScenario5) == false //false
+
+        DataContextUtils.hasOptionsInString(urlScenario6) == true //true
+        DataContextUtils.hasOptionsInString(urlScenario7) == false //false
+
+        DataContextUtils.hasOptionsInString(urlScenario8) == true //true
+        DataContextUtils.hasOptionsInString(urlScenario9) == false //false
+    }
 }


### PR DESCRIPTION
# Bugfix - Expanding tokens in file workflow step #
As described in: https://github.com/rundeckpro/rundeckpro/issues/2148, option tokens were not expanded when used within a URL in the step file. This PR solves that problem.

**About the solution**
We created a method that returns a boolean, if a certain regex identifies that there are tokens inside a string, we use this method to evaluate the path of the file that enters as a parameter for the execution of the step. So, if it finds tokens, we use the "replaceDataReferencesInString" method to expand the tokens inside the path.

**Exhibits**
After the fix:
![Screen Shot 2022-04-18 at 14 24 36](https://user-images.githubusercontent.com/81827734/163847318-5404f9f5-c4bd-411b-9613-4ab80390e9ee.png)
