### PR TITLE
Fix to user profile flash spacing

### DIFF
--- a/rundeckapp/grails-app/views/user/profile.gsp
+++ b/rundeckapp/grails-app/views/user/profile.gsp
@@ -71,9 +71,7 @@
   <input id="loginName" name="loginName" type="hidden" value="${user.login}">
   <div class="row">
       <div class="col-xs-12">
-        <div class="card">
-          <g:render template="/common/messages"/>
-        </div>
+        <g:render template="/common/messages"/>
       </div>
       <div class="col-sm-12">
           <div class="card">


### PR DESCRIPTION
# User Profile Flash with Wrong Spacing
The user flash has a wrong spacing when a notification pops up.

## The Problem
Has a 'card' component, wrapping the flash

## The Fix
Removing the wrapper

## Exhibits
Pre fix:
![Screenshot from 2023-01-26 11-50-14](https://user-images.githubusercontent.com/81827734/214866989-7ff3c5b4-c985-4d72-8c9e-7d10c46cd5b8.png)

Post-fix:
![Screenshot from 2023-01-26 11-51-51](https://user-images.githubusercontent.com/81827734/214867405-fa29099e-63e8-4ce8-852e-30777e42e8d5.png)
