### PR TITLE
RUN-849 Allow editing the endpoint in Pagerduty Plugins

### DIFF
--- a/core/src/main/java/com/dtolabs/launcher/Setup.java
+++ b/core/src/main/java/com/dtolabs/launcher/Setup.java
@@ -50,6 +50,7 @@ public class Setup implements CLIToolLogger {
     public static final boolean FORCE_FLAG = true;
     private Parameters parameters = new Parameters();
     public static final String TEMPLATE_RESOURCES_PATH = "com/dtolabs/launcher/setup/templates";
+    public static final String PAGERDUTY_DEFAULT_SERVICE_URL = "https://events.pagerduty.com";
 
     /**
      * default constructor
@@ -419,6 +420,7 @@ public class Setup implements CLIToolLogger {
             properties.setProperty("rdeck.base", Preferences.forwardSlashPath(baseDir));
             properties.setProperty("framework.server.hostname", serverHostname);
             properties.setProperty("framework.server.name", serverName);
+            properties.setProperty("framework.pagerduty.service.url", PAGERDUTY_DEFAULT_SERVICE_URL);
         }
 
         public String getNodeHostnameArg() {

--- a/core/src/main/resources/com/dtolabs/launcher/setup/templates/framework.properties.template
+++ b/core/src/main/resources/com/dtolabs/launcher/setup/templates/framework.properties.template
@@ -11,6 +11,12 @@ framework.server.port = @framework.server.port@
 framework.server.url = @framework.rundeck.url@
 
 # ----------------------------------------------------------------
+# Pager Duty Event Service URL
+# ----------------------------------------------------------------
+
+framework.pagerduty.service.url = @framework.pagerduty.service.url@
+
+# ----------------------------------------------------------------
 # Installation locations
 # ----------------------------------------------------------------
 

--- a/core/src/test/java/com/dtolabs/rundeck/core/common/TestFrameworkProject.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/common/TestFrameworkProject.java
@@ -158,7 +158,7 @@ public class TestFrameworkProject extends AbstractBaseTest {
         assertEquals("monkey", project.getProperty("a.b"));
         assertEquals("helmann", project.getProperty("b.c"));
         Map<String, String> projectProperties = project.getProperties();
-        assertEquals(3+15, projectProperties.size());
+        assertEquals(3+16, projectProperties.size());
     }
     public void testProjectProperties() throws IOException {
         final File projectDir = new File(getFrameworkProjectsBase(), PROJECT_NAME);


### PR DESCRIPTION
# Enhancement to allow Rundeck users to customize the target PagerDuty service URL #
Rundeck Pro PR: https://github.com/rundeckpro/rundeckpro/pull/2523
As seen in issue: https://github.com/rundeckpro/rundeckpro/issues/2464 it was not possible to change the target URL of the PagerDuty service. .

### Solution ###
We made changes to make possible the customization of the URL through the "framework.properties" file. In this file will be the property: "framework.pagerduty.service.url" and its value will enter as a parameter in the request of PagerDuty plugins.

*In this repo:* we added the property section in "framework.properties" file template to allow the user to input the wanted value and added the default value of the property in the first run.

### Exhibits ###
After fix, basic workflow step:
![Screen Shot 2022-05-10 at 12 35 44](https://user-images.githubusercontent.com/81827734/167686904-c4d184d8-40bf-45f8-b118-8afbd2c8a6b5.png)

Test execution 1, with default value:
![Screen Shot 2022-05-10 at 12 34 32](https://user-images.githubusercontent.com/81827734/167687015-9a946911-bc8b-4138-ad41-bad784154406.png)

Changing the value in the props file:
![Screen Shot 2022-05-10 at 12 09 44](https://user-images.githubusercontent.com/81827734/167687078-4e1b2769-16c8-4ac7-98c6-5cbb23b4c234.png)

Test execution 2, same Workflow Step parameters, different output:
![Screen Shot 2022-05-10 at 12 41 38](https://user-images.githubusercontent.com/81827734/167687251-e0d2660d-b876-496b-afbc-c0ad18f12ec9.png)

Bonus execution:
![Screen Shot 2022-05-10 at 12 47 23](https://user-images.githubusercontent.com/81827734/167687346-f2289f7e-e419-4253-8ab1-fd8ff18e956d.png)