### PR TITLE
RUN-1045: fixed broken error message that appears when you have not stored a password

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/storage/TypedStorageTreeImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/storage/TypedStorageTreeImpl.java
@@ -46,8 +46,9 @@ public class TypedStorageTreeImpl extends StorageTreeImpl implements TypedStorag
         if (resource.getContents().getContentType().equals(contentType)) {
             return resource;
         }
+        String errorMessage = "Path " + path + " does not store a password, content-type: " + contentType;
         throw new WrongContentType(
-                "Path ${path} does not store a password, content-type: ${resource.contents.contentType}",
+                errorMessage,
                 StorageException.Event.READ,
                 path
         );

--- a/plugins/copyfile-plugin/src/main/java/com/dtolabs/rundeck/plugin/copyfile/CopyFileNodeStepPlugin.java
+++ b/plugins/copyfile-plugin/src/main/java/com/dtolabs/rundeck/plugin/copyfile/CopyFileNodeStepPlugin.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * $INTERFACE is ... User: greg Date: 10/31/13 Time: 2:58 PM
  */
 @Plugin(service = ServiceNameConstants.WorkflowNodeStep, name = CopyFileNodeStepPlugin.TYPE)
-@PluginDescription(title = "Copy File",description = "Copy a file to a destination on a remote node.")
+@PluginDescription(title = "Copy File",description = "Copy a file to a destination on a remote node")
 public class CopyFileNodeStepPlugin implements NodeStepPlugin {
     public static final String TYPE = "copyfile";
     public static final String FILE_SEPARATOR = System.getProperty("file.separator");


### PR DESCRIPTION
I was using the debugger to trace an error I've been stuck on all day. Once I found it, I realized it was a bug. I found the message in the java file TypedStorageTreeImpl.java, but the string is hard coded with what looks to be interpolation, but since it's a java file and you cannot do that in Java, I'm literally getting an error with the interpolation syntax instead of any data. Because of this, it would print ${path} instead of printing the actual path that variables holds. So I fixed it to work with Java syntax instead of the broken Groovy syntax it was using. I also removed a period from the end of another plugin description to fit with the style I have been implementing in the moving cloud repos ticket