### PR TITLE
RUN-1139: Add link to execution mode toggle page on passive mode display

### DIFF
--- a/rundeckapp/grails-app/views/common/_mainbar.gsp
+++ b/rundeckapp/grails-app/views/common/_mainbar.gsp
@@ -141,7 +141,9 @@
                  data-toggle="tooltip"
                  data-placement="bottom"
               >
-                <i class="fas fa-pause-circle fa-lg"></i>
+                <g:link controller="menu" action="executionMode">
+                  <i class="fas fa-pause-circle fa-lg"></i>
+                </g:link>
               </span>
             </li>
 


### PR DESCRIPTION
Create a link to the execution mode toggle page when the execution mode is set to passive
