### PR TITLE
RUN-1041: Fix Date Format differences in Context Variable output

### DIFF
--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -40,6 +40,7 @@ import rundeck.services.*
 import rundeck.services.execution.ThresholdValue
 import rundeck.services.logging.LoggingThreshold
 
+import java.sql.Timestamp
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 
@@ -557,7 +558,7 @@ class ExecutionJob implements InterruptableJob {
             statusString = initMap.scheduledExecution?.logOutputThresholdStatus?:'failed'
         }
         //save Execution state
-        def dateCompleted = new Date()
+        def dateCompleted = new Timestamp(System.currentTimeMillis())
         def resultMap = [
                 status        : statusString?: success? ExecutionState.succeeded.toString():ExecutionState.failed.toString(),
                 dateCompleted : dateCompleted,


### PR DESCRIPTION
# RUN-1041 - Bugfix for date different formats

As seen here: https://github.com/rundeckpro/rundeckpro/issues/2617 there was a problem while displaying context variables with date data.

**Solution**
There is a difference between the date format of the classes: Date and Timestamp, which variable "dateStarted" is in Timestamp and "dateEnded" is in Date. It was changing to the same format using the SimpleDateFormat class, but the most comfortable and light solution is to use the class:

**Exhibits**
_Pre-fix:_
![image](https://user-images.githubusercontent.com/91557307/178857673-d6ba48b2-b8c9-4dfb-8575-2c52778dfca0.png)
_Post-fix_
![image](https://user-images.githubusercontent.com/91557307/178857683-0f2646ac-d61f-4d34-b3dc-14e10b65a36f.png)

PD: RUN-1041