### PR TITLE
rse-104: fix: jobs tags included when exporting yaml file with rd-cli

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3067,8 +3067,10 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 render(text:writer.toString(),contentType:"text/xml",encoding:"UTF-8")
             }
             yaml{
-                final def encoded = JobsYAMLCodec.encode(results.nextScheduled as List)
-                render(text:encoded,contentType:"text/yaml",encoding:"UTF-8")
+                def writer = new StringWriter()
+                rundeckJobDefinitionManager.exportAs('yaml', results.nextScheduled, writer)
+                writer.flush()
+                render(text:writer.toString(),contentType:"text/yaml",encoding:"UTF-8")
             }
         }
     }


### PR DESCRIPTION
**Problem:**

When a Job Definition is exported though CLI in Yaml format the Tags of the related job are not present into the file. With Xml format works as expected.

![image](https://user-images.githubusercontent.com/29233418/197602826-e504858b-3659-4048-acc3-5f874c935ae0.png)

**Solution:**

Some changes were made in order to get the jobs tags when exporting it into a yaml file using rd-cli.

![image](https://user-images.githubusercontent.com/29233418/197605148-0c28bddb-2ff3-4b8f-b2b1-f6cccc0196f7.png)
