### PR TITLE
RUN-982 Node tags being showed all in uppercase without distinction b…

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/knockout-node-filter-link.js
+++ b/rundeckapp/grails-app/assets/javascripts/knockout-node-filter-link.js
@@ -59,7 +59,7 @@ ko.components.register('node-filter-link', {
     viewModel:NodeFilterLinkParams,
     template: '<a  class="nodefilterlink link-quiet"  href="#"  data-bind="attr: attributes($root),  css: classnames"  > \
     <span data-bind="if: linkicon"><i data-bind="css: linkicon"></i></span>\
-    <span data-bind="if: !linkicon"><span data-bind="text: viewtext(), css: textcss"></span></span>\
+    <span data-bind="if: !linkicon"><span data-bind="text: viewtext()" style="text-transform: none;"></span></span>\
     <span data-bind="if: count">(<span data-bind="text: count"></span>)</span>\
     </a>'
 });
@@ -68,7 +68,7 @@ ko.components.register('node-exclude-filter-link', {
     viewModel:NodeFilterLinkParams,
     template: '<a  class="nodeexcludefilterlink link-quiet"  href="#"  data-bind="attr: attributes($root),  css: classnames"  > \
     <span data-bind="if: linkicon"><i data-bind="css: linkicon"></i></span>\
-    <span data-bind="if: !linkicon"><span data-bind="text: viewtext(), css: textcss"></span></span> \
+    <span data-bind="if: !linkicon"><span data-bind="text: viewtext()" style="text-transform: none;"></span></span> \
     <span data-bind="if: count">(<span data-bind="text: count"></span>)</span> \
     </a>'
 });


### PR DESCRIPTION
*Bugfix - On the 'Nodes" section of Rundeck GUI, all the node tags are uppercased*
As seen in here https://github.com/rundeckpro/rundeckpro/issues/2157

**Solution**
Since all the tags were uppercased by some css, we implemented an in-line style attribute to reset the modification.

**Exhibits**
Pre-fix:
![Screen Shot 2022-06-13 at 14 01 59](https://user-images.githubusercontent.com/81827734/173406659-09701f2e-b716-4c56-837f-ab1777153baa.png)

Uppercased by Css:
![Screen Shot 2022-06-13 at 14 02 30](https://user-images.githubusercontent.com/81827734/173406727-a0c68ed7-6e78-40d0-a59b-768424a7a94c.png)

Fixed:
<img width="879" alt="Screen Shot 2022-06-13 at 13 18 15" src="https://user-images.githubusercontent.com/81827734/173406799-25e98792-4dc9-4161-afaa-85c4f165c8be.png">
