### PR TITLE
RSE-245: Fix: deb install not taking wrong base dir for commands

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "packaging/packaging"]
 	path = packaging/packaging
 	url = git@github.com:rundeck/packaging.git
-	branch = main
+	branch = rse245-not-taking-rdeckbase-in-deb-install

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "packaging/packaging"]
 	path = packaging/packaging
 	url = git@github.com:rundeck/packaging.git
-	branch = rse245-not-taking-rdeckbase-in-deb-install
+	branch = main

--- a/packaging/lib/deb/etc/init.d/rundeckd
+++ b/packaging/lib/deb/etc/init.d/rundeckd
@@ -39,7 +39,7 @@ start() {
 	fi
 
 	cd /var/log/rundeck
-	start-stop-daemon --start --quiet --chuid $USER:$USER \
+	start-stop-daemon --start --quiet --chuid $USER:$USER --chdir $RDECK_BASE \
                     --make-pidfile --pidfile $PIDFILE \
                     --background --startas /bin/bash -- \
                     -c "exec $DAEMON_EXEC >> $LOG 2>&1" 


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-245

#### Problem

##### Steps to Reproduce

1. Install 4.7.0 DEB package & run “pwd” command on localhost.

2. Check system report for PWD env variable.

Related to https://github.com/rundeck/rundeck/issues/4554
##### Rundeck Details
Rundeck version: 4.7.0

Install type: DEB

OS Name/version: Ubuntu 20.04

DB Type/version: H2

#### Solution
This was happening because the `/` is the default directory to run daemons used by the `start-stop-daemon` command. To solve the issue it was necessary to set this directory through the `--chdir` parameter when the `start-stop-daemon` is called in the `rundeckd` daemon.