### PR TITLE
RUN-1290: Target new version of py winrm

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ rundeck:
   plugins: # Extra plugins to bundle
   - "com.github.rundeck-plugins:ansible-plugin:3.2.2"
   - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.7"
-  - "com.github.rundeck-plugins:py-winrm-plugin:2.0.15"
+  - "com.github.rundeck-plugins:py-winrm-plugin:2.1.0"
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.2"
   - "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.1.0"
   - "com.github.rundeck-plugins:attribute-match-node-enhancer:v0.1.5"


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is an enhancement to target a [new, more secure version of Py WinRM Plugin](https://github.com/rundeck-plugins/py-winrm-plugin/releases/tag/2.1.0).

**Describe the solution you've implemented**
Simple version bump

**Describe alternatives you've considered**
n/a

**Additional context**
This goes along with Rundeck Pro PR rundeckpro/rundeckpro#2770
