### PR TITLE
RUN-991: Fix: Incorrect "Forward Slash" parsing in File/URL Step

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/ScriptURLNodeStepExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/ScriptURLNodeStepExecutor.java
@@ -153,8 +153,7 @@ public class ScriptURLNodeStepExecutor implements NodeStepExecutor {
             throw new RuntimeException("Unable to create cachedir: " + cacheDir.getAbsolutePath());
         }
         //create node context for node and substitute data references in command
-        WFSharedContext sharedContext = new WFSharedContext();
-        sharedContext.merge(context.getSharedDataContext());
+        WFSharedContext sharedContext = new WFSharedContext(context.getSharedDataContext());
         sharedContext.merge(ContextView.global(), context.getDataContextObject());
         sharedContext.merge(
                 ContextView.node(node.getNodename()),

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/ScriptURLNodeStepExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/ScriptURLNodeStepExecutor.java
@@ -248,7 +248,7 @@ public class ScriptURLNodeStepExecutor implements NodeStepExecutor {
                         dataContext,
                         ContextView.node(nodename),
                         ContextView::nodeStep,
-                        urlPathEncoder,
+                        DataContextUtils.replaceMissingOptionsWithBlank,
                         true,
                         false
                 ));

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/ScriptURLNodeStepExecutorSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/ScriptURLNodeStepExecutorSpec.groovy
@@ -97,7 +97,7 @@ class ScriptURLNodeStepExecutorSpec extends Specification {
         url                                                                            | curnode     | expected
 
         'http://example.com/path/${node.name}?query=${data.value}'                     | "anodename" |
-                'http://example.com/path/node%2Fname?query=some%20value%20%3F%20for%20things%20%26%20stuff'
+                'http://example.com/path/node/name?query=some%20value%20%3F%20for%20things%20%26%20stuff'
         'http://example.com/path/${node.name}?query=${data.value}'                     | "bnodename" |
                 'http://example.com/path/bogus?query=hotenntot'
         'http://example.com/path/${node.name@bnodename}?query=${data.value}'           | "anodename" |

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptURLNodeStepExecutor.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/TestScriptURLNodeStepExecutor.java
@@ -212,6 +212,6 @@ public class TestScriptURLNodeStepExecutor extends AbstractBaseTest {
                 "http://example.com/path/${node.name}?query=${data.value}",
                 stringMapMap,
                 "anodename");
-            assertEquals("http://example.com/path/node%2Fname?query=some%20value%20%3F%20for%20things%20%26%20stuff", value);
+            assertEquals("http://example.com/path/node/name?query=some%20value%20%3F%20for%20things%20%26%20stuff", value);
     }
 }


### PR DESCRIPTION
fix https://github.com/rundeckpro/rundeckpro/issues/2598

This allows to use global variables as token replacement in the url script for remote script step.
It also changes the encoding to apply just to the parameters portion of the url