### PR TITLE
RSE-266 Fix: Cannot remove notifications from a job by loading an XML file

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3054,6 +3054,23 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
     }
 
+    /**
+     *Remove and delete all existing notifications from a scheduledExecution
+     * @param scheduledExecution
+     */
+    public void deleteExistingNotification(ScheduledExecution scheduledExecution) {
+        if (scheduledExecution.notifications) {
+            def todelete = []
+            scheduledExecution.notifications.each {
+                todelete << it
+            }
+            todelete.each {
+                scheduledExecution.removeFromNotifications(it)
+                it.delete()
+            }
+        }
+    }
+
     @CompileStatic
     public boolean validateDefinitionArgStringDatestamp(ScheduledExecution scheduledExecution) {
         if (scheduledExecution.argString) {
@@ -3227,6 +3244,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             }
         }else{
             deleteExistingOptions(scheduledExecution)
+            deleteExistingNotification(scheduledExecution)
             final Collection foundprops = input.properties.keySet().findAll {
                 it != 'lastUpdated' &&
                 it != 'dateCreated' &&

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -5045,6 +5045,27 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
             job.notifications.find{it.toMap()== job2.notifications[0].toMap()}!=null
             job.notifications.find{it.toMap()== job2.notifications[1].toMap()}!=null
     }
+
+    def "job definition notifications from input job should remove notifications"() {
+
+        given:"a base job with notifications"
+        setupDoUpdate()
+        def baseJob = new ScheduledExecution(createJobParams(notifications:[
+                new Notification(type:'email',content:'blah',eventTrigger: 'onsuccess'),
+                new Notification(type:'aplugin',content:'{}',eventTrigger: 'onfailure')
+        ])).save()
+        def jobEmptyNotifications = new ScheduledExecution(createJobParams(notifications:[]))
+        def params = [:]
+        def auth = Mock(UserAndRolesAuthContext)
+
+        when:"uploading the same job without any notifications"
+        service.jobDefinitionBasic(baseJob, jobEmptyNotifications, params, auth)
+        def notifications = Notification.findAllByScheduledExecution(baseJob)
+
+        then:"base job should not have any notifications"
+        notifications.size()==0
+    }
+
     def "job definition notifications from old params"() {
         given:
             def job = new ScheduledExecution(notifications:[])


### PR DESCRIPTION
Problem: When trying to update a job by uploading a job definition, it will not remove existing notifications if the new job definition does not have any notifications. This problem was generated by the way the notifications were trying to be deleted, not correctly removing it from the object. 

Solution: Create a method to remove notifications based on the method deleteExistingNotification, to correctly remove notifications from the updated job if the input job doesn't have any notifications. 
