### PR TITLE
RUN-945 return basic rundeck server info without any authorization.

### DIFF
--- a/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
@@ -339,7 +339,7 @@ class ApiControllerSpec extends Specification implements ControllerUnitTest<ApiC
         1 * controller.apiService.renderSuccessJson(_,_) >> {
             JSONBuilder builder = new JSONBuilder();
             JSON json = builder.build(it[1]);
-            json
+            json.toString() == jsonResult
         }
 
         where:

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
@@ -311,7 +311,7 @@ class ApiControllerSpec extends Specification implements ControllerUnitTest<ApiC
     }
 
     @Unroll
-    def "api system info"() {
+    def "api system info should return only basic data if user doesnt have read authorizarion"() {
         given:
         request.api_version = ApiVersions.V14
         request.addHeader('accept', 'application/json')


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
"Process Automation" menu does not work if the user does not have `read` access

**Describe the solution you've implemented**
The `/server/info` endpoint was changed to accept request without any authorization and returns only basic info. All other info is included if the user has `read` access