### PR TITLE
RUN-1369: Update spring-sec to fixed version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ bouncyCastleVersion=1.68
 # https://github.com/spring-projects/spring-boot/blob/1.5.x/spring-boot-dependencies/pom.xml
 #
 jetty.version=9.4.48.v20220622
-spring-security.version=5.6.1
+spring-security.version=5.6.9
 log4j2.version=2.17.1
 assetPluginVersion=3.4.3
 dbMigrationPluginVersion=4.1.0


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
An enhancement to address three CVEs involving spring-security: CVE-2022-31690, CVE-2022-22978, and CVE-2022-31692

**Describe the solution you've implemented**
Bumps the version of our spring-security packages via the gradle.properties file

**Describe alternatives you've considered**
N/a

**Additional context**
Pairs with https://github.com/rundeckpro/rundeckpro/pull/2809
