### PR TITLE
Fix class name inconsistency in projectHome.gsp

### DIFF
--- a/rundeckapp/grails-app/views/menu/projectHome.gsp
+++ b/rundeckapp/grails-app/views/menu/projectHome.gsp
@@ -88,7 +88,7 @@
 </content>
 <div class="content">
 <div id="layoutBody">
-  <div class="conntainer-fluid">
+  <div class="container-fluid">
     <div class="row">
         <div class="col-xs-12">
             <g:render template="/common/messages"/>


### PR DESCRIPTION
Just a small correction in the class name of container-fluid.

`conntainer-fluid` to `container-fluid`