### PR TITLE
RSE-140 MOTD (Message of the day) not displayed (Rundeck OSS)

### DIFF
--- a/rundeckapp/grails-app/views/menu/home.gsp
+++ b/rundeckapp/grails-app/views/menu/home.gsp
@@ -362,8 +362,7 @@
                 </div>
               </div>
             </div>
-            <!-- ko if: $root.projectForName(project).extra() -->
-            <!-- ko foreach: $root.projectForName(project).extra() -->
+            <!-- ko if: $root.projectForName(project).showMessage() -->
             <div data-bind="if: $root.projectForName(project)">
               <div class="row" data-bind="if: $root.projectForName(project).showMessage() ">
                 <div class="project_list_readme col-sm-10 col-sm-offset-1 col-xs-12">
@@ -373,15 +372,15 @@
                     </span>
                   </div>
                   <div data-bind="if:  $root.projectForName(project).showReadme() ">
+                  <hr style="width: 0px">
                     <span data-bind="if: $root.projectForName(project).readme().readmeHTML()">
                         <span data-bind="html: $root.projectForName(project).readme().readmeHTML()"></span>
                     </span>
                   </div>
                 </div>
               </div>
-            </div>
+            </div>         
             <div data-bind="component: $data"></div>
-            <!-- /ko -->
             <!-- /ko -->
           </div>
 


### PR DESCRIPTION
# Bugfix - MOTD don't show up since 3.4.0
As seen here: https://pagerduty.atlassian.net/browse/RSE-140 , in rundeck OSS the MOTD never displays in the project's home page.

## The problem
Knockout.Js takes certain comments as functions, there was a function that rendered the MOTD piece of code according to an array that was only populated when the 'rdpro-projectdash-detail-info' pro plugin was loaded into the app. That is, after the installation of the license.

## The solution
we used an observable attribute (updatable by AJAX requests) that renders the piece of code if and only if there is readme/motd; without waiting for a pro plugin.

## Exhibits
After the fix (tested in a compiled Rundeck OSS Instance):
![Screenshot from 2022-09-29 17-02-42](https://user-images.githubusercontent.com/81827734/193132993-0a1628bb-47e9-4f7f-b5b0-82b3e5c9deb2.png)

NOTE: added spacing between the MOTD and README messages.