### PR TITLE
RUN-660: Update version plugin to the new release version 1.1.0

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -5,6 +5,6 @@ rundeck:
   - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.7"
   - "com.github.rundeck-plugins:py-winrm-plugin:2.0.15"
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.1"
-  - "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.0.0"
+  - "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.1.0"
   - "com.github.rundeck-plugins:attribute-match-node-enhancer:v0.1.5"
   - "com.github.rundeck-plugins:sshj-plugin:v0.1.2"


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/2264

Updating [multiline-regex-datacapture-filter](https://github.com/rundeck-plugins/multiline-regex-datacapture-filter) log filter plugin version to the new release 1.1.0 which contains a new feature to capture multiple key-value pairs for each matched line. See PR https://github.com/rundeck-plugins/multiline-regex-datacapture-filter/pull/6