### PR TITLE
Convert DummyEmailNotificationPluginSpec from integration test to unit test

### DIFF
--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/notification/DummyEmailNotificationPluginSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/notification/DummyEmailNotificationPluginSpec.groovy
@@ -1,6 +1,7 @@
 package com.dtolabs.rundeck.server.plugins.notification
 
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyValidator
+import grails.testing.gorm.DataTest
 import grails.testing.mixin.integration.Integration
 import org.springframework.context.MessageSource
 import rundeck.Notification
@@ -8,8 +9,12 @@ import rundeck.ScheduledExecution
 import rundeck.services.ScheduledExecutionService
 import spock.lang.Specification
 
-@Integration
-class DummyEmailNotificationPluginSpec extends Specification {
+class DummyEmailNotificationPluginSpec extends Specification implements DataTest {
+
+    Class[] getDomainClassesToMock() {
+        [ScheduledExecution, Notification]
+    }
+
     def "property validators consistent with service validations" () {
         given:
         Map<PropertyValidator, Object> pluginValidations = [


### PR DESCRIPTION
Converting to a unit test makes this test run much faster, and removes the integration test from the unit test phase.