### PR TITLE
RSE-324 Fix: Updated vue-moment dependency to latest moment version

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
@@ -32733,7 +32733,7 @@
       "resolved": "https://registry.npmjs.org/vue-moment/-/vue-moment-4.1.0.tgz",
       "integrity": "sha512-Gzisqpg82ItlrUyiD9d0Kfru+JorW2o4mQOH06lEDZNgxci0tv/fua1Hl0bo4DozDV2JK1r52Atn/8QVCu8qQw==",
       "dependencies": {
-        "moment": "^2.19.2"
+        "moment": "^2.29.4"
       },
       "peerDependencies": {
         "vue": ">=1.x.x"
@@ -59629,7 +59629,7 @@
       "resolved": "https://registry.npmjs.org/vue-moment/-/vue-moment-4.1.0.tgz",
       "integrity": "sha512-Gzisqpg82ItlrUyiD9d0Kfru+JorW2o4mQOH06lEDZNgxci0tv/fua1Hl0bo4DozDV2JK1r52Atn/8QVCu8qQw==",
       "requires": {
-        "moment": "^2.19.2"
+        "moment": "^2.29.4"
       }
     },
     "vue-multiselect": {


### PR DESCRIPTION
# Dependency update due CVE-2022-24785
In concordance to [this](https://pagerduty.atlassian.net/browse/RSE-324) and [this](https://nvd.nist.gov/vuln/detail/cve-2022-24785) we updated the deprecated versions for moment.js.

# In This PR
:white_check_mark: Only UI-Trellis is affected.

## Plugins/projects affected
The list of project/plugins below were affected, mainly because of the dependency of vue-moment (moment.js) which was deprecated:

- rundeckpro-calendars
- rundeckpro-config/vue-spa
- rundeckpro-jobdata
- rundeckpro-node-wizard
- rundeckpro-nodehealthcheck
- rundeckpro-reactions
- rundeckpro-roimetrics
- rundeckpro-security
- rundeckpro-ui-components
- rundeckpro-tour-manager
- rundeckpro-webhooks
- ui-workflow-designer
- ui-trellis
