### PR TITLE
Run 1386-fix plugin groups deleted when not modified

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -1407,7 +1407,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                 //specific props for typed pluginValues
                 removePrefixes.add("project.plugin.PluginGroup.".toString())
                 removePrefixes.add("project.PluginGroup.".toString())
-                if (params.pluginValues?.PluginGroup?.json && params.pluginValues?.PluginGroup?.json != "[]") {
+                if (params.pluginValues?.PluginGroup?.json) {
                     def groupData = JSON.parse(params.pluginValues.PluginGroup.json.toString())
                     if (groupData instanceof Collection) {
                         for (Object data : groupData) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -829,10 +829,12 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                             && data.config instanceof Map) {
                         String type = data.get('type')
                         Map config = data.get('config')
-                        projProps.put(
-                                "project.PluginGroup.${type}.enabled".toString(),
-                                'true'
-                        )
+                        if(config && config.size()!=0){
+                            projProps.put(
+                                    "project.PluginGroup.${type}.enabled".toString(),
+                                    'true'
+                            )
+                        }
                         for (String confKey : config.keySet()) {
                             projProps.put(
                                     "project.plugin.PluginGroup.${type}.${confKey}".toString(),
@@ -1418,10 +1420,13 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                                     [[config: [type: type, props: config], type: type, index: 0]],
                                     pluginGroupDescs
                                 )
-                                projProps.put(
-                                    "project.PluginGroup.${type}.enabled".toString(),
-                                    'true'
-                                )
+                                if(config && config.size()!=0){
+                                    projProps.put(
+                                            "project.PluginGroup.${type}.enabled".toString(),
+                                            'true'
+                                    )
+                                }
+
                                 for (String confKey : config.keySet()) {
                                     projProps.put(
                                         "project.plugin.PluginGroup.${type}.${confKey}".toString(),

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -829,12 +829,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                             && data.config instanceof Map) {
                         String type = data.get('type')
                         Map config = data.get('config')
-                        if(config && config.size()!=0){
-                            projProps.put(
-                                    "project.PluginGroup.${type}.enabled".toString(),
-                                    'true'
-                            )
-                        }
+                        projProps.put(
+                                "project.PluginGroup.${type}.enabled".toString(),
+                                'true'
+                        )
                         for (String confKey : config.keySet()) {
                             projProps.put(
                                     "project.plugin.PluginGroup.${type}.${confKey}".toString(),
@@ -1420,12 +1418,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                                     [[config: [type: type, props: config], type: type, index: 0]],
                                     pluginGroupDescs
                                 )
-                                if(config && config.size()!=0){
-                                    projProps.put(
-                                            "project.PluginGroup.${type}.enabled".toString(),
-                                            'true'
-                                    )
-                                }
+                                projProps.put(
+                                        "project.PluginGroup.${type}.enabled".toString(),
+                                        'true'
+                                )
 
                                 for (String confKey : config.keySet()) {
                                     projProps.put(

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-config/PluginSetConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-config/PluginSetConfig.vue
@@ -6,6 +6,7 @@
     :edit-mode="true"
     :help="help"
     project=""
+    @loaded="pluginsConfigWasLoaded"
     @deleted="pluginsConfigWasDeleted"
     @saved="pluginsConfigWasSaved"
     @modified="pluginsConfigWasModified"
@@ -83,6 +84,10 @@ export default Vue.extend({
       this.pluginConfigs=pluginConfigs
     },
     pluginsConfigWasDeleted(pluginConfigs: ProjectPluginConfigEntry[]) {
+      this.pluginConfigs=pluginConfigs
+    },
+    pluginsConfigWasLoaded(pluginConfigs: ProjectPluginConfigEntry[]) {
+      this.$emit("loaded");
       this.pluginConfigs=pluginConfigs
     },
     pluginsConfigWasModified() {

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-config/ProjectPluginGroups.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-config/ProjectPluginGroups.vue
@@ -339,6 +339,9 @@ export default Vue.extend({
       this.$emit("modified");
       this.notifyPluginConfigs();
     },
+    setPluginConfigsLoaded() {
+      this.$emit("loaded", this.pluginConfigs);
+    },
     pluginConfigsModified() {
       if (this.loaded) {
         this.setPluginConfigsModified();
@@ -400,6 +403,7 @@ export default Vue.extend({
     const pluginGroups = window._rundeck.data.pluginGroups as PluginConf
     this.contextConfig = pluginGroups.config
     await this.getPluginConfigs()
+    await this.setPluginConfigsLoaded()
 
   }
 });


### PR DESCRIPTION
load plugins config everytime page is loaded for edge cases where there are no events. i.e save, delete a plugin group