### PR TITLE
RUN-524: Fix: Output freezes when switching from Nodes tab to Log Output tab

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logBuilder.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/execution-log/logBuilder.ts
@@ -44,18 +44,11 @@ export class LogBuilder {
   constructor(readonly executionOutput: ExecutionOutput,readonly rootElem: HTMLElement, opts: IBuilderOpts) {
     this.opts = Object.assign(LogBuilder.DefaultOpts(), opts)
 
-    let output: IObservableArray<ExecutionOutputEntry>
-
     const {node, stepCtx} = this.opts
 
-    if (node) {
-      this.observeFiltered(() => {
-        return executionOutput.getEntriesByNodeCtx(node, stepCtx)
-      })
-    } else {
-      output = executionOutput.entries
-      this.observeOutput(output)
-    }
+    this.observeFiltered(() => {
+      return executionOutput.getEntriesFiltered(node, stepCtx)
+    })
   }
 
   onNewLines(handler: (entries: Array<Vue>) => void) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/stores/ExecutionOutput.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/stores/ExecutionOutput.ts
@@ -76,12 +76,18 @@ export class ExecutionOutput {
     private jobWorkflowProm!: Promise<JobWorkflow>
     private executionStatusProm!: Promise<ExecutionStatusGetResponse>
 
-    /** Get an observable list of entries grouped by node or node and step */
-    getEntriesByNodeCtx(node: string, stepCtx?: string) {
-        if (stepCtx)
-            return this.entriesbyNodeCtx.get(`${node}:${JobWorkflow.cleanContextId(stepCtx)}`)
-        else
-            return this.entriesByNode.get(node)
+    /**
+     * Get an observable list of entries grouped by node or node and step.
+     * If no node filter given, all entries are returned
+     **/
+    getEntriesFiltered(node?: string, stepCtx?: string) {
+        if(node){
+            if (stepCtx)
+                return this.entriesbyNodeCtx.get(`${node}:${JobWorkflow.cleanContextId(stepCtx)}`)
+            else
+                return this.entriesByNode.get(node)
+        } else
+            return this.entries
     }
 
     /** Optional method to populate information about execution output */

--- a/rundeckapp/grails-spa/packages/ui/src/pages/execution-show/nodeView.ts
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/execution-show/nodeView.ts
@@ -55,7 +55,7 @@ window._rundeck.eventBus.$on('ko-exec-show-output', (nodeStep: any) => {
     /** Update the KO code when this views output starts showing up */
     const execOutput = rootStore.executionOutputStore.createOrGet(execId)
     autorun((reaction) => {
-        const entries = execOutput.getEntriesByNodeCtx(node, stepCtx)
+        const entries = execOutput.getEntriesFiltered(node, stepCtx)
 
         if (!entries || entries.length == 0) {
             /** There was no output so we update KO and remove the viewer */


### PR DESCRIPTION
Fix: https://github.com/rundeckpro/rundeckpro/issues/2166

Problem:
When selecting logoutput view, a listener was set to the log entry set. So when loading the nodes view first and then changing to logout view, the entry set was already loaded so there was no change to trigger the listener call.  

Fix:
Use the same logic for showing the log entries, no matter the content and only use a function `getEntriesFiltered` with the necessary filter to get the required entries.