### PR TITLE
Run 1466: fix create project plugin group null save error

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -1427,10 +1427,13 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                                         'true'
                                 )
                                 for (String confKey : config.keySet()) {
-                                    projProps.put(
-                                        "project.plugin.PluginGroup.${type}.${confKey}".toString(),
-                                        config.get(confKey).toString()
-                                    )
+                                    if(config.get(confKey).toString() != null){
+                                        projProps.put(
+                                                "project.plugin.PluginGroup.${type}.${confKey}".toString(),
+                                                config.get(confKey).toString()
+                                        )
+                                    }
+
                                 }
                             }
                         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -838,10 +838,12 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                                 'true'
                         )
                         for (String confKey : config.keySet()) {
-                            projProps.put(
-                                    "project.plugin.PluginGroup.${type}.${confKey}".toString(),
-                                    config.get(confKey).toString()
-                            )
+                            if(config.get(confKey) != null) {
+                                projProps.put(
+                                        "project.plugin.PluginGroup.${type}.${confKey}".toString(),
+                                        config.get(confKey).toString()
+                                )
+                            }
                         }
                     }
                 }
@@ -1006,17 +1008,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         def (descriptions, nodeexecdescriptions, filecopydescs) = frameworkService.listDescriptions()
 
-        List<Description> pluginGroupDescs = frameworkService.listPluginGroupDescriptions()
         List<Map<String, Object>> pluginGroupConfig = []
-        pluginGroupDescs.each {
-            List<Property> propList = it.getProperties()
-            Map<String, String> mapping = new HashMap<>();
-            for(Property item : propList){
-                mapping.put(item.getName(), null);
-            }
-
-            pluginGroupConfig.add(["type": it.name, "config":mapping])
-        }
         //get grails services that declare project configurations
         Map<String, Map> extraConfig = frameworkService.loadProjectConfigurableInput('extraConfig.', [:])
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -1419,12 +1419,10 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                                         'true'
                                 )
                                 for (String confKey : config.keySet()) {
-                                    if(config.get(confKey) != null){
-                                        projProps.put(
-                                                "project.plugin.PluginGroup.${type}.${confKey}".toString(),
-                                                config.get(confKey).toString()
-                                        )
-                                    }
+                                    projProps.put(
+                                            "project.plugin.PluginGroup.${type}.${confKey}".toString(),
+                                            config.get(confKey).toString()
+                                    )
 
                                 }
                             }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -1427,7 +1427,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
                                         'true'
                                 )
                                 for (String confKey : config.keySet()) {
-                                    if(config.get(confKey).toString() != null){
+                                    if(config.get(confKey) != null){
                                         projProps.put(
                                                 "project.plugin.PluginGroup.${type}.${confKey}".toString(),
                                                 config.get(confKey).toString()

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -1646,6 +1646,51 @@ project.label=A Label
 
     }
 
+    def "create project plugin groups don't save null"(){
+        setup:
+        controller.featureService = Mock(FeatureService)
+        controller.metricService = Mock(MetricService)
+        controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
+            1 * authorizeApplicationResourceTypeAll(null,'project',[ACTION_CREATE])>>true
+
+            1 * getAuthContextForSubject(_) >> null
+        }
+        def fwkService = Mock(FrameworkService)
+        controller.frameworkService = fwkService
+        def project = Mock(Project){
+            getName() >> "TestSaveProject"
+        }
+        def projectManager = Mock(ProjectManager){
+            existsFrameworkProject( )>>false
+        }
+        def rdframework=Mock(Framework){
+            1 * getFrameworkProjectMgr()>>projectManager
+        }
+
+        params.newproject = "TestSaveProject"
+        if(json){
+            params['pluginValues.PluginGroup.json']=json
+        }
+
+        setupFormTokens(params)
+        when:
+        request.method = "POST"
+        controller.createProjectPost()
+
+        then:
+        response.status==302
+        request.errors == null
+        1 * fwkService.validateProjectConfigurableInput(_,_,_)>>[props:[:]]
+        1 * fwkService.getRundeckFramework() >> rdframework
+        1 * fwkService.createFrameworkProject(
+                _,
+                { it.subMap(expected.keySet())==expected }) >> [project, null]
+
+        where:
+         json                                      |expected
+         '[{"type":"aplugin","config":{"a":null}}]'|[:]
+    }
+
     def "create project description name starting with space"(){
         setup:
         controller.featureService = Mock(FeatureService)

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -1680,15 +1680,16 @@ project.label=A Label
         then:
         response.status==302
         request.errors == null
+
         1 * fwkService.validateProjectConfigurableInput(_,_,_)>>[props:[:]]
         1 * fwkService.getRundeckFramework() >> rdframework
         1 * fwkService.createFrameworkProject(
                 _,
-                { it.subMap(expected.keySet())==expected }) >> [project, null]
+                { it.subMap(expected.keySet())==expected && it.getProperty("project.plugin.PluginGroup.aplugin.a") == null}) >> [project, null]
 
         where:
-         json                                      |expected
-         '[{"type":"aplugin","config":{"a":null}}]'|[:]
+         json                                                  |expected
+         '[{"type":"aplugin","config":{"a":null, "b":"good"}}]'|['project.PluginGroup.aplugin.enabled':'true',"project.plugin.PluginGroup.aplugin.b":"good"]
     }
 
     def "create project description name starting with space"(){


### PR DESCRIPTION
- Confirm value is set to something other than null before writing the value to project settings.
- Removed defined config for plugin groups for createProject view. It should never have any defined config, unlike editProject.
