### PR TITLE
BUGFIX RUN-1084: unable to update webhook

### DIFF
--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -160,7 +160,8 @@ class WebhookService {
         }
         hook.uuid = hookData.uuid ?: hook.uuid
         int countByNameInProject = Webhook.countByNameAndProject(hookData.name,hookData.project)
-        if(countByNameInProject > 0) {
+        def importFlag = (hook.hasProperty('importData') && hook.importData) ? hook.importData : false
+        if(countByNameInProject > 0 && importFlag ) {
             return [err: " A Webhook by that name already exists in this project"]
         }
         hook.name = hookData.name ?: hook.name

--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -159,13 +159,9 @@ class WebhookService {
             hook.uuid = UUID.randomUUID().toString()
         }
         hook.uuid = hookData.uuid ?: hook.uuid
-        // If there's an import, we validate that the name of the WH is not duplicated in the project.
-        int countByNameInProject = Webhook.countByNameAndProject(hookData.name, hookData.project)
-        if (countByNameInProject > 0) {
-            // If we find during the import a WH with the same name, we check for duplicated UUID.
-            int countByUuidInProject = Webhook.countByUuidAndProject(hookData.uuid, hookData.project)
-            // If we find the UUID, it means that is a different webhook with duplicated name, so we prevent the import
-            if( countByUuidInProject == 0 ) return [err: "A Webhook by that name already exists in project"]
+        def whsFound = Webhook.findAllByNameAndProjectAndUuidNotEqual(hookData.name, hookData.project, hook.uuid)
+        if( whsFound.size > 0) {
+            return [err: " A Webhook by that name already exists in this project"]
         }
         hook.name = hookData.name ?: hook.name
         hook.project = hookData.project ?: hook.project

--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -160,7 +160,7 @@ class WebhookService {
         }
         hook.uuid = hookData.uuid ?: hook.uuid
         def whsFound = Webhook.findAllByNameAndProjectAndUuidNotEqual(hookData.name, hookData.project, hook.uuid)
-        if( whsFound.size > 0) {
+        if( whsFound.size() > 0) {
             return [err: " A Webhook by that name already exists in this project"]
         }
         hook.name = hookData.name ?: hook.name

--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -159,11 +159,15 @@ class WebhookService {
             hook.uuid = UUID.randomUUID().toString()
         }
         hook.uuid = hookData.uuid ?: hook.uuid
+        // If there's an import, we validate that the name of the WH is not duplicated in the project.
         int countByNameInProject = Webhook.countByNameAndProject(hookData.name, hookData.project)
         if (countByNameInProject > 0) {
+            // If we find during the import a WH with a same name, we check for duplicated UUID.
             int countByUuidInProject = Webhook.countByUuidAndProject(hookData.uuid, hookData.project)
-            if( countByUuidInProject == 0 ) return [err: "A Webhook by that name already exists in project project"]
+            // If we find the UUID, it means that is different webhook with a duplicated name, so we prevent the import
+            if( countByUuidInProject == 0 ) return [err: "A Webhook by that name already exists in project"]
         }else{
+            // If we don't find the WH by name in the project, we check if the WH exists in other projects to prevent errors
             int countByUuidInDb = Webhook.countByUuid(hookData.uuid)
             if( countByUuidInDb > 0 ) return [err: "A Webhook by that uuid already exists in other project"]
         }

--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -166,10 +166,6 @@ class WebhookService {
             int countByUuidInProject = Webhook.countByUuidAndProject(hookData.uuid, hookData.project)
             // If we find the UUID, it means that is a different webhook with duplicated name, so we prevent the import
             if( countByUuidInProject == 0 ) return [err: "A Webhook by that name already exists in project"]
-        }else{
-            // If we don't find the WH by name in the project, we check if the WH exists in other projects to prevent errors
-            int countByUuidInDb = Webhook.countByUuid(hookData.uuid)
-            if( countByUuidInDb > 0 ) return [err: "A Webhook by that uuid already exists in other project"]
         }
         hook.name = hookData.name ?: hook.name
         hook.project = hookData.project ?: hook.project

--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -159,10 +159,13 @@ class WebhookService {
             hook.uuid = UUID.randomUUID().toString()
         }
         hook.uuid = hookData.uuid ?: hook.uuid
-        int countByNameInProject = Webhook.countByNameAndProject(hookData.name,hookData.project)
-        def importFlag = (hook.hasProperty('importData') && hook.importData) ? hook.importData : false
-        if(countByNameInProject > 0 && importFlag ) {
-            return [err: " A Webhook by that name already exists in this project"]
+        int countByNameInProject = Webhook.countByNameAndProject(hookData.name, hookData.project)
+        if (countByNameInProject > 0) {
+            int countByUuidInProject = Webhook.countByUuidAndProject(hookData.uuid, hookData.project)
+            if( countByUuidInProject == 0 ) return [err: "A Webhook by that name already exists in project project"]
+        }else{
+            int countByUuidInDb = Webhook.countByUuid(hookData.uuid)
+            if( countByUuidInDb > 0 ) return [err: "A Webhook by that uuid already exists in other project"]
         }
         hook.name = hookData.name ?: hook.name
         hook.project = hookData.project ?: hook.project

--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -162,9 +162,9 @@ class WebhookService {
         // If there's an import, we validate that the name of the WH is not duplicated in the project.
         int countByNameInProject = Webhook.countByNameAndProject(hookData.name, hookData.project)
         if (countByNameInProject > 0) {
-            // If we find during the import a WH with a same name, we check for duplicated UUID.
+            // If we find during the import a WH with the same name, we check for duplicated UUID.
             int countByUuidInProject = Webhook.countByUuidAndProject(hookData.uuid, hookData.project)
-            // If we find the UUID, it means that is different webhook with a duplicated name, so we prevent the import
+            // If we find the UUID, it means that is a different webhook with duplicated name, so we prevent the import
             if( countByUuidInProject == 0 ) return [err: "A Webhook by that name already exists in project"]
         }else{
             // If we don't find the WH by name in the project, we check if the WH exists in other projects to prevent errors

--- a/grails-webhooks/src/test/groovy/webhooks/WebhookServiceSpec.groovy
+++ b/grails-webhooks/src/test/groovy/webhooks/WebhookServiceSpec.groovy
@@ -461,6 +461,93 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
         !res
     }
 
+    def "edit webhook"() {
+        given:
+        def mockUserAuth = Mock(UserAndRolesAuthContext) {
+            getUsername() >> { "webhookUser" }
+            getRoles() >> { ["webhook", "test"] }
+        }
+        service.apiService = Mock(MockApiService)
+        service.rundeckAuthTokenManagerService = Mock(AuthTokenManager) {
+            parseAuthRoles(_) >> { ["webhook", "test"] }
+        }
+        service.userService = Mock(MockUserService) {
+            validateUserExists(_) >> { true }
+        }
+        service.pluginService = Mock(MockPluginService) {
+            validatePluginConfig(_, _, _) >> { return new ValidatedPlugin(report: new Validator.Report(), valid: true) }
+            getPlugin(_, _) >> { new TestWebhookEventPlugin() }
+            listPlugins(WebhookEventPlugin) >> { ["log-webhook-event": new TestWebhookEventPlugin()] }
+        }
+        Webhook existing = new Webhook(id: "1", uuid: "2c2d614b-34f5-4f52-969a-9c6a90fb8b75", name: "test", project: "Test", authToken: "12345", eventPlugin: "log-webhook-event")
+        existing.save()
+
+        when:
+        def result = service.saveHook(mockUserAuth, [id: "1", uuid: "2c2d614b-34f5-4f52-969a-9c6a90fb8b75", name: "test", project: "Test", user: "webhookUser", roles: "webhook,test", eventPlugin: "log-webhook-event", "config": ["cfg1": "val1"]])
+
+        then:
+        result == [msg: "Saved webhook"]
+
+    }
+
+    def "Cannot import a webhook with the same name and different uuid in the same project"() {
+        given:
+        def mockUserAuth = Mock(UserAndRolesAuthContext) {
+            getUsername() >> { "webhookUser" }
+            getRoles() >> { ["webhook", "test"] }
+        }
+        service.apiService = Mock(MockApiService)
+        service.rundeckAuthTokenManagerService = Mock(AuthTokenManager) {
+            parseAuthRoles(_) >> { ["webhook", "test"] }
+        }
+        service.userService = Mock(MockUserService) {
+            validateUserExists(_) >> { true }
+        }
+        service.pluginService = Mock(MockPluginService) {
+            validatePluginConfig(_, _, _) >> { return new ValidatedPlugin(report: new Validator.Report(), valid: true) }
+            getPlugin(_, _) >> { new TestWebhookEventPlugin() }
+            listPlugins(WebhookEventPlugin) >> { ["log-webhook-event": new TestWebhookEventPlugin()] }
+        }
+        Webhook existing = new Webhook(id: "1", uuid: "2c2d614b-34f5-4f52-969a-9c6a90fb8b75", name: "test", project: "Test", authToken: "12345", eventPlugin: "log-webhook-event")
+        existing.save()
+
+        when:
+        def result = service.importWebhook(mockUserAuth, [id: "1", uuid: "d1c6dcf7-dd12-4858-9373-c12639c689d4", name: "test", project: "Test", authToken: "12345", eventPlugin: "log-webhook-event"], false)
+
+        then:
+        result == [err:"Unable to import webhoook test. Error:A Webhook by that name already exists in project project"]
+
+    }
+
+    def "Cannot import a webhook from another project"() {
+        given:
+        def mockUserAuth = Mock(UserAndRolesAuthContext) {
+            getUsername() >> { "webhookUser" }
+            getRoles() >> { ["webhook", "test"] }
+        }
+        service.apiService = Mock(MockApiService)
+        service.rundeckAuthTokenManagerService = Mock(AuthTokenManager) {
+            parseAuthRoles(_) >> { ["webhook", "test"] }
+        }
+        service.userService = Mock(MockUserService) {
+            validateUserExists(_) >> { true }
+        }
+        service.pluginService = Mock(MockPluginService) {
+            validatePluginConfig(_, _, _) >> { return new ValidatedPlugin(report: new Validator.Report(), valid: true) }
+            getPlugin(_, _) >> { new TestWebhookEventPlugin() }
+            listPlugins(WebhookEventPlugin) >> { ["log-webhook-event": new TestWebhookEventPlugin()] }
+        }
+        Webhook existing = new Webhook(id: "1", uuid: "2c2d614b-34f5-4f52-969a-9c6a90fb8b75", name: "test", project: "Test", authToken: "12345", eventPlugin: "log-webhook-event")
+        existing.save()
+
+        when:
+        def result = service.importWebhook(mockUserAuth, [id: "1", uuid: "2c2d614b-34f5-4f52-969a-9c6a90fb8b75", name: "test", project: "Test2", authToken: "12345", eventPlugin: "log-webhook-event"], false)
+
+        then:
+        result == [err:"Unable to import webhoook test. Error:A Webhook by that uuid already exists in other project"]
+
+    }
+
     def "getWebhookWithAuth"() {
         setup:
         Webhook hook = new Webhook()

--- a/grails-webhooks/src/test/groovy/webhooks/WebhookServiceSpec.groovy
+++ b/grails-webhooks/src/test/groovy/webhooks/WebhookServiceSpec.groovy
@@ -545,7 +545,7 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
         def result = service.importWebhook(mockUserAuth, [id: "1", uuid: "d1c6dcf7-dd12-4858-9373-c12639c689d4", name: "test", project: "Test", authToken: "12345", eventPlugin: "log-webhook-event"], false)
 
         then:
-        result == [err:"Unable to import webhoook test. Error:A Webhook by that name already exists in project"]
+        result == [err:"Unable to import webhoook test. Error: A Webhook by that name already exists in this project"]
 
     }
 

--- a/grails-webhooks/src/test/groovy/webhooks/WebhookServiceSpec.groovy
+++ b/grails-webhooks/src/test/groovy/webhooks/WebhookServiceSpec.groovy
@@ -515,7 +515,7 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
         def result = service.importWebhook(mockUserAuth, [id: "1", uuid: "d1c6dcf7-dd12-4858-9373-c12639c689d4", name: "test", project: "Test", authToken: "12345", eventPlugin: "log-webhook-event"], false)
 
         then:
-        result == [err:"Unable to import webhoook test. Error:A Webhook by that name already exists in project project"]
+        result == [err:"Unable to import webhoook test. Error:A Webhook by that name already exists in project"]
 
     }
 

--- a/grails-webhooks/src/test/groovy/webhooks/WebhookServiceSpec.groovy
+++ b/grails-webhooks/src/test/groovy/webhooks/WebhookServiceSpec.groovy
@@ -490,6 +490,36 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
 
     }
 
+    def "edit webhook's name"() {
+        given:
+        def mockUserAuth = Mock(UserAndRolesAuthContext) {
+            getUsername() >> { "webhookUser" }
+            getRoles() >> { ["webhook", "test"] }
+        }
+        service.apiService = Mock(MockApiService)
+        service.rundeckAuthTokenManagerService = Mock(AuthTokenManager) {
+            parseAuthRoles(_) >> { ["webhook", "test"] }
+        }
+        service.userService = Mock(MockUserService) {
+            validateUserExists(_) >> { true }
+        }
+        service.pluginService = Mock(MockPluginService) {
+            validatePluginConfig(_, _, _) >> { return new ValidatedPlugin(report: new Validator.Report(), valid: true) }
+            getPlugin(_, _) >> { new TestWebhookEventPlugin() }
+            listPlugins(WebhookEventPlugin) >> { ["log-webhook-event": new TestWebhookEventPlugin()] }
+        }
+        Webhook existing = new Webhook(id: "1", uuid: "2c2d614b-34f5-4f52-969a-9c6a90fb8b75", name: "test", project: "Test", authToken: "12345", eventPlugin: "log-webhook-event")
+        existing.save()
+
+        when:
+        def result = service.saveHook(mockUserAuth, [id: "1", uuid: "2c2d614b-34f5-4f52-969a-9c6a90fb8b75", name: "test-change-name", project: "Test", user: "webhookUser", roles: "webhook,test", eventPlugin: "log-webhook-event", "config": ["cfg1": "val1"]])
+        def whPersisted = Webhook.findByUuid("2c2d614b-34f5-4f52-969a-9c6a90fb8b75")
+
+        then:
+        result == [msg: "Saved webhook"]
+        whPersisted.name == "test-change-name"
+    }
+
     def "Cannot import a webhook with the same name and different uuid in the same project"() {
         given:
         def mockUserAuth = Mock(UserAndRolesAuthContext) {
@@ -516,35 +546,6 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
 
         then:
         result == [err:"Unable to import webhoook test. Error:A Webhook by that name already exists in project"]
-
-    }
-
-    def "Cannot import a webhook from another project"() {
-        given:
-        def mockUserAuth = Mock(UserAndRolesAuthContext) {
-            getUsername() >> { "webhookUser" }
-            getRoles() >> { ["webhook", "test"] }
-        }
-        service.apiService = Mock(MockApiService)
-        service.rundeckAuthTokenManagerService = Mock(AuthTokenManager) {
-            parseAuthRoles(_) >> { ["webhook", "test"] }
-        }
-        service.userService = Mock(MockUserService) {
-            validateUserExists(_) >> { true }
-        }
-        service.pluginService = Mock(MockPluginService) {
-            validatePluginConfig(_, _, _) >> { return new ValidatedPlugin(report: new Validator.Report(), valid: true) }
-            getPlugin(_, _) >> { new TestWebhookEventPlugin() }
-            listPlugins(WebhookEventPlugin) >> { ["log-webhook-event": new TestWebhookEventPlugin()] }
-        }
-        Webhook existing = new Webhook(id: "1", uuid: "2c2d614b-34f5-4f52-969a-9c6a90fb8b75", name: "test", project: "Test", authToken: "12345", eventPlugin: "log-webhook-event")
-        existing.save()
-
-        when:
-        def result = service.importWebhook(mockUserAuth, [id: "1", uuid: "2c2d614b-34f5-4f52-969a-9c6a90fb8b75", name: "test", project: "Test2", authToken: "12345", eventPlugin: "log-webhook-event"], false)
-
-        then:
-        result == [err:"Unable to import webhoook test. Error:A Webhook by that uuid already exists in other project"]
 
     }
 


### PR DESCRIPTION
# Reactive Bugfix to Webhooks
As seen here: https://github.com/rundeckpro/rundeckpro/issues/2680, the GUI was not editing any webhooks.

## The problem
The method 'saveWebhook' of the 'WebhookService', is the responsible for a) saving a new webhook, b) Importing a new webhook and c) editing an existing webhook, so, when this PR: https://github.com/rundeck/rundeck/pull/7737, prevented the import process for webhooks with the same name, also caused the error when we call 'saveWebhook' with the same name for editing.

## The solution
When the 'importWebhook' is called, it puts an extra attribute inside the 'hook' object to be passed to 'saveWebhook' method, so, what we did was evaluate if that property exists in the hook in order to permit **'saving' for editing and not for importing**.
