### PR TITLE
RSE-50: fix: allowing user to see logs after the job is deleted

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -1184,7 +1184,7 @@ class LogFileStorageService
             boolean checkPartial = false
     )
     {
-        File file = getFileForExecutionFiletype(execution, filetype, false, false)
+        File file = getFileForExecutionFiletype(execution, filetype, execution.scheduledExecution == null, false)
         def key = logFileRetrievalKey(execution,filetype)
         def keyPartial = logFileRetrievalKey(execution, filetype, true)
 
@@ -1522,7 +1522,7 @@ class LogFileStorageService
         log.debug("requestLogFileLoad(${e.id},${filetype}): file state: ${state}: ${result}")
         switch (state) {
             case ExecutionFileState.AVAILABLE:
-                file = getFileForExecutionFiletype(e, filetype, false, false)
+                file = getFileForExecutionFiletype(e, filetype, e.scheduledExecution == null, false)
                 break
             case ExecutionFileState.AVAILABLE_PARTIAL:
                 file = getFileForExecutionFiletype(e, filetype, false, true)

--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -1525,7 +1525,7 @@ class LogFileStorageService
                 file = getFileForExecutionFiletype(e, filetype, e.scheduledExecution == null, false)
                 break
             case ExecutionFileState.AVAILABLE_PARTIAL:
-                file = getFileForExecutionFiletype(e, filetype, false, true)
+                file = getFileForExecutionFiletype(e, filetype, e.scheduledExecution == null, true)
                 retryBackoff = Math.max(getBackoffForPartialFile(e, filetype), retryBackoff)
                 if (performLoad && result.remotePartialState == LogFileState.AVAILABLE_PARTIAL) {
                     //intiate another partial retrieval if delay interval has passed
@@ -1558,7 +1558,7 @@ class LogFileStorageService
                 if (performLoad && result.remotePartialState == LogFileState.AVAILABLE_PARTIAL) {
                     state = requestLogFileRetrievalPartial(e, filetype, plugin)
                     if (state == ExecutionFileState.AVAILABLE_PARTIAL) {
-                        file = getFileForExecutionFiletype(e, filetype, false, true)
+                        file = getFileForExecutionFiletype(e, filetype, e.scheduledExecution == null, true)
                         retryBackoff = Math.max(getBackoffForPartialFile(e, filetype), retryBackoff)
                     }
                 }
@@ -1627,7 +1627,7 @@ class LogFileStorageService
     )
     {
         def key=logFileRetrievalKey(execution,filetype)
-        def file = getFileForExecutionFiletype(execution, filetype, false, false)
+        def file = getFileForExecutionFiletype(execution, filetype, execution.scheduledExecution == null, false)
         Map newstate = [state  : ExecutionFileState.PENDING_LOCAL, file: file, filetype: filetype,
                         ruuid  : UUID.randomUUID().toString(),
                         storage: plugin, id: key, name: getConfiguredPluginName(), count: 0]

--- a/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
@@ -804,20 +804,20 @@ class LogFileStorageServiceSpec extends RundeckHibernateSpec implements ServiceU
         def tempDir = Files.createTempDirectory('test_logs')
         def logsDir = tempDir.resolve('rundeck')
 
-
         def exec = new Execution(
             dateStarted: new Date(),
             dateCompleted: null,
             user: 'user2',
             project: 'test',
-            serverNodeUUID: 'C9CA0A6D-3F85-4F53-A714-313EB57A4D1F',
-            outputfilepath: '/tmp/file'
+            serverNodeUUID: 'C9CA0A6D-3F85-4F53-A714-313EB57A4D1F'
         ).save()
         def filetype = 'rdlog'
         def performLoad = true
 
         createLogFile(logsDir, exec, filetype)
 
+        exec.outputfilepath = logsDir.resolve("test/run/logs/${exec.id}.${filetype}")
+        exec.save()
 
         service.frameworkService = Mock(FrameworkService) {
             getFrameworkProperties() >> (
@@ -977,12 +977,14 @@ class LogFileStorageServiceSpec extends RundeckHibernateSpec implements ServiceU
             user: 'user2',
             project: 'test',
             serverNodeUUID: 'C9CA0A6D-3F85-4F53-A714-313EB57A4D1F',
-            outputfilepath: '/tmp/file'
         ).save()
         def filetype = 'rdlog'
         def performLoad = true
 
         createLogFile(logsDir, exec, filetype)
+
+        exec.outputfilepath = logsDir.resolve("test/run/logs/${exec.id}.${filetype}")
+        exec.save()
 
         service.frameworkService = Mock(FrameworkService) {
             isClusterModeEnabled() >> true

--- a/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
@@ -36,6 +36,7 @@ import org.springframework.core.task.SimpleAsyncTaskExecutor
 import org.springframework.scheduling.TaskScheduler
 import rundeck.Execution
 import rundeck.LogFileStorageRequest
+import rundeck.ScheduledExecution
 import spock.lang.Specification
 import spock.lang.Unroll
 import testhelper.RundeckHibernateSpec
@@ -776,6 +777,12 @@ class LogFileStorageServiceSpec extends RundeckHibernateSpec implements ServiceU
         def filetype = 'rdlog'
         def performLoad = true
 
+        def scheduledExecution = new ScheduledExecution()
+        scheduledExecution.id = 1
+
+        exec.scheduledExecution = scheduledExecution
+        exec.save()
+
         service.frameworkService = Mock(FrameworkService) {
             getFrameworkProperties() >> (
                 [
@@ -895,6 +902,12 @@ class LogFileStorageServiceSpec extends RundeckHibernateSpec implements ServiceU
         ).save()
         def filetype = 'rdlog'
         def performLoad = true
+
+        def scheduledExecution = new ScheduledExecution()
+        scheduledExecution.id = 1
+
+        exec.scheduledExecution = scheduledExecution
+        exec.save()
 
         service.frameworkService = Mock(FrameworkService) {
             isClusterModeEnabled() >> true
@@ -1018,11 +1031,10 @@ class LogFileStorageServiceSpec extends RundeckHibernateSpec implements ServiceU
 
             def exec = new Execution(
                     dateStarted: new Date(),
-                    dateCompleted: null,
+                    dateCompleted: new Date(),
                     user: 'user2',
                     project: 'test',
-                    serverNodeUUID: 'D0CA0A6D-3F85-4F53-A714-313EB57A4D1F',
-                    outputfilepath: '/tmp/file'
+                    serverNodeUUID: 'D0CA0A6D-3F85-4F53-A714-313EB57A4D1F'
             ).save()
             def filetype = 'rdlog'
             def performLoad = true
@@ -1082,11 +1094,10 @@ class LogFileStorageServiceSpec extends RundeckHibernateSpec implements ServiceU
 
             def exec = new Execution(
                     dateStarted: new Date(),
-                    dateCompleted: null,
+                    dateCompleted: new Date(),
                     user: 'user2',
                     project: 'test',
-                    serverNodeUUID: 'blabla',
-                    outputfilepath: '/tmp/file'
+                    serverNodeUUID: 'blabla'
             )
 
             exec.save()
@@ -1147,11 +1158,10 @@ class LogFileStorageServiceSpec extends RundeckHibernateSpec implements ServiceU
 
             def exec = new Execution(
                     dateStarted: new Date(),
-                    dateCompleted: null,
+                    dateCompleted: new Date(),
                     user: 'user2',
                     project: 'test',
-                    serverNodeUUID: 'D0CA0A6D-3F85-4F53-A714-313EB57A4D1F',
-                    outputfilepath: '/tmp/file'
+                    serverNodeUUID: 'D0CA0A6D-3F85-4F53-A714-313EB57A4D1F'
             ).save()
             def filetype = 'rdlog'
             def performLoad = true

--- a/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceTests.groovy
@@ -1516,7 +1516,7 @@ class LogFileStorageServiceTests extends Specification implements DataTest, Serv
         service.frameworkService = fmock.proxyInstance()
 //        service.frameworkService.serverUUID = null
         service.pluginService = pmock.proxyInstance()
-        List useStoredValues = [false, false]
+        List useStoredValues = [true, true]
         List partialValues = [false, false]
         int useStoredNdx=0
         service.metaClass.getFileForExecutionFiletype = {


### PR DESCRIPTION
**##### Problem**

When you delete a job from the job list page, and you try to see the log output of that job executions, an empty log is shown (it only happens when deleting the job from that page)

**##### Solution**

It was added a way to know if the job was deleted, if it was, Rundeck is going to use the path stored for that job in the execution table.

fix [RSE-50](https://pagerduty.atlassian.net/browse/RSE-50)
fix https://github.com/rundeckpro/rundeckpro/issues/2354

With this fix the user can watch the logs for a specific job even when this was deleted. The previous behavior did not allow to watch those logs even though they were stored in the file system. 

Execution panel with job deleted: 
![deletedJob](https://user-images.githubusercontent.com/29233418/192365416-6c9626e6-3f39-462d-ba2b-9140da6da647.png)

Activity screen for deleted job: 
![activityScreen](https://user-images.githubusercontent.com/29233418/192365488-720948ca-c91b-44d7-9453-595940397f97.png)

Logs from deleted job:
![logDeleted](https://user-images.githubusercontent.com/29233418/192365575-ba56456e-e29c-4c53-9183-c16eecfbd531.png)

This fix was also tested with a custom file system as minio 

![Screen Shot 2022-09-26 at 16 47 20](https://user-images.githubusercontent.com/29233418/192366522-3c79180a-3f02-4acc-b114-9c2ba4e9054c.png)
