### PR TITLE
RSE-203 Fix: Proper Inline Icon Rederization within Dropdowns

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/theme/scss/runstrap/_dropdown.scss
@@ -81,7 +81,7 @@
   // Links which have <span> that overflow the <li>
   // caret class (arrows) excluded 
   > li > a > span:not(.caret) {
-    display: block;
+    display: inline-block;
     padding: 3px 20px 3px 3px;
   }
 


### PR DESCRIPTION
# Proper Inline Icon Rederization within Dropdowns
Minor fix in the dropdown, the 'cell' in dropdown was breaking itself into two lines.

## The Problem
The display of the links inside each cell of the list, which was both icon and text had 'block' as display, that caused the line break.
![Screenshot from 2022-10-24 12-50-24](https://user-images.githubusercontent.com/81827734/197570147-7b016041-9499-4cab-baa5-662d69f4bede.png)

## The Fix
Appending all the icons within a line with 'inline-block'
![Screenshot from 2022-10-24 12-53-26](https://user-images.githubusercontent.com/81827734/197570488-4647864a-9242-4cfe-ad36-052be118b69c.png)

### Exhibits
Other dropdowns after the fix:
![Screenshot from 2022-10-24 12-54-21](https://user-images.githubusercontent.com/81827734/197570672-bfd56495-4101-4a6a-981a-52f8f18cf363.png)

![Screenshot from 2022-10-24 12-55-59](https://user-images.githubusercontent.com/81827734/197570994-c202e2d4-162d-439a-aab6-9e10a121bf78.png)

![Screenshot from 2022-10-24 12-57-18](https://user-images.githubusercontent.com/81827734/197571268-38a29093-cd63-4011-817c-f4a1cb6a45b1.png)
