### PR TITLE
Cleanup: remove unnecessary openapi flags

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -138,7 +138,6 @@ class ApiController extends ControllerBase{
                 in = ParameterIn.PATH,
                 description = 'Metric name, or blank to receive list of metrics',
                 allowEmptyValue = true,
-                required = false,
                 schema = @Schema(
                     type='string',
                     allowableValues=['metrics', 'ping', 'threads', 'healthcheck']
@@ -403,7 +402,6 @@ class ApiController extends ControllerBase{
                 in = ParameterIn.PATH,
                 description = 'username',
                 allowEmptyValue = true,
-                required = false,
                 schema = @Schema(
                     type='string'
                 )
@@ -488,7 +486,6 @@ Since: v11
                 in = ParameterIn.PATH,
                 description = 'username',
                 allowEmptyValue = true,
-                required = false,
                 schema = @Schema(
                     type = 'string'
                 )


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Fix: generated openapi spec 3.0.x has validation errors, due to `required:false` being unnecessary