### PR TITLE
RUN-1352 fix invalid property name

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -639,7 +639,7 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
     {
         if(properties['project.description'] != null ) {
             def description = properties['project.description']
-            RdProject dbproj = projectDataProvider.findByName(projectName)
+            RdProject dbproj = projectDataProvider.findByName(project.name)
             SimpleProjectBuilder updatedProject =  SimpleProjectBuilder.with(dbproj)
             updatedProject.setDescription(description ? description : null)
             projectDataProvider.update(dbproj.getId(), updatedProject)


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
An invalid property name was included in the code causing an error when changing and saving project settings

**Describe the solution you've implemented**
Change to `project.name` to access project name value