### PR TITLE
Add aws-mysql-jdbc to gradle build

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -194,6 +194,7 @@ dependencies {
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:2.7.0'
     runtimeOnly 'org.postgresql:postgresql:42.3.3'
     runtimeOnly 'org.rundeck.hibernate:rundeck-oracle-dialect:1.0.0'
+    runtimeOnly 'software.aws.rds:aws-mysql-jdbc:1.1.1'
 
     runtimeOnly "org.springframework:spring-jcl:${springVersion}"
     runtimeOnly "org.codehaus.groovy:groovy-dateutil:${groovyVersion}"


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is an enhancement to better support AWS Aurora mysql database. The mariadb driver works already, but not [officially supported in newer versions](https://aws.amazon.com/blogs/database/using-the-mariadb-jdbc-driver-with-amazon-aurora-with-mysql-compatibility/) and advanced Aurora features like failover do not work for Rundeck with mariadb driver.

https://github.com/awslabs/aws-mysql-jdbc

**Describe the solution you've implemented**
AWS MYSQL JDBC driver should be in the java classpath.

**Describe alternatives you've considered**
This has been tested by manually downloading the jar and placing it in the classpath. That is an acceptable alternative but requires operator involvement.

**Other Notes**
aws-mysql-jdbc is licensed under GPLv2 with a FOSS exception