### PR TITLE
RUN-758: add configuration to disable "Public Key" GUI download option

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -557,6 +557,7 @@ public class RundeckConfigBase {
         Boolean realJobTree;
         String logoSmall;
         Integer matchedNodesMaxCount;
+        Keystorage keystorage;
 
         @Data
         public static class GuiSystemConfig{
@@ -628,6 +629,11 @@ public class RundeckConfigBase {
         public static class Login {
             String welcome;
             String welcomeHtml;
+        }
+
+        @Data
+        public static class Keystorage{
+            Boolean downloadenabled;
         }
     }
 

--- a/rundeckapp/grails-app/assets/javascripts/menu/storage.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/storage.js
@@ -13,6 +13,7 @@ function init () {
     storageBrowse.staticRoot(true)
     storageBrowse.browseMode('browse')
     storageBrowse.allowUpload(true)
+    storageBrowse.downloadenabled(data.downloadenabled)
     if (data.project) {
         storageBrowse.basePath('project/' + data.project)
     }

--- a/rundeckapp/grails-app/assets/javascripts/storageBrowseKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/storageBrowseKO.js
@@ -208,6 +208,7 @@ function StorageBrowser(baseUrl, rootPath) {
     self.allowSelection=ko.observable(true);
     self.allowNotFound=ko.observable(false);
     self.notFound=ko.observable(false);
+    self.downloadenabled=ko.observable(true);
 
     //computed properties
     self.files = ko.computed(function () {
@@ -343,6 +344,9 @@ function StorageBrowser(baseUrl, rootPath) {
                 self.selectedPath(res.path());
                 self.selectedResource(res);
                 candownload = ( res.metaValue('Rundeck-key-type') != 'private' && res.metaValue('Rundeck-data-type')!='password') ;
+            }
+            if(!self.downloadenabled()){
+                candownload=false;
             }
             self.selectedIsDownloadable(candownload);
         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/StorageController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/StorageController.groovy
@@ -33,6 +33,7 @@ import org.rundeck.storage.api.StorageException
 import org.springframework.web.multipart.MultipartHttpServletRequest
 import com.dtolabs.rundeck.app.api.ApiVersions
 import rundeck.services.ApiService
+import rundeck.services.ConfigurationService
 import rundeck.services.FrameworkService
 import rundeck.services.StorageService
 
@@ -59,6 +60,8 @@ class StorageController extends ControllerBase{
     StorageService storageService
     FrameworkService frameworkService
     AuthContextProvider rundeckAuthContextProvider
+    ConfigurationService configurationService
+
     static allowedMethods = [
             apiKeys: ['GET','POST','PUT','DELETE'],
             keyStorageAccess:['GET'],
@@ -250,6 +253,12 @@ class StorageController extends ControllerBase{
      * non-api action wrapper for apiKeys method
      */
     public def keyStorageDownload(StorageParams storageParams){
+
+        Boolean downloadenabled = configurationService.getBoolean("gui.keystorage.downloadenabled", true)
+        if(!downloadenabled){
+            response.status=403
+            return renderError("download is not enabled")
+        }
         if (!storageParams.resourcePath ) {
             storageParams.resourcePath = "/keys${storageParams.relativePath ? ('/' + storageParams.relativePath) : ''}"
         }

--- a/rundeckapp/grails-app/views/framework/_storageBrowser.gsp
+++ b/rundeckapp/grails-app/views/framework/_storageBrowser.gsp
@@ -194,7 +194,7 @@ implied. - See the License for the specific language governing permissions and -
         </div>
       </div>
 
-      <div data-bind="if: selectedResource() && selectedResource().isPublicKey()">
+      <div data-bind="if: selectedResource() && selectedResource().isPublicKey() && selectedIsDownloadable()">
         <button data-bind="click: function(){$root.actionLoadContents('publicKeyContents',$element);}, visible: !selectedResource().wasDownloaded()" class="btn btn-sm btn-default" data-loading-text="${g.enc(code:"loading")}">
           <g:message code="button.view.public.key.contents"/>
           (<span data-bind="text: selectedResource().contentSize()"></span>

--- a/rundeckapp/grails-app/views/menu/storage.gsp
+++ b/rundeckapp/grails-app/views/menu/storage.gsp
@@ -18,9 +18,13 @@ implied. - See the License for the specific language governing permissions and -
         <meta name="tabpage" content="configure"/>
         <meta name="tabtitle" content="${g.message(code: 'gui.menu.KeyStorage')}"/>
         <title><g:message code="gui.menu.KeyStorage"/></title>
+        <g:set var="downloadenabled" value="${cfg.getBoolean(config: "gui.keystorage.downloadenabled", default: true)}"/>
+
         <g:embedJSON id="storageData" data="[
                 resourcePath:params.resourcePath,
-                project:params.project
+                project:params.project,
+                downloadenabled: downloadenabled
+
         ]"/>
         <asset:javascript src="menu/storage.js"/>
       </head>

--- a/rundeckapp/src/test/groovy/rundeck/controllers/StorageControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/StorageControllerSpec.groovy
@@ -113,6 +113,7 @@ class StorageControllerSpec extends Specification implements ControllerUnitTest<
     def "key storage download with params"() {
         given:
 
+        controller.configurationService = Mock(ConfigurationService)
         controller.storageService = Mock(StorageService)
         controller.frameworkService = Mock(FrameworkService)
             controller.rundeckAuthContextProvider=Mock(AuthContextProvider)
@@ -145,6 +146,7 @@ class StorageControllerSpec extends Specification implements ControllerUnitTest<
     def "key storage download with params directory format #format"() {
         given:
 
+        controller.configurationService = Mock(ConfigurationService)
         controller.storageService = Mock(StorageService)
         controller.frameworkService = Mock(FrameworkService)
             controller.rundeckAuthContextProvider=Mock(AuthContextProvider)
@@ -166,6 +168,26 @@ class StorageControllerSpec extends Specification implements ControllerUnitTest<
         0 * controller.apiService._(*_)
         where:
             format<<['xml','json']
+    }
+
+    @Unroll
+    def "key storage download disabled"() {
+        given:
+
+        controller.storageService = Mock(StorageService)
+        controller.frameworkService = Mock(FrameworkService)
+        controller.rundeckAuthContextProvider=Mock(AuthContextProvider)
+        controller.configurationService = Mock(ConfigurationService)
+        response.format="json"
+        when:
+        params.relativePath = 'donuts/'
+
+        def result = controller.keyStorageDownload()
+
+        then:
+        1 * controller.configurationService.getBoolean("gui.keystorage.downloadenabled", true)>>false
+        response.status == 403
+
     }
 
     def "key storage delete with relativePath"() {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/StorageControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/StorageControllerSpec.groovy
@@ -113,7 +113,9 @@ class StorageControllerSpec extends Specification implements ControllerUnitTest<
     def "key storage download with params"() {
         given:
 
-        controller.configurationService = Mock(ConfigurationService)
+        controller.configurationService = Mock(ConfigurationService){
+            getBoolean("gui.keystorage.downloadenabled", true)>>true
+        }
         controller.storageService = Mock(StorageService)
         controller.frameworkService = Mock(FrameworkService)
             controller.rundeckAuthContextProvider=Mock(AuthContextProvider)
@@ -146,7 +148,9 @@ class StorageControllerSpec extends Specification implements ControllerUnitTest<
     def "key storage download with params directory format #format"() {
         given:
 
-        controller.configurationService = Mock(ConfigurationService)
+        controller.configurationService = Mock(ConfigurationService){
+            getBoolean("gui.keystorage.downloadenabled", true)>>true
+        }
         controller.storageService = Mock(StorageService)
         controller.frameworkService = Mock(FrameworkService)
             controller.rundeckAuthContextProvider=Mock(AuthContextProvider)


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
enhancement: add configuration to disable "Public Key" GUI download option

**Describe the solution you've implemented**
add a new flag to disable the public key GUI download option: 

````
rundeck.gui.keystorage.downloadenabled=true
````

**Describe alternatives you've considered**

**Additional context**
