### PR TITLE
RUN-1140: Add a new rendering option t support the token script expansion in plugins

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/StringRenderingConstants.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/StringRenderingConstants.java
@@ -51,8 +51,7 @@ public class StringRenderingConstants {
         STATIC_TEXT,
         PASSWORD,
         CODE,
-        DYNAMIC_FORM,
-        SCRIPT_INVOCATION_STRING;
+        DYNAMIC_FORM;
         public boolean equalsOrString(Object o) {
             return this == o || toString().equals(o);
         }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/StringRenderingConstants.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/StringRenderingConstants.java
@@ -40,6 +40,7 @@ public class StringRenderingConstants {
     public static final String CODE_SYNTAX_MODE = "codeSyntaxMode";
     public static final String CODE_SYNTAX_SELECTABLE = "codeSyntaxSelectable";
     public static final String CODE_SYNTAX_MODES_ALLOWED = "codeSyntaxModesAllowed";
+    public static final String SCRIPT_TOKEN_AUTOCOMPLETE = "scriptTokenAutocomplete";
 
     /**
      * Values that can be specified for a key of {@link #DISPLAY_TYPE_KEY}
@@ -50,7 +51,8 @@ public class StringRenderingConstants {
         STATIC_TEXT,
         PASSWORD,
         CODE,
-        DYNAMIC_FORM;
+        DYNAMIC_FORM,
+        SCRIPT_INVOCATION_STRING;
         public boolean equalsOrString(Object o) {
             return this == o || toString().equals(o);
         }
@@ -65,6 +67,15 @@ public class StringRenderingConstants {
     public enum ValueConversion{
         STORAGE_PATH_AUTOMATIC_READ,
         PRIVATE_DATA_CONTEXT;
+
+        public boolean equalsOrString(Object o) {
+            return this == o || toString().equals(o);
+        }
+    }
+
+    public enum ScriptTokenAutocomplete{
+        ENABLED,
+        DISABLED;
 
         public boolean equalsOrString(Object o) {
             return this == o || toString().equals(o);

--- a/rundeckapp/grails-app/assets/javascripts/jobedit.js
+++ b/rundeckapp/grails-app/assets/javascripts/jobedit.js
@@ -296,9 +296,11 @@ function postLoadItemEdit(item, iseh, isnodestep) {
     if (isscriptStep) {
       var key = liitem.find('._wfiedit').data('rkey');
       if (key) {
-        workflowEditor.scriptSteps()[key].guessAceMode.subscribe(function (val) {
-          setAceSyntaxMode(val, editor);
-        });
+        if(workflowEditor.scriptSteps()[key]){
+          workflowEditor.scriptSteps()[key].guessAceMode.subscribe(function (val) {
+            setAceSyntaxMode(val, editor);
+          });
+        }
       }
     }
   }, function (elem) {

--- a/rundeckapp/grails-app/views/execution/_wfitemEdit.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfitemEdit.gsp
@@ -712,8 +712,7 @@
                             values             : item?.configuration,
                             fieldnamePrefix    : pluginprefix,
                             origfieldnamePrefix:'orig.' + pluginprefix,
-                            allowedScope       : PropertyScope.Instance,
-                            stepKey: rkey
+                            allowedScope       : PropertyScope.Instance
                     ]}"/>
 
                 </div>

--- a/rundeckapp/grails-app/views/execution/_wfitemEdit.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfitemEdit.gsp
@@ -712,7 +712,8 @@
                             values             : item?.configuration,
                             fieldnamePrefix    : pluginprefix,
                             origfieldnamePrefix:'orig.' + pluginprefix,
-                            allowedScope       : PropertyScope.Instance
+                            allowedScope       : PropertyScope.Instance,
+                            stepKey: rkey
                     ]}"/>
 
                 </div>

--- a/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
+++ b/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
@@ -270,7 +270,7 @@
 
 
         <g:set var="scriptTokenAutocomplete" value="${prop.renderingOptions?.(StringRenderingConstants.SCRIPT_TOKEN_AUTOCOMPLETE)}"/>
-        <g:set var="scriptTokenAutocompleteCss" value="${scriptTokenAutocomplete&&scriptTokenAutocomplete==StringRenderingConstants.ScriptTokenAutocomplete.ENABLED?'_wfscriptitem':''}"/>
+        <g:set var="scriptTokenAutocompleteCss" value="${scriptTokenAutocomplete&&StringRenderingConstants.ScriptTokenAutocomplete.ENABLED.equalsOrString(scriptTokenAutocomplete)?'_wfscriptitem':''}"/>
 
 
         <g:textArea name="${fieldname}" value="${valueText}"

--- a/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
+++ b/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
@@ -267,6 +267,12 @@
         <g:set var="syntax" value="${prop.renderingOptions?.(StringRenderingConstants.CODE_SYNTAX_MODE)}"/>
         <g:set var="syntaxSelectable" value="${prop.renderingOptions?.(StringRenderingConstants.CODE_SYNTAX_SELECTABLE)}"/>
         <g:set var="syntaxModes" value="${prop.renderingOptions?.(StringRenderingConstants.CODE_SYNTAX_MODES_ALLOWED)}"/>
+
+
+        <g:set var="scriptTokenAutocomplete" value="${prop.renderingOptions?.(StringRenderingConstants.SCRIPT_TOKEN_AUTOCOMPLETE)}"/>
+        <g:set var="scriptTokenAutocompleteCss" value="${scriptTokenAutocomplete&&scriptTokenAutocomplete==StringRenderingConstants.ScriptTokenAutocomplete.ENABLED?'_wfscriptitem':''}"/>
+
+
         <g:textArea name="${fieldname}" value="${valueText}"
             data-ace-session-mode="${syntax}"
             data-ace-control-syntax="${syntaxSelectable?true:false}"
@@ -274,7 +280,23 @@
             data-ace-height="100px"
             data-ace-resize-auto="true"
             data-ace-resize-max="20"
-                    id="${fieldid}" rows="10" cols="100" class="${formControlCodeType} ${extraInputCss}"/>
+                    data-ace-autofocus='true'
+                    id="${fieldid}" rows="10" cols="100" class="${formControlCodeType} ${scriptTokenAutocompleteCss} ${extraInputCss}"/>
+
+
+        <g:if test="${scriptTokenAutocomplete&&scriptTokenAutocomplete==StringRenderingConstants.ScriptTokenAutocomplete.ENABLED}">
+            <g:embedJSON id="scriptStepData_${stepKey}" data="${[invocationString: 'bash',fileExtension: '',args: '',argsQuoted: false, expandToken: true]}"/>
+
+            <g:javascript>
+                fireWhenReady("scriptStep_${stepKey}",function(){
+                    workflowEditor.bindScriptStepKey('${stepKey}','wfiedit_${stepKey}',loadJsonData('scriptStepData_${stepKey}'));
+                    if (typeof(_initPopoverContentRef) == 'function') {
+                        _initPopoverContentRef("#scriptStep_${stepKey}");
+                    }
+                });
+            </g:javascript>
+        </g:if>
+
     </g:elseif>
     <g:elseif test="${prop.renderingOptions?.(StringRenderingConstants.DISPLAY_TYPE_KEY) in [StringRenderingConstants.DisplayType.PASSWORD, 'PASSWORD']}">
        <g:passwordField name="${fieldname}" value="${valueText}"
@@ -305,9 +327,13 @@
             <g:enc html="${staticTextValue}"/>
         </g:else>
     </g:elseif>
+    <g:elseif test="${prop.renderingOptions?.(StringRenderingConstants.DISPLAY_TYPE_KEY) in [StringRenderingConstants.DisplayType.SCRIPT_INVOCATION_STRING, 'SCRIPT_INVOCATION_STRING']}">
+        <g:textField name="${fieldname}" value="${valueText}"
+                     id="${fieldid}" size="100" class="${formControlType} ${extraInputCss}" data-bind="value: invocationString, valueUpdate: 'keyup'" autofocus="true" />
+    </g:elseif>
     <g:else>
         <g:textField name="${fieldname}" value="${valueText}"
-                 id="${fieldid}" size="100" class="${formControlType} ${extraInputCss}"/>
+                 id="${fieldid}" size="100" class="${formControlType} ${extraInputCss}" />
     </g:else>
     </div>
     <g:if test="${hasStorageSelector}">

--- a/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
+++ b/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
@@ -280,22 +280,7 @@
             data-ace-height="100px"
             data-ace-resize-auto="true"
             data-ace-resize-max="20"
-                    data-ace-autofocus='true'
                     id="${fieldid}" rows="10" cols="100" class="${formControlCodeType} ${scriptTokenAutocompleteCss} ${extraInputCss}"/>
-
-
-        <g:if test="${scriptTokenAutocomplete&&scriptTokenAutocomplete==StringRenderingConstants.ScriptTokenAutocomplete.ENABLED}">
-            <g:embedJSON id="scriptStepData_${stepKey}" data="${[invocationString: 'bash',fileExtension: '',args: '',argsQuoted: false, expandToken: true]}"/>
-
-            <g:javascript>
-                fireWhenReady("scriptStep_${stepKey}",function(){
-                    workflowEditor.bindScriptStepKey('${stepKey}','wfiedit_${stepKey}',loadJsonData('scriptStepData_${stepKey}'));
-                    if (typeof(_initPopoverContentRef) == 'function') {
-                        _initPopoverContentRef("#scriptStep_${stepKey}");
-                    }
-                });
-            </g:javascript>
-        </g:if>
 
     </g:elseif>
     <g:elseif test="${prop.renderingOptions?.(StringRenderingConstants.DISPLAY_TYPE_KEY) in [StringRenderingConstants.DisplayType.PASSWORD, 'PASSWORD']}">
@@ -326,10 +311,6 @@
             %{--plain--}%
             <g:enc html="${staticTextValue}"/>
         </g:else>
-    </g:elseif>
-    <g:elseif test="${prop.renderingOptions?.(StringRenderingConstants.DISPLAY_TYPE_KEY) in [StringRenderingConstants.DisplayType.SCRIPT_INVOCATION_STRING, 'SCRIPT_INVOCATION_STRING']}">
-        <g:textField name="${fieldname}" value="${valueText}"
-                     id="${fieldid}" size="100" class="${formControlType} ${extraInputCss}" data-bind="value: invocationString, valueUpdate: 'keyup'" autofocus="true" />
     </g:elseif>
     <g:else>
         <g:textField name="${fieldname}" value="${valueText}"

--- a/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
+++ b/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
@@ -314,7 +314,7 @@
     </g:elseif>
     <g:else>
         <g:textField name="${fieldname}" value="${valueText}"
-                 id="${fieldid}" size="100" class="${formControlType} ${extraInputCss}" />
+                 id="${fieldid}" size="100" class="${formControlType} ${extraInputCss}"/>
     </g:else>
     </div>
     <g:if test="${hasStorageSelector}">


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Add a new rendering option to support the token script expansion (@ style) in plugin attributes defined with the CODE display type rendering option.

**Describe the solution you've implemented**
add a new static variable in StringRenderingConstants

**Describe alternatives you've considered**

**Additional context**

It can be used in the following way:


eg:

````
      PropertyBuilder.builder()
                                .string(SCRIPT)
                                .title("Script")
                                .description("Script")
                                .required(true)
                                .renderingAsTextarea()
                                .renderingOption(StringRenderingConstants.DISPLAY_TYPE_KEY, StringRenderingConstants.DisplayType.CODE)
                                .renderingOption(StringRenderingConstants.SCRIPT_TOKEN_AUTOCOMPLETE, StringRenderingConstants.ScriptTokenAutocomplete.ENABLED)
                                .build()
````


or 


````
 @PluginProperty(name = "test", title = "test", description = "Description to be used", required = false)
    @RenderingOptions({
            @RenderingOption(
                    key = StringRenderingConstants.DISPLAY_TYPE_KEY,
                    value = "CODE"
            ),
            @RenderingOption(
                    key = StringRenderingConstants.SCRIPT_TOKEN_AUTOCOMPLETE,
                    value = "ENABLED"
            )
    })
    private String test;

````

![Screen Shot 2022-08-23 at 12 49 23](https://user-images.githubusercontent.com/6034968/186216117-8fa8a293-c623-4527-8773-958c2821813b.png)


