### PR TITLE
RSE-159 Fix: Activity Tab no progress percentage displayed in a Progress-bar

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_progress-bars.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_progress-bars.scss
@@ -35,6 +35,7 @@
 .progress-bar {
   float: left;
   width: 0%;
+  max-width: 100%;
   height: 100%;
   font-size: $font-size-small;
   line-height: $line-height-computed;


### PR DESCRIPTION
**Problem:**
On the activity tab, the percentage on the progress bar moved to the right when the percentage was more than 200% making it impossible to see the percentage.

<img width="613" alt="imagen" src="https://user-images.githubusercontent.com/87494173/197027164-430a8343-59cb-4139-8a6d-d8d16081f9cc.png">

**Solution:**
Add to the CSS class **.progress-bar** a max-width property to limit the growth of the progress-bar to 100% making the percentage shown on the center whatever the percentage is.

**Before Fix:**
<img width="1829" alt="imagen" src="https://user-images.githubusercontent.com/87494173/197028419-b131451a-5a11-4a06-9030-5fb9250d2d99.png">

The progress bar grew with the percentage.
<img width="1871" alt="imagen" src="https://user-images.githubusercontent.com/87494173/197028586-a5ecb154-2cbc-40b7-ade5-c1f1a5459eac.png">

**After Fix:**
The percentage is always shown in the center.
<img width="1853" alt="imagen" src="https://user-images.githubusercontent.com/87494173/197029075-1231f65b-eb47-4ce7-8798-77adce48a18d.png">

The progress bar only grows until 100%.
<img width="1849" alt="imagen" src="https://user-images.githubusercontent.com/87494173/197029253-26e0d272-2f96-43fc-ac28-f12639408e31.png">



