### PR TITLE
RSE-169: Fix: Custom Replacement in Key-Value Log Filter Plugin

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
@@ -205,8 +205,7 @@ See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex
                     if(invalidKeyPattern){
                         def validKey = null
                         if( replaceFilteredResult ){
-                            if( emptyReplacement ){
-                                def emptyReplacement = invalidCharactersReplacement == null
+                            if( invalidCharactersReplacement == null ){
                                 validKey = key.replaceAll(invalidKeyPattern, '')
                             }else{
                                 validKey = key.replaceAll(invalidKeyPattern, invalidCharactersReplacement)

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
@@ -204,8 +204,7 @@ See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex
                 if (key && value) {
                     if(invalidKeyPattern){
                         def validKey = null
-                        def emptyReplacement = invalidCharactersReplacement == null
-                        if( replaceFilteredResult ){
+                        if( invalidCharactersReplacement == null ){
                             if( emptyReplacement ){
                                 validKey = key.replaceAll(invalidKeyPattern, '')
                             }else{

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
@@ -57,6 +57,7 @@ class SimpleDataFilterPlugin implements LogFilterPlugin {
     public static final String PROVIDER_NAME = 'key-value-data'
     public static final String PATTERN = '^RUNDECK:DATA:\\s*([^\\s]+?)\\s*=\\s*(.+)$'
     public static final String INVALID_KEY_PATTERN = '\\s|\\$|\\{|\\}|\\\\'
+    public static final String INVALID_KEY_PATTERN_DEFAULT_REPLACE_VALUE = ''
     public static final String EXTRA_SETTINGS_GROUP_NAME = "Advanced"
 
     @PluginProperty(
@@ -103,6 +104,36 @@ See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex
             ]
     )
     String invalidKeyPattern
+
+    @PluginProperty(
+            title = 'Replace filtered data',
+            description = '''If checked, the data will be replaced with a defined value below''',
+            defaultValue = 'false'
+    )
+    @RenderingOptions(
+            [
+                    @RenderingOption(key = "groupName", value = SimpleDataFilterPlugin.EXTRA_SETTINGS_GROUP_NAME),
+                    @RenderingOption(key = "grouping", value = "secondary"),
+                    @RenderingOption(key = "requiredValue", value = "false"),
+            ]
+    )
+    Boolean replaceFilteredResult
+
+    @PluginProperty(
+            title = "Replace Invalid Character Patterns With",
+            description = '''If the Invalid Character Pattern matches, the string will be replaced with an underscore by default, unless you specify which value do you want to replace the invalid character pattern with.''',
+            defaultValue = SimpleDataFilterPlugin.INVALID_KEY_PATTERN_DEFAULT_REPLACE_VALUE,
+            required = false
+
+    )
+    @RenderingOptions(
+            [
+                    @RenderingOption(key = "groupName", value = SimpleDataFilterPlugin.EXTRA_SETTINGS_GROUP_NAME),
+                    @RenderingOption(key = "grouping", value = "secondary"),
+                    @RenderingOption(key = "requiredValue", value = "false"),
+            ]
+    )
+    String invalidCharactersReplacement
 
     static class RegexValidator implements PropertyValidator {
         @Override
@@ -172,7 +203,17 @@ See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex
                 }
                 if (key && value) {
                     if(invalidKeyPattern){
-                        def validKey = key.replaceAll(invalidKeyPattern,"_")
+                        def validKey = null
+                        def emptyReplacement = invalidCharactersReplacement == null
+                        if( replaceFilteredResult ){
+                            if( emptyReplacement ){
+                                validKey = key.replaceAll(invalidKeyPattern, '')
+                            }else{
+                                validKey = key.replaceAll(invalidKeyPattern, invalidCharactersReplacement)
+                            }
+                        }else{
+                            validKey = key.replaceAll(invalidKeyPattern,"_")
+                        }
                         if (key != validKey) {
                             key = validKey
                             context.log(1,"Key contains not valid value which will be replaced")

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
@@ -204,7 +204,8 @@ See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex
                 if (key && value) {
                     if(invalidKeyPattern){
                         def validKey = null
-                        if( invalidCharactersReplacement == null ){
+                        if( replaceFilteredResult ){
+                            def emptyReplacement = invalidCharactersReplacement == null
                             if( emptyReplacement ){
                                 validKey = key.replaceAll(invalidKeyPattern, '')
                             }else{

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
@@ -205,8 +205,8 @@ See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex
                     if(invalidKeyPattern){
                         def validKey = null
                         if( replaceFilteredResult ){
-                            def emptyReplacement = invalidCharactersReplacement == null
                             if( emptyReplacement ){
+                                def emptyReplacement = invalidCharactersReplacement == null
                                 validKey = key.replaceAll(invalidKeyPattern, '')
                             }else{
                                 validKey = key.replaceAll(invalidKeyPattern, invalidCharactersReplacement)

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPluginSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPluginSpec.groovy
@@ -233,7 +233,7 @@ class SimpleDataFilterPluginSpec extends Specification {
         plugin.name = name
         plugin.invalidKeyPattern = validKeyPattern
         plugin.replaceFilteredResult = true
-        plugin.replaceFilteredResultWith = invalidStringReplacement
+        plugin.invalidCharactersReplacement = invalidStringReplacement
         def sharedoutput = new DataOutput(ContextView.global())
         def context = Mock(PluginLoggingContext) {
             getOutputContext() >> sharedoutput

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPluginSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPluginSpec.groovy
@@ -254,19 +254,13 @@ class SimpleDataFilterPluginSpec extends Specification {
         plugin.complete(context)
         then:
 
-        sharedoutput.getSharedContext().getData(ContextView.global())?.getData() == (expect ? ['data': expect] : null)
-        if (expect) {
-            if(doWarn){
-                1 * context.log(1, _)
-            }else{
-                0 * context.log(1, _)
-            }
-        }
+        1 * context.log(1, _)
 
         where:
         doWarn | validKeyPattern        | regex                    | invalidStringReplacement | name      | lines                           | expect
         true   | '\\s|\\$|\\{|\\}|\\\\' | '^RUNDECK:DATA:(.+?)$'   | ''                       | ' ubuntu' | ['RUNDECK:DATA:zangief']        | [ubuntu: 'zangief']
         true   | '\\s|\\$|\\{|\\}|\\\\' | '^RUNDECK:DATA:(.+?)$'   | 'Football'               | ' wimple' | ['RUNDECK:DATA:zangief']        | [Footballwimple: 'zangief']
+        false  | '\\s|\\$|\\{|\\}|\\\\' | '^RUNDECK:DATA:(.+?)$'   | 'Match'                  | ' wimple' | ['RUNDECK:DATA:zangief']        | [Matchwimple: 'zangief']
 
     }
 

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPluginSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPluginSpec.groovy
@@ -253,14 +253,14 @@ class SimpleDataFilterPluginSpec extends Specification {
         }
         plugin.complete(context)
         then:
+        sharedoutput.getSharedContext().getData(ContextView.global())?.getData() == ['data': expect]
 
         1 * context.log(1, _)
 
         where:
-        doWarn | validKeyPattern        | regex                    | invalidStringReplacement | name      | lines                           | expect
-        true   | '\\s|\\$|\\{|\\}|\\\\' | '^RUNDECK:DATA:(.+?)$'   | ''                       | ' ubuntu' | ['RUNDECK:DATA:zangief']        | [ubuntu: 'zangief']
-        true   | '\\s|\\$|\\{|\\}|\\\\' | '^RUNDECK:DATA:(.+?)$'   | 'Football'               | ' wimple' | ['RUNDECK:DATA:zangief']        | [Footballwimple: 'zangief']
-        false  | '\\s|\\$|\\{|\\}|\\\\' | '^RUNDECK:DATA:(.+?)$'   | 'Match'                  | ' wimple' | ['RUNDECK:DATA:zangief']        | [Matchwimple: 'zangief']
+        validKeyPattern        | regex                    | invalidStringReplacement | name      | lines                           | expect
+        '\\s|\\$|\\{|\\}|\\\\' | '^RUNDECK:DATA:(.+?)$'   | ''                       | ' ubuntu' | ['RUNDECK:DATA:zangief']        | [ubuntu: 'zangief']
+        '\\s|\\$|\\{|\\}|\\\\' | '^RUNDECK:DATA:(.+?)$'   | 'Football'               | ' wimple' | ['RUNDECK:DATA:zangief']        | [Footballwimple: 'zangief']
 
     }
 


### PR DESCRIPTION
# Fix: RSE-169 Issues with PDPAOP Data capture plugin and Ansible using force_color=true
As seen [here](https://pagerduty.atlassian.net/jira/software/c/projects/RSE/boards/716?modal=detail&selectedIssue=RSE-169&assignee=6201489c539d790069dd410f), if PDPAOP runs a command with Ansible configured to append Ansi Scape Codes to the output ***and*** we capture the data in key-values, the key value comes with the Ansi Scape Code appended.

## The problems
1. The ansi color codec for rundeck scapes the values to render the colors in the GUI but didn't remove the values from the values captured.
2. The user may not want in his keys a underscore.

## The solution
If we filter the output data with the 'invalid characters' method of the key-value plugin, we end up with an unwanted underscore in the 'key' parameter, so we extended plugin's functionality to make possible choosing the replacement for the unwanted values.

## Exhibits
Environment:
RD: Compiled WAR
Ansible -v ```2.10.8```, configured with ```force_color=true```
Command (job): ```ansible all -u <user> -m ping --private-key <key>``` 

Pre-fix:
![Screenshot from 2022-10-18 17-04-18](https://user-images.githubusercontent.com/81827734/196533379-5b22993e-6bc2-4370-b252-e6c099dd454b.png)

Key-Value Data log filter definition:
![Screenshot from 2022-10-18 17-04-54](https://user-images.githubusercontent.com/81827734/196533679-e7656f72-c5e3-49ae-912f-5be2c72bfaa5.png)

Post-fix:
![Screenshot from 2022-10-18 17-05-13](https://user-images.githubusercontent.com/81827734/196533483-1e076273-ad36-45a4-8f14-186ee9c64c63.png)

