### PR TITLE
RUN-1350: fix: step/global log filters not working after jquery upgrade

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/menu/logStorage.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/logStorage.js
@@ -96,7 +96,7 @@ function StorageStats(data) {
         }).done(_createAjaxReceiveTokensHandler(self.tokensName));
     };
     self.resumeAllIncomplete = function () {
-        return self.ajaxAction(self.resumeUrl,{}).success(function(data){
+        return self.ajaxAction(self.resumeUrl,{}).then(function(data){
             if(data.status=='ok'){
                 self.reload();
             }
@@ -109,7 +109,7 @@ function StorageStats(data) {
         }else if(typeof(obj)=='string'){
             id=obj;
         }
-        return self.ajaxAction(self.resumeUrl,{id:id}).success(function(data){
+        return self.ajaxAction(self.resumeUrl,{id:id}).then(function(data){
             if(data.status=='ok'){
                 self.reload();
             }
@@ -119,7 +119,7 @@ function StorageStats(data) {
         });
     };
     self.cleanupAllIncomplete = function () {
-        return self.ajaxAction(self.cleanupUrl,{}).success(function(data){
+        return self.ajaxAction(self.cleanupUrl,{}).then(function(data){
             if(data.status=='ok'){
                 self.reload();
             }
@@ -132,7 +132,7 @@ function StorageStats(data) {
         }else if(typeof(obj)=='string'){
             id=obj;
         }
-        return self.ajaxAction(self.cleanupUrl,{id:id}).success(function(data){
+        return self.ajaxAction(self.cleanupUrl,{id:id}).then(function(data){
             if(data.status=='ok'){
                 self.reload();
             }

--- a/rundeckapp/grails-app/assets/javascripts/nodeFiltersKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/nodeFiltersKO.js
@@ -76,7 +76,7 @@ function NodeSummary(data){
         }
     };
     self.removeDefault=function(){
-        setFilter('nodes','!').success(function(data, status, jqxhr){
+        setFilter('nodes','!').then(function(data, status, jqxhr){
             self.defaultFilter(null);
         });
     };
@@ -99,7 +99,7 @@ function NodeSummary(data){
         }else{
             fname=filter.name();
         }
-        setFilter('nodes',fname).success(function(data, status, jqxhr){
+        setFilter('nodes',fname).then(function(data, status, jqxhr){
             self.defaultFilter(fname);
         });
     };

--- a/rundeckapp/grails-app/assets/javascripts/workflowStepEditorKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/workflowStepEditorKO.js
@@ -106,7 +106,7 @@ function WorkflowEditor() {
 
         return step.editor.editFilter(step, stepfilter, newtype, validate, validatedata, function (params, data, type) {
 
-            return self.loadFilterPluginEditor(params, data, type).success(function () {
+            return self.loadFilterPluginEditor(params, data, type).then(function () {
                 jQuery('#editLogFilterPluginModal').modal('show');
             });
         });


### PR DESCRIPTION
function `.success()` was removed, should use `.done()` or `.then()`

reference: https://jquery.com/upgrade-guide/3.0/#ajax


**Is this a bugfix, or an enhancement? Please describe.**
Fix: adding log filters in job editor GUI does not work

**Additional context**
broken by jquery upgrade
