### PR TITLE
RUN-1297: Upgrade-Linux-Package-libksba8-To-Latest-Version

### DIFF
--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -1,4 +1,4 @@
-FROM rundeck/ubuntu-base@sha256:b985e4561ce61dc0865750394885f9afd9a1dffb56d4f72a8b6b575f2a342509
+FROM rundeck/ubuntu-base@sha256:9d5cc71424fcb1d80ab1cd0d5e6a9ba530406dfa3d56570cd3400640bb879d3e
 
 COPY --chown=rundeck:root .build .
 RUN java -jar rundeck.war --installonly \

--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -1,4 +1,4 @@
-FROM rundeck/ubuntu-base@sha256:9d5cc71424fcb1d80ab1cd0d5e6a9ba530406dfa3d56570cd3400640bb879d3e
+FROM rundeck/ubuntu-base@sha256:f26f1db704553f138c8ec70ea6a53d23329308589d2d2a3f781a410a9a154e5c
 
 COPY --chown=rundeck:root .build .
 RUN java -jar rundeck.war --installonly \

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -23,8 +23,6 @@ RUN set -euxo pipefail \
         uuid-runtime \
         wget \
         unzip \
-        # Fix CVE-2022-3515 - upgrade libksba8 to latest version
-        libksba8 \
     && rm -rf /var/lib/apt/lists/* \
     # Setup rundeck user
     && adduser --gid 0 --shell /bin/bash --home /home/rundeck --gecos "" --disabled-password rundeck \

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -23,6 +23,8 @@ RUN set -euxo pipefail \
         uuid-runtime \
         wget \
         unzip \
+        # Fix CVE-2022-3515 - upgrade libksba8 to latest version
+        libksba8 \
     && rm -rf /var/lib/apt/lists/* \
     # Setup rundeck user
     && adduser --gid 0 --shell /bin/bash --home /home/rundeck --gecos "" --disabled-password rundeck \


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is a security bugfix. The ubuntu package libksba8 has a security issue https://ubuntu.com/security/CVE-2022-3515. The issue has been fixed but we need to upgrade the package to its latest version.

**Describe the solution you've implemented**
Add a step in the ubuntu-base Dockerfile to upgrade the libksba8 package to its latest version.

