### PR TITLE
RUN-1225: Job Lifecycle Components

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContext.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContext.java
@@ -223,4 +223,10 @@ public interface ExecutionContext {
     public LoggingManager getLoggingManager();
 
     public PluginControlService getPluginControlService();
+    
+    /**
+     * Gets a reference to the execution being processed.
+     * @return An {@link ExecutionReference} to the execution, or null if doesn't apply.
+     */
+    public ExecutionReference getExecution();
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContextImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContextImpl.java
@@ -82,6 +82,8 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
     private OrchestratorConfig orchestrator;
     private PluginControlService pluginControlService;
     @Getter private List<ContextComponent<?>> componentList;
+    
+    private ExecutionReference execution;
 
     private ExecutionContextImpl() {
         stepContext = new ArrayList<>();
@@ -213,6 +215,7 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
         public Builder(final ExecutionContext original) {
             this();
             if(null!=original){
+                ctx.execution = original.getExecution();
                 ctx.frameworkProject = original.getFrameworkProject();
                 ctx.user = original.getUser();
                 ctx.nodeSet = original.getNodeSelector();
@@ -278,6 +281,9 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
             }
             if (null != other.ctx.charsetEncoding) {
                 ctx.charsetEncoding = other.ctx.charsetEncoding;
+            }
+            if (null != other.ctx.execution) {
+                ctx.execution = other.ctx.execution;
             }
             ctx.dataContext.merge(other.ctx.dataContext);
 
@@ -644,6 +650,11 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
             ctx.componentList.addAll(components);
             return this;
         }
+        
+        public Builder execution(ExecutionReference execution) {
+            ctx.execution = execution;
+            return this;
+        }
 
         public ExecutionContextImpl build() {
             return ctx;
@@ -758,4 +769,7 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
 
     @Override
     public PluginControlService getPluginControlService(){ return pluginControlService; }
+    
+    @Override
+    public ExecutionReference getExecution() { return execution; }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleComponent.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleComponent.java
@@ -1,8 +1,5 @@
 package com.dtolabs.rundeck.core.jobs;
 
-import com.dtolabs.rundeck.core.jobs.JobLifecycleStatus;
-import com.dtolabs.rundeck.core.jobs.JobPersistEvent;
-import com.dtolabs.rundeck.core.jobs.JobPreExecutionEvent;
 import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException;
 
 /**
@@ -17,16 +14,13 @@ public interface JobLifecycleComponent {
      * @param event event execution data
      * @return JobEventStatus
      */
-    default JobLifecycleStatus beforeJobExecution(JobPreExecutionEvent event) throws JobLifecyclePluginException {
-        return null;
-    }
+    JobLifecycleStatus beforeJobExecution(JobPreExecutionEvent event) throws JobLifecyclePluginException;
 
     /**
      * It triggers when a job is persisted
      * @param event event saving data
      * @return JobEventStatus
      */
-    default JobLifecycleStatus beforeSaveJob(JobPersistEvent event) throws JobLifecyclePluginException {
-        return null;
-    }
+    JobLifecycleStatus beforeSaveJob(JobPersistEvent event) throws JobLifecyclePluginException;
+    
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleComponent.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleComponent.java
@@ -1,0 +1,32 @@
+package com.dtolabs.rundeck.core.jobs;
+
+import com.dtolabs.rundeck.core.jobs.JobLifecycleStatus;
+import com.dtolabs.rundeck.core.jobs.JobPersistEvent;
+import com.dtolabs.rundeck.core.jobs.JobPreExecutionEvent;
+import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException;
+
+/**
+ * A Job LifeCycle Components allow independent components and plugins to intervene and
+ * modify a job behavior through various phases of its lifecycle.
+ * 
+ */
+public interface JobLifecycleComponent {
+
+    /**
+     * It triggers before the job execution context exist
+     * @param event event execution data
+     * @return JobEventStatus
+     */
+    default JobLifecycleStatus beforeJobExecution(JobPreExecutionEvent event) throws JobLifecyclePluginException {
+        return null;
+    }
+
+    /**
+     * It triggers when a job is persisted
+     * @param event event saving data
+     * @return JobEventStatus
+     */
+    default JobLifecycleStatus beforeSaveJob(JobPersistEvent event) throws JobLifecyclePluginException {
+        return null;
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleComponent.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleComponent.java
@@ -1,7 +1,5 @@
 package com.dtolabs.rundeck.core.jobs;
 
-import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException;
-
 /**
  * A Job LifeCycle Components allow independent components and plugins to intervene and
  * modify a job behavior through various phases of its lifecycle.

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleComponent.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleComponent.java
@@ -14,13 +14,13 @@ public interface JobLifecycleComponent {
      * @param event event execution data
      * @return JobEventStatus
      */
-    JobLifecycleStatus beforeJobExecution(JobPreExecutionEvent event) throws JobLifecyclePluginException;
+    JobLifecycleStatus beforeJobExecution(JobPreExecutionEvent event) throws JobLifecycleComponentException;
 
     /**
      * It triggers when a job is persisted
      * @param event event saving data
      * @return JobEventStatus
      */
-    JobLifecycleStatus beforeSaveJob(JobPersistEvent event) throws JobLifecyclePluginException;
+    JobLifecycleStatus beforeSaveJob(JobPersistEvent event) throws JobLifecycleComponentException;
     
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleComponentException.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleComponentException.java
@@ -1,0 +1,22 @@
+package com.dtolabs.rundeck.core.jobs;
+
+
+public class JobLifecycleComponentException extends Exception {
+
+    public JobLifecycleComponentException() {
+        super();
+    }
+
+    public JobLifecycleComponentException(String msg) {
+        super(msg);
+    }
+
+    public JobLifecycleComponentException(Exception cause) {
+        super(cause);
+    }
+
+    public JobLifecycleComponentException(String msg, Exception cause) {
+        super(msg, cause);
+    }
+
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleStatus.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleStatus.java
@@ -11,19 +11,32 @@ import java.util.TreeSet;
  * Status result returned from job lifecycle event handlers
  */
 public interface JobLifecycleStatus
-        extends LifecycleStatus
-{
-
+    extends LifecycleStatus {
+    
     /**
      * @return option values to use when isUseNewValues is true
      */
-    default Map getOptionsValues(){ return null; }
-
+    default Map getOptionsValues() {
+        return null;
+    }
+    
     /**
-     *
      * @return options to use when isUseNewValues is true
      */
     default SortedSet<JobOption> getOptions() {
         return new TreeSet<>();
     }
+    
+    
+    /**
+     * @return true indicates metadata returned by this status result should be used.
+     */
+    default boolean isUseNewMetadata() {
+        return false;
+    }
+    
+    default Map getNewExecutionMetadata() {
+        return null;
+    }
+    
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleStatusImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleStatusImpl.java
@@ -27,11 +27,11 @@ import java.util.SortedSet;
 public class JobLifecycleStatusImpl
     implements JobLifecycleStatus {
     
-    private boolean successful;
+    private boolean successful = false;
     private String errorMessage;
-    private boolean useNewValues;
+    private boolean useNewValues = false;
     private Map optionsValues;
     private SortedSet<JobOption> options;
-    private boolean useNewMetadata;
+    private boolean useNewMetadata = false;
     private Map newExecutionMetadata;
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleStatusImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobLifecycleStatusImpl.java
@@ -23,13 +23,15 @@ import java.util.Map;
 import java.util.SortedSet;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 public class JobLifecycleStatusImpl
-        implements JobLifecycleStatus
-{
+    implements JobLifecycleStatus {
+    
     private boolean successful;
     private String errorMessage;
     private boolean useNewValues;
     private Map optionsValues;
     private SortedSet<JobOption> options;
+    private boolean useNewMetadata;
+    private Map newExecutionMetadata;
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobPreExecutionEvent.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobPreExecutionEvent.java
@@ -22,15 +22,15 @@ public interface JobPreExecutionEvent {
 
     /**
      *
-     * @return List<LinkedHashMap> options of the job.
-     */
-    SortedSet<JobOption> getOptions();
-
-    /**
-     *
      * @return String user name triggering the job.
      */
     String getUserName();
+
+    /**
+     *
+     * @return List<LinkedHashMap> options of the job.
+     */
+    SortedSet<JobOption> getOptions();
 
     /**
      *

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobPreExecutionEvent.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobPreExecutionEvent.java
@@ -16,6 +16,12 @@ public interface JobPreExecutionEvent {
 
     /**
      *
+     * @return Job UUID
+     */
+    String getJobUUID();
+
+    /**
+     *
      * @return String project name.
      */
     String getProjectName();

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobPreExecutionEvent.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobPreExecutionEvent.java
@@ -3,8 +3,6 @@ package com.dtolabs.rundeck.core.jobs;
 
 import com.dtolabs.rundeck.core.common.INodeSet;
 
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 
@@ -51,4 +49,9 @@ public interface JobPreExecutionEvent {
      * @return INodeSet node set where the job will run
      */
     INodeSet getNodes();
+    
+    /**
+     * @return Execution metadata map.
+     */
+    Map getExecutionMetadata();
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/JobLifecyclePluginException.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/JobLifecyclePluginException.java
@@ -1,7 +1,9 @@
 package com.dtolabs.rundeck.core.plugins;
 
 
-public class JobLifecyclePluginException extends Exception {
+import com.dtolabs.rundeck.core.jobs.JobLifecycleComponentException;
+
+public class JobLifecyclePluginException extends JobLifecycleComponentException {
 
     public JobLifecyclePluginException() {
         super();

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/JobPersistEventImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/JobPersistEventImpl.java
@@ -6,43 +6,41 @@ import com.dtolabs.rundeck.core.jobs.JobPersistEvent;
 import lombok.Builder;
 import lombok.Data;
 
-import java.util.SortedSet;
+import java.util.*;
 
 @Data
 @Builder
 public class JobPersistEventImpl implements JobPersistEvent {
-
+    
     private String jobName;
     private String projectName;
     private SortedSet<JobOption> options;
     private INodeSet nodes;
     private String userName;
     private String nodeFilter;
-
-    public JobPersistEventImpl(
-            String jobName,
-            String projectName,
-            String userName,
-            INodeSet nodes,
-            String nodeFilter,
-            SortedSet<JobOption> options){
+    
+    public JobPersistEventImpl(String jobName,
+                               String projectName,
+                               SortedSet<JobOption> options,
+                               INodeSet nodes,
+                               String userName,
+                               String nodeFilter) {
         this.jobName = jobName;
         this.projectName = projectName;
-        this.userName = userName;
-        this.nodes = nodes;
-        this.nodeFilter = nodeFilter;
         this.options = options;
+        this.nodes = nodes;
+        this.userName = userName;
+        this.nodeFilter = nodeFilter;
     }
     
     public JobPersistEventImpl(JobPersistEvent origin) {
-        this(
-            origin.getJobName(),
+        this(origin.getJobName(),
             origin.getProjectName(),
-            origin.getUserName(),
+            origin.getOptions(),
             origin.getNodes(),
-            origin.getNodeFilter(),
-            origin.getOptions()
+            origin.getUserName(),
+            origin.getNodeFilter()
         );
     }
-
+    
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/JobPersistEventImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/JobPersistEventImpl.java
@@ -3,10 +3,13 @@ package com.dtolabs.rundeck.plugins.jobs;
 import com.dtolabs.rundeck.core.common.INodeSet;
 import com.dtolabs.rundeck.core.jobs.JobOption;
 import com.dtolabs.rundeck.core.jobs.JobPersistEvent;
-import com.dtolabs.rundeck.core.plugins.configuration.ValidationException;
+import lombok.Builder;
+import lombok.Data;
 
-import java.util.*;
+import java.util.SortedSet;
 
+@Data
+@Builder
 public class JobPersistEventImpl implements JobPersistEvent {
 
     private String jobName;
@@ -30,38 +33,16 @@ public class JobPersistEventImpl implements JobPersistEvent {
         this.nodeFilter = nodeFilter;
         this.options = options;
     }
-
+    
     public JobPersistEventImpl(JobPersistEvent origin) {
         this(
-                origin.getJobName(),
-                origin.getProjectName(),
-                origin.getUserName(),
-                origin.getNodes(),
-                origin.getNodeFilter(),
-                origin.getOptions()
+            origin.getJobName(),
+            origin.getProjectName(),
+            origin.getUserName(),
+            origin.getNodes(),
+            origin.getNodeFilter(),
+            origin.getOptions()
         );
     }
-
-    @Override
-    public String getJobName() { return this.jobName; }
-
-    @Override
-    public String getProjectName() { return this.projectName; }
-
-    @Override
-    public SortedSet<JobOption> getOptions() { return this.options; }
-
-    @Override
-    public INodeSet getNodes() { return this.nodes; }
-
-    public void setNodes(INodeSet nodeSet) { this.nodes = nodeSet; }
-
-    @Override
-    public String getUserName() { return this.userName; }
-
-    @Override
-    public String getNodeFilter() { return this.nodeFilter; }
-
-    public void setOptions(SortedSet<JobOption> options) { this.options = options; }
 
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/JobPreExecutionEventImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/JobPreExecutionEventImpl.java
@@ -14,51 +14,50 @@ import java.util.SortedSet;
 @Data
 @Builder
 public class JobPreExecutionEventImpl implements JobPreExecutionEvent {
-
+    
     private String jobName;
     private String projectName;
     private String userName;
-    private Map optionsValues;
+    private SortedSet<JobOption> options;
+    private Map<String, String> optionsValues;
     private String nodeFilter;
     private INodeSet nodes;
-    private SortedSet<JobOption> options;
-    
     private Map executionMetadata;
-
+    
     
     public JobPreExecutionEventImpl(String jobName,
                                     String projectName,
                                     String userName,
-                                    Map optionsValues,
-                                    INodeSet nodes,
-                                    String nodeFilter,
                                     SortedSet<JobOption> options,
+                                    Map<String, String> optionsValues,
+                                    String nodeFilter,
+                                    INodeSet nodes,
                                     Map executionMetadata) {
-
+        
         this.jobName = jobName;
         this.projectName = projectName;
         this.userName = userName;
-        this.nodes = nodes;
-        this.nodeFilter = nodeFilter;
         this.options = options;
         this.optionsValues = Optional.ofNullable(optionsValues)
-            .map(map -> new HashMap(map))
+            .map(HashMap::new)
             .orElseGet(HashMap::new);
+        this.nodeFilter = nodeFilter;
+        this.nodes = nodes;
         this.executionMetadata = Optional.ofNullable(executionMetadata)
             .map(map -> new HashMap(map))
             .orElseGet(HashMap::new);
     }
-
+    
     public JobPreExecutionEventImpl(JobPreExecutionEvent origin) {
         this(
-            origin.getJobName(), 
+            origin.getJobName(),
             origin.getProjectName(),
             origin.getUserName(),
-            origin.getOptionsValues(),
-            origin.getNodes(),
-            origin.getNodeFilter(),
             origin.getOptions(),
+            origin.getOptionsValues(),
+            origin.getNodeFilter(),
+            origin.getNodes(),
             origin.getExecutionMetadata());
     }
-
+    
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/JobPreExecutionEventImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/JobPreExecutionEventImpl.java
@@ -16,6 +16,7 @@ import java.util.SortedSet;
 public class JobPreExecutionEventImpl implements JobPreExecutionEvent {
     
     private String jobName;
+    private String jobUUID;
     private String projectName;
     private String userName;
     private SortedSet<JobOption> options;
@@ -26,6 +27,7 @@ public class JobPreExecutionEventImpl implements JobPreExecutionEvent {
     
     
     public JobPreExecutionEventImpl(String jobName,
+                                    String jobUUID,
                                     String projectName,
                                     String userName,
                                     SortedSet<JobOption> options,
@@ -35,6 +37,7 @@ public class JobPreExecutionEventImpl implements JobPreExecutionEvent {
                                     Map executionMetadata) {
         
         this.jobName = jobName;
+        this.jobUUID = jobUUID;
         this.projectName = projectName;
         this.userName = userName;
         this.options = options;
@@ -51,6 +54,7 @@ public class JobPreExecutionEventImpl implements JobPreExecutionEvent {
     public JobPreExecutionEventImpl(JobPreExecutionEvent origin) {
         this(
             origin.getJobName(),
+            origin.getJobUUID(),
             origin.getProjectName(),
             origin.getUserName(),
             origin.getOptions(),

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/JobPreExecutionEventImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/JobPreExecutionEventImpl.java
@@ -3,77 +3,62 @@ package com.dtolabs.rundeck.plugins.jobs;
 import com.dtolabs.rundeck.core.common.INodeSet;
 import com.dtolabs.rundeck.core.jobs.JobOption;
 import com.dtolabs.rundeck.core.jobs.JobPreExecutionEvent;
-import com.dtolabs.rundeck.core.plugins.configuration.ValidationException;
+import lombok.Builder;
+import lombok.Data;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedSet;
 
+@Data
+@Builder
 public class JobPreExecutionEventImpl implements JobPreExecutionEvent {
 
     private String jobName;
     private String projectName;
     private String userName;
-    private HashMap optionsValues;
+    private Map optionsValues;
     private String nodeFilter;
     private INodeSet nodes;
     private SortedSet<JobOption> options;
+    
+    private Map executionMetadata;
 
-
+    
     public JobPreExecutionEventImpl(String jobName,
                                     String projectName,
                                     String userName,
-                                    HashMap optionsValues,
+                                    Map optionsValues,
                                     INodeSet nodes,
                                     String nodeFilter,
-                                    SortedSet<JobOption> options) {
+                                    SortedSet<JobOption> options,
+                                    Map executionMetadata) {
 
         this.jobName = jobName;
         this.projectName = projectName;
         this.userName = userName;
-        if(optionsValues != null){
-            this.optionsValues = (HashMap) optionsValues.clone();
-        }else{
-            this.optionsValues = new HashMap();
-        }
         this.nodes = nodes;
         this.nodeFilter = nodeFilter;
         this.options = options;
+        this.optionsValues = Optional.ofNullable(optionsValues)
+            .map(map -> new HashMap(map))
+            .orElseGet(HashMap::new);
+        this.executionMetadata = Optional.ofNullable(executionMetadata)
+            .map(map -> new HashMap(map))
+            .orElseGet(HashMap::new);
     }
 
-    public JobPreExecutionEventImpl(JobPreExecutionEventImpl origin) {
-        this(origin.jobName, origin.projectName, origin.userName, origin.optionsValues, origin.nodes, origin.nodeFilter, origin.options);
+    public JobPreExecutionEventImpl(JobPreExecutionEvent origin) {
+        this(
+            origin.getJobName(), 
+            origin.getProjectName(),
+            origin.getUserName(),
+            origin.getOptionsValues(),
+            origin.getNodes(),
+            origin.getNodeFilter(),
+            origin.getOptions(),
+            origin.getExecutionMetadata());
     }
-
-    @Override
-    public String getJobName() {
-        return this.jobName;
-    }
-
-    @Override
-    public String getProjectName() {
-        return this.projectName;
-    }
-
-    @Override
-    public SortedSet<JobOption> getOptions() {
-        return this.options;
-    }
-
-    @Override
-    public String getUserName() {
-        return this.userName;
-    }
-
-    @Override
-    public HashMap getOptionsValues() {
-        return this.optionsValues;
-    }
-
-    @Override
-    public String getNodeFilter() {
-        return this.nodeFilter;
-    }
-
-    @Override
-    public INodeSet getNodes() { return this.nodes; }
 
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/project/JobLifecyclePlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/project/JobLifecyclePlugin.java
@@ -1,33 +1,17 @@
 package com.dtolabs.rundeck.plugins.project;
 
+import com.dtolabs.rundeck.core.jobs.JobLifecycleComponent;
 import com.dtolabs.rundeck.core.jobs.JobLifecycleStatus;
 import com.dtolabs.rundeck.core.jobs.JobPersistEvent;
 import com.dtolabs.rundeck.core.jobs.JobPreExecutionEvent;
 import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException;
 
 /**
- * ProjectPlugin interface for executing tasks based on a certain event
+ * Interface for creating JobLifecyclePlugins
  * Created by rnavarro
  * Date: 8/23/19
  * Time: 10:45 AM
  */
-public interface JobLifecyclePlugin {
+public interface JobLifecyclePlugin extends JobLifecycleComponent {
 
-    /**
-     * It triggers before the job execution context exist
-     * @param event event execution data
-     * @return JobEventStatus
-     */
-    default JobLifecycleStatus beforeJobExecution(JobPreExecutionEvent event) throws JobLifecyclePluginException {
-        return null;
-    }
-
-    /**
-     * It triggers when a job is persisted
-     * @param event event saving data
-     * @return JobEventStatus
-     */
-    default JobLifecycleStatus beforeSaveJob(JobPersistEvent event) throws JobLifecyclePluginException {
-        return null;
-    }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/project/JobLifecyclePlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/project/JobLifecyclePlugin.java
@@ -13,5 +13,23 @@ import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException;
  * Time: 10:45 AM
  */
 public interface JobLifecyclePlugin extends JobLifecycleComponent {
-
+    
+    /**
+     * It triggers before the job execution context exist
+     * @param event event execution data
+     * @return JobEventStatus
+     */
+    default JobLifecycleStatus beforeJobExecution(JobPreExecutionEvent event) throws JobLifecyclePluginException {
+        return null;
+    }
+    
+    /**
+     * It triggers when a job is persisted
+     * @param event event saving data
+     * @return JobEventStatus
+     */
+    default JobLifecycleStatus beforeSaveJob(JobPersistEvent event) throws JobLifecyclePluginException {
+        return null;
+    }
+    
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/ExecutionContextImplSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/ExecutionContextImplSpec.groovy
@@ -271,6 +271,8 @@ class ExecutionContextImplSpec extends Specification {
         def node2 = new NodeEntryImpl('bnode')
         def orc1 = new OrchestratorConfig('a', [b: 'c'])
         def orc2 = new OrchestratorConfig('b', [e: 'f'])
+        def execRef1 = Mock(ExecutionReference)
+        def execRef2 = Mock(ExecutionReference)
         def sharedctx1 = SharedDataContextUtils.sharedContext()
         sharedctx1.merge(ContextView.global(), DataContextUtils.context('data', [bob: 'data', blah: 'blee']))
         def sharedctx2 = SharedDataContextUtils.sharedContext()
@@ -300,6 +302,7 @@ class ExecutionContextImplSpec extends Specification {
                                          .outputContext(outcontext1)
                                          .sharedDataContext(sharedctx1)
                                          .loggingManager(logmanager1)
+                                         .execution(execRef1)
 //                                         .singleNodeContext(node1, false)
                                          .pluginControlService(plugincontrol1)
 
@@ -328,6 +331,7 @@ class ExecutionContextImplSpec extends Specification {
                                          .outputContext(outcontext2)
                                          .sharedDataContext(sharedctx2)
                                          .loggingManager(logmanager2)
+                                         .execution(execRef2)
 //                                         .singleNodeContext(node2, false)
                                          .pluginControlService(plugincontrol2)
 
@@ -357,6 +361,7 @@ class ExecutionContextImplSpec extends Specification {
             result.outputContext == (outcontext2)
             result.sharedDataContext.consolidate().getData(ContextView.global()).data == [bob: 'data2', blee: 'blah', blah: 'blee']
             result.loggingManager == (logmanager2)
+            result.execution == (execRef2)
             result.singleNodeContext == null
             result.pluginControlService == (plugincontrol2)
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -148,7 +148,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     def fileUploadService
     def pluginService
     def executorService
-    JobLifecycleComponentService jobLifecyclePluginService
+    JobLifecycleComponentService jobLifecycleComponentService
     def executionLifecyclePluginService
     AuditEventsService auditEventsService
 
@@ -2572,6 +2572,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         HashMap optparams
         optparams = parseJobOptionInput(props, scheduledExec, authContext)
         def result = checkBeforeJobExecution(scheduledExec, optparams, props, authContext)
+        if(result?.isUseNewMetadata()) {
+            props.extraMetadataMap = result.newExecutionMetadata
+        }
         if(result?.isUseNewValues()){
             optparams = result.optionsValues
             checkSecuredOptions(result.optionsValues, securedOpts, securedExposedOpts)
@@ -4223,9 +4226,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             optparams,
             nodeFilter,
             nodes,
-            null)
+            props.extraMetadataMap)
         try {
-            return jobLifecyclePluginService.beforeJobExecution(scheduledExecution, event)
+            return jobLifecycleComponentService.beforeJobExecution(scheduledExecution, event)
         } catch (JobLifecyclePluginException jpe) {
             throw new ExecutionServiceValidationException(jpe.message, optparams, null)
         }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2572,6 +2572,15 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         HashMap optparams
         optparams = parseJobOptionInput(props, scheduledExec, authContext)
         def result = checkBeforeJobExecution(scheduledExec, optparams, props, authContext)
+        
+        // TODO REFACTOR THIS METHOD!!!!!!
+        // TODO REFACTOR THIS METHOD!!!!!!
+        // TODO REFACTOR THIS METHOD!!!!!!
+        // TODO REFACTOR THIS METHOD!!!!!!
+        // TODO REFACTOR THIS METHOD!!!!!!
+        // TODO REFACTOR THIS METHOD!!!!!!
+        
+        
         if(result?.isUseNewMetadata()) {
             props.extraMetadataMap = result.newExecutionMetadata
         }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -45,8 +45,8 @@ import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepException
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepExecutionItem
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepExecutor
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepResult
+import com.dtolabs.rundeck.core.jobs.JobLifecycleComponentException
 import com.dtolabs.rundeck.core.logging.*
-import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException
 import com.dtolabs.rundeck.core.plugins.PluginConfiguration
 import com.dtolabs.rundeck.core.utils.NodeSet
 import com.dtolabs.rundeck.core.utils.OptsUtil
@@ -4244,7 +4244,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             props.extraMetadataMap)
         try {
             return jobLifecycleComponentService.beforeJobExecution(scheduledExecution, event)
-        } catch (JobLifecyclePluginException jpe) {
+        } catch (JobLifecycleComponentException jpe) {
             throw new ExecutionServiceValidationException(jpe.message, optparams, null)
         }
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -33,6 +33,7 @@ import com.dtolabs.rundeck.core.dispatcher.ContextView
 import com.dtolabs.rundeck.core.dispatcher.DataContextUtils
 import com.dtolabs.rundeck.core.execution.ExecutionContextImpl
 import com.dtolabs.rundeck.core.execution.ExecutionListener
+import com.dtolabs.rundeck.core.execution.ExecutionReference
 import com.dtolabs.rundeck.core.execution.ExecutionValidator
 import com.dtolabs.rundeck.core.execution.JobValidationReference
 import com.dtolabs.rundeck.core.execution.StepExecutionItem
@@ -1579,6 +1580,12 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         }else{
             orchestrator = null;
         }
+        
+        def ExecutionReference executionReference = null
+        if(execMap instanceof Execution) {
+            executionReference = execMap.asReference()
+        }
+        
 
         //create execution context
         def builder = ExecutionContextImpl.builder((StepExecutionContext)origContext)
@@ -1597,6 +1604,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             privateDataContext(privatecontext)
             executionListener(listener)
             workflowExecutionListener(wlistener)
+            execution(executionReference)
         }
         builder.charsetEncoding(charsetEncoding)
         builder.framework(framework)

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -148,7 +148,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     def fileUploadService
     def pluginService
     def executorService
-    JobLifecyclePluginService jobLifecyclePluginService
+    JobLifecycleComponentService jobLifecyclePluginService
     def executionLifecyclePluginService
     AuditEventsService auditEventsService
 

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -4214,15 +4214,16 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     def checkBeforeJobExecution(ScheduledExecution scheduledExecution, optparams, props, authContext) {
 
         INodeSet nodes = scheduledExecutionService.getNodes(scheduledExecution, props.filter, authContext, new HashSet<String>([AuthConstants.ACTION_READ, AuthConstants.ACTION_RUN]))
-        def nodeFilter = props.filter? props.filter : scheduledExecution.asFilter()
+        def nodeFilter = props.filter ? props.filter : scheduledExecution.asFilter()
         JobPreExecutionEventImpl event = new JobPreExecutionEventImpl(
-                scheduledExecution.jobName,
-                props.project,
-                props.user,
-                optparams,
-                nodes,
-                nodeFilter,
-                scheduledExecution.jobOptionsSet())
+            scheduledExecution.jobName,
+            props.project,
+            props.user,
+            scheduledExecution.jobOptionsSet(),
+            optparams,
+            nodeFilter,
+            nodes,
+            null)
         try {
             return jobLifecyclePluginService.beforeJobExecution(scheduledExecution, event)
         } catch (JobLifecyclePluginException jpe) {

--- a/rundeckapp/grails-app/services/rundeck/services/JobLifecycleComponentService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobLifecycleComponentService.groovy
@@ -2,6 +2,7 @@ package rundeck.services
 
 import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.core.config.Features
+import com.dtolabs.rundeck.core.jobs.JobLifecycleComponent
 import com.dtolabs.rundeck.core.jobs.JobLifecycleStatus
 import com.dtolabs.rundeck.core.jobs.JobOption
 import com.dtolabs.rundeck.core.jobs.JobPersistEvent
@@ -15,8 +16,11 @@ import com.dtolabs.rundeck.plugins.jobs.JobPreExecutionEventImpl
 import com.dtolabs.rundeck.plugins.project.JobLifecyclePlugin
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder
 import com.dtolabs.rundeck.server.plugins.services.JobLifecyclePluginProviderService
+import grails.events.annotation.Subscriber
 import groovy.transform.CompileStatic
 import org.rundeck.core.projects.ProjectConfigurable
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
 import rundeck.ScheduledExecution
 
 /**
@@ -25,6 +29,7 @@ import rundeck.ScheduledExecution
  * Date: 8/23/19
  * Time: 10:37 AM
  */
+@Service
 class JobLifecycleComponentService implements ProjectConfigurable {
 
     PluginService pluginService
@@ -36,17 +41,21 @@ class JobLifecycleComponentService implements ProjectConfigurable {
     Map<String, String> configPropertiesMapping
     Map<String, String> configProperties
     List<Property> projectConfigProperties
+    
+    @Autowired
+    List<JobLifecycleComponent> beanComponents
 
-    enum EventType{
-        PRE_EXECUTION("preExecution"), BEFORE_SAVE("beforeSave")
-        private final String value
-        EventType(String value){
-            this.value = value
+
+
+    @Subscriber('rundeck.bootstrap')
+    void setup() throws Exception {
+        println "  !!! WILL PRINT COMPONENTS!!! "        
+        beanComponents?.each {
+            println " !!!! COMPONENT BEAN: " + it.toString()
         }
-        String getValue(){
-            this.value
-        }
+        
     }
+
 
     /**
      *
@@ -338,7 +347,21 @@ class JobLifecycleComponentService implements ProjectConfigurable {
         }
     }
 
+    enum EventType {
+        PRE_EXECUTION("preExecution"),
+        BEFORE_SAVE("beforeSave")
 
+        private final String value
+
+        EventType(String value) {
+            this.value = value
+        }
+
+        String getValue() {
+            this.value
+        }
+    }
+    
 }
 
 @CompileStatic

--- a/rundeckapp/grails-app/services/rundeck/services/JobLifecycleComponentService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobLifecycleComponentService.groovy
@@ -25,7 +25,7 @@ import rundeck.ScheduledExecution
  * Date: 8/23/19
  * Time: 10:37 AM
  */
-class JobLifecyclePluginService implements ProjectConfigurable {
+class JobLifecycleComponentService implements ProjectConfigurable {
 
     PluginService pluginService
     FrameworkService frameworkService

--- a/rundeckapp/grails-app/services/rundeck/services/JobLifecycleComponentService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobLifecycleComponentService.groovy
@@ -9,7 +9,6 @@ import com.dtolabs.rundeck.core.jobs.JobOption
 import com.dtolabs.rundeck.core.jobs.JobPersistEvent
 import com.dtolabs.rundeck.core.jobs.JobPreExecutionEvent
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
-import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException
 import com.dtolabs.rundeck.core.plugins.configuration.Property
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.jobs.JobPersistEventImpl
@@ -124,7 +123,7 @@ class JobLifecycleComponentService implements ProjectConfigurable {
      * @return JobEventStatus response from plugin implementation
      */
     JobLifecycleStatus beforeJobExecution(ScheduledExecution job, JobPreExecutionEvent event)
-            throws JobLifecyclePluginException {
+            throws JobLifecycleComponentException {
         def components = loadProjectComponents(job.project)
         handleEvent(event, EventType.PRE_EXECUTION, components)
     }
@@ -135,7 +134,7 @@ class JobLifecycleComponentService implements ProjectConfigurable {
      * @param event job event
      * @return JobEventStatus response from plugin implementation
      */
-    JobLifecycleStatus beforeJobSave(ScheduledExecution job, JobPersistEvent event) throws JobLifecyclePluginException {
+    JobLifecycleStatus beforeJobSave(ScheduledExecution job, JobPersistEvent event) throws JobLifecycleComponentException {
         def plugins = loadProjectComponents(job.project)
         handleEvent(event, EventType.BEFORE_SAVE, plugins)
     }

--- a/rundeckapp/grails-app/services/rundeck/services/JobLifecycleComponentService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobLifecycleComponentService.groovy
@@ -46,7 +46,7 @@ class JobLifecycleComponentService implements ProjectConfigurable {
     Map<String, String> configProperties
     List<Property> projectConfigProperties
     
-    @Autowired
+    @Autowired(required = false)
     List<JobLifecycleComponent> beanComponents
 
 
@@ -138,17 +138,24 @@ class JobLifecycleComponentService implements ProjectConfigurable {
         handleEvent(event, EventType.BEFORE_SAVE, plugins)
     }
 
-    List<NamedJobLifecycleComponent> loadProjectComponents(String project){
+    /**
+     * Load all available components for a project.
+     * @param project
+     * @return
+     */
+    List<NamedJobLifecycleComponent> loadProjectComponents(String project) {
         List compList = []
-        compList.addAll(beanComponents.collect {
-            new NamedJobLifecycleComponent(
-                component: it,
-                name: it.class.canonicalName)
-        })
+        if (beanComponents) {
+            compList.addAll(beanComponents.collect {
+                new NamedJobLifecycleComponent(
+                    component: it,
+                    name: it.class.canonicalName)
+            })
+        }
         compList.addAll(loadProjectConfiguredPlugins(project))
         compList
     }
-    
+
     /**
      * Load configured JobLifecyclePlugin instances
      * @param project

--- a/rundeckapp/grails-app/services/rundeck/services/JobLifecycleComponentService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobLifecycleComponentService.groovy
@@ -52,9 +52,11 @@ class JobLifecycleComponentService implements ProjectConfigurable {
 
     @Subscriber('rundeck.bootstrap')
     void init() throws Exception {
-        LOG.debug("Initializing " + JobLifecycleComponentService.getSimpleName())
-        beanComponents?.each {
-            LOG.debug("Loaded JobLifecycleComponent Bean: ${it.toString()}")
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Initializing " + JobLifecycleComponentService.getSimpleName())
+            beanComponents?.each {
+                LOG.debug("Loaded JobLifecycleComponent Bean: ${it.toString()}")
+            }
         }
     }
 
@@ -164,7 +166,7 @@ class JobLifecycleComponentService implements ProjectConfigurable {
     List<NamedJobLifecycleComponent> loadProjectConfiguredPlugins(String project) {
         List<NamedJobLifecycleComponent> configured = []
         def rundeckProject = frameworkService.getFrameworkProject(project)
-        def defaultPluginTypes = new HashSet<String>(getProjectDefaultJobLifecyclePlugins(rundeckProject))
+        def defaultPluginTypes = new LinkedHashSet<String>(getProjectDefaultJobLifecyclePlugins(rundeckProject))
 
         defaultPluginTypes.each{type->
             def configuredPlugin = pluginService.configurePlugin(

--- a/rundeckapp/grails-app/services/rundeck/services/JobLifecycleComponentService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobLifecycleComponentService.groovy
@@ -318,9 +318,9 @@ class JobLifecycleComponentService implements ProjectConfigurable {
         JobLifecycleStatus jobEventStatus
     ) {
         if (jobEventStatus?.isUseNewMetadata() && jobEventStatus.newExecutionMetadata) {
-            def newOptionsValues = new HashMap(executionMetadata ?: [:])
-            newOptionsValues.putAll(jobEventStatus.newExecutionMetadata)
-            return newOptionsValues
+            def newExecutionMetadata = new HashMap(executionMetadata ?: [:])
+            newExecutionMetadata.putAll(jobEventStatus.newExecutionMetadata)
+            return newExecutionMetadata
         }
         return executionMetadata
     }

--- a/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
@@ -33,7 +33,6 @@ import org.springframework.web.context.request.RequestContextHolder
 import rundeck.services.feature.FeatureService
 
 import javax.servlet.ServletContext
-import java.text.SimpleDateFormat
 
 class PluginApiService {
 
@@ -52,7 +51,7 @@ class PluginApiService {
     StorageConverterPluginProviderService storageConverterPluginProviderService
     FeatureService featureService
     ExecutionLifecyclePluginService executionLifecyclePluginService
-    JobLifecyclePluginService jobLifecyclePluginService
+    JobLifecycleComponentService jobLifecyclePluginService
     def rundeckPluginRegistry
     LinkGenerator grailsLinkGenerator
 

--- a/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
@@ -51,7 +51,7 @@ class PluginApiService {
     StorageConverterPluginProviderService storageConverterPluginProviderService
     FeatureService featureService
     ExecutionLifecyclePluginService executionLifecyclePluginService
-    JobLifecycleComponentService jobLifecyclePluginService
+    JobLifecycleComponentService jobLifecycleComponentService
     def rundeckPluginRegistry
     LinkGenerator grailsLinkGenerator
 
@@ -104,7 +104,7 @@ class PluginApiService {
 
         //web-app level plugin descriptions
         if(featureService.featurePresent(Features.JOB_LIFECYCLE_PLUGIN)) {
-            pluginDescs[jobLifecyclePluginService.jobLifecyclePluginProviderService.name]=jobLifecyclePluginService.listJobLifecyclePlugins().collect {
+            pluginDescs[jobLifecycleComponentService.jobLifecyclePluginProviderService.name]=jobLifecycleComponentService.listJobLifecyclePlugins().collect {
                 it.value.description
             }.sort { a, b -> a.name <=> b.name }
         }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -177,7 +177,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     def executionUtilService
     FileUploadService fileUploadService
     JobSchedulerService jobSchedulerService
-    JobLifecycleComponentService jobLifecyclePluginService
+    JobLifecycleComponentService jobLifecycleComponentService
     ExecutionLifecyclePluginService executionLifecyclePluginService
     SchedulesManager jobSchedulesService
     private def triggerComponents
@@ -4156,7 +4156,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         )
         def jobEventStatus
         try {
-            jobEventStatus = jobLifecyclePluginService?.beforeJobSave(scheduledExecution, jobPersistEvent)
+            jobEventStatus = jobLifecycleComponentService?.beforeJobSave(scheduledExecution, jobPersistEvent)
         } catch (JobLifecyclePluginException exception) {
             log.debug("JobLifecycle error: " + exception.message, exception)
             log.warn("JobLifecycle error: " + exception.message)

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -26,7 +26,6 @@ import com.dtolabs.rundeck.core.plugins.DescribedPlugin
 import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException
 import com.dtolabs.rundeck.core.plugins.ValidatedPlugin
 import com.dtolabs.rundeck.core.schedule.SchedulesManager
-import grails.compiler.GrailsCompileStatic
 import grails.converters.JSON
 import grails.gorm.transactions.NotTransactional
 import grails.orm.HibernateCriteriaBuilder
@@ -178,7 +177,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     def executionUtilService
     FileUploadService fileUploadService
     JobSchedulerService jobSchedulerService
-    JobLifecyclePluginService jobLifecyclePluginService
+    JobLifecycleComponentService jobLifecyclePluginService
     ExecutionLifecyclePluginService executionLifecyclePluginService
     SchedulesManager jobSchedulesService
     private def triggerComponents

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -22,8 +22,8 @@ import com.dtolabs.rundeck.core.audit.ResourceTypes
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRoles
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import com.dtolabs.rundeck.core.jobs.JobLifecycleComponentException
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
-import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException
 import com.dtolabs.rundeck.core.plugins.ValidatedPlugin
 import com.dtolabs.rundeck.core.schedule.SchedulesManager
 import grails.converters.JSON
@@ -4157,7 +4157,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         def jobEventStatus
         try {
             jobEventStatus = jobLifecycleComponentService?.beforeJobSave(scheduledExecution, jobPersistEvent)
-        } catch (JobLifecyclePluginException exception) {
+        } catch (JobLifecycleComponentException exception) {
             log.debug("JobLifecycle error: " + exception.message, exception)
             log.warn("JobLifecycle error: " + exception.message)
             return [success: false, scheduledExecution: scheduledExecution, error: exception.message]

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -4149,10 +4149,10 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         JobPersistEventImpl jobPersistEvent = new JobPersistEventImpl(
                 scheduledExecution.jobName,
                 scheduledExecution.project,
-                authContext.getUsername(),
+                scheduledExecution.jobOptionsSet(),
                 nodeSet,
-                scheduledExecution?.filter,
-                scheduledExecution.jobOptionsSet()
+                authContext.getUsername(),
+                scheduledExecution?.filter
         )
         def jobEventStatus
         try {

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionService2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionService2Spec.groovy
@@ -1,6 +1,6 @@
 package rundeck
 
-import com.dtolabs.rundeck.core.authorization.AuthContext
+
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.INodeSet
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
@@ -27,7 +27,6 @@ import com.dtolabs.rundeck.core.jobs.JobOption
  */
 
 import com.dtolabs.rundeck.core.utils.NodeSet
-import grails.test.hibernate.HibernateSpec
 import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import grails.web.mapping.LinkGenerator
@@ -107,7 +106,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
         try{
@@ -162,7 +161,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
         def execution=svc.createExecution(se,createAuthContext("user1"),null,[executionType:'user'])
@@ -191,7 +190,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
         svc.scheduledExecutionService = Mock(ScheduledExecutionService){
             1 * getNodes(_,_,_,_)
         }
-        svc.jobLifecyclePluginService = Mock(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = Mock(JobLifecycleComponentService){
             1 * beforeJobExecution(_,_)
         }
 
@@ -244,7 +243,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -296,7 +295,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -342,7 +341,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -382,7 +381,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -424,7 +423,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -537,7 +536,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -584,7 +583,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -626,7 +625,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -667,7 +666,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -708,7 +707,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -755,7 +754,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
         when:
@@ -805,7 +804,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
         when:
@@ -836,7 +835,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -867,7 +866,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -899,7 +898,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -929,7 +928,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -978,7 +977,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -2499,7 +2498,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -2546,7 +2545,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -2608,7 +2607,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecyclePluginService){
+        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionService2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionService2Spec.groovy
@@ -106,7 +106,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
         try{
@@ -161,7 +161,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
         def execution=svc.createExecution(se,createAuthContext("user1"),null,[executionType:'user'])
@@ -190,7 +190,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
         svc.scheduledExecutionService = Mock(ScheduledExecutionService){
             1 * getNodes(_,_,_,_)
         }
-        svc.jobLifecyclePluginService = Mock(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = Mock(JobLifecycleComponentService){
             1 * beforeJobExecution(_,_)
         }
 
@@ -243,7 +243,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -295,7 +295,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -341,7 +341,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -381,7 +381,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -423,7 +423,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -536,7 +536,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -583,7 +583,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -625,7 +625,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -666,7 +666,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -707,7 +707,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -754,7 +754,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
         when:
@@ -804,7 +804,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
         when:
@@ -835,7 +835,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -866,7 +866,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -898,7 +898,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -928,7 +928,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -977,7 +977,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -2498,7 +2498,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -2545,7 +2545,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService=fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 
@@ -2607,7 +2607,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
         svc.frameworkService = fsvc
-        svc.jobLifecyclePluginService = mockWith(JobLifecycleComponentService){
+        svc.jobLifecycleComponentService = mockWith(JobLifecycleComponentService){
             beforeJobExecution(1..1){job,event->}
         }
 

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceParseJobOptsSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceParseJobOptsSpec.groovy
@@ -18,9 +18,8 @@ package rundeck
 import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import grails.testing.spring.AutowiredTest
-import rundeck.*
 import rundeck.services.ExecutionService
-import rundeck.services.JobLifecyclePluginService
+import rundeck.services.JobLifecycleComponentService
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -34,7 +33,7 @@ class ExecutionServiceParseJobOptsSpec extends Specification implements ServiceU
     }
 
     def setup(){
-        service.jobLifecyclePluginService = Mock(JobLifecyclePluginService)
+        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService)
     }
 
     @Unroll

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceParseJobOptsSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceParseJobOptsSpec.groovy
@@ -33,7 +33,7 @@ class ExecutionServiceParseJobOptsSpec extends Specification implements ServiceU
     }
 
     def setup(){
-        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService)
+        service.jobLifecycleComponentService = Mock(JobLifecycleComponentService)
     }
 
     @Unroll

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -83,7 +83,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
     }
 
     def setup(){
-        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService)
+        service.jobLifecycleComponentService = Mock(JobLifecycleComponentService)
         service.executionValidatorService = new ExecutionValidatorService()
         service.logFileStorageService=Mock(LogFileStorageService)
         service.fileUploadService=Mock(FileUploadService)
@@ -5322,7 +5322,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
     def "execute job with secure remote option changed by job life cycle" () {
         given:
-        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService){
+        service.jobLifecycleComponentService = Mock(JobLifecycleComponentService){
             beforeJobExecution(_,_) >> Mock(JobLifecycleStatus){
                 1 * isUseNewValues() >> true
                 2 * getOptionsValues() >> ["securedOption1" : "secured option changed value"]
@@ -5380,7 +5380,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
     def "execute job with secure exposed option changed by job life cycle" () {
         given:
-        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService){
+        service.jobLifecycleComponentService = Mock(JobLifecycleComponentService){
             beforeJobExecution(_,_) >> Mock(JobLifecycleStatus){
                 1 * isUseNewValues() >> true
                 2 * getOptionsValues() >> ["securedExposedOption1" : "secured exposed option changed value"]
@@ -5439,7 +5439,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
     def "execute job with secure remote and exposed options changed by job life cycle" () {
         given:
-        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService){
+        service.jobLifecycleComponentService = Mock(JobLifecycleComponentService){
             beforeJobExecution(_,_) >> Mock(JobLifecycleStatus){
                 1 * isUseNewValues() >> true
                 2 * getOptionsValues() >> ["securedExposedOption1" : "secured exposed option changed value",

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -1,7 +1,4 @@
 package rundeck
-
-import com.dtolabs.rundeck.app.support.ExecutionQuery
-
 /*
  * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
  *
@@ -29,7 +26,6 @@ import com.dtolabs.rundeck.core.execution.workflow.NodeRecorder
 import com.dtolabs.rundeck.core.execution.workflow.WFSharedContext
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepResult
 import groovy.time.TimeCategory
-import org.hibernate.JDBCException
 import org.rundeck.app.auth.types.AuthorizingProject
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.app.authorization.domain.execution.AuthorizingExecution
@@ -87,7 +83,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
     }
 
     def setup(){
-        service.jobLifecyclePluginService = Mock(JobLifecyclePluginService)
+        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService)
         service.executionValidatorService = new ExecutionValidatorService()
         service.logFileStorageService=Mock(LogFileStorageService)
         service.fileUploadService=Mock(FileUploadService)
@@ -5326,7 +5322,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
     def "execute job with secure remote option changed by job life cycle" () {
         given:
-        service.jobLifecyclePluginService = Mock(JobLifecyclePluginService){
+        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService){
             beforeJobExecution(_,_) >> Mock(JobLifecycleStatus){
                 1 * isUseNewValues() >> true
                 2 * getOptionsValues() >> ["securedOption1" : "secured option changed value"]
@@ -5384,7 +5380,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
     def "execute job with secure exposed option changed by job life cycle" () {
         given:
-        service.jobLifecyclePluginService = Mock(JobLifecyclePluginService){
+        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService){
             beforeJobExecution(_,_) >> Mock(JobLifecycleStatus){
                 1 * isUseNewValues() >> true
                 2 * getOptionsValues() >> ["securedExposedOption1" : "secured exposed option changed value"]
@@ -5443,7 +5439,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
     def "execute job with secure remote and exposed options changed by job life cycle" () {
         given:
-        service.jobLifecyclePluginService = Mock(JobLifecyclePluginService){
+        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService){
             beforeJobExecution(_,_) >> Mock(JobLifecycleStatus){
                 1 * isUseNewValues() >> true
                 2 * getOptionsValues() >> ["securedExposedOption1" : "secured exposed option changed value",

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceTempSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceTempSpec.groovy
@@ -36,7 +36,7 @@ class ExecutionServiceTempSpec extends Specification implements DataTest {
         service = new ExecutionService()
         service.executionValidatorService = new ExecutionValidatorService()
         service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
-        service.jobLifecyclePluginService = Mock(JobLifecyclePluginService)
+        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService)
     }
 
     def "loadSecureOptionStorageDefaults replace job vars"() {

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceTempSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceTempSpec.groovy
@@ -36,7 +36,7 @@ class ExecutionServiceTempSpec extends Specification implements DataTest {
         service = new ExecutionService()
         service.executionValidatorService = new ExecutionValidatorService()
         service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
-        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService)
+        service.jobLifecycleComponentService = Mock(JobLifecycleComponentService)
     }
 
     def "loadSecureOptionStorageDefaults replace job vars"() {

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionServiceSpec.groovy
@@ -65,7 +65,7 @@ public class ScheduledExecutionServiceSpec extends Specification implements Data
         ScheduledExecutionService service = new ScheduledExecutionService()
         def authContext = Mock(UserAndRolesAuthContext)
         service.frameworkService = Mock(FrameworkService)
-        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService){
+        service.jobLifecycleComponentService = Mock(JobLifecycleComponentService){
             beforeJobSave(_, _) >> {throw new JobLifecyclePluginException("message from life cycle plugin")}
         }
         def fwknode = new NodeEntryImpl('fwknode')

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionServiceSpec.groovy
@@ -4,7 +4,7 @@ import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import com.dtolabs.rundeck.core.common.NodeSetImpl
-import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException
+import com.dtolabs.rundeck.core.jobs.JobLifecycleComponentException
 import grails.testing.gorm.DataTest
 
 /*
@@ -66,7 +66,7 @@ public class ScheduledExecutionServiceSpec extends Specification implements Data
         def authContext = Mock(UserAndRolesAuthContext)
         service.frameworkService = Mock(FrameworkService)
         service.jobLifecycleComponentService = Mock(JobLifecycleComponentService){
-            beforeJobSave(_, _) >> {throw new JobLifecyclePluginException("message from life cycle plugin")}
+            beforeJobSave(_, _) >> {throw new JobLifecycleComponentException("message from life cycle plugin")}
         }
         def fwknode = new NodeEntryImpl('fwknode')
         def filtered = new NodeSetImpl([fwknode: fwknode])

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionServiceSpec.groovy
@@ -2,14 +2,10 @@ package rundeck
 
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
-import com.dtolabs.rundeck.core.common.IFrameworkNodes
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import com.dtolabs.rundeck.core.common.NodeSetImpl
 import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException
-import grails.test.hibernate.HibernateSpec
 import grails.testing.gorm.DataTest
-import groovy.mock.interceptor.MockFor
-import net.bytebuddy.implementation.bytecode.Throw
 
 /*
  * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
@@ -31,7 +27,7 @@ import net.bytebuddy.implementation.bytecode.Throw
 
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import rundeck.services.FrameworkService
-import rundeck.services.JobLifecyclePluginService
+import rundeck.services.JobLifecycleComponentService
 import rundeck.services.ScheduledExecutionService
 import spock.lang.Specification
 
@@ -69,7 +65,7 @@ public class ScheduledExecutionServiceSpec extends Specification implements Data
         ScheduledExecutionService service = new ScheduledExecutionService()
         def authContext = Mock(UserAndRolesAuthContext)
         service.frameworkService = Mock(FrameworkService)
-        service.jobLifecyclePluginService = Mock(JobLifecyclePluginService){
+        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService){
             beforeJobSave(_, _) >> {throw new JobLifecyclePluginException("message from life cycle plugin")}
         }
         def fwknode = new NodeEntryImpl('fwknode')

--- a/rundeckapp/src/test/groovy/rundeck/services/JobLifecycleComponentServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/JobLifecycleComponentServiceSpec.groovy
@@ -1,6 +1,8 @@
 package rundeck.services
 
 import com.dtolabs.rundeck.core.common.IRundeckProject
+import com.dtolabs.rundeck.core.jobs.JobLifecycleComponent
+import com.dtolabs.rundeck.core.jobs.JobLifecycleComponentException
 import com.dtolabs.rundeck.core.jobs.JobLifecycleStatus
 import com.dtolabs.rundeck.core.jobs.JobOption
 import com.dtolabs.rundeck.core.jobs.JobPersistEvent
@@ -163,7 +165,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
         given:
             def evt = Mock(JobPersistEvent)
             def plugins = [new NamedJobLifecycleComponent(
-                    name: 'test', plugin: Mock(JobLifecyclePlugin) {
+                    name: 'test', component: Mock(JobLifecycleComponent) {
                 beforeSaveJob(_) >> {
                     throw new JobLifecyclePluginException("oops")
                 }
@@ -172,17 +174,18 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
         when:
             def result = service.handleEvent(evt, type, plugins)
         then:
-            JobLifecyclePluginException err = thrown()
+            JobLifecycleComponentException err = thrown()
             err.message =~ /oops/
         where:
             type                                            | _
             JobLifecycleComponentService.EventType.BEFORE_SAVE | _
     }
+    
     def "handleEvent plugin exception PRE_EXECUTION"() {
         given:
             def evt = Mock(JobPreExecutionEvent)
             def plugins = [new NamedJobLifecycleComponent(
-                    name: 'test', plugin: Mock(JobLifecyclePlugin) {
+                    name: 'test', component: Mock(JobLifecycleComponent) {
                 beforeJobExecution(_) >> {
                     throw new JobLifecyclePluginException("oops")
                 }
@@ -191,7 +194,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
         when:
             def result = service.handleEvent(evt, type, plugins)
         then:
-            JobLifecyclePluginException err = thrown()
+        JobLifecycleComponentException err = thrown()
             err.message =~ /oops/
         where:
             type                                            | _

--- a/rundeckapp/src/test/groovy/rundeck/services/JobLifecycleComponentServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/JobLifecycleComponentServiceSpec.groovy
@@ -162,7 +162,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
     def "handleEvent plugin exception BEFORE_SAVE"() {
         given:
             def evt = Mock(JobPersistEvent)
-            def plugins = [new NamedJobLifecyclePlugin(
+            def plugins = [new NamedJobLifecycleComponent(
                     name: 'test', plugin: Mock(JobLifecyclePlugin) {
                 beforeSaveJob(_) >> {
                     throw new JobLifecyclePluginException("oops")
@@ -181,7 +181,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
     def "handleEvent plugin exception PRE_EXECUTION"() {
         given:
             def evt = Mock(JobPreExecutionEvent)
-            def plugins = [new NamedJobLifecyclePlugin(
+            def plugins = [new NamedJobLifecycleComponent(
                     name: 'test', plugin: Mock(JobLifecyclePlugin) {
                 beforeJobExecution(_) >> {
                     throw new JobLifecyclePluginException("oops")

--- a/rundeckapp/src/test/groovy/rundeck/services/JobLifecycleComponentServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/JobLifecycleComponentServiceSpec.groovy
@@ -8,12 +8,11 @@ import com.dtolabs.rundeck.core.jobs.JobPreExecutionEvent
 import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException
 import com.dtolabs.rundeck.plugins.jobs.JobOptionImpl
 import com.dtolabs.rundeck.plugins.project.JobLifecyclePlugin
-import grails.test.mixin.TestFor
 import grails.testing.services.ServiceUnitTest
 import spock.lang.Specification
 
 
-class JobLifecyclePluginServiceSpec extends Specification implements ServiceUnitTest<JobLifecyclePluginService> {
+class JobLifecycleComponentServiceSpec extends Specification implements ServiceUnitTest<JobLifecycleComponentService> {
 
     class JobLifecycleStatusImplTest implements JobLifecycleStatus{
 
@@ -42,9 +41,9 @@ class JobLifecyclePluginServiceSpec extends Specification implements ServiceUnit
         given:
         def project = Mock(IRundeckProject) {
             getProjectProperties() >> [
-                    (JobLifecyclePluginService.CONF_PROJECT_ENABLED + 'typeA'): 'true',
-                    (JobLifecyclePluginService.CONF_PROJECT_ENABLED + 'typeB'): 'true',
-                    (JobLifecyclePluginService.CONF_PROJECT_ENABLED + 'typeC'): 'false',
+                    (JobLifecycleComponentService.CONF_PROJECT_ENABLED + 'typeA'): 'true',
+                    (JobLifecycleComponentService.CONF_PROJECT_ENABLED + 'typeB'): 'true',
+                    (JobLifecycleComponentService.CONF_PROJECT_ENABLED + 'typeC'): 'false',
             ]
         }
         when:
@@ -144,7 +143,7 @@ class JobLifecyclePluginServiceSpec extends Specification implements ServiceUnit
             result==null
         where:
             type                                              | _
-            JobLifecyclePluginService.EventType.PRE_EXECUTION | _
+            JobLifecycleComponentService.EventType.PRE_EXECUTION | _
     }
 
     def "handleEvent no plugins BEFORE_SAVE"() {
@@ -157,7 +156,7 @@ class JobLifecyclePluginServiceSpec extends Specification implements ServiceUnit
             result==null
         where:
             type                                            | _
-            JobLifecyclePluginService.EventType.BEFORE_SAVE | _
+            JobLifecycleComponentService.EventType.BEFORE_SAVE | _
     }
 
     def "handleEvent plugin exception BEFORE_SAVE"() {
@@ -177,7 +176,7 @@ class JobLifecyclePluginServiceSpec extends Specification implements ServiceUnit
             err.message =~ /oops/
         where:
             type                                            | _
-            JobLifecyclePluginService.EventType.BEFORE_SAVE | _
+            JobLifecycleComponentService.EventType.BEFORE_SAVE | _
     }
     def "handleEvent plugin exception PRE_EXECUTION"() {
         given:
@@ -196,6 +195,6 @@ class JobLifecyclePluginServiceSpec extends Specification implements ServiceUnit
             err.message =~ /oops/
         where:
             type                                            | _
-            JobLifecyclePluginService.EventType.PRE_EXECUTION | _
+            JobLifecycleComponentService.EventType.PRE_EXECUTION | _
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/JobLifecycleComponentServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/JobLifecycleComponentServiceSpec.groovy
@@ -10,7 +10,6 @@ import com.dtolabs.rundeck.core.jobs.JobOption
 import com.dtolabs.rundeck.core.jobs.JobPersistEvent
 import com.dtolabs.rundeck.core.jobs.JobPreExecutionEvent
 import com.dtolabs.rundeck.core.plugins.ConfiguredPlugin
-import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException
 import com.dtolabs.rundeck.plugins.jobs.JobOptionImpl
 import com.dtolabs.rundeck.plugins.project.JobLifecyclePlugin
 import grails.testing.services.ServiceUnitTest
@@ -170,7 +169,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
             def plugins = [new NamedJobLifecycleComponent(
                     name: 'test', component: Mock(JobLifecycleComponent) {
                 beforeSaveJob(_) >> {
-                    throw new JobLifecyclePluginException("oops")
+                    throw new JobLifecycleComponentException("oops")
                 }
             }
             )]
@@ -190,7 +189,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
             def plugins = [new NamedJobLifecycleComponent(
                     name: 'test', component: Mock(JobLifecycleComponent) {
                 beforeJobExecution(_) >> {
-                    throw new JobLifecyclePluginException("oops")
+                    throw new JobLifecycleComponentException("oops")
                 }
             }
             )]

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -125,7 +125,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         service.executionUtilService=Mock(ExecutionUtilService){
             createExecutionItemForWorkflow(_)>>Mock(WorkflowExecutionItem)
         }
-        service.jobLifecyclePluginService = Mock(JobLifecyclePluginService)
+        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService)
         service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
         service.rundeckJobDefinitionManager=Mock(RundeckJobDefinitionManager){
             updateJob(_,_,_)>>{
@@ -3492,7 +3492,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         def uuid=setupDoUpdate(true, serverUuid)
         def se = new ScheduledExecution(createJobParams([serverNodeUUID:jobOwnerUuid])).save()
         service.jobSchedulerService = Mock(JobSchedulerService)
-        service.jobLifecyclePluginService=Mock(JobLifecyclePluginService)
+        service.jobLifecyclePluginService=Mock(JobLifecycleComponentService)
 
         when:
         def results = service._doupdate([id: se.id.toString()] + inparams, mockAuth())
@@ -3516,7 +3516,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         def uuid=setupDoUpdate(true, serverUuid)
         def se = new ScheduledExecution(createJobParams([serverNodeUUID:jobOwnerUuid])).save()
         service.jobSchedulerService = Mock(JobSchedulerService)
-        service.jobLifecyclePluginService=Mock(JobLifecyclePluginService)
+        service.jobLifecyclePluginService=Mock(JobLifecycleComponentService)
 
         service.jobSchedulesService = Mock(SchedulesManager)
         when:
@@ -3544,7 +3544,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
                     workflow: new Workflow(threadcount: 1, keepgoing: true, commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'test what')]),
             ]
         service.jobSchedulerService = Mock(JobSchedulerService)
-        service.jobLifecyclePluginService=Mock(JobLifecyclePluginService)
+        service.jobLifecyclePluginService=Mock(JobLifecycleComponentService)
 
         service.frameworkService = Stub(FrameworkService) {
             existsFrameworkProject('testProject') >> true
@@ -3994,7 +3994,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         newJob = new RundeckJobDefinitionManager.ImportedJobDefinition(job:newJob, associations: [:])
         service.frameworkService.getNodeStepPluginDescription('asdf') >> Mock(Description)
         service.frameworkService.validateDescription(_, '', _, _, _, _) >> [valid: true]
-        service.jobLifecyclePluginService=Mock(JobLifecyclePluginService)
+        service.jobLifecyclePluginService=Mock(JobLifecycleComponentService)
 
         service.jobSchedulesService = Mock(SchedulesManager)
         when:

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -125,7 +125,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         service.executionUtilService=Mock(ExecutionUtilService){
             createExecutionItemForWorkflow(_)>>Mock(WorkflowExecutionItem)
         }
-        service.jobLifecyclePluginService = Mock(JobLifecycleComponentService)
+        service.jobLifecycleComponentService = Mock(JobLifecycleComponentService)
         service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
         service.rundeckJobDefinitionManager=Mock(RundeckJobDefinitionManager){
             updateJob(_,_,_)>>{
@@ -2380,7 +2380,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
                 valid: true,
         ]
         0 * service.frameworkService.validateDescription(*_)
-        0 * service.jobLifecyclePluginService.beforeJobSave(_,_)
+        0 * service.jobLifecycleComponentService.beforeJobSave(_,_)
         1 * service.frameworkService.getFrameworkNodeName()
         1 * service.rundeckAuthContextProcessor.authorizeProjectJobAny(_,_,['update'],'AProject')>>true
         2 * service.executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(_)
@@ -2429,7 +2429,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
             1 * service.executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(se) >> pluginConfigSet
             1 * service.frameworkService.getFrameworkNodeName()
             1 * service.rundeckAuthContextProcessor.authorizeProjectJobAny(_,_,['update'],_)>>true
-            0 * service.jobLifecyclePluginService.beforeJobSave(_,_)
+            0 * service.jobLifecycleComponentService.beforeJobSave(_,_)
             1 * service.rundeckJobDefinitionManager.persistComponents(_,_)
             1 * service.rundeckJobDefinitionManager.waspersisted(_,_)
             service.jobSchedulesService = Mock(SchedulesManager){
@@ -2472,7 +2472,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
             1 * service.executionLifecyclePluginService.setExecutionLifecyclePluginConfigSetForJob(_, _)
             1 * service.executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(se) >> configSet
             0 * service.frameworkService.getFrameworkNodeName()
-            0 * service.jobLifecyclePluginService.beforeJobSave(_,_)
+            0 * service.jobLifecycleComponentService.beforeJobSave(_,_)
             0 * service.rundeckJobDefinitionManager.persistComponents(_,_)>>true
             service.jobSchedulesService = Mock(SchedulesManager){
                 1 * isScheduled(_)
@@ -2517,7 +2517,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
                 valid: false, report: Validator.errorReport('a','wrong')
         ]
         0 * service.frameworkService.validateDescription(*_)
-        0 * service.jobLifecyclePluginService.beforeJobSave(_,_)
+        0 * service.jobLifecycleComponentService.beforeJobSave(_,_)
         0 * service.frameworkService.getFrameworkNodeName()
         2 * service.executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(_)
         1 * service.executionLifecyclePluginService.setExecutionLifecyclePluginConfigSetForJob(_,_)
@@ -3492,7 +3492,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         def uuid=setupDoUpdate(true, serverUuid)
         def se = new ScheduledExecution(createJobParams([serverNodeUUID:jobOwnerUuid])).save()
         service.jobSchedulerService = Mock(JobSchedulerService)
-        service.jobLifecyclePluginService=Mock(JobLifecycleComponentService)
+        service.jobLifecycleComponentService=Mock(JobLifecycleComponentService)
 
         when:
         def results = service._doupdate([id: se.id.toString()] + inparams, mockAuth())
@@ -3500,7 +3500,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
 
         then:
         results.success
-        1 * service.jobLifecyclePluginService.beforeJobSave(se,_)>>lfresult
+        1 * service.jobLifecycleComponentService.beforeJobSave(se,_)>>lfresult
 
         where:
         inparams                                        | lfresult
@@ -3516,7 +3516,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         def uuid=setupDoUpdate(true, serverUuid)
         def se = new ScheduledExecution(createJobParams([serverNodeUUID:jobOwnerUuid])).save()
         service.jobSchedulerService = Mock(JobSchedulerService)
-        service.jobLifecyclePluginService=Mock(JobLifecycleComponentService)
+        service.jobLifecycleComponentService=Mock(JobLifecycleComponentService)
 
         service.jobSchedulesService = Mock(SchedulesManager)
         when:
@@ -3526,7 +3526,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         !results.success
         se.errors.hasErrors()
         se.errors.hasGlobalErrors()
-        1 * service.jobLifecyclePluginService.beforeJobSave(se,_) >> {
+        1 * service.jobLifecycleComponentService.beforeJobSave(se,_) >> {
             throw new JobLifecyclePluginException('an error')
         }
 
@@ -3544,7 +3544,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
                     workflow: new Workflow(threadcount: 1, keepgoing: true, commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'test what')]),
             ]
         service.jobSchedulerService = Mock(JobSchedulerService)
-        service.jobLifecyclePluginService=Mock(JobLifecycleComponentService)
+        service.jobLifecycleComponentService=Mock(JobLifecycleComponentService)
 
         service.frameworkService = Stub(FrameworkService) {
             existsFrameworkProject('testProject') >> true
@@ -3570,7 +3570,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         results.scheduledExecution.errors.hasErrors()
         results.scheduledExecution.errors.hasGlobalErrors()
         results.scheduledExecution.errors.globalErrors.any{it.code=='scheduledExecution.plugin.error.message'}
-        1 * service.jobLifecyclePluginService.beforeJobSave(_,_) >> {
+        1 * service.jobLifecycleComponentService.beforeJobSave(_,_) >> {
             throw new JobLifecyclePluginException('an error')
         }
 
@@ -3994,7 +3994,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         newJob = new RundeckJobDefinitionManager.ImportedJobDefinition(job:newJob, associations: [:])
         service.frameworkService.getNodeStepPluginDescription('asdf') >> Mock(Description)
         service.frameworkService.validateDescription(_, '', _, _, _, _) >> [valid: true]
-        service.jobLifecyclePluginService=Mock(JobLifecycleComponentService)
+        service.jobLifecycleComponentService=Mock(JobLifecycleComponentService)
 
         service.jobSchedulesService = Mock(SchedulesManager)
         when:
@@ -4005,7 +4005,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
             se.errors.hasErrors()
             se.errors.hasGlobalErrors()
             se.errors.globalErrors.any{it.code=='scheduledExecution.plugin.error.message'}
-            1 * service.jobLifecyclePluginService.beforeJobSave(se,_) >> {
+            1 * service.jobLifecycleComponentService.beforeJobSave(se,_) >> {
                 throw new JobLifecyclePluginException('an error')
             }
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -19,8 +19,8 @@ package rundeck.services
 import com.dtolabs.rundeck.core.common.PluginControlService
 import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.ProjectManager
+import com.dtolabs.rundeck.core.jobs.JobLifecycleComponentException
 import com.dtolabs.rundeck.core.jobs.JobLifecycleStatus
-import com.dtolabs.rundeck.core.plugins.JobLifecyclePluginException
 import com.dtolabs.rundeck.core.schedule.SchedulesManager
 import com.dtolabs.rundeck.core.plugins.configuration.Validator
 import com.dtolabs.rundeck.core.utils.PropertyLookup
@@ -3527,7 +3527,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         se.errors.hasErrors()
         se.errors.hasGlobalErrors()
         1 * service.jobLifecycleComponentService.beforeJobSave(se,_) >> {
-            throw new JobLifecyclePluginException('an error')
+            throw new JobLifecycleComponentException('an error')
         }
 
         where:
@@ -3571,7 +3571,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         results.scheduledExecution.errors.hasGlobalErrors()
         results.scheduledExecution.errors.globalErrors.any{it.code=='scheduledExecution.plugin.error.message'}
         1 * service.jobLifecycleComponentService.beforeJobSave(_,_) >> {
-            throw new JobLifecyclePluginException('an error')
+            throw new JobLifecycleComponentException('an error')
         }
 
     }
@@ -4006,7 +4006,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
             se.errors.hasGlobalErrors()
             se.errors.globalErrors.any{it.code=='scheduledExecution.plugin.error.message'}
             1 * service.jobLifecycleComponentService.beforeJobSave(se,_) >> {
-                throw new JobLifecyclePluginException('an error')
+                throw new JobLifecycleComponentException('an error')
             }
 
 


### PR DESCRIPTION
Adds support for `JobLifecycleComponents`, which allow adding additional behavior to the Job lifecycle in the same way as `JobLifecyclePlugins`, but without passing through the plugin layer.