### PR TITLE
RUN-933: Add note about new example plugins repo

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Rundeck Plugin Examples (Outdated)
+_Updated 2022-10-01_
+Historically, example plugin code has existed in this folder. However, this code is in need of a refresh to come into alignment with our new plugin development guidelines (coming soon).
+
+To that end, you'll see these examples disappear over time as they are migrated to the new [rundeck-plugin-examples repo](https://github.com/rundeck/rundeck-plugin-examples). In the meantime, you can keep using these examples as a loose guideline of how to produce our different types of plugins for your Rundeck instance.


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is an enhancement to notify users about the new location for [Rundeck plugin examples](https://github.com/rundeck/rundeck-plugin-examples) once it is released.

**Describe the solution you've implemented**
README note in the root folder of example content.

**Describe alternatives you've considered**
N/a

**Additional context**
**Shouldn't be merged until https://github.com/rundeck/rundeck-plugin-examples/pull/1 is merged, and we're ready to open that example plugin repo to the public (currently internal only).**
