### PR TITLE
RUN-538: Ace editor no contrast in dark mode

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/application.js
+++ b/rundeckapp/grails-app/assets/javascripts/application.js
@@ -417,7 +417,7 @@ function _setupAceTextareaEditor(textarea, callback, autoCompleter) {
   });
 
   setAceSyntaxMode(data.aceSessionMode, editor);
-  editor.setTheme("ace/theme/chrome");
+  applyAceTheme(editor);
   editor.getSession().on('change', function (e) {
     jQuery(textarea).val(editor.getValue());
     // Create synthetic change since jQuery val, trigger, and change do not trigger all listeners


### PR DESCRIPTION
Fix: https://github.com/rundeckpro/rundeckpro/issues/2186
Fix: https://github.com/rundeck/rundeck/issues/7545

Ace editor theme was fixed to ace/theme/chrome since: https://github.com/rundeck/rundeck/commit/04f0335424084c49234193e0c63d66810543fc1d

It fixes at least the following ace editor views:

    Ruleset WF strategy
    Inline script
    Ansible Inline Playbooks

The [PR](https://github.com/rundeck/rundeck/pull/7612) had a revert for commits added by mistake but it reverted the commit with the fix too...