### PR TITLE
RUN-1676: 4.12.0-rc2: disable defer for ui plugins

### DIFF
--- a/rundeckapp/grails-app/views/layouts/base.gsp
+++ b/rundeckapp/grails-app/views/layouts/base.gsp
@@ -189,7 +189,7 @@
                         controller: 'plugin',
                         action: 'pluginFile',
                         params: [service: 'UI', name: pluginname, path: scriptPath]
-                )}" defer="defer" type="text/javascript"></script>
+                )}" type="text/javascript"></script>
             </g:each>
             <!-- END UI Plugin scripts for ${pluginname} -->
         </g:each>


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
defered script loading conflicts with expected script loading order
