### PR TITLE
RSE-56 rundeck.gui.helpLink property replace the doc link instead of support link

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -565,6 +565,7 @@ public class RundeckConfigBase {
         String instanceNameLabelTextColor;
         String titleLink;
         String helpLink;
+        String helpLinkName;
         Boolean realJobTree;
         String logoSmall;
         Integer matchedNodesMaxCount;

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/HelplinkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/HelplinkController.groovy
@@ -1,0 +1,25 @@
+package rundeck.controllers
+
+import grails.converters.JSON
+import rundeck.services.ConfigurationService
+
+class HelplinkController {
+
+    def configurationService
+    def defaultHelplinkName = 'Get Help'
+
+    def index() { }
+
+    def helplinkName() {
+        def userHelpLinkName = configurationService.getString("gui.helpLinkName", defaultHelplinkName)
+        render(
+                contentType: 'application/json', text:
+                (
+                        [
+                                name           : userHelpLinkName,
+                        ]
+                ) as JSON
+        )
+    }
+
+}

--- a/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
+++ b/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
@@ -312,6 +312,8 @@ class UrlMappings {
 
         "/search-plugins"(controller:'SearchPluginsController', action:'index')
 
+        "/helplink/name"(controller:'helplink',action:'helplinkName')
+
         "404"(controller:"error",action:"notFound")
         "405"(controller:"error",action:"notAllowed")
         "500"(controller:"error",action:"fiveHundred")

--- a/rundeckapp/src/test/groovy/rundeck/controllers/HelplinkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/HelplinkControllerSpec.groovy
@@ -1,0 +1,28 @@
+package rundeck.controllers
+
+import grails.testing.web.controllers.ControllerUnitTest
+
+import rundeck.services.ConfigurationService
+import spock.lang.Specification
+
+class HelplinkControllerSpec extends Specification implements ControllerUnitTest<HelplinkController> {
+
+    def setup(){
+    }
+
+    def "render config property"() {
+        given:
+        controller.configurationService = Mock(ConfigurationService){
+            getString("gui.helpLinkName", controller.defaultHelplinkName)>>controller.defaultHelplinkName
+        }
+
+        when:
+        request.method='GET'
+        def result=controller.helplinkName()
+
+        then:
+        response.status==200
+        response.contentAsString == '{"name":"' + controller.defaultHelplinkName + '"}'
+    }
+
+}


### PR DESCRIPTION
# Customization to 'get help' link in the GUI footer
As seen here: https://github.com/rundeckpro/rundeckpro/issues/2659, there was an inconsistency when we set the custom url for a 'helpLink' in rundeck's GUI footer.

## The problem
When we go ahead and change the property ``rundeck.gui.helplink`` in ``rundeck-config.properties`` file, it changes the URL for 'help' but leaves 'Documentation' as a name for that URL, making a confusion. Exhibit:

![Screenshot from 2022-08-24 22-36-00](https://user-images.githubusercontent.com/81827734/186554281-572240f8-7c41-4d75-b0bd-0b0d85ba2db7.png)

## The problem
We were harcoding 'Documentation' as a name for that customizable URL.

## The solution (proposal)
We've implemented between both oss and pro repos, a controller to raise a property ``rundeck.gui.helpLinkName`` from the same config file, to map the custom url name.
**OSS PR: https://github.com/rundeckpro/rundeckpro/pull/2721**

## Post fix snap

![Screenshot from 2022-08-24 22-57-09](https://user-images.githubusercontent.com/81827734/186556719-66092783-06da-4e7d-a7e6-93c2e9926118.png)