### PR TITLE
RSE-117 [QA 4.6.1] Minor GUI Bug on WH Dropdown

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
@@ -46,6 +46,7 @@
   background-clip: padding-box;
   border: 0 none;
   border-radius: $border-radius-extreme;
+  padding-right: 2rem;
   @include box-shadow($dropdown-shadow);
 
   // Aligns the dropdown menu to right


### PR DESCRIPTION
# Bugfix WH Dropdown
Minor GUI bug found during the 4.6.1 QA.

## Exhibits
Pre-fix:
<img width="831" alt="Captura de Pantalla 2022-09-09 a la(s) 13 19 40" src="https://user-images.githubusercontent.com/81827734/189416931-a3621e67-7e95-479e-ae1f-43cffeadb8d2.png">

After fix:
![Screenshot from 2022-09-09 15-14-40](https://user-images.githubusercontent.com/81827734/189417266-a34bc584-b001-4b3c-8dbe-f4e9877f3e0f.png)


