### PR TITLE
Fix: Fix to the text-overflow on the WH's hadler plugin list

### DIFF
--- a/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
@@ -266,6 +266,7 @@
 
                             <li data-bind="foreach: descriptions['${serviceDefaults.service}']">
                                 <a href="#" data-bind="click: function(){$parent.defaults['${serviceDefaults.service}'].type(type())}">
+                                    <span>
                                     <!-- ko if: iconSrc -->
                                     <img width="16px" height="16px" data-bind="attr: {src: iconSrc}"/>
                                     <!-- /ko -->
@@ -282,7 +283,7 @@
                                     <i class="rdicon icon-small plugin"></i>
                                     <!-- /ko -->
                                     <span data-bind="text: title"></span>
-
+                                    </span>
                                 </a>
                             </li>
                     </ul>

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
@@ -77,16 +77,11 @@
       background-color: $dropdown-link-hover-bg;
     }
   }
+  // Links which have <span> that overflow the <li>
+  // caret class (arrows) excluded 
   > li > a > span:not(.caret) {
     display: block;
     padding: 3px 20px 3px 3px;
-
-    &:hover,
-    &:focus {
-      color: $dropdown-link-hover-color;
-      text-decoration: none;
-      background-color: $dropdown-link-hover-bg;
-    }
   }
 }
 
@@ -106,9 +101,7 @@
   &,
   &:hover,
   &:focus {
-    color: $dropdown-link-active-color;
     text-decoration: none;
-    background-color: $dropdown-link-active-bg;
     outline: 0;
   }
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
@@ -33,7 +33,7 @@
   top: 100%;
   left: 0;
   z-index: $zindex-dropdown;
-  display: none; // none by default, but table on "open" of the menu
+  display: none; // none by default, but block on "open" of the menu
   float: left;
   min-width: 160px;
   padding: 0px;
@@ -77,12 +77,14 @@
       background-color: $dropdown-link-hover-bg;
     }
   }
+
   // Links which have <span> that overflow the <li>
   // caret class (arrows) excluded 
   > li > a > span:not(.caret) {
     display: block;
     padding: 3px 20px 3px 3px;
   }
+
 }
 
 // Active state
@@ -95,8 +97,7 @@
     outline: 0;
   }
 }
-// The background color change on hover delegated to the span tag
-// to occupy all the list item and prevent visual overflow on corners
+//Active state of the text inside the links in the dropdown-m
 .dropdown-menu > .active > a > span {
   &,
   &:hover,
@@ -110,7 +111,6 @@
 // Disabled state
 //
 // Gray out text and ensure the hover/focus state remains gray
-
 .dropdown-menu > .disabled > a {
   &,
   &:hover,
@@ -148,7 +148,6 @@
 }
 
 // Open state for the dropdown
-// Display table to fit correctly the content of li's
 .open {
   // Show the menu
   > .dropdown-menu {

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
@@ -92,7 +92,6 @@
   &:focus {
     color: $dropdown-link-active-color;
     text-decoration: none;
-    background-color: $dropdown-link-active-bg;
     outline: 0;
   }
 }
@@ -102,6 +101,7 @@
   &:hover,
   &:focus {
     text-decoration: none;
+    background-color: $dropdown-link-active-bg;
     outline: 0;
   }
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
@@ -46,7 +46,6 @@
   background-clip: padding-box;
   border: 0 none;
   border-radius: $border-radius-extreme;
-  padding-right: 2rem;
   @include box-shadow($dropdown-shadow);
 
   // Aligns the dropdown menu to right
@@ -65,7 +64,6 @@
   // Links within the dropdown menu
   > li > a {
     display: block;
-    padding: 3px 20px;
     clear: both;
     font-weight: 400;
     line-height: $line-height-base;
@@ -77,6 +75,16 @@
       color: $dropdown-link-hover-color;
       text-decoration: none;
       background-color: $dropdown-link-hover-bg;
+    }
+  }
+  > li > a > span {
+    display: block;
+    padding: 3px 20px 3px 3px;
+
+    &:hover,
+    &:focus {
+      color: $dropdown-link-active-color;
+      text-decoration: none;
     }
   }
 }
@@ -119,7 +127,7 @@
 .open {
   // Show the menu
   > .dropdown-menu {
-    display: block;
+    display: table;
   }
 
   // Remove the outline when :focus is triggered

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
@@ -77,14 +77,15 @@
       background-color: $dropdown-link-hover-bg;
     }
   }
-  > li > a > span {
+  > li > a > span:not(.caret) {
     display: block;
     padding: 3px 20px 3px 3px;
 
     &:hover,
     &:focus {
-      color: $dropdown-link-active-color;
+      color: $dropdown-link-hover-color;
       text-decoration: none;
+      background-color: $dropdown-link-hover-bg;
     }
   }
 }
@@ -101,11 +102,40 @@
   }
 }
 
+.dropdown-menu > .active > a > span {
+  &,
+  &:hover,
+  &:focus {
+    color: $dropdown-link-active-color;
+    text-decoration: none;
+    background-color: $dropdown-link-active-bg;
+    outline: 0;
+  }
+}
+
 // Disabled state
 //
 // Gray out text and ensure the hover/focus state remains gray
 
 .dropdown-menu > .disabled > a {
+  &,
+  &:hover,
+  &:focus {
+    color: $dropdown-link-disabled-color;
+  }
+
+  // Nuke hover/focus effects
+  &:hover,
+  &:focus {
+    text-decoration: none;
+    cursor: $cursor-disabled;
+    background-color: transparent;
+    background-image: none; // Remove CSS gradient
+    @include reset-filter;
+  }
+}
+
+.dropdown-menu > .disabled > a > span{
   &,
   &:hover,
   &:focus {

--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
@@ -33,7 +33,7 @@
   top: 100%;
   left: 0;
   z-index: $zindex-dropdown;
-  display: none; // none by default, but block on "open" of the menu
+  display: none; // none by default, but table on "open" of the menu
   float: left;
   min-width: 160px;
   padding: 0px;
@@ -95,7 +95,8 @@
     outline: 0;
   }
 }
-
+// The background color change on hover delegated to the span tag
+// to occupy all the list item and prevent visual overflow on corners
 .dropdown-menu > .active > a > span {
   &,
   &:hover,
@@ -147,6 +148,7 @@
 }
 
 // Open state for the dropdown
+// Display table to fit correctly the content of li's
 .open {
   // Show the menu
   > .dropdown-menu {


### PR DESCRIPTION
# Fix to the text-overflow on the WH's hadler plugin list
As seen here: , in the webhook section could be seen a overflow of certain list items.

## The problem
Was that the css was arranging the link tags within the list but not the span tags inside the links.

## The solution
We added css to the spans, arranging the spans within the links and so the list items.

Note: by doing this, we have to add css to the arrows inside the list and wrapping icons in span as well.

## Exhibits:
Dropdown in the Webhooks page (original bug v4.6.1):
![Screenshot from 2022-10-06 18-18-39](https://user-images.githubusercontent.com/81827734/194420510-45d11e41-a0e1-4d73-a607-be7dbaf37d49.png)

Post-fix:
![Screenshot from 2022-10-06 18-20-16](https://user-images.githubusercontent.com/81827734/194420702-36ede033-0269-48db-96b8-17bd090ddf91.png)

Examples of the same dropdown in other pages:
![Screenshot from 2022-10-06 18-21-18](https://user-images.githubusercontent.com/81827734/194420872-0945e453-fc90-44a2-9e71-7fcf3937f4b5.png)

![Screenshot from 2022-10-06 18-21-36](https://user-images.githubusercontent.com/81827734/194420920-5d5ef6c6-147b-4e5c-b4d4-66c5f322e4bc.png)
![Screenshot from 2022-10-06 18-25-27](https://user-images.githubusercontent.com/81827734/194421539-0725b74d-a034-4232-a8e7-c7ea5a6abd98.png)

![Screenshot from 2022-10-06 18-26-43](https://user-images.githubusercontent.com/81827734/194421659-e240d884-493c-4ef4-a244-657d5acd8b28.png)

![Screenshot from 2022-10-06 18-27-17](https://user-images.githubusercontent.com/81827734/194421770-68b73dca-83d8-4085-83fd-64ad2223dde8.png)


