### PR TITLE
RUN-944: Add bootstrap storage tree rewrite feature

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -27,6 +27,8 @@ import com.dtolabs.rundeck.app.internal.framework.FrameworkPropertyLookupFactory
 import com.dtolabs.rundeck.app.internal.framework.RundeckFilesystemProjectImporter
 import com.dtolabs.rundeck.app.internal.framework.RundeckFrameworkFactory
 import com.dtolabs.rundeck.app.tree.DelegateStorageTree
+import com.dtolabs.rundeck.app.tree.RundeckBootstrapStorageTreeUpdater
+import com.dtolabs.rundeck.app.tree.JasyptEncryptionEnforcerUpdaterConfig
 import com.dtolabs.rundeck.app.tree.StorageTreeCreator
 import com.dtolabs.rundeck.core.Constants
 import com.dtolabs.rundeck.core.authorization.AclsUtil
@@ -105,7 +107,6 @@ import org.rundeck.web.infosec.HMacSynchronizerTokensManager
 import org.rundeck.web.infosec.PreauthenticatedAttributeRoleSource
 import org.springframework.beans.factory.config.MapFactoryBean
 import org.springframework.boot.actuate.jdbc.DataSourceHealthIndicator
-import org.springframework.boot.jdbc.metadata.DataSourcePoolMetadataProvider
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.core.task.SimpleAsyncTaskExecutor
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
@@ -550,6 +551,17 @@ beans={
         rundeckKeyStorageContextProvider(ProjectKeyStorageContextProvider)
     }else{
         rundeckKeyStorageContextProvider(KeyStorageContextProvider)
+    }
+
+    rundeckJasyptConverterUpdaterConfig(JasyptEncryptionEnforcerUpdaterConfig){
+        treeCreator = ref('rundeckStorageTreeCreator')
+    }
+
+    rundeckBootstrapStorageTreeUpdater(RundeckBootstrapStorageTreeUpdater){
+        storageTree = ref('rundeckStorageTree')
+        updaterConfig = ref('rundeckJasyptConverterUpdaterConfig')
+        enabled = grailsApplication.config.getProperty('rundeck.feature.storageRewrite.enabled', Boolean.class, false)
+        basePath = grailsApplication.config.getProperty('rundeck.storage.rewrite.basePath', String.class, 'keys')
     }
 
     authRundeckStorageTree(AuthRundeckStorageTree, rundeckStorageTree, rundeckKeyStorageContextProvider)

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/JasyptEncryptionEnforcerUpdaterConfig.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/JasyptEncryptionEnforcerUpdaterConfig.groovy
@@ -1,0 +1,43 @@
+package com.dtolabs.rundeck.app.tree
+
+import com.dtolabs.rundeck.core.storage.ResourceMeta
+import groovy.transform.CompileStatic
+import org.rundeck.storage.api.Resource
+
+/**
+ * Defines update logic for re-storing unencrypted values when jasypt-encryption is enabled, to enforce encrypted
+ * content
+ */
+@CompileStatic
+class JasyptEncryptionEnforcerUpdaterConfig implements UpdaterConfig {
+    TreeCreator treeCreator
+
+
+    @Override
+    boolean shouldPerform() {
+        def configuration = treeCreator.storageConfigMap
+        return configuration.entrySet().find {
+            it.key =~ /^converter\.\d+\.type/ && it.value == 'jasypt-encryption'
+        }
+    }
+
+    @Override
+    ResourceMeta getUpdatedContents(final Resource<ResourceMeta> resource) {
+        def contents = resource.contents
+
+        if (contents.meta.get('jasypt-encryption:encrypted') == 'true') {
+            //don't modify existing encrypted data
+            return null
+        }
+
+        //return original content so it is simply restored without change
+        return contents
+    }
+
+    final String name = "Jasypt Encryption Enforcement - rewrites unencrypted values"
+
+    @Override
+    String toString() {
+        name
+    }
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/RundeckBootstrapStorageTreeUpdater.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/RundeckBootstrapStorageTreeUpdater.groovy
@@ -1,0 +1,34 @@
+package com.dtolabs.rundeck.app.tree
+
+import com.dtolabs.rundeck.core.storage.StorageTree
+import grails.events.annotation.Subscriber
+import grails.gorm.transactions.Transactional
+import groovy.transform.CompileStatic
+
+/**
+ * Wraps calls to the update method with a gorm transaction, and performs the update on bootstrap event
+ */
+@CompileStatic
+class RundeckBootstrapStorageTreeUpdater {
+
+    StorageTree storageTree
+    UpdaterConfig updaterConfig
+
+    Boolean enabled
+    String basePath
+    Updater updater = new TreeUpdater()
+
+
+    @Subscriber("rundeck.bootstrap")
+    void bootstrapEvent() {
+        performTreeUpdate()
+    }
+
+    @Transactional
+    void performTreeUpdate() {
+        if (!enabled) {
+            return
+        }
+        updater.updateTree(storageTree, basePath, updaterConfig)
+    }
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreator.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/StorageTreeCreator.groovy
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import rundeck.services.ConfigurationService
 
 @CompileStatic
-class StorageTreeCreator {
+class StorageTreeCreator implements TreeCreator{
     IPropertyLookup frameworkPropertyLookup
     PluginRegistry pluginRegistry
     StorageTreeFactory storageTreeFactory

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/TreeCreator.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/TreeCreator.groovy
@@ -1,0 +1,8 @@
+package com.dtolabs.rundeck.app.tree
+
+import com.dtolabs.rundeck.core.storage.StorageTree
+
+interface TreeCreator {
+    StorageTree create(Boolean startup)
+    Map<String, String> getStorageConfigMap()
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/TreeUpdater.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/TreeUpdater.groovy
@@ -1,0 +1,60 @@
+package com.dtolabs.rundeck.app.tree
+
+import com.dtolabs.rundeck.core.storage.ResourceMeta
+import com.dtolabs.rundeck.core.storage.StorageTree
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.rundeck.storage.api.Resource
+/**
+ * Iterates over given storage tree, and updates resources according to the config
+ */
+@CompileStatic
+@Slf4j
+class TreeUpdater implements Updater {
+
+    void updateTree(StorageTree storageTree, String basePath, UpdaterConfig updaterConfig) {
+        if (!updaterConfig.shouldPerform()) {
+            return
+        }
+        //detect if configuration contains jasypt-encryption
+        log.info("Storage Tree Updater: begin: ${updaterConfig.name}")
+        int count = 0
+        List<String> paths = [basePath]
+        while (paths.size() > 0) {
+            String dirPath = paths.remove(0)
+
+            if (!storageTree.hasDirectory(dirPath)) {
+                log.warn("Skipping a path ${dirPath} - it was not a directory")
+                continue
+            }
+
+            Set<Resource<ResourceMeta>> dirList = storageTree.listDirectory(dirPath)
+            paths.addAll(
+                dirList.findAll {
+                    it.directory
+                }.collect {
+                    it.path.toString()
+                }
+            )
+
+            dirList.findAll{
+                !it.directory
+            }.each { Resource<ResourceMeta> resource->
+                def contents = updaterConfig.getUpdatedContents(resource)
+                if (!contents) {
+                    log.debug("Not updating path: ${resource.path}")
+                    return
+                }
+
+                log.info("Updating path: ${resource.path}")
+                count++
+                storageTree.updateResource(
+                    resource.path,
+                    contents
+                )
+            }
+        }
+        log.info("Storage Tree Updater: completed with ${count} updates: ${updaterConfig.name}")
+    }
+
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/Updater.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/Updater.groovy
@@ -1,0 +1,15 @@
+package com.dtolabs.rundeck.app.tree
+
+import com.dtolabs.rundeck.core.storage.StorageTree
+import groovy.transform.CompileStatic
+
+@CompileStatic
+interface Updater {
+    /**
+     * Perform updates to the tree
+     * @param storageTree tree
+     * @param basePath base path of the tree to update
+     * @param updaterConfig config
+     */
+    void updateTree(StorageTree storageTree, String basePath, UpdaterConfig updaterConfig)
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/UpdaterConfig.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/UpdaterConfig.groovy
@@ -1,0 +1,31 @@
+package com.dtolabs.rundeck.app.tree
+
+import com.dtolabs.rundeck.core.storage.ResourceMeta
+import groovy.transform.CompileStatic
+import org.rundeck.storage.api.Resource
+
+/**
+ * Configuration for Updater
+ */
+@CompileStatic
+interface UpdaterConfig {
+
+    /**
+     *
+     * @return updater name
+     */
+    String getName()
+
+    /**
+     *
+     * @return true if update should occur
+     */
+    boolean shouldPerform()
+
+    /**
+     *
+     * @param resource
+     * @return updated contents, or null to skip update
+     */
+    ResourceMeta getUpdatedContents(Resource<ResourceMeta> resource)
+}

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/JasyptEncryptionEnforcerUpdaterConfigSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/JasyptEncryptionEnforcerUpdaterConfigSpec.groovy
@@ -1,0 +1,52 @@
+package com.dtolabs.rundeck.app.tree
+
+import com.dtolabs.rundeck.core.storage.ResourceMeta
+import org.rundeck.storage.api.Resource
+import spock.lang.Specification
+
+class JasyptEncryptionEnforcerUpdaterConfigSpec extends Specification {
+    def "should perform with correct config"() {
+        given:
+            def sut = new JasyptEncryptionEnforcerUpdaterConfig()
+            sut.treeCreator = Mock(TreeCreator) {
+                getStorageConfigMap() >> config
+            }
+        when:
+            def result = sut.shouldPerform()
+        then:
+            result == expected
+        where:
+            config                                     | expected
+            [:]                                        | false
+            ['converter.1.type': 'jasypt-encryption']  | true
+            ['converter.23.type': 'jasypt-encryption'] | true
+            ['converter.1.type': 'other']              | false
+    }
+
+    def "modifyContents value when metadata matches"() {
+        given:
+            def sut = new JasyptEncryptionEnforcerUpdaterConfig()
+            def resourceMeta = Mock(ResourceMeta) {
+                getMeta() >> meta
+            }
+            def resource = Mock(Resource) {
+                getContents() >> resourceMeta
+            }
+        when: "modify contents called with resource"
+            def result = sut.getUpdatedContents(resource)
+
+        then: "result is the same as the input resource meta if the content should be modified, otherwise null"
+            (result == resourceMeta) == modified
+            (result == null) == !modified
+
+        where: "jasypt-encryption metadata values"
+            meta                                     | modified
+            [:]                                      | true
+            ['jasypt-encryption:encrypted': 'false'] | true
+            [blah: 'bloo']                           | true
+            ['jasypt-encryption:encrypted': 'true']  | false
+
+
+    }
+
+}

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/TreeUpdaterSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/tree/TreeUpdaterSpec.groovy
@@ -1,0 +1,58 @@
+package com.dtolabs.rundeck.app.tree
+
+import com.dtolabs.rundeck.core.storage.ResourceMeta
+import com.dtolabs.rundeck.core.storage.StorageTree
+import org.rundeck.storage.api.PathUtil
+import org.rundeck.storage.api.Resource
+import spock.lang.Specification
+
+class TreeUpdaterSpec extends Specification {
+    def "performTreeUpdate"() {
+        given:
+
+            def content1 = Stub(ResourceMeta) {
+                getMeta() >> [special: 'true']
+            }
+            def res2 = Stub(Resource) {
+                isDirectory() >> false
+                getPath() >> PathUtil.asPath('apath/sub1/res2')
+
+                getContents() >> content1
+            }
+            StorageTree tree = Mock(StorageTree) {
+                1 * hasDirectory('apath') >> true
+                1 * hasDirectory('apath/sub1') >> true
+                1 * listDirectory('apath') >> [
+                    Stub(Resource) {
+                        isDirectory() >> true
+                        getPath() >> PathUtil.asPath('apath/sub1')
+                    },
+                    Stub(Resource) {
+                        isDirectory() >> false
+                        getPath() >> PathUtil.asPath('apath/res1')
+                        getContents() >> Stub(ResourceMeta) {
+                            getMeta() >> [special: 'false']
+                        }
+                    }
+                ].toSet()
+
+
+                1 * listDirectory('apath/sub1') >> [res2].toSet()
+            }
+
+            UpdaterConfig updaterConfig = Mock(UpdaterConfig)
+            def sut = new TreeUpdater()
+
+        when: "update performed"
+            sut.updateTree(tree, 'apath', updaterConfig)
+        then: "resources matching test should be updated"
+            1 * updaterConfig.shouldPerform() >> true
+            1 * updaterConfig.getUpdatedContents({ it.contents.meta.special == 'true' }) >> {
+                it[0].contents
+            }
+            1 * updaterConfig.getUpdatedContents({ it.contents.meta.special == 'false' }) >> null
+            1 * tree.updateResource({ it.toString() == 'apath/sub1/res2' }, content1)
+            0 * tree.updateResource(*_)
+
+    }
+}


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**
this feature will automatically re-store any key storage resource that is not encrypted,
when the jasypt-encryption converter plugin is in use. 

**Describe the solution you've implemented**

If the jasypt-encryption plugin is not configured, this feature will not do anything.
If it is in use, and the enabled flag is set, each resource that is not already encrypted will be restored to encrypt it.

configuration:

enabled (default false):

    rundeck.feature.storageRewrite.enabled=true

base path (default "keys"):

    rundeck.storage.rewrite.basePath=keys


**Additional context**
Add any other context or screenshots about the change here.
