### PR TITLE
RUN-842: Remove options when importing Job Definitions

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3041,6 +3041,10 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
     }
 
+    /**
+     *Remove and delete all existing options from a scheduledExecution, setting options param to null
+     * @param scheduledExecution
+     */
     public void deleteExistingOptions(ScheduledExecution scheduledExecution) {
         if (scheduledExecution.options) {
             def todelete = []

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3274,7 +3274,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         ].each {
             scheduledExecution."$it" = null
         }
-
+        deleteExistingOptions(scheduledExecution)
         scheduledExecution.properties = basicProps
         if (scheduledExecution.groupPath) {
             def re = /^\/*(.+?)\/*$/

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3227,6 +3227,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 !it.key.startsWith( 'nodeExclude')
             }
         }else{
+            deleteExistingOptions(scheduledExecution)
             final Collection foundprops = input.properties.keySet().findAll {
                 it != 'lastUpdated' &&
                 it != 'dateCreated' &&
@@ -3274,7 +3275,6 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         ].each {
             scheduledExecution."$it" = null
         }
-        deleteExistingOptions(scheduledExecution)
         scheduledExecution.properties = basicProps
         if (scheduledExecution.groupPath) {
             def re = /^\/*(.+?)\/*$/

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -4948,7 +4948,7 @@ class ScheduledExecutionServiceSpec extends RundeckHibernateSpec implements Serv
 
         when: "same job is uploaded with no options "
 
-        service.jobDefinitionOptions(baseJob,emptyOptionsJob,params,auth)
+        service.jobDefinitionBasic(baseJob,emptyOptionsJob,params,auth)
         baseJob.save(flush:true)
         def options = Option.findAll()
 
@@ -4959,6 +4959,7 @@ class ScheduledExecutionServiceSpec extends RundeckHibernateSpec implements Serv
     }
     @Unroll
     def "job definition option should update options"() {
+        //this test is failing it gets 0 options should get 1
 
         given: "a job with options"
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -3966,7 +3966,6 @@ class ScheduledExecutionServiceSpec extends RundeckHibernateSpec implements Serv
             [scheduleEnabled: true, executionEnabled: true] | false
     }
 
-
     @Unroll
     def "do update job with job lifecycle plugin, error thrown"(){
         given:
@@ -4596,6 +4595,60 @@ class ScheduledExecutionServiceSpec extends RundeckHibernateSpec implements Serv
             null                  | [:]
             [jobName: 'zocaster'] | null
     }
+
+    @Unroll
+    def "job definition basic should remove options when updating"() {
+
+        given: "a job with options"
+
+        Map params = [:]
+        setupDoUpdate()
+        def auth = Mock(UserAndRolesAuthContext)
+        def baseJob = new ScheduledExecution(createJobParams(options:[
+                new Option(name: 'test1', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c'])]))
+                .save(flush:true)
+        def  emptyOptionsJob = new ScheduledExecution(createJobParams(options:[]))
+
+        when: "same job is uploaded with no options "
+
+        service.jobDefinitionBasic(baseJob,emptyOptionsJob,params,auth)
+        baseJob.save(flush:true)
+        def options = Option.findAll()
+
+        then: "job options are empty"
+
+        options.size() == 0
+
+    }
+    @Unroll
+    def "job definition basic should update options"() {
+
+        given: "a job with options"
+
+        Map params = [:]
+        setupDoUpdate()
+        def auth = Mock(UserAndRolesAuthContext)
+        def baseJob = new ScheduledExecution(createJobParams(options:[
+                new Option(name: 'test1', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c']),
+                new Option(name: 'test2', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c'])
+        ])).save(flush:true)
+        def  updatedJob = new ScheduledExecution(createJobParams(options:[
+                new Option(name: 'test1', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c'])]))
+                .save(flush:true)
+
+        when: "same job with diferents options"
+
+        service.jobDefinitionBasic(baseJob,updatedJob,params,auth)
+        baseJob.save(flush:true)
+        def options = Option.findAll()
+
+        then: "baseJob options should be equals to updatedJob "
+
+        options.size() == 1
+
+    }
+
+
 
     @Unroll
     def "job definition basic blank #propName should be set to #expect"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -4597,60 +4597,6 @@ class ScheduledExecutionServiceSpec extends RundeckHibernateSpec implements Serv
     }
 
     @Unroll
-    def "job definition basic should remove options when updating"() {
-
-        given: "a job with options"
-
-        Map params = [:]
-        setupDoUpdate()
-        def auth = Mock(UserAndRolesAuthContext)
-        def baseJob = new ScheduledExecution(createJobParams(options:[
-                new Option(name: 'test1', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c'])]))
-                .save(flush:true)
-        def  emptyOptionsJob = new ScheduledExecution(createJobParams(options:[]))
-
-        when: "same job is uploaded with no options "
-
-        service.jobDefinitionBasic(baseJob,emptyOptionsJob,params,auth)
-        baseJob.save(flush:true)
-        def options = Option.findAll()
-
-        then: "job options are empty"
-
-        options.size() == 0
-
-    }
-    @Unroll
-    def "job definition basic should update options"() {
-
-        given: "a job with options"
-
-        Map params = [:]
-        setupDoUpdate()
-        def auth = Mock(UserAndRolesAuthContext)
-        def baseJob = new ScheduledExecution(createJobParams(options:[
-                new Option(name: 'test1', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c']),
-                new Option(name: 'test2', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c'])
-        ])).save(flush:true)
-        def  updatedJob = new ScheduledExecution(createJobParams(options:[
-                new Option(name: 'test1', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c'])]))
-                .save(flush:true)
-
-        when: "same job with diferents options"
-
-        service.jobDefinitionBasic(baseJob,updatedJob,params,auth)
-        baseJob.save(flush:true)
-        def options = Option.findAll()
-
-        then: "baseJob options should be equals to updatedJob "
-
-        options.size() == 1
-
-    }
-
-
-
-    @Unroll
     def "job definition basic blank #propName should be set to #expect"() {
         given:
             def job = new ScheduledExecution(createJobParams())
@@ -4985,6 +4931,57 @@ class ScheduledExecutionServiceSpec extends RundeckHibernateSpec implements Serv
             job.errors.hasErrors()
             !job.errors.hasFieldErrors('options')
             job.errors.hasFieldErrors('jobName')
+    }
+
+    @Unroll
+    def "job definition option should remove options when updating"() {
+
+        given: "a job with options"
+
+        Map params = [:]
+        setupDoUpdate()
+        def auth = Mock(UserAndRolesAuthContext)
+        def baseJob = new ScheduledExecution(createJobParams(options:[
+                new Option(name: 'test1', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c'])]))
+                .save(flush:true)
+        def  emptyOptionsJob = new ScheduledExecution(createJobParams(options:[]))
+
+        when: "same job is uploaded with no options "
+
+        service.jobDefinitionOptions(baseJob,emptyOptionsJob,params,auth)
+        baseJob.save(flush:true)
+        def options = Option.findAll()
+
+        then: "job options are empty"
+
+        options.size() == 0
+
+    }
+    @Unroll
+    def "job definition option should update options"() {
+
+        given: "a job with options"
+
+        Map params = [:]
+        setupDoUpdate()
+        def auth = Mock(UserAndRolesAuthContext)
+        def baseJob = new ScheduledExecution(createJobParams(options:[
+                new Option(name: 'test1', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c']),
+                new Option(name: 'test2', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c'])
+        ])).save(flush:true)
+        def  updatedJob = new ScheduledExecution(createJobParams(options:[
+                new Option(name: 'test1', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c'])]))
+
+        when: "same job with diferents options"
+
+        service.jobDefinitionOptions(baseJob,updatedJob,params,auth)
+        baseJob.save(flush:true)
+        def options = Option.findAll()
+
+        then: "baseJob options should be equals to updatedJob "
+
+        options.size() == 1
+
     }
 
     def "job definition notifications from input job"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -4958,30 +4958,29 @@ class ScheduledExecutionServiceSpec extends RundeckHibernateSpec implements Serv
 
     }
     @Unroll
-    def "job definition option should update options"() {
-        //this test is failing it gets 0 options should get 1
+    def "update job definition should update options"() {
 
         given: "a job with options"
 
+        setupDoValidate()
         Map params = [:]
-        setupDoUpdate()
-        def auth = Mock(UserAndRolesAuthContext)
         def baseJob = new ScheduledExecution(createJobParams(options:[
                 new Option(name: 'test1', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c']),
                 new Option(name: 'test2', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c'])
-        ])).save(flush:true)
+        ])).save()
         def  updatedJob = new ScheduledExecution(createJobParams(options:[
                 new Option(name: 'test1', defaultValue: 'val1', enforced: true, values: ['a', 'b', 'c'])]))
 
-        when: "same job with diferents options"
+        when: "same job with different options"
 
-        service.jobDefinitionOptions(baseJob,updatedJob,params,auth)
+        def importedJob = RundeckJobDefinitionManager.importedJob(updatedJob, [:])
+        service.updateJobDefinition(importedJob, params, mockAuth(), baseJob)
         baseJob.save(flush:true)
-        def options = Option.findAll()
+        def options = Option.findAll().size()
 
-        then: "baseJob options should be equals to updatedJob "
+        then: "baseJob should have 1 option remaining"
 
-        options.size() == 1
+        options == 1
 
     }
 


### PR DESCRIPTION
Bugfix
Fix: https://github.com/rundeckpro/rundeckpro/issues/2469

**Description**
When a job was created with some defined options and is exported in a YAML or XML job, removing the option field or enforcing to an empty array (options:[]) doesn't delete the old options.

**Solution** 
Clear the job options and use the new options given on the file. 

