### PR TITLE
RUN-1349 | Fix Missing Execution Clean History Form Display

### DIFF
--- a/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
@@ -61,9 +61,9 @@
     }
     function cleanerchkbox(el) {
         if(el.checked){
-            $('cleaner_config').show()
+            jQuery('#cleaner_config').show()
         } else {
-            $('cleaner_config').hide()
+            jQuery('#cleaner_config').hide()
         }
     }
 </script>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Bugfix: Upon toggling the checkbox in Execution Clean Form tab in Project Settings, the form associated was not showing.

**Describe the solution you've implemented**
Update jQuery function call and update ID selector