### PR TITLE
fix: project context not shown in storage view

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageEdit.vue
@@ -365,7 +365,7 @@ export default Vue.extend({
 
       return fullPath;
 
-    }
+    },
     calcBrowsePath(path: string){
       let browse=path
       if (this.rootPath != 'keys/') {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageEdit.vue
@@ -164,7 +164,6 @@ export default Vue.extend({
       errorMsg: '',
       directories: [] as any,
       files: [] as any,
-      rootPath: '',
       keyTypes: [
         {text: 'Private Key', value: 'privateKey'},
         {text: 'Public Key', value: 'publicKey'},
@@ -177,7 +176,6 @@ export default Vue.extend({
     }
   },
   async mounted(){
-    this.rootPath = this.project ? "keys/project/" + this.project + "/" : "keys/"
   },
   methods: {
     allowedResource(meta: any) {
@@ -214,7 +212,7 @@ export default Vue.extend({
     async handleUploadKey() {
       const rundeckContext = getRundeckContext();
 
-      let fullPath = this.getKeyPath();
+      let fullPath = this.calcBrowsePath(this.getKeyPath())
 
       let contentType = 'application/pgp-keys';
 
@@ -284,7 +282,7 @@ export default Vue.extend({
     },
     loadKeys() {
       const rundeckContext = getRundeckContext();
-      rundeckContext.rundeckClient.storageKeyGetMetadata(this.path).then((result: any) => {
+      rundeckContext.rundeckClient.storageKeyGetMetadata(this.browsePath).then((result: any) => {
         this.directories = [];
         this.files = [];
 
@@ -368,11 +366,25 @@ export default Vue.extend({
       return fullPath;
 
     }
+    calcBrowsePath(path: string){
+      let browse=path
+      if (this.rootPath != 'keys/') {
+        browse = (this.rootPath) + path
+        browse = browse.substring(5)
+      }
+      return browse
+    }
   },
   computed: {
     uploadFullPath(): string {
-      return 'keys/' + this.getKeyPath();
+      return this.rootPath + this.getKeyPath();
     },
+    rootPath(): string {
+      return this.project ? "keys/project/" + this.project + "/" : "keys/"
+    },
+    browsePath(): string{
+      return this.calcBrowsePath(this.path)
+    }
   }
 })
 </script>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStoragePage.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStoragePage.vue
@@ -1,6 +1,6 @@
 <template>
 <div>
-  <key-storage-view ref="keyStorageViewRef" :project="project" :read-only="readOnly" :allow-upload="allowUpload" :value="path" @openEditor="openEditor"></key-storage-view>
+  <key-storage-view v-if="ready" ref="keyStorageViewRef" :project="project" :read-only="readOnly" :allow-upload="allowUpload" :value="path" @openEditor="openEditor"></key-storage-view>
   <modal v-model="modalEdit" title="Add or Upload a Key" id="storageuploadkey" ref="modalEdit" auto-focus append-to-body :footer="false">
     <key-storage-edit :project="this.project" :uploadSetting="uploadSetting" :storage-filter="storageFilter" @cancelEditing="handleCancelEditing" @finishEditing="handleFinishEditing"></key-storage-edit>
   </modal>
@@ -27,7 +27,8 @@ export default Vue.extend({
       modalEdit: false,
       path: '',
       uploadSetting: {},
-      project: ''
+      project: '',
+      ready:false
     }
   },
   methods: {
@@ -47,6 +48,7 @@ export default Vue.extend({
   async mounted() {
     this.project = getRundeckContext().projectName;
     this.path=this.value ? this.value : ""
+    this.ready=true
   }
 })
 </script>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageView.vue
@@ -251,6 +251,14 @@ export default Vue.extend({
     cancelDeleteKey() {
       this.isConfirmingDeletion=false
     },
+    calcBrowsePath(path: string){
+      let browse=path
+      if (this.rootPath != 'keys/') {
+        browse = (this.rootPath) + path
+        browse = browse.substring(5)
+      }
+      return browse
+    },
     loadKeys(selectedKey?: any) {
       if(selectedKey) {
         this.selectedKey = selectedKey
@@ -258,7 +266,7 @@ export default Vue.extend({
       this.loading=true
 
       const rundeckContext = getRundeckContext();
-      rundeckContext.rundeckClient.storageKeyGetMetadata(this.path).then((result: any) => {
+      rundeckContext.rundeckClient.storageKeyGetMetadata(this.calcBrowsePath(this.path)).then((result: any) => {
         this.directories = [];
         this.files = [];
 
@@ -462,7 +470,7 @@ export default Vue.extend({
     defaultSelectKey(path: any) {
       const rundeckContext = getRundeckContext();
 
-      rundeckContext.rundeckClient.storageKeyGetMetadata(this.path).then((result: any) => {
+      rundeckContext.rundeckClient.storageKeyGetMetadata(this.calcBrowsePath(path)).then((result: any) => {
         if (result.resources != null) {
           result.resources.forEach((resource: any) => {
             if (resource.type === 'file') {
@@ -525,7 +533,7 @@ export default Vue.extend({
       const rundeckContext = getRundeckContext();
       const fullPath = this.absolutePath(path);
 
-      rundeckContext.rundeckClient.storageKeyGetMetadata(path).then((result: any) => {
+      rundeckContext.rundeckClient.storageKeyGetMetadata(this.calcBrowsePath(path)).then((result: any) => {
         if (result.resources != null) {
           const keys = result.resources.filter((resource: any) => resource.path.indexOf(fullPath) >= 0);
           if (keys.length == 0) {


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

fix: project context not shown in storage view (new Vue implementation)

* don't render key-storage-view until after mount of key-storage-page, so that project param is used (other solution would be to watch the project prop inside key-storage-view)
* use correct key storage path in API requests, based on rootPath

