### PR TITLE
RSE-297: Notifications fixes for Average Duration, OnRestart, etc.

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -241,7 +241,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData {
         return cancelled ? ExecutionService.EXECUTION_ABORTED :
             (null == dateCompleted && status == ExecutionService.EXECUTION_QUEUED) ? ExecutionService.EXECUTION_QUEUED :
                 null != dateStarted && dateStarted.getTime() > System.currentTimeMillis() ? ExecutionService.EXECUTION_SCHEDULED :
-                    null == dateCompleted ? ExecutionService.EXECUTION_RUNNING :
+                    (null == dateCompleted && !timedOut) ? ExecutionService.EXECUTION_RUNNING :
                         (status in ['true', 'succeeded']) ? ExecutionService.EXECUTION_SUCCEEDED :
                             cancelled ? ExecutionService.EXECUTION_ABORTED :
                                 willRetry ? ExecutionService.EXECUTION_FAILED_WITH_RETRY :

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -241,8 +241,8 @@ class Execution extends ExecutionContext implements EmbeddedJsonData {
         return cancelled ? ExecutionService.EXECUTION_ABORTED :
             (null == dateCompleted && status == ExecutionService.EXECUTION_QUEUED) ? ExecutionService.EXECUTION_QUEUED :
                 null != dateStarted && dateStarted.getTime() > System.currentTimeMillis() ? ExecutionService.EXECUTION_SCHEDULED :
-                    (null == dateCompleted && status!='overAverage') ? ExecutionService.EXECUTION_RUNNING :
-                        (status == 'overAverage') ? ExecutionService.AVERAGE_DURATION_EXCEEDED:
+                    (null == dateCompleted && status!=ExecutionService.AVERAGE_DURATION_EXCEEDED) ? ExecutionService.EXECUTION_RUNNING :
+                        (status == ExecutionService.AVERAGE_DURATION_EXCEEDED) ? ExecutionService.AVERAGE_DURATION_EXCEEDED:
                             (status in ['true', 'succeeded']) ? ExecutionService.EXECUTION_SUCCEEDED :
                                 cancelled ? ExecutionService.EXECUTION_ABORTED :
                                     willRetry ? ExecutionService.EXECUTION_FAILED_WITH_RETRY :
@@ -268,7 +268,8 @@ class Execution extends ExecutionContext implements EmbeddedJsonData {
                                                  ExecutionService.EXECUTION_SUCCEEDED,
                                                  ExecutionService.EXECUTION_FAILED,
                                                  ExecutionService.EXECUTION_QUEUED,
-                                                 ExecutionService.EXECUTION_SCHEDULED])
+                                                 ExecutionService.EXECUTION_SCHEDULED,
+                                                 ExecutionService.AVERAGE_DURATION_EXCEEDED])
     }
 
     // various utility methods helpful to the presentation layer

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -241,14 +241,15 @@ class Execution extends ExecutionContext implements EmbeddedJsonData {
         return cancelled ? ExecutionService.EXECUTION_ABORTED :
             (null == dateCompleted && status == ExecutionService.EXECUTION_QUEUED) ? ExecutionService.EXECUTION_QUEUED :
                 null != dateStarted && dateStarted.getTime() > System.currentTimeMillis() ? ExecutionService.EXECUTION_SCHEDULED :
-                    (null == dateCompleted && !timedOut) ? ExecutionService.EXECUTION_RUNNING :
-                        (status in ['true', 'succeeded']) ? ExecutionService.EXECUTION_SUCCEEDED :
-                            cancelled ? ExecutionService.EXECUTION_ABORTED :
-                                willRetry ? ExecutionService.EXECUTION_FAILED_WITH_RETRY :
-                                    timedOut ? ExecutionService.EXECUTION_TIMEDOUT :
-                                        (status == 'missed') ? ExecutionService.EXECUTION_MISSED :
-                                            (status in ['false', 'failed']) ? ExecutionService.EXECUTION_FAILED :
-                                                isCustomStatusString(status) ? ExecutionService.EXECUTION_STATE_OTHER : status.toLowerCase()
+                    (null == dateCompleted && status!='overAverage') ? ExecutionService.EXECUTION_RUNNING :
+                        (status == 'overAverage') ? ExecutionService.AVERAGE_DURATION_EXCEEDED:
+                            (status in ['true', 'succeeded']) ? ExecutionService.EXECUTION_SUCCEEDED :
+                                cancelled ? ExecutionService.EXECUTION_ABORTED :
+                                    willRetry ? ExecutionService.EXECUTION_FAILED_WITH_RETRY :
+                                        timedOut ? ExecutionService.EXECUTION_TIMEDOUT :
+                                            (status == 'missed') ? ExecutionService.EXECUTION_MISSED :
+                                                (status in ['false', 'failed']) ? ExecutionService.EXECUTION_FAILED :
+                                                    isCustomStatusString(status) ? ExecutionService.EXECUTION_STATE_OTHER : status.toLowerCase()
 
     }
 

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -296,6 +296,7 @@ status.label.aborted=Killed
 status.label.short.OK=OK
 status.label.short.FAIL=FAIL
 status.label.missed=Missed Scheduled Execution
+status.label.timedout=Average time exceeded
 
 # date format used in content of All Events list items
 jobslist.date.format=M/d/yy h:mm a

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -296,7 +296,8 @@ status.label.aborted=Killed
 status.label.short.OK=OK
 status.label.short.FAIL=FAIL
 status.label.missed=Missed Scheduled Execution
-status.label.timedout=Average time exceeded
+status.label.average-duration-exceeded=Average time exceeded
+status.label.timedout=Duration time limit reached
 
 # date format used in content of All Events list items
 jobslist.date.format=M/d/yy h:mm a

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -284,7 +284,8 @@ status.label.cancel=Eliminado
 status.label.aborted=Eliminado
 status.label.short.OK=OK
 status.label.short.FAIL=FALLO
-status.label.timedout=Tiempo promedio excedido 
+status.label.average-duration-exceeded=Tiempo promedio excedido
+status.label.timedout=Limite de tiempo alcanzado   
 
 # date format used in content of All Events list items
 jobslist.date.format=M/d/yy h:mm a

--- a/rundeckapp/grails-app/i18n/messages_es_419.properties
+++ b/rundeckapp/grails-app/i18n/messages_es_419.properties
@@ -284,6 +284,7 @@ status.label.cancel=Eliminado
 status.label.aborted=Eliminado
 status.label.short.OK=OK
 status.label.short.FAIL=FALLO
+status.label.timedout=Tiempo promedio excedido 
 
 # date format used in content of All Events list items
 jobslist.date.format=M/d/yy h:mm a

--- a/rundeckapp/grails-app/i18n/messages_fr_FR.properties
+++ b/rundeckapp/grails-app/i18n/messages_fr_FR.properties
@@ -282,6 +282,7 @@ status.label.aborted=Tu\u00e9
 # TODO - Probablement pas la bonne traduction pour OK (contexte à vérifier)
 status.label.short.OK=D\u02bcaccord
 status.label.short.FAIL=\u00c9CHOUER
+status.label.timedout=Temps moyen d\u00e9pass\u00e9
 
 # date format used in content of All Events list items
 jobslist.date.format=dd/MM/yyyy H:mm

--- a/rundeckapp/grails-app/i18n/messages_fr_FR.properties
+++ b/rundeckapp/grails-app/i18n/messages_fr_FR.properties
@@ -282,7 +282,8 @@ status.label.aborted=Tu\u00e9
 # TODO - Probablement pas la bonne traduction pour OK (contexte à vérifier)
 status.label.short.OK=D\u02bcaccord
 status.label.short.FAIL=\u00c9CHOUER
-status.label.timedout=Temps moyen d\u00e9pass\u00e9
+status.label.average-duration-exceeded=Temps moyen d\u00e9pass\u00e9
+status.label.timedout=Limite de temps a \u00e9t\u00e9 atteinte
 
 # date format used in content of All Events list items
 jobslist.date.format=dd/MM/yyyy H:mm

--- a/rundeckapp/grails-app/i18n/messages_pt_BR.properties
+++ b/rundeckapp/grails-app/i18n/messages_pt_BR.properties
@@ -287,7 +287,8 @@ status.label.cancel=Abortado
 status.label.aborted=Abortado
 status.label.short.OK=OK
 status.label.short.FAIL=FALHA
-status.label.timedout=Tempo m\u00e9dio excedido
+status.label.average-duration-exceeded=Tempo m\u00e9dio excedido
+status.label.timedout=Limite de tempo foi excedido
 
 # date format used in content of All Events list items
 jobslist.date.format=M/d/aa h:mm a

--- a/rundeckapp/grails-app/i18n/messages_pt_BR.properties
+++ b/rundeckapp/grails-app/i18n/messages_pt_BR.properties
@@ -287,6 +287,7 @@ status.label.cancel=Abortado
 status.label.aborted=Abortado
 status.label.short.OK=OK
 status.label.short.FAIL=FALHA
+status.label.timedout=Tempo m\u00e9dio excedido
 
 # date format used in content of All Events list items
 jobslist.date.format=M/d/aa h:mm a

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -415,7 +415,9 @@ class ExecutionJob implements InterruptableJob {
             def duration = System.currentTimeMillis() - startTime
             if(!avgNotificationSent && jobAverageDurationFinal>0){
                 if(duration > jobAverageDurationFinal){
-                    execmap.execution.timedOut=true
+                    if(execmap.execution){
+                        execmap.execution.timedOut=true
+                    }
                     runContext.executionService.avgDurationExceeded(
                             execmap.scheduledExecution.id,
                             [

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -416,7 +416,7 @@ class ExecutionJob implements InterruptableJob {
             if(!avgNotificationSent && jobAverageDurationFinal>0){
                 if(duration > jobAverageDurationFinal){
                     if(execmap.execution){
-                        execmap.execution.timedOut=true
+                        execmap.execution.status='overAverage'
                     }
                     runContext.executionService.avgDurationExceeded(
                             execmap.scheduledExecution.id,

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -415,6 +415,7 @@ class ExecutionJob implements InterruptableJob {
             def duration = System.currentTimeMillis() - startTime
             if(!avgNotificationSent && jobAverageDurationFinal>0){
                 if(duration > jobAverageDurationFinal){
+                    execmap.execution.timedOut=true
                     runContext.executionService.avgDurationExceeded(
                             execmap.scheduledExecution.id,
                             [

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -416,7 +416,7 @@ class ExecutionJob implements InterruptableJob {
             if(!avgNotificationSent && jobAverageDurationFinal>0){
                 if(duration > jobAverageDurationFinal){
                     if(execmap.execution){
-                        execmap.execution.status='overAverage'
+                        execmap.execution.status=ExecutionService.AVERAGE_DURATION_EXCEEDED
                     }
                     runContext.executionService.avgDurationExceeded(
                             execmap.scheduledExecution.id,

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1420,6 +1420,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     public static String EXECUTION_SCHEDULED = "scheduled"
     public static String EXECUTION_MISSED = "missed"
     public static String EXECUTION_QUEUED = "queued"
+    public static String AVERAGE_DURATION_EXCEEDED = "average-duration-exceeded"
 
     public static String ABORT_PENDING = "pending"
     public static String ABORT_ABORTED = "aborted"

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -305,6 +305,7 @@ public class NotificationService implements ApplicationContextAware{
                             (ExecutionService.EXECUTION_TIMEDOUT):'TIMEDOUT',
                             (ExecutionService.EXECUTION_MISSED):'MISSED',
                             (ExecutionService.EXECUTION_FAILED_WITH_RETRY):'FAILED WITH RETRY',
+                            (ExecutionService.AVERAGE_DURATION_EXCEEDED):'AVERAGE DURATION EXCEEDED',
                     ]
 
                     def execMap = null

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -304,6 +304,7 @@ public class NotificationService implements ApplicationContextAware{
                             (ExecutionService.EXECUTION_SUCCEEDED):'SUCCESS',
                             (ExecutionService.EXECUTION_TIMEDOUT):'TIMEDOUT',
                             (ExecutionService.EXECUTION_MISSED):'MISSED',
+                            (ExecutionService.EXECUTION_FAILED_WITH_RETRY):'FAILED WITH RETRY',
                     ]
 
                     def execMap = null

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/notification/DummyEmailNotificationPlugin.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/notification/DummyEmailNotificationPlugin.groovy
@@ -61,7 +61,7 @@ class DummyEmailNotificationPlugin implements NotificationPlugin {
         title = "Subject",
         description = '''Template for the email subject. Can contain property references: ${group.key}
 
-A default template of `${notification.eventStatus} [${exec.project}] ${job.group}/${job.name} ${exec.argstring}}` will be used unless 
+A default template of `${notification.eventStatus} [${execution.project}] ${job.group}/${job.name} ${execution.argstring}}` will be used unless 
 overridden in the configuration file.
 
 See [Documentation](https://docs.rundeck.com/docs/administration/configuration/email-settings.html#custom-email-templates)'''

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionTest.groovy
@@ -181,54 +181,25 @@ class ExecutionTest extends Specification implements DataTest  {
 
     void testIsCustomStatusString() {
         given:
-        String value
         boolean result
 
         when:
-        value = ExecutionService.EXECUTION_TIMEDOUT
-        result = Execution.isCustomStatusString(value)
+        result = Execution.isCustomStatusString(statusValue)
+
         then:
-        result == false
-        when:
-        value = ExecutionService.EXECUTION_FAILED_WITH_RETRY
-        result = Execution.isCustomStatusString(value)
-        then:
-        result == false
-        when:
-        value = ExecutionService.ABORT_ABORTED
-        result = Execution.isCustomStatusString(value)
-        then:
-        result == false
-        when:
-        value = ExecutionService.EXECUTION_SUCCEEDED
-        result = Execution.isCustomStatusString(value)
-        then:
-        result == false
-        when:
-        value = ExecutionService.EXECUTION_FAILED
-        result = Execution.isCustomStatusString(value)
-        then:
-        result == false
-        when:
-        value = ExecutionService.EXECUTION_QUEUED
-        result = Execution.isCustomStatusString(value)
-        then:
-        result == false
-        when:
-        value = ExecutionService.EXECUTION_SCHEDULED
-        result = Execution.isCustomStatusString(value)
-        then:
-        result == false
-        when:
-        value = ExecutionService.AVERAGE_DURATION_EXCEEDED
-        result = Execution.isCustomStatusString(value)
-        then:
-        result == false
-        when:
-        value = "CUSTOM STRING"
-        result = Execution.isCustomStatusString(value)
-        then:
-        result == true
+        result == isCustom
+
+        where:
+        statusValue                                     | isCustom
+        ExecutionService.EXECUTION_TIMEDOUT             | false
+        ExecutionService.EXECUTION_FAILED_WITH_RETRY    | false
+        ExecutionService.ABORT_ABORTED                  | false
+        ExecutionService.EXECUTION_SUCCEEDED            | false
+        ExecutionService.EXECUTION_FAILED               | false
+        ExecutionService.EXECUTION_QUEUED               | false
+        ExecutionService.EXECUTION_SCHEDULED            | false
+        ExecutionService.AVERAGE_DURATION_EXCEEDED      | false
+        "CUSTOM STRING"                                 | true
     }
 
     void testStatusSucceededTrue() {

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionTest.groovy
@@ -173,7 +173,64 @@ class ExecutionTest extends Specification implements DataTest  {
         se.status = "any string"
         then:
         assertEquals(ExecutionService.EXECUTION_STATE_OTHER,se.executionState)
+        when:
+        se.status ="average-duration-exceeded"
+        then:
+        assertEquals(ExecutionService.AVERAGE_DURATION_EXCEEDED,se.executionState)
     }
+
+    void testIsCustomStatusString() {
+        given:
+        String value
+        boolean result
+
+        when:
+        value = ExecutionService.EXECUTION_TIMEDOUT
+        result = Execution.isCustomStatusString(value)
+        then:
+        result == false
+        when:
+        value = ExecutionService.EXECUTION_FAILED_WITH_RETRY
+        result = Execution.isCustomStatusString(value)
+        then:
+        result == false
+        when:
+        value = ExecutionService.ABORT_ABORTED
+        result = Execution.isCustomStatusString(value)
+        then:
+        result == false
+        when:
+        value = ExecutionService.EXECUTION_SUCCEEDED
+        result = Execution.isCustomStatusString(value)
+        then:
+        result == false
+        when:
+        value = ExecutionService.EXECUTION_FAILED
+        result = Execution.isCustomStatusString(value)
+        then:
+        result == false
+        when:
+        value = ExecutionService.EXECUTION_QUEUED
+        result = Execution.isCustomStatusString(value)
+        then:
+        result == false
+        when:
+        value = ExecutionService.EXECUTION_SCHEDULED
+        result = Execution.isCustomStatusString(value)
+        then:
+        result == false
+        when:
+        value = ExecutionService.AVERAGE_DURATION_EXCEEDED
+        result = Execution.isCustomStatusString(value)
+        then:
+        result == false
+        when:
+        value = "CUSTOM STRING"
+        result = Execution.isCustomStatusString(value)
+        then:
+        result == true
+    }
+
     void testStatusSucceededTrue() {
         when:
         Execution se = createBasicExecution()

--- a/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
@@ -737,12 +737,11 @@ class ExecutionJobSpec extends Specification implements DataTest {
         def result=executionJob.executeCommand(runContext)
 
         then:
-
         1 * es.avgDurationExceeded(_, content) >> {
             latch.countDown()
         }
         result != null
-
+        se.executions.status.get(0) == ExecutionService.AVERAGE_DURATION_EXCEEDED
     }
 
     def "scheduled job quartz checking the same format of dates"() {


### PR DESCRIPTION
Problems:

1. Notifications triggered when the average duration exceeded were being sent with the template of the on-start notification, causing confusion to some clients. 
2. On the notifications triggered for the on-restart failure if the subject was left empty the default template the subject of the email didn't expand the variable name.
3. The email template body for average time exceeded and for retry-failure was missing information, a variable name was being shown without being expanded. 

Solution:
Modify the execution status when the average time was exceeded and add the missing messages to messages.properties 