### PR TITLE
RSE-238 Fix: Dynamic max nodes shown in rundeck GUI

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -414,11 +414,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         if(params.page){
             page=Integer.parseInt(params.page)
             if(params.max){
-                def maxByProps = configurationService.getInteger("gui.matchedNodesMaxCount",null)
-                if( maxByProps ) {
-                    max = maxByProps
-                }
-                max=Integer.parseInt(params.max)
+                max = configurationService.getInteger("gui.matchedNodesMaxCount",null) ? configurationService.getInteger("gui.matchedNodesMaxCount",null) : Integer.parseInt(params.max)
             }else{
                 max=20
             }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -109,6 +109,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
     ScheduledExecutionService scheduledExecutionService
     UserService userService
     ProjectService projectService
+    ConfigurationService configurationService
 
     PasswordFieldsService obscurePasswordFieldsService
     PasswordFieldsService resourcesPasswordFieldsService

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -413,15 +413,14 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         if(params.page){
             page=Integer.parseInt(params.page)
             if(params.max){
-                def maxByParams= Integer.parseInt(params.max)
                 def maxByProps = configurationService.getInteger("gui.matchedNodesMaxCount",null)
-                if( maxByProps > maxByParams ) {
+                if( maxByProps ) {
                     max = maxByProps
                 }else{
-                    max = maxByParams
+                    max = Integer.parseInt(params.max)
                 }
             }else{
-                max=20
+                max=30
             }
             if(page<0){
                 //if page is negative, load all remaining values starting at page -1*page

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -416,9 +416,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             if(params.max){
                 def maxByProps = configurationService.getInteger("gui.matchedNodesMaxCount",null)
                 if( maxByProps ) {
-                    max = maxByProps
+                    max = Integer.parseInt(maxByProps)
+                }else{
+                    max=Integer.parseInt(params.max)
                 }
-                max=Integer.parseInt(params.max)
             }else{
                 max=20
             }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -413,7 +413,13 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         if(params.page){
             page=Integer.parseInt(params.page)
             if(params.max){
-                max=Integer.parseInt(params.max)
+                def maxByParams= Integer.parseInt(params.max)
+                def maxByProps = configurationService.getInteger("gui.matchedNodesMaxCount",null)
+                if( maxByProps > maxByParams ) {
+                    max = maxByProps
+                }else{
+                    max = maxByParams
+                }
             }else{
                 max=20
             }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -59,6 +59,7 @@ import org.springframework.util.InvalidMimeTypeException
 import rundeck.Execution
 import rundeck.ScheduledExecution
 import rundeck.services.ApiService
+import rundeck.services.ConfigurationService
 import rundeck.services.PasswordFieldsService
 import rundeck.services.PluginService
 import rundeck.services.ProjectService
@@ -416,11 +417,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                 def maxByProps = configurationService.getInteger("gui.matchedNodesMaxCount",null)
                 if( maxByProps ) {
                     max = maxByProps
-                }else{
-                    max = Integer.parseInt(params.max)
                 }
+                max=Integer.parseInt(params.max)
             }else{
-                max=30
+                max=20
             }
             if(page<0){
                 //if page is negative, load all remaining values starting at page -1*page

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -416,7 +416,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             if(params.max){
                 def maxByProps = configurationService.getInteger("gui.matchedNodesMaxCount",null)
                 if( maxByProps ) {
-                    max = Integer.parseInt(maxByProps)
+                    max = maxByProps
                 }else{
                     max=Integer.parseInt(params.max)
                 }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -414,7 +414,11 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         if(params.page){
             page=Integer.parseInt(params.page)
             if(params.max){
-                max = configurationService.getInteger("gui.matchedNodesMaxCount",null) ? configurationService.getInteger("gui.matchedNodesMaxCount",null) : Integer.parseInt(params.max)
+                def maxByProps = configurationService.getInteger("gui.matchedNodesMaxCount",null)
+                if( maxByProps ) {
+                    max = maxByProps
+                }
+                max=Integer.parseInt(params.max)
             }else{
                 max=20
             }

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/resources/NodeFilterResults.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/resources/NodeFilterResults.vue
@@ -12,7 +12,7 @@
 
         <span v-if="total>maxShown">
             <span class="text-strong">
-                  {{$t('count.nodes.shown',[total,$tc('Node.count.vue',total)])}}
+                  {{$t('count.nodes.shown',[maxShown,$tc('Node.count.vue',maxShown)])}}
             </span>
         </span>
       </div>
@@ -177,6 +177,7 @@ export default class NodeFilterResults extends Vue {
         this.total = data.total
         this.truncated = data.truncated
         this.colkeys = data.colkeys
+        this.maxShown = data.max
       }
     }).catch((err) => {
       this.loading = false

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/resources/NodeFilterResults.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/resources/NodeFilterResults.vue
@@ -177,6 +177,7 @@ export default class NodeFilterResults extends Vue {
         this.total = data.total
         this.truncated = data.truncated
         this.colkeys = data.colkeys
+        this.maxShown = data.max
       }
     }).catch((err) => {
       this.loading = false

--- a/rundeckapp/grails-spa/packages/ui/src/components/job/resources/NodeFilterResults.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/components/job/resources/NodeFilterResults.vue
@@ -177,7 +177,6 @@ export default class NodeFilterResults extends Vue {
         this.total = data.total
         this.truncated = data.truncated
         this.colkeys = data.colkeys
-        this.maxShown = data.max
       }
     }).catch((err) => {
       this.loading = false


### PR DESCRIPTION
# RSE-238 Fix: Dynamic max nodes shown in rundeck's GUI
The maximum quantity of shown nodes in the rundeck's 'edit job' page was different than the current shown nodes tags within the rendered list of nodes.

## The problem
The parameter 'max number of nodes' was 'harcoded' in the frontend.

## The solution
Using the prop [rundeck.gui.matchedNodesMaxCount](https://docs.rundeck.com/docs/administration/configuration/gui-customization.html#rundeck-gui-matchednodesmaxcount) to dynamically tell the GUI the user's desired max nodes to be shown in the GUI.

## Additional fixes
When a default or other number of nodes are displayed, the exact number of nodes shown is displayed.

## Exhibits
'17 nodes shown' displayed (custom value)
![Screenshot from 2022-11-30 11-51-36](https://user-images.githubusercontent.com/81827734/204827932-719d6bf7-b09e-44dc-bfc9-139aca02bc47.png)

101 of 101 nodes shown
![101 nodes shown](https://user-images.githubusercontent.com/81827734/204643673-20ddc2b4-c6ab-4462-a691-1e16418d5b05.png)
