### PR TITLE
RSE-335: Fix: Enable schedules from project settings don't work as expected in clustermode

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -452,6 +452,16 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService, F
         return rundeckFramework.getFrameworkProjectMgr().existsFrameworkProject(project)
     }
 
+    /**
+     * Force project configuration load and returns it
+     * @param projectName
+     * @return new project configuration object
+     */
+    @CompileStatic
+    IRundeckProjectConfig getProjectConfigReloaded(String projectName){
+        return rundeckFramework.getFrameworkProjectMgr().loadProjectConfig(projectName)
+    }
+
     @CompileStatic
     IRundeckProject getFrameworkProject(String project) {
         return rundeckFramework.getFrameworkProjectMgr().getFrameworkProject(project)

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3856,32 +3856,37 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         TimeZone.getAvailableIDs()
     }
     @NotTransactional
-    def isProjectExecutionEnabled(String project){
+    def isProjectExecutionEnabled(String project, IRundeckProjectConfig projectConfig = null){
         IRundeckProject fwProject = frameworkService.getFrameworkProject(project)
-        isRundeckProjectExecutionEnabled(fwProject)
+        isRundeckProjectExecutionEnabled(fwProject, projectConfig?.getProjectProperties())
     }
 
     @NotTransactional
-    boolean isRundeckProjectExecutionEnabled(IRundeckProject fwProject) {
-        def disableEx = fwProject.getProjectProperties().get(CONF_PROJECT_DISABLE_EXECUTION)
+    boolean isRundeckProjectExecutionEnabled(IRundeckProject fwProject, Map<String,String> config = null) {
+        if(config == null)
+            config = fwProject.getProjectProperties()
+        def disableEx = config.get(CONF_PROJECT_DISABLE_EXECUTION)
         ((!disableEx) || disableEx.toLowerCase() != 'true')
     }
 
     @NotTransactional
-    def isProjectScheduledEnabled(String project){
+    def isProjectScheduledEnabled(String project, IRundeckProjectConfig projectConfig = null){
         IRundeckProject fwProject = frameworkService.getFrameworkProject(project)
-        isRundeckProjectScheduleEnabled(fwProject)
+        isRundeckProjectScheduleEnabled(fwProject, projectConfig?.getProjectProperties())
     }
 
     @NotTransactional
-    boolean isRundeckProjectScheduleEnabled(IRundeckProject fwProject) {
-        def disableSe = fwProject.getProjectProperties().get(CONF_PROJECT_DISABLE_SCHEDULE)
+    boolean isRundeckProjectScheduleEnabled(IRundeckProject fwProject, Map<String,String> config = null) {
+        if(config == null)
+            config = fwProject.getProjectProperties()
+        def disableSe = config.get(CONF_PROJECT_DISABLE_SCHEDULE)
         ((!disableSe) || disableSe.toLowerCase() != 'true')
     }
 
     @NotTransactional
     def shouldScheduleInThisProject(String project){
-        return isProjectExecutionEnabled(project) && isProjectScheduledEnabled(project)
+        IRundeckProjectConfig config = frameworkService.getProjectConfigReloaded(project)
+        return isProjectExecutionEnabled(project, config) && isProjectScheduledEnabled(project, config)
     }
 
     def deleteScheduledExecutionById(jobid, String callingAction){


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-335

#### Problem
Cluster member wasn't able to reschedule jobs that are not owned by it because it was reading the `project.disable.schedule` property from cache (which was invalid after the schedule state was changed from other member and before the schedule change message was processed)

#### Solution
Allow `FrameworkService` to return project configuration after reloading it.
