### PR TITLE
RUN-994: Show proper error message when an existing filter with same name is already present

### DIFF
--- a/rundeckapp/grails-spa/packages/ui/src/components/activity/savedFilters.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/activity/savedFilters.vue
@@ -7,7 +7,7 @@
 
     <dropdown v-if="filters && filters.length > 0">
       <span class="dropdown-toggle btn btn-secondary btn-sm" :class="query && query.filterName?'text-info':'text-secondary'">
-        
+
         {{$t('Filters')}}
         <span class="caret"></span>
       </span>
@@ -118,6 +118,9 @@ export default {
             this.query
           )
         });
+        if(response.parsedBody.error){
+          this.$notify.error(response.parsedBody.message);
+        }
         if (response.parsedBody && response.parsedBody.success) {
           const newfilter=Object.assign({ name: name }, this.query)
           this.filters.push(newfilter);


### PR DESCRIPTION
Fix [rundeck/rundeckpro#2183](https://github.com/rundeckpro/rundeckpro/issues/2183)

Notification added when filters already exists in the activity page.

![image](https://user-images.githubusercontent.com/29233418/176512643-a45fbf94-b1bf-4088-bf3f-1f6d4aaa1bc3.png)

Another card was created in order to add the test to the qa framework https://pagerduty.atlassian.net/browse/RUN-1037