### PR TITLE
fix: RSE-34 validation added to prevent invalid captured pattern

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PropertyValidator.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PropertyValidator.java
@@ -32,7 +32,14 @@ import java.util.*;
 public interface PropertyValidator {
     public boolean isValid(String value) throws ValidationException;
 
-    default boolean isValid(String value,Map<String,Object> props) throws ValidationException {
+    /**
+     * Custom validator to check for any property from a defined plugin.
+     * @param value Regex to validate
+     * @param props Plugin properties
+     * @return Boolean indicating validity of presented values
+     * @throws ValidationException
+     */
+    default boolean isValid(String value, Map<String,Object> props) throws ValidationException {
         return isValid(value);
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PropertyValidator.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PropertyValidator.java
@@ -31,4 +31,8 @@ import java.util.*;
  */
 public interface PropertyValidator {
     public boolean isValid(String value) throws ValidationException;
+
+    default boolean isValid(String value,Map<String,Object> props) throws ValidationException {
+        return isValid(value);
+    }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/Validator.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/Validator.java
@@ -201,7 +201,7 @@ public class Validator {
                     if (null != validator) {
                         try {
                             if (value instanceof String ) {
-                                if (!validator.isValid((String) value)) {
+                                if (!value.equals("\\s|\\$|\\{|\\}|\\\\") && !validator.isValid((String) value, props)) {
                                     report.errors.put(key, "Invalid value: " + value);
                                 }
                             }else if(validator instanceof PropertyObjectValidator ){

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/Validator.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/Validator.java
@@ -201,7 +201,7 @@ public class Validator {
                     if (null != validator) {
                         try {
                             if (value instanceof String ) {
-                                if (!value.equals("\\s|\\$|\\{|\\}|\\\\") && !validator.isValid((String) value, props)) {
+                                if (!validator.isValid((String) value, props)) {
                                     report.errors.put(key, "Invalid value: " + value);
                                 }
                             }else if(validator instanceof PropertyObjectValidator ){

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
@@ -106,6 +106,25 @@ See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex
     String invalidKeyPattern
 
     static class RegexValidator implements PropertyValidator {
+
+        @Override
+        boolean isValid(String value, Map<String,Object> props) throws ValidationException {
+            try {
+                def compile = Pattern.compile(value)
+                Matcher m = compile.matcher("");
+
+                if(m.groupCount() == 0){
+                    throw new PatternSyntaxException("Patter must have at least one group", value, -1)
+                }
+                if(m.groupCount() == 1 && !props.containsKey("name")){
+                    throw new PatternSyntaxException("It must be defined the field name", value, -1)
+                }
+                return true
+            } catch (PatternSyntaxException e) {
+                throw new ValidationException(e.message, e)
+            }
+        }
+
         @Override
         boolean isValid(final String value) throws ValidationException {
             try {

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
@@ -69,7 +69,7 @@ the data key, and the second group defines the data value.
 See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html) documentation.''',
             defaultValue = SimpleDataFilterPlugin.PATTERN,
             required = true,
-            validatorClass = SimpleDataFilterPlugin.RegexPropertyValidator
+            validatorClass = SimpleDataFilterPlugin.NamePropertyValidator
     )
     String regex
 
@@ -116,7 +116,7 @@ See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex
         }
     }
 
-    static class RegexPropertyValidator implements PropertyValidator {
+    static class NamePropertyValidator implements PropertyValidator {
 
         @Override
         boolean isValid(String value) throws ValidationException {

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
@@ -22,7 +22,6 @@ import com.dtolabs.rundeck.core.logging.LogLevel
 import com.dtolabs.rundeck.core.logging.PluginLoggingContext
 import com.dtolabs.rundeck.core.plugins.Plugin
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyValidator
-import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants
 import com.dtolabs.rundeck.core.plugins.configuration.ValidationException
 import com.dtolabs.rundeck.plugins.descriptions.PluginDescription
 import com.dtolabs.rundeck.plugins.descriptions.PluginProperty
@@ -110,13 +109,20 @@ See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex
         @Override
         boolean isValid(String value, Map<String,Object> props) throws ValidationException {
             try {
+
+                def invalidKeyPattern = "";
+
+                if(props.containsKey("invalidKeyPattern")){
+                    invalidKeyPattern = props.get("invalidKeyPattern")
+                }
+
                 def compile = Pattern.compile(value)
                 Matcher m = compile.matcher("");
 
-                if(m.groupCount() == 0){
+                if(value != invalidKeyPattern && m.groupCount() == 0){
                     throw new PatternSyntaxException("Patter must have at least one group", value, -1)
                 }
-                if(m.groupCount() == 1 && !props.containsKey("name")){
+                if(value != invalidKeyPattern && m.groupCount() == 1 && !props.containsKey("name")){
                     throw new PatternSyntaxException("It must be defined the field name", value, -1)
                 }
                 return true

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
@@ -69,7 +69,7 @@ the data key, and the second group defines the data value.
 See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html) documentation.''',
             defaultValue = SimpleDataFilterPlugin.PATTERN,
             required = true,
-            validatorClass = SimpleDataFilterPlugin.RegexValidator
+            validatorClass = SimpleDataFilterPlugin.RegexPropertyValidator
     )
     String regex
 
@@ -105,32 +105,6 @@ See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex
     String invalidKeyPattern
 
     static class RegexValidator implements PropertyValidator {
-
-        @Override
-        boolean isValid(String value, Map<String,Object> props) throws ValidationException {
-            try {
-
-                def invalidKeyPattern = "";
-
-                if(props.containsKey("invalidKeyPattern")){
-                    invalidKeyPattern = props.get("invalidKeyPattern")
-                }
-
-                def compile = Pattern.compile(value)
-                Matcher m = compile.matcher("");
-
-                if(value != invalidKeyPattern && m.groupCount() == 0){
-                    throw new PatternSyntaxException("Patter must have at least one group", value, -1)
-                }
-                if(value != invalidKeyPattern && m.groupCount() == 1 && !props.containsKey("name")){
-                    throw new PatternSyntaxException("It must be defined the field name", value, -1)
-                }
-                return true
-            } catch (PatternSyntaxException e) {
-                throw new ValidationException(e.message, e)
-            }
-        }
-
         @Override
         boolean isValid(final String value) throws ValidationException {
             try {
@@ -139,6 +113,34 @@ See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex
             } catch (PatternSyntaxException e) {
                 throw new ValidationException(e.message, e)
             }
+        }
+    }
+
+    static class RegexPropertyValidator implements PropertyValidator {
+
+        @Override
+        boolean isValid(String value) throws ValidationException {
+            return false
+        }
+
+        @Override
+        boolean isValid(String value, Map<String,Object> props) throws ValidationException {
+            def compile
+
+            try {
+                compile = Pattern.compile(value)
+            } catch (PatternSyntaxException e) {
+                throw new ValidationException(e.message, e)
+            }
+            Matcher m = compile.matcher("");
+
+            if(m.groupCount() == 0){
+                throw new ValidationException("Pattern must have at least one group")
+            }
+            if(m.groupCount() == 1 && !props.containsKey("name")){
+                throw new ValidationException("The Name field must be defined when only one capture group is specified")
+            }
+            return true
         }
     }
 

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPluginSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPluginSpec.groovy
@@ -227,7 +227,7 @@ class SimpleDataFilterPluginSpec extends Specification {
     @Unroll
     def "Test good parameters"() {
 
-        SimpleDataFilterPlugin.RegexPropertyValidator simpleDataFilterPluginValidator = new SimpleDataFilterPlugin.RegexPropertyValidator()
+        SimpleDataFilterPlugin.NamePropertyValidator simpleDataFilterPluginValidator = new SimpleDataFilterPlugin.NamePropertyValidator()
 
         expect:
         simpleDataFilterPluginValidator.isValid(regexValue, props)
@@ -241,7 +241,7 @@ class SimpleDataFilterPluginSpec extends Specification {
     @Unroll
     def "Test failing parameters"() {
 
-        SimpleDataFilterPlugin.RegexPropertyValidator simpleDataFilterPluginValidator = new SimpleDataFilterPlugin.RegexPropertyValidator()
+        SimpleDataFilterPlugin.NamePropertyValidator simpleDataFilterPluginValidator = new SimpleDataFilterPlugin.NamePropertyValidator()
 
         when:
         simpleDataFilterPluginValidator.isValid(regexValue, props)

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPluginSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPluginSpec.groovy
@@ -21,6 +21,7 @@ import com.dtolabs.rundeck.core.execution.workflow.DataOutput
 import com.dtolabs.rundeck.core.logging.LogEventControl
 import com.dtolabs.rundeck.core.logging.LogLevel
 import com.dtolabs.rundeck.core.logging.PluginLoggingContext
+import com.dtolabs.rundeck.core.plugins.configuration.ValidationException
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -69,6 +70,7 @@ class SimpleDataFilterPluginSpec extends Specification {
 
         where:
         dolog | regex                          | lines                           | expect
+        true  | SimpleDataFilterPlugin.PATTERN | ['.*']                          | [:]
         true  | SimpleDataFilterPlugin.PATTERN | ['RUNDECK:DATA:wimple=zangief'] | [wimple: 'zangief']
         false | SimpleDataFilterPlugin.PATTERN | ['RUNDECK:DATA:wimple=zangief'] | [wimple: 'zangief']
         true  | SimpleDataFilterPlugin.PATTERN | ['blah', 'blee']                | [:]
@@ -220,5 +222,37 @@ class SimpleDataFilterPluginSpec extends Specification {
         false  | ''              | '.*:(.+?)\\s*=\\s*(.+)$'   | null | ['Incident:Number= 1235'] | [Number: '1235']
 
 
+    }
+
+    @Unroll
+    def "Test good parameters"() {
+
+        SimpleDataFilterPlugin.RegexValidator simpleDataFilterPluginValidator = new SimpleDataFilterPlugin.RegexValidator()
+
+        expect:
+        simpleDataFilterPluginValidator.isValid(regexValue, props)
+
+        where:
+        regexValue                             |            props              | expectedResult
+        '^RUNDECK:DATA:\\s*([^\\s]+?)\\s*=\\s*(.+)\$'         | [name: "TestValue"]           | true
+        '(.*)'                                                | [name: "TestValue"]           | true
+    }
+
+    @Unroll
+    def "Test failing parameters"() {
+
+        SimpleDataFilterPlugin.RegexValidator simpleDataFilterPluginValidator = new SimpleDataFilterPlugin.RegexValidator()
+
+        when:
+        simpleDataFilterPluginValidator.isValid(regexValue, props)
+
+        then:
+        def error = thrown(expectedException)
+        error.message == expectedMessage
+
+        where:
+        regexValue   |            props              | expectedException      |     expectedMessage
+        '.*'     | [name: "TestValue"]           | ValidationException |  'Patter must have at least one group\n.*'
+        '(.*)'    | [:]                           | ValidationException    |  'It must be defined the field name\n(.*)'
     }
 }

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPluginSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPluginSpec.groovy
@@ -227,7 +227,7 @@ class SimpleDataFilterPluginSpec extends Specification {
     @Unroll
     def "Test good parameters"() {
 
-        SimpleDataFilterPlugin.RegexValidator simpleDataFilterPluginValidator = new SimpleDataFilterPlugin.RegexValidator()
+        SimpleDataFilterPlugin.RegexPropertyValidator simpleDataFilterPluginValidator = new SimpleDataFilterPlugin.RegexPropertyValidator()
 
         expect:
         simpleDataFilterPluginValidator.isValid(regexValue, props)
@@ -241,7 +241,7 @@ class SimpleDataFilterPluginSpec extends Specification {
     @Unroll
     def "Test failing parameters"() {
 
-        SimpleDataFilterPlugin.RegexValidator simpleDataFilterPluginValidator = new SimpleDataFilterPlugin.RegexValidator()
+        SimpleDataFilterPlugin.RegexPropertyValidator simpleDataFilterPluginValidator = new SimpleDataFilterPlugin.RegexPropertyValidator()
 
         when:
         simpleDataFilterPluginValidator.isValid(regexValue, props)
@@ -252,7 +252,7 @@ class SimpleDataFilterPluginSpec extends Specification {
 
         where:
         regexValue   |            props              | expectedException      |     expectedMessage
-        '.*'     | [name: "TestValue"]           | ValidationException |  'Patter must have at least one group\n.*'
-        '(.*)'    | [:]                           | ValidationException    |  'It must be defined the field name\n(.*)'
+            '.*'     | [name: "TestValue"]           | ValidationException    |  'Pattern must have at least one group'
+           '(.*)'    | [:]                           | ValidationException    |  'The Name field must be defined when only one capture group is specified'
     }
 }


### PR DESCRIPTION
fix: https://github.com/rundeckpro/rundeckpro/issues/2661
The validation was added when you are trying to save a new capture pattern:

Case 1, pattern with no captured group: 

![image](https://user-images.githubusercontent.com/29233418/186042859-e58de27b-1549-4600-bb29-57c3064113c2.png)

Case 2, valid pattern group with no name:

![image](https://user-images.githubusercontent.com/29233418/186043024-e2af0b9b-1079-420c-83e1-0a9279a974a8.png)
