### PR TITLE
RUN-1465: Fix null save error on plugin groups

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -1427,10 +1427,13 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                                         'true'
                                 )
                                 for (String confKey : config.keySet()) {
-                                    projProps.put(
-                                        "project.plugin.PluginGroup.${type}.${confKey}".toString(),
-                                        config.get(confKey).toString()
-                                    )
+                                    if(config.get(confKey).toString() != null){
+                                        projProps.put(
+                                                "project.plugin.PluginGroup.${type}.${confKey}".toString(),
+                                                config.get(confKey).toString()
+                                        )
+                                    }
+
                                 }
                             }
                         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -1427,7 +1427,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                                         'true'
                                 )
                                 for (String confKey : config.keySet()) {
-                                    if(config.get(confKey).toString() != null){
+                                    if(config.get(confKey) != null){
                                         projProps.put(
                                                 "project.plugin.PluginGroup.${type}.${confKey}".toString(),
                                                 config.get(confKey).toString()

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -762,7 +762,7 @@ class FrameworkControllerSpec extends Specification implements ControllerUnitTes
             request.errors == null
             1 * fwkService.updateFrameworkProjectConfig(
                 _,
-                { it.subMap(expected.keySet())==expected },
+                { it.subMap(expected.keySet())==expected && it.getProperty("project.plugin.PluginGroup.aplugin.c") == null},
                 { it.containsAll(rmPrefixes) }
             ) >> [success: true]
 
@@ -778,12 +778,12 @@ class FrameworkControllerSpec extends Specification implements ControllerUnitTes
             1 * fwkService.loadSessionProjectLabel(_, 'TestSaveProject', 'A Label')
             0 * fwkService._(*_)
             1 * controller.pluginGroupPasswordFieldsService.reset()
-            (expected?1:0) * controller.pluginGroupPasswordFieldsService.untrack([[config: [type: 'aplugin', props: [a:'b']], type: 'aplugin', index: 0]],_)
+            (expected?1:0) * controller.pluginGroupPasswordFieldsService.untrack([[config: [type: 'aplugin', props: [a:'b', 'c':null]], type: 'aplugin', index: 0]],_)
         where:
             pgEnabled | rmPrefixes                                              | json |expected
             true      | ['project.plugin.PluginGroup.', 'project.PluginGroup.'] | ''   |[:]
             true      | ['project.plugin.PluginGroup.', 'project.PluginGroup.'] | '[]' |[:]
-            true      | ['project.plugin.PluginGroup.', 'project.PluginGroup.'] | '[{"type":"aplugin","config":{"a":"b"}}]'|['project.PluginGroup.aplugin.enabled':'true','project.plugin.PluginGroup.aplugin.a':'b']
+            true      | ['project.plugin.PluginGroup.', 'project.PluginGroup.'] | '[{"type":"aplugin","config":{"a":"b", "c":null}}]'|['project.PluginGroup.aplugin.enabled':'true','project.plugin.PluginGroup.aplugin.a':'b']
     }
     def "save project with out description"(){
         setup:


### PR DESCRIPTION
Confirm that all keys are set before writing to project properties. if the value set is null, do not write to project properties