### PR TITLE
RCLOUD-728: Fix Project Picker not loading when Projects with special characters exist

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2381,6 +2381,9 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             summary[project.name]=allsummary[project.name]?:[:]
             def prj = projectService.findProjectByName(project.name)
             def description = prj?.description
+            if(!description){
+                description = project.hasProperty("project.description")?project.getProperty("project.description"):''
+            }
             summary[project.name].label= project.hasProperty("project.label")?project.getProperty("project.label"):''
             summary[project.name].description= description
             def projectAuth = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project.name)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -2381,13 +2381,6 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             summary[project.name]=allsummary[project.name]?:[:]
             def prj = projectService.findProjectByName(project.name)
             def description = prj?.description
-            if(!description){
-                description = project.hasProperty("project.description")?project.getProperty("project.description"):''
-                if(description && prj){
-                    def simplePrj = SimpleProjectBuilder.with(prj).setDescription(description)
-                    projectService.update(prj.getId(), simplePrj)
-                }
-            }
             summary[project.name].label= project.hasProperty("project.label")?project.getProperty("project.label"):''
             summary[project.name].description= description
             def projectAuth = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project.name)

--- a/rundeckapp/grails-app/domain/rundeck/Project.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Project.groovy
@@ -30,7 +30,7 @@ class Project implements RdProject {
 
     static constraints={
         name(matches: '^[a-zA-Z0-9\\.,@\\(\\)_\\\\/-]+$',unique: true)
-        description(nullable:true, matches: '^[a-zA-Z0-9\\p{L}\\p{M}\\s\\.,\\(\\)_-]+$')
+        description(nullable:true, maxSize: 50)
     }
 
     static mapping = {

--- a/rundeckapp/grails-app/domain/rundeck/Project.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Project.groovy
@@ -30,7 +30,7 @@ class Project implements RdProject {
 
     static constraints={
         name(matches: '^[a-zA-Z0-9\\.,@\\(\\)_\\\\/-]+$',unique: true)
-        description(nullable:true, maxSize: 50)
+        description(nullable:true, maxSize: 255)
     }
 
     static mapping = {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -44,6 +44,7 @@ import org.rundeck.app.auth.CoreTypedRequestAuthorizer
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.app.authorization.domain.AppAuthorizer
 import org.rundeck.app.components.RundeckJobDefinitionManager
+import org.rundeck.app.data.model.v1.project.RdProject
 import org.rundeck.app.data.providers.GormProjectDataProvider
 import org.rundeck.app.gui.JobListLinkHandler
 import org.rundeck.core.auth.AuthConstants
@@ -1373,10 +1374,7 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         controller.configurationService = Mock(ConfigurationService)
         controller.menuService = Mock(MenuService)
         controller.scheduledExecutionService = Mock(ScheduledExecutionService)
-        controller.projectService = Mock(ProjectService){
-            projectDataProvider >>  new GormProjectDataProvider()
-
-        }
+        controller.projectService = Mock(ProjectService)
         request.addHeader('x-rundeck-ajax', 'true')
 
         when:
@@ -1386,8 +1384,10 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
         1 * controller.frameworkService.projectNames(_) >> []
         1 * controller.frameworkService.projects(_) >> projects
+        1 * controller.projectService.findProjectByName('proj') >> Mock(RdProject)
         1 * iproj.hasProperty('project.description') >> true
         1 * iproj.getProperty('project.description') >> description
+        0 * controller.projectService.update(_,_)
         description == response.json.projects[0].description
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
@@ -1065,7 +1065,7 @@ class ProjectManagerServiceSpec extends Specification implements ServiceUnitTest
 
         def props = new Properties()
         props['abc'] = 'def'
-        props['project.description'] = 'desc_test'
+        props['project.description'] = description
 
         service.configStorageService=Stub(ConfigStorageService) {
             existsFileResource("projects/test1/etc/project.properties") >> false
@@ -1090,6 +1090,13 @@ class ProjectManagerServiceSpec extends Specification implements ServiceUnitTest
         }
         service.rundeckNodeService = Mock(NodeService)
         service.projectCache = Mock(LoadingCache)
+        service.projectDataProvider=Mock(RundeckProjectDataProvider){
+            1 * findByName('test1')
+            1 * create({
+                it.description==description
+                it.name=='test1'
+            })
+        }
 
         when:
 


### PR DESCRIPTION
bugfix: Remove Database update for project on an ajax method who's purpose is to retrieve the project list for the picker.  Change the strict character constraint for the description field on project.  Change max length of the description field to match the corresponding text box length