### PR TITLE
RSE-133: Fix: Notifications payload format are not imported properly by the API and the UI

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/app/components/JobYAMLFormat.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/components/JobYAMLFormat.groovy
@@ -51,19 +51,18 @@ class JobYAMLFormat implements JobFormat {
             throw new JobDefinitionException("Yaml: Expected list of Maps")
         }
         data.each { jobMap ->
-            Map notifTriggers = jobMap['notification']
+            Map notifTriggers = jobMap['notification'] as Map
             if(notifTriggers) {
                 (notifTriggers as Map).keySet().each { trigger ->
                     def notifsMap = notifTriggers[trigger]
 
                     if (notifsMap instanceof Map) {
                         def notifList = []
-
+                        Map notifToAdd = [:]
                         notifsMap.each {
-                            Map notifToAdd = [:]
                             notifToAdd.put(it.key, it.value)
-                            notifList.add(notifToAdd)
                         }
+                        notifList.add(notifToAdd)
                         notifTriggers[trigger] = notifList
                     }
                 }


### PR DESCRIPTION
## BugFix: Notifications payload format are not imported properly by the API and the UI

Fix to modify the LinkedHashMap mapping and insert a single map to the array. Related to https://github.com/rundeck/rundeck/issues/6711

#### Considering the following YAML:
``` yaml
# YAML
...
notification:
  onfailure:
    format: json
    method: post
    urls: http://rundeck-server:4440/api/36/webhook/TOKEN#webhook
  onsuccess:
    format: json
    method: post
    urls: http://rundeck-server:4440/api/36/webhook/TOKEN#webhook
```
### The Problem:
When the yaml is identified as coming in Map format (without "-", this symbol reference a list type), each map is inserted into the list:
code reference:
```
iteration {
   map.put(key,value)
   array.add(map)
}
```
### The Fix:
The mapping of the LinkedHashMap is modified to insert a single map to the array.
code reference:
```
iteration {
   map.put(key,value)
}
array.add(map)
```
Now list types and map types are accepted
``` yaml
# YAML
...
notification:
  onfailure:
    - format: json
       method: post
       urls: http://rundeck-server:4440/api/36/webhook/TOKEN#webhook
    - format: json
       method: post
       urls: http://rundeck-server:4440/api/36/webhook/TOKEN#webhook
  onsuccess:
    format: json
    method: post
    urls: http://rundeck-server:4440/api/36/webhook/TOKEN#webhook
```