### PR TITLE
RSE-259 Fix:Ruleset Plugin fails to evaluate conditions if negative number are used

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericCondition.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/rules/NumericCondition.java
@@ -6,7 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class NumericCondition {
-    final static String DOUBLE_PATTERN = "^([0-9]+\\.?[0-9]*).*";
+    final static String DOUBLE_PATTERN = "^(-?[0-9]+\\.?[0-9]*).*";
 
     public static Float extractFloat(final String value){
         if(value == null){


### PR DESCRIPTION
Problem: Rundeck didn't recognize negative numbers on the ruleset and converted any negative number to  0 causing failings when evaluating conditions like **if:option.1>=0** .

Solution: Fix the method in charge of parse values from the ruleset to float numbers to accept negative numbers.