### PR TITLE
RUN-1385: Plugin group null definitions

### DIFF
--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-config/PluginSetConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-config/PluginSetConfig.vue
@@ -65,8 +65,6 @@ export default Vue.extend({
   },
   methods:{
     inputReceived(pluginConfigs: ProjectPluginConfigEntry[]) {
-      console.log("input received")
-      console.log(pluginConfigs)
       this.pluginConfigs=pluginConfigs
     },
   }

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-config/PluginSetConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-config/PluginSetConfig.vue
@@ -6,18 +6,13 @@
     :edit-mode="true"
     :help="help"
     project=""
-    @loaded="pluginsConfigWasLoaded"
-    @deleted="pluginsConfigWasDeleted"
-    @saved="pluginsConfigWasSaved"
-    @modified="pluginsConfigWasModified"
-    @cancelled="pluginsConfigWasCancelled"
-    @reset="pluginsConfigWasReset"
+    @input="inputReceived"
     :edit-button-text="$t('Edit Plugin Groups')"
     :mode-toggle="modeToggle"
   >
   </project-plugin-groups>
-    <template v-if="exportedData">
-      <input type="hidden" :value="JSON.stringify(exportedData)" :name="configPrefix+'json'"/>
+    <template v-if="this.pluginConfigs">
+      <input type="hidden" :value="JSON.stringify(this.pluginConfigs)" :name="configPrefix+'json'"/>
     </template>
   </div>
 
@@ -68,38 +63,12 @@ export default Vue.extend({
       pluginConfigs: [] as ProjectPluginConfigEntry[],
     }
   },
-  computed:{
-    exportedData():any[]{
-      let data = [] as any
-      let inputData = this.pluginConfigs
-      inputData.forEach((plugin, index) => {
-          data.push({type: plugin.entry.type, config: plugin.entry.config})
-      });
-      return data
-
-    }
-  },
   methods:{
-    pluginsConfigWasSaved(pluginConfigs: ProjectPluginConfigEntry[]) {
-      this.$emit("saved");
+    inputReceived(pluginConfigs: ProjectPluginConfigEntry[]) {
+      console.log("input received")
+      console.log(pluginConfigs)
       this.pluginConfigs=pluginConfigs
     },
-    pluginsConfigWasDeleted(pluginConfigs: ProjectPluginConfigEntry[]) {
-      this.pluginConfigs=pluginConfigs
-    },
-    pluginsConfigWasLoaded(pluginConfigs: ProjectPluginConfigEntry[]) {
-      this.$emit("loaded");
-      this.pluginConfigs=pluginConfigs
-    },
-    pluginsConfigWasModified() {
-      this.$emit("modified");
-    },
-    pluginsConfigWasCancelled(pluginConfigs: ProjectPluginConfigEntry[]) {
-      this.pluginConfigs=pluginConfigs
-    },
-    pluginsConfigWasReset() {
-      this.$emit("reset");
-    }
   }
 })
 

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-config/ProjectPluginGroups.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-config/ProjectPluginGroups.vue
@@ -287,12 +287,10 @@ export default Vue.extend({
       this.editFocus = focus;
     },
     editPlugin(index:any, plugin: ProjectPluginConfigEntry){
-      console.log("editPlugin")
       this.editFocus=index
       this.editedPlugins[plugin.entry.type]= {entry: plugin.entry}
     },
     didCancel(plugin: ProjectPluginConfigEntry, index: any){
-      console.log("didCancel")
       if(this.errors.length >0 && !this.editedPlugins[plugin.entry.type]){
         this.errors=[]
         this.removePlugin(plugin, index)
@@ -312,7 +310,7 @@ export default Vue.extend({
 
     },
     async savePlugin(plugin: ProjectPluginConfigEntry, index: number) {
-      console.log("savePlugin")
+
       if(this.errors.length>0){
         this.errors=[]
       }
@@ -346,7 +344,6 @@ export default Vue.extend({
       this.$emit("input", this.exportedData);
     },
     removePlugin(plugin: ProjectPluginConfigEntry, index: number) {
-      console.log("removePlugin")
       const type = plugin.entry.type
       this.pluginProviders.forEach((item: any, index: any)=> {
         if(item.name == type){
@@ -362,7 +359,6 @@ export default Vue.extend({
     },
 
     movePlugin(index: number, plugin: ProjectPluginConfigEntry, shift: number) {
-      console.log("movePlugin")
       const found = this.workingData.indexOf(plugin);
       const item = this.workingData.splice(found, 1)[0];
       const newindex = found + shift;
@@ -371,26 +367,21 @@ export default Vue.extend({
       this.editFocus = -1;
     },
     didSave(success: boolean) {
-      console.log("didSave")
       if (this.modeToggle) {
         this.mode = "show";
       }
     },
     async savePlugins() {
-        console.log("savePlugins")
         this.$emit("saved", this.pluginConfigs);
     },
     configUpdated() {
-      console.log("configUpdated")
       this.modified = true;
     },
     hasKeyStorageAccess(provider: any){
-      console.log("hasKeyStorageAccess")
       this.pluginStorageAccess.push(provider)
       this.$emit('plugin-storage-access',[provider])
     },
     cleanStorageAccess(plugin: any){
-      console.log("cleanStorageAccess")
       const pluginStorageAccess = [] as any[];
       this.pluginStorageAccess.forEach((pluginAccess:any)=>{
         if(pluginAccess !== plugin.entry.type){

--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-config/ProjectPluginGroups.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-config/ProjectPluginGroups.vue
@@ -314,6 +314,11 @@ export default Vue.extend({
       if(this.errors.length>0){
         this.errors=[]
       }
+
+    if(Object.keys(plugin.entry.config).length===0){
+        this.removePlugin(plugin,index)
+        return
+    }
       const type = plugin.entry.type
       this.pluginProviders.forEach((item: any, index: any)=> {
         if(item.name == type){
@@ -327,12 +332,6 @@ export default Vue.extend({
         plugin.entry.type,
         plugin.entry.config
       );
-      if(Object.keys(plugin.entry.config).length===0){
-        // let emptyValidation = {errors: {"email":"Plugin config empty"}, valid: false} as PluginValidation
-        // Vue.set(plugin, "validation", emptyValidation);
-        this.errors.push("Plugin config must be defined to save")
-        this.workingData=this.pluginConfigs
-      }
       if (!validation.valid) {
         Vue.set(plugin, "validation", validation);
         return;
@@ -344,7 +343,7 @@ export default Vue.extend({
       this.setFocus(-1);
       this.$emit("input", this.exportedData);
     },
-    removePlugin(plugin: ProjectPluginConfigEntry, index: string) {
+    removePlugin(plugin: ProjectPluginConfigEntry, index: number) {
       console.log("removePlugin")
       const type = plugin.entry.type
       this.pluginProviders.forEach((item: any, index: any)=> {


### PR DESCRIPTION
Plugin groups were able to be saved even if no value was provided. This PR fixes that by confirming the config is set before saving. This PR also updated the emissions to the parent component to only use one method upon loading or when the user saves or deletes.