### PR TITLE
RSE-280 Fix: Cannot Edit Job Schedules

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -831,12 +831,12 @@ class ScheduledExecution extends ExecutionContext implements EmbeddedJsonData {
         }else{
             months = params.selectedMonths?.trim() ? valueStringToIndexString(params.selectedMonths, monthsofyearlist) : parseCheckboxFieldFromParams("month", params,true, monthsofyearlist)
         }
-        this.month = months
-        this.dayOfWeek = daysOfWeek ?: '?'
-        this.dayOfMonth = daysOfMonth
-        this.seconds = params.seconds?params.seconds:"0"
-        this.year = params.year?params.year:"*"
-        this.crontabString=null
+        setMonth(months)
+        setDayOfWeek(daysOfWeek ?: '?')
+        setDayOfMonth(daysOfMonth)
+        setSeconds(params.seconds?params.seconds:"0")
+        setYear(params.year?params.year:"*")
+        setCrontabString(null)
     }
 
     String valueStringToIndexString(inputString, valuesArray) {

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3352,6 +3352,9 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
         def modify = true
         boolean schedulingWasChanged = oldjob.schedulingWasChanged(scheduledExecution)
+        if( schedulingWasChanged ){
+            scheduledExecution.markDirty()
+        }
         if(frameworkService.isClusterModeEnabled()){
             if (schedulingWasChanged) {
                 JobReferenceImpl jobReference = scheduledExecution.asReference()

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3352,9 +3352,6 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
         def modify = true
         boolean schedulingWasChanged = oldjob.schedulingWasChanged(scheduledExecution)
-        if( schedulingWasChanged ){
-            scheduledExecution.markDirty()
-        }
         if(frameworkService.isClusterModeEnabled()){
             if (schedulingWasChanged) {
                 JobReferenceImpl jobReference = scheduledExecution.asReference()


### PR DESCRIPTION
# RSE-280 Fix: Cannot Edit Job Schedules
when a description is set in a job, the changes made to job schedules are not applied or persisted in DB.

## The Problem
By an unknown reason to date, some of the 'ScheduledExcecution" model's attributes, weren't marked as dirty if the description is set. In other words, if the description is set, the scheduled doesn't turn into an 'updated' value and not persisted in grails "save()" method.

## Solutions Iterated
- Annotate the 'ScheduleExcecution' model with @DirtyCheck, to track the changes. (not working)
- Validating the pre-saved object, to see if the property is dirty; triggered by other validation. (resource-expensive and not working)
- Passing another param to the save method (failOnError: true) to make a rollback of the save action (since the app works as expected before, this didn't work)

## The Solution
Mark the imported (new) job to be updated in db as dirty if the scheduling was changed.
