### PR TITLE
RUN-833: avoid logging warnings by removing dot notation config value access

### DIFF
--- a/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/XFOSecurityHeaderProvider.groovy
+++ b/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/XFOSecurityHeaderProvider.groovy
@@ -42,10 +42,10 @@ class XFOSecurityHeaderProvider implements SecurityHeaderProvider {
             final Map config
     ) {
         def value = defaultValue
-        if (config?.sameorigin in ['true', true]) {
+        if (config.get('sameorigin') in ['true', true]) {
             value = XFO_VALUE_SAME_ORIGIN
-        } else if (config?.allowFrom instanceof String) {
-            value = XFO_VALUE_ALLOW_FROM_PREFIX + config.allowFrom
+        } else if (config.get('allowFrom') instanceof String) {
+            value = XFO_VALUE_ALLOW_FROM_PREFIX + config.get('allowFrom')
         }
         [
                 new SecurityHeaderImpl(name: XFO_HEADER_NAME, value: value)

--- a/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/XXSSPSecurityHeaderProvider.groovy
+++ b/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/XXSSPSecurityHeaderProvider.groovy
@@ -38,10 +38,10 @@ class XXSSPSecurityHeaderProvider implements SecurityHeaderProvider {
             final Map config
     ) {
         def value = '1'
-        if (config.block in ['true', true]) {
+        if (config.get('block') in ['true', true]) {
             value = '1; mode=block'
-        } else if (config.report) {
-            value = '1; report=' + config.report
+        } else if (config.get('report')) {
+            value = '1; report=' + config.get('report')
         }
 
         [


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Change config access to remove warnings
