### PR TITLE
RUN-1006: Fix Notification Property Value type when SCM Export YAML format.

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Notification.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Notification.groovy
@@ -198,6 +198,7 @@ public class Notification {
         if(data.type=='email'){
             def map=data.config
             if(map['attachLog']) {
+                map['attachLog'] = true
                 if (map.attachType=='inline') {
                     map['attachLogInline'] = true
                 }else{

--- a/rundeckapp/src/test/groovy/rundeck/NotificationSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/NotificationSpec.groovy
@@ -4,6 +4,27 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class NotificationSpec extends Specification {
+
+
+    @Unroll
+    def "fromNormalizeMap should set the attachLog values as true"() {
+
+        given:"the data collected from a job"
+        def type = 'email'
+        def data = [type : type , config : config]
+
+        when:"creating or updating a notification from a normalized map "
+        def result = Notification.fromNormalizedMap(data)
+
+        then:"attachLog should have a true value"
+        result.type == type
+        result.configuration == expect
+
+        where:"the attachLog is set as 'true'"
+        config = [recipients: 'recip1',subject: 'subj1',attachLog:"true",attachType:'inline']
+        expect = [recipients: 'recip1',subject: 'subj1',attachLog:true,attachLogInline: true]
+    }
+
     @Unroll
     def "toNormalizedMap email"() {
         given:


### PR DESCRIPTION
Fix: https://github.com/rundeckpro/rundeckpro/issues/2212

Problem
Exporting a job on YAML format using SCM a notification property was showing a string value when a boolean was expected. 

Solution
Change the value set from 'true' to true. 