### PR TITLE
RUN-941: Fix: Can't access some menu items in main menu

### DIFF
--- a/rundeckapp/grails-app/views/menu/_sysConfigNavMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_sysConfigNavMenu.gsp
@@ -64,7 +64,7 @@
 }
 </style>
 
-<ul class="dropdown-menu dropdown-menu-right">
+<ul class="dropdown-menu dropdown-menu-right scroll-area" style="max-height: 85vh">
   <li class="dropdown-header">System</li>
   <li>
     <g:link controller="menu" action="storage">


### PR DESCRIPTION
Fix: https://github.com/rundeck/rundeck/issues/7740

Added scroll bar to main menu and set to have max size of 85vh.
![image](https://user-images.githubusercontent.com/49494423/171703853-e8fa1e42-15e3-4a89-8f6e-18c805d05c8d.png)
