### PR TITLE
RUN-796: internal project config change event includes changed keys info

### DIFF
--- a/core/src/main/java/org/rundeck/app/grails/events/AppEvents.java
+++ b/core/src/main/java/org/rundeck/app/grails/events/AppEvents.java
@@ -1,0 +1,8 @@
+package org.rundeck.app.grails.events;
+
+/**
+ * Defined event names used by the app within Grails events framework
+ */
+public class AppEvents {
+    public static final String PROJECT_CONFIG_CHANGED = "project.config.changed";
+}

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -499,7 +499,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
         rundeckNodeService.refreshProjectNodes(projectName)
 
         eventBus.notify(
-            'project.config.changed',
+            AppEvents.PROJECT_CONFIG_CHANGED,
             [
                 project    : projectName,
                 props      : properties,

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -51,6 +51,7 @@ import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import org.apache.commons.fileupload.util.Streams
 import org.rundeck.app.authorization.AppAuthContextProcessor
+import org.rundeck.app.grails.events.AppEvents
 import org.rundeck.app.spi.RundeckSpiBaseServicesProvider
 import org.rundeck.app.spi.Services
 import org.rundeck.storage.api.PathUtil
@@ -484,7 +485,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
     }
 
     @CompileStatic(TypeCheckingMode.SKIP)
-    private Map storeProjectConfig(String projectName, Properties properties) {
+    private Map storeProjectConfig(String projectName, Properties oldprops, Properties properties) {
         def storagePath = ETC_PROJECT_PROPERTIES_PATH
         def baos = new ByteArrayOutputStream()
         properties['project.name']=projectName
@@ -500,8 +501,9 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
         eventBus.notify(
             'project.config.changed',
             [
-                project: projectName,
-                props  : properties
+                project    : projectName,
+                props      : properties,
+                changedKeys: getKeyDiff(oldprops, properties)
             ]
         )
         return [
@@ -509,6 +511,32 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
                 lastModified: resource.contents.modificationTime,
                 creationTime: resource.contents.creationTime
         ]
+    }
+
+    /**
+     *
+     * @param orig
+     * @param newval
+     * @return set of keys which are changed, added, or removed
+     */
+    @CompileStatic
+    Set<String> getKeyDiff(Properties orig, Properties newval) {
+        Set<String> vals = new HashSet<>()
+        if(orig){
+            for (String key : orig.propertyNames()) {
+                if (newval.getProperty(key) != orig.getProperty(key)) {
+                    vals.add(key)
+                }
+            }
+            for (String key : newval.propertyNames()) {
+                if (newval.getProperty(key) != orig.getProperty(key)) {
+                    vals.add(key)
+                }
+            }
+        } else if (newval) {
+            vals.addAll(newval.propertyNames().collect())
+        }
+        vals
     }
     @CompileStatic(TypeCheckingMode.SKIP)
     private void deleteProjectResources(String projectName) {
@@ -571,7 +599,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
             }
             storedProps.putAll(newProps)
         }
-        def res = storeProjectConfig(projectName, storedProps)
+        def res = storeProjectConfig(projectName, null, storedProps)
         def rdprojectconfig = new RundeckProjectConfig(projectName,
                                                        createProjectPropertyLookup(projectName, res.config ?: new Properties()),
                                                        createDirectProjectPropertyLookup(projectName, res.config ?: new Properties()),
@@ -647,7 +675,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
         def res = loadProjectConfigResource(projectName)
         Properties oldprops = res?.config?:new Properties()
         Properties newprops = mergeProperties(removePrefixes, oldprops, properties)
-        Map newres=storeProjectConfig(projectName, newprops)
+        Map newres=storeProjectConfig(projectName, oldprops, newprops)
         newres
     }
 
@@ -695,7 +723,8 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
             found.save(flush: true)
 
         }
-        Map resource=storeProjectConfig(projectName, properties)
+        def res = loadProjectConfigResource(projectName)
+        Map resource=storeProjectConfig(projectName, res?.config, properties)
         resource
     }
 

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -520,7 +520,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
      * @return set of keys which are changed, added, or removed
      */
     @CompileStatic
-    Set<String> getKeyDiff(Properties orig, Properties newval) {
+    static Set<String> getKeyDiff(Properties orig, Properties newval) {
         Set<String> vals = new HashSet<>()
         if(orig){
             for (String key : orig.propertyNames()) {

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
@@ -1107,4 +1107,24 @@ class ProjectManagerServiceSpec extends RundeckHibernateSpec implements ServiceU
             'a description' | 'a description'
             null            | null
     }
+
+    def "getKeyDiff"() {
+        given:
+            Properties orig = new Properties()
+            orig.putAll([a: 'aaa', b: 'bbb'])
+            Properties newvals = new Properties()
+            newvals.putAll(newprops)
+        when:
+            def result = ProjectManagerService.getKeyDiff(orig, newvals)
+        then:
+            result == expected.toSet()
+        where:
+            newprops             | expected
+            [a: 'aaa', b: 'bbb'] | []
+            [a: 'XXX', b: 'bbb'] | ['a']
+            [b: 'bbb']           | ['a']
+            [a: 'aaa', b: 'XXX'] | ['b']
+            [a: 'aaa']           | ['b']
+            [:]                  | ['a', 'b']
+    }
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Enhancement: updates grails project config change event
* event includes `changedKeys` set of changed/removed/added key names
