### PR TITLE
RSE-173: Fix: Key-Value data log filter unable to capture empty values

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPlugin.groovy
@@ -201,9 +201,7 @@ See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex
                     key = match.group(1)
                     value = match.group(2)
                 }
-                // If the key has a empty value, will be replaced with a space (could be changed)
-                value = value != '' ? value : ' '
-                if (key && value) {
+                if (key) {
                     if(invalidKeyPattern){
                         def validKey = null
                         if( replaceFilteredResult ){

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPluginSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/server/plugins/logging/SimpleDataFilterPluginSpec.groovy
@@ -115,7 +115,7 @@ class SimpleDataFilterPluginSpec extends Specification {
 
         where:
         dolog | regex                            | lines                           | expect
-        true  | '^\\s*([^\\s]+?)\\s*=\\s*(.*)$'  | ['key=']                        | [key:' ']
+        true  | '^\\s*([^\\s]+?)\\s*=\\s*(.*)$'  | ['key=']                        | [key:'']
 
     }
 


### PR DESCRIPTION
# RSE-173 Fix: Key-Value data log filter unable to capture empty values
Unlike other log filter plugin, current key-value data plugin is unable to populate a value with empty data for any use that may have for an user.

## The Problem
The plugin validates the existence of a key and a value, to output the 'key-value' table.

## Possible Solutions
1. Capturing the null value and replace the null by an actual string that has 'null' as value. This approach cause a 'readable' and non-empty value, so the user may not like an actual value.

## The Solution
Validate only if a key exists.

## Exhibits
Pre-fix:
![Screenshot from 2022-11-28 16-59-31](https://user-images.githubusercontent.com/81827734/204369950-e854d297-2062-4578-8767-fa32869ffb82.png)

![Screenshot from 2022-11-28 17-04-32](https://user-images.githubusercontent.com/81827734/204370430-cccedb8e-bcfc-44fd-9796-c34fd45c9023.png)

Post-fix:
![Screenshot from 2022-11-28 17-02-51](https://user-images.githubusercontent.com/81827734/204370496-3ca6bd4e-ec83-45e2-bfc8-73bb73da1672.png)


![Screenshot from 2022-11-28 17-01-39](https://user-images.githubusercontent.com/81827734/204370008-211fc26b-f691-42da-9351-73335774b4e0.png)