### PR TITLE
RSE-244 Fix: edit/view jobs when SCM Import Plugin is forbidden for user

### DIFF
--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -343,6 +343,9 @@ search
                     bulkeditor.scmImportJobStatus(data.scmImportJobStatus);
                     bulkeditor.scmImportStatus(data.scmImportStatus);
                     bulkeditor.scmImportActions(data.scmImportActions);
+                    if( data.warning !== undefined ){
+                        showError(data.warning)
+                    }
 
                     bulkeditor.scmDone(true);
                 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1593,7 +1593,7 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
                                                                                 AuthConstants.ACTION_SCM_IMPORT]) >> true
         1 * controller.scmService.projectHasConfiguredExportPlugin(project) >> false
         1 * controller.scmService.projectHasConfiguredImportPlugin(project) >> true
-        1 * controller.scmService.loadScmConfig(project,'import') >> scmConfig
+        2 * controller.scmService.loadScmConfig(project,'import') >> scmConfig
         2 * scmConfig.getEnabled() >> enabled
         1 * controller.storageService.hasPath(_,_) >> true
         (count) * controller.scmService.getJobsPluginMeta(project, false)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1594,7 +1594,7 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         1 * controller.scmService.projectHasConfiguredExportPlugin(project) >> false
         1 * controller.scmService.projectHasConfiguredImportPlugin(project) >> true
         2 * controller.scmService.loadScmConfig(project,'import') >> scmConfig
-        2 * scmConfig.getEnabled() >> enabled
+        1 * scmConfig.getEnabled() >> enabled
         1 * controller.storageService.hasPath(_,_) >> true
         (count) * controller.scmService.getJobsPluginMeta(project, false)
         (count) * controller.scmService.importStatusForJobs(project,_, _, _, _)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1567,6 +1567,7 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         controller.aclFileManagerService = Mock(AclFileManagerService)
         controller.scheduledExecutionService = Mock(ScheduledExecutionService)
         controller.scmService = Mock(ScmService)
+        controller.storageService = Mock(StorageService)
         def project = 'test'
         def scmConfig = Mock(ScmPluginConfigData)
 
@@ -1592,7 +1593,8 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         1 * controller.scmService.projectHasConfiguredExportPlugin(project) >> false
         1 * controller.scmService.projectHasConfiguredImportPlugin(project) >> true
         1 * controller.scmService.loadScmConfig(project,'import') >> scmConfig
-        1 * scmConfig.getEnabled() >> enabled
+        2 * scmConfig.getEnabled() >> enabled
+        1 * controller.storageService.hasPath(_,_) >> true
         (count) * controller.scmService.getJobsPluginMeta(project, false)
         (count) * controller.scmService.importStatusForJobs(project,_, _, _, _)
         (count) * controller.scmService.importPluginStatus(_,project)


### PR DESCRIPTION
# Fix: Edit/View Jobs when SCM Import Plugin is Forbidden for User
Previously if the user don't have permissions to the key configured in the SCM Import Plugin, an internal server error could be seen and the basic job actions couldn't be performed.

## The Problem
1. Since th SCM service use the SESSION user to perform SCM operations, an error occurs when the system search for the keys in the plugin's config

## The Solution
1. In the controller of the menu (who renders job page and its functions) ask if the current user has permission to the key, if not disable the plugin and populate a message to the frontend.
2. Log at ERROR level the incidence.
3. Flash the unauthorized user with a message, letting the user now what happened with the SCM.

## Exhibits
a) If an unauthorized user with the SCM import enabled sees the jobs page, an error message will be displayed
![Screenshot from 2022-12-15 15-50-18](https://user-images.githubusercontent.com/81827734/207943277-9b4d0af4-c3d7-4215-aa73-cdfdeff042a7.png)

b) But if we go ahead and try to edit the job or see its details, the system will allow us since the SCM is disabled
![Screenshot from 2022-12-15 15-50-42](https://user-images.githubusercontent.com/81827734/207943474-843e77f9-13cd-4bdc-8504-a8b6ce2f7532.png)

c) A line of log could be seen in the general log
![Screenshot from 2022-12-15 15-51-16](https://user-images.githubusercontent.com/81827734/207944034-4c5df310-d6a1-4141-8e4e-fbdcce3844ab.png)
