### PR TITLE
RUN-790: Fix bug where Health Status Enhancers affects performance with lots of nodes.

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/Constants.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/Constants.java
@@ -163,4 +163,10 @@ public final class Constants {
     public static final String SSH_KEYRESOURCE_PROP = "framework.ssh.key.resource";
     public static final String SSH_USER_PROP = "framework.ssh.user";
 
+    /**
+     * Health check properties
+     */
+    public static final String PROJECT_PROPERTY_HEALTHCHECK_ENABLED = "project.healthcheck.enabled";
+    public static final String HEALTH_STATUS_PROVIDER_NAME = "healthstatus";
+
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/Constants.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/Constants.java
@@ -163,10 +163,4 @@ public final class Constants {
     public static final String SSH_KEYRESOURCE_PROP = "framework.ssh.key.resource";
     public static final String SSH_USER_PROP = "framework.ssh.user";
 
-    /**
-     * Health check properties
-     */
-    public static final String PROJECT_PROPERTY_HEALTHCHECK_ENABLED = "project.healthcheck.enabled";
-    public static final String HEALTH_STATUS_PROVIDER_NAME = "healthstatus";
-
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/nodes/NodeEnhancerPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/nodes/NodeEnhancerPlugin.java
@@ -32,6 +32,7 @@ public interface NodeEnhancerPlugin {
 
     /**
      * It allows the node enhancer to indicate that it should be skipped
+     * This provides a way to dinamically disable/enable the enhancer based on the implementation requirements
      * @param projectName project name
      * @return boolean indicates whether this enhancer should be skipped
      */

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/nodes/NodeEnhancerPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/nodes/NodeEnhancerPlugin.java
@@ -29,4 +29,13 @@ public interface NodeEnhancerPlugin {
      * @param node     node
      */
     void updateNode(String project, IModifiableNodeEntry node);
+
+    /**
+     * It allows the node enhancer to indicate that it should be skipped
+     * @param projectName project name
+     * @return boolean indicates whether this enhancer should be skipped
+     */
+    default boolean shouldSkip(String projectName){
+        return false;
+    }
 }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/services/EnhancedNodeService.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/services/EnhancedNodeService.groovy
@@ -16,6 +16,7 @@
 
 package org.rundeck.app.services
 
+import com.dtolabs.rundeck.core.Constants
 import com.dtolabs.rundeck.core.common.INodeSet
 import com.dtolabs.rundeck.core.common.IProjectNodes
 import com.dtolabs.rundeck.core.common.IProjectNodesFactory
@@ -78,7 +79,12 @@ class EnhancedNodeService
     }
 
     IProjectNodes getNodes(final String name) {
-        this.getNodes(name, null)
+        def projectConfig = frameworkService.rundeckFramework.frameworkProjectMgr.loadProjectConfig(name)
+        if(projectConfig.hasProperty(Constants.PROJECT_PROPERTY_HEALTHCHECK_ENABLED) && 'true'.equals(projectConfig.getProperty(Constants.PROJECT_PROPERTY_HEALTHCHECK_ENABLED))){
+            this.getNodes(name, null)
+        }else{
+            this.getNodes(name, [Constants.HEALTH_STATUS_PROVIDER_NAME])
+        }
     }
 
     private ProjectNodesEnhancer loadPlugins(final String project) {

--- a/rundeckapp/src/test/groovy/org/rundeck/app/services/EnhancedNodeServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/services/EnhancedNodeServiceSpec.groovy
@@ -16,6 +16,7 @@
 
 package org.rundeck.app.services
 
+import com.dtolabs.rundeck.core.Constants
 import com.dtolabs.rundeck.core.common.FrameworkProjectMgr
 import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.INodeEntry
@@ -60,8 +61,8 @@ class EnhancedNodeServiceSpec extends Specification implements GrailsUnitTest {
             sut.frameworkService = Mock(FrameworkService)
             sut.pluginService = Mock(PluginService)
             sut.frameworkService.getRundeckFramework() >> Mock(IFramework) {
-                1 * getFrameworkProjectMgr() >> Mock(ProjectManager) {
-                    1 * loadProjectConfig('AProject') >> Mock(IRundeckProjectConfig) {
+                2 * getFrameworkProjectMgr() >> Mock(ProjectManager) {
+                    2 * loadProjectConfig('AProject') >> Mock(IRundeckProjectConfig) {
                         getProjectProperties() >> projProps
                     }
                 }
@@ -102,8 +103,8 @@ class EnhancedNodeServiceSpec extends Specification implements GrailsUnitTest {
             sut.frameworkService = Mock(FrameworkService)
             sut.pluginService = Mock(PluginService)
             sut.frameworkService.getRundeckFramework() >> Mock(IFramework) {
-                1 * getFrameworkProjectMgr() >> Mock(ProjectManager) {
-                    1 * loadProjectConfig('AProject') >> Mock(IRundeckProjectConfig) {
+                2 * getFrameworkProjectMgr() >> Mock(ProjectManager) {
+                    2 * loadProjectConfig('AProject') >> Mock(IRundeckProjectConfig) {
                         getProjectProperties() >> projProps
                     }
                 }


### PR DESCRIPTION
fix https://github.com/rundeckpro/rundeckpro/issues/2347

With this change it is possible to skip the healthstatus node enhancer when healthchecks are disabled at project level