### PR TITLE
RUN-1327: Fix: cluster test harness token auth fails [testing]

### DIFF
--- a/test/testdeck/src/DockerCompose.ts
+++ b/test/testdeck/src/DockerCompose.ts
@@ -20,10 +20,13 @@ export class DockerCompose {
             let burnedHeader = false
             const rl = readline.createInterface(cp.stdout)
             for await (let l of rl) {
-                if (burnedHeader)
+                if (burnedHeader) {
                     output.push(l.split(/\s+/)[0])
-                if (l.startsWith('----'))
+                }else if (l.startsWith('----')) {
                     burnedHeader = true
+                }else if(l.startsWith('NAME ')){
+                    burnedHeader = true
+                }
             }
             return output
         })()

--- a/test/testdeck/src/test/api.ts
+++ b/test/testdeck/src/test/api.ts
@@ -6,6 +6,7 @@ import { TestProject, IRequiredResources } from '../TestProject'
 import {PasswordCredentialProvider, RundeckClient, rundeckPasswordAuth, TokenCredentialProvider} from 'ts-rundeck'
 import { cookieEnrichPolicy, waitForRundeckReady } from '../util/RundeckAPI'
 import { ClusterFactory } from '../ClusterManager'
+import { RequestPolicyFactory } from "@azure/ms-rest-js"
 
 import {envOpts} from './rundeck'
 
@@ -64,6 +65,6 @@ function clientForBackend(url: string, creds:BaseCredentialProvider, backend: st
     return new RundeckClient(creds,{
         baseUri: url,
         noRetryPolicy: true,
-        requestPolicyFactories: [cookiePolicy]
+        requestPolicyFactories: (factories:RequestPolicyFactory[])=>factories.concat([cookiePolicy])
     })
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
testing harness in cluster mode does not fully work with token auth due to headers not be correctly sent when targeting individual nodes in the tests.

**Describe the solution you've implemented**
Update client construction to augment the existing HTTP request policies instead of overwriting them.

