### PR TITLE
RUN-1646: Always use chromedriver latest in selenium tests

### DIFF
--- a/test/selenium/.gitignore
+++ b/test/selenium/.gitignore
@@ -1,3 +1,4 @@
+!.npmrc
 __image_snapshots__/__diff_output__
 dist
 test_out

--- a/test/selenium/.npmrc
+++ b/test/selenium/.npmrc
@@ -1,0 +1,1 @@
+chromedriver_version=LATEST


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**
Fix selenium failures when chrome is updated, by always using latest chromedriver

**Describe the solution you've implemented**
Set npmrc value to force latest chromedriver 