### PR TITLE
RUN-1356: remove in-page js tests in dev mode

### DIFF
--- a/rundeckapp/grails-app/views/execution/_wfAddStep.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfAddStep.gsp
@@ -14,9 +14,6 @@
   - limitations under the License.
   --}%
 <%@ page import="grails.util.Environment; grails.converters.JSON" %>
-<g:if test="${grails.util.Environment.current==grails.util.Environment.DEVELOPMENT}">
-    <asset:javascript src="filterStepPluginsKOTest.js"/>
-</g:if>
 <div class="panel-heading">
     <span class="h3 ">
         <g:message code="${addMessage}"/>

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -63,10 +63,6 @@
       <g:embedJSON id="workflowDataJSON" data="${workflowTree}"/>
       <g:embedJSON id="nodeStepPluginsJSON" data="${stepPluginDescriptions.node.collectEntries { [(it.key): [title: it.value.title]] }}"/>
       <g:embedJSON id="wfStepPluginsJSON" data="${stepPluginDescriptions.workflow.collectEntries { [(it.key): [title: it.value.title]] }}"/>
-      <g:if test="${grails.util.Environment.current==grails.util.Environment.DEVELOPMENT}">
-          <asset:javascript src="workflow.test.js"/>
-          <asset:javascript src="util/compactMapList.test.js"/>
-      </g:if>
       <g:jsMessages codes="['execution.show.mode.Log.title','execution.page.show.tab.Nodes.title']"/>
 
       <asset:stylesheet href="static/css/pages/project-dashboard.css"/>

--- a/rundeckapp/grails-app/views/framework/nodes.gsp
+++ b/rundeckapp/grails-app/views/framework/nodes.gsp
@@ -25,9 +25,6 @@
     <g:set var="projectLabel" value="${session.frameworkLabels?session.frameworkLabels[projectName]:projectName}"/>
     <title><g:message code="gui.menu.Nodes"/> - <g:enc>${projectLabel}</g:enc></title>
     <asset:javascript src="framework/nodes.js"/>
-    <g:if test="${grails.util.Environment.current==grails.util.Environment.DEVELOPMENT}">
-        <asset:javascript src="nodeFiltersKOTest.js"/>
-    </g:if>
     <g:embedJSON id="filterParamsJSON"
                  data="${[filterName: params.filterName, filter: query?.filter, filterAll: params.showall in ['true', true]]}"/>
     <g:embedJSON id="pageParams"

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -34,10 +34,6 @@
     <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
 
     <asset:javascript src="menu/jobs.js"/>
-    <g:if test="${grails.util.Environment.current==grails.util.Environment.DEVELOPMENT}">
-        <asset:javascript src="menu/joboptionsTest.js"/>
-        <asset:javascript src="menu/job-remote-optionsTest.js"/>
-    </g:if>
     <g:embedJSON data="${projectNames ?: []}" id="projectNamesData"/>
     <g:embedJSON data="${jobListIds ?: []}" id="nextScheduled"/>
     <g:embedJSON id="pageParams" data="${[project: params.project?:request.project,]}"/>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Remove links to JS tests that are inserted in development mode.
