### PR TITLE
RSE-45: remote options simple json sort

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3959,6 +3959,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         def validationerrors = []
         if (result) {
             if (result instanceof Collection) {
+                def resultForString = []
                 result.eachWithIndex { entry, i ->
                     if (entry instanceof JSONObject) {
                         if (!entry.name) {
@@ -3972,7 +3973,12 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                     } else if (!(entry instanceof String)) {
                         valid = false;
                         validationerrors << "Item: ${i} expected string or map like {name:\"..\",value:\"..\"}"
+                    } else if (entry instanceof String){
+                        resultForString << [name: entry, value: entry]
                     }
+                }
+                if(!resultForString.isEmpty()){
+                    result = resultForString
                 }
             } else if (result instanceof JSONObject) {
                 JSONObject jobject = result

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -5567,7 +5567,7 @@ class ScheduledExecutionServiceSpec extends RundeckHibernateSpec implements Serv
             input.timeout==expectTimeout
             input.contimeout==expectConTimeout
             input.retry==expectRetry
-            result.values==['some','option','values']
+            result.values==[[name:'some', value:'some'],[name:'option', value:'option'],[name:'values', value:'values']]
 
         where:
             timeout | conTimeout | retry | expectTimeout | expectConTimeout | expectRetry
@@ -5623,7 +5623,7 @@ class ScheduledExecutionServiceSpec extends RundeckHibernateSpec implements Serv
         input.timeout==expectTimeout
         input.contimeout==expectConTimeout
         input.retry==expectRetry
-        result.values==['some','option','values']
+        result.values==[[name:'some', value:'some'],[name:'option', value:'option'],[name:'values', value:'values']]
 
         where:
         timeout | conTimeout | retry | expectTimeout | expectConTimeout | expectRetry


### PR DESCRIPTION
fix https://github.com/rundeck/rundeck/issues/7858

now it will generate a map with name and value for the options even if they are just a simple string, this way the sortRemoteOptions method doesn't need to perform any additional validations