### PR TITLE
RSE-38 MOTD is not shown on screen anymore. Have to scroll right

### DIFF
--- a/rundeckapp/grails-spa/packages/ui/src/components/motd/motd.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/motd/motd.vue
@@ -1,6 +1,6 @@
 <template>
   <Drawer
-    v-if="message"
+    v-if="message && showMessage"
     placement="right"
     :closeable="false"
     :visible="message && showMessage"


### PR DESCRIPTION
# Fix over Message Of The Day misplaced position
Message of the day was visible at the right side of the GUI, as shown even if we closed it.
![Screenshot from 2022-08-19 14-34-38](https://user-images.githubusercontent.com/81827734/185675697-417f47c5-571e-4890-86e8-432c534090d7.png)

## The fix
Vue's directive "v-if" was evaluating only the message, so even if the component was hidden of the view the "v-if' will always be rendering it to the view.