### PR TITLE
RUN-1389: fix error choosing runner on execution runtime

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -477,6 +477,11 @@
 </g:uploadForm>
 
 <script lang="text/javascript">
+
+    window._rundeck = Object.assign(window._rundeck || {}, {
+        "data": {"jobComponentProperties": loadJsonData('jobComponentProperties')}
+    })
+
     function init() {
         var pageParams = loadJsonData('pageParams');
         jQuery('body').on('click', '.nodefilterlink', function (evt) {
@@ -584,9 +589,7 @@
         });
 
         initKoBind('#exec_options_form', kocontrollers, /*'execform'*/)
-        window._rundeck = Object.assign(window._rundeck || {}, {
-            "data": {"jobComponentProperties": loadJsonData('jobComponentProperties')}
-        })
+
     }
     jQuery(document).ready(init);
 </script>


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
bug fix.
If I choose the option to change the runner on execution time, when I’m on the job pages to execute the job I don’t have the option to change the runner

**Describe the solution you've implemented**
in firefox, the code that loads `jobComponentProperties` runs after the VUE component is loaded.
The solution was moving the jobComponentProperties load outside the jquery block.

**Describe alternatives you've considered**

**Additional context**
