### PR TITLE
RUN-1015 Use length check to find unencrypted storage keys 

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/JasyptEncryptionEnforcerUpdaterConfig.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/tree/JasyptEncryptionEnforcerUpdaterConfig.groovy
@@ -1,7 +1,9 @@
 package com.dtolabs.rundeck.app.tree
 
 import com.dtolabs.rundeck.core.storage.ResourceMeta
+import com.dtolabs.rundeck.core.storage.StorageUtil
 import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
 import org.rundeck.storage.api.Resource
 
 /**
@@ -9,6 +11,7 @@ import org.rundeck.storage.api.Resource
  * content
  */
 @CompileStatic
+@Slf4j
 class JasyptEncryptionEnforcerUpdaterConfig implements UpdaterConfig {
     TreeCreator treeCreator
 
@@ -26,6 +29,26 @@ class JasyptEncryptionEnforcerUpdaterConfig implements UpdaterConfig {
         def contents = resource.contents
 
         if (contents.meta.get('jasypt-encryption:encrypted') == 'true') {
+            // There are edge cases that the JSON meta information indicate the content is encrypted,
+            // but it actually plain text saved.
+            // To tackle this issue, only check the meta `jasypt-encryption:encrypted` is not enough,
+            // we also need to verify if the content is really encrypted.
+            // We will use the length of the content to compare with the `Rundeck-content-size` meta value,
+            // if those two values are exact the same then we can confirm the saved value is not encrypted.
+            //
+            // Due to there is no guaranteed way to check if the content is encrypted or not, so we use this
+            // opt-in style implementation to limit the logic only applied to the specific error case.
+
+            try {
+                if(contents.getInputStream().getBytes().size() ==
+                        Integer.parseInt(contents.meta.get(StorageUtil.RES_META_RUNDECK_CONTENT_LENGTH))) {
+                    return contents
+                }
+            } catch(Exception ex) {
+                // Suppress the error, we don't want to block the application startup.
+                log.info(String.format("Encounter error [%s] when checking if storage key at path [%s] is properly encrypted. Suppressed.",
+                        ex.getMessage(), resource.path));
+            }
             //don't modify existing encrypted data
             return null
         }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is a bugfix. In some cases, the user updated a key in v4.2.1 could result in the key being saved as plain text but the metadata still marked it as encrypted so if upgraded to newer versions the key auto-conversion process ignored this key. This issue leads to keys saved as plain text in storage. 

**Describe the solution you've implemented**
To fix this issue, we add an extra check in the storage key auto-conversion process to catch this edge case. The logic is to compare the key's length with the Rundeck-content-size meta info. If those two have the same value, it means the key is plain text so we can encrypt it.

**Describe alternatives you've considered**
There is no other guaranteed ways to determine if the key is plain text or encrypted. Using the string length comparison method, we can guarantee the key is incorrect.

**Additional context**
This PR is a patch to https://pagerduty.atlassian.net/browse/RUN-944
