### PR TITLE
RUN-845: Export to instance not working when preserving UUID

### DIFF
--- a/rundeckapp/grails-app/views/menu/_projectExportForm.gsp
+++ b/rundeckapp/grails-app/views/menu/_projectExportForm.gsp
@@ -273,7 +273,7 @@
                                     <label for="preserveuuid"><g:message code="project.archive.import.jobUuidOption.preserve.label"/></label>
                                 </div>
                                 <div class="col-sm-10">
-                                    <input type='checkbox' name="preserveuuid" value="preserveuuid" id="preserveuuid" class="form-control"/>
+                                    <g:checkBox name="preserveuuid" value="false" checked="${params.preserveuuid}" id="preserveuuid" class="form-control"/>
                                     <span class="help-block">
                                         <g:message code="project.archive.import.jobUuidOption.preserve.description"/>
                                     </span>


### PR DESCRIPTION
# Bugfix to get the value on the "export to instance" form
A described here: https://github.com/rundeckpro/rundeckpro/issues/2478 there was an error while we try to export a project to other instance of rundeck when the checkbox "preserve uuid" was selected. Technically, the problem was the checkbox used in the form, which was not getting the given value.

**Solution**
What we made was change the current html tag to a built-in GSP component named "g:checkbox", and bind the component to the actual param that will travel to the controller.

**Exhibits**
After the fix, we are able to see the export process result.
![Screen Shot 2022-04-25 at 20 17 11](https://user-images.githubusercontent.com/81827734/165189839-cf5b89bd-414f-41fb-bba0-b7773ad7dc0c.png)

**QA Framework tests**
https://github.com/rundeckpro/rundeck-tester/pull/146