### PR TITLE
RUN-1492: Fix: Webhooks not showing proper information After Create

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/webhooks/views/WebhooksView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/webhooks/views/WebhooksView.vue
@@ -379,7 +379,12 @@ export default observer(Vue.extend({
         this.setValidation(true)
         this.dirty = false
         await this.rootStore.webhooks.refresh(this.projectName)
-        this.select(this.rootStore.webhooks.webhooksByUuid.get(webhook.uuid))
+ 
+        const currentHooks = this.rootStore.webhooks.webhooksByUuid._data
+        const curHooksArrMap = Array.from(currentHooks.values());
+        const curHookByUUID = curHooksArrMap[curHooksArrMap.length - 1].value.uuid;
+  
+        this.select(this.rootStore.webhooks.webhooksByUuid.get(curHookByUUID))
       }
     },
     handleCancel() {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Bugfix: Upon creation of a webhook, the page wouldn't show the correct information, and appear to have had an issue.

**Describe the solution you've implemented**
Currently the UUID that is used to select the webhook is incorrect, and has been modified to use the correct UUID from the API.
