### PR TITLE
RUN-20: WF engine updates

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/EngineWorkflowExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/EngineWorkflowExecutor.java
@@ -256,7 +256,7 @@ public class EngineWorkflowExecutor extends BaseWorkflowExecutor {
                     WorkflowSystem.SharedData.with(
                             sharedContext::merge,
                             () -> sharedContext,
-                            () -> DataContextUtils.flattenDataContext(sharedContext.getData(ContextView.global()))
+                            () -> DataContextUtils.flattenDataContext(sharedContext.consolidate().getData(ContextView.global()))
                     );
 
             Set<WorkflowSystem.OperationResult<WFSharedContext, OperationCompleted, StepOperation>>

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/EngineWorkflowExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/EngineWorkflowExecutor.java
@@ -598,9 +598,7 @@ public class EngineWorkflowExecutor extends BaseWorkflowExecutor {
                 final StepExecutionContext executionContext
         )
         {
-            MutableStateObj
-                    mutable =
-                    States.mutable(DataContextUtils.flattenDataContext(executionContext.getDataContext()));
+            MutableStateObj mutable = States.mutable();
             mutable.updateState(Workflows.getNewWorkflowState());
             mutable.updateState(WORKFLOW_KEEPGOING_KEY, Boolean.toString(item.getWorkflow().isKeepgoing()));
             return mutable;

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/engine/StepOperation.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/engine/StepOperation.java
@@ -99,23 +99,6 @@ public class StepOperation implements WorkflowSystem.Operation<WFSharedContext,O
                 EngineWorkflowExecutor.stepKey(EngineWorkflowExecutor.STEP_STATE_KEY, stepNum),
                 stepResultValue
         );
-        if (label != null) {
-            stateChanges.updateState(
-                    EngineWorkflowExecutor.stepKey(EngineWorkflowExecutor.STEP_STATE_KEY, "label." + label),
-                    stepResultValue
-            );
-            stateChanges.updateState(
-                    EngineWorkflowExecutor.stepKey(EngineWorkflowExecutor.STEP_COMPLETED_KEY, "label." + label),
-                    EngineWorkflowExecutor.VALUE_TRUE
-            );
-            if (result != null) {
-                EngineWorkflowExecutor.updateStateWithStepResultData(
-                        stateChanges,
-                        "label." + label,
-                        result.getFailureData()
-                );
-            }
-        }
         if (success) {
             stateChanges.updateState(
                     EngineWorkflowExecutor.STEP_ANY_STATE_SUCCESS_KEY,

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/Rules.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/Rules.java
@@ -198,10 +198,25 @@ public class Rules {
      * @return true if state was modified, false if no state change occured
      */
     public static boolean update(RuleEngine ruleEngine, MutableStateObj state) {
-        StateObj newState = ruleEngine.evaluateRules(state);
+        return update(ruleEngine, state, null);
+    }
+
+    /**
+     * Update the state by evaluating the rules, and applying state changes
+     * @param ruleEngine rule engine
+     * @param state state
+     * @param readableState optional additional state
+     * @return
+     */
+    public static boolean update(RuleEngine ruleEngine, MutableStateObj state, StateObj readableState) {
+        Map<String, String> evalState = new HashMap<>();
+        if (readableState != null) {
+            evalState.putAll(readableState.getState());
+        }
+        evalState.putAll(state.getState());
+        StateObj newState = ruleEngine.evaluateRules(new DataState(evalState));
         state.updateState(newState);
         return newState.getState().size() > 0;
-
     }
 
     public static java.util.function.Predicate<? super Rule> ruleApplies(final StateObj state) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngine.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngine.java
@@ -167,12 +167,13 @@ public class WorkflowEngine
         if (null != newData) {
             sharedData.addData(newData);
         }
-        Map<String, String> additionalState = sharedData.produceState();
+        Map<String, String> additionalState = sharedData != null?sharedData.produceState():null;
 
         boolean update = getState().updateState(newState);
-        D nextShared = sharedData.produceNext();
+        D nextShared = sharedData != null ? sharedData.produceNext() : null;
 
-        update |= Rules.update(getRuleEngine(), getState(), States.state(additionalState));
+        StateObj additional = additionalState != null ? States.state(additionalState) : null;
+        update |= Rules.update(getRuleEngine(), getState(), additional);
         event(
                 WorkflowSystemEventType.DidProcessStateChange,
                 String.format(
@@ -184,7 +185,7 @@ public class WorkflowEngine
                 StateWorkflowSystem.stateChangeEvent(
                         identity,
                         getState(),
-                        StateWorkflowSystem.stateChange(identity, States.state(additionalState), nextShared, sharedData)
+                        StateWorkflowSystem.stateChange(identity, additional, nextShared, sharedData)
                 )
         );
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessor.java
@@ -101,8 +101,6 @@ class WorkflowEngineOperationsProcessor<DAT, RES extends WorkflowSystem.Operatio
      * Continue processing from current state
      */
     private void continueProcessing() {
-        boolean cancel = false;
-        boolean cancelInterrupt = false;
         try {
             while (!Thread.currentThread().isInterrupted()) {
                 //wait for changes
@@ -147,8 +145,6 @@ class WorkflowEngineOperationsProcessor<DAT, RES extends WorkflowSystem.Operatio
             eventHandler.event(WorkflowSystemEventType.Interrupted, "Engine interrupted, stopping engine...");
             cancelFutures(true);
             interrupted = Thread.interrupted();
-        } else if (cancel) {
-            cancelFutures(cancelInterrupt);
         }
         awaitFutures();
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessor.java
@@ -62,12 +62,6 @@ class WorkflowEngineOperationsProcessor<DAT, RES extends WorkflowSystem.Operatio
     private final List<ListenableFuture<RES>> futures = new ArrayList<>();
 
     private WorkflowEngine.Sleeper sleeper = new WorkflowEngine.Sleeper();
-    /**
-     * when wf is in end state, wait until existing operations finish
-     */
-    private boolean
-            endStateGather =
-            Boolean.parseBoolean(System.getProperty("WorkflowEngineOperationsProcessor.endStateGather", "true"));
 
 
     public WorkflowEngineOperationsProcessor(
@@ -88,9 +82,6 @@ class WorkflowEngineOperationsProcessor<DAT, RES extends WorkflowSystem.Operatio
         this.manager = manager;
     }
 
-    public void tuneEndStateGather(boolean gather){
-        endStateGather = gather;
-    }
 
     /**
      * Process the operations from a begin state
@@ -163,7 +154,7 @@ class WorkflowEngineOperationsProcessor<DAT, RES extends WorkflowSystem.Operatio
     }
 
     boolean shouldWorkflowEnd() {
-        return workflowEngine.isWorkflowEndState() && (!endStateGather || detectNoMoreChanges());
+        return workflowEngine.isWorkflowEndState() && detectNoMoreChanges();
     }
 
     private boolean processCompletedChanges(

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessor.java
@@ -177,22 +177,12 @@ class WorkflowEngineOperationsProcessor<DAT, RES extends WorkflowSystem.Operatio
         }
         boolean changed = false;
         for (WorkflowSystem.OperationCompleted<DAT> task : operationCompleteds) {
-            DAT result = task.getResult();
-            Map<String, String> state = new HashMap<>(task.getNewState().getState());
             changed |=
                     workflowEngine.processStateChange(
-                            StateWorkflowSystem.stateChange(
-                                    task.getIdentity(),
-                                    () -> {
-                                        if (null != sharedData && null != result) {
-                                            sharedData.addData(result);
-                                            Map<String, String> sharedState = sharedData.produceState();
-                                            state.putAll(sharedState);
-                                        }
-                                        return state;
-                                    },
-                                    sharedData
-                            )
+                            task.getIdentity(),
+                            task.getNewState(),
+                            task.getResult(),
+                            sharedData
                     );
         }
         return changed;

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessor.java
@@ -114,10 +114,8 @@ class WorkflowEngineOperationsProcessor<DAT, RES extends WorkflowSystem.Operatio
         boolean cancelInterrupt = false;
         try {
             while (!Thread.currentThread().isInterrupted()) {
-                boolean changed = false;
-
                 //wait for changes
-                changed |= processCompletedChanges(waitForChanges());
+                boolean changed = processCompletedChanges(waitForChanges());
 
                 if (!changed) {
                     if (detectNoMoreChanges()) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessor.java
@@ -373,30 +373,6 @@ class WorkflowEngineOperationsProcessor<DAT, RES extends WorkflowSystem.Operatio
     }
 
     /**
-     * Handle the state changes for the rule engine
-     *
-     * @param changes
-     */
-    private void processStateChanges(final Map<String, String> changes) {
-        eventHandler.event(WorkflowSystemEventType.WillProcessStateChange,
-                           String.format("saw state changes: %s", changes), changes
-        );
-
-        workflowEngine.getState().updateState(changes);
-
-        boolean update = Rules.update(workflowEngine.getRuleEngine(), workflowEngine.getState());
-        eventHandler.event(
-                WorkflowSystemEventType.DidProcessStateChange,
-                String.format(
-                        "applied state changes and rules (changed? %s): %s",
-                        update,
-                        workflowEngine.getState()
-                ),
-                workflowEngine.getState()
-        );
-    }
-
-    /**
      * Run and skip pending operations
      *
      * @param resultConsumer consumer for result of operations

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/EngineWorkflowExecutorSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/EngineWorkflowExecutorSpec.groovy
@@ -28,6 +28,7 @@ import com.dtolabs.rundeck.core.rules.Rules
 import com.dtolabs.rundeck.core.rules.StateObj
 import com.dtolabs.rundeck.core.rules.WorkflowEngineBuilder
 import com.dtolabs.rundeck.core.rules.WorkflowSystem
+import com.dtolabs.rundeck.core.rules.Workflows
 import com.dtolabs.rundeck.core.tools.AbstractBaseTest
 import spock.lang.Specification
 
@@ -821,5 +822,26 @@ class EngineWorkflowExecutorSpec extends Specification {
         !result.success
         result.stepFailures
         result.stepFailures.size() == 1
+    }
+
+    def "default augmentor initial state should not include shared data in state"(){
+        given:
+            def sut = new EngineWorkflowExecutor.DefaultAugmentor()
+            def item = Mock(WorkflowExecutionItem){
+                getWorkflow()>>Mock(IWorkflow){
+                    isKeepgoing()>>keepgoing
+                }
+            }
+            def context = Mock(StepExecutionContext)
+        when:
+            def result=sut.getInitialState(item,context)
+        then:
+            result.getState().size()==2
+            result.getState().get(Workflows.WORKFLOW_STATE_ID_KEY)!= null
+            result.getState().get(EngineWorkflowExecutor.WORKFLOW_KEEPGOING_KEY)==keepgoing.toString()
+
+        where:
+            keepgoing<<[true,false]
+
     }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessorSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/rules/WorkflowEngineOperationsProcessorSpec.groovy
@@ -134,7 +134,6 @@ class WorkflowEngineOperationsProcessorSpec extends Specification {
                     executor,
                     manager
             )
-            processor.tuneEndStateGather(gather)
             if(ops){
                 processor.inProcess.add(new TestOperation())
             }
@@ -149,9 +148,6 @@ class WorkflowEngineOperationsProcessorSpec extends Specification {
             ops   | changes | endState | gather | expect
             false | false   | false    | false  | false
             false | false   | true     | false  | true
-            false | true    | true     | false  | true
-            true  | false   | true     | false  | true
-            true  | true    | true     | false  | true
             false | false   | true     | true   | true
             true  | false   | true     | true   | false
             true  | true    | true     | true   | false

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/rules/WorkflowEngineSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/rules/WorkflowEngineSpec.groovy
@@ -417,7 +417,7 @@ class WorkflowEngineSpec extends Specification {
         operations[1].input == [c: 'd']
     }
 
-    def "global data refresh"() {
+    def "global shared data should not modify engine state"() {
         given:
         RuleEngine ruleEngine = Rules.createEngine()
         MutableStateObj state = States.mutable()
@@ -450,8 +450,7 @@ class WorkflowEngineSpec extends Specification {
         def result = engine.processOperations(operations, shared)
 
         then:
-        state.state.containsKey(expect)
-        state.state.get(expect) == value
+        !state.state.containsKey(expect)
 
         where:
         map                         | expect        | value

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -343,7 +343,7 @@
                                                     showNodeIcon   : false,
                                                     hideTitle      : false,
                                                     hideDescription: false,
-                                                    fullDescription: true
+                                                    fullDescription: false
                                             ]}"/>
                                         </label>
                                     </div>


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Enhancements to workflow engine
* cleanup state data to remove unnecessary data (shared data + "label" data)
* update events sent from WF engine to include more data
* some WF engine changes:
    * process state changes updated to clean up the logic, and keep shared data state separate from WF engine state
    * add "gather" behavior to not end workflow before all running operations are truly completed