### PR TITLE
Rcloud 662

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ rundeckapp/out
 rundeckapp/rundeck-runtime
 /rundeckapp/grails-app/assets/node_modules
 /rundeckapp/grails-app/assets/**/node_modules
+/rundeckapp/grails-app/conf/application-development.yml

--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/model/v1/SimpleTokenBuilder.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/model/v1/SimpleTokenBuilder.java
@@ -97,6 +97,16 @@ public class SimpleTokenBuilder implements AuthenticationToken {
     return this;
   }
 
+  public SimpleTokenBuilder setClearToken(String clearToken) {
+    this.clearToken = clearToken;
+    return this;
+  }
+
+  public SimpleTokenBuilder setTokenMode(AuthTokenMode mode) {
+    this.tokenMode = mode;
+    return this;
+  }
+
   public SimpleTokenBuilder setType(AuthTokenType type) {
     this.type = type;
     return this;
@@ -122,6 +132,8 @@ public class SimpleTokenBuilder implements AuthenticationToken {
     token1.name = input.getName();
     token1.expiration = input.getExpiration();
     token1.type = input.getType();
+    token1.tokenMode = input.getTokenMode();
+
     return token1;
   }
 }

--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/DataProvider.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/DataProvider.java
@@ -1,0 +1,7 @@
+package org.rundeck.app.data.providers.v1;
+
+/**
+ * Marker interface for all interfaces that define a data provider
+ */
+public interface DataProvider {
+}

--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/TokenDataProvider.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/TokenDataProvider.java
@@ -11,7 +11,7 @@ import java.util.List;
  * TokenDataProvider defines a base set of AuthenticationToken datastore methods.
  *
  */
-public interface TokenDataProvider {
+public interface TokenDataProvider extends DataProvider {
     /**
      * Retrieves an AuthenticationToken based on the id/uuid provided.
      *

--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/utils/Utils.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/utils/Utils.java
@@ -24,7 +24,7 @@ public class Utils {
     public static String encodeAsSHA256(String pluginName) {
         MessageDigest digest = DigestUtils.getSha256Digest();
         digest.update(pluginName.getBytes());
-        return bytesAsHex(digest.digest()).substring(0,12);
+        return bytesAsHex(digest.digest());
     }
 
     public static String bytesAsHex(byte[] bytes) {

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -94,13 +94,11 @@ import org.rundeck.app.cluster.ClusterInfo
 import org.rundeck.app.components.RundeckJobDefinitionManager
 import org.rundeck.app.components.JobXMLFormat
 import org.rundeck.app.components.JobYAMLFormat
-import org.rundeck.app.data.ProviderRegistration
 import org.rundeck.app.data.providers.GormTokenDataProvider
 import org.rundeck.app.services.EnhancedNodeService
 import org.rundeck.app.spi.RundeckSpiBaseServicesProvider
 import org.rundeck.core.auth.app.RundeckAccess
 import org.rundeck.security.*
-import org.rundeck.spi.data.BaseDataManager
 import org.rundeck.web.ExceptionHandler
 import org.rundeck.web.WebUtil
 import org.rundeck.web.infosec.ContainerPrincipalRoleSource
@@ -810,19 +808,7 @@ beans={
     pluginCachePreloader(PluginCachePreloader)
     interceptorHelper(DefaultInterceptorHelper)
 
-    gormTokenDataProvider(GormTokenDataProvider)
-
     //provider implementations
     tokenDataProvider(GormTokenDataProvider)
-
-
-    //manager setup
-    rundeckDataManager(BaseDataManager)
-    rundeckDataProviderRegistration(ProviderRegistration) {
-        dataManager = ref('rundeckDataManager')
-        providers = [
-            ref('tokenDataProvider')
-        ]
-    }
 
 }

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -810,6 +810,8 @@ beans={
     pluginCachePreloader(PluginCachePreloader)
     interceptorHelper(DefaultInterceptorHelper)
 
+    gormTokenDataProvider(GormTokenDataProvider)
+
     //provider implementations
     tokenDataProvider(GormTokenDataProvider)
 

--- a/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
@@ -138,7 +138,11 @@ class ApiService implements WebUtilService{
 
         String id = tokenProvider.create(token1);
         AuthenticationToken token = tokenProvider.getData(id)
-        return token
+
+        SimpleTokenBuilder createdToken = SimpleTokenBuilder.with(token)
+        createdToken.clearToken  = newtoken
+
+        return createdToken
     }
 
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
@@ -54,11 +54,7 @@ class ApiService implements WebUtilService{
     def userService
     @Delegate
     WebUtilService rundeckWebUtil
-    DataManager rundeckDataManager
-
-    private TokenDataProvider getTokenProvider() {
-        rundeckDataManager.getProviderForType(TokenDataProvider)
-    }
+    TokenDataProvider tokenDataProvider
 
     public static final Map<String,String> HTTP_METHOD_ACTIONS = Collections.unmodifiableMap (
             POST: AuthConstants.ACTION_CREATE,
@@ -120,7 +116,7 @@ class ApiService implements WebUtilService{
         String encToken = AuthenticationToken.encodeTokenValue(newtoken, tokenMode)
 
         // regenerate if we find collisions.
-        while (tokenProvider.tokenLookup(encToken) != null) {
+        while (tokenDataProvider.tokenLookup(encToken) != null) {
             newtoken = genRandomString()
             encToken = AuthenticationToken.encodeTokenValue(newtoken, tokenMode)
         }
@@ -135,10 +131,8 @@ class ApiService implements WebUtilService{
                 .setName(tokenData.name)
                 .setUuid(uuid)
 
-
-        String id = tokenProvider.create(token1);
-        AuthenticationToken token = tokenProvider.getData(id)
-
+        String id = tokenDataProvider.create(token1);
+        AuthenticationToken token = tokenDataProvider.getData(id)
         SimpleTokenBuilder createdToken = SimpleTokenBuilder.with(token)
         createdToken.clearToken  = newtoken
 
@@ -160,21 +154,21 @@ class ApiService implements WebUtilService{
      * Find a token by UUID and creator
      */
     AuthenticationToken findUserTokenId(String creator, String id) {
-        tokenProvider.findByUuidAndCreator(id, creator)
+        tokenDataProvider.findByUuidAndCreator(id, creator)
     }
 
     /**
      * Find a token by UUID and creator
      */
     List<AuthenticationToken> findUserTokensCreator(String creator) {
-        tokenProvider.findAllByCreator(creator)
+        tokenDataProvider.findAllByCreator(creator)
     }
 
     /**
      * Find a token by UUID
      */
     AuthenticationToken findTokenId(String id) {
-        tokenProvider.getData(id)
+        tokenDataProvider.getData(id)
     }
 
     /**
@@ -881,7 +875,7 @@ class ApiService implements WebUtilService{
         def id = token.getUuid()
         def oldAuthRoles = token.getAuthRolesSet()
 
-        tokenProvider.delete(id)
+        tokenDataProvider.delete(id)
 
         log.info("DELETED TOKEN ${id} (creator:$creator) User ${user} with roles: ${oldAuthRoles}")
     }
@@ -894,10 +888,10 @@ class ApiService implements WebUtilService{
     @Transactional
     def removeAllExpiredTokens(final String creator) {
         def now = Date.from(Clock.systemUTC().instant())
-        List<AuthenticationToken> found = tokenProvider.findAllByCreatorAndExpirationLessThan(creator, now)
+        List<AuthenticationToken> found = tokenDataProvider.findAllByCreatorAndExpirationLessThan(creator, now)
         if (found) {
             found.each {
-                tokenProvider.delete(it.uuid)
+                tokenDataProvider.delete(it.uuid)
             }
         }
         found.size()
@@ -912,10 +906,10 @@ class ApiService implements WebUtilService{
     @CompileStatic
     def removeAllExpiredTokens() {
         def now = Date.from(Clock.systemUTC().instant())
-        def found = tokenProvider.findAllByExpirationLessThan(now)
+        def found = tokenDataProvider.findAllByExpirationLessThan(now)
         if (found) {
             found.each {
-                tokenProvider.delete(it.uuid)
+                tokenDataProvider.delete(it.uuid)
             }
         }
         found.size()
@@ -924,25 +918,25 @@ class ApiService implements WebUtilService{
     @Transactional
     @CompileStatic
     AuthenticationToken findByTokenAndCreator(final String token, String creator){
-        List<AuthenticationToken> userTokens =  tokenProvider.findAllByCreator(creator)
+        List<AuthenticationToken> userTokens =  tokenDataProvider.findAllByCreator(creator)
         return userTokens.find{it.getToken() == token}
     }
 
     @Transactional
     @CompileStatic
     AuthenticationToken tokenLookup(final String token){
-        return tokenProvider.tokenLookup(token)
+        return tokenDataProvider.tokenLookup(token)
     }
 
     @Transactional
     @CompileStatic
     AuthenticationToken tokenLookupWithType(final String token, AuthenticationToken.AuthTokenType type){
-        return tokenProvider.tokenLookupWithType(token, type)
+        return tokenDataProvider.tokenLookupWithType(token, type)
     }
 
     @Transactional
     @CompileStatic
     List<AuthenticationToken> listTokens(){
-        return tokenProvider.list()
+        return tokenDataProvider.list()
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/RundeckAuthTokenManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/RundeckAuthTokenManagerService.groovy
@@ -15,26 +15,22 @@ import org.rundeck.spi.data.DataManager
 class RundeckAuthTokenManagerService implements AuthTokenManager {
 
     ApiService apiService
-    DataManager rundeckDataManager
-
-    private TokenDataProvider getTokenProvider() {
-        rundeckDataManager.getProviderForType(TokenDataProvider)
-    }
+    TokenDataProvider tokenDataProvider
 
     @Override
     AuthenticationToken getToken(final String token) {
-        return tokenProvider.tokenLookup(token)
+        return tokenDataProvider.tokenLookup(token)
     }
 
     @Override
     AuthenticationToken getTokenWithType(final String token, final AuthTokenType type) {
-        return tokenProvider.tokenLookupWithType(token,type)
+        return tokenDataProvider.tokenLookupWithType(token,type)
     }
 
     @Override
     boolean updateAuthRoles(UserAndRolesAuthContext authContext, final String token, final Set<String> roleSet)
         throws Exception {
-        AuthenticationToken token1 = tokenProvider.findByTokenAndType(token, AuthenticationToken.AuthTokenType.WEBHOOK)
+        AuthenticationToken token1 = tokenDataProvider.findByTokenAndType(token, AuthenticationToken.AuthTokenType.WEBHOOK)
         if (!token1) {
             return false
         }
@@ -47,7 +43,7 @@ class RundeckAuthTokenManagerService implements AuthTokenManager {
 
         newToken.authRolesSet = check.roles
          try {
-            tokenProvider.update(token1.uuid, newToken)
+            tokenDataProvider.update(token1.uuid, newToken)
             return true
         } catch (Exception ex) {
             log.error("Save token ${token} failed:", ex)
@@ -58,7 +54,7 @@ class RundeckAuthTokenManagerService implements AuthTokenManager {
     @Override
     boolean deleteToken(final String uuid) {
         try {
-            tokenProvider.delete(uuid)
+            tokenDataProvider.delete(uuid)
             return true
         } catch(Exception ex) {
             log.error("Delete token ${uuid} failed:",ex)
@@ -71,7 +67,7 @@ class RundeckAuthTokenManagerService implements AuthTokenManager {
         try {
             AuthenticationToken authToken = getTokenWithType(token, type)
             if(authToken) {
-                tokenProvider.delete(authToken.getUuid())
+                tokenDataProvider.delete(authToken.getUuid())
                 return true
             }
         } catch(Exception ex) {
@@ -91,11 +87,11 @@ class RundeckAuthTokenManagerService implements AuthTokenManager {
             final String user,
             final Set<String> roleSet
     ) throws Exception {
-        if (tokenProvider.tokenLookup(token)) {
+        if (tokenDataProvider.tokenLookup(token)) {
             throw new Exception("Cannot import webhook token")
         }
-        AuthenticationToken webookToken = tokenProvider.findByTokenAndType(token, AuthenticationToken.AuthTokenType.WEBHOOK)
-        if (tokenProvider.findByTokenAndType(token, AuthenticationToken.AuthTokenType.WEBHOOK)) {
+        AuthenticationToken webhookToken = tokenDataProvider.findByTokenAndType(token, AuthenticationToken.AuthTokenType.WEBHOOK)
+        if (webhookToken) {
             return updateAuthRoles(authContext, token, roleSet)
         }
 

--- a/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
@@ -62,7 +62,6 @@ class UserService {
     }
 
     String getOwnerName(Long userId) {
-        User.createCriteria().get {}
         User.createCriteria().get {
             eq("id", userId)
             projections {
@@ -70,7 +69,7 @@ class UserService {
             }
         }
     }
-    
+
     def registerLogin(String login, String sessionId){
         User user = User.findByLogin(login)
         if(!user){

--- a/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
@@ -61,6 +61,16 @@ class UserService {
         return user
     }
 
+    String getOwnerName(Long userId) {
+        User.createCriteria().get {}
+        User.createCriteria().get {
+            eq("id", userId)
+            projections {
+                property "login"
+            }
+        }
+    }
+    
     def registerLogin(String login, String sessionId){
         User user = User.findByLogin(login)
         if(!user){

--- a/rundeckapp/grails-app/views/user/_token.gsp
+++ b/rundeckapp/grails-app/views/user/_token.gsp
@@ -38,8 +38,8 @@
             </g:if>
         </td>
         <td width="10%" title="Creator: ${token.creator}">
-            ${token.user.login}
-            <g:if test="${!token?.user?.login?.equalsIgnoreCase(token.creator)}">
+            ${token.ownerName}
+            <g:if test="${!token.creator.equalsIgnoreCase(token.ownerName)}">
                 (${token.creator})
             </g:if>
         </td>

--- a/rundeckapp/src/test/groovy/rundeck/controllers/UserControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/UserControllerSpec.groovy
@@ -420,9 +420,7 @@ class UserControllerSpec extends Specification implements ControllerUnitTest<Use
         UserAndRolesAuthContext auth = Mock(UserAndRolesAuthContext){
             getUsername()>>userToSearch
         }
-        controller.rundeckDataManager=Mock(DataManager){
-            getProviderForType(TokenDataProvider)>>Mock(TokenDataProvider)
-        }
+        controller.tokenDataProvider = Mock(TokenDataProvider)
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
                 1 * authorizeApplicationResourceAny(_,_,_) >> true
 
@@ -454,9 +452,8 @@ class UserControllerSpec extends Specification implements ControllerUnitTest<Use
         UserAndRolesAuthContext auth = Mock(UserAndRolesAuthContext){
             getUsername()>>userToSearch
         }
-        controller.rundeckDataManager=Mock(DataManager){
-            getProviderForType(TokenDataProvider)>>Mock(TokenDataProvider)
-        }
+        controller.tokenDataProvider = Mock(TokenDataProvider)
+
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
                 1 * authorizeApplicationResourceAny(_,_,_) >> true
 
@@ -543,13 +540,12 @@ class UserControllerSpec extends Specification implements ControllerUnitTest<Use
         userTks.add(createAuthToken(user:user,creator:'admin',type: AuthenticationToken.AuthTokenType.USER))
         def authCtx = Mock(UserAndRolesAuthContext)
         session.user='admin'
-        controller.rundeckDataManager=Mock(DataManager){
-            getProviderForType(TokenDataProvider)>>Mock(TokenDataProvider) {
+        controller.tokenDataProvider = Mock(TokenDataProvider) {
                 countTokensByType(_) >> total
                 countTokensByCreatorAndType(_,_)>>total
                 findAllTokensByType(_,_)>>adminTks
                 findAllUserTokensByCreator(_,_)>>userTks
-            }
+
         }
             controller.rundeckAppAuthorizer=Mock(AppAuthorizer){
                 1 * applicationType(_,AuthConstants.TYPE_USER)>>Mock(AuthorizingAppType){
@@ -604,9 +600,7 @@ class UserControllerSpec extends Specification implements ControllerUnitTest<Use
 
     def "loadUsersList summary with last exec"() {
         given:
-        controller.rundeckDataManager=Mock(DataManager){
-            getProviderForType(TokenDataProvider)>>Mock(TokenDataProvider)
-        }
+        controller.tokenDataProvider = Mock(TokenDataProvider)
             UserAndRolesAuthContext auth = Mock(UserAndRolesAuthContext)
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
                 1 * authorizeApplicationResourceAny(_,_,[AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]) >> true
@@ -661,9 +655,7 @@ class UserControllerSpec extends Specification implements ControllerUnitTest<Use
 
     def "loadUsersList summary with logged in status"() {
         given:
-        controller.rundeckDataManager=Mock(DataManager){
-            getProviderForType(TokenDataProvider)>>Mock(TokenDataProvider)
-        }
+        controller.tokenDataProvider = Mock(TokenDataProvider)
             UserAndRolesAuthContext auth = Mock(UserAndRolesAuthContext)
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
                 1 * authorizeApplicationResourceAny(_,_,[AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]) >> true
@@ -721,9 +713,7 @@ class UserControllerSpec extends Specification implements ControllerUnitTest<Use
 
     def "loadUsersList summary with no session id"() {
         given:
-        controller.rundeckDataManager=Mock(DataManager){
-            getProviderForType(TokenDataProvider)>>Mock(TokenDataProvider)
-        }
+        controller.tokenDataProvider = Mock(TokenDataProvider)
             UserAndRolesAuthContext auth = Mock(UserAndRolesAuthContext)
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
                 1 * authorizeApplicationResourceAny(_,_,[AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]) >> true

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
@@ -154,11 +154,8 @@ class SetUserInterceptorSpec extends Specification implements InterceptorUnitTes
         def svCtx = Mock(ServletContext)
         request.setAttribute(SetUserInterceptor.RUNNER_RQ_ATTRIB, runnerRq)
         def apiService = new ApiService()
-        apiService.rundeckDataManager =  Mock(DataManager){
-            getProviderForType(_) >>  {
-                new GormTokenDataProvider()
-            }
-        }
+        apiService.tokenDataProvider = new GormTokenDataProvider()
+
         when:
         interceptor.apiService = apiService
         AuthenticationToken foundToken = interceptor.lookupToken(tk,svCtx,webhookToken)
@@ -195,11 +192,8 @@ class SetUserInterceptorSpec extends Specification implements InterceptorUnitTes
         userTk3.save()
         def svCtx = Mock(ServletContext)
         def apiService = new ApiService()
-        apiService.rundeckDataManager =  Mock(DataManager){
-            getProviderForType(_) >>  {
-                new GormTokenDataProvider()
-            }
-        }
+        apiService.tokenDataProvider = new GormTokenDataProvider()
+
         when:
         interceptor.apiService = apiService
         Set<String> foundRoles = interceptor.lookupTokenRoles(userTk3,svCtx)

--- a/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
@@ -61,11 +61,7 @@ class ApiServiceSpec extends Specification implements ControllerUnitTest<ApiCont
             findOrCreateUser(_) >>  new User(login: 'auser')
         }
         service = new ApiService()
-        service.rundeckDataManager =  Mock(DataManager){
-            getProviderForType(_) >>  {
-                provider
-            }
-        }
+        service.tokenDataProvider = provider
     }
 
     def "renderWrappedFileContents xml"(){
@@ -442,11 +438,7 @@ class ApiServiceSpec extends Specification implements ControllerUnitTest<ApiCont
         }
         service.userService = mockedUserService
         provider.userService = mockedUserService
-        service.rundeckDataManager =  Mock(DataManager){
-            getProviderForType(_) >>  {
-                provider
-            }
-        }
+        service.tokenDataProvider = provider
 
         when:
         def result = service.generateUserToken(auth, tokenTime, tokenUser, tokenRoles)

--- a/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
@@ -26,6 +26,7 @@ import grails.web.JSONBuilder
 import groovy.xml.MarkupBuilder
 import org.grails.plugins.codecs.JSONCodec
 import org.rundeck.app.authorization.AppAuthContextEvaluator
+import org.rundeck.app.data.model.v1.AuthenticationToken
 import org.rundeck.app.data.providers.GormTokenDataProvider
 import org.rundeck.app.web.WebUtilService
 import org.rundeck.core.auth.AuthConstants
@@ -360,7 +361,7 @@ class ApiServiceSpec extends Specification implements ControllerUnitTest<ApiCont
         def result = service.generateUserToken(auth, tokenTime, tokenUser, tokenRoles)
         then:
         result != null
-        result.user.login == user.login
+        result.getOwnerName() == user.login
         result.generateAuthRoles(result.getAuthRolesSet()) == 'role1'
         result.getAuthRolesSet() == tokenRoles
         result.expiration != null
@@ -401,8 +402,8 @@ class ApiServiceSpec extends Specification implements ControllerUnitTest<ApiCont
         def result = service.generateUserToken(auth, tokenTime, tokenUser, tokenRoles)
         then:
         result != null
-        result.user.login == user.login
-        result.authRoles == 'role1,svc_roleA'
+        result.getOwnerName() == user.login
+        result.authRolesSet == AuthenticationToken.parseAuthRoles('role1,svc_roleA')
         result.getAuthRolesSet() == tokenRoles
         result.expiration != null
         if (tokenaction == 'admin') {
@@ -451,8 +452,8 @@ class ApiServiceSpec extends Specification implements ControllerUnitTest<ApiCont
         def result = service.generateUserToken(auth, tokenTime, tokenUser, tokenRoles)
         then:
         result != null
-        result.user.login == tokenUser
-        result.authRoles == 'role1,svc_roleA'
+        result.getOwnerName() == tokenUser
+        result.authRolesSet == AuthenticationToken.parseAuthRoles('role1,svc_roleA')
         result.getAuthRolesSet() == tokenRoles
         result.expiration != null
         _ * service.rundeckAuthContextEvaluator.authorizeApplicationResourceAny(auth, AuthConstants.RESOURCE_TYPE_APITOKEN, [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]) >>
@@ -531,7 +532,7 @@ class ApiServiceSpec extends Specification implements ControllerUnitTest<ApiCont
         def result = service.generateUserToken(auth, tokenTime, tokenUser, tokenRoles)
         then:
         result != null
-        result.user.login == user.login
+        result.getOwnerName() == user.login
         result.getAuthRolesSet() == tokenRoles
         result.expiration != null
         service.rundeckAuthContextEvaluator.authorizeApplicationResourceAny(auth, AuthConstants.RESOURCE_TYPE_APITOKEN, [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]) >> true

--- a/rundeckapp/src/test/groovy/rundeck/services/RundeckAuthTokenManagerServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/RundeckAuthTokenManagerServiceSpec.groovy
@@ -25,10 +25,8 @@ class RundeckAuthTokenManagerServiceSpec extends Specification
     def "get token calls tokenLookup"(){
         given:
             def token='abc123'
-        service.rundeckDataManager=Mock(DataManager){
-            1 * getProviderForType(TokenDataProvider)>>Mock(TokenDataProvider){
-                 1 * tokenLookup('abc123')>>Mock(AuthenticationToken)
-            }
+        service.tokenDataProvider = Mock(TokenDataProvider){
+            1 * tokenLookup('abc123')>>Mock(AuthenticationToken)
         }
         when:
             def result = service.getToken(token)
@@ -40,10 +38,8 @@ class RundeckAuthTokenManagerServiceSpec extends Specification
     def "get token with type calls tokenLookupWithType"(){
         given:
             def token='abc123'
-        service.rundeckDataManager=Mock(DataManager){
-            1 * getProviderForType(TokenDataProvider)>>Mock(TokenDataProvider){
-                 1 * tokenLookupWithType('abc123',type)>>Mock(AuthenticationToken)
-            }
+        service.tokenDataProvider = Mock(TokenDataProvider) {
+            1 * tokenLookupWithType('abc123',type)>>Mock(AuthenticationToken)
         }
         when:
             def result = service.getTokenWithType(token, type)
@@ -61,11 +57,7 @@ class RundeckAuthTokenManagerServiceSpec extends Specification
     def "importWebhookToken"() {
         given:
             service.apiService = Mock(ApiService)
-            service.rundeckDataManager =  Mock(DataManager){
-                getProviderForType(_) >>  {
-                    Mock(TokenDataProvider)
-                }
-            }
+            service.tokenDataProvider = Mock(TokenDataProvider)
             def auth = Mock(UserAndRolesAuthContext)
             def token = '123'
             def user = 'auser'
@@ -82,11 +74,8 @@ class RundeckAuthTokenManagerServiceSpec extends Specification
             def provider = new GormTokenDataProvider()
             mockDataService(AuthTokenDataService)
             provider.authTokenDataService = applicationContext.getBean(AuthTokenDataService)
-            service.rundeckDataManager =  Mock(DataManager){
-                getProviderForType(_) >>  {
-                    provider
-                }
-            }
+            service.tokenDataProvider = provider
+
             User user1 = new User(login: 'auser')
             user1.save()
             AuthToken existing = new AuthToken(
@@ -115,11 +104,7 @@ class RundeckAuthTokenManagerServiceSpec extends Specification
     def "importWebhookToken existing user token"() {
         given:
             service.apiService = Mock(ApiService)
-            service.rundeckDataManager =  Mock(DataManager){
-                getProviderForType(_) >>  {
-                    new GormTokenDataProvider()
-                }
-            }
+            service.tokenDataProvider = new GormTokenDataProvider()
             User user1 = new User(login: 'auser')
             user1.save()
             AuthToken existing = new AuthToken(
@@ -149,11 +134,7 @@ class RundeckAuthTokenManagerServiceSpec extends Specification
         def provider  = new GormTokenDataProvider()
         provider.authTokenDataService = applicationContext.getBean(AuthTokenDataService)
 
-        service.rundeckDataManager =  Mock(DataManager){
-            getProviderForType(_) >>  {
-                provider
-            }
-        }
+        service.tokenDataProvider = provider
         User user1 = new User(login: 'auser')
         user1.save()
         AuthToken createdToken = new AuthToken(


### PR DESCRIPTION
This PR removes the use of the DataManager in the Rundeck services that are managed by Spring. Spring wiring makes the data providers much easier to use and makes advanced Spring bean management much more convenient.

I've added a DataProvider marker interface to the SPI that should be used by all data providers in the future so that we can easily identify them.
