### PR TITLE
RSE-366: Fix: SCM import plugin does not refresh status in API unless GUI is refreshed

### DIFF
--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/BaseGitPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/BaseGitPlugin.groovy
@@ -76,6 +76,7 @@ class BaseGitPlugin {
     JobFileMapper mapper
     RawTextComparator COMP = RawTextComparator.DEFAULT
     Map<String, Map> jobStateMap = Collections.synchronizedMap([:])
+    boolean clusterFixPullNotConsumed = false
 
     BaseGitPlugin(Common commonConfig) {
         this.input = commonConfig.rawInput
@@ -295,6 +296,7 @@ class BaseGitPlugin {
     PullResult gitPull(ScmOperationContext context, Git git1 = null) {
         def pullCommand = (git1 ?: git).pull().setRemote(REMOTE_NAME).setRemoteBranchName(branch)
         setupTransportAuthentication(sshConfig, context, pullCommand)
+        this.clusterFixPullNotConsumed = true
         pullCommand.call()
     }
 

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
@@ -762,12 +762,14 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
         fetchFromRemote(context)
 
         def bstat = BranchTrackingStatus.of(repo, branch)
-        if (bstat && bstat.behindCount > 0) {
+        if (bstat && bstat.behindCount > 0 || clusterFixPullNotConsumed) {
             try {
-                PullResult result = gitPull(context)
+                if(bstat && bstat.behindCount > 0)
+                    PullResult result = gitPull(context)
                 jobs.each{job ->
                     refreshJobStatus(job,originalPaths?.get(job.id))
                 }
+                clusterFixPullNotConsumed = false
             } catch (TransportException e) {
                 log.warn("skipping automatic fix jobs between cluster on https configuration issue")
             }

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
@@ -762,20 +762,20 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
         fetchFromRemote(context)
 
         def bstat = BranchTrackingStatus.of(repo, branch)
+        PullResult pullResult = null
         if (bstat && bstat.behindCount > 0 || clusterFixPullNotConsumed) {
             try {
                 if(bstat && bstat.behindCount > 0)
-                    PullResult result = gitPull(context)
-                jobs.each{job ->
-                    refreshJobStatus(job,originalPaths?.get(job.id))
-                }
+                    pullResult = gitPull(context)
                 clusterFixPullNotConsumed = false
             } catch (TransportException e) {
                 log.warn("skipping automatic fix jobs between cluster on https configuration issue")
             }
-            return [updated:true]
         }
-        [:]
+        jobs.each{job ->
+            refreshJobStatus(job,originalPaths?.get(job.id))
+        }
+        return (pullResult != null)? [updated:true]:[:]
     }
 
     @Override


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-366

#### Problem
After committing a change in a job in the Remote Repo, the SCM import status API call:
`curl --location 'http://hostname:4440/api/15/project/PROJECT_NAME/scm/import/status' --header 'X-Rundeck-Auth-Token: API_TOKEN'`

returns:
`{"actions":[],"integration":"import","message":"","project":"test","synchState":"CLEAN"}`

where it should be:
`{"actions":["import-jobs"],"integration":"import","message":"1 file(s) need to be imported","project":"Pimport","synchState":"IMPORT_NEEDED"}`

This happens sometimes because some other method pulled the changes from the repo without updating the sync status of the jobs.

#### Solution
Check if the local repo was updated from another place. This check is made in the existing `clusterFixJobs` method, which is called every `rundeck.scmLoader.interval` seconds.