### PR TITLE
RUN-1434: fix exec page UI plugins: send event to indicate page loaded has completed

### DIFF
--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -1283,6 +1283,7 @@ search
             nodeflowvm.activeTab("nodes");
         }
         initKoBind(null, {nodeflow: nodeflowvm})
+        window.dispatchEvent(new Event('rundeck-exec-show-page-loaded'));
     }
     jQuery(init);
     </script>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Adds a custom page loaded event for UI 
