### PR TITLE
RUN-1418: Job activity tab not loading

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -478,8 +478,8 @@
 
 <script lang="text/javascript">
 
-    window._rundeck = Object.assign(window._rundeck || {}, {
-        "data": {"jobComponentProperties": loadJsonData('jobComponentProperties')}
+    window._rundeck.data = Object.assign(window._rundeck.data || {}, {
+        "jobComponentProperties": loadJsonData('jobComponentProperties')
     })
 
     function init() {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Data attribute in `window._rundeck`object is overriden when loading job page

**Describe the solution you've implemented**
`jobComponentProperties` should be merged into `data` object instead of override
