### PR TITLE
RUN-1477: Fix error handling on job component failure

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -4237,7 +4237,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         try {
             return jobLifecycleComponentService.beforeJobExecution(scheduledExecution, event)
         } catch (JobLifecycleComponentException jpe) {
-            throw new ExecutionServiceValidationException(jpe.message, optparams, null)
+            throw new ExecutionServiceException(jpe.message, 'error')
         }
     }
 

--- a/rundeckapp/src/main/groovy/rundeck/services/JobLifecycleComponentService.groovy
+++ b/rundeckapp/src/main/groovy/rundeck/services/JobLifecycleComponentService.groovy
@@ -165,7 +165,7 @@ class JobLifecycleComponentService implements ProjectConfigurable, ApplicationCo
             compList.addAll(beanComponents.collect { name, component->
                 new NamedJobLifecycleComponent(
                     component: component,
-                    name: component.class.canonicalName)
+                    name: component.class.simpleName)
             })
         }
         compList.addAll(loadProjectConfiguredPlugins(project))
@@ -240,12 +240,14 @@ class JobLifecycleComponentService implements ProjectConfigurable, ApplicationCo
         }
         
         if (!success || errors) {
-            LOG.warn("Errors processing Job Component Event [${eventType}]. See debug log for details.")
-            errors.each { name, e ->
-                LOG.debug("    For component [${name}]: " + e.getMessage(), e)
+            LOG.warn("Errors processing Job Component Event [${eventType}]:")
+            errors.each { name, e -> 
+                LOG.warn(" -- For component [${name}]: " + e.getMessage())
+                LOG.debug(" -- For component [${name}]: " + e.getMessage(), e)
             }
-            throw new JobLifecycleComponentException("Aborting event handling due to (${errors.size()}) errors: " + errors.collect { name, e ->
-                "{Component: [${name}] Message: [${e.message}]}"
+            
+            throw new JobLifecycleComponentException("Error: " + errors.collect { name, e ->
+                "{[${name}]: ${e.message}}"
             }.join(", "))
         }
 


### PR DESCRIPTION
This PR corrects the way job components errors are handled, so they are considered as execution errors and not option validation errors.

This fixes the issue of executions not running when triggered from the job list page (inline run), where the absence of a runner won't render any error message.

Also small improvements on job component error reporting messages