### PR TITLE
RUN-1298: generate copyright year at build time

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/version/Copyright.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/version/Copyright.vue
@@ -1,12 +1,16 @@
 <template>
     <span class="copyright">
-        © Copyright 2021 PagerDuty, Inc. All rights reserved.
+        {{ copyright }}
     </span>
 </template>
 
 <script>
 export default {
-    
+    data () {
+        return {
+            copyright: BUILD_COPYRIGHT
+        }
+    }
 }
 </script>
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/vue.config.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/vue.config.js
@@ -3,8 +3,10 @@ const Glob = require('glob')
 const fse = require('fs-extra')
 const Path = require('path')
 const walk = require('walk')
+const webpack = require('webpack')
 
 const nodeExternals = require('webpack-node-externals');
+const BUILD_COPYRIGHT = `© ${new Date().getFullYear()} PagerDuty, Inc. All Rights Reserved.`
 
 /** Create a "page" for each component */
 pages = {}
@@ -146,5 +148,10 @@ module.exports = {
         })
       }
     })
+    config.plugins.push(
+        new webpack.DefinePlugin({
+          BUILD_COPYRIGHT: JSON.stringify(BUILD_COPYRIGHT)
+        })
+    )
   }
 };


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Defines copyright string with current year at build time
