### PR TITLE
RUN-983: Package Updates to address new CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,7 @@ logger.lifecycle("Building version {}", project.resolvedVersion)
 
 allprojects {
     version = project.resolvedVersion
+    ext["spring.version"] = springVersion
     ext.isReleaseBuild = false
     ext.isSnapshotBuild = false
     ext.isDevBuild = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 group=org.rundeck
 currentVersion = 4.5.0
 grailsVersion=5.1.8
-grailsGradlePluginVersion=5.2.0
+grailsGradlePluginVersion=5.1.5
 springVersion=5.3.19
 gormVersion=7.1.2
 hibernateVersion=5.4.24.Final

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,8 +18,9 @@
 #####################################################################
 group=org.rundeck
 currentVersion = 4.5.0
-grailsVersion=5.1.7
-grailsGradlePluginVersion=5.1.2
+grailsVersion=5.1.8
+grailsGradlePluginVersion=5.2.0
+springVersion=5.3.19
 gormVersion=7.1.2
 hibernateVersion=5.4.24.Final
 groovyVersion=3.0.9
@@ -29,20 +30,21 @@ jacksonDatabindVersion=2.13.2.2
 jacksonDataformatCBORVersion=2.13.2
 jackson-bom.version=2.13.2.1
 snakeyamlVersion=1.29
-gsonVersion=2.8.6
+gsonVersion=2.8.9
 httpClientVersion=4.5.13
 bouncyCastleVersion=1.68
-springVersion=5.3.19
+
 #
 # Override of spring-boot dependencies versions.
 # available properties at:
 # https://github.com/spring-projects/spring-boot/blob/1.5.x/spring-boot-dependencies/pom.xml
 #
-jetty.version=9.4.44.v20210927
+jetty.version=9.4.48.v20220622
 spring-security.version=5.6.1
 log4j2.version=2.17.1
 assetPluginVersion=3.4.3
 dbMigrationPluginVersion=4.1.0
+liquibaseVersion=4.6.2
 micronautVersion=3.2.6
 node.install=16.13.0
 org.gradle.daemon=true

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -169,7 +169,7 @@ dependencies {
         exclude(group:"org.yaml",module:"snakeyaml")
     }
     implementation "org.grails.plugins:database-migration:${dbMigrationPluginVersion}"
-    implementation 'org.liquibase:liquibase-core:4.6.2'
+    implementation "org.liquibase:liquibase-core:${liquibaseVersion}"
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: "${httpClientVersion}"
     profile ("org.grails.profiles:web"){
         exclude(group:"org.grails.profiles",module:"web")

--- a/testbuild.groovy
+++ b/testbuild.groovy
@@ -45,7 +45,7 @@ def debug=Boolean.getBoolean('debug')?:("-debug" in args)
 
 //versions of dependency we want to verify
 def versions=[
-        jetty:'9.4.44.v20210927',
+        jetty:'9.4.48.v20220622',
         servlet:'api-3.1.0',
         log4j:'2.17.1'
 ]
@@ -120,7 +120,7 @@ def manifest=[
         "WEB-INF/lib/log4j-api-${versions.log4j}.jar",
         "WEB-INF/lib/log4j-core-${versions.log4j}.jar",
         "WEB-INF/lib/log4j-slf4j-impl-${versions.log4j}.jar",
-        "WEB-INF/lib/slf4j-api-1.7.32.jar",
+        "WEB-INF/lib/slf4j-api-1.7.36.jar",
         "WEB-INF/lib/libpam4j-1.11.jar"
     ],
     "plugins/script-plugin/${target}/rundeck-script-plugin-${version}.jar":[:],


### PR DESCRIPTION
This PR updates the following dependencies reported by twistlock scan: 
- **gson** -> `2.8.6` to `2.8.9` (CVE-2022-25647)
- **jetty** -> `9.4.44.v20210927` to `9.4.48.v20220622` (CVE-2022-2048)

Also includes the following additional updates:
- **grails** -> `5.1.7` to `5.1.8`
- **grails gradle plugin** -> `5.1.2` to `5.1.5`
