### PR TITLE
RSE-410 Fix: SCM enabled if user dont have the key to SCM import.

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3235,8 +3235,9 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     if (scmService.projectHasConfiguredImportPlugin(params.project)) {
                         def userHasPathAccessToSshKey = storageService.hasPath(authContext, scmService.loadScmConfig(params.project, 'import')?.config?.sshPrivateKeyPath)
                         if( !userHasPathAccessToSshKey ){
-                            results.warning = "Failed to update SCM Import status; user don't have access rights to SCM's configured key."
-                            log.error("Failed to update SCM Import status; user don't have access rights to SCM's configured key.")
+                            def warning = "Failed to update SCM Import status; user don't have access rights to SCM's configured key."
+                            results.warning = warning
+                            log.error(warning)
                         }else{
                             pluginData.scmImportEnabled = scmService.loadScmConfig(params.project, 'import')?.enabled
                             if (pluginData.scmImportEnabled) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3235,10 +3235,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     if (scmService.projectHasConfiguredImportPlugin(params.project)) {
                         def userHasPathAccessToSshKey = storageService.hasPath(authContext, scmService.loadScmConfig(params.project, 'import')?.config?.sshPrivateKeyPath)
                         if( !userHasPathAccessToSshKey ){
-                            def unauthorizedMessage = "[SCM disabled] User don't have permissions to the configuration key. Please refer to the system's SCM key owner or administrator for further actions."
-                            scmService.disablePlugin('import', params.project, scmService.loadScmConfig(params.project, 'import').type)
-                            pluginData.warning = unauthorizedMessage
-                            log.error(unauthorizedMessage)
+                            results.warning = "Failed to update SCM Import status; user don't have access rights to SCM's configured key."
+                            log.error("Failed to update SCM Import status; user don't have access rights to SCM's configured key.")
                         }else{
                             pluginData.scmImportEnabled = scmService.loadScmConfig(params.project, 'import')?.enabled
                             if (pluginData.scmImportEnabled) {
@@ -3246,11 +3244,10 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                 pluginData.scmImportJobStatus = scmService.importStatusForJobs(params.project, authContext, result.nextScheduled,false, jobsPluginMeta)
                                 pluginData.scmImportStatus = scmService.importPluginStatus(authContext, params.project)
                                 pluginData.scmImportActions = scmService.importPluginActions(authContext, params.project, pluginData.scmImportStatus)
+                                results.putAll(pluginData)
                             }
                         }
-                        results.putAll(pluginData)
                     }
-
                 } catch (ScmPluginException e) {
                     results.warning = "Failed to update SCM Import status: ${e.message}"
                 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1611,7 +1611,6 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         where:
             enabled | count
             true    | 1
-            false   | 0
     }
 
     def "SCM NOT disabled when an unauthorized user request status and import is enabled"(){

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1614,9 +1614,8 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
             false   | 0
     }
 
-    def "SCM disabled when an unauthorized user request status and import is enabled"(){
+    def "SCM NOT disabled when an unauthorized user request status and import is enabled"(){
         given:
-        def unauthorizedMessage = "[SCM disabled] User don't have permissions to the configuration key. Please refer to the system's SCM key owner or administrator for further actions."
         controller.frameworkService = Mock(FrameworkService){
             isClusterModeEnabled() >> true
         }
@@ -1651,13 +1650,13 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
                                                                                           AuthConstants.ACTION_SCM_IMPORT]) >> true
         1 * controller.scmService.projectHasConfiguredExportPlugin(project) >> false
         1 * controller.scmService.projectHasConfiguredImportPlugin(project) >> true
-        2 * controller.scmService.loadScmConfig(project,'import') >> scmConfig
+        1 * controller.scmService.loadScmConfig(project,'import') >> scmConfig
         1 * controller.storageService.hasPath(_,_) >> false
         0 * controller.scmService.initProject(project,'export')
         0 * controller.scmService.initProject(project,'import')
 
-        1 * controller.scmService.disablePlugin(_,_,_)
-        response.json.warning == unauthorizedMessage
+        0 * controller.scmService.disablePlugin(_,_,_)
+        response.json.warning !== null
 
     }
 


### PR DESCRIPTION
# RSE-410 Fix: SCM enabled if user dont have the key to SCM import
As a side effect of [this](https://github.com/rundeck/rundeck/pull/8047), the SCM gets disabled when a user don't have the rights to see the key configured in the SCM config.

# The Problem
The "disable" method gets called when the user don't have the rights to the key.

# The Fix
Prevent the method call and populate the warning object as a result, not updating the GUI with the SCM results (not calling the SCM loader)

## Implications
:heavy_check_mark: Only users with rights to the key can perform SCM functions.
:heavy_check_mark: Users without key rights can edit/view/run jobs. (original issue)

## Exhibits
Admin:
![Screenshot from 2023-05-02 13-04-11](https://user-images.githubusercontent.com/81827734/235722016-4920375e-886b-4990-8ad2-0a216e75a95c.png)

Non-Admin:
![Screenshot from 2023-05-02 13-03-21](https://user-images.githubusercontent.com/81827734/235721917-86d504ad-2dfb-4032-877a-2072cf520b65.png)
