### PR TITLE
RUN-1295: Allow form data in webhooks

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/plugins/webhook/WebhookData.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/webhook/WebhookData.java
@@ -31,4 +31,5 @@ public interface WebhookData {
     String getContentType();
     Map<String,String> getHeaders();
     InputStream getData();
+    Map<String,Object> getFormData();
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/webhook/WebhookDataImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/webhook/WebhookDataImpl.java
@@ -19,6 +19,7 @@ import lombok.Data;
 
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -34,5 +35,7 @@ public class WebhookDataImpl implements WebhookData {
     private String                 project;
     private String                 contentType;
     private InputStream            data;
+
+    private Map<String, Object>    formData;
     private HashMap<String,String> headers = new HashMap<>();
 }

--- a/grails-webhooks/grails-app/controllers/webhooks/WebhookController.groovy
+++ b/grails-webhooks/grails-app/controllers/webhooks/WebhookController.groovy
@@ -158,7 +158,11 @@ class WebhookController {
         whkdata.sender = request.remoteAddr
         whkdata.project = hook.project
         whkdata.contentType = request.contentType
-        whkdata.data = request.inputStream
+        if(request.contentType == "application/x-www-form-urlencoded") {
+            whkdata.formData = params
+        } else {
+            whkdata.data = request.inputStream
+        }
 
         try {
             def responder = webhookService.processWebhook(hook.eventPlugin, hook.pluginConfigurationJson, whkdata, authContext, request)

--- a/grails-webhooks/grails-app/controllers/webhooks/WebhookController.groovy
+++ b/grails-webhooks/grails-app/controllers/webhooks/WebhookController.groovy
@@ -16,6 +16,7 @@ import javax.servlet.http.HttpServletResponse
 
 class WebhookController {
     static final String AUTH_HEADER = "Authorization"
+    static final String FORM_URLENCODED = "application/x-www-form-urlencoded"
     static allowedMethods = [post:'POST']
 
     def webhookService
@@ -158,8 +159,8 @@ class WebhookController {
         whkdata.sender = request.remoteAddr
         whkdata.project = hook.project
         whkdata.contentType = request.contentType
-        if(request.contentType == "application/x-www-form-urlencoded") {
-            whkdata.formData = params
+        if(FORM_URLENCODED == request.contentType) {
+            whkdata.formData = cleanedFormDataFromParams(params)
         } else {
             whkdata.data = request.inputStream
         }
@@ -170,6 +171,13 @@ class WebhookController {
         } catch(WebhookEventException wee) {
             sendJsonError(wee.message)
         }
+    }
+    static final def KEYS_TO_CLEAN = ["controller","action","authtoken","api_version"]
+
+    static Map cleanedFormDataFromParams(def params) {
+        def cleanMap = new HashMap(params)
+        cleanMap.removeAll( e -> KEYS_TO_CLEAN.contains(e.key))
+        return cleanMap
     }
 
     private def sendJsonError(String errMessage,int statusCode = 400) {

--- a/grails-webhooks/src/test/groovy/webhooks/WebhookControllerSpec.groovy
+++ b/grails-webhooks/src/test/groovy/webhooks/WebhookControllerSpec.groovy
@@ -61,6 +61,40 @@ class WebhookControllerSpec extends Specification implements ControllerUnitTest<
         "1234#test" | '{"msg":"ok"}' | new DefaultJsonWebhookResponder([msg:"ok"])
     }
 
+    def "test post content types"() {
+        given:
+        controller.rundeckAuthContextProvider = Mock(AuthContextProvider)
+        controller.rundeckAuthContextEvaluator = Mock(AuthContextEvaluator)
+        controller.webhookService = Mock(MockWebhookService)
+
+        when:
+        params.authtoken = "1234"
+        if(isFormData) {
+            params.putAll(payload)
+        } else {
+            request.JSON = payload
+        }
+        request.method = 'POST'
+        request.contentType = contentType
+        controller.post()
+
+        then:
+        1 * controller.webhookService.getWebhookByToken(_) >> { new Webhook(name:"test",authToken: "1234")}
+        1 * controller.rundeckAuthContextProvider.getAuthContextForSubjectAndProject(_, _) >> { new SubjectAuthContext(null, null) }
+        1 * controller.rundeckAuthContextEvaluator.authorizeProjectResourceAny(_,_,_,_) >> { return true }
+        1 * controller.webhookService.processWebhook(_,_,_,_,_) >> { args ->
+            if(isFormData) {
+                args[2].formData["key1"] == "val1"
+            }
+            new DefaultWebhookResponder()
+        }
+
+        where:
+        authtoken   | contentType | payload | isFormData
+        "1234"      | 'application/json' | '{"key1":"val1"}' | false
+        "1234"      | 'application/x-www-form-urlencoded' | [key1:"val1"] | true
+    }
+
     def "post fail when not authorized"() {
         given:
 

--- a/grails-webhooks/src/test/groovy/webhooks/WebhookControllerSpec.groovy
+++ b/grails-webhooks/src/test/groovy/webhooks/WebhookControllerSpec.groovy
@@ -84,7 +84,7 @@ class WebhookControllerSpec extends Specification implements ControllerUnitTest<
         1 * controller.rundeckAuthContextEvaluator.authorizeProjectResourceAny(_,_,_,_) >> { return true }
         1 * controller.webhookService.processWebhook(_,_,_,_,_) >> { args ->
             if(isFormData) {
-                args[2].formData["key1"] == "val1"
+                assert args[2].formData["key1"] == "val1"
             }
             new DefaultWebhookResponder()
         }


### PR DESCRIPTION
This PR fixes the bug where Grails eats the inputStream if x-www-form-urlencoded is the content type. The form data is passed to the webhook service in a new formData field in the WebhookData interface.