### PR TITLE
RUN-1703: Fix RSS feed servlet

### DIFF
--- a/rundeckapp/grails-app/views/feed/_jobreportItem.gsp
+++ b/rundeckapp/grails-app/views/feed/_jobreportItem.gsp
@@ -31,8 +31,8 @@
 <g:if test="${rpt?.jcJobId}">
     <g:set var="foundJob" value="${ScheduledExecution.getByIdOrUUID(rpt.jcJobId)}"/>
 </g:if>
-<g:if test="${rpt?.jcExecId}">
-    <g:set var="execution" value="${Execution.get(rpt.jcExecId)}"/>
+<g:if test="${rpt?.executionId}">
+    <g:set var="execution" value="${Execution.get(rpt.executionId)}"/>
     <g:set var="status" value="${execution.executionState}"/>
 </g:if>
 <div class="" >
@@ -55,9 +55,9 @@
 
 
     <span >
-        <g:link controller="execution" action="show" id="${rpt.jcExecId}" class="_defaultAction"
+        <g:link controller="execution" action="show" id="${rpt.executionId}" class="_defaultAction"
                 params="[project:execution?execution.project:rpt.ctxProject?:params.project]"
-                title="View execution output" absolute="true">#<g:enc>${rpt.jcExecId}</g:enc></g:link>
+                title="View execution output" absolute="true">#<g:enc>${rpt.executionId}</g:enc></g:link>
         <g:if test="${rpt?.jcJobId}">
             <g:set var="foundJob" value="${ScheduledExecution.getByIdOrUUID(rpt.jcJobId)}"/>
             <g:if test="${foundJob}">

--- a/rundeckapp/grails-app/views/feed/index.gsp
+++ b/rundeckapp/grails-app/views/feed/index.gsp
@@ -21,12 +21,12 @@
 --%><g:set var="item" value="[:]"/><%--
 --%><%
         def exec
-        if (report.jcExecId) {
-            exec = Execution.get(Long.parseLong(report.jcExecId))
+        if (report.executionId) {
+            exec = Execution.get(report.executionId)
         }
         item.title=(exec?exec.executionState:report.status=='succeed'?'SUCCEEDED':'FAILED')
-        if(report.jcExecId){
-            item.link=createLink(controller:'execution', action:'show',params:[id:report.jcExecId,project:report.ctxProject], absolute: true)
+        if(report.executionId){
+            item.link=createLink(controller:'execution', action:'show',params:[id:report.executionId,project:report.ctxProject], absolute: true)
         }
         if(report.reportId){
             item.title+=": "+ report.reportId


### PR DESCRIPTION
This is a bugfix.

After 4adf6cdd6624facaf69866f3cee03d63abd32c98 the RSS feed generation stopped working. Missing property "jcExecId". This commit fixes the RSS feed.
