### PR TITLE
RUN-1410: Add a new ExecutionLifecicleComponent

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionLifecycleComponentException.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionLifecycleComponentException.java
@@ -1,0 +1,23 @@
+package com.dtolabs.rundeck.core.execution;
+
+public class ExecutionLifecycleComponentException extends Exception{
+
+    public ExecutionLifecycleComponentException() {
+    }
+
+    public ExecutionLifecycleComponentException(String message) {
+        super(message);
+    }
+
+    public ExecutionLifecycleComponentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ExecutionLifecycleComponentException(Throwable cause) {
+        super(cause);
+    }
+
+    public ExecutionLifecycleComponentException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionLifecyclePluginException.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionLifecyclePluginException.java
@@ -8,7 +8,7 @@ import com.dtolabs.rundeck.core.execution.workflow.steps.FailureReason;
  * @author rnavarro
  * @version $Revision$
  */
-public class ExecutionLifecyclePluginException extends Exception {
+public class ExecutionLifecyclePluginException extends ExecutionLifecycleComponentException {
 
     public ExecutionLifecyclePluginException() {
         super();

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/WorkflowExecutionServiceThread.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/WorkflowExecutionServiceThread.java
@@ -24,8 +24,8 @@
 package com.dtolabs.rundeck.core.execution;
 
 import com.dtolabs.rundeck.core.execution.workflow.*;
+import com.dtolabs.rundeck.core.jobs.ExecutionLifecycleComponentHandler;
 import com.dtolabs.rundeck.core.jobs.ExecutionLifecycleStatus;
-import com.dtolabs.rundeck.core.jobs.ExecutionLifecyclePluginHandler;
 import com.dtolabs.rundeck.core.logging.LoggingManager;
 import com.dtolabs.rundeck.core.logging.PluginLoggingManager;
 import com.dtolabs.rundeck.plugins.jobs.JobEventResultImpl;
@@ -44,21 +44,21 @@ public class WorkflowExecutionServiceThread
     private StepExecutionContext context;
     private WorkflowExecutionResult result;
     private LoggingManager loggingManager;
-    private ExecutionLifecyclePluginHandler executionLifecyclePluginHandler;
+    private ExecutionLifecycleComponentHandler executionLifecycleComponentHandler;
 
     public WorkflowExecutionServiceThread(
             WorkflowExecutionService eservice,
             WorkflowExecutionItem eitem,
             StepExecutionContext econtext,
             LoggingManager loggingManager,
-            ExecutionLifecyclePluginHandler executionLifecyclePluginHandler
+            ExecutionLifecycleComponentHandler executionLifecycleComponentHandler
     )
     {
         this.weservice = eservice;
         this.weitem = eitem;
         this.context = econtext;
         this.loggingManager = loggingManager;
-        this.executionLifecyclePluginHandler = executionLifecyclePluginHandler;
+        this.executionLifecycleComponentHandler = executionLifecycleComponentHandler;
     }
 
     public void run() {
@@ -83,10 +83,10 @@ public class WorkflowExecutionServiceThread
     public WorkflowExecutionResult runWorkflow() {
         try {
             StepExecutionContext executionContext = context;
-            if (executionLifecyclePluginHandler != null) {
+            if (executionLifecycleComponentHandler != null) {
                 //TODO: check success and stop execution
                 StepExecutionContext newExecutionContext =
-                        executionLifecyclePluginHandler.beforeJobStarts(context, weitem)
+                        executionLifecycleComponentHandler.beforeJobStarts(context, weitem)
                                                        .map(ExecutionLifecycleStatus::getExecutionContext)
                                                        .orElse(null);
                 executionContext = newExecutionContext != null? newExecutionContext: executionContext;
@@ -98,10 +98,10 @@ public class WorkflowExecutionServiceThread
                 thrown = getResult().getException();
             }
 
-            if (null != executionLifecyclePluginHandler) {
+            if (null != executionLifecycleComponentHandler) {
                 try {
-                    executionLifecyclePluginHandler.afterJobEnds(executionContext, new JobEventResultImpl(getResult(), isAborted()));
-                } catch (ExecutionLifecyclePluginException err) {
+                    executionLifecycleComponentHandler.afterJobEnds(executionContext, new JobEventResultImpl(getResult(), isAborted()));
+                } catch (ExecutionLifecycleComponentException err) {
                     err.printStackTrace(System.err);
                 }
             }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/service/FileCopierService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/service/FileCopierService.java
@@ -84,7 +84,7 @@ public class FileCopierService
         return PRESET_PROVIDERS.containsKey(name);
     }
     @Override
-    protected String getDefaultProviderNameForNodeAndProject(INodeEntry node, String project) {
+    public String getDefaultProviderNameForNodeAndProject(INodeEntry node, String project) {
         return getProviderNameForNode(
                 framework.isLocalNode(node),
                 framework.getProjectManager().loadProjectConfig(project)
@@ -114,7 +114,7 @@ public class FileCopierService
     }
 
     @Override
-    protected String getServiceProviderNodeAttributeForNode(INodeEntry node) {
+    public String getServiceProviderNodeAttributeForNode(INodeEntry node) {
         return getNodeAttributeForProvider(framework.isLocalNode(node));
     }
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeExecutorService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeExecutorService.java
@@ -86,7 +86,7 @@ public class NodeExecutorService
     }
 
     @Override
-    protected String getDefaultProviderNameForNodeAndProject(INodeEntry node, String project) {
+    public String getDefaultProviderNameForNodeAndProject(INodeEntry node, String project) {
         return getProviderNameForNode(
                 framework.isLocalNode(node),
                 framework.getProjectManager().loadProjectConfig(project)
@@ -104,7 +104,7 @@ public class NodeExecutorService
     }
 
     @Override
-    protected String getServiceProviderNodeAttributeForNode(INodeEntry node) {
+    public String getServiceProviderNodeAttributeForNode(INodeEntry node) {
         return getNodeAttributeForProvider(framework.isLocalNode(node));
     }
     public static String getProviderNameForNode(

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/ExecutionLifecycleComponent.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/ExecutionLifecycleComponent.java
@@ -1,0 +1,20 @@
+package com.dtolabs.rundeck.core.jobs;
+
+import com.dtolabs.rundeck.core.execution.ExecutionLifecycleComponentException;
+
+public interface ExecutionLifecycleComponent {
+
+    /**
+     * It triggers before the job starts
+     * @param event event execution data
+     * @return JobEventStatus
+     */
+    ExecutionLifecycleStatus beforeJobStarts(JobExecutionEvent event) throws ExecutionLifecycleComponentException;
+
+    /**
+     * It triggers when a job ends
+     * @param event event execution data
+     * @return JobEventStatus
+     */
+    ExecutionLifecycleStatus afterJobEnds(JobExecutionEvent event) throws ExecutionLifecycleComponentException;
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/ExecutionLifecycleComponentHandler.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/ExecutionLifecycleComponentHandler.java
@@ -1,6 +1,6 @@
 package com.dtolabs.rundeck.core.jobs;
 
-import com.dtolabs.rundeck.core.execution.ExecutionLifecyclePluginException;
+import com.dtolabs.rundeck.core.execution.ExecutionLifecycleComponentException;
 import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext;
 import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionItem;
 
@@ -9,25 +9,25 @@ import java.util.Optional;
 /**
  * Can invoke execution lifecycle events given just execution context
  */
-public interface ExecutionLifecyclePluginHandler {
+public interface ExecutionLifecycleComponentHandler {
     /**
      * Job start event
      *
      * @param executionContext input execution context
-     * @throws ExecutionLifecyclePluginException
+     * @throws ExecutionLifecycleComponentException
      */
     Optional<ExecutionLifecycleStatus> beforeJobStarts(
             final StepExecutionContext executionContext,
             final WorkflowExecutionItem workflowItem
-    ) throws ExecutionLifecyclePluginException;
+    ) throws ExecutionLifecycleComponentException;
 
     /**
      * Job end event
      *
      * @param executionContext execution context
      * @param result           result of job execution
-     * @throws ExecutionLifecyclePluginException
+     * @throws ExecutionLifecycleComponentException
      */
     Optional<ExecutionLifecycleStatus> afterJobEnds(final StepExecutionContext executionContext, final JobEventResult result)
-            throws ExecutionLifecyclePluginException;
+            throws ExecutionLifecycleComponentException;
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/IExecutionLifecycleComponentService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/IExecutionLifecycleComponentService.java
@@ -3,7 +3,7 @@ package com.dtolabs.rundeck.core.jobs;
 import com.dtolabs.rundeck.core.execution.ExecutionReference;
 import com.dtolabs.rundeck.core.plugins.PluginConfigSet;
 
-public interface IExecutionLifecyclePluginService {
+public interface IExecutionLifecycleComponentService {
     /**
      * Creates a handler with configured plugins for the execution reference, may return null if no plugins are configured,
      * or job plugins are disabled
@@ -12,5 +12,5 @@ public interface IExecutionLifecyclePluginService {
      * @param executionReference reference
      * @return handler to process events for the execution, or null
      */
-    ExecutionLifecyclePluginHandler getExecutionHandler(PluginConfigSet configurations, ExecutionReference executionReference);
+    ExecutionLifecycleComponentHandler getExecutionHandler(PluginConfigSet configurations, ExecutionReference executionReference);
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/ExecutionLifecyclePlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/ExecutionLifecyclePlugin.java
@@ -1,6 +1,8 @@
 package com.dtolabs.rundeck.plugins.jobs;
 
+import com.dtolabs.rundeck.core.execution.ExecutionLifecycleComponentException;
 import com.dtolabs.rundeck.core.execution.ExecutionLifecyclePluginException;
+import com.dtolabs.rundeck.core.jobs.ExecutionLifecycleComponent;
 import com.dtolabs.rundeck.core.jobs.ExecutionLifecycleStatus;
 import com.dtolabs.rundeck.core.jobs.JobExecutionEvent;
 
@@ -11,7 +13,7 @@ import com.dtolabs.rundeck.core.jobs.JobExecutionEvent;
  * Date: 9/04/19
  * Time: 01:32 PM
  */
-public interface ExecutionLifecyclePlugin {
+public interface ExecutionLifecyclePlugin extends ExecutionLifecycleComponent {
 
     /**
      * It triggers before the job starts

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -140,6 +140,7 @@ import rundeck.interceptors.DefaultInterceptorHelper
 import rundeck.services.DirectNodeExecutionService
 import rundeck.services.ExecutionLifecycleComponentService
 import rundeck.services.ExecutionValidatorService
+import rundeck.services.JobLifecycleComponentService
 import rundeck.services.LocalJobSchedulesManager
 import rundeck.services.PasswordFieldsService
 import rundeck.services.QuartzJobScheduleManagerService
@@ -461,6 +462,12 @@ beans={
      * the Execution life cycle component service
      */
     executionLifecycleComponentService(ExecutionLifecycleComponentService)
+
+
+    /**
+     * the Execution life cycle component service
+     */
+    jobLifecycleComponentService(JobLifecycleComponentService)
 
     /**
      * the Notification plugin provider service

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -138,6 +138,7 @@ import org.springframework.security.web.jaasapi.JaasApiIntegrationFilter
 import org.springframework.security.web.session.ConcurrentSessionFilter
 import rundeck.interceptors.DefaultInterceptorHelper
 import rundeck.services.DirectNodeExecutionService
+import rundeck.services.ExecutionLifecycleComponentService
 import rundeck.services.ExecutionValidatorService
 import rundeck.services.LocalJobSchedulesManager
 import rundeck.services.PasswordFieldsService
@@ -455,6 +456,11 @@ beans={
     executionLifecyclePluginProviderService(ExecutionLifecyclePluginProviderService){
         rundeckServerServiceProviderLoader=ref('rundeckServerServiceProviderLoader')
     }
+
+    /**
+     * the Execution life cycle component service
+     */
+    executionLifecycleComponentService(ExecutionLifecycleComponentService)
 
     /**
      * the Notification plugin provider service

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -144,7 +144,6 @@ class ScheduledExecutionController  extends ControllerBase{
     def StorageService storageService
     OptionValuesService optionValuesService
     FeatureService featureService
-    ExecutionLifecyclePluginService executionLifecyclePluginService
     RundeckJobDefinitionManager rundeckJobDefinitionManager
     AuthorizedServicesProvider rundeckAuthorizedServicesProvider
     ConfigurationService configurationService

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionLifecycleComponentService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionLifecycleComponentService.groovy
@@ -212,7 +212,7 @@ class ExecutionLifecycleComponentService implements IExecutionLifecycleComponent
                 //TODO: could not load plugin, or config was invalid
                 return
             }
-            configured << new NamedExecutionLifecycleComponent(plugin: (ExecutionLifecyclePlugin) configuredPlugin.instance, name: type)
+            configured << new NamedExecutionLifecycleComponent(component: (ExecutionLifecyclePlugin) configuredPlugin.instance, name: type)
         }
         configured
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionReferenceLifecycleComponentHandler.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionReferenceLifecycleComponentHandler.groovy
@@ -17,39 +17,39 @@
 package rundeck.services
 
 import com.dtolabs.rundeck.core.execution.ExecutionReference
-import com.dtolabs.rundeck.core.execution.ExecutionLifecyclePluginException
+import com.dtolabs.rundeck.core.execution.ExecutionLifecycleComponentException
 import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext
 import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionItem
 import com.dtolabs.rundeck.core.jobs.ExecutionLifecycleStatus
 import com.dtolabs.rundeck.core.jobs.JobEventResult
-import com.dtolabs.rundeck.core.jobs.ExecutionLifecyclePluginHandler
+import com.dtolabs.rundeck.core.jobs.ExecutionLifecycleComponentHandler
 import com.dtolabs.rundeck.plugins.jobs.JobExecutionEventImpl
 
 /**
- * Handles execution lifecycle event calls using multiple plugins and an execution reference, via the {@link ExecutionLifecyclePluginService}
+ * Handles execution lifecycle event calls using multiple plugins and an execution reference, via the {@link ExecutionLifecycleComponentService}
  */
-class ExecutionReferenceLifecyclePluginHandler implements ExecutionLifecyclePluginHandler {
-    ExecutionLifecyclePluginService executionLifecyclePluginService
+class ExecutionReferenceLifecycleComponentHandler implements ExecutionLifecycleComponentHandler {
+    ExecutionLifecycleComponentService executionLifecycleComponentService
     ExecutionReference executionReference
-    List<NamedExecutionLifecyclePlugin> plugins
+    List<NamedExecutionLifecycleComponent> components
 
     @Override
-    Optional<ExecutionLifecycleStatus> beforeJobStarts(final StepExecutionContext executionContext, WorkflowExecutionItem item) throws ExecutionLifecyclePluginException {
-        Optional.ofNullable executionLifecyclePluginService.handleEvent(
+    Optional<ExecutionLifecycleStatus> beforeJobStarts(final StepExecutionContext executionContext, WorkflowExecutionItem item) throws ExecutionLifecycleComponentException {
+        Optional.ofNullable executionLifecycleComponentService.handleEvent(
                 JobExecutionEventImpl.beforeRun(executionContext, executionReference, item),
-                ExecutionLifecyclePluginService.EventType.BEFORE_RUN,
-                plugins
+                ExecutionLifecycleComponentService.EventType.BEFORE_RUN,
+                components
         )
 
     }
 
     @Override
     Optional<ExecutionLifecycleStatus> afterJobEnds(final StepExecutionContext executionContext, final JobEventResult result)
-            throws ExecutionLifecyclePluginException {
-        Optional.ofNullable executionLifecyclePluginService.handleEvent(
+            throws ExecutionLifecycleComponentException {
+        Optional.ofNullable executionLifecycleComponentService.handleEvent(
                 JobExecutionEventImpl.afterRun(executionContext, executionReference, result),
-                ExecutionLifecyclePluginService.EventType.AFTER_RUN,
-                plugins
+                ExecutionLifecycleComponentService.EventType.AFTER_RUN,
+                components
         )
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -151,7 +151,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     def pluginService
     def executorService
     JobLifecycleComponentService jobLifecycleComponentService
-    def executionLifecyclePluginService
+    def executionLifecycleComponentService
     AuditEventsService auditEventsService
     UserDataProvider userDataProvider
 
@@ -1213,9 +1213,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
 
             def executionLifecyclePluginConfigs = scheduledExecution ?
-                                   executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(scheduledExecution) :
+                                   executionLifecycleComponentService.getExecutionLifecyclePluginConfigSetForJob(scheduledExecution) :
                                    null
-            def executionLifecyclePluginExecHandler = executionLifecyclePluginService.getExecutionHandler(executionLifecyclePluginConfigs, execution.asReference())
+            def executionLifecyclePluginExecHandler = executionLifecycleComponentService.getExecutionHandler(executionLifecyclePluginConfigs, execution.asReference())
             //create service object for the framework and listener
             Thread thread = new WorkflowExecutionServiceThread(
                     framework.getWorkflowExecutionService(),
@@ -3812,9 +3812,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             def shouldCheckTimeout = timeoutms > 0
 
             def executionLifecyclePluginConfigs = se ?
-                                   executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(se) :
+                                   executionLifecycleComponentService.getExecutionLifecyclePluginConfigSetForJob(se) :
                                    null
-            def executionLifecyclePluginExecHandler = executionLifecyclePluginService.getExecutionHandler(executionLifecyclePluginConfigs, executionReference)
+            def executionLifecyclePluginExecHandler = executionLifecycleComponentService.getExecutionHandler(executionLifecyclePluginConfigs, executionReference)
             Thread thread = new WorkflowExecutionServiceThread(
                     wservice,
                     newExecItem,

--- a/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
@@ -51,7 +51,7 @@ class PluginApiService {
     StoragePluginProviderService storagePluginProviderService
     StorageConverterPluginProviderService storageConverterPluginProviderService
     FeatureService featureService
-    ExecutionLifecyclePluginService executionLifecyclePluginService
+    ExecutionLifecycleComponentService executionLifecycleComponentService
     JobLifecycleComponentService jobLifecycleComponentService
     def rundeckPluginRegistry
     LinkGenerator grailsLinkGenerator
@@ -110,7 +110,7 @@ class PluginApiService {
             }.sort { a, b -> a.name <=> b.name }
         }
         if(featureService.featurePresent(Features.EXECUTION_LIFECYCLE_PLUGIN)) {
-            pluginDescs[executionLifecyclePluginService.executionLifecyclePluginProviderService.name]=executionLifecyclePluginService.listExecutionLifecyclePlugins().collect {
+            pluginDescs[executionLifecycleComponentService.executionLifecyclePluginProviderService.name]=executionLifecycleComponentService.listExecutionLifecyclePlugins().collect {
                 it.value.description
             }.sort { a, b -> a.name <=> b.name }
         }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -180,7 +180,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     FileUploadService fileUploadService
     JobSchedulerService jobSchedulerService
     JobLifecycleComponentService jobLifecycleComponentService
-    ExecutionLifecyclePluginService executionLifecyclePluginService
+    ExecutionLifecycleComponentService executionLifecycleComponentService
     SchedulesManager jobSchedulesService
     private def triggerComponents
     AuthorizedServicesProvider rundeckAuthorizedServicesProvider
@@ -2637,7 +2637,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     @CompileStatic
     boolean validateDefinitionExecLifecyclePlugins(ScheduledExecution scheduledExecution, Map params, Map validationMap) {
         boolean failed = false
-        PluginConfigSet pluginConfigSet=executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(scheduledExecution)
+        PluginConfigSet pluginConfigSet=executionLifecycleComponentService.getExecutionLifecyclePluginConfigSetForJob(scheduledExecution)
         if (pluginConfigSet && pluginConfigSet.pluginProviderConfigs?.size()>0) {
             //validate execution life cycle plugins
             Map<String,Validator.Report> pluginValidations = [:]
@@ -2908,13 +2908,13 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     public void jobDefinitionExecLifecyclePlugins(ScheduledExecution scheduledExecution, ScheduledExecution input,Map params, UserAndRoles userAndRoles) {
         PluginConfigSet configSet=null
         if(input){
-            configSet=executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(input)
+            configSet=executionLifecycleComponentService.getExecutionLifecyclePluginConfigSetForJob(input)
         }else if (params.executionLifecyclePlugins && params.executionLifecyclePlugins instanceof Map) {
             Map plugins=(Map)params.executionLifecyclePlugins
             //define execution life cycle plugins config
             configSet = parseExecutionLifecyclePluginsParams(plugins)
         }
-        executionLifecyclePluginService.setExecutionLifecyclePluginConfigSetForJob(scheduledExecution, configSet)
+        executionLifecycleComponentService.setExecutionLifecyclePluginConfigSetForJob(scheduledExecution, configSet)
     }
 
 
@@ -4493,7 +4493,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             !pluginControlService?.isDisabledPlugin(k,ServiceNameConstants.LogFilter)
         }
 
-        def executionLifecyclePlugins = executionLifecyclePluginService.listEnabledExecutionLifecyclePlugins(pluginControlService)
+        def executionLifecyclePlugins = executionLifecycleComponentService.listEnabledExecutionLifecyclePlugins(pluginControlService)
         def jobComponents = rundeckJobDefinitionManager.getJobDefinitionComponents()
 
         def fprojects = frameworkService.projectNames(authContext)

--- a/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/TestWEServiceThread.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/TestWEServiceThread.groovy
@@ -21,7 +21,7 @@ import com.dtolabs.rundeck.core.execution.WorkflowExecutionServiceThread
 import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext
 import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionItem
 import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionService
-import com.dtolabs.rundeck.core.jobs.ExecutionLifecyclePluginHandler
+import com.dtolabs.rundeck.core.jobs.ExecutionLifecycleComponentHandler
 import com.dtolabs.rundeck.core.logging.LoggingManager
 
 /**
@@ -34,7 +34,7 @@ class TestWEServiceThread extends WorkflowExecutionServiceThread {
             final WorkflowExecutionItem eitem,
             final StepExecutionContext econtext,
             LoggingManager loggingManager,
-            ExecutionLifecyclePluginHandler jobPluginExecutionHandler
+            ExecutionLifecycleComponentHandler jobPluginExecutionHandler
     )
     {
         super(eservice, eitem, econtext, loggingManager, jobPluginExecutionHandler)

--- a/rundeckapp/src/integration-test/groovy/rundeck/services/ScheduledExecutionServiceJobIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/services/ScheduledExecutionServiceJobIntegrationSpec.groovy
@@ -11,11 +11,6 @@ import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import com.dtolabs.rundeck.core.common.NodeSetImpl
 import com.dtolabs.rundeck.core.common.NodesSelector
 import com.dtolabs.rundeck.core.common.ProjectManager
-import com.dtolabs.rundeck.core.plugins.ConfiguredPlugin
-import com.dtolabs.rundeck.core.plugins.DescribedPlugin
-import com.dtolabs.rundeck.core.plugins.PluggableProviderService
-import com.dtolabs.rundeck.core.plugins.PluginRegistry
-import com.dtolabs.rundeck.core.plugins.configuration.DynamicProperties
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolverFactory
 import com.dtolabs.rundeck.core.schedule.SchedulesManager
 import com.dtolabs.rundeck.core.storage.keys.KeyStorageTree
@@ -24,7 +19,6 @@ import com.dtolabs.rundeck.server.plugins.RundeckPluginRegistry
 import grails.spring.BeanBuilder
 import grails.testing.mixin.integration.Integration
 import grails.gorm.transactions.*
-import okhttp3.Request
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.app.components.RundeckJobDefinitionManager
 import org.rundeck.app.spi.AuthorizedServicesProvider
@@ -195,7 +189,7 @@ class ScheduledExecutionServiceJobIntegrationSpec extends Specification {
 
         service.notificationService = notificationService
         service.orchestratorPluginService=Mock(OrchestratorPluginService)
-        service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+        service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
         service.rundeckJobDefinitionManager=Mock(RundeckJobDefinitionManager)
         service.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
             authorizeProjectJobAll(_, _, ['update'], _) >> true

--- a/rundeckapp/src/main/groovy/rundeck/services/ExecutionLifecycleComponentService.groovy
+++ b/rundeckapp/src/main/groovy/rundeck/services/ExecutionLifecycleComponentService.groovy
@@ -20,8 +20,7 @@ import com.dtolabs.rundeck.plugins.jobs.JobExecutionEventImpl
 import com.dtolabs.rundeck.server.plugins.services.ExecutionLifecyclePluginProviderService
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
@@ -35,10 +34,8 @@ import rundeck.services.feature.FeatureService
  * Time: 10:32 AM
  */
 @CompileStatic
+@Slf4j
 class ExecutionLifecycleComponentService implements IExecutionLifecycleComponentService, ApplicationContextAware  {
-
-    public static Logger log = LoggerFactory.getLogger(ExecutionLifecycleComponentService.class.name)
-
 
     @Autowired
     ExecutionLifecyclePluginProviderService executionLifecyclePluginProviderService

--- a/rundeckapp/src/main/groovy/rundeck/services/ExecutionReferenceLifecycleComponentHandler.groovy
+++ b/rundeckapp/src/main/groovy/rundeck/services/ExecutionReferenceLifecycleComponentHandler.groovy
@@ -24,10 +24,12 @@ import com.dtolabs.rundeck.core.jobs.ExecutionLifecycleStatus
 import com.dtolabs.rundeck.core.jobs.JobEventResult
 import com.dtolabs.rundeck.core.jobs.ExecutionLifecycleComponentHandler
 import com.dtolabs.rundeck.plugins.jobs.JobExecutionEventImpl
+import groovy.transform.CompileStatic
 
 /**
  * Handles execution lifecycle event calls using multiple plugins and an execution reference, via the {@link ExecutionLifecycleComponentService}
  */
+@CompileStatic
 class ExecutionReferenceLifecycleComponentHandler implements ExecutionLifecycleComponentHandler {
     ExecutionLifecycleComponentService executionLifecycleComponentService
     ExecutionReference executionReference

--- a/rundeckapp/src/main/groovy/rundeck/services/JobLifecycleComponentService.groovy
+++ b/rundeckapp/src/main/groovy/rundeck/services/JobLifecycleComponentService.groovy
@@ -17,13 +17,15 @@ import com.dtolabs.rundeck.plugins.project.JobLifecyclePlugin
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder
 import com.dtolabs.rundeck.server.plugins.services.JobLifecyclePluginProviderService
 import grails.events.annotation.Subscriber
+import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
 import org.rundeck.core.projects.ProjectConfigurable
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.stereotype.Service
 import rundeck.ScheduledExecution
+import rundeck.services.feature.FeatureService
 
 /**
  * Provides capability to execute certain based on an event
@@ -31,23 +33,30 @@ import rundeck.ScheduledExecution
  * Date: 8/23/19
  * Time: 10:37 AM
  */
-@Service
+@CompileStatic
+@Slf4j
 class JobLifecycleComponentService implements ProjectConfigurable {
     private static final Logger LOG = LoggerFactory.getLogger(JobLifecycleComponentService)
 
+    @Autowired
     PluginService pluginService
+
+    @Autowired
     FrameworkService frameworkService
-    def featureService
+
+    @Autowired
+    FeatureService featureService
+
+    @Autowired
     JobLifecyclePluginProviderService jobLifecyclePluginProviderService
     public static final String CONF_PROJECT_ENABLED = 'project.enable.jobLifecyclePlugin.'
 
     Map<String, String> configPropertiesMapping
     Map<String, String> configProperties
     List<Property> projectConfigProperties
-    
+
     @Autowired(required = false)
     List<JobLifecycleComponent> beanComponents
-
 
     @Subscriber('rundeck.bootstrap')
     void init() throws Exception {
@@ -59,11 +68,11 @@ class JobLifecycleComponentService implements ProjectConfigurable {
         }
     }
 
-
     /**
      *
      * It loads the plugin properties to be shown under the project configuration
      */
+    @CompileDynamic
     def loadProperties(){
         List<Property> projectConfigProperties = []
         Map<String, String> configPropertiesMapping = [:]
@@ -288,6 +297,7 @@ class JobLifecycleComponentService implements ProjectConfigurable {
         }
     }
 
+    @CompileDynamic
     static JobLifecycleStatus handleEventForPlugin(
         EventType eventType,
         NamedJobLifecycleComponent plugin,
@@ -344,6 +354,7 @@ class JobLifecycleComponentService implements ProjectConfigurable {
      * @param jobEventStatus result of event
      * @return merged set, or null
      */
+    @CompileDynamic
     static TreeSet<JobOption> mergePersistOptions(SortedSet<JobOption> initial, JobLifecycleStatus jobEventStatus) {
         SortedSet<JobOption> options = initial ? new TreeSet<JobOption>(initial) : null
 
@@ -367,7 +378,7 @@ class JobLifecycleComponentService implements ProjectConfigurable {
             it.key.startsWith(CONF_PROJECT_ENABLED) && it.value == 'true'
         }.collect {
             it.key.substring(CONF_PROJECT_ENABLED.length())
-        }
+        }.toSet()
     }
 
     enum EventType {

--- a/rundeckapp/src/main/groovy/rundeck/services/JobLifecycleComponentService.groovy
+++ b/rundeckapp/src/main/groovy/rundeck/services/JobLifecycleComponentService.groovy
@@ -20,7 +20,6 @@ import grails.events.annotation.Subscriber
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
-import org.rundeck.app.components.jobs.JobQuery
 import org.rundeck.core.projects.ProjectConfigurable
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionService2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionService2Spec.groovy
@@ -1133,7 +1133,7 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
             }
         }
 
-        service.executionLifecyclePluginService = mockWith(ExecutionLifecyclePluginService){
+        service.executionLifecycleComponentService = mockWith(ExecutionLifecycleComponentService){
 
         }
 

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -3286,7 +3286,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
         }
 
-            service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+            service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
 
 
 
@@ -3403,7 +3403,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
         }
 
-        service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+        service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
 
         def origContext = Mock(StepExecutionContext){
             getDataContext()>>datacontext
@@ -4803,7 +4803,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
                     nodeSet
                 }
             }
-        service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+        service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
 
 
 
@@ -5073,7 +5073,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
                     nodeSet
                 }
             }
-            service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+            service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
 
 
         def origContext = Mock(StepExecutionContext){
@@ -5189,7 +5189,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
                     nodeSet
                 }
             }
-            service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+            service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
 
         service.notificationService = Mock(NotificationService)
         def framework = Mock(Framework)
@@ -5574,7 +5574,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
                     nodeSet
                 }
             }
-            service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+            service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
 
 
         def origContext = Mock(StepExecutionContext){
@@ -5723,7 +5723,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
                 }
             }
 
-        service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+        service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
         service.workflowService = Mock(WorkflowService)
         service.notificationService = Mock(NotificationService)
         service.reportService = Mock(ReportService){

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceTempSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceTempSpec.groovy
@@ -35,7 +35,7 @@ class ExecutionServiceTempSpec extends Specification implements DataTest {
     def setup(){
         service = new ExecutionService()
         service.executionValidatorService = new ExecutionValidatorService()
-        service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+        service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
         service.jobLifecycleComponentService = Mock(JobLifecycleComponentService)
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ExecutionLifecyclComponentServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ExecutionLifecyclComponentServiceSpec.groovy
@@ -6,7 +6,7 @@ import com.dtolabs.rundeck.core.common.PluginControlService
 import com.dtolabs.rundeck.core.common.ProjectManager
 import com.dtolabs.rundeck.core.config.Features
 import com.dtolabs.rundeck.core.execution.ExecutionReference
-import com.dtolabs.rundeck.core.execution.ExecutionLifecyclePluginException
+import com.dtolabs.rundeck.core.execution.ExecutionLifecycleComponentException
 import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext
 import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionItem
 import com.dtolabs.rundeck.core.jobs.JobExecutionEvent
@@ -19,21 +19,13 @@ import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.jobs.ExecutionLifecyclePlugin
 import com.dtolabs.rundeck.plugins.jobs.JobExecutionEventImpl
 import com.dtolabs.rundeck.server.plugins.services.ExecutionLifecyclePluginProviderService
-import grails.test.mixin.Mock
-import grails.test.mixin.TestFor
 import grails.testing.services.ServiceUnitTest
-import rundeck.CommandExec
-import rundeck.Execution
 import rundeck.ScheduledExecution
-import rundeck.ScheduledExecutionStats
-import rundeck.User
-import rundeck.Workflow
 import rundeck.services.feature.FeatureService
-import rundeck.services.feature.FeatureServiceSpec
 import spock.lang.Specification
 import spock.lang.Unroll
 
-class ExecutionLifecyclePluginServiceSpec extends Specification implements ServiceUnitTest<ExecutionLifecyclePluginService> {
+class ExecutionLifecyclComponentServiceSpec extends Specification implements ServiceUnitTest<ExecutionLifecycleComponentService> {
 
     def item = Mock(WorkflowExecutionItem)
     def featureService = Mock(FeatureService){
@@ -63,13 +55,13 @@ class ExecutionLifecyclePluginServiceSpec extends Specification implements Servi
     static class ExecutionLifecyclePluginImpl implements ExecutionLifecyclePlugin {
 
         @Override
-        public ExecutionLifecycleStatus beforeJobStarts(JobExecutionEvent event)throws ExecutionLifecyclePluginException{
-            throw new ExecutionLifecyclePluginException("Test job life cycle exception")
+        public ExecutionLifecycleStatus beforeJobStarts(JobExecutionEvent event)throws ExecutionLifecycleComponentException{
+            throw new ExecutionLifecycleComponentException("Test job life cycle exception")
         }
 
         @Override
-        public ExecutionLifecycleStatus afterJobEnds(JobExecutionEvent event)throws ExecutionLifecyclePluginException{
-            throw new ExecutionLifecyclePluginException("Test job life cycle exception")
+        public ExecutionLifecycleStatus afterJobEnds(JobExecutionEvent event)throws ExecutionLifecycleComponentException{
+            throw new ExecutionLifecycleComponentException("Test job life cycle exception")
         }
     }
 
@@ -89,18 +81,18 @@ class ExecutionLifecyclePluginServiceSpec extends Specification implements Servi
             }
         when:
             ExecutionLifecycleStatus result = service.handleEvent(
-                    eventType == ExecutionLifecyclePluginService.EventType.BEFORE_RUN ?
+                    eventType == ExecutionLifecycleComponentService.EventType.BEFORE_RUN ?
                     JobExecutionEventImpl.beforeRun(executionContext, null, null) :
                     JobExecutionEventImpl.afterRun(executionContext, null, null),
                     eventType,
-                    [new NamedExecutionLifecyclePlugin(name: 'TestPlugin', plugin: plugin)]
+                    [new NamedExecutionLifecycleComponent(name: 'TestPlugin', plugin: plugin)]
             )
         then:
             result.isSuccessful()
         where:
             eventType                                            | _
-            ExecutionLifecyclePluginService.EventType.BEFORE_RUN | _
-            ExecutionLifecyclePluginService.EventType.AFTER_RUN  | _
+            ExecutionLifecycleComponentService.EventType.BEFORE_RUN | _
+            ExecutionLifecycleComponentService.EventType.AFTER_RUN  | _
     }
 
     @Unroll
@@ -119,18 +111,18 @@ class ExecutionLifecyclePluginServiceSpec extends Specification implements Servi
             }
         when:
             ExecutionLifecycleStatus result = service.handleEvent(
-                    eventType == ExecutionLifecyclePluginService.EventType.BEFORE_RUN ?
+                    eventType == ExecutionLifecycleComponentService.EventType.BEFORE_RUN ?
                     JobExecutionEventImpl.beforeRun(executionContext, null, null) :
                     JobExecutionEventImpl.afterRun(executionContext, null, null),
                     eventType,
-                    [new NamedExecutionLifecyclePlugin(name: 'TestPlugin', plugin: plugin)]
+                    [new NamedExecutionLifecycleComponent(name: 'TestPlugin', plugin: plugin)]
             )
         then:
-            thrown(ExecutionLifecyclePluginException)
+            thrown(ExecutionLifecycleComponentException)
         where:
             eventType                                            | _
-            ExecutionLifecyclePluginService.EventType.BEFORE_RUN | _
-            ExecutionLifecyclePluginService.EventType.AFTER_RUN  | _
+            ExecutionLifecycleComponentService.EventType.BEFORE_RUN | _
+            ExecutionLifecycleComponentService.EventType.AFTER_RUN  | _
     }
 
     @Unroll
@@ -142,18 +134,18 @@ class ExecutionLifecyclePluginServiceSpec extends Specification implements Servi
             def plugin = new ExecutionLifecyclePluginImpl()
         when:
             ExecutionLifecycleStatus result = service.handleEvent(
-                    eventType == ExecutionLifecyclePluginService.EventType.BEFORE_RUN ?
+                    eventType == ExecutionLifecycleComponentService.EventType.BEFORE_RUN ?
                     JobExecutionEventImpl.beforeRun(executionContext, null, null) :
                     JobExecutionEventImpl.afterRun(executionContext, null, null),
                     eventType,
-                    [new NamedExecutionLifecyclePlugin(name: 'TestPlugin', plugin: plugin)]
+                    [new NamedExecutionLifecycleComponent(name: 'TestPlugin', plugin: plugin)]
             )
         then:
-            thrown(ExecutionLifecyclePluginException)
+            thrown(ExecutionLifecycleComponentException)
         where:
             eventType                                            | _
-            ExecutionLifecyclePluginService.EventType.BEFORE_RUN | _
-            ExecutionLifecyclePluginService.EventType.AFTER_RUN  | _
+            ExecutionLifecycleComponentService.EventType.BEFORE_RUN | _
+            ExecutionLifecycleComponentService.EventType.AFTER_RUN  | _
     }
 
     def "create configured plugins with no project defaults"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/ExecutionLifecyclComponentServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ExecutionLifecyclComponentServiceSpec.groovy
@@ -21,9 +21,6 @@ import com.dtolabs.rundeck.plugins.jobs.ExecutionLifecyclePlugin
 import com.dtolabs.rundeck.plugins.jobs.JobExecutionEventImpl
 import com.dtolabs.rundeck.plugins.project.JobLifecyclePlugin
 import com.dtolabs.rundeck.server.plugins.services.ExecutionLifecyclePluginProviderService
-import grails.testing.services.ServiceUnitTest
-import org.grails.spring.beans.factory.InstanceFactoryBean
-import org.grails.testing.GrailsUnitTest
 import rundeck.ScheduledExecution
 import rundeck.services.feature.FeatureService
 import spock.lang.Specification
@@ -325,8 +322,8 @@ class ExecutionLifecyclComponentServiceSpec extends Specification {
         service.frameworkService = frameworkService
 
         service.beanComponents = [
-                new TestExecutionLifecycleComponentImpl(name: "Comp1"),
-                new TestExecutionLifecycleComponentImpl(name: "Comp2")
+                "Comp1":new TestExecutionLifecycleComponentImpl(name: "Comp1"),
+                "Comp2":new TestExecutionLifecycleComponentImpl(name: "Comp2")
         ]
 
         def configs = PluginConfigSet.with(

--- a/rundeckapp/src/test/groovy/rundeck/services/ExecutionLifecyclComponentServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ExecutionLifecyclComponentServiceSpec.groovy
@@ -22,13 +22,14 @@ import com.dtolabs.rundeck.plugins.jobs.JobExecutionEventImpl
 import com.dtolabs.rundeck.plugins.project.JobLifecyclePlugin
 import com.dtolabs.rundeck.server.plugins.services.ExecutionLifecyclePluginProviderService
 import grails.testing.services.ServiceUnitTest
+import org.grails.spring.beans.factory.InstanceFactoryBean
+import org.grails.testing.GrailsUnitTest
 import rundeck.ScheduledExecution
 import rundeck.services.feature.FeatureService
 import spock.lang.Specification
 import spock.lang.Unroll
 
-class ExecutionLifecyclComponentServiceSpec extends Specification implements ServiceUnitTest<ExecutionLifecycleComponentService> {
-
+class ExecutionLifecyclComponentServiceSpec extends Specification {
     def item = Mock(WorkflowExecutionItem)
     def featureService = Mock(FeatureService){
         featurePresent(Features.EXECUTION_LIFECYCLE_PLUGIN, false) >> true
@@ -86,6 +87,7 @@ class ExecutionLifecyclComponentServiceSpec extends Specification implements Ser
     @Unroll
     def "custom plugin successful answer via plugin list"() {
         given:
+            ExecutionLifecycleComponentService service = new ExecutionLifecycleComponentService()
             service.executionLifecyclePluginProviderService = executionLifecyclePluginProviderService
             service.frameworkService = frameworkService
             service.featureService = featureService
@@ -116,6 +118,7 @@ class ExecutionLifecyclComponentServiceSpec extends Specification implements Ser
     @Unroll
     def "custom plugin unsuccessful answer via plugin list event #eventType"() {
         given:
+            ExecutionLifecycleComponentService service = new ExecutionLifecycleComponentService()
             service.executionLifecyclePluginProviderService = executionLifecyclePluginProviderService
             service.frameworkService = frameworkService
             service.featureService = featureService
@@ -146,6 +149,7 @@ class ExecutionLifecyclComponentServiceSpec extends Specification implements Ser
     @Unroll
     def "custom plugin exception thrown via plugin list event #eventType"() {
         given:
+            ExecutionLifecycleComponentService service = new ExecutionLifecycleComponentService()
             service.executionLifecyclePluginProviderService = executionLifecyclePluginProviderService
             service.frameworkService = frameworkService
             service.featureService = featureService
@@ -168,6 +172,7 @@ class ExecutionLifecyclComponentServiceSpec extends Specification implements Ser
 
     def "create configured plugins with no project defaults"() {
         given:
+            ExecutionLifecycleComponentService service = new ExecutionLifecycleComponentService()
             def configs = PluginConfigSet.with(
                     ServiceNameConstants.ExecutionLifecycle, [
                     SimplePluginConfiguration.builder().provider('typeA').configuration([a: 'b']).build()
@@ -195,6 +200,7 @@ class ExecutionLifecyclComponentServiceSpec extends Specification implements Ser
 
     def "list enabled plugins"() {
         given:
+            ExecutionLifecycleComponentService service = new ExecutionLifecycleComponentService()
             service.featureService = featureService
             def controlService = Mock(PluginControlService) {
                 isDisabledPlugin('typeA', ServiceNameConstants.ExecutionLifecycle) >> true
@@ -216,6 +222,7 @@ class ExecutionLifecyclComponentServiceSpec extends Specification implements Ser
 
     def "merge job before run execution event"() {
         given:
+            ExecutionLifecycleComponentService service = new ExecutionLifecycleComponentService()
             def ctx1 = Mock(StepExecutionContext) {
                 getFrameworkProject() >> 'ATest'
                 getLoglevel() >> 2
@@ -246,6 +253,7 @@ class ExecutionLifecyclComponentServiceSpec extends Specification implements Ser
 
     def "set exec lifecycle plugin config"() {
         given:
+            ExecutionLifecycleComponentService service = new ExecutionLifecycleComponentService()
             ScheduledExecution job = ScheduledExecution.
                     fromMap([jobName: 'test', project: 'aProject', sequence: [commands: [[exec: 'echo test']]]])
             def configSet =
@@ -262,6 +270,7 @@ class ExecutionLifecyclComponentServiceSpec extends Specification implements Ser
 
     def "set exec lifecycle multi plugin config"() {
         given:
+            ExecutionLifecycleComponentService service = new ExecutionLifecycleComponentService()
             ScheduledExecution job = ScheduledExecution.
                     fromMap([jobName: 'test', project: 'aProject', sequence: [commands: [[exec: 'echo test']]]])
             def configSet =
@@ -278,6 +287,7 @@ class ExecutionLifecyclComponentServiceSpec extends Specification implements Ser
     }
     def "set exec lifecycle multi plugin config null"() {
         given:
+            ExecutionLifecycleComponentService service = new ExecutionLifecycleComponentService()
             ScheduledExecution job = ScheduledExecution.
                     fromMap([jobName: 'test', project: 'aProject', sequence: [commands: [[exec: 'echo test']]]])
             def configSet =null
@@ -290,6 +300,7 @@ class ExecutionLifecyclComponentServiceSpec extends Specification implements Ser
 
     def "get exec lifecycle multi plugin config"() {
         given:
+            ExecutionLifecycleComponentService service = new ExecutionLifecycleComponentService()
             ScheduledExecution job = ScheduledExecution.
                     fromMap([jobName: 'test', project: 'aProject', sequence: [commands: [[exec: 'echo test']]]])
             job.pluginConfigMap = [ExecutionLifecycle: [aProvider: [a: 'b'], bProvider: [b: 'c']]]
@@ -309,6 +320,7 @@ class ExecutionLifecyclComponentServiceSpec extends Specification implements Ser
 
     def "list enabled components and plugins"() {
         given:
+        ExecutionLifecycleComponentService service = new ExecutionLifecycleComponentService()
         service.featureService = featureService
         service.frameworkService = frameworkService
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ExecutionLifecyclComponentServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ExecutionLifecyclComponentServiceSpec.groovy
@@ -85,7 +85,7 @@ class ExecutionLifecyclComponentServiceSpec extends Specification implements Ser
                     JobExecutionEventImpl.beforeRun(executionContext, null, null) :
                     JobExecutionEventImpl.afterRun(executionContext, null, null),
                     eventType,
-                    [new NamedExecutionLifecycleComponent(name: 'TestPlugin', plugin: plugin)]
+                    [new NamedExecutionLifecycleComponent(name: 'TestPlugin', component: plugin)]
             )
         then:
             result.isSuccessful()
@@ -115,7 +115,7 @@ class ExecutionLifecyclComponentServiceSpec extends Specification implements Ser
                     JobExecutionEventImpl.beforeRun(executionContext, null, null) :
                     JobExecutionEventImpl.afterRun(executionContext, null, null),
                     eventType,
-                    [new NamedExecutionLifecycleComponent(name: 'TestPlugin', plugin: plugin)]
+                    [new NamedExecutionLifecycleComponent(name: 'TestPlugin', component: plugin)]
             )
         then:
             thrown(ExecutionLifecycleComponentException)
@@ -138,7 +138,7 @@ class ExecutionLifecyclComponentServiceSpec extends Specification implements Ser
                     JobExecutionEventImpl.beforeRun(executionContext, null, null) :
                     JobExecutionEventImpl.afterRun(executionContext, null, null),
                     eventType,
-                    [new NamedExecutionLifecycleComponent(name: 'TestPlugin', plugin: plugin)]
+                    [new NamedExecutionLifecycleComponent(name: 'TestPlugin', component: plugin)]
             )
         then:
             thrown(ExecutionLifecycleComponentException)

--- a/rundeckapp/src/test/groovy/rundeck/services/JobLifecycleComponentServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/JobLifecycleComponentServiceSpec.groovy
@@ -1,6 +1,5 @@
 package rundeck.services
 
-import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.core.jobs.JobLifecycleComponent
 import com.dtolabs.rundeck.core.jobs.JobLifecycleComponentException
@@ -12,11 +11,10 @@ import com.dtolabs.rundeck.core.jobs.JobPreExecutionEvent
 import com.dtolabs.rundeck.core.plugins.ConfiguredPlugin
 import com.dtolabs.rundeck.plugins.jobs.JobOptionImpl
 import com.dtolabs.rundeck.plugins.project.JobLifecyclePlugin
-import grails.testing.services.ServiceUnitTest
 import spock.lang.Specification
 
 
-class JobLifecycleComponentServiceSpec extends Specification implements ServiceUnitTest<JobLifecycleComponentService> {
+class JobLifecycleComponentServiceSpec extends Specification{
 
     class JobLifecycleStatusImplTest implements JobLifecycleStatus{
 
@@ -43,6 +41,8 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
 
     def "get project default job plugin types"() {
         given:
+        JobLifecycleComponentService service = new JobLifecycleComponentService()
+
         def project = Mock(IRundeckProject) {
             getProjectProperties() >> [
                     (JobLifecycleComponentService.CONF_PROJECT_ENABLED + 'typeA'): 'true',
@@ -59,6 +59,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
 
     def "merge options with new values"(){
         given:
+        JobLifecycleComponentService service = new JobLifecycleComponentService()
         SortedSet<JobOption> initial = new TreeSet<JobOption>()
         initial.add(JobOptionImpl.fromOptionMap([name: "oldTestOption"]))
         JobLifecycleStatus jobEventStatus = new JobLifecycleStatusImplTest()
@@ -76,6 +77,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
 
     def "merge options with new values, with no replace"(){
         given:
+        JobLifecycleComponentService service = new JobLifecycleComponentService()
         SortedSet<JobOption> initial = new TreeSet<JobOption>()
         initial.add(JobOptionImpl.fromOptionMap([name: "oldTestOption"]))
         JobLifecycleStatus jobEventStatus = new JobLifecycleStatusImplTest()
@@ -93,6 +95,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
 
     def "merge option values, modifing value" (){
         given:
+        JobLifecycleComponentService service = new JobLifecycleComponentService()
         Map<String, String> optionsValues = ["firstKey":"firstValue"]
         JobLifecycleStatus jobEventStatus = new JobLifecycleStatusImplTest()
 
@@ -107,6 +110,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
 
     def "merge option values, adding value" (){
         given:
+        JobLifecycleComponentService service = new JobLifecycleComponentService()
         Map<String, String> optionsValues = ["firstKey":"firstValue"]
         JobLifecycleStatus jobEventStatus = new JobLifecycleStatusImplTest()
         jobEventStatus.newOptionValues << ["thirdKey":"new third value"]
@@ -122,6 +126,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
 
     def "merge option values, without new values" (){
         given:
+        JobLifecycleComponentService service = new JobLifecycleComponentService()
         Map<String, String> optionsValues = ["firstKey":"firstValue"]
         JobLifecycleStatus jobEventStatus = new JobLifecycleStatusImplTest()
         jobEventStatus.newOptionValues << ["thirdKey":"new third value"]
@@ -139,6 +144,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
 
     def "handleEvent no plugins PRE_EXECUTION"() {
         given:
+            JobLifecycleComponentService service = new JobLifecycleComponentService()
             def evt = Mock(JobPreExecutionEvent)
             def plugins = []
         when:
@@ -152,6 +158,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
 
     def "handleEvent no plugins BEFORE_SAVE"() {
         given:
+            JobLifecycleComponentService service = new JobLifecycleComponentService()
             def evt = Mock(JobPersistEvent)
             def plugins = []
         when:
@@ -165,6 +172,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
 
     def "handleEvent plugin exception BEFORE_SAVE"() {
         given:
+            JobLifecycleComponentService service = new JobLifecycleComponentService()
             def evt = Mock(JobPersistEvent)
             def plugins = [new NamedJobLifecycleComponent(
                     name: 'test', component: Mock(JobLifecycleComponent) {
@@ -185,6 +193,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
     
     def "handleEvent plugin exception PRE_EXECUTION"() {
         given:
+            JobLifecycleComponentService service = new JobLifecycleComponentService()
             def evt = Mock(JobPreExecutionEvent)
             def plugins = [new NamedJobLifecycleComponent(
                     name: 'test', component: Mock(JobLifecycleComponent) {
@@ -206,6 +215,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
 
     def "merge execution metadata replacing values"() {
         given:
+        JobLifecycleComponentService service = new JobLifecycleComponentService()
 
         def status = JobLifecycleStatusImpl.builder()
             .useNewMetadata(newMeta != null && !newMeta.isEmpty())
@@ -236,6 +246,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
 
     def "lifecycle component loading"() {
         given:
+        JobLifecycleComponentService service = new JobLifecycleComponentService()
         def project = Stub(IRundeckProject) {
             getProjectProperties() >> {
                 Map<String,String> map = new LinkedHashMap()
@@ -281,6 +292,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
 
     def "lifecycle component loading with plugins only"() {
         given:
+        JobLifecycleComponentService service = new JobLifecycleComponentService()
         def project = Stub(IRundeckProject) {
             getProjectProperties() >> {
                 Map<String,String> map = new LinkedHashMap()
@@ -319,6 +331,7 @@ class JobLifecycleComponentServiceSpec extends Specification implements ServiceU
 
     def "lifecycle component loading with internal components only"() {
         given:
+        JobLifecycleComponentService service = new JobLifecycleComponentService()
         def project = Stub(IRundeckProject) {
             getProjectProperties() >> [:]
         }

--- a/rundeckapp/src/test/groovy/rundeck/services/JobLifecycleComponentServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/JobLifecycleComponentServiceSpec.groovy
@@ -269,8 +269,8 @@ class JobLifecycleComponentServiceSpec extends Specification{
         }
 
         service.beanComponents = [
-            new JLCompTestImpl(name: "Comp1"),
-            new JLCompTestImpl(name: "Comp2")
+            "Comp1": new JLCompTestImpl(name: "Comp1"),
+            "Comp2":new JLCompTestImpl(name: "Comp2")
         ]
 
         when:
@@ -343,8 +343,8 @@ class JobLifecycleComponentServiceSpec extends Specification{
         }
 
         service.beanComponents = [
-            new JLCompTestImpl(name: "Comp1"),
-            new JLCompTestImpl(name: "Comp2")
+            "Comp1":new JLCompTestImpl(name: "Comp1"),
+            "Comp2":new JLCompTestImpl(name: "Comp2")
         ]
 
         when:

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -135,7 +135,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
             createExecutionItemForWorkflow(_)>>Mock(WorkflowExecutionItem)
         }
         service.jobLifecycleComponentService = Mock(JobLifecycleComponentService)
-        service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+        service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
         service.rundeckJobDefinitionManager=Mock(RundeckJobDefinitionManager){
             updateJob(_,_,_)>>{
                 RundeckJobDefinitionManager.importedJob(it[0],[:])
@@ -772,13 +772,13 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         then:
             1 * service.pluginService.validatePluginConfig('aType', ExecutionLifecyclePlugin,'AProject',[a:'b'])>>new ValidatedPlugin(valid:true)
             1 * service.pluginService.validatePluginConfig('bType', ExecutionLifecyclePlugin,'AProject',[b:'c'])>>new ValidatedPlugin(valid:true)
-            1 * service.executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(_)>>{
+            1 * service.executionLifecycleComponentService.getExecutionLifecyclePluginConfigSetForJob(_)>>{
                 PluginConfigSet.with ServiceNameConstants.ExecutionLifecycle, [
                         SimplePluginConfiguration.builder().provider('aType').configuration([a:'b']).build(),
                         SimplePluginConfiguration.builder().provider('bType').configuration([b:'c']).build(),
                 ]
             }
-            1 * service.executionLifecyclePluginService.setExecutionLifecyclePluginConfigSetForJob(_,_)
+            1 * service.executionLifecycleComponentService.setExecutionLifecyclePluginConfigSetForJob(_,_)
             !results.failed
 
     }
@@ -810,13 +810,13 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         then:
             1 * service.pluginService.validatePluginConfig('aType',ExecutionLifecyclePlugin,'AProject',[a:'b'])>>new ValidatedPlugin(valid:false,report:Validator.errorReport('a','wrong'))
             1 * service.pluginService.validatePluginConfig('bType',ExecutionLifecyclePlugin,'AProject',[b:'c'])>>new ValidatedPlugin(valid:true)
-            1 * service.executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(_)>>{
+            1 * service.executionLifecycleComponentService.getExecutionLifecyclePluginConfigSetForJob(_)>>{
                 PluginConfigSet.with ServiceNameConstants.ExecutionLifecycle, [
                         SimplePluginConfiguration.builder().provider('aType').configuration([a:'b']).build(),
                         SimplePluginConfiguration.builder().provider('bType').configuration([b:'c']).build(),
                 ]
             }
-            1 * service.executionLifecyclePluginService.setExecutionLifecyclePluginConfigSetForJob(_,_)
+            1 * service.executionLifecycleComponentService.setExecutionLifecyclePluginConfigSetForJob(_,_)
             results.failed
             results.scheduledExecution.errors.hasFieldErrors('pluginConfig')
     }
@@ -1411,7 +1411,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
             createExecutionItemForWorkflow(_)>>Mock(WorkflowExecutionItem)
         }
         service.quartzScheduler = Mock(Scheduler)
-        service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+        service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
         service.rundeckJobDefinitionManager=Mock(RundeckJobDefinitionManager){
             updateJob(_,_,_)>>{ RundeckJobDefinitionManager.importedJob(it[0],it[1]?.associations)}
             validateImportedJob(_)>>new RundeckJobDefinitionManager.ReportSet(valid:true, validations:[:])
@@ -1469,7 +1469,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
             }
         }
         service.quartzScheduler = Mock(Scheduler)
-        service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+        service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
         service.rundeckJobDefinitionManager = Mock(RundeckJobDefinitionManager){
             updateJob(_,_,_)>>{
                 RundeckJobDefinitionManager.importedJob(it[0],it[1]?.associations?:[:])
@@ -2123,7 +2123,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         service.executionUtilService=Mock(ExecutionUtilService){
             createExecutionItemForWorkflow(_)>>Mock(WorkflowExecutionItem)
         }
-        service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+        service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
         service.rundeckJobDefinitionManager = Mock(RundeckJobDefinitionManager){
             updateJob(_,_,_)>>{ RundeckJobDefinitionManager.importedJob(it[0],it[1]?.associations)}
             validateImportedJob(_)>>new RundeckJobDefinitionManager.ReportSet(valid: true,validations:[:])
@@ -2401,8 +2401,8 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         0 * service.jobLifecycleComponentService.beforeJobSave(_,_)
         1 * service.frameworkService.getFrameworkNodeName()
         1 * service.rundeckAuthContextProcessor.authorizeProjectJobAny(_,_,['update'],'AProject')>>true
-        2 * service.executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(_)
-        1 * service.executionLifecyclePluginService.setExecutionLifecyclePluginConfigSetForJob(_,_)
+        2 * service.executionLifecycleComponentService.getExecutionLifecyclePluginConfigSetForJob(_)
+        1 * service.executionLifecycleComponentService.setExecutionLifecyclePluginConfigSetForJob(_,_)
         1 * service.rundeckJobDefinitionManager.persistComponents(_,_)
         1 * service.rundeckJobDefinitionManager.waspersisted(_,_)
         0 * _
@@ -2444,8 +2444,8 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
                                     build()
                     ]
             )
-            1 * service.executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(newJob.job) >> pluginConfigSet
-            1 * service.executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(se) >> pluginConfigSet
+            1 * service.executionLifecycleComponentService.getExecutionLifecyclePluginConfigSetForJob(newJob.job) >> pluginConfigSet
+            1 * service.executionLifecycleComponentService.getExecutionLifecyclePluginConfigSetForJob(se) >> pluginConfigSet
             1 * service.frameworkService.getFrameworkNodeName()
             1 * service.rundeckAuthContextProcessor.authorizeProjectJobAny(_,_,['update'],_)>>true
             0 * service.jobLifecycleComponentService.beforeJobSave(_,_)
@@ -2465,7 +2465,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
 
             1 * service.pluginService.validatePluginConfig('aPlugin', ExecutionLifecyclePlugin, 'AProject', [some: 'config']) >>
             new ValidatedPlugin(valid: true)
-            1 * service.executionLifecyclePluginService.setExecutionLifecyclePluginConfigSetForJob(_, _)
+            1 * service.executionLifecycleComponentService.setExecutionLifecyclePluginConfigSetForJob(_, _)
 
     }
 
@@ -2488,9 +2488,9 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
                                     build()
                     ]
             )
-            1 * service.executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(newJob.job) >> configSet
-            1 * service.executionLifecyclePluginService.setExecutionLifecyclePluginConfigSetForJob(_, _)
-            1 * service.executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(se) >> configSet
+            1 * service.executionLifecycleComponentService.getExecutionLifecyclePluginConfigSetForJob(newJob.job) >> configSet
+            1 * service.executionLifecycleComponentService.setExecutionLifecyclePluginConfigSetForJob(_, _)
+            1 * service.executionLifecycleComponentService.getExecutionLifecyclePluginConfigSetForJob(se) >> configSet
             0 * service.frameworkService.getFrameworkNodeName()
             0 * service.jobLifecycleComponentService.beforeJobSave(_,_)
             0 * service.rundeckJobDefinitionManager.persistComponents(_,_)>>true
@@ -2540,8 +2540,8 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         0 * service.frameworkService.validateDescription(*_)
         0 * service.jobLifecycleComponentService.beforeJobSave(_,_)
         0 * service.frameworkService.getFrameworkNodeName()
-        2 * service.executionLifecyclePluginService.getExecutionLifecyclePluginConfigSetForJob(_)
-        1 * service.executionLifecyclePluginService.setExecutionLifecyclePluginConfigSetForJob(_,_)
+        2 * service.executionLifecycleComponentService.getExecutionLifecyclePluginConfigSetForJob(_)
+        1 * service.executionLifecycleComponentService.setExecutionLifecyclePluginConfigSetForJob(_,_)
 
         0 * service.rundeckJobDefinitionManager.persistComponents(newJob,_)
         service.jobSchedulesService = Mock(SchedulesManager){
@@ -5541,7 +5541,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
             service.notificationService = Mock(NotificationService){
             }
             service.orchestratorPluginService=Mock(OrchestratorPluginService)
-            service.executionLifecyclePluginService = Mock(ExecutionLifecyclePluginService)
+            service.executionLifecycleComponentService = Mock(ExecutionLifecycleComponentService)
             service.rundeckJobDefinitionManager=Mock(RundeckJobDefinitionManager)
             service.configurationService=Mock(ConfigurationService)
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Refactor ExecutionLifecyclePlugin to have a new ExecutionLifecycleComponent similar to JobLifecycleComponent. With this new Component, we can create an ExecutionLifecycle component that cannot be turned off by the final user.

**Describe the solution you've implemented**
add a new ExecutionLifecycleComponent interface. The current ExecutionLifecyclePlugin interface depends on the first one. 
Now both, the plugins and components are loaded in `ExecutionLifecycleComponentService`

**Describe alternatives you've considered**

**Additional context**
