### PR TITLE
Fix: Long node names overlapping each other

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/custom/nodes-embed.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/custom/nodes-embed.scss
@@ -1,7 +1,7 @@
 .nodes-embed{
 
   .embedded_node {
-    display: inline-block;
+    display: block;
     cursor: pointer;
 
     &.tight {


### PR DESCRIPTION
# Fix Node Names Overlapping on Create Job Page
As seen here: https://github.com/rundeckpro/rundeckpro/issues/2755, when the node name exceeds the maximum visual capacity it overlaps with the next node name horizontally.

## The Problem
Was the display of the list of nodes, which was 'inline-block', that display prevent the component to break into another line or have overflow (hidden).

## The Fix
Changing its display to block, allowing the component to overflow or break in another line.

## Important note 👋
The modified class, style this components:
- 'Create Job' page
- 'Commands' page

## Exhibit
After the fix:
![Screenshot from 2022-10-11 12-39-28](https://user-images.githubusercontent.com/81827734/195139686-a9732f82-09cb-455e-a17e-a1c5b84edf0a.png)
