### PR TITLE
RSE-247 Fix: Remove WARN message in service.log related to SSO

### DIFF
--- a/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
@@ -2008,9 +2008,6 @@ ansi-bg-default'''))
 
     def showLocalLogin = { attrs, body ->
         boolean shouldShowLocalLogin = configurationService.getBoolean("login.localLogin.enabled", true)
-        if(configurationService.getBoolean("login.showLocalLoginAfterFirstSSOLogin",false)) {
-            shouldShowLocalLogin = frameworkService.getFirstLoginFile().exists()
-        }
         if(shouldShowLocalLogin) {
             out << body()
         }

--- a/rundeckapp/src/test/groovy/rundeck/UtilityTagLibSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/UtilityTagLibSpec.groovy
@@ -126,7 +126,6 @@ class UtilityTagLibSpec extends Specification implements TagLibUnitTest<UtilityT
         File firstLoginFile = File.createTempFile("first","login")
         tagLib.configurationService = Mock(ConfigurationService) {
             getBoolean("login.localLogin.enabled",true) >> { false }
-            getBoolean("login.showLocalLoginAfterFirstSSOLogin",false) >> { true }
         }
         tagLib.frameworkService = Mock(FrameworkService) {
             getFirstLoginFile() >> { return firstLoginFile }
@@ -142,7 +141,6 @@ class UtilityTagLibSpec extends Specification implements TagLibUnitTest<UtilityT
         File firstLoginFile = new File("/tmp/doesnotexist")
         tagLib.configurationService = Mock(ConfigurationService) {
             getBoolean("login.localLogin.enabled",true) >> { false }
-            getBoolean("login.showLocalLoginAfterFirstSSOLogin",false) >> { true }
         }
         tagLib.frameworkService = Mock(FrameworkService) {
             getFirstLoginFile() >> { return firstLoginFile }
@@ -157,7 +155,6 @@ class UtilityTagLibSpec extends Specification implements TagLibUnitTest<UtilityT
         when:
         tagLib.configurationService = Mock(ConfigurationService) {
             getBoolean("login.localLogin.enabled",true) >> { toggle }
-            getBoolean("login.showLocalLoginAfterFirstSSOLogin",false) >> { false }
         }
         def result = tagLib.showLocalLogin(null,"loginform").toString()
 


### PR DESCRIPTION
# Remove WARN message in service.log related to SSO
Unnecessary log line when users disable local login.
