### PR TITLE
RUN-887: Fix local file copier config error

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/LocalFileCopier.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/LocalFileCopier.java
@@ -29,20 +29,21 @@ import com.dtolabs.rundeck.core.execution.ExecutionContext;
 import com.dtolabs.rundeck.core.execution.impl.common.BaseFileCopier;
 import com.dtolabs.rundeck.core.execution.service.FileCopier;
 import com.dtolabs.rundeck.core.execution.service.FileCopierException;
-import com.dtolabs.rundeck.core.execution.service.MultiFileCopier;
-import com.dtolabs.rundeck.core.execution.service.NodeExecutorResultImpl;
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepFailureReason;
+import com.dtolabs.rundeck.core.plugins.Plugin;
+import com.dtolabs.rundeck.plugins.ServiceNameConstants;
+import com.dtolabs.rundeck.plugins.descriptions.PluginDescription;
 
 import java.io.File;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * LocalFileCopier is ...
  *
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
  */
+@Plugin(name = LocalFileCopier.SERVICE_PROVIDER_TYPE, service = ServiceNameConstants.FileCopier)
+@PluginDescription(title = "Local", description = "Copies files locally on the Rundeck server")
 public class LocalFileCopier extends BaseFileCopier implements FileCopier {
     public static final String SERVICE_PROVIDER_TYPE = "local";
     private boolean disableLocalExecutor = false;

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -19,12 +19,7 @@ package rundeck.services
 import com.dtolabs.rundeck.app.support.ExecutionCleanerConfig
 import com.dtolabs.rundeck.app.support.ExecutionCleanerConfigImpl
 import com.dtolabs.rundeck.app.support.ExecutionQuery
-import com.dtolabs.rundeck.core.authentication.Group
-import com.dtolabs.rundeck.core.authentication.Urn
-import com.dtolabs.rundeck.core.authentication.Username
 import com.dtolabs.rundeck.core.authorization.*
-import com.dtolabs.rundeck.core.authorization.providers.Policies
-import com.dtolabs.rundeck.core.authorization.providers.PolicyCollection
 import com.dtolabs.rundeck.core.cluster.ClusterInfoService
 import com.dtolabs.rundeck.core.common.*
 import com.dtolabs.rundeck.core.config.Features
@@ -47,10 +42,8 @@ import grails.events.bus.EventBus
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import org.grails.plugins.metricsweb.MetricService
-import org.rundeck.app.acl.AppACLContext
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.core.auth.AuthConstants
-import org.rundeck.core.auth.AuthResources
 import org.rundeck.core.projects.ProjectConfigurable
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
@@ -58,11 +51,9 @@ import rundeck.PluginStep
 import rundeck.ScheduledExecution
 import rundeck.services.feature.FeatureService
 
-import javax.security.auth.Subject
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import javax.servlet.http.HttpSession
-import java.util.function.Function
 import java.util.function.Predicate
 
 /**
@@ -1010,9 +1001,8 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
         if (serviceType) {
             try {
                 def described = pluginService.getPluginDescriptor(serviceType, service)
-                if(described) {
-                    final desc = described.description
-                    properties = Validator.demapProperties(props, desc)
+                if(described?.description) {
+                    properties = Validator.demapProperties(props, described.description)
                 }
             } catch (ExecutionServiceException e) {
                 log.error(e.message)
@@ -1033,8 +1023,9 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService {
         if (serviceType) {
             try {
                 def described = pluginService.getPluginDescriptor(serviceType, service)
-                final desc = described.description
-                properties = Validator.mapProperties(report.errors, desc)
+                if(described?.description) {
+                    properties = Validator.mapProperties(report.errors, described.description)
+                }
             } catch (ExecutionServiceException e) {
                 log.error(e.message)
                 log.debug(e.message,e)

--- a/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
@@ -40,6 +40,7 @@ import com.dtolabs.rundeck.core.config.Features
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutionService
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepExecutionService
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
+import com.dtolabs.rundeck.core.plugins.PluggableProviderRegistryService
 import com.dtolabs.rundeck.core.plugins.PluggableProviderService
 import com.dtolabs.rundeck.core.plugins.configuration.Description
 import com.dtolabs.rundeck.core.plugins.configuration.DynamicProperties
@@ -398,8 +399,30 @@ class FrameworkServiceSpec extends Specification implements ServiceUnitTest<Fram
         when:
             def result = service.getServicePropertiesMapForType(type, svc, props)
         then:
-            1 * service.pluginService.getPluginDescriptor(type, svc) >> null
+            1 * service.pluginService.getPluginDescriptor(type, svc) >> retval
             result == [:]
+        where:
+            retval                                   | _
+            null                                     | _
+            new DescribedPlugin(null, null, 'atype') | _
+    }
+
+    def "remapReportProperties missing provider"() {
+        given:
+            service.pluginService = Mock(PluginService)
+            def type = 'atype'
+            def svc = Mock(PluggableProviderRegistryService)
+        when:
+            def result = service.remapReportProperties(null, type, svc)
+        then:
+            1 * service.pluginService.getPluginDescriptor(type, svc) >> retval
+            result != null
+            result.errors == [:]
+
+        where:
+            retval                                   | _
+            null                                     | _
+            new DescribedPlugin(null, null, 'atype') | _
     }
 
     def "addProjectNodeExecutorPropertiesForType missing provider"() {

--- a/test/api/blocklist-plugin-count-test.sh
+++ b/test/api/blocklist-plugin-count-test.sh
@@ -13,7 +13,7 @@ echo "TEST: /api/projects "
 # get listing
 docurl ${runurl}?${params} > $DIR/curl.out
 
-assert_json_value '58' 'length' $DIR/curl.out
+assert_json_value '59' 'length' $DIR/curl.out
 
 
 rm $DIR/curl.out


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Fix: if `local` file copier is configured for a project, GUI fails with an error message
* fix npe when a provider definition is not found
* fix `local` file copier cannot be selected as default project config for file copier
