### PR TITLE
RUN-1372: Fix plugin property mappings

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/StepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/StepPluginAdapter.java
@@ -113,13 +113,9 @@ public class StepPluginAdapter implements StepExecutor, Describable, DynamicProp
             );
         }
         final String providerName = item.getType();
-        final PropertyResolver resolver = PropertyResolverFactory.createStepPluginRuntimeResolver(executionContext,
-                instanceConfiguration,
-                ServiceNameConstants.WorkflowStep,
-                providerName
-        );
+            final PropertyResolverFactory.Factory resolverFactory =  PropertyResolverFactory.createFrameworkProjectRuntimeResolverFactory(executionContext.getIFramework(), executionContext.getFrameworkProject(), instanceConfiguration);
         final PluginStepContext stepContext = PluginStepContextImpl.from(executionContext);
-        final Map<String, Object> config = PluginAdapterUtility.configureProperties(resolver, description,
+        final Map<String, Object> config = PluginAdapterUtility.configureProperties(resolverFactory.create(ServiceNameConstants.WorkflowStep,description), description,
                 plugin, PropertyScope.InstanceOnly);
         try {
             plugin.executeStep(stepContext, config);

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
@@ -160,7 +160,7 @@ public class NodeStepPluginAdapter implements NodeStepExecutor, Describable, Dyn
         final PropertyResolverFactory.Factory resolverFactory =  PropertyResolverFactory.createFrameworkProjectRuntimeResolverFactory(context.getIFramework(), context.getFrameworkProject(), instanceConfiguration);
 
         final PluginStepContext pluginContext = PluginStepContextImpl.from(context);
-        final Map<String, Object> config = PluginAdapterUtility.configureProperties(resolverFactory.create(ServiceNameConstants.WorkflowNodeStep,description), description, plugin, PropertyScope.InstanceOnly);
+        final Map<String, Object> config = PluginAdapterUtility.configureProperties(resolverFactory.create(getServiceName(),description), description, plugin, PropertyScope.InstanceOnly);
         try {
             plugin.executeNodeStep(pluginContext, config, node);
         } catch (NodeStepException e) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
@@ -157,12 +157,10 @@ public class NodeStepPluginAdapter implements NodeStepExecutor, Describable, Dyn
         }
         final String providerName = item.getNodeStepType();
 
-        final PropertyResolver resolver = PropertyResolverFactory.createStepPluginRuntimeResolver(context,
-                                                                                                  instanceConfiguration,
-                                                                                                  getServiceName(),
-                                                                                                  providerName);
+        final PropertyResolverFactory.Factory resolverFactory =  PropertyResolverFactory.createFrameworkProjectRuntimeResolverFactory(context.getIFramework(), context.getFrameworkProject(), instanceConfiguration);
+
         final PluginStepContext pluginContext = PluginStepContextImpl.from(context);
-        final Map<String, Object> config = PluginAdapterUtility.configureProperties(resolver, description, plugin, PropertyScope.InstanceOnly);
+        final Map<String, Object> config = PluginAdapterUtility.configureProperties(resolverFactory.create(ServiceNameConstants.WorkflowStep,description), description, plugin, PropertyScope.InstanceOnly);
         try {
             plugin.executeNodeStep(pluginContext, config, node);
         } catch (NodeStepException e) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
@@ -160,7 +160,7 @@ public class NodeStepPluginAdapter implements NodeStepExecutor, Describable, Dyn
         final PropertyResolverFactory.Factory resolverFactory =  PropertyResolverFactory.createFrameworkProjectRuntimeResolverFactory(context.getIFramework(), context.getFrameworkProject(), instanceConfiguration);
 
         final PluginStepContext pluginContext = PluginStepContextImpl.from(context);
-        final Map<String, Object> config = PluginAdapterUtility.configureProperties(resolverFactory.create(ServiceNameConstants.WorkflowStep,description), description, plugin, PropertyScope.InstanceOnly);
+        final Map<String, Object> config = PluginAdapterUtility.configureProperties(resolverFactory.create(ServiceNameConstants.WorkflowNodeStep,description), description, plugin, PropertyScope.InstanceOnly);
         try {
             plugin.executeNodeStep(pluginContext, config, node);
         } catch (NodeStepException e) {

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapterSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapterSpec.groovy
@@ -85,6 +85,14 @@ class NodeStepPluginAdapterSpec extends Specification {
         shared.merge(ContextView.global(), optionContext)
         StepExecutionContext context = Mock(StepExecutionContext) {
             getFramework() >> framework
+            getIFramework() >> Mock(IFramework){
+                getFrameworkProjectMgr() >> Mock(ProjectManager){
+                    getFrameworkProject(_) >>Mock(IRundeckProject) {
+                        getProperties() >> [:]
+                    }
+
+                }
+            }
             getDataContext() >> optionContext
             getSharedDataContext() >> shared
             getFrameworkProject() >> PROJECT_NAME
@@ -132,6 +140,14 @@ class NodeStepPluginAdapterSpec extends Specification {
         shared.merge(ContextView.global(), optionContext)
         StepExecutionContext context = Mock(StepExecutionContext) {
             getFramework() >> framework
+            getIFramework() >> Mock(IFramework){
+                getFrameworkProjectMgr() >> Mock(ProjectManager){
+                    getFrameworkProject(_) >>Mock(IRundeckProject) {
+                        getProperties() >> [:]
+                    }
+
+                }
+            }
             getDataContext() >> optionContext
             getSharedDataContext() >> shared
             getFrameworkProject() >> PROJECT_NAME

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/RemoteScriptNodeStepPluginAdapter_ExtTest.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/RemoteScriptNodeStepPluginAdapter_ExtTest.groovy
@@ -20,7 +20,9 @@ import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.FrameworkProject
 import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.IFrameworkServices
+import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
+import com.dtolabs.rundeck.core.common.ProjectManager
 import com.dtolabs.rundeck.core.data.DataContext
 import com.dtolabs.rundeck.core.data.SharedDataContextUtils
 import com.dtolabs.rundeck.core.dispatcher.DataContextUtils
@@ -94,6 +96,14 @@ class RemoteScriptNodeStepPluginAdapter_ExtTest extends Specification {
 
             StepExecutionContext context = Mock(StepExecutionContext) {
                 getFramework() >> framework
+                getIFramework() >> Mock(IFramework){
+                    getFrameworkProjectMgr() >> Mock(ProjectManager){
+                        getFrameworkProject(_) >>Mock(IRundeckProject) {
+                            getProperties() >> [:]
+                        }
+
+                    }
+                }
                 getFrameworkProject() >> PROJECT_NAME
                 getDataContextObject() >> dataContext
                 getSharedDataContext() >> sharedContext
@@ -305,6 +315,14 @@ class RemoteScriptNodeStepPluginAdapter_ExtTest extends Specification {
 
             StepExecutionContext context = Mock(StepExecutionContext) {
                 getFramework() >> framework
+                getIFramework() >> Mock(IFramework){
+                    getFrameworkProjectMgr() >> Mock(ProjectManager){
+                        getFrameworkProject(_) >>Mock(IRundeckProject) {
+                            getProperties() >> [:]
+                        }
+
+                    }
+                }
                 getFrameworkProject() >> PROJECT_NAME
                 getDataContextObject() >> dataContext
                 getSharedDataContext() >> sharedContext


### PR DESCRIPTION
Workflow and node steps ability to map project and framework values was broken with the addition of the plugin group feature. This fixes that issue by updating the property resolver used to lookup and configure the plugin properties.