### PR TITLE
RUN-1205: fix: dev-mode: failing ui pseudo-test

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/menu/joboptionsTest.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/joboptionsTest.js
@@ -163,7 +163,7 @@ jQuery(function () {
                 " hasTextfield({0})",
                 [
                     [{enforced: false, multivalued: false, secureInput: false, hasError: false}, true],
-                    [{enforced: false, multivalued: true, secureInput: false, hasError: true}, true],
+                    [{enforced: false, multivalued: true, secureInput: false, hasError: true}, false],
                     [{enforced: true, multivalued: false, secureInput: true, hasError: false}, true],
 
                     [{enforced: true, multivalued: true, secureInput: false, hasError: false}, false],


### PR DESCRIPTION
Behavior of hasTextfield changed with commit c29630753e6e8b8800b9c24d340473e8a936aaab

text field should not be shown for multivalue options

before: shown in UI in dev mode:

> FAIL: hasTextfield_Test: hasTextfield({"enforced":false,"multivalued":true,"secureInput":false,"hasError":true}): expected: true, was: false

