### PR TITLE
RSE-257 Fix: Cannot edit rulesets if the page is too heavy

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -580,6 +580,7 @@ public class RundeckConfigBase {
         String titleLink;
         String helpLink;
         String helpLinkName;
+        Boolean workflowGraph;
         Boolean realJobTree;
         String logoSmall;
         Integer matchedNodesMaxCount;

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowGraphController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowGraphController.groovy
@@ -1,0 +1,26 @@
+package rundeck.controllers
+
+import grails.converters.JSON
+import rundeck.services.ConfigurationService
+
+class WorkflowGraphController {
+
+    def configurationService
+    def defaultPropValue = true
+
+    def index() { }
+
+    def WorkflowGraph() {
+        def showGraphFlag = configurationService.getBoolean('gui.workflowGraph', defaultPropValue)
+
+        render(
+                contentType: 'application/json', text:
+                (
+                        [
+                                showGraph : showGraphFlag,
+                        ]
+                ) as JSON
+        )
+    }
+
+}

--- a/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
+++ b/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
@@ -323,6 +323,7 @@ class UrlMappings {
         "/search-plugins"(controller:'SearchPluginsController', action:'index')
 
         "/helplink/name"(controller:'helplink',action:'helplinkName')
+        "/workflowgraph/show"(controller:'WorkflowGraph',action:'WorkflowGraph')
 
         "404"(controller:"error",action:"notFound")
         "405"(controller:"error",action:"notAllowed")

--- a/rundeckapp/src/test/groovy/rundeck/controllers/WorkflowGraphControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/WorkflowGraphControllerSpec.groovy
@@ -1,0 +1,27 @@
+package rundeck.controllers
+
+import grails.testing.web.controllers.ControllerUnitTest
+
+import rundeck.services.ConfigurationService
+import spock.lang.Specification
+
+class WorkflowGraphControllerSpec extends Specification implements ControllerUnitTest<WorkflowGraphController> {
+
+    def setup(){
+    }
+
+    def "render config property"() {
+        given:
+        controller.configurationService = Mock(ConfigurationService){
+            getBoolean("gui.workflowGraph", controller.defaultPropValue) >> controller.defaultPropValue
+        }
+
+        when:
+        request.method='GET'
+        def result=controller.WorkflowGraph()
+
+        then:
+        response.status==200
+        response.contentAsString == '{"showGraph":' + controller.defaultPropValue + '}'
+    }
+


### PR DESCRIPTION
# (Re-upload) RSE-257 Fix: Cannot edit rulesets if the page is too heavy
As of version 4.8, a client reported that the job's page of the Rundeck's GUI was too heavy to do changes in the rulesets.

## The Problem
The graphical representation of the rulesets, is delaying the changes in the GUI

## The Possible Solutions
1. Add a "v-if" directive to the "canvas" referenced div to prevent the renderization: wrong since the component behave erratic in matters of design.
2. Prevent the graph data population: wrong, the graph renders empty with "START" and "END" only (poor design).

## The Solution
 a) Set a controller to retrieve a property that prevent the workflow graph to render (`rundeck.gui.workflowGraph`)
 b) Call the controller from the plugin to see if the graph render or not
 c) The "main" of the workflow graph plugin, will not write in memory the graph if the property is false (is true by default)
 d) if the user decide not to render the graph, the graph will be replaced with a message but the text area to manage the rulesets will remain
 
### Testing routines
:heavy_check_mark: The rulesets works either if the graph is rendered or not
:heavy_check_mark: The graph and the replacement works atleast in firefox and chrome browsers
:heavy_check_mark: No changes-produced errors in browser's console

### OSS PR
https://github.com/rundeck/rundeck/pull/8076
 
## Exhibits
Changes in dark mode
![Screenshot from 2023-01-09 14-13-22](https://user-images.githubusercontent.com/81827734/211367548-4d024ba2-7143-4a05-a84a-32a5c616e4c8.png)

Changes in light mode
![Screenshot from 2023-01-09 14-13-15](https://user-images.githubusercontent.com/81827734/211367630-d7cc5d3d-88ec-4193-926e-9a4a235ec05c.png)

Component grows with new lines
![Screenshot from 2023-01-09 14-13-49](https://user-images.githubusercontent.com/81827734/211367795-6b9539e8-53ab-49a2-b7de-08fea020c078.png)