### PR TITLE
RUN-1367: Fix: groovy plugins with suffix matching the service should load correctly

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/PluginService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/PluginService.groovy
@@ -40,7 +40,6 @@ import com.dtolabs.rundeck.core.resources.format.UnsupportedFormatException
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.ServiceTypes
 import com.dtolabs.rundeck.plugins.storage.StoragePlugin
-import com.dtolabs.rundeck.server.plugins.RenamedDescription
 import com.dtolabs.rundeck.core.plugins.ValidatedPlugin
 import groovy.transform.CompileStatic
 import org.rundeck.app.spi.Services
@@ -583,24 +582,7 @@ class PluginService implements ResourceFormats, PluginConfigureService {
      * @return map of [name: DescribedPlugin]
      */
     def <T> Map<String, DescribedPlugin<T>> listPlugins(Class<T> clazz,PluggableProviderService<T> service) {
-        def plugins = rundeckPluginRegistry?.listPluginDescriptors(clazz, service)
-        //XX: avoid groovy bug where generic types referenced in closure can cause NPE: http://jira.codehaus.org/browse/GROOVY-5034
-        String svcName=service.name
-        //clean up name of any Groovy plugin without annotations that ends with the service name
-        plugins.each { key, DescribedPlugin plugin ->
-            def desc = plugin.description
-            if(plugin.file && plugin.name.endsWith(svcName)){
-                def newname = plugin.name
-                newname=plugin.name.substring(0, plugin.name.length() - svcName.length())
-                plugin.name = newname
-                if (desc?.name?.endsWith(svcName)) {
-                    plugin.description = new RenamedDescription(delegate: desc, name: newname)
-                }
-            }
-        }
-//        System.err.println("listed plugins: ${plugins}")
-
-        plugins
+        return rundeckPluginRegistry?.listPluginDescriptors(clazz, service)
     }
 
     ResourceFormatParser getResourceFormatParser(String format) {

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/PluginCustomizer.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/PluginCustomizer.groovy
@@ -16,6 +16,7 @@
 
 package com.dtolabs.rundeck.server.plugins
 
+import com.dtolabs.rundeck.plugins.ServiceTypes
 import com.dtolabs.rundeck.server.plugins.builder.ScriptPluginBuilder
 import org.springframework.scripting.groovy.GroovyObjectCustomizer
 
@@ -36,11 +37,16 @@ class PluginCustomizer implements GroovyObjectCustomizer {
                     clos.delegate = builder
                     clos.resolveStrategy = Closure.DELEGATE_FIRST
                     clos.call()
-                    pluginRegistry[goo.class.name] = goo.class.name
+                    String svcName = findServiceName(clazz)
+                    pluginRegistry[svcName + ':' + goo.class.name] = goo.class.name
                     return builder
                 }
                 return goo;
             }
         }
+    }
+
+    private static String findServiceName(Class type) {
+        return ServiceTypes.pluginTypesMap.find { it.value == type }?.key
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/PluginServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/PluginServiceSpec.groovy
@@ -390,6 +390,20 @@ class PluginServiceSpec extends Specification implements ServiceUnitTest<PluginS
         result == configuredPlugin
         result.instance.getService() != null
     }
+    def "listPlugins"(){
+        given:
+            def test = [
+                a: new DescribedPlugin(null, null, 'alphaTestService', new File("alphaTestService.groovy"),null),
+                b: new DescribedPlugin(null, null, 'bTestService', new File("bTestService.groovy"),null)
+            ]
+            service.rundeckPluginRegistry = Mock(PluginRegistry)
+        when:
+            def result = service.listPlugins(String, Mock(PluggableProviderService))
+        then:
+            1 * service.rundeckPluginRegistry.listPluginDescriptors(String,_)>>test
+            result['a'].name=='alphaTestService'
+            result['b'].name=='bTestService'
+    }
 
 
     class TestNotificationPlugin implements NotificationPlugin, AcceptsServices{

--- a/rundeckapp/src/test/groovy/rundeck/services/PluginServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/PluginServiceTests.groovy
@@ -470,32 +470,4 @@ class PluginServiceTests extends Specification {
         assertEquals(test, service.validatePlugin("blah",new testProvider(),null,null))
         assertTrue(testReg.validateWithResolverCalled)
     }
-    void testListPlugins(){
-        mockLogging(PluginService)
-        def service = new PluginService()
-        def TestRegistry testReg = new TestRegistry()
-        service.rundeckPluginRegistry = testReg
-        def test = ['a': new DescribedPlugin(null,null,'a'), 'b': new DescribedPlugin(null,null,'b')]
-        testReg.pluginDescriptorMap= test
-        assertFalse(testReg.listPluginDescriptorsCalled)
-        def result = service.listPlugins(String,new testProvider("test service"))
-        assertTrue(testReg.listPluginDescriptorsCalled)
-        assertEquals('a', result['a'].name)
-        assertEquals('b', result['b'].name)
-    }
-    void testListPluginsCullName(){
-        mockLogging(PluginService)
-        def service = new PluginService()
-        def TestRegistry testReg = new TestRegistry()
-        service.rundeckPluginRegistry = testReg
-        def test = ['a': new DescribedPlugin(null,null, 'alphaTestService',new File("alphaTestService.groovy")),
-                'b': new DescribedPlugin(null,null, 'bTestService',new File("bTestService.groovy"))]
-        testReg.pluginDescriptorMap= test
-        assertFalse(testReg.listPluginDescriptorsCalled)
-        def result = service.listPlugins(String,new testProvider("TestService"))
-        assertTrue(testReg.listPluginDescriptorsCalled)
-        assertEquals('alpha', result['a'].name)
-        assertEquals('b', result['b'].name)
-
-    }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Some code remains which strips the suffix of a plugin name if it matches the service name, for “.groovy” plugins. This causes some groovy plugins to not be loadable.

Example: “SlackNotification.groovy”, if defined in libext/ even with valid plugin DSL usage, will not be usable.  The code removes “Notification” and lists a plugin named “Slack”, but attempting to load the plugin “Slack” causes an error because it is not found.

**Describe the solution you've implemented**
* change registration code to use proper "service name:" prefix
* PluginService.listPlugins no longer removes the service name suffix automatically from registered name, which causes groovy plugins to not be loaded correctly


