### PR TITLE
RSE-183 Fix: Misplaced SCM Tooltip on Job Show

### DIFF
--- a/rundeckapp/grails-app/views/scm/_statusBadge.gsp
+++ b/rundeckapp/grails-app/views/scm/_statusBadge.gsp
@@ -34,7 +34,7 @@
             )
         }%
     </g:if>
-    <span title="${tooltips.join(", ")}" class="has_tooltip" data-viewport="#section-content">
+    <span title="${tooltips.join(", ")}" class="has_tooltip" data-viewport="#section-content" data-placement="right">
         <g:render template="/scm/statusIcon"
                   model="[exportStatus: exportStatus,
                           importStatus: importStatus,


### PR DESCRIPTION
# Misplaced SCM Tooltip on Job Show
## Before:
![image](https://user-images.githubusercontent.com/81827734/232821642-b979f543-43ac-496e-a5bf-3d79a8d4f488.png)

## After:
![Screenshot from 2023-04-18 12-17-03](https://user-images.githubusercontent.com/81827734/232823291-fac656f3-5183-4846-b48f-00dba8c68aa6.png)