### PR TITLE
RSE-9-job-remote-option-url-retry-connection-parameter-is-not-honored

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -58,6 +58,18 @@ public class RundeckConfigBase {
     RundeckApiConfig api;
     ScmLoader scmLoader;
     RundeckHealthIndicatorConfig health;
+    RundeckJobsConfig jobs;
+
+    @Data public static class RundeckJobsConfig{
+        JobOptionsConfig options;
+    }
+
+    @Data
+    public static class JobOptionsConfig{
+        int remoteUrlTimeout;
+        int remoteUrlConnectionTimeout;
+        int remoteUrlRetry;
+    }
 
     @Data
     public static class UserSessionProjectsCache {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -842,9 +842,6 @@ class ScheduledExecutionController  extends ControllerBase{
             client.setFollowRedirects(true)
             client.setTimeout(timeout*1000)
 
-            if(retry>0) {
-                client.setRetryCount(retry)
-            }
 
             URL urlo
             String cleanUrl = url.replaceAll("^(https?://)([^:@/]+):[^@/]*@", '$1$2:****@');

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3921,9 +3921,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             try {
                 //validate is no the first attempt
                 if ( retryCount > count ){
-                    if(count>0){
-                        Thread.sleep(contimeout*1000)
-                    }
+                    Thread.sleep(contimeout*1000)
                 }
                 def framework = frameworkService.getRundeckFramework()
                 def projectConfig = framework.frameworkProjectMgr.loadProjectConfig(scheduledExecution.project)

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3917,7 +3917,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         int count = retryCount
         do{
             try {
-                if (count > retryCount){
+                if ( retryCount > count ){
                     if(count>0){
                         Thread.sleep(contimeout*1000)
                     }
@@ -3950,8 +3950,8 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 log.error("getRemoteJSON error: URL ${cleanUrl} : ${remoteResult.error}");
             }
             logRemoteOptionStats(remoteStats, [jobName: scheduledExecution.generateFullName(), id: scheduledExecution.extid, jobProject: scheduledExecution.project, optionName: mapConfig.option, user: username])
-            retryCount--
-        }while(retryCount > 0 && (httpResponseCode < 200 || httpResponseCode > 300 ))
+            count--
+        }while(count > 0 && (httpResponseCode < 200 || httpResponseCode > 300 ))
 
         //validate result contents
         boolean valid = true;

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3915,8 +3915,11 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
 
         int count = retryCount
+
+        //cycle to retry getting the JSON from a remoteURL
         do{
             try {
+                //validate is no the first attempt
                 if ( retryCount > count ){
                     if(count>0){
                         Thread.sleep(contimeout*1000)

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3844,7 +3844,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
         if (configurationService.getString("jobs.options.remoteUrlTimeout")) {
             try {
-                timeout = configurationService.getInteger("jobs.options.remoteUrlTimeout", 10)
+                timeout = configurationService.getInteger("jobs.options.remoteUrlTimeout", null)
             } catch (NumberFormatException e) {
                 log.warn(
                         "Configuration value rundeck.jobs.options.remoteUrlTimeout is not a valid integer: "
@@ -3854,7 +3854,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
         if (configurationService.getString("jobs.options.remoteUrlConnectionTimeout")) {
             try {
-                contimeout = configurationService.getInteger("jobs.options.remoteUrlConnectionTimeout", 0)
+                contimeout = configurationService.getInteger("jobs.options.remoteUrlConnectionTimeout", null)
             } catch (NumberFormatException e) {
                 log.warn(
                         "Configuration value rundeck.jobs.options.remoteUrlConnectionTimeout is not a valid integer: "
@@ -3864,7 +3864,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
         if (configurationService.getString("jobs.options.remoteUrlRetry")) {
             try {
-                retryCount = configurationService.getInteger("jobs.options.remoteUrlRetry", 5)
+                retryCount = configurationService.getInteger("jobs.options.remoteUrlRetry", null)
             } catch (NumberFormatException e) {
                 log.warn(
                         "Configuration value rundeck.jobs.options.remoteUrlRetry is not a valid integer: "

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -5601,11 +5601,11 @@ class ScheduledExecutionServiceSpec extends RundeckHibernateSpec implements Serv
 
         when:
         service.configurationService.getString("jobs.options.remoteUrlTimeout") >> timeout
-        service.configurationService.getInteger("jobs.options.remoteUrlTimeout",10) >> timeout
+        service.configurationService.getInteger("jobs.options.remoteUrlTimeout",null) >> timeout
         service.configurationService.getString("jobs.options.remoteUrlConnectionTimeout") >> conTimeout
-        service.configurationService.getInteger("jobs.options.remoteUrlConnectionTimeout",0) >> conTimeout
+        service.configurationService.getInteger("jobs.options.remoteUrlConnectionTimeout",null) >> conTimeout
         service.configurationService.getString("jobs.options.remoteUrlRetry") >> retry
-        service.configurationService.getInteger("jobs.options.remoteUrlRetry",5) >> retry
+        service.configurationService.getInteger("jobs.options.remoteUrlRetry",null) >> retry
         _ * service.frameworkService.getRundeckFramework()>>Mock(IFramework){
             _ * getFrameworkProjectMgr()>>Mock(ProjectManager){
                 _ * loadProjectConfig('testProject')


### PR DESCRIPTION
Fix: https://github.com/rundeckpro/rundeckpro/issues/2644

Problem: 

When a job option was set from a remote URL the retry param was not taken in count, any retry was made.
There are two ways of setting those configurations, directly on the URL or the config.properties, the ones from the config.properties weren't being used. 

Solution:

On the RundeckBaseConfig add the missing params to be accessible. 
Implement on the Rundeck side a retry method if something fails when trying to obtain the values from an URL. 

A similar solution is already implemented on the code on rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy on the postDataUrl method 
