### PR TITLE
RUN-1392 Duplicated fields at Notification settings modal

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/components/plugins/pluginConfig.vue
@@ -81,7 +81,7 @@
                   </div>
 
             </div>
-            <details :open="!group.secondary" v-else class="more-info details-reset">
+            <details :open="!group.secondary" v-if="group.name" class="more-info details-reset">
               <summary >
                 <span class="row">
                   <span class="col-sm-2 control-label h5 header-reset">


### PR DESCRIPTION
Fix: duplicated fields at notification settings modal

**Is this a bugfix, or an enhancement? Please describe.**
The modal fields for configuring notifications are being displayed repeatedly

**Describe the solution you've implemented**
The v-else statement behaves differently than when using v-if, causing fields to be rendered repeatedly.

