### PR TITLE
RUN-1691: pass configuration values to the runner when plugins use @PluginProperty annotations

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/StepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/StepPluginAdapter.java
@@ -96,7 +96,14 @@ public class StepPluginAdapter implements StepExecutor, Describable, DynamicProp
 
         final String providerName = item.getType();
         final PluginStepContext stepContext = PluginStepContextImpl.from(executionContext);
-        final Map<String, Object> config = createConfig(executionContext, item);
+        final Map<String, Object> instanceConfiguration = createConfig(executionContext, item);
+
+        final PropertyResolver resolver = PropertyResolverFactory.createStepPluginRuntimeResolver(executionContext,
+                instanceConfiguration,
+                ServiceNameConstants.WorkflowStep,
+                providerName
+        );
+        Map<String, Object>  config = PluginAdapterUtility.configureProperties(resolver, getDescription(),plugin, PropertyScope.InstanceOnly);
 
         try {
             plugin.executeStep(stepContext, config);
@@ -146,13 +153,9 @@ public class StepPluginAdapter implements StepExecutor, Describable, DynamicProp
                     blankIfUnexMap
             );
         }
-        final String providerName = item.getType();
-        final PropertyResolver resolver = PropertyResolverFactory.createStepPluginRuntimeResolver(executionContext,
-                instanceConfiguration,
-                ServiceNameConstants.WorkflowStep,
-                providerName
-        );
-        return PluginAdapterUtility.configureProperties(resolver, description,plugin, PropertyScope.InstanceOnly);
+
+        return instanceConfiguration;
+
     }
 
     private Map<String, Object> getStepConfiguration(StepExecutionItem item) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
@@ -138,7 +138,13 @@ public class NodeStepPluginAdapter implements NodeStepExecutor, Describable, Dyn
 
         final String providerName = item.getNodeStepType();
         final PluginStepContext pluginContext = PluginStepContextImpl.from(context);
-        final Map<String, Object> config = createConfig(context, item, node);
+        final Map<String, Object> instanceConfiguration = createConfig(context, item, node);
+
+        final PropertyResolver resolver = PropertyResolverFactory.createStepPluginRuntimeResolver(context,
+                instanceConfiguration,
+                getServiceName(),
+                providerName);
+        Map<String, Object>  config =  PluginAdapterUtility.configureProperties(resolver, getDescription(), plugin, PropertyScope.InstanceOnly);
 
         try {
             plugin.executeNodeStep(pluginContext, config, node);
@@ -187,13 +193,7 @@ public class NodeStepPluginAdapter implements NodeStepExecutor, Describable, Dyn
                     blankIfUnexMap
             );
         }
-        final String providerName = item.getNodeStepType();
-
-        final PropertyResolver resolver = PropertyResolverFactory.createStepPluginRuntimeResolver(context,
-                instanceConfiguration,
-                getServiceName(),
-                providerName);
-        return PluginAdapterUtility.configureProperties(resolver, description, plugin, PropertyScope.InstanceOnly);
+        return instanceConfiguration;
     }
 
     public Map<String, Object> getStepConfiguration(StepExecutionItem item) {

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/StepPluginAdapterSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/StepPluginAdapterSpec.groovy
@@ -1,0 +1,148 @@
+package com.dtolabs.rundeck.core.execution.workflow.steps
+
+import com.dtolabs.rundeck.core.common.Framework
+import com.dtolabs.rundeck.core.common.FrameworkProject
+import com.dtolabs.rundeck.core.common.IFrameworkServices
+import com.dtolabs.rundeck.core.data.BaseDataContext
+import com.dtolabs.rundeck.core.data.SharedDataContextUtils
+import com.dtolabs.rundeck.core.dispatcher.ContextView
+import com.dtolabs.rundeck.core.execution.ConfiguredStepExecutionItem
+import com.dtolabs.rundeck.core.execution.StepExecutionItem
+import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext
+import com.dtolabs.rundeck.core.plugins.Plugin
+import com.dtolabs.rundeck.core.plugins.configuration.Describable
+import com.dtolabs.rundeck.core.plugins.configuration.Description
+import com.dtolabs.rundeck.core.tools.AbstractBaseTest
+import com.dtolabs.rundeck.plugins.ServiceNameConstants
+import com.dtolabs.rundeck.plugins.descriptions.PluginProperty
+import com.dtolabs.rundeck.plugins.step.PluginStepContext
+import com.dtolabs.rundeck.plugins.step.StepPlugin
+import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
+import com.dtolabs.rundeck.plugins.util.PropertyBuilder
+import spock.lang.Specification
+
+class StepPluginAdapterSpec extends Specification {
+    public static final String PROJECT_NAME = 'NodeStepPluginAdapterSpec'
+    Framework framework
+    FrameworkProject testProject
+
+    def setup() {
+        framework = AbstractBaseTest.createTestFramework()
+        testProject = framework.getFrameworkProjectMgr().createFrameworkProject(PROJECT_NAME)
+    }
+
+    def cleanup() {
+        framework.getFrameworkProjectMgr().removeFrameworkProject(PROJECT_NAME)
+    }
+
+    def "get plugin variables using PluginProperty"() {
+        given:
+        framework.frameworkServices = Mock(IFrameworkServices)
+        def optionContext = new BaseDataContext([option: [:]])
+        def shared = SharedDataContextUtils.sharedContext()
+        shared.merge(ContextView.global(), optionContext)
+        StepExecutionContext context = Mock(StepExecutionContext) {
+            getFramework() >> framework
+            getDataContext() >> optionContext
+            getSharedDataContext() >> shared
+            getFrameworkProject() >> PROJECT_NAME
+        }
+        def plugin = Mock(StepPlugin)
+        def wrap = new Test2Plugin(
+                impl: plugin
+        )
+        def adapter = new StepPluginAdapter(wrap)
+        def config = [test: '123456']
+        def item = new TestExecItem(
+                type: 'atype',
+                stepConfiguration: config,
+                label: 'a label'
+        )
+        when:
+        def result = adapter.executeWorkflowStep(context, item)
+
+        then:
+        1 * plugin.executeStep(!null as PluginStepContext, [:])
+        result.isSuccess()
+        wrap.test == "123456"
+
+    }
+
+    def "expand config vars uses blank for unexpanded"() {
+        given:
+        framework.frameworkServices = Mock(IFrameworkServices)
+        def optionContext = new BaseDataContext([option: data])
+        def shared = SharedDataContextUtils.sharedContext()
+        shared.merge(ContextView.global(), optionContext)
+        StepExecutionContext context = Mock(StepExecutionContext) {
+            getFramework() >> framework
+            getDataContext() >> optionContext
+            getSharedDataContext() >> shared
+            getFrameworkProject() >> PROJECT_NAME
+        }
+        def plugin = Mock(StepPlugin)
+        def wrap = new TestPlugin(
+                impl: plugin,
+                description: DescriptionBuilder.builder()
+                        .name('stepplugin')
+                        .property(PropertyBuilder.builder().string('a').build())
+                        .property(PropertyBuilder.builder().string('c').build())
+                        .property(PropertyBuilder.builder().string('d').build())
+                        .build()
+        )
+        def adapter = new StepPluginAdapter(wrap)
+        def item = new TestExecItem(
+                type: 'atype',
+                stepConfiguration: inputconfig,
+                label: 'a label'
+        )
+        when:
+        def result = adapter.executeWorkflowStep(context, item)
+
+        then:
+        1 * plugin.executeStep(!null as PluginStepContext, expect)
+        result.isSuccess()
+
+        where:
+
+        inputconfig = [a: 'b', c: '${option.c}', d: 'something "xyz${option.p}qws"']
+        data | expect
+        [:] | [a: 'b', c: '', d: 'something "xyzqws"']
+        [c: 'q'] | [a: 'b', c: 'q', d: 'something "xyzqws"']
+        [p: 'Q'] | [a: 'b', c: '', d: 'something "xyzQqws"']
+        [c: 'Z', p: 'Q'] | [a: 'b', c: 'Z', d: 'something "xyzQqws"']
+    }
+
+    static class TestPlugin implements StepPlugin, Describable {
+        StepPlugin impl
+        Description description
+
+        @Override
+        void executeStep(PluginStepContext context, Map<String, Object> configuration) throws StepException {
+            impl.executeStep(context, configuration)
+        }
+    }
+
+    @Plugin(name = "test2", service = ServiceNameConstants.WorkflowNodeStep)
+    static class Test2Plugin implements StepPlugin {
+        StepPlugin impl
+
+        @PluginProperty(title = "test",
+                description = "test",
+                defaultValue = "test")
+        private String test
+
+        @Override
+        void executeStep(PluginStepContext context, Map<String, Object> configuration) throws StepException {
+            impl.executeStep(context, configuration)
+        }
+    }
+
+    static class TestExecItem implements StepExecutionItem, ConfiguredStepExecutionItem {
+        String type
+
+        Map<String, Object> stepConfiguration
+
+        String label
+    }
+}

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapterSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapterSpec.groovy
@@ -28,6 +28,7 @@ import com.dtolabs.rundeck.core.plugins.configuration.Describable
 import com.dtolabs.rundeck.core.plugins.configuration.Description
 import com.dtolabs.rundeck.core.tools.AbstractBaseTest
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
+import com.dtolabs.rundeck.plugins.descriptions.PluginProperty
 import com.dtolabs.rundeck.plugins.step.NodeStepPlugin
 import com.dtolabs.rundeck.plugins.step.PluginStepContext
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
@@ -55,6 +56,26 @@ class NodeStepPluginAdapterSpec extends Specification {
     static class TestPlugin implements NodeStepPlugin, Describable {
         NodeStepPlugin impl
         Description description
+
+        @Override
+        void executeNodeStep(
+                final PluginStepContext context,
+                final Map<String, Object> configuration,
+                final INodeEntry entry
+        ) throws NodeStepException
+        {
+            impl.executeNodeStep(context, configuration, entry)
+        }
+    }
+
+    @Plugin(name = "test2", service = ServiceNameConstants.WorkflowNodeStep)
+    static class Test2Plugin implements NodeStepPlugin {
+        NodeStepPlugin impl
+
+        @PluginProperty(title = "test",
+                description = "test",
+                defaultValue = "test")
+        private String test
 
         @Override
         void executeNodeStep(
@@ -169,5 +190,40 @@ class NodeStepPluginAdapterSpec extends Specification {
         [c: 'q'] | [a: 'b', c: 'q', d: 'something "xyz${option.p}qws"']
         [p: 'Q'] | [a: 'b', c: '${option.c}', d: 'something "xyzQqws"']
         [c: 'Z', p: 'Q'] | [a: 'b', c: 'Z', d: 'something "xyzQqws"']
+    }
+
+
+    def "get plugin variables using PluginProperty"() {
+        given:
+        framework.frameworkServices = Mock(IFrameworkServices)
+        def optionContext = new BaseDataContext([option: [:]])
+        def shared = SharedDataContextUtils.sharedContext()
+        shared.merge(ContextView.global(), optionContext)
+        StepExecutionContext context = Mock(StepExecutionContext) {
+            getFramework() >> framework
+            getDataContext() >> optionContext
+            getSharedDataContext() >> shared
+            getFrameworkProject() >> PROJECT_NAME
+        }
+        def node = new NodeEntryImpl('node')
+        def plugin = Mock(NodeStepPlugin)
+        def wrap = new Test2Plugin(
+                impl: plugin
+        )
+        def adapter = new NodeStepPluginAdapter(wrap)
+        def config = [test: '123456']
+        def item = new TestExecItem(
+                type: 'atype',
+                stepConfiguration: config,
+                nodeStepType: 'nodetype',
+                label: 'a label'
+        )
+        when:
+        def result = adapter.executeNodeStep(context, item, node)
+
+        then:
+        1 * plugin.executeNodeStep(!null as PluginStepContext, [:], node)
+        result.isSuccess()
+        wrap.test == "123456"
     }
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
refactor to pass configuration values to the runner when plugins use @PluginProperty annotations

**Describe the solution you've implemented**

**Describe alternatives you've considered**

**Additional context**
