### PR TITLE
RUN-1623 Add doNodedispatch property to execution reference

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionReference.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionReference.java
@@ -41,6 +41,6 @@ public interface ExecutionReference extends PreparedExecutionReference{
     String getAdhocCommand();
 
     Map getMetadata();
-
+    boolean isDoNodedispatch();
 
 }

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -504,7 +504,8 @@ class Execution extends ExecutionContext implements EmbeddedJsonData {
                 targetNodes: targetNodes,
                 metadata: extraMetadataMap,
                 scheduled: executionType in ['scheduled','user-scheduled'],
-                executionType: executionType
+                executionType: executionType,
+                doNodedispatch: doNodedispatch
         )
     }
 

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1619,7 +1619,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             privateDataContext(privatecontext)
             executionListener(listener)
             workflowExecutionListener(wlistener)
-            execution(executionReference)
+            execution(executionReference?:origContext?.getExecution())
         }
         builder.charsetEncoding(charsetEncoding)
         builder.framework(framework)

--- a/rundeckapp/grails-app/services/rundeck/services/execution/ExecutionReferenceImpl.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/execution/ExecutionReferenceImpl.groovy
@@ -23,6 +23,7 @@ class ExecutionReferenceImpl implements ExecutionReference {
     String adhocCommand
     Map metadata
     boolean scheduled
+    boolean doNodedispatch
     String executionType
 
     @Override


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Include doNodedispatch property to the executionReference to get that info from executionContext