### PR TITLE
RUN-849 Webhook UI duplicates webhook when imported with the same name

### DIFF
--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -159,6 +159,10 @@ class WebhookService {
             hook.uuid = UUID.randomUUID().toString()
         }
         hook.uuid = hookData.uuid ?: hook.uuid
+        int countByNameInProject = Webhook.countByNameAndProject(hookData.name,hookData.project)
+        if(countByNameInProject > 0) {
+            return [err: " A Webhook by that name already exists in this project"]
+        }
         hook.name = hookData.name ?: hook.name
         hook.project = hookData.project ?: hook.project
         String generatedSecureString = null

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/filter-list/FilterList.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/filter-list/FilterList.vue
@@ -19,7 +19,7 @@
                     :item-size="itemSize"
                     :key="items.length"
                     v-slot="{ item }"
-                    key-field="name"
+                    key-field="id"
                     class="scroller"
                 >
                     <div style="height: 100%;" :ref="item[idField]" role="button" tabindex="0" class="scroller__item" :class="{'scroller__item--selected': item[idField] == selected}" @click="() => itemClicked(item)" @keypress.enter="itemClicked(item)">


### PR DESCRIPTION
**Bugfix to render duplicated webhooks in the GUI and prevent import when the webhook exists**
As seen in here: https://github.com/rundeckpro/rundeckpro/issues/2491 there is an issue when we import a webhook with the same name but different UUID.

**Solution**
We changed the logic of the scroll panel to enable the duplicated webhook renderization (for clients with duplicates) and prevented further duplicated webhooks imports.

**Exhibits**
1. When the import process end, it prompts the user with the warning about the duplicated uninported webhook.
<img width="754" alt="Screen Shot 2022-05-27 at 13 47 54" src="https://user-images.githubusercontent.com/81827734/170743433-8dbdd512-6a85-4859-b1e6-eb3f3e12dc73.png">

