### PR TITLE
RSE-118: Fix: select-all-function

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/menu/joboptions.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/joboptions.js
@@ -143,7 +143,11 @@ function Option(data) {
 
         var testselected = function (val) {
             if (self.selectedMultiValues() && self.selectedMultiValues().length > 0) {
-                return ko.utils.arrayIndexOf(self.selectedMultiValues(), val) >= 0;
+                if (self.multivalueAllSelected()) {
+                    return true;
+                } else {
+                    return ko.utils.arrayIndexOf(self.selectedMultiValues(), val) >= 0;
+                }
             } else if (self.defaultMultiValues() && self.defaultMultiValues().length > 0) {
                 return ko.utils.arrayIndexOf(self.defaultMultiValues(), val) >= 0;
             } else if (self.value()) {


### PR DESCRIPTION
# BugFix: RSE-118

**Describe the bug**

When the “Select-all Values by default” is enabled within a Job option: when you change an upstream option, the cascading options don't render as selected, it toggles between select-all and non select all.

Select-all Values by defaul is related to:
1. Click to Edit this Job
2. Go to Workflow -> when adding an option you have this option when delimiting a list by commas or another character:

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/91557307/196556811-6adf21f5-f65f-426e-b592-7135ba3ee839.png">

**Describe the solution you've implemented**
An additional validation is added when the values selected by default come and these are not considered in a subsequent validation.

**Additional context**

Before change:
![Before_Change](https://user-images.githubusercontent.com/91557307/196556302-8a7187ac-c7ab-453b-abec-35b0a54a61d4.gif)

After change:
![After_Change](https://user-images.githubusercontent.com/91557307/196560218-dcbb4934-6a4e-48fc-bf83-f53a8906f4c3.gif)

