### PR TITLE
instance name color fixed at login and logout

### DIFF
--- a/rundeckapp/grails-app/views/user/loggedout.gsp
+++ b/rundeckapp/grails-app/views/user/loggedout.gsp
@@ -60,7 +60,7 @@
             <g:set var="userDefinedInstanceName" value="${cfg.getString(config: "gui.instanceName")}"/>
             <g:if test="${userDefinedInstanceName}">
               <div class="col-md-12" style="text-align:center;margin-bottom:3em;">
-                  <span class="label label-white" style="padding:.8em;font-size: 20px; border-radius:3px;    box-shadow: 0 6px 10px -4px rgba(0, 0, 0, 0.15);">
+                  <span class="label label-default instance-label" style="padding:.8em;font-size: 20px; border-radius:3px;    box-shadow: 0 6px 10px -4px rgba(0, 0, 0, 0.15);">
                       ${enc(sanitize:userDefinedInstanceName)}
                   </span>
               </div>

--- a/rundeckapp/grails-app/views/user/login.gsp
+++ b/rundeckapp/grails-app/views/user/login.gsp
@@ -104,7 +104,7 @@
             <cfg:setVar var="userDefinedInstanceName" key="gui.instanceName" />
             <g:if test="${userDefinedInstanceName}">
               <div class="col-md-12" style="text-align:center;margin-bottom:3em;">
-                  <span class="label label-white" style="padding:.8em;font-size: 20px; border-radius:3px;    box-shadow: 0 6px 10px -4px rgba(0, 0, 0, 0.15);">
+                  <span class="label label-default instance-label" style="padding:.8em;font-size: 20px; border-radius:3px;    box-shadow: 0 6px 10px -4px rgba(0, 0, 0, 0.15);">
                       ${enc(sanitize:userDefinedInstanceName)}
                   </span>
               </div>


### PR DESCRIPTION
Partially fix: https://github.com/rundeckpro/rundeckpro/issues/1868

This PR only fix property rundeck.gui.instanceNameLabelColor.  
 
Problem:
When using rundeck.gui.instanceNameLabelColor didn't change the color of the instance name on the login page nor on the logout page. A CSS class was missing on the HTML.

Solution:
Change the CSS class to match other views where this class worked as expected.  


**Before fix:**
![imagen](https://user-images.githubusercontent.com/87494173/173629576-23fb1691-60b9-4d29-b687-3120134a30e0.png)


**After fix:**
![imagen](https://user-images.githubusercontent.com/87494173/173627039-3481fc7b-2869-4077-bd0a-0cb3d3934f7e.png)

