### PR TITLE
RUN-1000: System Report 'Allocated Memory' display broken in the GUI

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/app/api/model/SystemInfoModel.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/api/model/SystemInfoModel.groovy
@@ -90,9 +90,9 @@ class SystemInfoModel {
         @Schema(name="memory", description="Memory Information")
         static class MemoryInfoModel {
             String unit
-            int max
-            int free
-            int total
+            long max
+            long free
+            long total
         }
         @Schema(name="scheduler", description="Scheduler Information")
         static class SchedulerInfoModel {


### PR DESCRIPTION
# Bugfix for the system report allocated and max memory metric

As seen here: https://github.com/rundeckpro/rundeckpro/issues/2587 there was a problem while displaying the max and allocated memory in system report section of Rundeck GUI.

*Solution*
We were storing a long type value in an integer variable, this caused data overflow and this in turn caused some values ​​in the system memory to be negative, which caused the error described. So we changed the data type and fixed the problem.

*Exhibits*
Pre-fix:

![Screen Shot 2022-06-22 at 16 03 37](https://user-images.githubusercontent.com/81827734/175116370-b1a30d87-5f79-41fd-bdf4-8ff4c66b46bd.png)

Post-fix:
![Screen Shot 2022-06-22 at 15 54 45](https://user-images.githubusercontent.com/81827734/175116319-213938af-d5fa-4b08-ad78-de0115af3634.png)
