### PR TITLE
RSE-78: Unable to edit job when SCM is still activated

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
@@ -33,8 +33,8 @@ class ScmLoaderService implements EventBusAware {
     ScheduledExecutionService scheduledExecutionService
     ConfigurationService configurationService
     public static final long DEFAULT_LOADER_DELAY = 0
-    public static final long DEFAULT_LOADER_INTERVAL_SEC = 20
-    public static final long INIT_RETRY_TIMES = 5
+    public static final long DEFAULT_LOADER_INTERVAL_SEC = 10
+    public static final long INIT_RETRY_TIMES = 2
     public static final long INIT_RETRY_TIMES_DELAY = 1000
 
     /**
@@ -140,6 +140,7 @@ class ScmLoaderService implements EventBusAware {
                                 if(retryCount>retryTimes){
                                     scmFailedProjectInit.put(projectIntegration, pluginConfigData)
                                     process = true
+                                    scmToFalse(pluginConfigData, project, integration)
                                     removingLoaderProcess(project, integration)
                                 }else{
                                     retryCount++
@@ -158,6 +159,11 @@ class ScmLoaderService implements EventBusAware {
                 TimeUnit.SECONDS
         )
         scheduler
+    }
+
+    def scmToFalse(ScmPluginConfigData scmPluginConfig, String project, String integration) {
+        scmPluginConfig.enabled = false
+        scmService.storeConfig(scmPluginConfig, project, integration)
     }
 
     def removingLoaderProcess(String project, String integration){


### PR DESCRIPTION
Fixes: https://github.com/rundeckpro/rundeckpro/issues/2567
Related to this PR too: https://github.com/rundeck/rundeck/pull/7786

# Bugfix for displaying menu option for jobs

This solution performs the improvement to cover the specific scenarios, where to remove the key storage, and then the latter is added again, the job options menu will not be opened to edit it.

**Steps for this specific scenario:**
1) Create a key storage with the password from the git. (path: keys/admin/git.pass)
2) Create a job
3) Configure SCM Export with the referenced key. (key path: keys/${user.login}/git.pass)
4) Check that the options of the job are called.
5) Delete the key storage.
6) Verify that the job options are called.
7) Add the same key storage again
8) Verify that the job options are called (here the error occurred)