### PR TITLE
RUN-1705: cleanup: simplify gradle config slightly

### DIFF
--- a/grails-execution-mode-timer/build.gradle
+++ b/grails-execution-mode-timer/build.gradle
@@ -42,11 +42,7 @@ configurations{
 
 dependencies {
 
-    if (findProject(":core")) {
-        implementation project(":core")
-    }else{
-        implementation "org.rundeck:rundeck-core:${rundeckVersion}"
-    }
+    implementation project(":core")
 
     implementation 'org.quartz-scheduler:quartz:2.3.1'
     implementation 'org.grails.plugins:quartz:2.0.13'


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Cleanup some gradle code. no need to conditionally add project, core project is always present
