### PR TITLE
Fix: Wrong padding in dropdowns

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
@@ -46,7 +46,6 @@
   background-clip: padding-box;
   border: 0 none;
   border-radius: $border-radius-extreme;
-  padding-right: 2rem;
   @include box-shadow($dropdown-shadow);
 
   // Aligns the dropdown menu to right

--- a/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/views/WebhooksView.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/views/WebhooksView.vue
@@ -114,7 +114,7 @@
                         </span>
                         <span class="caret"></span>
                       </button>
-                      <ul class="dropdown-menu ">
+                      <ul class="dropdown-menu " style="padding-right: 2rem;">
 
                         <li v-for="plugin in webhookPlugins" v-bind:key="plugin.id">
                           <a href="#" @click="setSelectedPlugin(false,plugin)">

--- a/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/views/WebhooksView.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/webhooks/views/WebhooksView.vue
@@ -114,7 +114,7 @@
                         </span>
                         <span class="caret"></span>
                       </button>
-                      <ul class="dropdown-menu " style="padding-right: 2rem;">
+                      <ul class="dropdown-menu ">
 
                         <li v-for="plugin in webhookPlugins" v-bind:key="plugin.id">
                           <a href="#" @click="setSelectedPlugin(false,plugin)">


### PR DESCRIPTION
# Bugfix RSE-117 Unnecessary padding at the right of dropdowns
As seen here https://github.com/rundeck/rundeck/pull/7899, the dropdown in the WH page were having a text overflow so the PR RSE-117 was supposed to fix it, but we added padding to all the dropdowns with the modified class.

## The problem
We modified a SASS global file and several dropdowns were having a unnecessary padding.

## The solution
We added padding to the specific component that needed padding, writing in-line CSS.

## Exhibits
Pre-fix dropdowns:
Webhook Dropdown:
![Screenshot from 2022-10-05 13-04-33](https://user-images.githubusercontent.com/81827734/194108188-d76c6ad7-249d-4cde-8f37-cf3a9fc71e6d.png)

Job dropdown:
![Screenshot from 2022-10-05 11-54-44](https://user-images.githubusercontent.com/81827734/194092240-e383bc2b-983a-43ba-a270-aee3a31d0d24.png)

Post-fix dropdowns:
Webhook Dropdown:
![Screenshot from 2022-10-05 13-04-33](https://user-images.githubusercontent.com/81827734/194108260-4ce87962-fa77-481b-8129-dd19eb2f0ba7.png)

Job dropdown:
![Screenshot from 2022-10-05 11-56-18](https://user-images.githubusercontent.com/81827734/194092661-a13e0caa-209a-48df-b275-eb422df7f106.png)

Action dropdown:
![Screenshot from 2022-10-05 11-57-34](https://user-images.githubusercontent.com/81827734/194092921-94dd4fae-4cee-4e75-a0fb-2acd9e4ff2e8.png)

Job Run Options dropdown:
![Screenshot from 2022-10-05 11-58-17](https://user-images.githubusercontent.com/81827734/194093152-947a6a47-4744-486f-852a-d39e75f0e826.png)