### PR TITLE
RUN-1665: Remote URL doesn't work with Json Path Filter

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -864,7 +864,7 @@ class ScheduledExecutionController  extends ControllerBase{
                     client.setUri(new URL(cleanUrl).toURI())
                     UsernamePasswordCredentials cred = new UsernamePasswordCredentials(urlo.userInfo)
                     client.setBasicAuthCredentials(cred.userName, cred.password)
-                } else if (configRemoteUrl) {
+                } else if (configRemoteUrl && configRemoteUrl.authenticationType) {
                     logger.debug("getRemoteJSON using authentication")
                     URIBuilder uriBuilder = new URIBuilder(cleanUrl)
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -4297,6 +4297,7 @@ class ScheduledExecutionControllerSpec extends RundeckHibernateSpec implements C
         def result = controller.getRemoteJSON(httpClientCreator, url, configRemoteUrl, 100, 100, 5,false)
 
         then:
+        1 * client.setUri(_)
         1 * client.execute(_) >> {
             RequestProcessor processor = it[0]
             processor.accept(rsp)


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
bug:
if the configRemoteUrl auth is not set the setUrl wasn't called wich trigger an error


**Describe the solution you've implemented**
check configRemoteUrl authenticationType is set


**Describe alternatives you've considered**

**Additional context**
