### PR TITLE
Changes rollback

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
@@ -46,7 +46,6 @@
   background-clip: padding-box;
   border: 0 none;
   border-radius: $border-radius-extreme;
-  padding-right: 2rem;
   @include box-shadow($dropdown-shadow);
 
   // Aligns the dropdown menu to right


### PR DESCRIPTION
# Rollback for RSE-117
As seen in here: https://github.com/rundeck/rundeck/pull/7899, the RSE-117 PR was intended to fix a text overflow in the WH dropdown. This PR rollback that change due other GUI inconsistencies that we have scheduled to fix in further releases. 
