### PR TITLE
RUN-752 Add error code parameter to login error page for custom message support

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -60,6 +60,11 @@ class UserController extends ControllerBase{
     }
 
     def error() {
+        // A caller can pass in an error code URL parameter to support customized message other than the default generic message.
+        if (params.code) {
+            flash.loginErrorCode = params.code
+        }
+
         if(!flash.loginErrorCode){
             flash.loginErrorCode = 'invalid.username.and.password'
         }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Enhancement

**Describe the solution you've implemented**
Use a URL parameter `code` to let callers pass in a custom error code so the error page can display a custom message based on the value of the code.

**Describe alternatives you've considered**
One alternative option could be to set the session variable at the caller side but it requires every caller to implement this logic in their code. But the code parameter can be configured in Spring Security `failureHandler.exceptionMappers` which is much more flexible.

**Additional context**
This is a change to support RUN-752 reserved username check to show the user a more specific message than the default invalid username and password message.
