### PR TITLE
RUN-1663: SameSite configuration incorrect indent

### DIFF
--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -335,7 +335,7 @@ server:
             persistent: false
             cookie:
                 http-only: true
-            same-site: "Strict"
+                same-site: "Strict"
             tracking-modes: 'cookie'
 rundeck:
     web:


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Bugfix. The configuration item SameSite="Strict" was not correctly indented.

