### PR TITLE
RSE-186: syncOauthUser properties don't have hot reload

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -418,6 +418,7 @@ public class RundeckConfigBase {
         Boolean syncLdapUser;
         String requiredRole;
         String jaasRolePrefix;
+        Boolean syncOauthUser = Boolean.valueOf(false);
 
         ApiCookieAccess apiCookieAccess;
         Authorization authorization;

--- a/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
@@ -124,7 +124,9 @@ class ConfigurationService implements InitializingBean {
      * @return
      */
     boolean getBoolean(String service, String name, String property, boolean defval) {
-        return grailsApplication.config.getProperty("rundeck.${service}.${name}.${property}",Boolean.class, defval)
+        String systemProperty = property? "rundeck.${service}.${name}.${property}" : "rundeck.${service}.${name}"
+
+        return grailsApplication.config.getProperty(systemProperty,Boolean.class, defval)
     }
 
     /**


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-186

#### Problem

The following settings work through Configuration Management but they require a restart:

`rundeck.security.syncOauthUser=true`

#### Solution

Added the property as part of the solution mentioned in enterprise PR
