### PR TITLE
RUN-873:Fix: bug ansible plugins dont show properly

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/custom/autocomplete.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/custom/autocomplete.scss
@@ -2,6 +2,7 @@
   border: 1px solid var(--border-color);
   background: var(--background-color);
   overflow: auto;
+  display: none !important;
 }
 
 .autocomplete-suggestion {


### PR DESCRIPTION
Fix: https://github.com/rundeckpro/rundeckpro/issues/2430

Problem
A CSS property was being changed to block when it should remain on none, that class was  "autocomplete-suggestions"

Solution
Add a the CSS property display none to the class autocomplete-suggestions

