### PR TITLE
RSE-271 Fix: Successful remote job import from API but getting error in SCM API response

### DIFF
--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/imp/actions/ImportJobs.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/imp/actions/ImportJobs.groovy
@@ -134,6 +134,7 @@ class ImportJobs extends BaseAction implements GitImportAction {
                     jobsChanged.add(importResult.getJob())
                 }
                 plugin.importTracker.trackJobAtPath(importResult.job,walk.getPathString())
+                success = true
                 sb << ("Succeeded importing ${walk.getPathString()}: ${importResult}")
             }
         }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScmController.groovy
@@ -2377,7 +2377,7 @@ The response will include information about the result.
         if (!validateCommandInput(scm)) {
             return
         }
-        ScheduledExecution scheduledExecution = ScheduledExecution.getByIdOrUUID(scm.id)
+        ScheduledExecution scheduledExecution = scheduledExecutionService.getByIDorUUID(scm.id)
         if (!apiRequireJob(scheduledExecution, scm)) {
             return
         }

--- a/test/api/test-scm-plugins-job-action-perform.sh
+++ b/test/api/test-scm-plugins-job-action-perform.sh
@@ -74,7 +74,7 @@ test_job_action_perform_json(){
 	local JOBID=$(setup_export_job $project)
 	local actionId="job-commit"
 	local commitMessage="test commit message"
-	
+
 	sleep 2
 
 	#get job status
@@ -84,7 +84,7 @@ test_job_action_perform_json(){
 	TYPE=application/json
 	EXPECT_STATUS=200
 	ENDPOINT="${APIURL}/job/$JOBID/scm/$integration/action/$actionId"
-	
+
 	TMPDIR=`tmpdir`
 	tmp=$TMPDIR/commit.json
 	cat >$tmp <<END
@@ -100,7 +100,7 @@ END
 
 	api_request $ENDPOINT $DIR/curl.out
 
-	
+
 	assert_json_value "true" '.success' $DIR/curl.out
 	assert_json_value "SCM export Action was Successful: $actionId" '.message' $DIR/curl.out
 
@@ -109,9 +109,51 @@ END
 	remove_project $project
 }
 
+test_job_import_perform(){
+  local project=$1
+
+  create_project $project
+  do_setup_export_json_valid "import" "git-import" $project
+  local actionId="import-jobs"
+  local integration=import
+
+  sleep 2
+
+  #get job status
+
+  METHOD=POST
+  ACCEPT=application/json
+  TYPE=application/json
+  EXPECT_STATUS=200
+  ENDPOINT="${APIURL}/project/$project/scm/$integration/action/$actionId"
+
+  TMPDIR=`tmpdir`
+  tmp=$TMPDIR/importjob.json
+  cat >$tmp <<END
+{
+    "items": [
+        "$JOBNAME.yaml"
+    ]
+}
+END
+  POSTFILE=$tmp
+
+  test_begin "SCM Job Import Action"
+
+  api_request $ENDPOINT $DIR/curl.out
+
+  assert_json_value "true" '.success' $DIR/curl.out
+  assert_json_value "SCM import Action was Successful: $actionId" '.message' $DIR/curl.out
+
+  test_succeed
+
+  remove_project $project
+}
+
 main(){
 	test_job_action_perform_xml "testscm1"
 	test_job_action_perform_json "testscm2"
+	test_job_import_perform "testscm3"
 }
 
 main

--- a/test/api/test-scm-plugins-job-action-perform.sh
+++ b/test/api/test-scm-plugins-job-action-perform.sh
@@ -74,7 +74,7 @@ test_job_action_perform_json(){
 	local JOBID=$(setup_export_job $project)
 	local actionId="job-commit"
 	local commitMessage="test commit message"
-
+	
 	sleep 2
 
 	#get job status
@@ -84,7 +84,7 @@ test_job_action_perform_json(){
 	TYPE=application/json
 	EXPECT_STATUS=200
 	ENDPOINT="${APIURL}/job/$JOBID/scm/$integration/action/$actionId"
-
+	
 	TMPDIR=`tmpdir`
 	tmp=$TMPDIR/commit.json
 	cat >$tmp <<END
@@ -100,7 +100,7 @@ END
 
 	api_request $ENDPOINT $DIR/curl.out
 
-
+	
 	assert_json_value "true" '.success' $DIR/curl.out
 	assert_json_value "SCM export Action was Successful: $actionId" '.message' $DIR/curl.out
 
@@ -109,51 +109,9 @@ END
 	remove_project $project
 }
 
-test_job_import_perform(){
-  local project=$1
-
-  create_project $project
-  do_setup_export_json_valid "import" "git-import" $project
-  local actionId="import-jobs"
-  local integration=import
-
-  sleep 2
-
-  #get job status
-
-  METHOD=POST
-  ACCEPT=application/json
-  TYPE=application/json
-  EXPECT_STATUS=200
-  ENDPOINT="${APIURL}/project/$project/scm/$integration/action/$actionId"
-
-  TMPDIR=`tmpdir`
-  tmp=$TMPDIR/importjob.json
-  cat >$tmp <<END
-{
-    "items": [
-        "$JOBNAME.yaml"
-    ]
-}
-END
-  POSTFILE=$tmp
-
-  test_begin "SCM Job Import Action"
-
-  api_request $ENDPOINT $DIR/curl.out
-
-  assert_json_value "true" '.success' $DIR/curl.out
-  assert_json_value "SCM import Action was Successful: $actionId" '.message' $DIR/curl.out
-
-  test_succeed
-
-  remove_project $project
-}
-
 main(){
 	test_job_action_perform_xml "testscm1"
 	test_job_action_perform_json "testscm2"
-	test_job_import_perform "testscm3"
 }
 
 main


### PR DESCRIPTION
# RSE-271 Fix: Successful remote job import from API but getting error in SCM API response
When you import remote jobs with SCM configured using the API, you get an error in the response but the job WAS imported.

# The problem
When you consume the `performAction` method to import the remote job, you first check if you're going to delete any jobs, and if you don't delete any jobs, the response is set to `success = false`.
# The Fix:
The field `success = true` is added after successfully importing the remote job.

## Exhibits
**Before fix:**
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/91557307/234733858-7da69f25-d0d1-4ba5-b128-2d3e92906b8c.png">
**After fix:**
<img width="1080" alt="image" src="https://user-images.githubusercontent.com/91557307/234732185-6940b648-14d7-41f2-9493-278997e24e98.png">