### PR TITLE
RSE-60 Failed to Import project, error 500 whitelabel on screen

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
@@ -432,7 +432,7 @@ class ProjectController extends ControllerBase{
                 }
                 flash.warn=warning.join(",")
                 }catch( Exception e ){
-                    flash.error="There was some errors with the import process with at least one of the jobs: [ ${e.getMessage()} ]"
+                    flash.error="There was some errors with the import process: [ ${e.getMessage()} ]"
                 }
 
                 return redirect(controller: 'menu', action: 'projectImport', params: [project: project])

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
@@ -432,7 +432,7 @@ class ProjectController extends ControllerBase{
                 }
                 flash.warn=warning.join(",")
                 }catch( Exception e ){
-                    flash.error="There was some errors with the import process: [ ${e.getMessage()} ]"
+                    flash.error="There was some errors in the import process: [ ${e.getMessage()} ]"
                 }
 
                 return redirect(controller: 'menu', action: 'projectImport', params: [project: project])

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
@@ -394,13 +394,15 @@ class ProjectController extends ControllerBase{
                     flash.error = message(code:"no.file.was.uploaded")
                     return redirect(controller: 'menu', action: 'projectImport', params: [project: project])
                 }
-                def result = projectService.importToProject(
-                    project1,
-                    frameworkService.getRundeckFramework(),
-                    authorizing.authContext,
-                    file.getInputStream(),
-                    archiveParams
-                )
+
+                try{
+                    def result = projectService.importToProject(
+                        project1,
+                        frameworkService.getRundeckFramework(),
+                        authorizing.authContext,
+                        file.getInputStream(),
+                        archiveParams
+                    )
 
 
                 if(result.success){
@@ -429,6 +431,10 @@ class ProjectController extends ControllerBase{
                     }
                 }
                 flash.warn=warning.join(",")
+                }catch( Exception e ){
+                    flash.error="There was some errors with the import process with at least one of the jobs: [ ${e.getMessage()} ]"
+                }
+
                 return redirect(controller: 'menu', action: 'projectImport', params: [project: project])
             }
         }.invalidToken {

--- a/rundeckapp/grails-app/utils/rundeck/codecs/JobsXMLCodec.groovy
+++ b/rundeckapp/grails-app/utils/rundeck/codecs/JobsXMLCodec.groovy
@@ -377,7 +377,7 @@ class JobsXMLCodec {
                                 setValidNotifData(notifVal, notifType, trigger)
                             }
                         }else {
-                            throw new JobXMLException("${notifType} is not a valid/supported notification definition")
+                            throw new JobXMLException("Invalid Notification: [ name: ${map.name}, desc: ${map.desc}, group: ${map.group}, type: ${notifType}")
                         }
                     }
             }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerSpec.groovy
@@ -2058,7 +2058,7 @@ class ProjectControllerSpec extends RundeckHibernateSpec implements ControllerUn
         def result=controller.importArchive()
 
         then:
-        flash.error == 'There was some errors with the import process: [ No such property: success for class: java.lang.Exception ]'
+        flash.error == 'There was some errors in the import process: [ No such property: success for class: java.lang.Exception ]'
     }
 
     def "import archive no importACL"(){


### PR DESCRIPTION
# Internal server error importing a project with invalid notification plugins

## The solution
A 'try/catch' block in the importToProject method call, to add a fallback.

## Exhibits
Pre fix:
![Screenshot from 2022-08-23 12-01-18](https://user-images.githubusercontent.com/81827734/186974349-2843ce0e-7d7d-4477-8e25-fbaf7547bef8.png)

Post fix:
![Screenshot from 2022-08-26 16-19-02](https://user-images.githubusercontent.com/81827734/186976403-228e087c-b2e0-41d7-9b9c-49f4cbac9855.png)



