### PR TITLE
RUN-1436: Change FeatureService to use an interface instead of the Features enum

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/FeatureService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/FeatureService.java
@@ -6,7 +6,7 @@ public interface FeatureService {
      * @param feature
      * @return
      */
-    boolean featurePresent(Features feature);
+    boolean featurePresent(FeaturesDefinition feature);
 
     /**
      * Return true if grails configuration allows given feature
@@ -21,7 +21,7 @@ public interface FeatureService {
      * @param defaultEnabled default enabled value for the feature, if unset
      * @return true if enabled
      */
-    boolean featurePresent(Features feature, boolean defaultEnabled);
+    boolean featurePresent(FeaturesDefinition feature, boolean defaultEnabled);
 
     /**
      * Return true if grails configuration allows given feature
@@ -36,7 +36,7 @@ public interface FeatureService {
      * @param feature
      * @param enable
      */
-    void toggleFeature(Features feature, boolean enable);
+    void toggleFeature(FeaturesDefinition feature, boolean enable);
 
     /**
      * Set an incubator feature toggle on or off
@@ -45,7 +45,7 @@ public interface FeatureService {
      */
     void toggleFeature(String name, boolean enable);
 
-    Object getFeatureConfig(Features feature);
+    Object getFeatureConfig(FeaturesDefinition feature);
 
     Object getFeatureConfig(String name);
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
@@ -15,7 +15,7 @@
  */
 package com.dtolabs.rundeck.core.config;
 
-public enum Features {
+public enum Features implements FeaturesDefinition{
     ENHANCED_NODES("enhancedNodes"),
     REPOSITORY("repository"),
     WEBHOOKS("webhooks"),

--- a/core/src/main/java/com/dtolabs/rundeck/core/config/FeaturesDefinition.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/FeaturesDefinition.java
@@ -1,0 +1,6 @@
+package com.dtolabs.rundeck.core.config;
+
+public interface FeaturesDefinition {
+
+    public String getPropertyName();
+}

--- a/rundeckapp/grails-app/services/rundeck/services/feature/FeatureService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/feature/FeatureService.groovy
@@ -16,7 +16,7 @@
 
 package rundeck.services.feature
 
-import com.dtolabs.rundeck.core.config.Features
+import com.dtolabs.rundeck.core.config.FeaturesDefinition
 
 /**
  * Manage feature configuration in the 'rundeck.feature.X' namespace, a
@@ -31,7 +31,7 @@ class FeatureService implements com.dtolabs.rundeck.core.config.FeatureService {
      * @param feature
      * @return
      */
-    def boolean featurePresent(Features feature) {
+    def boolean featurePresent(FeaturesDefinition feature) {
         featurePresent(feature.propertyName)
     }
     /**
@@ -49,7 +49,7 @@ class FeatureService implements com.dtolabs.rundeck.core.config.FeatureService {
      * @param defaultEnabled default enabled value for the feature, if unset
      * @return true if enabled
      */
-    def boolean featurePresent(Features feature, boolean defaultEnabled) {
+    def boolean featurePresent(FeaturesDefinition feature, boolean defaultEnabled) {
         featurePresent(feature.propertyName, defaultEnabled)
     }
 
@@ -68,7 +68,7 @@ class FeatureService implements com.dtolabs.rundeck.core.config.FeatureService {
      * @param feature
      * @param enable
      */
-    def void toggleFeature(Features feature, boolean enable) {
+    def void toggleFeature(FeaturesDefinition feature, boolean enable) {
         configurationService.setBoolean("feature.${feature.propertyName}.enabled", enable)
     }
     /**
@@ -84,7 +84,7 @@ class FeatureService implements com.dtolabs.rundeck.core.config.FeatureService {
      * @param name
      * @param enable
      */
-    def getFeatureConfig(Features feature) {
+    def getFeatureConfig(FeaturesDefinition feature) {
         configurationService.getConfig("feature.${feature.propertyName}.config")
     }
     /**


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Refactor:
Change FeatureService to use an interface instead of the Features enum
This will allows us to manage a Features set for enterprise

**Describe the solution you've implemented**

**Describe alternatives you've considered**

**Additional context**
