### PR TITLE
RSE-328 Fix: NPE Job Retry with No Failed Nodes

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2281,17 +2281,26 @@ class ScheduledExecutionController  extends ControllerBase{
                 Execution e = Execution.get(params.retryFailedExecId)
                 if (e && e.scheduledExecution?.id == scheduledExecution.id) {
                     model.failedNodes = e.failedNodeList
-                    if(varfound){
-                        nset = ExecutionService.filtersAsNodeSet([filter: OptsUtil.join("name:", e.failedNodeList)])
+                    // If there is no "failed nodes" from previous execution, we use the original node set to prevent NPE
+                    if( e.failedNodeList ){
+                        if(varfound){
+                            nset = ExecutionService.filtersAsNodeSet([filter: OptsUtil.join("name:", e.failedNodeList)])
+                        }
+                        model.nodesetvariables = false
+                        def failedSet = ExecutionService.filtersAsNodeSet([filter: OptsUtil.join("name:", e.failedNodeList)])
+                        failedNodes = rundeckAuthContextProcessor.filterAuthorizedNodes(
+                                scheduledExecution.project,
+                                new HashSet<String>(["read", "run"]),
+                                frameworkService.filterNodeSet(failedSet, scheduledExecution.project),
+                                authContext).nodes;
+                    }else{
+                        def originalSet = ExecutionService.filtersAsNodeSet([filter: e.filter])
+                        failedNodes = rundeckAuthContextProcessor.filterAuthorizedNodes(
+                                scheduledExecution.project,
+                                new HashSet<String>(["read", "run"]),
+                                frameworkService.filterNodeSet(originalSet, scheduledExecution.project),
+                                authContext).nodes;
                     }
-                    model.nodesetvariables = false
-
-                    def failedSet = ExecutionService.filtersAsNodeSet([filter: OptsUtil.join("name:", e.failedNodeList)])
-                    failedNodes = rundeckAuthContextProcessor.filterAuthorizedNodes(
-                            scheduledExecution.project,
-                            new HashSet<String>(["read", "run"]),
-                            frameworkService.filterNodeSet(failedSet, scheduledExecution.project),
-                            authContext).nodes;
                 }
             }
             def nodes = rundeckAuthContextProcessor.filterAuthorizedNodes(

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -746,6 +746,80 @@ class ScheduledExecutionControllerSpec extends RundeckHibernateSpec implements C
 
     }
 
+    def "no failed nodes show job retry with original nodeset"(){
+        given:
+        ScheduledExecution.metaClass.static.withNewSession = {Closure c -> c.call() }
+
+        def se = new ScheduledExecution(
+                uuid: 'testUUID',
+                jobName: 'test1',
+                project: 'project1',
+                groupPath: 'testgroup',
+                doNodedispatch: true,
+                filter:'name: ${option.nodes}',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [
+                                new CommandExec([
+                                        adhocRemoteString: 'test buddy',
+                                        argString: '-delay 12 -monkey cheese -particle'
+                                ])
+                        ]
+                )
+        ).save()
+        def exec = new Execution(
+                user: "testuser",
+                project: "project1",
+                loglevel: 'WARN',
+                status: 'FAILED',
+                doNodedispatch: true,
+                filter:'name: nodea',
+                succeededNodeList: null,
+                failedNodeList: null,
+                workflow: new Workflow(commands: [new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')]).save(),
+                scheduledExecution: se
+        ).save()
+
+        NodeSetImpl originalNodeSet = new NodeSetImpl()
+        originalNodeSet.putNode(new NodeEntryImpl("nodea"))
+        originalNodeSet.putNode(new NodeEntryImpl("nodec xyz"))
+
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor){
+            _*authorizeProjectJobAny(_,_,_,_)>>true
+            _*filterAuthorizedNodes(_,_,_,_)>>{args-> args[2]}
+        }
+
+        controller.executionService = Mock(ExecutionService){
+            filtersAsNodeSet(_,_) >> originalNodeSet
+        }
+
+        controller.frameworkService=Mock(FrameworkService){
+            filterNodeSet(_,_)>>originalNodeSet
+            getRundeckFramework()>>Mock(Framework){
+                getFrameworkNodeName()>>'fwnode'
+            }
+        }
+        controller.scheduledExecutionService=Mock(ScheduledExecutionService){
+            getByIDorUUID(_)>>se
+        }
+
+        controller.rundeckJobDefinitionManager=Mock(RundeckJobDefinitionManager)
+        controller.notificationService=Mock(NotificationService)
+        controller.orchestratorPluginService=Mock(OrchestratorPluginService)
+        controller.pluginService = Mock(PluginService)
+        controller.featureService = Mock(FeatureService)
+
+        when:
+        request.parameters = [id: se.id.toString(),project:'project1',retryFailedExecId:exec.id.toString()]
+        def model = controller.show()
+
+        then:
+        response.redirectedUrl==null
+        model != null
+        model.nodes == originalNodeSet.nodes
+
+    }
+
     @Unroll
     def "job download #format"() {
         given:


### PR DESCRIPTION
# RSE-328 Fix: NPE Job Retry with No Failed Nodes
When the execution doesn't report about the failed or successful nodes, when the execution attempt was activated on the "failed nodes" there was an NPE as there was no information on failed nodes.

## The problem
The plugin adapter doesn't report about failed nodes.

## The solution
As discussed internally in previous reviews about this, the NPE was handled at the controller level, preventing null values ​​from being read and triggering the retry with the original nodeset