### PR TITLE
RUN-1058: Add the missing public key into apt trusted list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,8 @@ jobs:
         type: string
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.14
       - fetch-common-artifacts
       - run:
           name: Test
@@ -391,7 +392,8 @@ jobs:
       - checkout
       - install-node
       - restore-gradle-cache
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.14
       - fetch-common-artifacts
       - fetch-ci-resources
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,8 @@ jobs:
           command: |
             source .circleci/circle-shim.sh
             bash scripts/circle-build.sh build
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.14
       - run:
           name: Build Docker Images
           command: |

--- a/test/ci-test-docker-selenium.sh
+++ b/test/ci-test-docker-selenium.sh
@@ -13,7 +13,7 @@ main() {
     docker-compose -f selenium-docker-compose.yml run \
         -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
         -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-        selenium "apt-get update && apt-get -y --no-install-recommends install google-chrome-stable && npm install && npm run bootstrap && ./selenium/bin/deck test -s selenium -u http://rundeck:4440 -h --s3-upload --s3-base ${S3_BASE}" || RET=$?
+        selenium "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B && apt-get update && apt-get -y --no-install-recommends install google-chrome-stable && npm install && npm run bootstrap && ./selenium/bin/deck test -s selenium -u http://rundeck:4440 -h --s3-upload --s3-base ${S3_BASE}" || RET=$?
 
     local DIFF_DIR=__image_snapshots__/__diff_output__
 

--- a/test/docker/dockers/tomcat/Dockerfile
+++ b/test/docker/dockers/tomcat/Dockerfile
@@ -3,9 +3,6 @@ ARG TOMCAT_TAG
 FROM tomcat:${TOMCAT_TAG:-8}
 
 RUN apt-get update && \
-    apt-get -y install gnupg2 && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 871920D1991BC93C && \
-    apt-get update && \
     apt-get -y install coreutils file jq netcat xmlstarlet unzip
 
 RUN mkdir -p /usr/local/tomcat/webapps/rundeck/rundeck/server/config \

--- a/test/docker/dockers/tomcat/Dockerfile
+++ b/test/docker/dockers/tomcat/Dockerfile
@@ -3,6 +3,9 @@ ARG TOMCAT_TAG
 FROM tomcat:${TOMCAT_TAG:-8}
 
 RUN apt-get update && \
+    apt-get -y install gnupg2 && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 871920D1991BC93C && \
+    apt-get update && \
     apt-get -y install coreutils file jq netcat xmlstarlet unzip
 
 RUN mkdir -p /usr/local/tomcat/webapps/rundeck/rundeck/server/config \


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Bugfix

**Describe the solution you've implemented**
Add the missing public key into the apt trusted list.
https://support.google.com/chrome/thread/4032170/gpg-key-error-debian-repo-for-chrome?hl=en
https://askubuntu.com/questions/13065/how-do-i-fix-the-gpg-error-no-pubkey

