### PR TITLE
RUN-1509: Fix: ExecutionLifecycle component is not loaded when a job is imported

### DIFF
--- a/rundeckapp/src/main/groovy/rundeck/services/ExecutionLifecycleComponentService.groovy
+++ b/rundeckapp/src/main/groovy/rundeck/services/ExecutionLifecycleComponentService.groovy
@@ -263,8 +263,6 @@ class ExecutionLifecycleComponentService implements IExecutionLifecycleComponent
                 }
             }
         }
-
-        compList.addAll(createConfiguredPlugins(configurations, project))
         compList
     }
 
@@ -315,10 +313,12 @@ class ExecutionLifecycleComponentService implements IExecutionLifecycleComponent
      * @param configSet config set
      */
     def setExecutionLifecyclePluginConfigSetForJob(final ScheduledExecution job, final PluginConfigSet configSet) {
-        Map<String, Map<String, Object>> data = configSet?.pluginProviderConfigs?.collectEntries {
-            [it.provider, it.configuration]
+        if(configSet){
+            Map<String, Map<String, Object>> data = configSet?.pluginProviderConfigs?.collectEntries {
+                [it.provider, it.configuration]
+            }
+            job.setPluginConfigVal(ServiceNameConstants.ExecutionLifecycle, data)
         }
-        job.setPluginConfigVal(ServiceNameConstants.ExecutionLifecycle, data)
     }
 
 
@@ -333,10 +333,10 @@ class ExecutionLifecycleComponentService implements IExecutionLifecycleComponent
         if (!featureService?.featurePresent(Features.EXECUTION_LIFECYCLE_PLUGIN, false)) {
             return null
         }
-        if (!configurations) {
-            return null
-        }
         def components = loadConfiguredComponents(configurations, executionReference.project)
+        if(configurations){
+            components.addAll(createConfiguredPlugins(configurations, executionReference.project))
+        }
         new ExecutionReferenceLifecycleComponentHandler(
                 executionReference: executionReference,
                 executionLifecycleComponentService: this,

--- a/rundeckapp/src/main/groovy/rundeck/services/ExecutionLifecycleComponentService.groovy
+++ b/rundeckapp/src/main/groovy/rundeck/services/ExecutionLifecycleComponentService.groovy
@@ -313,12 +313,10 @@ class ExecutionLifecycleComponentService implements IExecutionLifecycleComponent
      * @param configSet config set
      */
     def setExecutionLifecyclePluginConfigSetForJob(final ScheduledExecution job, final PluginConfigSet configSet) {
-        if(configSet){
-            Map<String, Map<String, Object>> data = configSet?.pluginProviderConfigs?.collectEntries {
-                [it.provider, it.configuration]
-            }
-            job.setPluginConfigVal(ServiceNameConstants.ExecutionLifecycle, data)
+        Map<String, Map<String, Object>> data = configSet?.pluginProviderConfigs?.collectEntries {
+            [it.provider, it.configuration]
         }
+        job.setPluginConfigVal(ServiceNameConstants.ExecutionLifecycle, data)
     }
 
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Bug: When a job is imported, the execution life cycle components are not loaded

**Describe the solution you've implemented**
- split component load from plugin load
- if the configuration is empty, don't call setPluginConfigVal

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the change here.
