### PR TITLE
RUN-1351: deprecate user saved filters via feature flag

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
@@ -36,7 +36,8 @@ public enum Features {
     PLUGIN_SECURITY("pluginSecurity"),
     PROJECT_KEY_STORAGE("projectKeyStorage"),
     FILE_UPLOAD_PLUGIN("fileUploadPlugin"),
-    PLUGIN_GROUPS("pluginGroups");
+    PLUGIN_GROUPS("pluginGroups"),
+    LEGACY_USER_FILTERS("legacyUserFilters");
 
     private final String propertyName;
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -740,7 +740,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             renderErrorView(g.message(code:'request.error.invalidtoken.message'))
         }
     }
-    def deleteNodeFilter={
+    def deleteNodeFilter(){
         if(!featureService.featurePresent(Features.LEGACY_USER_FILTERS)) {
             request.error = g.message(code:'request.error.notfound.title')
             response.setStatus(HttpServletResponse.SC_NOT_FOUND)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -31,6 +31,7 @@ import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.INodeEntry
 import com.dtolabs.rundeck.core.common.NodeSetImpl
+import com.dtolabs.rundeck.core.config.Features
 import com.dtolabs.rundeck.core.http.ApacheHttpClient
 import com.dtolabs.rundeck.core.http.HttpClient
 import com.dtolabs.rundeck.core.utils.NodeSet
@@ -1882,7 +1883,8 @@ class ScheduledExecutionController  extends ControllerBase{
             }
             scheduledExecution.argString=params.argString
         }
-        if(params.filterName){
+
+        if(featureService.featurePresent(Features.LEGACY_USER_FILTERS)) {
             if (params.filterName) {
                 def User u = userService.findOrCreateUser(authContext.username)
                 //load a named filter and create a query from it
@@ -2015,14 +2017,16 @@ class ScheduledExecutionController  extends ControllerBase{
         params.nodeThreadcount= runAdhocRequest.nodeThreadcount?:1
         params.description = runAdhocRequest.description ?: ""
         params.excludeFilterUncheck = false
-        if (params.filterName) {
-            def User u = userService.findOrCreateUser(authContext.username)
-            //load a named filter and create a query from it
-            if (u) {
-                NodeFilter filter = NodeFilter.findByNameAndUser(params.filterName, u)
-                if (filter) {
-                    def query2 = filter.createExtNodeFilters()
-                    params.put('filter',query2.asFilter())
+        if(featureService.featurePresent(Features.LEGACY_USER_FILTERS)) {
+            if (params.filterName) {
+                def User u = userService.findOrCreateUser(authContext.username)
+                //load a named filter and create a query from it
+                if (u) {
+                    NodeFilter filter = NodeFilter.findByNameAndUser(params.filterName, u)
+                    if (filter) {
+                        def query2 = filter.createExtNodeFilters()
+                        params.put('filter',query2.asFilter())
+                    }
                 }
             }
         }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -1744,6 +1744,9 @@ project.label=A Label
             new NodeFilter(user: testUser, filter: 'tags:basdf', name: 'filter3', project: 'otherProject'),
 
         ]*.save(flush: true)
+        controller.featureService = Mock(com.dtolabs.rundeck.core.config.FeatureService) {
+            featurePresent(Features.LEGACY_USER_FILTERS) >> legacyFiltersEnabled
+        }
         when:
         controller.nodeSummaryAjax(project)
         then:
@@ -1754,10 +1757,15 @@ project.label=A Label
         }
         1 * controller.frameworkService.summarizeTags(_) >> [asdf: 1]
 
-        response.json.filters == [
-            [filter: 'tags:xyz', name: 'filter2', project: project],
-            [filter: 'abc', name: 'filter1', project: project],
-        ]
+            response.json.filters == (
+                legacyFiltersEnabled ? [
+                    [filter: 'tags:xyz', name: 'filter2', project: project],
+                    [filter: 'abc', name: 'filter1', project: project]
+                ]
+                                     : []
+            )
+        where:
+            legacyFiltersEnabled<<[true,false]
     }
 
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -109,6 +109,7 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
                 grailsApplication = grailsApplication
             }
         }
+        controller.featureService = Mock(FeatureService)
     }
     def "home without sidebar feature"(){
         given:

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ReportsControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ReportsControllerSpec.groovy
@@ -18,6 +18,7 @@ package rundeck.controllers
 
 import com.dtolabs.rundeck.app.support.ExecQuery
 import com.dtolabs.rundeck.core.authorization.AuthContextProvider
+import com.dtolabs.rundeck.core.config.FeatureService
 import grails.test.hibernate.HibernateSpec
 import grails.testing.web.controllers.ControllerUnitTest
 import org.grails.plugins.metricsweb.MetricService
@@ -53,6 +54,9 @@ class ReportsControllerSpec extends RundeckHibernateSpec implements ControllerUn
                 "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
         ]
     }}
+    def setup(){
+        controller.featureService=Mock(FeatureService)
+    }
 
     @Unroll
     def "events query date binding format #dateFilter"() {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionController2Spec.groovy
@@ -80,6 +80,7 @@ class ScheduledExecutionController2Spec extends RundeckHibernateSpec implements 
                 grailsApplication = grailsApplication
             }
         }
+        controller.featureService=Mock(FeatureService)
     }
 
     private void assertMap(key, map, value) {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -1654,6 +1654,7 @@ class ScheduledExecutionControllerSpec extends RundeckHibernateSpec implements C
                     getUsername() >> 'bob'
                 }
             }
+            controller.featureService = Mock(FeatureService)
         when:
         def result = controller.createFromExecution()
         then:


### PR DESCRIPTION
WIP
**Is this a bugfix, or an enhancement? Please describe.**
Deprecates the Node, Job and Report saved user filters featureset, by disabling the backend behaviors unless the feature flag is enabled. `rundeck.feature.legacyUserFilters.enabled`

**Describe the solution you've implemented**
Add the feature flag definition.
Disable all controller behavior related to the saved filters unless the feature flag is enabled.

## TODO
- [ ] disable GUI behaviors unless feature flag is enabled