### PR TITLE
RUN-1397: modular annotation authZ 

### DIFF
--- a/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/app/BaseAppRequestMethodAuthorizer.java
+++ b/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/app/BaseAppRequestMethodAuthorizer.java
@@ -1,0 +1,67 @@
+package org.rundeck.core.auth.app;
+
+import org.rundeck.core.auth.web.*;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Defines base authorization annotations for controller actions
+ */
+public class BaseAppRequestMethodAuthorizer
+        implements RequestMethodAuthorizer
+{
+    public List<TypedNamedAuthRequest> requestsFromAnnotations(Method method) {
+        List<TypedNamedAuthRequest> list = new ArrayList<>();
+        list.addAll(Arrays
+                            .stream(method.getAnnotationsByType(RdAuthorize.class))
+                            .map(NamedAuthRequestUtil::authorizeRequest)
+                            .collect(
+                                    Collectors.toList()));
+        list.addAll(Arrays
+                            .stream(method.getAnnotationsByType(RdAuthorizeSystem.class))
+                            .map(NamedAuthRequestUtil::authorizeRequest)
+                            .collect(
+                                    Collectors.toList()));
+        list.addAll(Arrays
+                            .stream(method.getAnnotationsByType(RdAuthorizeProject.class))
+                            .map(NamedAuthRequestUtil::authorizeRequest)
+                            .collect(
+                                    Collectors.toList()));
+        list.addAll(Arrays
+                            .stream(method.getAnnotationsByType(RdAuthorizeAdhoc.class))
+                            .map(NamedAuthRequestUtil::authorizeRequest)
+                            .collect(
+                                    Collectors.toList()));
+        list.addAll(Arrays
+                            .stream(method.getAnnotationsByType(RdAuthorizeExecution.class))
+                            .map(NamedAuthRequestUtil::authorizeRequest)
+                            .collect(
+                                    Collectors.toList()));
+        list.addAll(Arrays
+                            .stream(method.getAnnotationsByType(RdAuthorizeJob.class))
+                            .map(NamedAuthRequestUtil::authorizeRequest)
+                            .collect(
+                                    Collectors.toList()));
+        list.addAll(Arrays
+                            .stream(method.getAnnotationsByType(RdAuthorizeApplicationType.class))
+                            .map(NamedAuthRequestUtil::authorizeRequest)
+                            .collect(
+                                    Collectors.toList()));
+        list.addAll(Arrays
+                            .stream(method.getAnnotationsByType(RdAuthorizeProjectAcl.class))
+                            .map(NamedAuthRequestUtil::authorizeRequest)
+                            .collect(
+                                    Collectors.toList()));
+        list.addAll(Arrays
+                            .stream(method.getAnnotationsByType(RdAuthorizeProjectType.class))
+                            .map(NamedAuthRequestUtil::authorizeRequest)
+                            .collect(
+                                    Collectors.toList()));
+        return list;
+    }
+
+}

--- a/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/app/RequestMethodAuthorizer.java
+++ b/rundeck-authz/rundeck-authz-core/src/main/java/org/rundeck/core/auth/app/RequestMethodAuthorizer.java
@@ -1,0 +1,8 @@
+package org.rundeck.core.auth.app;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+public interface RequestMethodAuthorizer {
+    List<TypedNamedAuthRequest> requestsFromAnnotations(Method method);
+}

--- a/rundeck-authz/rundeck-authz-core/src/main/resources/META-INF/services/org.rundeck.core.auth.app.RequestMethodAuthorizer
+++ b/rundeck-authz/rundeck-authz-core/src/main/resources/META-INF/services/org.rundeck.core.auth.app.RequestMethodAuthorizer
@@ -1,0 +1,1 @@
+org.rundeck.core.auth.app.BaseAppRequestMethodAuthorizer


### PR DESCRIPTION
define ServiceLoader interface for new method interceptor authorization checks


**Is this a bugfix, or an enhancement? Please describe.**
Allows extending authZ checks that can be applied to controller actions with new annotations
