### PR TITLE
Configure rundeckapp tests to fork every 500 tests for speed improvements.

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -311,6 +311,10 @@ tasks.withType(Test) {
     systemProperty "webdriver.gecko.driver", System.getProperty('webdriver.gecko.driver')
 }
 
+tasks.withType(Test).configureEach {
+    forkEvery = 500
+}
+
 assets {
     minifyJs = false
     minifyCss = false


### PR DESCRIPTION
On some systems this change can produce a 30-45% speed improvement when running the tests.