### PR TITLE
RSE-263 Fix: Exec-Cleaner Delete Cluster Dead Member's Executions

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -721,6 +721,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      * @void clean non-completed jobs
      * */
     Consumer<List<Map<String, Object>>> cleanExecutionsOnDeadClusterMembers = (inactiveNodes) -> {
+        log.info("Beginning dead cluster member's executions cleanup.")
         // First we get the list of inactive nodes (from heartbeat service) to extract the UUID's
         def deadNodes = inactiveNodes as ArrayList
         if (null !== deadNodes && deadNodes.size() > 0) {
@@ -735,12 +736,14 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                             'executionService.startup.cleanupStatus',
                             'incomplete'
                     ) as String
-                    cleanupRunningJobsAsync(UUID, status, new Date())
+                    cleanupRunningJobs_currentTransaction(UUID, status, new Date())
                 }}
             }else{
+                log.info("Dead cluster members found, but no executions bound.")
                 return
             }
         }else{
+            log.info("No dead cluster members found.")
             return
         }
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -726,7 +726,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         if (null !== deadNodes && deadNodes.size() > 0) {
             def deadNodesUUIDs = new ArrayList<String>()
             deadNodes.forEach { node -> {
-                deadNodesUUIDs << node.sender as String
+                deadNodesUUIDs.push(node.sender as String)
             }}
             if( deadNodesUUIDs.size() > 0 ){
                 // Once we have the UUID list from the dead nodes, we use it to clean executions

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -124,6 +124,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     def JobScheduleManager rundeckJobScheduleManager
     RundeckJobDefinitionManager rundeckJobDefinitionManager
     AuditEventsService auditEventsService
+    ExecutionService executionService
 
     public final String REMOTE_OPTION_DISABLE_JSON_CHECK = 'project.jobs.disableRemoteOptionJsonCheck'
 
@@ -205,6 +206,10 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
     @Override
     Map<String, String> getPropertiesMapping() { ConfigPropertiesMapping }
+
+    def cleanExecutionsOnDeadClusterMembers(List<Map<String, Object>> inactiveMembers){
+        return executionService.cleanExecutionsOnDeadClusterMembers.accept(inactiveMembers)
+    }
 
     /**
      * Return project config for node cache delay

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -124,7 +124,6 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     def JobScheduleManager rundeckJobScheduleManager
     RundeckJobDefinitionManager rundeckJobDefinitionManager
     AuditEventsService auditEventsService
-    ExecutionService executionService
 
     public final String REMOTE_OPTION_DISABLE_JSON_CHECK = 'project.jobs.disableRemoteOptionJsonCheck'
 
@@ -206,10 +205,6 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
 
     @Override
     Map<String, String> getPropertiesMapping() { ConfigPropertiesMapping }
-
-    def cleanExecutionsOnDeadClusterMembers(List<Map<String, Object>> inactiveMembers){
-        return executionService.cleanExecutionsOnDeadClusterMembers.accept(inactiveMembers)
-    }
 
     /**
      * Return project config for node cache delay

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -25,7 +25,6 @@ import com.dtolabs.rundeck.core.execution.workflow.DataOutput
 import com.dtolabs.rundeck.core.execution.workflow.NodeRecorder
 import com.dtolabs.rundeck.core.execution.workflow.WFSharedContext
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepResult
-import grails.plugins.executor.PersistenceContextExecutorWrapper
 import groovy.time.TimeCategory
 import org.rundeck.app.auth.types.AuthorizingProject
 import org.rundeck.app.authorization.AppAuthContextProcessor

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -2996,9 +2996,6 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         List<Map<String, Object>> inactiveNodes = Arrays.asList(
                 [sender: serverNodeUUID] as Map<String, Object>
         )
-        service.executorService = Mock(PersistenceContextExecutorWrapper){
-
-        }
         service.configurationService = Mock(ConfigurationService){
             it.getString('executionService.startup.cleanupStatus', 'incomplete') >> 'incomplete'
         }

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -2962,7 +2962,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
     def "cleaned executions by different UUID"() {
 
-        // This is to test the capability to clean executions of dead cluster members
+        // This is to test the capability to clean dead cluster member's executions
 
         given:
         def serverNodeUUID = "49318ae1-e8c9-4897-bf24-01c826f01f39"


### PR DESCRIPTION
# Executions Cleaner Delete Cluster Dead Member's Executions
As seen in [this](https://pagerduty.atlassian.net/browse/RSE-263) when a scheduled job was in the running process during a server restart, the job got stuck in that status forever.

# PR Status :speech_balloon: 
:heavy_check_mark: Functionality developed
:heavy_check_mark: Unit Test
:heavy_check_mark:: Support Revision
:clock1: Engineering Approval
:checkered_flag: Merge

## The problem
The execution cleaner was not able to determine the jobs to be deleted, because the main parameter was the UUID of the executor node. This means that if the server was interrupted in a cluster environment like Kubernetes, the UUID of the server node was changed and the bug takes place.

## More Context
The cleaning action takes place at the moment of bootstrap, so each cluster member is in charge of cleaning its own executions before the server fully starts.

## The Fix
A) First we had to get the dead/inactive nodes information from the server, making use of the 'HeartBeatService' we were able to get the information
B) Developing a functionality to take the list of inactive nodes, extract the UUID and then find executions by these UUID's
C) Then clean all the executions of dead members of the cluster (actually, dead member's executions are the "Stale" executions)

## PRO PR (Part Two of this PR)
https://github.com/rundeckpro/rundeckpro/pull/2924

## Exhibits
With the fix, the execution is cleaned, we see in the logs "Stale execution cleaned up" and inside the GUI the job has the status: "incomplete".
![Screenshot from 2023-03-08 17-12-34](https://user-images.githubusercontent.com/81827734/224036411-341595d7-50dc-4c9c-8819-64fc6b8b62e5.png)

![Screenshot from 2023-03-09 10-04-58](https://user-images.githubusercontent.com/81827734/224036461-c6d55b26-b5f4-4f58-bd80-d1ba9593b520.png)