### PR TITLE
RUN-740: Expose spring actuator health check endpoints

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -58,6 +58,7 @@ public class RundeckConfigBase {
     RundeckNotificationConfig notification;
     RundeckApiConfig api;
     ScmLoader scmLoader;
+    RundeckHealthIndicatorConfig health;
 
     @Data
     public static class UserSessionProjectsCache {
@@ -654,6 +655,17 @@ public class RundeckConfigBase {
     public static class ScmLoader {
         Long delay;
         Long interval;
+    }
+
+    /**
+     * This is a configuration proxy for Spring boot health indicator configurations.
+     * Configuration parameters here are used to manually configure Spring Boot Health endpoints.
+     */
+    @Data
+    public static class RundeckHealthIndicatorConfig {
+        // The validation SQL Query to check if the database is still in good status
+        // This is a parameter necessary to configure Spring DataSourceHealthIndicator bean.
+        String databaseValidationQuery;
     }
 
     public static final Map<String,String> DEPRECATED_PROPS = ImmutableMap.of(

--- a/rundeckapp/grails-app/conf/application.groovy
+++ b/rundeckapp/grails-app/conf/application.groovy
@@ -126,6 +126,8 @@ grails.plugin.springsecurity.interceptUrlMap = [
         [pattern: '/feed/**',        access: ['permitAll']],
         [pattern: '/api/**',         access: ['permitAll']],
         [pattern: '/health',         access: ['permitAll']],
+        [pattern: '/actuator/**',    access: ['permitAll']],
+        [pattern: '/actuator/health/**',    access: ['permitAll']],
         [pattern: '/**',             access: ['IS_AUTHENTICATED_REMEMBERED']]
 ]
 
@@ -145,6 +147,8 @@ grails.plugin.springsecurity.filterChain.chainMap = [
         [pattern: '/404.gsp',        filters: 'none'],
         [pattern: '/favicon.ico',    filters: 'none'],
         [pattern: '/health',         filters: 'none'],
+        [pattern: '/actuator/**',    filters: 'none'],
+        [pattern: '/actuator/health/**',    filters: 'none'],
         [pattern: '/**',             filters: 'JOINED_FILTERS']
 ]
 grails.plugin.springsecurity.useSecurityEventListener=true

--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -48,23 +48,17 @@ spring:
                 - '**/*.gson'
                 - 'logback.groovy'
                 - '*.properties'
-                -
 management:
     endpoints:
         enabled-by-default: false
-        jmx:
-            unique-names: true
-        web:
-            exposure:
-                include: "*"
     health:
         defaults:
             enabled: true
     endpoint:
         health:
+            enabled: false
             probes:
                 enabled: true
-            enabled: true
             show-details: always
             group:
                 liveness:
@@ -73,9 +67,8 @@ management:
                         - ping
                 readiness:
                     include:
-                        - livenessState
-                        - db
-
+                        - readinessState
+                        - rundeckDataSourceHeathIndicator
 
 ---
 
@@ -328,6 +321,8 @@ rundeck:
             enabled: false #FYI FALSE
         fileUploadPlugin:
             enabled: true
+    health:
+        databaseValidationQuery: "SELECT 1"
 ---
 
 beans:
@@ -355,3 +350,4 @@ hibernate:
     allow_update_outside_transaction: true
     physical_naming_strategy: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
     implicit_naming_strategy: org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy
+

--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -54,6 +54,29 @@ management:
         enabled-by-default: false
         jmx:
             unique-names: true
+        web:
+            exposure:
+                include: "*"
+    health:
+        defaults:
+            enabled: true
+    endpoint:
+        health:
+            probes:
+                enabled: true
+            enabled: true
+            show-details: always
+            group:
+                liveness:
+                    include:
+                        - livenessState
+                        - ping
+                readiness:
+                    include:
+                        - livenessState
+                        - db
+
+
 ---
 
 grails:
@@ -204,6 +227,10 @@ rundeck:
                     - /favicon.ico
                     - /health
                     - /user/reset
+                    - /actuator/health
+                    - /actuator/health/liveness
+                    - /actuator/health/readiness
+                    - /actuator/health/custom
     storage:
         default: deleteMe
     execution:

--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -223,7 +223,6 @@ rundeck:
                     - /actuator/health
                     - /actuator/health/liveness
                     - /actuator/health/readiness
-                    - /actuator/health/custom
     storage:
         default: deleteMe
     execution:
@@ -350,4 +349,3 @@ hibernate:
     allow_update_outside_transaction: true
     physical_naming_strategy: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
     implicit_naming_strategy: org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy
-

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -102,6 +102,8 @@ import org.rundeck.web.infosec.ContainerRoleSource
 import org.rundeck.web.infosec.HMacSynchronizerTokensManager
 import org.rundeck.web.infosec.PreauthenticatedAttributeRoleSource
 import org.springframework.beans.factory.config.MapFactoryBean
+import org.springframework.boot.actuate.jdbc.DataSourceHealthIndicator
+import org.springframework.boot.jdbc.metadata.DataSourcePoolMetadataProvider
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.core.task.SimpleAsyncTaskExecutor
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
@@ -771,6 +773,13 @@ beans={
             configurationService = ref('configurationService')
         }
     }
+
+
+    // Activate Spring Actuator DataSourceHealthIndicator
+    db(DataSourceHealthIndicator) {
+        dataSource = ref("dataSource")
+    }
+
     rundeckConfig(RundeckConfig)
     if(!Environment.isWarDeployed()) {
         appRestarter(AppRestarter)

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -775,9 +775,11 @@ beans={
     }
 
 
-    // Activate Spring Actuator DataSourceHealthIndicator
-    db(DataSourceHealthIndicator) {
+    // Activate Spring Actuator DataSourceHealthIndicator with a Rundeck specific bean name `rundeckDataSourceHeathIndicator`
+    rundeckDataSourceHeathIndicator(DataSourceHealthIndicator) {
         dataSource = ref("dataSource")
+        // Get the validation query from config, if not provided the Spring DataSourceHealthIndicator will use the Connection.isValid() to test the database connection.
+        query = grailsApplication.config.getProperty("rundeck.health.databaseValidationQuery")
     }
 
     rundeckConfig(RundeckConfig)

--- a/rundeckapp/grails-app/services/rundeck/services/actuator/RundeckReadinessHealthIndicatorService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/actuator/RundeckReadinessHealthIndicatorService.groovy
@@ -3,12 +3,9 @@ package rundeck.services.actuator
 import grails.core.GrailsApplication
 import grails.events.annotation.Subscriber
 import grails.events.bus.EventBusAware
-import groovy.transform.CompileDynamic
-import groovy.transform.CompileStatic
 import org.springframework.boot.availability.AvailabilityChangeEvent
 import org.springframework.boot.availability.ReadinessState
 
-@CompileStatic
 class RundeckReadinessHealthIndicatorService implements EventBusAware {
 
     GrailsApplication grailsApplication

--- a/rundeckapp/grails-app/services/rundeck/services/actuator/RundeckReadinessHealthIndicatorService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/actuator/RundeckReadinessHealthIndicatorService.groovy
@@ -1,0 +1,20 @@
+package rundeck.services.actuator
+
+import grails.core.GrailsApplication
+import grails.events.annotation.Subscriber
+import grails.events.bus.EventBusAware
+import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
+import org.springframework.boot.availability.AvailabilityChangeEvent
+import org.springframework.boot.availability.ReadinessState
+
+@CompileStatic
+class RundeckReadinessHealthIndicatorService implements EventBusAware {
+
+    GrailsApplication grailsApplication
+
+    @Subscriber("rundeck.bootstrap")
+    void rundeckReady() {
+        AvailabilityChangeEvent.publish(grailsApplication.mainContext, ReadinessState.ACCEPTING_TRAFFIC);
+    }
+}


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Enhancement

**Describe the solution you've implemented**
Configure Spring Boot Actuator Health Indicator out-of-box feature to expose liveness and readiness endpoints. Manually configure DataSourceHealthIndictor to fit into the Rundeck application.

**Describe alternatives you've considered**
A fully in-house developed solution could be an option but it cost too much effort unnecessarily when we already have a standard Spring Boot out-of-box framework.

**Additional context**
How to test it in a local environment:
1. The default configuration has already been set in `application.yml` file under the rundeckapp/grails-app/conf/ folder.
![Screen Shot 2022-04-28 at 10 30 39 AM](https://user-images.githubusercontent.com/96143000/165816778-11e4cfbd-3713-4425-b0b5-32c1699704a3.png)

2. By default, the Health indicator endpoints are disabled. There are a few ways to turn it on:
    - Use OS Environment variable:
      ```env "management.endpoint.health.enabled=true" gradle bootRun```
    - Pass it as a JVM parameter
      ```gradle bootRun --system-prop="management.endpoint.health.enabled=true"```
    - If you are using a docker image, you can provide this env parameter when starting the container.
   
After the application started. You should be able to access the endpoints:
- {RUNDECK_BASE_URL}/actuator/health/readiness
- {RUNDECK_BASE_URL}/actuator/health/liveness

If everything is good. The endpoints should return JSON content with the `status` UP and an HTTP Status Code `200`.
If something goes wrong:
- You either can not access the endpoint successfully 
- Or you will receive the return JSON content with `status` DOWN or OUT_SERVICE. And the HTTP status code is `503` service unavailable.

For detail please refer to the Spring Boot Actuator documentation: https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html?query=health%27%20target=_blank%3E%3Cb%3Ehealth%3C/b%3E%3C/a%3E-groups