### PR TITLE
RSE-321: Fix: ERROR while running a dir command in a path with Japanese files (Upgrade plugin version)

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ rundeck:
   plugins: # Extra plugins to bundle
   - "com.github.rundeck-plugins:ansible-plugin:3.2.3"
   - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.7"
-  - "com.github.rundeck-plugins:py-winrm-plugin:2.1.1"
+  - "com.github.rundeck-plugins:py-winrm-plugin:2.1.2"
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.2"
   - "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.1.0"
   - "com.github.rundeck-plugins:attribute-match-node-enhancer:v0.1.5"


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-321

Fixed in: https://github.com/rundeck-plugins/py-winrm-plugin/pull/94

Upgrading py-winrm plugin version, fix is present in v2.1.2