### PR TITLE
RUN-1616: Set Cookie SemeSite Flag To Strict

### DIFF
--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -335,6 +335,7 @@ server:
             persistent: false
             cookie:
                 http-only: true
+		same-site: "Strict"
             tracking-modes: 'cookie'
 rundeck:
     web:

--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -335,7 +335,7 @@ server:
             persistent: false
             cookie:
                 http-only: true
-		same-site: "Strict"
+            same-site: "Strict"
             tracking-modes: 'cookie'
 rundeck:
     web:


### PR DESCRIPTION
 **Is this a bugfix, or an enhancement? Please describe.**
It's a security enhancement. 

**Describe the solution you've implemented**
Add a spring configuration `server.servlet.session.cookie.same-site` to application.yml file. Spring boot will automatically add `SameSite=Strict` header into the HTTP cookie.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
https://github.com/rundeck/rundeck/pull/new/RUN-1616-Cookie-Missing-SameSite-Security-Flag
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#strict
