### PR TITLE
RUN-874: Fix: XXSSP header is deprecated

### DIFF
--- a/grails-securityheaders/src/main/groovy/grails/securityheaders/SecurityheadersGrailsPlugin.groovy
+++ b/grails-securityheaders/src/main/groovy/grails/securityheaders/SecurityheadersGrailsPlugin.groovy
@@ -55,11 +55,13 @@ Brief summary/description of the plugin.
             }
 
             /**
-             * X-XSS-Protection: 1
+             * X-XSS-Protection: 0
+             * (value 1 is deprecated, see https://owasp.org/www-project-secure-headers/#x-xss-protection )
              */
             xxsspSecurityHeaderProvider(XXSSPSecurityHeaderProvider) {
                 name = 'xxssp'
                 defaultEnabled = true
+                protectionValue = '0'
             }
 
             /**

--- a/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/XXSSPSecurityHeaderProvider.groovy
+++ b/grails-securityheaders/src/main/groovy/org/rundeck/grails/plugins/securityheaders/XXSSPSecurityHeaderProvider.groovy
@@ -30,6 +30,7 @@ class XXSSPSecurityHeaderProvider implements SecurityHeaderProvider {
     public static final String X_XSS_PROTECTION_HEADER_NAME = 'X-XSS-Protection'
     String name = 'xxssp'
     Boolean defaultEnabled = true
+    String protectionValue = '0'
 
     @Override
     List<SecurityHeader> getSecurityHeaders(
@@ -37,11 +38,11 @@ class XXSSPSecurityHeaderProvider implements SecurityHeaderProvider {
             final HttpServletResponse response,
             final Map config
     ) {
-        def value = '1'
+        def value = protectionValue
         if (config.block in ['true', true]) {
-            value = '1; mode=block'
+            value += '; mode=block'
         } else if (config.report) {
-            value = '1; report=' + config.report
+            value += '; report=' + config.report
         }
 
         [


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Fix RUN-874
* set `X-XSS-Protection: 0` by default

ref: https://owasp.org/www-project-secure-headers/#x-xss-protection
> ⚠️ Warning: The X-XSS-Protection header has been deprecated by modern browsers and its use can introduce additional security issues on the client side. As such, it is recommended to set the header as X-XSS-Protection: 0 in order to disable the XSS Auditor, and not allow it to take the default behavior of the browser handling the response. Please use Content-Security-Policy instead.
