### PR TITLE
RUN-1470 Includes ui-socket-vue component to show runner info for each step in execution page

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContext.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContext.java
@@ -229,4 +229,6 @@ public interface ExecutionContext {
      * @return An {@link ExecutionReference} to the execution, or null if doesn't apply.
      */
     public ExecutionReference getExecution();
+
+    public Map<String, Object> getExtraMetadata();
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContextImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionContextImpl.java
@@ -82,6 +82,8 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
     private OrchestratorConfig orchestrator;
     private PluginControlService pluginControlService;
     @Getter private List<ContextComponent<?>> componentList;
+
+    private Map<String, Object> extraMetadata;
     
     private ExecutionReference execution;
 
@@ -93,6 +95,7 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
         sharedDataContext = new WFSharedContext();
         outputContext = SharedDataContextUtils.outputContext(ContextView.global());
         componentList = new ArrayList<>();
+        extraMetadata = new LinkedHashMap<>();
     }
 
     public static Builder builder() {
@@ -257,6 +260,9 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
                 if (null != original.getComponentList()) {
                     ctx.componentList.addAll(original.getComponentList());
                 }
+                if(null!=original.getExtraMetadata()){
+                    ctx.extraMetadata.putAll(original.getExtraMetadata());
+                }
             }
         }
 
@@ -363,6 +369,10 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
             newList.addAll(ctx.componentList.stream().filter(otherContainsNotMatch).collect(Collectors.toList()));
             newList.addAll(other.ctx.componentList);
             ctx.componentList = newList;
+
+            if(null != other.ctx.extraMetadata){
+                ctx.extraMetadata.putAll(other.ctx.extraMetadata);
+            }
 
             return this;
         }
@@ -650,6 +660,11 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
             return this;
         }
 
+        public Builder putExtraMetadata(Map<String, Object> extraMetadata) {
+            ctx.extraMetadata.putAll(extraMetadata);
+            return this;
+        }
+
         public Builder addComponents(Collection<ContextComponent<?>> components) {
             ctx.componentList.addAll(components);
             return this;
@@ -780,4 +795,9 @@ public class ExecutionContextImpl implements ExecutionContext, StepExecutionCont
     
     @Override
     public ExecutionReference getExecution() { return execution; }
+
+    @Override
+    public Map<String, Object> getExtraMetadata() {
+        return extraMetadata;
+    }
 }

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -686,6 +686,7 @@ function RDNode(name, steps,flow){
     self.toggleExpand=function(){
         self.expanded(!self.expanded());
         if(self.expanded()){
+            window.dispatchEvent(new Event('toggleExpandNodes'))
             flow.selectedNodes.push(self.name);
             flow.loadStateForNode(self);
         }else {
@@ -865,6 +866,7 @@ function RDNode(name, steps,flow){
         self.dedupeSteps(data.steps);
         self.updateSummary(data.summary);
         self.updateSteps(data.steps);
+        window.dispatchEvent(new Event('nodeStepDataLoaded'))
     };
     self.dedupeSteps=function(steps) {
         var seen = []
@@ -1351,6 +1353,7 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
                     obj.errorMessage( "Failed to load state: " + (jqxhr.responseJSON && jqxhr.responseJSON.error? jqxhr.responseJSON.error: err),jqxhr.responseJSON);
                 }else{
                     node.loadData(data);
+                    window.dispatchEvent(new Event('loadedNodeSteps'))
                 }
             },
             error: function (jqxhr,status,err) {

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -866,7 +866,6 @@ function RDNode(name, steps,flow){
         self.dedupeSteps(data.steps);
         self.updateSummary(data.summary);
         self.updateSteps(data.steps);
-        window.dispatchEvent(new Event('nodeStepDataLoaded'))
     };
     self.dedupeSteps=function(steps) {
         var seen = []
@@ -1354,7 +1353,6 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
                     obj.errorMessage( "Failed to load state: " + (jqxhr.responseJSON && jqxhr.responseJSON.error? jqxhr.responseJSON.error: err),jqxhr.responseJSON);
                 }else{
                     node.loadData(data);
-                    window.dispatchEvent(new Event('loadedNodeSteps'))
                 }
             },
             error: function (jqxhr,status,err) {

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -686,7 +686,7 @@ function RDNode(name, steps,flow){
     self.toggleExpand=function(){
         self.expanded(!self.expanded());
         if(self.expanded()){
-            window.dispatchEvent(new Event('toggleExpandNodes'))
+            window.dispatchEvent(new CustomEvent('toggleExpandNodes', {detail:{rdnode: self}}))
             flow.selectedNodes.push(self.name);
             flow.loadStateForNode(self);
         }else {
@@ -924,6 +924,7 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
     self.executionId = ko.observable(data.executionId);
     self.outputScrollOffset=0;
     self.activeView = ko.observable("nodes");
+    self.workflowStepMetadata=null;
     /**
      * synonym with activeView, to maintain compatibility
      */
@@ -1443,7 +1444,8 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
                     execDuration: data.execDuration,
                     jobAverageDuration: data.jobAverageDuration,
                     startTime: data.startTime ? data.startTime : data.state ? data.state.startTime : null,
-                    endTime: data.endTime ? data.endTime : data.state ? data.state.endTime : null
+                    endTime: data.endTime ? data.endTime : data.state ? data.state.endTime : null,
+                    workflowStepMetadata:ko.pureComputed(function(){return data.workflowStepMetadata})
                 }, {}, self);
                 if(followNodes) {
                     self.updateNodes(data.state);

--- a/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/executionStateKO.js
@@ -1431,6 +1431,7 @@ function NodeFlowViewModel(workflow, outputUrl, nodeStateUpdateUrl, multiworkflo
                 }, {}, self);
             },
             updateState: function (data) {
+                window.dispatchEvent(new Event('updateStateStep'))
                 ko.mapping.fromJS({
                     executionState: data.executionState,
                     executionStatusString: data.executionStatusString,

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -346,7 +346,7 @@ class ExecutionController extends ControllerBase{
                 retryAttempt         : e.retryAttempt,
                 retry                : e.retry,
                 serverNodeUUID       : e.serverNodeUUID,
-                workflowStepMetadata : e.getWorkflow().getWorkflowStepMetadataMap(),
+                workflowStepMetadata : e.getWorkflow()?.getWorkflowStepMetadataMap(),
                 clusterExec          : isClusterExec
         ]
         if(e.retryExecution){

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -346,6 +346,7 @@ class ExecutionController extends ControllerBase{
                 retryAttempt         : e.retryAttempt,
                 retry                : e.retry,
                 serverNodeUUID       : e.serverNodeUUID,
+                workflowStepMetadata : e.getWorkflow().getWorkflowStepMetadataMap(),
                 clusterExec          : isClusterExec
         ]
         if(e.retryExecution){

--- a/rundeckapp/grails-app/domain/rundeck/Workflow.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Workflow.groovy
@@ -158,7 +158,8 @@ public class Workflow implements WorkflowData, EmbeddedJsonData {
 
     void setWorkflowStepMetadataMap(List<Integer> stepContext, int stepNumber, Map config) {
         Map metadata = getWorkflowStepMetadataMap() ?: [:]
-        String key = "${stepContext.join('/')}/${stepNumber}"
+        List contextKey = stepContext + stepNumber
+        String key = "${contextKey.join('/')}"
         metadata.put(key, config)
         setWorkflowStepMetadataMap(metadata)
     }

--- a/rundeckapp/grails-app/domain/rundeck/Workflow.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Workflow.groovy
@@ -152,11 +152,15 @@ public class Workflow implements WorkflowData, EmbeddedJsonData {
         workflowStepMetadata ? asJsonMap(workflowStepMetadata) : [:]
     }
 
+    void setWorkflowStepMetadataMap(Map config) {
+        workflowStepMetadata = config ? serializeJsonMap(config) : null
+    }
+
     void setWorkflowStepMetadataMap(List<Integer> stepContext, int stepNumber, Map config) {
         Map metadata = getWorkflowStepMetadataMap() ?: [:]
-        String key = "${stepContext.join('/')}/${stepNumber()}"
+        String key = "${stepContext.join('/')}/${stepNumber}"
         metadata.put(key, config)
-        workflowStepMetadata = metadata ? serializeJsonMap(metadata) : null
+        setWorkflowStepMetadataMap(metadata)
     }
 
     public boolean validatePluginConfigMap(){

--- a/rundeckapp/grails-app/domain/rundeck/Workflow.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Workflow.groovy
@@ -152,8 +152,11 @@ public class Workflow implements WorkflowData, EmbeddedJsonData {
         workflowStepMetadata ? asJsonMap(workflowStepMetadata) : [:]
     }
 
-    void setWorkflowStepMetadataMap(Map config) {
-        workflowStepMetadata = config ? serializeJsonMap(config) : null
+    void setWorkflowStepMetadataMap(List<Integer> stepContext, int stepNumber, Map config) {
+        Map metadata = getWorkflowStepMetadataMap() ?: [:]
+        String key = "${stepContext.join('/')}/${stepNumber()}"
+        metadata.put(key, config)
+        workflowStepMetadata = metadata ? serializeJsonMap(metadata) : null
     }
 
     public boolean validatePluginConfigMap(){

--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -115,5 +115,6 @@ databaseChangeLog = {
         include file: 'core/WorkflowWorkflowStepPrimaryKey.groovy'
         include file: 'core/OptionRemoveValues.groovy'
         include file: 'core/DBChangelogPrimaryKey.groovy'
+        include file: 'core/Tag-4.13.0.groovy'
         include file: 'core/WorkflowStepMetadata.groovy'
 }

--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -115,4 +115,5 @@ databaseChangeLog = {
         include file: 'core/WorkflowWorkflowStepPrimaryKey.groovy'
         include file: 'core/OptionRemoveValues.groovy'
         include file: 'core/DBChangelogPrimaryKey.groovy'
+        include file: 'core/WorkflowStepMetadata.groovy'
 }

--- a/rundeckapp/grails-app/migrations/core/Tag-4.13.0.groovy
+++ b/rundeckapp/grails-app/migrations/core/Tag-4.13.0.groovy
@@ -1,0 +1,7 @@
+databaseChangeLog = {
+    changeSet(author: "rundeckuser (generated)", id: "tag-4.13.0") {
+        tagDatabase(tag: "4.13.0")
+        empty()
+        rollback()
+    }
+}

--- a/rundeckapp/grails-app/migrations/core/WorkflowStepMetadata.groovy
+++ b/rundeckapp/grails-app/migrations/core/WorkflowStepMetadata.groovy
@@ -1,16 +1,5 @@
 databaseChangeLog = {
-    changeSet(author: "Carlos Franco", id: "4.12.0-workflow-step-metadata") {
-        preConditions(onFail: "MARK_RAN") {
-            not {
-                columnExists(tableName: "workflow_step", columnName: 'step_metadata')
-            }
-        }
-        addColumn(tableName: "workflow_step") {
-            column(name: 'step_metadata', type: '${text.type}')
-        }
-    }
-
-    changeSet(author: "Carlos Franco", id: "4.12.0-workflow-step-metadata2") {
+    changeSet(author: "Carlos Franco", id: "4.13.0-workflow-step-metadata") {
         preConditions(onFail: "MARK_RAN") {
             not {
                 columnExists(tableName: "workflow", columnName: 'workflow_step_metadata')

--- a/rundeckapp/grails-app/migrations/core/WorkflowStepMetadata.groovy
+++ b/rundeckapp/grails-app/migrations/core/WorkflowStepMetadata.groovy
@@ -1,0 +1,23 @@
+databaseChangeLog = {
+    changeSet(author: "Carlos Franco", id: "4.12.0-workflow-step-metadata") {
+        preConditions(onFail: "MARK_RAN") {
+            not {
+                columnExists(tableName: "workflow_step", columnName: 'step_metadata')
+            }
+        }
+        addColumn(tableName: "workflow_step") {
+            column(name: 'step_metadata', type: '${text.type}')
+        }
+    }
+
+    changeSet(author: "Carlos Franco", id: "4.12.0-workflow-step-metadata2") {
+        preConditions(onFail: "MARK_RAN") {
+            not {
+                columnExists(tableName: "workflow", columnName: 'workflow_step_metadata')
+            }
+        }
+        addColumn(tableName: "workflow") {
+            column(name: 'workflow_step_metadata', type: '${text.type}')
+        }
+    }
+}

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1619,7 +1619,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             privateDataContext(privatecontext)
             executionListener(listener)
             workflowExecutionListener(wlistener)
-            execution(executionReference)
+            execution(executionReference?:origContext?.getExecution())
         }
         builder.charsetEncoding(charsetEncoding)
         builder.framework(framework)

--- a/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
@@ -156,7 +156,7 @@
                           </div>
                       </div>
 
-                      <div class="col-sm-2">
+                      <div data-bind="if: executionState() != 'WAITING'" class="col-sm-2">
                           <div id="vue-ui-socket-element" class="vue-ui-socket" vue-socket-on="vue-ui-socket-node-added">
                               <div>
                                   <ui-socket section="job-runner-execution-steps" location="top" :event-bus="EventBus" data-bind="attr: { ':socket-data': '{stepctx:\'' + $data.stepctx + '\'}', 'elma': 'chips' }" />

--- a/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
@@ -78,20 +78,12 @@
   <div data-bind="foreach: activeNodes()">
     <div class="wfnodestate" data-bind="css: { open: expanded() }, attr: { 'data-node': name } ">
       <div class="row wfnodeoverall action" data-bind="click: toggleExpand">
-          <div class="col-sm-3  nodectx"
+          <div class="col-sm-6  nodectx"
                data-bind="attr: { title: name }, css: { 'auto-caret-container': expanded() } ">
               <div class="execstate nodename action isnode" data-bind="attr: { 'data-execstate': summaryState }, css: { active: expanded() }">
                   <i class="auto-caret text-muted"></i>
                   <i class="fas fa-hdd"></i>
                   <span data-bind="text: name"></span>
-              </div>
-          </div>
-
-          <div class="col-sm-3">
-              <div class="vue-ui-socket" vue-socket-on="vue-ui-socket-node-added">
-                  <div>
-                      <ui-socket section="job-runner-execution" location="top" :event-bus="EventBus" />
-                  </div>
               </div>
           </div>
 
@@ -129,14 +121,14 @@
       </div>
       %{--step specific info for node--}%
       <div data-bind="if: expanded">
-      <div  data-bind="visible: expanded" >
+      <div  class="workflowstepitem" data-bind="visible: expanded" >
           <div data-bind="foreach: steps">
               <div data-bind="if: !$data.parameterizedStep()">
               <div class="wfnodesteps" data-bind="attr: { 'data-node': node.name }">
               <div class=" wfnodestep" data-bind="css: { open: followingOutput() }, attr: { 'data-node': node.name, 'data-stepctx': $data.stepctx }">
                   <div class="row action" data-bind="click: $root.toggleOutputForNodeStep,
                                  event: { mouseover: function(){hovering(true);}, mouseout: function(){hovering(false);} } ">
-                      <div class="col-sm-2 " >
+                      <div class="col-sm-3 " >
                           <div class="stepident action col-inset"
                                 data-bind="
                                 attr: { 'data-execstate': executionState },
@@ -164,8 +156,8 @@
                           </div>
                       </div>
 
-                      <div class="col-sm-2 col-sm-offset-1">
-                          <div id="vue-ui-socket-element" class="vue-ui-socket" vue-socket-on="loadedNodeSteps">
+                      <div class="col-sm-2">
+                          <div id="vue-ui-socket-element" class="vue-ui-socket" vue-socket-on="vue-ui-socket-node-added">
                               <div>
                                   <ui-socket section="job-runner-execution-steps" location="top" :event-bus="EventBus" data-bind="attr: { ':socket-data': '{stepctx:\'' + $data.stepctx + '\'}', 'elma': 'chips' }" />
                               </div>

--- a/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
@@ -136,7 +136,7 @@
               <div class=" wfnodestep" data-bind="css: { open: followingOutput() }, attr: { 'data-node': node.name, 'data-stepctx': $data.stepctx }">
                   <div class="row action" data-bind="click: $root.toggleOutputForNodeStep,
                                  event: { mouseover: function(){hovering(true);}, mouseout: function(){hovering(false);} } ">
-                      <div class="col-sm-3 " >
+                      <div class="col-sm-2 " >
                           <div class="stepident action col-inset"
                                 data-bind="
                                 attr: { 'data-execstate': executionState },
@@ -164,7 +164,16 @@
                           </div>
                       </div>
 
-                      <div class=" col-sm-2">
+                      <div class="col-sm-2 col-sm-offset-1">
+                          <div id="vue-ui-socket-element" class="vue-ui-socket" vue-socket-on="loadedNodeSteps">
+                              <div>
+                                  <ui-socket section="job-runner-execution-steps" location="top" :event-bus="EventBus" data-bind="attr: { ':socket-data': '{stepctx:\'' + $data.stepctx + '\'}', 'elma': 'chips' }" />
+                              </div>
+                          </div>
+                      </div>
+
+
+                      <div class=" col-sm-2 col-sm-offset-1">
                           <span class="execstate execstatedisplay " data-bind="attr: {
                                'data-execstate': executionState,
                                'data-next': ( node.currentStep()==$data && executionState() == 'WAITING' )
@@ -172,7 +181,7 @@
                       </div>
 
 
-                      <div class="col-sm-2 col-sm-offset-3">
+                      <div class="col-sm-2">
                           <span class="execstart info time" data-bind="text: startTimeFormat('h:mm:ss a')"></span>
                       </div>
 

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -1109,9 +1109,23 @@ search
                     observer.disconnect();
                 }
             });
-        });
+            });
     })
     observer.observe(document.querySelector("#nodeflowstate"), { subtree: true, childList: true });
+
+    // const observer2 = new MutationObserver(function(mutations_list) {
+    //     mutations_list.forEach(function(mutation) {
+    //         mutation.addedNodes.forEach(function(added_node) {
+    //             console.log('added_node', added_node.className)
+    //             if(added_node.className == 'nodestepinfo' && added_node.getElementsByClassName('vue-ui-socket')?.length > 0) {
+    //                 var eventKOProcessed = new Event('vue-ui-socket-node-added-2');
+    //                 window.dispatchEvent(eventKOProcessed)
+    //                 observer2.disconnect();
+    //             }
+    //         });
+    //     });
+    // })
+    // observer2.observe(document.querySelector("#nodeflowstate"), { subtree: true, childList: true });
 
     function init() {
         var execInfo=loadJsonData('execInfoJSON');

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -1131,6 +1131,7 @@ search
     }
 
     window.addEventListener('toggleExpandNodes', watchVueSocket)
+    window.addEventListener('updateStateStep', watchVueSocket)
 
     function init() {
         var execInfo=loadJsonData('execInfoJSON');

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -1100,32 +1100,37 @@ search
         "execution": loadJsonData('execDataJSON')
     })
 
-    const observer = new MutationObserver(function(mutations_list) {
-        mutations_list.forEach(function(mutation) {
-            mutation.addedNodes.forEach(function(added_node) {
-                if(added_node.className == 'wfnodestate' && added_node.getElementsByClassName('vue-ui-socket')?.length > 0) {
+    var node_added = []
+    var watchVueSocket= (evt) => {
+        var vueSocketFound = false
+        var nodename = evt.detail?.rdnode?.name
+        window._rundeck.data.execution = Object.assign(window._rundeck.data || {}, {
+            workflow: {workflowStepMetadata: nodeflowvm.workflowStepMetadata}
+        })
+        if(node_added.indexOf(nodename) < 0){
+            node_added.push(nodename)
+            const observer2 = new MutationObserver(function(mutations_list) {
+                mutations_list.forEach(function(mutation) {
+                    mutation.addedNodes.forEach(function(added_node) {
+                        if(added_node.getElementsByClassName && added_node.getElementsByClassName('vue-ui-socket')?.length > 0) {
+                            vueSocketFound = true
+                        }
+                    });
+                });
+                if(vueSocketFound){
                     var eventKOProcessed = new Event('vue-ui-socket-node-added');
                     window.dispatchEvent(eventKOProcessed)
-                    observer.disconnect();
+                    observer2.disconnect();
                 }
-            });
-            });
-    })
-    observer.observe(document.querySelector("#nodeflowstate"), { subtree: true, childList: true });
+            })
+            observer2.observe(document.querySelector("[data-node='" + nodename + "']"), { subtree: true, childList: true });
+        } else {
+            var eventKOProcessed = new Event('vue-ui-socket-node-added');
+            window.dispatchEvent(eventKOProcessed)
+        }
+    }
 
-    // const observer2 = new MutationObserver(function(mutations_list) {
-    //     mutations_list.forEach(function(mutation) {
-    //         mutation.addedNodes.forEach(function(added_node) {
-    //             console.log('added_node', added_node.className)
-    //             if(added_node.className == 'nodestepinfo' && added_node.getElementsByClassName('vue-ui-socket')?.length > 0) {
-    //                 var eventKOProcessed = new Event('vue-ui-socket-node-added-2');
-    //                 window.dispatchEvent(eventKOProcessed)
-    //                 observer2.disconnect();
-    //             }
-    //         });
-    //     });
-    // })
-    // observer2.observe(document.querySelector("#nodeflowstate"), { subtree: true, childList: true });
+    window.addEventListener('toggleExpandNodes', watchVueSocket)
 
     function init() {
         var execInfo=loadJsonData('execInfoJSON');

--- a/rundeckapp/src/test/groovy/org/rundeck/app/components/RundeckJobDefinitionManagerSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/components/RundeckJobDefinitionManagerSpec.groovy
@@ -87,6 +87,7 @@ class RundeckJobDefinitionManagerSpec extends Specification implements DataTest 
         <scriptargs />
         <scriptfile>path/to/file.sh</scriptfile>
       </command>
+      <workflowStepMetadata />
     </sequence>
   </job>
 </joblist>"""
@@ -116,6 +117,7 @@ class RundeckJobDefinitionManagerSpec extends Specification implements DataTest 
       scriptfile: path/to/file.sh""" : "- scriptfile: path/to/file.sh"}
     keepgoing: true
     strategy: node-first
+    workflowStepMetadata: {}
 """
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/WorkflowTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/WorkflowTests.groovy
@@ -51,7 +51,7 @@ class WorkflowTests extends Specification implements DataTest {
             def cmds = map.remove('commands')
         then:
             2== cmds.size()
-            [keepgoing: true, strategy: 'node-first']== map
+            [keepgoing: true, strategy: 'node-first', workflowStepMetadata:[:]]== map
 
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
@@ -1682,6 +1682,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
     <project>testproj</project>
     <user>testuser</user>
     <workflow keepgoing='false' strategy='node-first'>
+      <workflowStepMetadata />
       <command>
         <exec>exec command</exec>
       </command>
@@ -1805,6 +1806,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
     <project>testproj</project>
     <user>testuser</user>
     <workflow keepgoing='false' strategy='node-first'>
+      <workflowStepMetadata />
       <command>
         <exec>exec command</exec>
       </command>
@@ -1838,6 +1840,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
     <project>testproj</project>
     <user>testuser</user>
     <workflow keepgoing='false' strategy='node-first'>
+      <workflowStepMetadata />
       <command>
         <exec>exec command</exec>
       </command>
@@ -1846,6 +1849,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
       <scheduleEnabled>true</scheduleEnabled>
       <executionEnabled>true</executionEnabled>
       <sequence keepgoing='true' strategy='node-first'>
+        <workflowStepMetadata />
         <command>
           <exec>exec command</exec>
         </command>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
An execution can use multiple runners if it has job referenced that uses different runners than parent job.

**Describe the solution you've implemented**
Moved the ui-vue-socket component to be injected in each step. Also, was included a new field to the workflow table to store step metadata
