### PR TITLE
RSE-290: Fix: cannot update jobs after upgrade 3.3 to 4.8 job (error 500)

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -24,6 +24,7 @@ import com.dtolabs.rundeck.core.dispatcher.DataContextUtils
 import com.dtolabs.rundeck.core.jobs.JobOption
 import com.dtolabs.rundeck.core.jobs.JobReference
 import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.core.JsonProcessingException
 import org.rundeck.util.Sizes
 import rundeck.services.JobReferenceImpl
 
@@ -668,7 +669,7 @@ class ScheduledExecution extends ExecutionContext implements EmbeddedJsonData {
             //check if the string is a valid JSON
             try {
                 return asJsonList(userRoleList)
-            } catch(JsonParseException ex) {
+            } catch(JsonParseException | JsonProcessingException ex) {
                 return Arrays.asList(userRoleList.split(/,/))
             }
 

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionSpec.groovy
@@ -82,6 +82,31 @@ class ScheduledExecutionSpec extends Specification implements DataTest
             notification.content == '{"urls":"url1","httpMethod":"POST"}'
     }
 
+    def "should return a user role list given comma separated roles or json list"() {
+        given:
+        ScheduledExecution se = new ScheduledExecution(
+                jobName: "TestName",
+                project: "TestFrameworkProject",
+                argString: "-test",
+                description: "whatever",
+                userRoleList: givenUserRolesString
+        )
+
+        when:
+        List userRolesList = se.getUserRoles()
+
+        then:
+        userRolesList == expectedUserRoleList
+
+        where:
+        givenUserRolesString            | expectedUserRoleList
+        ""                              | []
+        "role1,role2"                   | ["role1","role2"]
+        "123 role1,321 role2"           | ["123 role1","321 role2"]
+        "[\"role1\",\"role2\"]"         | ["role1","role2"]
+        "[\"123 role1\",\"321 role2\"]" | ["123 role1","321 role2"]
+    }
+
     void testGenerateJobScheduledName() {
         when:
         def ScheduledExecution se = new ScheduledExecution()


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-290

### Problem
Roles in Active Directory can have spaces as part of their name, this results on the following error after upgrading from 3.3.x to 4.x (`3.3.10 -> 4.4.8` tested) and editing-saving a job.

![image](https://user-images.githubusercontent.com/49494423/214072900-13707383-b685-44ac-b6ed-243e16d2cf2a.png)


These are the steps to reproduce the same issue:
1. In a 3.3.X instance (tested on 3.3.10) create a project and a simple job. (WAR/RPM install used)

2. Perform the [upgrade](https://docs.rundeck.com/docs/upgrading/upgrading.html) to 4.X.X version (4.8.0 used)

2. Within the DB schema, change the user_role_list table row of that job to this value (old version because coming from format): `1234ExampleOfRole1,4321ExampleOfRole2`

3. Try to update the job on the UI (just click save without any actual changes) > updates as expected and the list is updated to the new JSON format

4. Within the DB schema, change the user_role_list table row of that job to this value: `1234 ExampleOfRole1,4321 ExampleOfRole2`

5. Try to update the job on the UI (just click save without any actual changes) > see error, job is not updated neither the user_role_list in DB.


### Solution
The library that was used for parsing the userRoleList was replaced with another which is throwing a different type of exception (`com.fasterxml.jackson.databind.exc.MismatchedInputException`) for this case. The solution was to consider a supertype of this exception (`com.fasterxml.jackson.core.JsonProcessingException`) in the `getUserRoles` method implementation.