### PR TITLE
RSE-241: Fix: upgrade pywinrm dependancy for shift_jis encoding issue

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ rundeck:
   plugins: # Extra plugins to bundle
   - "com.github.rundeck-plugins:ansible-plugin:3.2.2"
   - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.7"
-  - "com.github.rundeck-plugins:py-winrm-plugin:2.1.0"
+  - "com.github.rundeck-plugins:py-winrm-plugin:2.1.1"
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.2"
   - "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.1.0"
   - "com.github.rundeck-plugins:attribute-match-node-enhancer:v0.1.5"


### PR DESCRIPTION
Depends On: https://github.com/rundeck-plugins/py-winrm-plugin/pull/91

Upgrade pywinrm plugin dependency