### PR TITLE
RUN-1016: Fix:  .circleci ignored by gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.orig
 !.github
 !.gitignore
+!.circleci
 *~
 *.swp
 *.iws


### PR DESCRIPTION
git warns that .circleci is ignored by gitignore when changing contents of .circleci

**Is this a bugfix, or an enhancement? Please describe.**

Fix gitignore to not ignore the `.circleci` dir
