### PR TITLE
RSE-9-job-remote-option-url-retry-connection-parameter-not-honored

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -58,6 +58,18 @@ public class RundeckConfigBase {
     RundeckApiConfig api;
     ScmLoader scmLoader;
     RundeckHealthIndicatorConfig health;
+    RundeckJobsConfig jobs;
+
+    @Data public static class RundeckJobsConfig{
+        JobOptionsConfig options;
+    }
+
+    @Data
+    public static class JobOptionsConfig{
+        int remoteUrlTimeout;
+        int remoteUrlConnectionTimeout;
+        int remoteUrlRetry;
+    }
 
     @Data
     public static class UserSessionProjectsCache {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -842,9 +842,6 @@ class ScheduledExecutionController  extends ControllerBase{
             client.setFollowRedirects(true)
             client.setTimeout(timeout*1000)
 
-            if(retry>0) {
-                client.setRetryCount(retry)
-            }
 
             URL urlo
             String cleanUrl = url.replaceAll("^(https?://)([^:@/]+):[^@/]*@", '$1$2:****@');


### PR DESCRIPTION
Fix: https://github.com/rundeckpro/rundeckpro/issues/2644

Problem:

When a job option was set from a remote URL the retry param was not taken in count, any retry was made.
There are two ways of setting those configurations, directly on the URL or the config.properties, the ones from the config.properties weren't being used.

Solution:

On the RundeckBaseConfig add the missing params to be accessible.
Implement on the Rundeck side a retry method if something fails when trying to obtain the values from an URL.

A similar solution is already implemented on the code on rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy on the postDataUrl method