### PR TITLE
RUN-1664: Job option Json Path Filter can’t be deleted

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
@@ -772,13 +772,15 @@ class EditOptsController extends ControllerBase{
                     }
                 }
 
-                if(params.remoteUrlJsonFilter){
-                    jobOptionConfigRemoteUrl.jsonFilter = params.remoteUrlJsonFilter
-                }
+                jobOptionConfigRemoteUrl.jsonFilter = params.remoteUrlJsonFilter?:null
 
                 JobOptionConfigData jobOptionConfigData = new JobOptionConfigData()
                 jobOptionConfigData.addConfig(jobOptionConfigRemoteUrl)
                 opt.setOptionConfigData(jobOptionConfigData)
+            }else{
+                if(opt.getConfigRemoteUrl()!=null){
+                    opt.setOptionConfigData(null)
+                }
             }
         }
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
@@ -16,6 +16,7 @@
 
 package rundeck.controllers
 
+import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
@@ -819,4 +820,21 @@ class EditOptsControllerSpec extends Specification implements ControllerUnitTest
         "\$.test" | false
 
     }
+
+    def "cleaning remoteUrlConfig json filter"() {
+        given:
+        def option = new Option(name:"test",enforced:false, valuesType:'url', valuesUrl:'http://test.com', "configData":"{\"jobOptionConfigEntries\":{\"remote-url\":{\"@class\":\"org.rundeck.app.jobs.options.JobOptionConfigRemoteUrl\",\"jsonFilter\":\"\$.test\"}}}")
+        params.name='test'
+        params.newoption = 'modify'
+        params.valuesType = 'url'
+        params.valuesUrl = 'http://test.com'
+
+        when:
+        def result = controller._setOptionFromParams(option, params)
+
+        then:
+        result!=null
+        result.configRemoteUrl == null
+    }
+
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
bug,  
fix removing remoteUrl json-filter when the value is removed from the option form

**Describe the solution you've implemented**

**Describe alternatives you've considered**

**Additional context**
