### PR TITLE
RUN-1619: Add JSON Path Option to Remote URL Option Input

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -177,7 +177,7 @@ dependencies {
         exclude(group:"org.grails.profiles",module:"web")
     }
 
-    implementation ("com.jayway.jsonpath:json-path:2.7.0"){
+    implementation ("com.jayway.jsonpath:json-path:2.8.0"){
         exclude group:"org.slf4j",module:"slf4j-api"
         exclude group:'org.ow2.asm', module: 'asm'
     }

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -176,6 +176,11 @@ dependencies {
     profile ("org.grails.profiles:web"){
         exclude(group:"org.grails.profiles",module:"web")
     }
+
+    implementation ("com.jayway.jsonpath:json-path:2.7.0"){
+        exclude group:"org.slf4j",module:"slf4j-api"
+        exclude group:'org.ow2.asm', module: 'asm'
+    }
     
     // OpenApi Dependencies
     compileOnly "io.micronaut.openapi:micronaut-openapi:4.0.1"

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
@@ -742,23 +742,30 @@ class EditOptsController extends ControllerBase{
             params.valuesList = null
             valuesUrl = params.valuesUrl
 
-            if(params.remoteUrlAuthenticationType){
+            if(params.remoteUrlAuthenticationType || params.remoteUrlJsonFilter){
                 JobOptionConfigRemoteUrl jobOptionConfigRemoteUrl = new JobOptionConfigRemoteUrl()
-                jobOptionConfigRemoteUrl.authenticationType = RemoteUrlAuthenticationType.valueOf(params.remoteUrlAuthenticationType)
 
-                if(jobOptionConfigRemoteUrl.authenticationType == RemoteUrlAuthenticationType.BASIC){
-                    jobOptionConfigRemoteUrl.username = params.remoteUrlUsername
-                    jobOptionConfigRemoteUrl.passwordStoragePath = params.remoteUrlPassword
+                if(params.remoteUrlAuthenticationType){
+                    jobOptionConfigRemoteUrl.authenticationType = RemoteUrlAuthenticationType.valueOf(params.remoteUrlAuthenticationType)
+
+                    if(jobOptionConfigRemoteUrl.authenticationType == RemoteUrlAuthenticationType.BASIC){
+                        jobOptionConfigRemoteUrl.username = params.remoteUrlUsername
+                        jobOptionConfigRemoteUrl.passwordStoragePath = params.remoteUrlPassword
+                    }
+
+                    if(jobOptionConfigRemoteUrl.authenticationType == RemoteUrlAuthenticationType.API_KEY){
+                        jobOptionConfigRemoteUrl.keyName = params.remoteUrlKey
+                        jobOptionConfigRemoteUrl.tokenStoragePath = params.remoteUrlToken
+                        jobOptionConfigRemoteUrl.apiTokenReporter = ApiTokenReporter.valueOf(params.remoteUrlApiTokenReporter)
+                    }
+
+                    if(jobOptionConfigRemoteUrl.authenticationType == RemoteUrlAuthenticationType.BEARER_TOKEN){
+                        jobOptionConfigRemoteUrl.tokenStoragePath = params.remoteUrlBearerToken
+                    }
                 }
 
-                if(jobOptionConfigRemoteUrl.authenticationType == RemoteUrlAuthenticationType.API_KEY){
-                    jobOptionConfigRemoteUrl.keyName = params.remoteUrlKey
-                    jobOptionConfigRemoteUrl.tokenStoragePath = params.remoteUrlToken
-                    jobOptionConfigRemoteUrl.apiTokenReporter = ApiTokenReporter.valueOf(params.remoteUrlApiTokenReporter)
-                }
-
-                if(jobOptionConfigRemoteUrl.authenticationType == RemoteUrlAuthenticationType.BEARER_TOKEN){
-                    jobOptionConfigRemoteUrl.tokenStoragePath = params.remoteUrlBearerToken
+                if(params.remoteUrlJsonFilter){
+                    jobOptionConfigRemoteUrl.jsonFilter = params.remoteUrlJsonFilter
                 }
 
                 JobOptionConfigData jobOptionConfigData = new JobOptionConfigData()

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.http.ApacheHttpClient
 import com.dtolabs.rundeck.core.http.HttpClient
 import com.dtolabs.rundeck.core.jobs.options.JobOptionConfigData
+import com.jayway.jsonpath.JsonPath
 import org.apache.http.HttpResponse
 import org.rundeck.util.HttpClientCreator
 import org.rundeck.app.jobs.options.ApiTokenReporter
@@ -722,6 +723,13 @@ class EditOptsController extends ControllerBase{
                 }
             }
             if(!hasSelectedOnRemoteValue) opt.errors.rejectValue('defaultValue', 'option.defaultValue.required.message')
+        }
+        if(opt.realValuesUrl && opt.getConfigRemoteUrl()?.getJsonFilter()){
+            try{
+                JsonPath.compile(opt.getConfigRemoteUrl()?.getJsonFilter())
+            } catch (Exception e){
+                opt.errors.rejectValue('configRemoteUrl', 'form.option.valuesType.url.filter.error.label')
+            }
         }
         return result
     }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -945,7 +945,6 @@ class ScheduledExecutionController  extends ControllerBase{
                         if(parseResult.error){
                             results = [error:parseResult.error]
                         }else{
-                            //grails.converters.JSON.parse(string)
                             if(parseResult.jsonElement){
                                 stats.contentSHA1=parseResult.jsonElement.encodeAsSHA1()
                                 if(stats.contentLength<0){
@@ -1004,7 +1003,11 @@ class ScheduledExecutionController  extends ControllerBase{
         def jpath = JsonPath.using(Configuration.defaultConfiguration())
         try {
             def jsonFilterResult = jpath.parse(payload).read(jobOptionConfigRemoteUrl.getJsonFilter())
+            if(jsonFilterResult instanceof ArrayList){
+                return [error: "the filter ${jobOptionConfigRemoteUrl.getJsonFilter()} return a list, please use another filter"]
+            }
             return [jsonElement: jsonFilterResult]
+
         }catch (Exception e){
             return [error: e.getMessage()]
         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -37,6 +37,8 @@ import com.dtolabs.rundeck.core.utils.OptsUtil
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.jayway.jsonpath.Configuration
+import com.jayway.jsonpath.JsonPath
 import grails.compiler.GrailsCompileStatic
 import grails.converters.JSON
 import io.micronaut.http.MediaType
@@ -845,6 +847,7 @@ class ScheduledExecutionController  extends ControllerBase{
      */
     static Object getRemoteJSON(HttpClientCreator clientCreator, String url, JobOptionConfigRemoteUrl configRemoteUrl, int timeout, int contimeout, int retry=5,boolean disableRemoteOptionJsonCheck=false){
         logger.debug("getRemoteJSON: "+url+", timeout: "+timeout+", retry: "+retry)
+
         //attempt to get the URL JSON data
         def stats=[:]
         if(url.startsWith("http:") || url.startsWith("https:")){
@@ -937,16 +940,22 @@ class ScheduledExecutionController  extends ControllerBase{
                         stream.close()
                         writer.flush()
                         final string = writer.toString()
-                        def json=grails.converters.JSON.parse(string)
-                        if(string){
-                            stats.contentSHA1=string.encodeAsSHA1()
-                            if(stats.contentLength<0){
-                                stats.contentLength= len
-                            }
+                        def parseResult=remoteUrlParse(string, configRemoteUrl)
+
+                        if(parseResult.error){
+                            results = [error:parseResult.error]
                         }else{
-                            stats.contentSHA1=""
+                            //grails.converters.JSON.parse(string)
+                            if(parseResult.jsonElement){
+                                stats.contentSHA1=parseResult.jsonElement.encodeAsSHA1()
+                                if(stats.contentLength<0){
+                                    stats.contentLength= len
+                                }
+                            }else{
+                                stats.contentSHA1=""
+                            }
+                            results = [json:parseResult.jsonElement,stats:stats]
                         }
-                        results = [json:json,stats:stats]
                     }else{
                         results = [error:"Unexpected content type received: "+resultType,stats:stats]
                     }
@@ -982,6 +991,24 @@ class ScheduledExecutionController  extends ControllerBase{
         } else {
             throw new Exception("Unsupported protocol: " + url)
         }
+    }
+
+
+    static Map<String, Object> remoteUrlParse(String payload, JobOptionConfigRemoteUrl jobOptionConfigRemoteUrl){
+
+        String jsonFilter = jobOptionConfigRemoteUrl?.getJsonFilter()
+        if(!jsonFilter){
+            return [jsonElement: grails.converters.JSON.parse(payload)]
+        }
+
+        def jpath = JsonPath.using(Configuration.defaultConfiguration())
+        try {
+            def jsonFilterResult = jpath.parse(payload).read(jobOptionConfigRemoteUrl.getJsonFilter())
+            return [jsonElement: jsonFilterResult]
+        }catch (Exception e){
+            return [error: e.getMessage()]
+        }
+
     }
 
     static int copyToWriter(Reader read, Writer writer){

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -945,8 +945,8 @@ class ScheduledExecutionController  extends ControllerBase{
                         if(parseResult.error){
                             results = [error:parseResult.error]
                         }else{
-                            if(parseResult.jsonElement){
-                                stats.contentSHA1=parseResult.jsonElement.encodeAsSHA1()
+                            if(parseResult.string){
+                                stats.contentSHA1=parseResult.string.encodeAsSHA1()
                                 if(stats.contentLength<0){
                                     stats.contentLength= len
                                 }
@@ -997,7 +997,7 @@ class ScheduledExecutionController  extends ControllerBase{
 
         String jsonFilter = jobOptionConfigRemoteUrl?.getJsonFilter()
         if(!jsonFilter){
-            return [jsonElement: grails.converters.JSON.parse(payload)]
+            return [jsonElement: grails.converters.JSON.parse(payload), string: payload]
         }
 
         def jpath = JsonPath.using(Configuration.defaultConfiguration())
@@ -1006,7 +1006,7 @@ class ScheduledExecutionController  extends ControllerBase{
             if(jsonFilterResult instanceof ArrayList){
                 return [error: "the filter ${jobOptionConfigRemoteUrl.getJsonFilter()} return a list, please use another filter"]
             }
-            return [jsonElement: jsonFilterResult]
+            return [jsonElement: jsonFilterResult, string: jsonFilterResult.toString()]
 
         }catch (Exception e){
             return [error: e.getMessage()]

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -848,6 +848,7 @@ form.option.defaultValue.label=Default Value
 form.option.values.label=Allowed Values
 form.label.valuesType.list.label=List
 form.option.valuesType.url.label=Remote URL
+form.option.valuesType.url.filter.label=Json Path Filter
 form.option.valuesType.url.authType.label=Authentication Type
 form.option.valuesType.url.authType.empty.label=Select Auth Type
 form.option.valuesType.url.authType.basic.label=Basic 

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -849,6 +849,8 @@ form.option.values.label=Allowed Values
 form.label.valuesType.list.label=List
 form.option.valuesType.url.label=Remote URL
 form.option.valuesType.url.filter.label=Json Path Filter
+form.option.valuesType.url.filter.description=Filter JSON results using a key path, for example "$.key.path"
+
 form.option.valuesType.url.authType.label=Authentication Type
 form.option.valuesType.url.authType.empty.label=Select Auth Type
 form.option.valuesType.url.authType.basic.label=Basic 

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -864,6 +864,7 @@ form.option.valuesType.url.authentication.token.label=Token
 form.option.valuesType.url.authentication.tokenInformer.label=Inject key 
 form.option.valuesType.url.authentication.tokenInformer.header.label=Header
 form.option.valuesType.url.authentication.tokenInformer.query.label=Query Parameter
+form.option.valuesType.url.filter.error.label=The Remote URL Json Path Filter has an invalid syntax
 
 form.option.valuesUrl.description=A URL to a Remote JSON service.
 rundeck.user.guide.option.model.provider=Rundeck User Guide - Option model provider

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -4060,6 +4060,12 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 jobject.keys().each { k ->
                     result << [name: k, value: jobject.get(k)]
                 }
+            } else if (result instanceof Map) {
+                Map map = result
+                result = []
+                map.forEach { key, value ->
+                    result << [name: key, value: value]
+                }
             } else {
                 validationerrors << "Expected top-level list with format: [{name:\"..\",value:\"..\"},..], or ['value','value2',..] or simple object with {name:\"value\",...}"
                 valid = false

--- a/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
@@ -468,6 +468,24 @@ form.option.valuesType.url.authType.bearerToken.label
 
                     <div class="row">
                         <div class="col-md-12">
+                            <label class="control-label"><g:message code="form.option.valuesType.url.filter.label" /></label>
+                        </div>
+
+                        <div class="col-md-4">
+                            <div class="">
+                                <g:textField type="text"
+                                             class=" form-control"
+                                             name="remoteUrlJsonFilter"
+                                             value="${option?.configRemoteUrl?.jsonFilter}"
+                                             size="30"
+                                             id="vurl_json_filter_${rkey}"
+                                />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-12">
                             <label class="control-label"><g:message code="form.option.valuesType.url.authType.label" /></label>
                         </div>
 

--- a/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
@@ -466,7 +466,7 @@ form.option.valuesType.url.authType.bearerToken.label
                         </a>
                     </div>
 
-                    <div class="row">
+                    <div class="row" class="${hasErrors(bean: option, field: 'configRemoteUrl', 'has-error')}">
                         <div class="col-md-12">
                             <label class="control-label"><g:message code="form.option.valuesType.url.filter.label" /></label>
                         </div>

--- a/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
@@ -482,6 +482,13 @@ form.option.valuesType.url.authType.bearerToken.label
                                 />
                             </div>
                         </div>
+                        <div class="col-md-12">
+                            <div class="">
+                                <div class="help-block">
+                                    <g:message code="form.option.valuesType.url.filter.description" />
+                                </div>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="row">

--- a/rundeckapp/src/main/groovy/org/rundeck/app/jobs/options/JobOptionConfigRemoteUrl.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/jobs/options/JobOptionConfigRemoteUrl.groovy
@@ -38,6 +38,9 @@ class JobOptionConfigRemoteUrl implements JobOptionConfigEntry {
     @JsonIgnore
     String errors
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String jsonFilter
+
     static JobOptionConfigRemoteUrl fromMap(Map map){
         JobOptionConfigRemoteUrl configRemoteUrl = new JobOptionConfigRemoteUrl()
         configRemoteUrl.authenticationType = RemoteUrlAuthenticationType.valueOf(map.authenticationType)
@@ -58,6 +61,10 @@ class JobOptionConfigRemoteUrl implements JobOptionConfigEntry {
         }
         if(map.apiTokenReporter){
             configRemoteUrl.apiTokenReporter = ApiTokenReporter.valueOf(map.apiTokenReporter)
+        }
+
+        if(map.jsonFilter){
+            configRemoteUrl.jsonFilter = map.jsonFilter
         }
 
         return configRemoteUrl
@@ -83,6 +90,9 @@ class JobOptionConfigRemoteUrl implements JobOptionConfigEntry {
         }
         if(apiTokenReporter){
             map.apiTokenReporter=apiTokenReporter.name()
+        }
+        if(jsonFilter){
+            map.jsonFilter=jsonFilter
         }
 
         return map

--- a/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
@@ -21,6 +21,7 @@ import grails.testing.web.controllers.ControllerUnitTest
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.app.data.providers.GormUserDataProvider
+import org.rundeck.app.jobs.options.JobOptionConfigRemoteUrl
 import org.rundeck.core.auth.AuthConstants
 import rundeck.*
 import rundeck.codecs.URIComponentCodec
@@ -789,6 +790,33 @@ class EditOptsControllerSpec extends Specification implements ControllerUnitTest
         map1.remove('name')
         map2.remove('name')
         map1==map2
+
+    }
+
+
+    def "validate opt configRemoteUrl json path filter"() {
+        given:
+        Option opt = new Option(name: "test",
+                                defaultValue: "123",
+                                required: true,
+                                enforced: false,
+                                valuesUrl: "http://test.com",
+                                configData: "{\"jobOptionConfigEntries\":{\"remote-url\":{\"@class\":\"org.rundeck.app.jobs.options.JobOptionConfigRemoteUrl\",\"jsonFilter\":\"${jsonFilter}\"}}}")
+
+        when:
+        JobOptionConfigRemoteUrl configRemoteUrl = new JobOptionConfigRemoteUrl()
+        configRemoteUrl.jsonFilter = jsonFilter
+        def result = EditOptsController._validateOption(opt, provider, null, configRemoteUrl, params, true)
+        then:
+        opt.errors.hasErrors()==hasError
+        opt.errors.hasFieldErrors('configRemoteUrl') == hasError
+
+        where:
+        jsonFilter | hasError
+        "dsdasd." | true
+        "\$\$" | true
+        "\$" | false
+        "\$.test" | false
 
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -4263,5 +4263,49 @@ class ScheduledExecutionControllerSpec extends RundeckHibernateSpec implements C
 
     }
 
+    def "test remote url filter, filter return a list"() {
+        given:
+        controller.apiService = Mock(ApiService)
+        controller.frameworkService = Mock(FrameworkService)
+
+        def client = Mock(HttpClient)
+        def httpClientCreator = Mock(HttpClientCreator){
+            createClient()>>client
+        }
+
+        def url = 'http://web.server/geto'
+
+        def jobChangeLogger = Mock(Logger)
+        controller.logger = jobChangeLogger
+
+        JobOptionConfigRemoteUrl configRemoteUrl = new JobOptionConfigRemoteUrl()
+        configRemoteUrl.jsonFilter = "\$..*"
+
+        HttpResponse rsp = Mock(HttpResponse){
+            getStatusLine()>>Mock(StatusLine){
+                getStatusCode()>>200
+            }
+            getEntity()>>Mock(HttpEntity){
+                getContent()>>new ByteArrayInputStream('{"key1":"value1", "key2": {"sub-key3":"value3", "sub-key4":"value4"}}'.getBytes());
+            }
+            getFirstHeader("Content-Type")>>Mock(Header){
+                getValue()>>"application/json"
+            }
+        }
+
+        when:
+        def result = controller.getRemoteJSON(httpClientCreator, url, configRemoteUrl, 100, 100, 5,false)
+
+        then:
+        1 * client.execute(_) >> {
+            RequestProcessor processor = it[0]
+            processor.accept(rsp)
+        }
+
+        result != null
+        result.error == "the filter \$..* return a list, please use another filter"
+
+    }
+
 
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -4133,6 +4133,135 @@ class ScheduledExecutionControllerSpec extends RundeckHibernateSpec implements C
     }
 
 
+    def "test remote url filter"() {
+        given:
+        controller.apiService = Mock(ApiService)
+        controller.frameworkService = Mock(FrameworkService)
+
+        def client = Mock(HttpClient)
+        def httpClientCreator = Mock(HttpClientCreator){
+            createClient()>>client
+        }
+
+        def url = 'http://web.server/geto'
+
+        def jobChangeLogger = Mock(Logger)
+        controller.logger = jobChangeLogger
+
+        JobOptionConfigRemoteUrl configRemoteUrl = new JobOptionConfigRemoteUrl()
+        configRemoteUrl.jsonFilter = "\$.key2"
+
+        HttpResponse rsp = Mock(HttpResponse){
+            getStatusLine()>>Mock(StatusLine){
+                getStatusCode()>>200
+            }
+            getEntity()>>Mock(HttpEntity){
+                getContent()>>new ByteArrayInputStream('{"key1":"value1", "key2": {"sub-key3":"value3", "sub-key4":"value4"}}'.getBytes());
+            }
+            getFirstHeader("Content-Type")>>Mock(Header){
+                getValue()>>"application/json"
+            }
+        }
+
+        when:
+        def result = controller.getRemoteJSON(httpClientCreator, url, configRemoteUrl, 100, 100, 5,false)
+
+        then:
+        1 * client.execute(_) >> {
+            RequestProcessor processor = it[0]
+            processor.accept(rsp)
+        }
+
+        result != null
+        result.json == ["sub-key3":"value3", "sub-key4":"value4"]
+
+    }
+
+    def "test remote url filter, filter not found"() {
+        given:
+        controller.apiService = Mock(ApiService)
+        controller.frameworkService = Mock(FrameworkService)
+
+        def client = Mock(HttpClient)
+        def httpClientCreator = Mock(HttpClientCreator){
+            createClient()>>client
+        }
+
+        def url = 'http://web.server/geto'
+
+        def jobChangeLogger = Mock(Logger)
+        controller.logger = jobChangeLogger
+
+        JobOptionConfigRemoteUrl configRemoteUrl = new JobOptionConfigRemoteUrl()
+        configRemoteUrl.jsonFilter = "\$.test"
+
+        HttpResponse rsp = Mock(HttpResponse){
+            getStatusLine()>>Mock(StatusLine){
+                getStatusCode()>>200
+            }
+            getEntity()>>Mock(HttpEntity){
+                getContent()>>new ByteArrayInputStream('{"key1":"value1", "key2": {"sub-key3":"value3", "sub-key4":"value4"}}'.getBytes());
+            }
+            getFirstHeader("Content-Type")>>Mock(Header){
+                getValue()>>"application/json"
+            }
+        }
+
+        when:
+        def result = controller.getRemoteJSON(httpClientCreator, url, configRemoteUrl, 100, 100, 5,false)
+
+        then:
+        1 * client.execute(_) >> {
+            RequestProcessor processor = it[0]
+            processor.accept(rsp)
+        }
+
+        result != null
+        result.error != null
+        result.error == "No results for path: \$['test']"
+
+    }
+
+    def "test remote url filter, filter is empty"() {
+        given:
+        controller.apiService = Mock(ApiService)
+        controller.frameworkService = Mock(FrameworkService)
+
+        def client = Mock(HttpClient)
+        def httpClientCreator = Mock(HttpClientCreator){
+            createClient()>>client
+        }
+
+        def url = 'http://web.server/geto'
+
+        def jobChangeLogger = Mock(Logger)
+        controller.logger = jobChangeLogger
+
+        HttpResponse rsp = Mock(HttpResponse){
+            getStatusLine()>>Mock(StatusLine){
+                getStatusCode()>>200
+            }
+            getEntity()>>Mock(HttpEntity){
+                getContent()>>new ByteArrayInputStream('{"key1":"value1", "key2": {"sub-key3":"value3", "sub-key4":"value4"}}'.getBytes());
+            }
+            getFirstHeader("Content-Type")>>Mock(Header){
+                getValue()>>"application/json"
+            }
+        }
+
+        when:
+        def result = controller.getRemoteJSON(httpClientCreator, url, null, 100, 100, 5,false)
+
+        then:
+        1 * client.execute(_) >> {
+            RequestProcessor processor = it[0]
+            processor.accept(rsp)
+        }
+
+        result != null
+        result.json == [key1:"value1", key2:["sub-key4":"value4", "sub-key3":"value3"]]
+
+    }
 
 
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Enhancement:  Add JSON Path Option to Remote URL Option Input

This enhancement would allow customers to specify the JSON path where they would pull the value from.

For example, having a JSON payload as the following:
```
{
  "key1":"value1",
  "key2":
    {
      "sub-key3":"value3",
      "sub-key4":"value4"
    }
}
```
Users would like to be able to just show in the Option list the “sub-key” list above by presenting a JSON path of $.key2 for the path to return.


![Screenshot 2023-04-03 at 13 38 18](https://user-images.githubusercontent.com/6034968/229594262-e1968459-71e8-4cb5-ab56-63b3b6b5045a.png)
![Screenshot 2023-04-03 at 13 35 19](https://user-images.githubusercontent.com/6034968/229594270-d7947c22-4022-47f3-afc6-292e9732bced.png)


**Describe the solution you've implemented**

- add a new field in the remote option URL
- if the filter is set, use `JsonPath` to filter the remote URL payload
- return the results

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the change here.
