### PR TITLE
RUN-1116: Fix nightly build: tomcat docker test requires tag argument to script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -623,7 +623,7 @@ workflows:
           <<: *filter-default
           name: Tomcat 8 API Test
           requires: *stage-build
-          command: bash test/run-docker-tomcat-tests.sh
+          command: bash test/run-docker-tomcat-tests.sh 8-jdk11
           context:
             - slack-secrets
           <<: *slack-fail-post-step
@@ -631,7 +631,7 @@ workflows:
           <<: *filter-default
           name: Tomcat 9 API Test
           requires: *stage-build
-          command: bash test/run-docker-tomcat-tests.sh 9
+          command: bash test/run-docker-tomcat-tests.sh 9-jdk11
           context:
             - slack-secrets
           <<: *slack-fail-post-step


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Fix: nightly circle build fails due to missing argument

**Describe the solution you've implemented**
supply missing argument


**Additional context**
Argument requirement was added, and used in the primary build, but not scheduled nightly build
