### PR TITLE
RUN-1423: Update add plugin button label

### DIFF
--- a/rundeckapp/grails-spa/packages/ui/src/pages/project-config/ProjectPluginGroups.vue
+++ b/rundeckapp/grails-spa/packages/ui/src/pages/project-config/ProjectPluginGroups.vue
@@ -97,8 +97,8 @@
         </div>
         <div class="card-footer" v-if="mode==='edit' && editFocus===-1">
           <btn type="primary" @click="modalAddOpen=true">
-            {{serviceName}}
             <i class="fas fa-plus"></i>
+            {{"Plugin Config"}}
           </btn>
 
           <modal


### PR DESCRIPTION
Update the button for adding a new plugin group to say "+ Plugin Config" instead of plugin group
