### PR TITLE
Modernize tests extending RundeckHibernateSpec where possible.

### DIFF
--- a/rundeckapp/src/test/groovy/org/rundeck/app/components/RundeckJobDefinitionManagerSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/components/RundeckJobDefinitionManagerSpec.groovy
@@ -1,16 +1,18 @@
 package org.rundeck.app.components
 
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import org.rundeck.app.components.jobs.ImportedJob
 import rundeck.CommandExec
 import rundeck.ScheduledExecution
 import rundeck.Workflow
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
-class RundeckJobDefinitionManagerSpec extends RundeckHibernateSpec   {
+class RundeckJobDefinitionManagerSpec extends Specification implements DataTest   {
     RundeckJobDefinitionManager rundeckJobDefinitionManager = new RundeckJobDefinitionManager()
 
-    List<Class> getDomainClasses() { [Workflow, ScheduledExecution, CommandExec] }
+    void setupSpec() {
+        mockDomains Workflow, ScheduledExecution, CommandExec
+    }
 
 
     def "test decode format file with/without expandTokenInScriptFile field"(){
@@ -54,7 +56,7 @@ class RundeckJobDefinitionManagerSpec extends RundeckHibernateSpec   {
         writer.flush()
 
         then:
-        jobDefinition == writer.toString()
+        jobDefinition.replace("IDSUB",se.id.toString()) == writer.toString()
 
         where:
         format | jobDefinition
@@ -68,7 +70,7 @@ class RundeckJobDefinitionManagerSpec extends RundeckHibernateSpec   {
     <description>a job</description>
     <executionEnabled>true</executionEnabled>
     <group>some/where</group>
-    <id>1</id>
+    <id>IDSUB</id>
     <loglevel>WARN</loglevel>
     <name>blue</name>
     <nodeFilterEditable>false</nodeFilterEditable>
@@ -94,7 +96,7 @@ class RundeckJobDefinitionManagerSpec extends RundeckHibernateSpec   {
         return """- description: a job
   executionEnabled: true
   group: some/where
-  id: 2
+  id: IDSUB
   loglevel: WARN
   name: blue
   nodeFilterEditable: false

--- a/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormTokenDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormTokenDataProviderSpec.groovy
@@ -10,12 +10,12 @@ import rundeck.AuthToken
 import rundeck.User
 import rundeck.services.UserService
 import rundeck.services.data.AuthTokenDataService
+import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 import static org.rundeck.app.data.model.v1.AuthenticationToken.*
 
-class GormTokenDataProviderSpec extends RundeckHibernateSpec implements DataTest{
+class GormTokenDataProviderSpec extends Specification implements DataTest{
     GormTokenDataProvider provider = new GormTokenDataProvider()
 
     void setup() {

--- a/rundeckapp/src/test/groovy/rundeck/ExecReportSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecReportSpec.groovy
@@ -16,15 +16,15 @@
 
 package rundeck
 
-import grails.test.hibernate.HibernateSpec
-import testhelper.RundeckHibernateSpec
+import grails.testing.gorm.DataTest
+import spock.lang.Specification
 
 /**
  * Created by greg on 6/13/15.
  */
-class ExecReportSpec extends RundeckHibernateSpec {
+class ExecReportSpec extends Specification implements DataTest {
 
-    List<Class> getDomainClasses() { [Execution,Workflow,CommandExec,JobExec] }
+    def setupSpec() { mockDomains Execution,Workflow,CommandExec,JobExec }
 
     def "adhoc from execution"(){
         given:

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionService2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionService2Spec.groovy
@@ -28,24 +28,24 @@ import com.dtolabs.rundeck.core.jobs.JobOption
 
 import com.dtolabs.rundeck.core.utils.NodeSet
 import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import grails.web.mapping.LinkGenerator
 import groovy.mock.interceptor.MockFor
 import groovy.mock.interceptor.StubFor
 import org.grails.plugins.metricsweb.MetricService
-import org.rundeck.app.authorization.AppAuthContextEvaluator
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.springframework.context.MessageSource
 import rundeck.services.*
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 import static org.junit.Assert.*
 
 //import grails.test.GrailsMock
 
-class ExecutionService2Spec extends RundeckHibernateSpec implements ServiceUnitTest<ExecutionService> {
+class ExecutionService2Spec extends Specification implements ServiceUnitTest<ExecutionService>, DataTest {
 
-    List<Class> getDomainClasses() { [ScheduledExecution,Workflow,WorkflowStep,Execution,CommandExec,Option,User] }
+    def setupSpec() { mockDomains ScheduledExecution,Workflow,WorkflowStep,Execution,CommandExec,Option,User }
 
     def setup(){
         service.executionValidatorService = new ExecutionValidatorService()

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceTempSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceTempSpec.groovy
@@ -20,16 +20,16 @@ import com.dtolabs.rundeck.core.authorization.AuthContext
 
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.storage.keys.KeyStorageTree
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import rundeck.services.*
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 /**
  * Created by greg on 2/17/15.
  */
-class ExecutionServiceTempSpec extends RundeckHibernateSpec {
+class ExecutionServiceTempSpec extends Specification implements DataTest {
 
-    List<Class> getDomainClasses() { [Execution, ScheduledExecution, Workflow, CommandExec, Option, ExecReport, LogFileStorageRequest, ReferencedExecution] }
+    def setupSpec() { mockDomains Execution, ScheduledExecution, Workflow, CommandExec, Option, ExecReport, LogFileStorageRequest, ReferencedExecution }
 
     ExecutionService service
     def setup(){

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionSpec.groovy
@@ -16,16 +16,16 @@
 
 package rundeck
 
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.validation.ValidationException
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 /**
  * Created by greg on 9/27/16.
  */
-class ExecutionSpec extends RundeckHibernateSpec {
+class ExecutionSpec extends Specification implements DataTest {
 
-    List<Class> getDomainClasses() { [Execution, ScheduledExecution, Workflow, LogFileStorageRequest, Orchestrator] }
+    def setupSpec() { mockDomains Execution, ScheduledExecution, Workflow, LogFileStorageRequest, Orchestrator }
 
     def "with server uuid"() {
         given:

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionTest.groovy
@@ -16,9 +16,9 @@
 
 package rundeck
 
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import rundeck.services.ExecutionService
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 import static org.junit.Assert.*
 
@@ -30,9 +30,9 @@ import static org.junit.Assert.*
  * Time: 11:25 AM
  */
 
-class ExecutionTest extends RundeckHibernateSpec  {
+class ExecutionTest extends Specification implements DataTest  {
 
-    List<Class> getDomainClasses() { [Execution, Workflow, CommandExec]}
+    def setupSpec() { mockDomains Execution, Workflow, CommandExec }
 
     void "testValidateBasic"() {
         when:

--- a/rundeckapp/src/test/groovy/rundeck/GormEventStoreServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/GormEventStoreServiceSpec.groovy
@@ -3,18 +3,15 @@ package rundeck
 import com.dtolabs.rundeck.core.event.EventQueryType
 import com.fasterxml.jackson.databind.ObjectMapper
 import grails.gorm.transactions.Rollback
-import grails.test.hibernate.HibernateSpec
-import org.grails.orm.hibernate.HibernateDatastore
+import grails.testing.gorm.DataTest
 import rundeck.services.Evt
 import rundeck.services.EvtQuery
 import rundeck.services.FrameworkService
 import rundeck.services.GormEventStoreService
-import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
-import testhelper.RundeckHibernateSpec
 
-class GormEventStoreServiceSpec extends RundeckHibernateSpec {
+class GormEventStoreServiceSpec extends Specification implements DataTest {
     @Shared GormEventStoreService service
     @Shared FrameworkService framework
 
@@ -22,9 +19,8 @@ class GormEventStoreServiceSpec extends RundeckHibernateSpec {
         String event
     }
 
-    List<Class> getDomainClasses() { [StoredEvent] }
-
     def setupSpec() {
+        mockDomain StoredEvent
         framework = Mock(FrameworkService) {
             it.serverUUID >> '16b02806-f4b3-4628-9d9c-2dd2cc67d53c'
         }

--- a/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobExecSpec.groovy
@@ -16,16 +16,16 @@
 
 package rundeck
 
-import grails.test.hibernate.HibernateSpec
-import testhelper.RundeckHibernateSpec
+import grails.testing.gorm.DataTest
+import spock.lang.Specification
 
 /**
  * @author greg
  * @since 6/26/17
  */
-class JobExecSpec extends RundeckHibernateSpec {
+class JobExecSpec extends Specification implements DataTest {
 
-    List<Class> getDomainClasses() { [JobExec, ScheduledExecution, Workflow, CommandExec]}
+    def setupSpec() { mockDomains JobExec, ScheduledExecution, Workflow, CommandExec }
 
     def "to map with node filter"() {
         when:

--- a/rundeckapp/src/test/groovy/rundeck/JobFileRecordSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobFileRecordSpec.groovy
@@ -1,21 +1,15 @@
 package rundeck
 
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import rundeck.services.FileUploadService
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 /**
  * See the API for {@link grails.test.mixin.domain.DomainClassUnitTestMixin} for usage instructions
  */
-class JobFileRecordSpec extends RundeckHibernateSpec {
+class JobFileRecordSpec extends Specification implements DataTest {
 
-    List<Class> getDomainClasses() { [Execution, Workflow, CommandExec, JobFileRecord] }
-
-    def setup() {
-    }
-
-    def cleanup() {
-    }
+    def setupSpec() { mockDomains Execution, Workflow, CommandExec, JobFileRecord }
 
     def "invalid state changes"() {
         given:

--- a/rundeckapp/src/test/groovy/rundeck/ReportFilterTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ReportFilterTests.groovy
@@ -16,14 +16,8 @@
 
 package rundeck
 
-import grails.test.hibernate.HibernateSpec
-import org.grails.orm.hibernate.HibernateDatastore
-import org.junit.AfterClass
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
-import org.springframework.transaction.PlatformTransactionManager
-import testhelper.RundeckHibernateSpec
+import grails.testing.gorm.DataTest
+import spock.lang.Specification
 
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue
@@ -31,9 +25,9 @@ import static org.junit.Assert.assertTrue
 /**
  * See the API for {@link grails.test.mixin.support.GrailsUnitTestMixin} for usage instructions
  */
-class ReportFilterSpec extends RundeckHibernateSpec {
+class ReportFilterSpec extends Specification implements DataTest {
 
-    List<Class> getDomainClasses() { [ReportFilter] }
+    def setupSpec() { mockDomain ReportFilter }
 
     void "testValidation"() {
         when:

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionFilterTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionFilterTests.groovy
@@ -16,14 +16,14 @@
 
 package rundeck
 
-import grails.test.hibernate.HibernateSpec
-import testhelper.RundeckHibernateSpec
+import grails.testing.gorm.DataTest
+import spock.lang.Specification
 
 import static org.junit.Assert.*
 
-class ScheduledExecutionFilterTests extends RundeckHibernateSpec {
+class ScheduledExecutionFilterTests extends Specification implements DataTest {
 
-    List<Class> getDomainClasses() { [ScheduledExecutionFilter ]}
+    def setupSpec() { mockDomain ScheduledExecutionFilter }
 
     void "testValidation"() {
         when:

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionServiceSpec.groovy
@@ -7,6 +7,7 @@ import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import com.dtolabs.rundeck.core.common.NodeSetImpl
 import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException
 import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import groovy.mock.interceptor.MockFor
 import net.bytebuddy.implementation.bytecode.Throw
 
@@ -28,14 +29,11 @@ import net.bytebuddy.implementation.bytecode.Throw
 
 //import grails.test.GrailsUnitTestCase
 
-import org.junit.Test
-import org.rundeck.app.authorization.AppAuthContextEvaluator
 import org.rundeck.app.authorization.AppAuthContextProcessor
-import rundeck.controllers.ScheduledExecutionController
 import rundeck.services.FrameworkService
 import rundeck.services.JobLifecyclePluginService
 import rundeck.services.ScheduledExecutionService
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 import static org.junit.Assert.*
 
@@ -47,9 +45,9 @@ import static org.junit.Assert.*
 * $Id$
 */
 
-public class ScheduledExecutionServiceSpec extends RundeckHibernateSpec {
+public class ScheduledExecutionServiceSpec extends Specification implements DataTest {
 
-    List<Class> getDomainClasses() { [ScheduledExecution, Workflow,CommandExec]}
+    def setupSpec() { mockDomains ScheduledExecution, Workflow,CommandExec }
 
     void runBeforeSave(){
         when:

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionSpec.groovy
@@ -16,17 +16,16 @@
 
 package rundeck
 
-import grails.test.hibernate.HibernateSpec
-import org.eclipse.jetty.util.ajax.JSON
-import testhelper.RundeckHibernateSpec
+import grails.testing.gorm.DataTest
+import spock.lang.Specification
 import static org.junit.Assert.*
 
 /**
  * Created by greg on 10/21/15.
  */
-class ScheduledExecutionSpec extends RundeckHibernateSpec
+class ScheduledExecutionSpec extends Specification implements DataTest
 {
-    List<Class> getDomainClasses() { [ScheduledExecution, Workflow, CommandExec]}
+    def setupSpec() { mockDomains ScheduledExecution, Workflow, CommandExec}
     def "has nodes selected by default"() {
         given:
             def se = new ScheduledExecution(nodesSelectedByDefault: value)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
@@ -16,12 +16,9 @@
 
 package rundeck.controllers
 
-import com.dtolabs.rundeck.core.authorization.AuthContextProvider
-import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
-import org.rundeck.app.authorization.AppAuthContextEvaluator
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.core.auth.AuthConstants
 import rundeck.*
@@ -30,15 +27,15 @@ import rundeck.services.ConfigurationService
 import rundeck.services.FileUploadService
 import rundeck.services.FrameworkService
 import rundeck.services.optionvalues.OptionValuesService
+import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 /**
  * Created by greg on 2/11/16.
  */
-class EditOptsControllerSpec extends RundeckHibernateSpec implements ControllerUnitTest<EditOptsController>{
+class EditOptsControllerSpec extends Specification implements ControllerUnitTest<EditOptsController>, DataTest {
 
-    List<Class> getDomainClasses() { [Option, ScheduledExecution, CommandExec, Workflow] }
+    def setupSpec() { mockDomains Option, ScheduledExecution, CommandExec, Workflow }
 
     def setup() {
         mockCodec(URIComponentCodec)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionController2Spec.groovy
@@ -20,11 +20,9 @@ import com.dtolabs.rundeck.app.internal.logging.FSStreamingLogReader
 import com.dtolabs.rundeck.app.internal.logging.RundeckLogFormat
 import com.dtolabs.rundeck.app.support.ExecutionQuery
 import com.dtolabs.rundeck.core.execution.logstorage.ExecutionFileState
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import groovy.json.JsonSlurper
-import groovy.time.TimeCategory
-import org.hibernate.JDBCException
 import org.quartz.JobExecutionContext
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.app.authorization.domain.AppAuthorizer
@@ -36,7 +34,6 @@ import org.rundeck.core.auth.app.RundeckAccess
 import org.rundeck.core.auth.web.RdAuthorizeExecution
 import org.rundeck.core.auth.web.RdAuthorizeSystem
 import org.rundeck.core.auth.web.WebDefaultParameterNamesMapper
-import org.springframework.context.ApplicationContext
 import rundeck.CommandExec
 import rundeck.Execution
 import rundeck.ScheduledExecution
@@ -44,19 +41,18 @@ import rundeck.Workflow
 import rundeck.services.*
 import rundeck.services.logging.ExecutionLogReader
 import rundeck.services.logging.WorkflowStateFileLoader
+import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 import javax.security.auth.Subject
 import java.lang.annotation.Annotation
-import java.sql.Time
 
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
 
-class ExecutionController2Spec extends RundeckHibernateSpec implements ControllerUnitTest<ExecutionController>  {
+class ExecutionController2Spec extends Specification implements ControllerUnitTest<ExecutionController>, DataTest  {
 
-    List<Class> getDomainClasses() { [Workflow,ScheduledExecution,Execution,CommandExec]}
+    def setupSpec() { mockDomains Workflow,ScheduledExecution,Execution,CommandExec }
 
     public static <T extends Annotation> T getMethodAnnotation(Object instance, String name, Class<T> clazz) {
         instance.getClass().getDeclaredMethods().find { it.name == name }.getAnnotation(clazz)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -31,7 +31,7 @@ import com.dtolabs.rundeck.core.logging.LogEvent
 import com.dtolabs.rundeck.core.logging.LogLevel
 import com.dtolabs.rundeck.core.logging.LogUtil
 import com.dtolabs.rundeck.core.logging.StreamingLogReader
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import groovy.xml.MarkupBuilder
 import org.grails.plugins.codecs.JSONCodec
@@ -55,8 +55,8 @@ import rundeck.codecs.HTMLElementCodec
 import rundeck.services.*
 import rundeck.services.logging.ExecutionLogReader
 import rundeck.services.logging.WorkflowStateFileLoader
+import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 import javax.security.auth.Subject
 import javax.servlet.http.HttpServletResponse
@@ -65,9 +65,9 @@ import java.text.SimpleDateFormat
 /**
  * Created by greg on 1/6/16.
  */
-class ExecutionControllerSpec extends RundeckHibernateSpec implements ControllerUnitTest<ExecutionController> {
+class ExecutionControllerSpec extends Specification implements ControllerUnitTest<ExecutionController>, DataTest {
 
-    List<Class> getDomainClasses() { [Execution] }
+    def setupSpec() { mockDomain Execution }
 
     def setup() {
         mockCodec(AnsiColorCodec)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkController2Spec.groovy
@@ -27,18 +27,17 @@ import com.dtolabs.rundeck.core.plugins.configuration.Description
 import com.dtolabs.rundeck.core.plugins.configuration.Property
 import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import groovy.mock.interceptor.MockFor
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
-import org.rundeck.app.authorization.AppAuthContextEvaluator
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.core.auth.AuthConstants
 import rundeck.*
 import rundeck.services.*
 import rundeck.services.feature.FeatureService
+import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 import static org.junit.Assert.*
 
@@ -48,9 +47,9 @@ import static org.junit.Assert.*
  * Date: 1/30/14
  * Time: 5:19 PM
  */
-class FrameworkController2Spec extends RundeckHibernateSpec implements ControllerUnitTest<FrameworkController> {
+class FrameworkController2Spec extends Specification implements ControllerUnitTest<FrameworkController>, DataTest {
 
-    List<Class> getDomainClasses() { [ScheduledExecution, Workflow, WorkflowStep, CommandExec, Execution, Project]}
+    def setupSpec() { mockDomains ScheduledExecution, Workflow, WorkflowStep, CommandExec, Execution, Project}
 
     /**
      * utility method to mock a class

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -33,7 +33,7 @@ import com.dtolabs.rundeck.core.resources.WriteableModelSource
 import com.dtolabs.rundeck.core.resources.format.ResourceFormatGeneratorService
 import com.dtolabs.rundeck.core.resources.format.ResourceXMLFormatGenerator
 import com.dtolabs.rundeck.core.resources.format.json.ResourceJsonFormatGenerator
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import org.grails.plugins.metricsweb.MetricService
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
@@ -48,20 +48,19 @@ import rundeck.NodeFilter
 import rundeck.Project
 import rundeck.User
 import rundeck.UtilityTagLib
-import rundeck.codecs.URIComponentCodec
 import rundeck.services.*
 import rundeck.services.feature.FeatureService
+import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 import static org.rundeck.core.auth.AuthConstants.*
 
 /**
  * Created by greg on 7/28/15.
  */
-class FrameworkControllerSpec extends RundeckHibernateSpec implements ControllerUnitTest<FrameworkController> {
+class FrameworkControllerSpec extends Specification implements ControllerUnitTest<FrameworkController>, DataTest {
 
-    List<Class> getDomainClasses() { [NodeFilter, User] }
+    def setupSpec() { mockDomains NodeFilter, User }
 
     def setup() {
         grailsApplication.config.clear()

--- a/rundeckapp/src/test/groovy/rundeck/controllers/OptionsUtilsTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/OptionsUtilsTests.groovy
@@ -17,7 +17,7 @@
 package rundeck.controllers
 
 
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import grails.web.servlet.mvc.GrailsHttpSession
 import groovy.mock.interceptor.MockFor
@@ -25,14 +25,14 @@ import rundeck.*
 import rundeck.codecs.URIComponentCodec
 import rundeck.services.FrameworkService
 import rundeck.utils.OptionsUtil
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
 
-class OptionsUtilsTests extends RundeckHibernateSpec implements ControllerUnitTest<ScheduledExecutionController>{
+class OptionsUtilsTests extends Specification implements ControllerUnitTest<ScheduledExecutionController>, DataTest {
 
-    List<Class> getDomainClasses() { [ScheduledExecution,Option,Workflow,CommandExec,Execution,JobExec, ReferencedExecution, ScheduledExecutionStats, FrameworkService, User] }
+    def setupSpec() { mockDomains ScheduledExecution,Option,Workflow,CommandExec,Execution,JobExec, ReferencedExecution, ScheduledExecutionStats, User }
     /**
      * utility method to mock a class
      */

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectController2Spec.groovy
@@ -21,7 +21,7 @@ import com.dtolabs.rundeck.app.api.ApiVersions
 import com.dtolabs.rundeck.app.support.ProjectArchiveParams
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.IRundeckProject
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import groovy.mock.interceptor.MockFor
 import groovy.mock.interceptor.StubFor
@@ -45,8 +45,8 @@ import rundeck.services.ApiService
 import rundeck.services.ExecutionService
 import rundeck.services.FrameworkService
 import rundeck.services.ProjectService
+import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 import javax.security.auth.Subject
 import javax.servlet.http.HttpServletRequest
@@ -55,9 +55,9 @@ import java.lang.annotation.Annotation
 
 import static org.junit.Assert.*
 
-class ProjectController2Spec extends RundeckHibernateSpec implements ControllerUnitTest<ProjectController> {
+class ProjectController2Spec extends Specification implements ControllerUnitTest<ProjectController>, DataTest {
 
-    List<Class> getDomainClasses() { [Project] }
+    def setupSpec() { mockDomain Project }
 
     def setup(){
         controller.apiService = Mock(ApiService)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectControllerSpec.groovy
@@ -23,7 +23,7 @@ import com.dtolabs.rundeck.core.authorization.RuleSetValidation
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.IRundeckProject
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import groovy.xml.MarkupBuilder
 import org.grails.plugins.testing.GrailsMockMultipartFile
@@ -49,8 +49,8 @@ import rundeck.services.FrameworkService
 import rundeck.services.ImportResponse
 import rundeck.services.ProgressSummary
 import rundeck.services.ProjectService
+import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 import webhooks.component.project.WebhooksProjectComponent
 import webhooks.exporter.WebhooksProjectExporter
 import webhooks.importer.WebhooksProjectImporter
@@ -66,7 +66,7 @@ import static org.rundeck.core.auth.AuthConstants.ACTION_UPDATE
 /**
  * Created by greg on 2/26/15.
  */
-class ProjectControllerSpec extends RundeckHibernateSpec implements ControllerUnitTest<ProjectController> {
+class ProjectControllerSpec extends Specification implements ControllerUnitTest<ProjectController>, DataTest {
 
     def setup(){
         session.subject = new Subject()

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScmControllerSpec.groovy
@@ -22,13 +22,11 @@ import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.plugins.views.BasicInputView
 import com.dtolabs.rundeck.plugins.scm.ImportSynchState
 import com.dtolabs.rundeck.plugins.scm.JobImportState
-import com.dtolabs.rundeck.plugins.scm.JobState
 import com.dtolabs.rundeck.plugins.scm.JobStateImpl
-import com.dtolabs.rundeck.plugins.scm.ScmExportSynchState
 import com.dtolabs.rundeck.plugins.scm.ScmImportTrackedItem
 import com.dtolabs.rundeck.plugins.scm.ScmImportTrackedItemBuilder
 import com.dtolabs.rundeck.plugins.scm.SynchState
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 import org.rundeck.app.authorization.AppAuthContextProcessor
@@ -39,15 +37,15 @@ import rundeck.Workflow
 import rundeck.services.ApiService
 import rundeck.services.FrameworkService
 import rundeck.services.ScmService
+import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 /**
  * See the API for {@link grails.test.mixin.web.ControllerUnitTestMixin} for usage instructions
  */
-class ScmControllerSpec extends RundeckHibernateSpec implements ControllerUnitTest<ScmController>{
+class ScmControllerSpec extends Specification implements ControllerUnitTest<ScmController>, DataTest {
 
-    List<Class> getDomainClasses() { [ScheduledExecution, Workflow, CommandExec] }
+    def setupSpec() { mockDomains ScheduledExecution, Workflow, CommandExec }
 
     protected setupFormTokens(session) {
         def token = SynchronizerTokensHolder.store(session)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/WorkflowController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/WorkflowController2Spec.groovy
@@ -20,17 +20,18 @@ import com.dtolabs.rundeck.core.authorization.AuthContextProvider
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import rundeck.*
 import rundeck.services.FrameworkService
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 import static org.junit.Assert.*
 
-class WorkflowController2Spec extends RundeckHibernateSpec implements ControllerUnitTest<WorkflowController> {
+class WorkflowController2Spec extends Specification implements ControllerUnitTest<WorkflowController>, DataTest {
 
-    List<Class> getDomainClasses() { [Workflow, WorkflowStep, JobExec, CommandExec, PluginStep] }
+    def setupSpec() { mockDomains Workflow, WorkflowStep, JobExec, CommandExec, PluginStep }
 
     public void testWFEditActionsInsertJob() {
         WorkflowController ctrl = controller

--- a/rundeckapp/src/test/groovy/rundeck/controllers/WorkflowControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/WorkflowControllerSpec.groovy
@@ -18,6 +18,7 @@ package rundeck.controllers
 
 import com.dtolabs.rundeck.core.authorization.AuthContextProcessor
 import com.dtolabs.rundeck.core.authorization.AuthContextProvider
+import grails.testing.gorm.DataTest
 import org.grails.plugins.codecs.URLCodec
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 import org.rundeck.app.authorization.AppAuthContextEvaluator
@@ -31,18 +32,16 @@ import com.dtolabs.rundeck.core.plugins.DescribedPlugin
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
-import grails.test.hibernate.HibernateSpec
 import grails.testing.web.controllers.ControllerUnitTest
 import rundeck.CommandExec
 import rundeck.JobExec
 import rundeck.ScheduledExecution
 import rundeck.Workflow
-import rundeck.codecs.URIComponentCodec
 import rundeck.services.ConfigurationService
 import rundeck.services.FrameworkService
 import rundeck.services.PluginService
+import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertNull
@@ -50,9 +49,9 @@ import static org.junit.Assert.assertNull
 /**
  * Created by greg on 2/16/16.
  */
-class WorkflowControllerSpec extends RundeckHibernateSpec implements ControllerUnitTest<WorkflowController> {
+class WorkflowControllerSpec extends Specification implements ControllerUnitTest<WorkflowController>, DataTest {
 
-    List<Class> getDomainClasses() { [Workflow, CommandExec, JobExec, ScheduledExecution, PluginStep]}
+    def setupSpec() { mockDomains Workflow, CommandExec, JobExec, ScheduledExecution, PluginStep }
 
     def setup() {
         grailsApplication.config.clear()

--- a/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
@@ -22,12 +22,8 @@ import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.core.execution.WorkflowExecutionServiceThread
 import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext
-import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionItem
-import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionService
-import com.dtolabs.rundeck.core.jobs.ExecutionLifecyclePluginHandler
-import com.dtolabs.rundeck.core.logging.LoggingManager
 import com.dtolabs.rundeck.core.schedule.JobScheduleManager
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import org.quartz.*
 import rundeck.*
 import rundeck.services.ExecutionService
@@ -35,7 +31,7 @@ import rundeck.services.ExecutionUtilService
 import rundeck.services.FrameworkService
 import rundeck.services.JobSchedulerService
 import rundeck.services.JobSchedulesService
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 import java.sql.Timestamp
 import java.util.concurrent.CountDownLatch
@@ -43,9 +39,9 @@ import java.util.concurrent.CountDownLatch
 /**
  * Created by greg on 4/12/16.
  */
-class ExecutionJobSpec extends RundeckHibernateSpec {
+class ExecutionJobSpec extends Specification implements DataTest {
 
-    List<Class> getDomainClasses() { [ScheduledExecution, Workflow, CommandExec, Execution,ScheduledExecutionStats] }
+    def setupSpec() { mockDomains ScheduledExecution, Workflow, CommandExec, Execution,ScheduledExecutionStats }
 
     def "execute missing job"() {
         given:
@@ -785,8 +781,8 @@ class ExecutionJobSpec extends RundeckHibernateSpec {
         se.save(flush:true)
         Execution e = new Execution(
                 scheduledExecution: se,
-                dateStarted: new Date(),
-                dateCompleted: new Date(),
+                dateStarted: new Timestamp(new Date().time),
+                dateCompleted: new Timestamp(new Date().time),
                 project: se.project,
                 user: 'bob',
                 workflow: new Workflow(commands: [new CommandExec(

--- a/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
@@ -20,37 +20,22 @@ import com.dtolabs.rundeck.app.api.ApiVersions
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.authorization.Validation
 import grails.converters.JSON
-import grails.test.hibernate.HibernateSpec
-import grails.test.mixin.Mock
-import grails.test.mixin.TestFor
-import grails.test.mixin.TestMixin
-import grails.test.mixin.web.ControllerUnitTestMixin
 import grails.testing.gorm.DataTest
-import grails.testing.services.ServiceUnitTest
 import grails.testing.web.controllers.ControllerUnitTest
 import grails.web.JSONBuilder
-import groovy.util.slurpersupport.GPathResult
 import groovy.xml.MarkupBuilder
 import org.grails.plugins.codecs.JSONCodec
 import org.rundeck.app.authorization.AppAuthContextEvaluator
 import org.rundeck.app.data.providers.GormTokenDataProvider
-import org.rundeck.app.data.providers.v1.TokenDataProvider
 import org.rundeck.app.web.WebUtilService
 import org.rundeck.core.auth.AuthConstants
 import org.rundeck.spi.data.DataManager
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.context.MessageSource
 import rundeck.AuthToken
-import rundeck.CommandExec
-import rundeck.Option
-import rundeck.ScheduledExecution
 import rundeck.User
-import rundeck.Workflow
 import rundeck.controllers.ApiController
 import rundeck.services.data.AuthTokenDataService
 import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 import java.time.Clock
 import java.time.Instant
@@ -59,9 +44,7 @@ import java.time.ZoneId
 /**
  * Created by greg on 7/28/15.
  */
-class ApiServiceSpec extends RundeckHibernateSpec implements ControllerUnitTest<ApiController>, DataTest {
-
-    List<Class> getDomainClasses() { [User, AuthToken] }
+class ApiServiceSpec extends Specification implements ControllerUnitTest<ApiController>, DataTest {
 
     ApiService service
     GormTokenDataProvider provider = new GormTokenDataProvider()

--- a/rundeckapp/src/test/groovy/rundeck/services/ConfigStorageServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ConfigStorageServiceSpec.groovy
@@ -16,32 +16,16 @@
 
 package rundeck.services
 
-import com.dtolabs.rundeck.core.storage.ResourceMeta
-import com.dtolabs.rundeck.core.storage.StorageManager
-import com.dtolabs.rundeck.core.storage.StorageTree
 import com.dtolabs.rundeck.core.storage.TreeStorageManager
-import grails.test.hibernate.HibernateSpec
-import grails.test.mixin.TestFor
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
-import org.rundeck.storage.api.PathUtil
-import org.rundeck.storage.api.Resource
-import org.rundeck.storage.api.StorageException
 import spock.lang.Specification
-import testhelper.RundeckHibernateSpec
-
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * See the API for {@link grails.test.mixin.services.ServiceUnitTestMixin} for usage instructions
  */
 
-class ConfigStorageServiceSpec extends RundeckHibernateSpec implements ServiceUnitTest<ConfigStorageService> {
-
-    def setup() {
-    }
-
-    def cleanup() {
-    }
+class ConfigStorageServiceSpec extends Specification implements ServiceUnitTest<ConfigStorageService>, DataTest {
 
     def "has fix indicator"() {
         given:

--- a/rundeckapp/src/test/groovy/rundeck/services/DbStorageServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/DbStorageServiceTests.groovy
@@ -17,17 +17,17 @@
 package rundeck.services
 
 import com.dtolabs.rundeck.core.storage.StorageUtil
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import org.rundeck.storage.api.StorageException
 import rundeck.Storage
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 import static org.junit.Assert.*
 
-class DbStorageServiceTests extends RundeckHibernateSpec implements ServiceUnitTest<DbStorageService> {
+class DbStorageServiceTests extends Specification implements ServiceUnitTest<DbStorageService>, DataTest {
 
-    List<Class> getDomainClasses() { [Storage] }
+    def setupSpec() { mockDomain Storage }
 
     void testHasResource() {
         when:

--- a/rundeckapp/src/test/groovy/rundeck/services/ExecutionServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ExecutionServiceTests.groovy
@@ -18,6 +18,7 @@ package rundeck.services
 
 import com.dtolabs.rundeck.app.support.ExecutionQuery
 import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import groovy.mock.interceptor.MockFor
 
 //import grails.test.GrailsUnitTestCase
@@ -27,7 +28,7 @@ import rundeck.CommandExec
 import rundeck.Execution
 import rundeck.ScheduledExecution
 import rundeck.Workflow
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 /**
  * $INTERFACE is ...
@@ -35,9 +36,9 @@ import testhelper.RundeckHibernateSpec
  * Date: 8/7/13
  * Time: 3:07 PM
  */
-class ExecutionServiceTests extends RundeckHibernateSpec {
+class ExecutionServiceTests extends Specification implements DataTest {
 
-    List<Class> getDomainClasses() { [ScheduledExecution, Workflow, CommandExec]}
+    def setupSpec() { mockDomains ScheduledExecution, Workflow, CommandExec }
 
     private getAppCtxtMock(){
         def mockAppCtxt = new MockFor(ApplicationContext)

--- a/rundeckapp/src/test/groovy/rundeck/services/ExecutionUtilServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ExecutionUtilServiceSpec.groovy
@@ -6,7 +6,7 @@ import com.dtolabs.rundeck.core.execution.workflow.ControlBehavior
 import com.dtolabs.rundeck.core.execution.workflow.WFSharedContext
 import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionResult
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutionResult
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import org.grails.plugins.metricsweb.MetricService
 import rundeck.CommandExec
@@ -14,12 +14,12 @@ import rundeck.Execution
 import rundeck.ScheduledExecution
 import rundeck.Workflow
 import rundeck.services.logging.ExecutionLogWriter
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 import static org.junit.Assert.assertNotNull
 
-class ExecutionUtilServiceSpec extends RundeckHibernateSpec implements ServiceUnitTest<ExecutionUtilService> {
-    List<Class> getDomainClasses() { [Execution, ScheduledExecution, Workflow, CommandExec] }
+class ExecutionUtilServiceSpec extends Specification implements ServiceUnitTest<ExecutionUtilService>, DataTest {
+    def setupSpec() { mockDomains Execution, ScheduledExecution, Workflow, CommandExec }
 
     def testfinishExecutionMetricsSuccess() {
         given:

--- a/rundeckapp/src/test/groovy/rundeck/services/ExecutionUtilServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ExecutionUtilServiceTests.groovy
@@ -30,25 +30,22 @@ import com.dtolabs.rundeck.core.execution.workflow.steps.node.impl.ScriptURLComm
 import com.dtolabs.rundeck.core.utils.ThreadBoundOutputStream
 import com.dtolabs.rundeck.execution.JobExecutionItem
 import com.dtolabs.rundeck.execution.JobRefCommand
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
-import groovy.mock.interceptor.MockFor
-import org.grails.plugins.metricsweb.MetricService
 import rundeck.CommandExec
 import rundeck.JobExec
 import rundeck.Workflow
 import rundeck.Execution
-import rundeck.services.logging.ExecutionLogWriter
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 import static org.junit.Assert.*
 
 /**
  * See the API for {@link grails.test.mixin.services.ServiceUnitTestMixin} for usage instructions
  */
-class ExecutionUtilServiceTests extends RundeckHibernateSpec implements ServiceUnitTest<ExecutionUtilService>{
+class ExecutionUtilServiceTests extends Specification implements ServiceUnitTest<ExecutionUtilService>, DataTest{
 
-    List<Class> getDomainClasses() { [Execution, CommandExec, JobExec, Workflow] }
+    def setupSpec() { mockDomains Execution, CommandExec, JobExec, Workflow }
 
 
     void testItemForWFCmdItem_command(){

--- a/rundeckapp/src/test/groovy/rundeck/services/FileUploadServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/FileUploadServiceSpec.groovy
@@ -10,9 +10,7 @@ import com.dtolabs.rundeck.core.plugins.configuration.Validator
 import com.dtolabs.rundeck.plugins.file.FileUploadPlugin
 import com.dtolabs.rundeck.core.plugins.ConfiguredPlugin
 import com.dtolabs.rundeck.server.plugins.RundeckPluginRegistry
-import grails.test.hibernate.HibernateSpec
-import grails.test.mixin.Mock
-import grails.test.mixin.TestFor
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import rundeck.CommandExec
 import rundeck.Execution
@@ -24,20 +22,14 @@ import rundeck.services.events.ExecutionCompleteEvent
 import rundeck.services.feature.FeatureService
 import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 /**
  * See the API for {@link grails.test.mixin.services.ServiceUnitTestMixin} for usage instructions
  */
 
-class FileUploadServiceSpec extends RundeckHibernateSpec implements ServiceUnitTest<FileUploadService> {
+class FileUploadServiceSpec extends Specification implements ServiceUnitTest<FileUploadService>, DataTest {
 
-    List<Class> getDomainClasses() { [JobFileRecord, Execution, ScheduledExecution, Workflow, Option, CommandExec] }
-    def setup() {
-    }
-
-    def cleanup() {
-    }
+    def setupSpec() { mockDomains JobFileRecord, Execution, ScheduledExecution, Workflow, Option, CommandExec }
 
     void "create record"() {
         given:

--- a/rundeckapp/src/test/groovy/rundeck/services/JobStateServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/JobStateServiceSpec.groovy
@@ -25,7 +25,7 @@ import com.dtolabs.rundeck.core.dispatcher.ExecutionState
 import com.dtolabs.rundeck.core.execution.ExecutionReference
 import com.dtolabs.rundeck.core.jobs.JobNotFound
 import com.dtolabs.rundeck.core.jobs.JobReference
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import org.rundeck.app.authorization.AppAuthContextEvaluator
 import org.rundeck.core.auth.AuthConstants
@@ -33,16 +33,16 @@ import rundeck.CommandExec
 import rundeck.Execution
 import rundeck.ScheduledExecution
 import rundeck.Workflow
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 import static org.junit.Assert.assertNotNull
 
 /**
  * See the API for {@link grails.test.mixin.services.ServiceUnitTestMixin} for usage instructions
  */
-class JobStateServiceSpec extends RundeckHibernateSpec implements ServiceUnitTest<JobStateService> {
+class JobStateServiceSpec extends Specification implements ServiceUnitTest<JobStateService>, DataTest {
 
-    List<Class> getDomainClasses() { [Execution,ScheduledExecution,Workflow,CommandExec] }
+    def setupSpec() { mockDomains Execution,ScheduledExecution,Workflow,CommandExec }
 
     def setup() {
 
@@ -65,8 +65,6 @@ class JobStateServiceSpec extends RundeckHibernateSpec implements ServiceUnitTes
 
     }
 
-    def cleanup() {
-    }
     void "job ref not found by uuid"() {
         def jobName = 'abc'
         def groupPath = null

--- a/rundeckapp/src/test/groovy/rundeck/services/LocalJobSchedulesManagerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/LocalJobSchedulesManagerSpec.groovy
@@ -1,19 +1,19 @@
 package rundeck.services
 
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import org.quartz.Scheduler
 import rundeck.CommandExec
 import rundeck.ScheduledExecution
 import rundeck.Workflow
+import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 /**
  * Created by ronaveva on 2/17/20.
  */
-class LocalJobSchedulesManagerSpec extends RundeckHibernateSpec {
+class LocalJobSchedulesManagerSpec extends Specification implements DataTest {
 
-    List<Class> getDomainClasses() { [ScheduledExecution, CommandExec] }
+    def setupSpec() { mockDomains ScheduledExecution, CommandExec }
 
     public static final String TEST_UUID2 = '490966E0-2E2F-4505-823F-E2665ADC66FB'
 

--- a/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
@@ -25,9 +25,7 @@ import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolver
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
 import com.dtolabs.rundeck.plugins.logging.ExecutionFileStoragePlugin
 import com.dtolabs.rundeck.core.plugins.ConfiguredPlugin
-import grails.test.hibernate.HibernateSpec
-import grails.test.mixin.Mock
-import grails.test.mixin.TestFor
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import org.rundeck.app.services.ExecutionFile
 import org.rundeck.app.services.ExecutionFileProducer
@@ -39,7 +37,6 @@ import rundeck.LogFileStorageRequest
 import rundeck.ScheduledExecution
 import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -56,18 +53,14 @@ import static com.dtolabs.rundeck.core.execution.logstorage.ExecutionFileState.W
 /**
  * Created by greg on 3/28/16.
  */
-class LogFileStorageServiceSpec extends RundeckHibernateSpec implements ServiceUnitTest<LogFileStorageService> {
+class LogFileStorageServiceSpec extends Specification implements ServiceUnitTest<LogFileStorageService>, DataTest {
     File tempDir
 
-    List<Class> getDomainClasses() { [LogFileStorageRequest, Execution] }
+    def setupSpec() { mockDomains LogFileStorageRequest, Execution }
 
     def setup() {
         tempDir = Files.createTempDirectory("LogFileStorageServiceSpec").toFile()
-    }
-
-    def cleanup() {
-
-
+        tempDir.deleteOnExit()
     }
 
     def "resume incomplete delayed"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/LoggingServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/LoggingServiceTests.groovy
@@ -18,9 +18,10 @@ package rundeck.services
 
 import com.dtolabs.rundeck.core.utils.ThreadBoundLogOutputStream
 import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import groovy.mock.interceptor.MockFor
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 import static org.junit.Assert.*
 
@@ -49,9 +50,9 @@ import rundeck.services.logging.NodeCountingLogWriter
 import rundeck.services.logging.StepLabellingStreamingLogWriter
 import rundeck.services.logging.ThresholdLogWriter
 
-class LoggingServiceTests  extends RundeckHibernateSpec implements ServiceUnitTest<LoggingService> {
+class LoggingServiceTests  extends Specification implements ServiceUnitTest<LoggingService>, DataTest {
 
-    List<Class> getDomainClasses() { [Execution, LogFileStorageService, Workflow, CommandExec] }
+    def setupSpec() { mockDomains Execution, Workflow, CommandExec }
 
     //TODO: cleanup test code
 

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -40,6 +40,7 @@ import grails.plugins.mail.MailService
 import grails.test.hibernate.HibernateSpec
 import grails.test.mixin.Mock
 import grails.test.mixin.TestFor
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import grails.testing.web.GrailsWebUnitTest
 import grails.util.Holders
@@ -57,17 +58,15 @@ import rundeck.User
 import rundeck.Workflow
 import rundeck.services.logging.ExecutionLogReader
 import com.dtolabs.rundeck.core.execution.logstorage.ExecutionFileState
-import rundeck.services.logging.WorkflowStateFileLoader
 import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 /**
  * Created by greg on 7/12/16.
  */
-class NotificationServiceSpec extends RundeckHibernateSpec implements ServiceUnitTest<NotificationService>, GrailsWebUnitTest {
+class NotificationServiceSpec extends Specification implements ServiceUnitTest<NotificationService>, GrailsWebUnitTest, DataTest {
 
-    List<Class> getDomainClasses() { [Execution, ScheduledExecution, Notification, Workflow, CommandExec, User, ScheduledExecutionStats] }
+    def setupSpec() { mockDomains Execution, ScheduledExecution, Notification, Workflow, CommandExec, User, ScheduledExecutionStats }
 
 
     private List createTestJob() {

--- a/rundeckapp/src/test/groovy/rundeck/services/PluginConfigServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/PluginConfigServiceSpec.groovy
@@ -17,14 +17,12 @@
 package rundeck.services
 
 import com.dtolabs.rundeck.core.common.IRundeckProject
-import grails.test.hibernate.HibernateSpec
-import grails.test.mixin.TestFor
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import rundeck.services.scm.ScmPluginConfig
 import spock.lang.Specification
-import testhelper.RundeckHibernateSpec
 
-class PluginConfigServiceSpec extends RundeckHibernateSpec implements ServiceUnitTest<PluginConfigService> {
+class PluginConfigServiceSpec extends Specification implements ServiceUnitTest<PluginConfigService>, DataTest {
 
 
     def "loadScmConfig dne"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
@@ -16,33 +16,27 @@
 
 package rundeck.services
 
-import com.dtolabs.rundeck.core.authorization.Authorization
-import com.dtolabs.rundeck.core.authorization.LoggingAuthorization
-import com.dtolabs.rundeck.core.authorization.RuleEvaluator
 import com.dtolabs.rundeck.core.common.Framework
-import com.dtolabs.rundeck.core.common.IRundeckProject
-import com.dtolabs.rundeck.core.common.ProjectManager
 import com.dtolabs.rundeck.core.storage.ResourceMeta
 import com.dtolabs.rundeck.core.storage.StorageTree
 import com.dtolabs.rundeck.core.storage.StorageUtil
 import com.dtolabs.rundeck.core.utils.PropertyLookup
 import com.google.common.cache.LoadingCache
 import grails.events.bus.EventBus
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
-import org.apache.commons.fileupload.util.Streams
 import org.rundeck.app.grails.events.AppEvents
 import org.rundeck.storage.api.PathUtil
 import org.rundeck.storage.api.Resource
 import org.rundeck.storage.api.StorageException
 import org.rundeck.storage.data.DataUtil
 import rundeck.Project
+import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
-class ProjectManagerServiceSpec extends RundeckHibernateSpec implements ServiceUnitTest<ProjectManagerService> {
+class ProjectManagerServiceSpec extends Specification implements ServiceUnitTest<ProjectManagerService>, DataTest {
 
-    List<Class> getDomainClasses() { [Project] }
+    def setupSpec() { mockDomains Project }
 
     def setup() {
     }

--- a/rundeckapp/src/test/groovy/rundeck/services/ReportServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ReportServiceSpec.groovy
@@ -19,13 +19,10 @@ package rundeck.services
 import com.dtolabs.rundeck.app.support.ExecQuery
 import com.dtolabs.rundeck.core.authorization.Attribute
 import com.dtolabs.rundeck.core.authorization.AuthContext
-import com.dtolabs.rundeck.core.authorization.AuthContextEvaluator
 import com.dtolabs.rundeck.core.authorization.Decision
 import com.dtolabs.rundeck.core.authorization.Explanation
 import grails.gorm.DetachedCriteria
-import grails.test.hibernate.HibernateSpec
-import grails.test.mixin.Mock
-import grails.test.mixin.TestFor
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import org.grails.datastore.mapping.query.Query
 import org.rundeck.app.authorization.AppAuthContextEvaluator
@@ -37,15 +34,16 @@ import rundeck.ReferencedExecution
 import rundeck.ScheduledExecution
 import rundeck.Workflow
 import spock.lang.Specification
-import testhelper.RundeckHibernateSpec
 
 import javax.security.auth.Subject
 import javax.sql.DataSource
 import java.sql.Connection
 import java.sql.DatabaseMetaData
 
-class ReportServiceSpec extends RundeckHibernateSpec implements ServiceUnitTest<ReportService> {
-    List<Class> getDomainClasses() { [ScheduledExecution, ReferencedExecution, CommandExec, ExecReport] }
+class ReportServiceSpec extends Specification implements ServiceUnitTest<ReportService>, DataTest {
+    void setupSpec() {
+        mockDomains ScheduledExecution, ReferencedExecution, CommandExec, ExecReport
+    }
 
     def "executions history authorizations"(){
         given:

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExServiceSpec.groovy
@@ -18,24 +18,17 @@
 
 package rundeck.services
 
-import com.dtolabs.rundeck.core.authorization.AuthContextProvider
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import groovy.mock.interceptor.MockFor
 import groovy.mock.interceptor.StubFor
-import org.junit.Ignore
 import org.rundeck.app.authorization.AppAuthContextProcessor
-import org.springframework.context.ApplicationContext
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 import static org.junit.Assert.*
 
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.IRundeckProject
-import grails.test.mixin.TestMixin
 import grails.test.runtime.DirtiesRuntime
-import grails.test.mixin.Mock
-import grails.test.mixin.TestFor
-import grails.test.mixin.web.ControllerUnitTestMixin;
 
 import org.junit.Assert
 import org.quartz.*
@@ -44,7 +37,6 @@ import org.quartz.spi.JobFactory
 import org.springframework.context.MessageSource
 
 import rundeck.*
-import rundeck.controllers.ScheduledExecutionController
 
 /*
  * rundeck.ScheduledExecutionServiceTests.java
@@ -53,9 +45,9 @@ import rundeck.controllers.ScheduledExecutionController
  * Created: 6/22/11 5:55 PM
  *
  */
-class ScheduledExServiceSpec extends RundeckHibernateSpec {
+class ScheduledExServiceSpec extends Specification implements DataTest {
 
-    List<Class> getDomainClasses() { [Execution, FrameworkService, WorkflowStep, CommandExec, JobExec, PluginStep, Workflow, ScheduledExecution, Option, Notification]}
+    def setupSpec() { mockDomains Execution, WorkflowStep, CommandExec, JobExec, PluginStep, Workflow, ScheduledExecution, Option, Notification }
 
 
     /**

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -25,7 +25,7 @@ import com.dtolabs.rundeck.core.schedule.SchedulesManager
 import com.dtolabs.rundeck.core.plugins.configuration.Validator
 import com.dtolabs.rundeck.core.utils.PropertyLookup
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import groovy.transform.CompileStatic
 import org.grails.spring.beans.factory.InstanceFactoryBean
@@ -50,7 +50,7 @@ import rundeck.Orchestrator
 import org.slf4j.Logger
 import rundeck.ScheduledExecutionStats
 import rundeck.User
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
 import static org.junit.Assert.*
 
@@ -86,12 +86,12 @@ import spock.lang.Unroll
 /**
  * Created by greg on 6/24/15.
  */
-class ScheduledExecutionServiceSpec extends RundeckHibernateSpec implements ServiceUnitTest<ScheduledExecutionService> {
+class ScheduledExecutionServiceSpec extends Specification implements ServiceUnitTest<ScheduledExecutionService>, DataTest {
 
     public static final String TEST_UUID1 = 'BB27B7BB-4F13-44B7-B64B-D2435E2DD8C7'
 
-    List<Class> getDomainClasses() { [Workflow, ScheduledExecution, CommandExec, Notification, Option, PluginStep, JobExec,
-                                      WorkflowStep, Execution, ReferencedExecution, ScheduledExecutionStats, Orchestrator, User] }
+    def setupSpec() { mockDomains Workflow, ScheduledExecution, CommandExec, Notification, Option, PluginStep, JobExec,
+                                      WorkflowStep, Execution, ReferencedExecution, ScheduledExecutionStats, Orchestrator, User }
 
     def setupSchedulerService(clusterEnabled = false){
         SchedulesManager rundeckJobSchedulesManager = new LocalJobSchedulesManager()
@@ -4983,7 +4983,7 @@ class ScheduledExecutionServiceSpec extends RundeckHibernateSpec implements Serv
         def importedJob = RundeckJobDefinitionManager.importedJob(updatedJob, [:])
         service.updateJobDefinition(importedJob, params, mockAuth(), baseJob)
         baseJob.save(flush:true)
-        def options = Option.findAll().size()
+        def options = baseJob.options.size()
 
         then: "baseJob should have 1 option remaining"
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
@@ -46,22 +46,22 @@ import com.dtolabs.rundeck.plugins.scm.ScmPluginInvalidInput
 import com.dtolabs.rundeck.core.plugins.ValidatedPlugin
 import com.dtolabs.rundeck.server.plugins.services.ScmExportPluginProviderService
 import com.dtolabs.rundeck.server.plugins.services.ScmImportPluginProviderService
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import rundeck.PluginMeta
 import rundeck.ScheduledExecution
 import rundeck.User
 import rundeck.Storage
 import rundeck.services.scm.ScmPluginConfigData
+import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
 /**
  * Created by greg on 10/15/15.
  */
-class ScmServiceSpec extends RundeckHibernateSpec implements ServiceUnitTest<ScmService> {
+class ScmServiceSpec extends Specification implements ServiceUnitTest<ScmService>, DataTest {
 
-    List<Class> getDomainClasses() { [ScheduledExecution, User, Storage ] }
+    def setupSpec() { mockDomains ScheduledExecution, User, Storage  }
 
     class TestCloseable implements Closeable {
         boolean closed

--- a/rundeckapp/src/test/groovy/rundeck/services/WorkflowServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/WorkflowServiceSpec.groovy
@@ -16,26 +16,18 @@
 
 package rundeck.services
 
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import rundeck.CommandExec
 import rundeck.Execution
 import rundeck.Workflow
 import rundeck.services.workflow.StateMapping
 import spock.lang.Specification
-import testhelper.RundeckHibernateSpec
 
-class WorkflowServiceSpec extends RundeckHibernateSpec implements ServiceUnitTest<WorkflowService>{
+class WorkflowServiceSpec extends Specification implements ServiceUnitTest<WorkflowService>, DataTest {
 
-    @Override
-    List<Class> getDomainClasses() {
-        [Workflow,Execution,CommandExec]
-    }
-
-    def setup() {
-    }
-
-    def cleanup() {
+    def setupSpec() {
+        mockDomains Workflow,Execution,CommandExec
     }
 
     def "state mapping"(){

--- a/rundeckapp/src/test/groovy/rundeck/services/events/UserActionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/events/UserActionServiceSpec.groovy
@@ -1,13 +1,13 @@
 package rundeck.services.events
 
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent
 import org.springframework.security.core.Authentication
 import rundeck.services.UserService
-import testhelper.RundeckHibernateSpec
+import spock.lang.Specification
 
-class UserActionServiceSpec extends RundeckHibernateSpec implements ServiceUnitTest<UserActionService> {
+class UserActionServiceSpec extends Specification implements ServiceUnitTest<UserActionService>, DataTest {
 
 
     void "handleAuthenticationSuccessEvent"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/scm/ScmLoaderServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/scm/ScmLoaderServiceSpec.groovy
@@ -9,18 +9,17 @@ import com.dtolabs.rundeck.plugins.scm.ScmExportPlugin
 import com.dtolabs.rundeck.plugins.scm.ScmImportPlugin
 import com.dtolabs.rundeck.plugins.scm.ScmOperationContext
 import grails.events.bus.EventBus
-import grails.test.hibernate.HibernateSpec
+import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
-import org.rundeck.storage.api.StorageException
 import rundeck.ScheduledExecution
 import rundeck.services.FrameworkService
 import rundeck.services.JobRevReferenceImpl
 import rundeck.services.ScheduledExecutionService
 import rundeck.services.ScmService
+import spock.lang.Specification
 import spock.lang.Unroll
-import testhelper.RundeckHibernateSpec
 
-class  ScmLoaderServiceSpec extends RundeckHibernateSpec implements ServiceUnitTest<ScmLoaderService> {
+class  ScmLoaderServiceSpec extends Specification implements ServiceUnitTest<ScmLoaderService>, DataTest {
 
     def "loaded export plugin not configured"(){
 


### PR DESCRIPTION
Tests extending RundeckHibernateSpec rely on legacy testing mechanisms. Unit tests that rely on GORM classes should implement DataTest. 

The only tests that cannot be updated have classes that use Hibernate criteria queries. It would be beneficial to update these classes to mock the result of criteria queries, or switch the tests to the integration or functional layer.

Applying this PR should provide a nice speed improvement to the gradle test task.
