### PR TITLE
RUN-1001 preventing warning message to show up in logs

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -241,7 +241,7 @@ class ExecutionController extends ControllerBase{
         def inputFiles = fileUploadService.findRecords(e, FileUploadService.RECORD_TYPE_OPTION_INPUT)
         def inputFilesMap = inputFiles.collectEntries { [it.uuid, it] }
 
-        String max = getGrailsApplication().config.get("rundeck.logviewer.trimOutput")
+        String max = getGrailsApplication().config.getProperty("rundeck.logviewer.trimOutput", String)
         Long trimOutput = Sizes.parseFileSize(max)
 
         return loadExecutionViewPlugins() + [


### PR DESCRIPTION
Using the recommended approach to load properties from rundeck-config.properties file
This prevents displaying a warning message when loading the property

Fix: https://github.com/rundeckpro/rundeckpro/issues/2601