### PR TITLE
improve query to get referenced executions

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
@@ -159,10 +159,10 @@ class ReportsController extends ControllerBase{
                 ScheduledExecution sched = !params.jobIdFilter.toString().isNumber() ? ScheduledExecution.findByUuid(params.jobIdFilter) : ScheduledExecution.get(params.jobIdFilter)
                 def list = ReferencedExecution.executionProjectList(sched)
                 def allowedProjects = []
-                list.each {project ->
+                list.each { project ->
                     if(project != params.project){
-                        if(unauthorizedResponse(rundeckAuthContextProcessor.authorizeProjectResource(authContext, AuthConstants.RESOURCE_TYPE_EVENT, AuthConstants.ACTION_READ,
-                                params.project), AuthConstants.ACTION_READ,'Events in project', project)){
+                        if(!rundeckAuthContextProcessor.authorizeProjectResource(authContext, AuthConstants.RESOURCE_TYPE_EVENT, AuthConstants.ACTION_READ,
+                                project)){
                             log.debug('Cant read executions on project ' + project)
                         }else{
                             allowedProjects << project

--- a/rundeckapp/grails-app/domain/rundeck/ReferencedExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ReferencedExecution.groovy
@@ -36,14 +36,12 @@ class ReferencedExecution {
         } as List<ScheduledExecution>
     }
 
-    static List executionIdList(ScheduledExecution se, int max = 0){
+    static List executionProjectList(ScheduledExecution se, int max = 0){
         return createCriteria().list(max: (max!=0)?max:null) {
-            resultTransformer(CriteriaSpecification.ALIAS_TO_ENTITY_MAP)
             createAlias('execution', 'e', JoinType.LEFT_OUTER_JOIN)
             eq("scheduledExecution", se)
             projections {
-                property('e.id', "executionId")
-                property('e.project', "project")
+                groupProperty('e.project', "project")
             }
         }
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ReportService.groovy
@@ -21,11 +21,13 @@ import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.Decision
 import com.dtolabs.rundeck.core.authorization.Explanation
 import com.google.common.collect.Lists
+import grails.gorm.DetachedCriteria
 import grails.gorm.transactions.Transactional
 import org.rundeck.app.authorization.AppAuthContextEvaluator
 import org.rundeck.core.auth.AuthConstants
 import org.springframework.transaction.TransactionDefinition
 import rundeck.ExecReport
+import rundeck.ReferencedExecution
 import rundeck.ScheduledExecution
 
 import javax.sql.DataSource
@@ -230,7 +232,8 @@ class ReportService  {
         }
         return total
     }
-    def applyExecutionCriteria(ExecQuery query, delegate, boolean isJobs=true){
+
+    def applyExecutionCriteria(ExecQuery query, delegate, boolean isJobs=true, ScheduledExecution se=null){
         def eqfilters = [
                 stat: 'status',
                 reportId: 'reportId',
@@ -295,36 +298,37 @@ class ReportService  {
                     }
                 }
 
-                if (query.execIdFilter) {
+                if (query.execProjects && se) {
                     or {
-                        if(isOracleDatasource()){
-                            //Hack to avoid error: ORA-01795: maximum number of expressions in a list is 1000
-                            or {
-                                List execIdFilterPartioned = Lists.partition(query.execIdFilter, 1000)
-                                execIdFilterPartioned.each { List partition ->
-                                    'in'('executionId', partition.collect{Long.parseLong(it)})
+                        exists(new DetachedCriteria(ReferencedExecution, "re").build {
+                            projections { property 're.execution.id' }
+                            eq('re.scheduledExecution.id', se.id)
+                            eqProperty('re.execution.id', 'this.executionId')
+                            List execProjectsPartitioned = Lists.partition(query.execProjects, 1000)
+                            or{
+                                for(def partition : execProjectsPartitioned){
+                                    'in'('this.ctxProject', partition)
                                 }
                             }
-                        } else {
-                            'in'('executionId', query.execIdFilter.collect{Long.parseLong(it)})
-                        }
+                        })
+                        eq('jcJobId', String.valueOf(se.id))
                         and{
-                                    jobfilters.each { key, val ->
-                                        if (query["${key}Filter"] == 'null') {
-                                            or {
-                                                isNull(val)
-                                                eq(val, '')
-                                            }
-                                        } else if (query["${key}Filter"] == '!null') {
-                                            and {
-                                                isNotNull(val)
-                                                if(!isOracleDatasource())
-                                                    ne(val,'')
-                                            }
-                                        } else if (query["${key}Filter"]) {
-                                            eq(val, query["${key}Filter"])
-                                        }
+                            jobfilters.each { key, val ->
+                                if (query["${key}Filter"] == 'null') {
+                                    or {
+                                        isNull(val)
+                                        eq(val, '')
                                     }
+                                } else if (query["${key}Filter"] == '!null') {
+                                    and {
+                                        isNotNull(val)
+                                        if(!isOracleDatasource())
+                                            ne(val,'')
+                                    }
+                                } else if (query["${key}Filter"]) {
+                                    eq(val, query["${key}Filter"])
+                                }
+                            }
                         }
                     }
                 }else{
@@ -439,13 +443,14 @@ class ReportService  {
                 execnode: 'execnode'
         ]
 
+        def se
         if(query?.jobIdFilter) {
-            def found = ScheduledExecution.findByUuid(query.jobIdFilter)
-            if(!found && query.jobIdFilter.isNumber()) {
-                found = ScheduledExecution.get(query.jobIdFilter)
+            se = ScheduledExecution.findByUuid(query.jobIdFilter)
+            if(!se && query.jobIdFilter.isNumber()) {
+                se = ScheduledExecution.get(query.jobIdFilter)
             }
-            if(found) {
-                query.jobIdFilter = found.id.toString()
+            if(se) {
+                query.jobIdFilter = se.id.toString()
             }
         }
 
@@ -464,7 +469,7 @@ class ReportService  {
                 firstResult(query.offset.toInteger())
             }
 
-            applyExecutionCriteria(query, delegate,isJobs)
+            applyExecutionCriteria(query, delegate,isJobs, se)
 
             if (query && query.sortBy && filters[query.sortBy]) {
                 order(filters[query.sortBy], query.sortOrder == 'ascending' ? 'asc' : 'desc')
@@ -484,7 +489,7 @@ class ReportService  {
         def isolationLevel = (minLevel=='UNCOMMITTED')?TransactionDefinition.ISOLATION_READ_UNCOMMITTED:TransactionDefinition.ISOLATION_DEFAULT
         def total = ExecReport.withTransaction([isolationLevel: isolationLevel]) {
             ExecReport.createCriteria().count {
-                applyExecutionCriteria(query, delegate, isJobs)
+                applyExecutionCriteria(query, delegate, isJobs, se)
             }
         }
         filters.putAll(specialfilters)

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ExecQuery.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ExecQuery.groovy
@@ -31,6 +31,7 @@ class ExecQuery extends ReportQuery implements Validateable{
     String groupPathFilter
     String groupPathExactFilter
     List execIdFilter
+    List execProjects
 
     static constraints = {
         abortedByFilter(nullable: true)
@@ -60,6 +61,7 @@ class ExecQuery extends ReportQuery implements Validateable{
         statFilter(nullable:true,inList:["succeed","fail","cancel","missed"])
         execnodeFilter(nullable: true)
         execIdFilter(nullable:true)
+        execProjects(nullable:true)
         sortBy(nullable:true,inList:[
             "jobFilter",
             "jobIdFilter",

--- a/rundeckapp/src/test/groovy/rundeck/ReferencedExecutionSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ReferencedExecutionSpec.groovy
@@ -60,11 +60,11 @@ class ReferencedExecutionSpec extends RundeckHibernateSpec
         def re = new ReferencedExecution(scheduledExecution: se,execution: exec).save()
 
         when:
-        List l = ReferencedExecution.executionIdList(se)
+        List l = ReferencedExecution.executionProjectList(se)
 
         then:
         l.size() == 1
-        l == [[executionId:1, project:"project1"]]
+        l == ["project1"]
     }
 
     def "execution id list with max result"(){
@@ -137,19 +137,17 @@ class ReferencedExecutionSpec extends RundeckHibernateSpec
         def executionIdList = [[executionId: exec.id, project: exec.project], [executionId: exec2.id, project: exec2.project]]
 
         when:
-        List l = ReferencedExecution.executionIdList(se, max)
+        List l = ReferencedExecution.executionProjectList(se, max)
 
         then:
         l.size() == sizeList
-        (0..(sizeList-1)).each {
-            l.get(it) == executionIdList.get(it)
-        }
+        l == ["project1"]
 
         where:
         max  | sizeList
-        0    | 2
+        0    | 1
         1    | 1
-        2    | 2
+        2    | 1
     }
 
     def "parent list"(){


### PR DESCRIPTION
fix https://github.com/rundeckpro/rundeckpro/issues/2404

This PR prevents the use of a huge "in" sentence to retrieve the referenced executions, instead it joins the tables based on the scheduled execution id. Still uses a "in" sentence but a fairly smaller one just for the allowed projects for the user performing the search (this can't be done directly in the query since the project list needs to go trough the authorization context processor first)