### PR TITLE
RUN-1370: Change jaas-loginmodule remco template to be able to use ReloadablePropertyFileLoginModule

### DIFF
--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -63,8 +63,13 @@
     ;
 {% endmacro %}
 
-{% macro PropertyFileLoginModule() %}
-    org.eclipse.jetty.jaas.spi.PropertyFileLoginModule {{ getv("/rundeck/jaas/file/required", "required") }}
+{% macro PropertyFileLoginModule(module) %}
+    {% if module == "PropertyFileLoginModule" %}
+    org.eclipse.jetty.jaas.spi.{{module}} 
+    {% else %}
+    org.rundeck.jaas.jetty.{{module}}
+    {% endif %}
+        {{ getv("/rundeck/jaas/file/required", "required") }}
         debug="true"
         file="{{ rundeckHome }}/server/config/realm.properties";
 {% endmacro %}
@@ -76,12 +81,14 @@ rundeck {
             {{ JettyCachingLdapLoginModule("JettyCachingLdapLoginModule") }}
         {% elif module == "JettyCombinedLdapLoginModule" -%}
             {{ JettyCachingLdapLoginModule("JettyCombinedLdapLoginModule") }}
+        {% elif module == "ReloadablePropertyFileLoginModule" -%}
+            {{ PropertyFileLoginModule("ReloadablePropertyFileLoginModule") }}
         {% elif module == "PropertyFileLoginModule" -%}
-            {{ PropertyFileLoginModule() }}
+            {{ PropertyFileLoginModule("PropertyFileLoginModule") }}
         {% endif %}
     {% endfor %}
 
     {% if not exists("/rundeck/jaas/modules/0") -%}
-        {{ PropertyFileLoginModule() }}
+        {{ PropertyFileLoginModule("PropertyFileLoginModule") }}
     {% endif %}
 };


### PR DESCRIPTION
resolve #6251

In official docker image, Cannot set `ReloadablePropertyFileLoginModule` in `jaas-loginmodule` by environment variables. so i added.
JettyRolePropertyFileLoginModule and JettyAuthPropertyFileLoginModule also cannot be set. but i haven't used that so i didn't change.

### TEST
**request**
```
rundeck:
  jaas:
    modules:
      - "ReloadablePropertyFileLoginModule"
```

**response**
```
rundeck {
    org.rundeck.jaas.jetty.ReloadablePropertyFileLoginModule
        required
        debug="true"
        file=".tmp/rundeck/server/config/realm.properties";
};
```

**default**
```
rundeck {
    org.eclipse.jetty.jaas.spi.PropertyFileLoginModule 
        required
        debug="true"
        file=".tmp/rundeck/server/config/realm.properties";
};
```