### PR TITLE
RSE-49: Fix: passing groups via proxy for preauth shows dupe groups in the Rundeck Profile

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -544,16 +544,16 @@ beans={
 
     containerPrincipalRoleSource(ContainerPrincipalRoleSource){
         enabled=grailsApplication.config.getProperty("rundeck.security.authorization.containerPrincipal.enabled", Boolean.class, false)
-        delimiter=grailsApplication.config.getProperty("rundeck.security.authorization.preauthenticated.delimiter", String.class)
+        delimiter=grailsApplication.config.getProperty("rundeck.security.authorization.preauthenticated.delimiter", String.class, ',')
     }
     containerRoleSource(ContainerRoleSource){
         enabled=grailsApplication.config.getProperty("rundeck.security.authorization.container.enabled", Boolean.class, false)
-        delimiter=grailsApplication.config.getProperty("rundeck.security.authorization.preauthenticated.delimiter", String.class)
+        delimiter=grailsApplication.config.getProperty("rundeck.security.authorization.preauthenticated.delimiter", String.class, ',')
     }
     preauthenticatedAttributeRoleSource(PreauthenticatedAttributeRoleSource){
         enabled=grailsApplication.config.getProperty("rundeck.security.authorization.preauthenticated.enabled", Boolean.class,false)
         attributeName=grailsApplication.config.getProperty("rundeck.security.authorization.preauthenticated.attributeName", String.class)
-        delimiter=grailsApplication.config.getProperty("rundeck.security.authorization.preauthenticated.delimiter", String.class)
+        delimiter=grailsApplication.config.getProperty("rundeck.security.authorization.preauthenticated.delimiter", String.class, ',')
     }
 
     def storageDir= new File(varDir, 'storage')

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -544,9 +544,11 @@ beans={
 
     containerPrincipalRoleSource(ContainerPrincipalRoleSource){
         enabled=grailsApplication.config.getProperty("rundeck.security.authorization.containerPrincipal.enabled", Boolean.class, false)
+        delimiter=grailsApplication.config.getProperty("rundeck.security.authorization.preauthenticated.delimiter", String.class)
     }
     containerRoleSource(ContainerRoleSource){
         enabled=grailsApplication.config.getProperty("rundeck.security.authorization.container.enabled", Boolean.class, false)
+        delimiter=grailsApplication.config.getProperty("rundeck.security.authorization.preauthenticated.delimiter", String.class)
     }
     preauthenticatedAttributeRoleSource(PreauthenticatedAttributeRoleSource){
         enabled=grailsApplication.config.getProperty("rundeck.security.authorization.preauthenticated.enabled", Boolean.class,false)

--- a/rundeckapp/src/main/groovy/org/rundeck/web/infosec/ContainerPrincipalRoleSource.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/web/infosec/ContainerPrincipalRoleSource.groovy
@@ -20,11 +20,13 @@ import org.springframework.security.authentication.AbstractAuthenticationToken
 
 import javax.security.auth.Subject
 import javax.servlet.http.HttpServletRequest
+import java.util.regex.Pattern
 
 /**
  * Return a list of roles by introspecting the userPrincipal object
  */
 class ContainerPrincipalRoleSource implements AuthorizationRoleSource {
+    String delimiter=','
     boolean enabled
     @Override
     Collection<String> getUserRoles(final String username, final HttpServletRequest request) {
@@ -60,7 +62,8 @@ class ContainerPrincipalRoleSource implements AuthorizationRoleSource {
             }
         } else if(principal instanceof AbstractAuthenticationToken) {
             principal.authorities.each {
-                roles << it.authority
+                roles.addAll((it.authority).split(" *${Pattern.quote(delimiter)} *")
+                        .collect{it.trim()} as List<String>)
             }
         }
         roles

--- a/rundeckapp/src/main/groovy/org/rundeck/web/infosec/ContainerPrincipalRoleSource.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/web/infosec/ContainerPrincipalRoleSource.groovy
@@ -26,7 +26,7 @@ import java.util.regex.Pattern
  * Return a list of roles by introspecting the userPrincipal object
  */
 class ContainerPrincipalRoleSource implements AuthorizationRoleSource {
-    String delimiter=','
+    String delimiter
     boolean enabled
     @Override
     Collection<String> getUserRoles(final String username, final HttpServletRequest request) {

--- a/rundeckapp/src/main/groovy/org/rundeck/web/infosec/ContainerRoleSource.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/web/infosec/ContainerRoleSource.groovy
@@ -22,11 +22,13 @@ import org.springframework.security.core.context.SecurityContextHolder
 import rundeck.services.FrameworkService
 
 import javax.servlet.http.HttpServletRequest
+import java.util.regex.Pattern
 
 /**
  * Returns list of known roles that user is in via {@link HttpServletRequest#isUserInRole(java.lang.String)}
  */
 class ContainerRoleSource implements AuthorizationRoleSource {
+    String delimiter=','
     boolean enabled
 
     @Override
@@ -36,7 +38,8 @@ class ContainerRoleSource implements AuthorizationRoleSource {
         def roles=new ArrayList<String>()
 
         authorities?.each {GrantedAuthority grantedAuthority ->
-            roles.add(grantedAuthority.authority)
+            roles.addAll((grantedAuthority.authority).split(" *${Pattern.quote(delimiter)} *")
+                    .collect{it.trim()} as List<String>)
         }
 
         roles

--- a/rundeckapp/src/main/groovy/org/rundeck/web/infosec/ContainerRoleSource.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/web/infosec/ContainerRoleSource.groovy
@@ -28,7 +28,7 @@ import java.util.regex.Pattern
  * Returns list of known roles that user is in via {@link HttpServletRequest#isUserInRole(java.lang.String)}
  */
 class ContainerRoleSource implements AuthorizationRoleSource {
-    String delimiter=','
+    String delimiter
     boolean enabled
 
     @Override

--- a/rundeckapp/src/main/groovy/org/rundeck/web/infosec/PreauthenticatedAttributeRoleSource.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/web/infosec/PreauthenticatedAttributeRoleSource.groovy
@@ -25,7 +25,7 @@ import java.util.regex.Pattern
  */
 class PreauthenticatedAttributeRoleSource implements AuthorizationRoleSource {
     String attributeName
-    String delimiter=','
+    String delimiter
     boolean enabled
     @Override
     Collection<String> getUserRoles(final String username, final HttpServletRequest request) {

--- a/rundeckapp/src/test/groovy/org/rundeck/web/infosec/ContainerRoleSourceSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/web/infosec/ContainerRoleSourceSpec.groovy
@@ -23,13 +23,17 @@ import org.springframework.security.core.context.SecurityContextImpl
 import spock.lang.Specification
 
 class ContainerRoleSourceSpec extends Specification {
+
     def "GetUserRoles"() {
         setup:
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(user, "***", userRoles)
         SecurityContextHolder.setContext(new SecurityContextImpl(auth))
 
         when:
-        def roles = new ContainerRoleSource().getUserRoles(user, null)
+        def container = new ContainerRoleSource()
+        container.setDelimiter(',')
+        container.setEnabled(true)
+        def roles = container.getUserRoles(user, null)
 
         then:
         roles == expected

--- a/rundeckapp/src/test/groovy/org/rundeck/web/infosec/ContainerRoleSourceSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/web/infosec/ContainerRoleSourceSpec.groovy
@@ -37,6 +37,7 @@ class ContainerRoleSourceSpec extends Specification {
         where:
         user    | userRoles                                                                 | expected
         "admin" | [new SimpleGrantedAuthority("admin"), new SimpleGrantedAuthority("user")] | ["admin", "user"]
+        "admin" | [new SimpleGrantedAuthority("admin")]                                     | ["admin"]
         "admin" | [new SimpleGrantedAuthority("admin,user")]                                | ["admin", "user"]
         "admin" | null                                                                      | []
 

--- a/rundeckapp/src/test/groovy/org/rundeck/web/infosec/ContainerRoleSourceSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/web/infosec/ContainerRoleSourceSpec.groovy
@@ -15,18 +15,17 @@
  */
 package org.rundeck.web.infosec
 
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.context.SecurityContextImpl
 import spock.lang.Specification
 
-
 class ContainerRoleSourceSpec extends Specification {
     def "GetUserRoles"() {
         setup:
-        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(user, "***",
-                                                                                           userRoles)
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(user, "***", userRoles)
         SecurityContextHolder.setContext(new SecurityContextImpl(auth))
 
         when:
@@ -36,9 +35,10 @@ class ContainerRoleSourceSpec extends Specification {
         roles == expected
 
         where:
-        user | userRoles | expected
+        user    | userRoles                                                                 | expected
         "admin" | [new SimpleGrantedAuthority("admin"), new SimpleGrantedAuthority("user")] | ["admin", "user"]
-        "admin" | null | []
+        "admin" | [new SimpleGrantedAuthority("admin,user")]                                | ["admin", "user"]
+        "admin" | null                                                                      | []
 
     }
 }


### PR DESCRIPTION
## BugFix :: Roles are split according to delimiter.
Fixes: https://github.com/rundeckpro/rundeckpro/issues/2180.

### Description: 
The roles are coming in a single comma-separated string. We have 3 authorizing classes for the roles, of which 2 arrive as "admin,user" and another one arrives as "admin", "user". In the first 2 classes, the proper split is not being carried out by the delimiter.

**Describe the solution you've implemented**
The improvement consists of adding a split to the roles that arrive with commas or better said many roles.

**NGINX config:**
<img width="557" alt="image" src="https://user-images.githubusercontent.com/91557307/198366013-2dd3d72d-88bf-494d-adf6-5bc6fe2788c3.png">

**Before:**
![image](https://user-images.githubusercontent.com/91557307/198378383-282b879c-f2c2-402c-bd60-e987cda9b5af.png)

**After:**
<img width="681" alt="image" src="https://user-images.githubusercontent.com/91557307/198378265-bf4e6d25-449c-488f-8455-793b135126cd.png">



