### PR TITLE
RUN-1666: fix import when configRemoteUrl is set

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/app/jobs/options/JobOptionConfigRemoteUrl.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/jobs/options/JobOptionConfigRemoteUrl.groovy
@@ -12,6 +12,7 @@ class JobOptionConfigRemoteUrl implements JobOptionConfigEntry {
         return TYPE
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     RemoteUrlAuthenticationType authenticationType
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -43,7 +44,11 @@ class JobOptionConfigRemoteUrl implements JobOptionConfigEntry {
 
     static JobOptionConfigRemoteUrl fromMap(Map map){
         JobOptionConfigRemoteUrl configRemoteUrl = new JobOptionConfigRemoteUrl()
-        configRemoteUrl.authenticationType = RemoteUrlAuthenticationType.valueOf(map.authenticationType)
+
+        if(map.authenticationType){
+            configRemoteUrl.authenticationType = RemoteUrlAuthenticationType.valueOf(map.authenticationType)
+        }
+
         if(map.username){
             configRemoteUrl.username = map.username
         }

--- a/rundeckapp/src/test/groovy/rundeck/OptionSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/OptionSpec.groovy
@@ -196,4 +196,16 @@ class OptionSpec extends Specification implements DomainUnitTest<Option> {
 
 
     }
+
+    def "from map to remote URL json filter"() {
+        given:
+        def opt = Option.fromMap('test', [type: 'text', configRemoteUrl: [jsonFilter:"\$.key"]])
+        expect:
+        opt.optionType == 'text'
+        opt.configData == '{"jobOptionConfigEntries":{"remote-url":{"@class":"org.rundeck.app.jobs.options.JobOptionConfigRemoteUrl","jsonFilter":"\$.key"}}}'
+        opt.configRemoteUrl !=null
+        opt.configRemoteUrl.jsonFilter == "\$.key"
+
+
+    }
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
When the remote URL is set with a `json-filter`, when a job is imported an exception is thrown 

**Describe the solution you've implemented**
check if the `authenticationType` is set before loading the option value.

**Describe alternatives you've considered**

**Additional context**
