### PR TITLE
RSE-418 Fix: Expanded SCM Path Variables in MenuController

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3242,8 +3242,10 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                         // Validate of the user have rights to access the key
                         def userHasPathAccessToSshKey = storageService.hasPath(authContext, userExpandedSshKeyPath)
                         if( !userHasPathAccessToSshKey ){
-                            results.warning = "Failed to update SCM Import status; user don't have access rights to SCM's configured key."
-                            log.error("Failed to update SCM Import status; user don't have access rights to SCM's configured key.")
+                            def unauthorizedMessage = "[SCM disabled] User don't have permissions to the configuration key. Please refer to the system's SCM key owner or administrator for further actions."
+                            scmService.disablePlugin('import', params.project, scmService.loadScmConfig(params.project, 'import').type)
+                            pluginData.warning = unauthorizedMessage
+                            log.error(unauthorizedMessage)
                         }else{
                             pluginData.scmImportEnabled = scmService.loadScmConfig(params.project, 'import')?.enabled
                             if (pluginData.scmImportEnabled) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3253,9 +3253,9 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                 pluginData.scmImportJobStatus = scmService.importStatusForJobs(params.project, authContext, result.nextScheduled,false, jobsPluginMeta)
                                 pluginData.scmImportStatus = scmService.importPluginStatus(authContext, params.project)
                                 pluginData.scmImportActions = scmService.importPluginActions(authContext, params.project, pluginData.scmImportStatus)
-                                results.putAll(pluginData)
                             }
                         }
+                        results.putAll(pluginData)
                     }
                 } catch (ScmPluginException e) {
                     results.warning = "Failed to update SCM Import status: ${e.message}"

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3235,10 +3235,8 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                     if (scmService.projectHasConfiguredImportPlugin(params.project)) {
                         def userHasPathAccessToSshKey = storageService.hasPath(authContext, scmService.loadScmConfig(params.project, 'import')?.config?.sshPrivateKeyPath)
                         if( !userHasPathAccessToSshKey ){
-                            def unauthorizedMessage = "[SCM disabled] User don't have permissions to the configuration key. Please refer to the system's SCM key owner or administrator for further actions."
-                            scmService.disablePlugin('import', params.project, scmService.loadScmConfig(params.project, 'import').type)
-                            pluginData.warning = unauthorizedMessage
-                            log.error(unauthorizedMessage)
+                            results.warning = "Failed to update SCM Import status; user don't have access rights to SCM's configured key."
+                            log.error("Failed to update SCM Import status; user don't have access rights to SCM's configured key.")
                         }else{
                             pluginData.scmImportEnabled = scmService.loadScmConfig(params.project, 'import')?.enabled
                             if (pluginData.scmImportEnabled) {
@@ -3246,11 +3244,10 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                                 pluginData.scmImportJobStatus = scmService.importStatusForJobs(params.project, authContext, result.nextScheduled,false, jobsPluginMeta)
                                 pluginData.scmImportStatus = scmService.importPluginStatus(authContext, params.project)
                                 pluginData.scmImportActions = scmService.importPluginActions(authContext, params.project, pluginData.scmImportStatus)
+                                results.putAll(pluginData)
                             }
                         }
-                        results.putAll(pluginData)
                     }
-
                 } catch (ScmPluginException e) {
                     results.warning = "Failed to update SCM Import status: ${e.message}"
                 }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3233,7 +3233,14 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 def pluginData = [:]
                 try {
                     if (scmService.projectHasConfiguredImportPlugin(params.project)) {
-                        def userHasPathAccessToSshKey = storageService.hasPath(authContext, scmService.loadScmConfig(params.project, 'import')?.config?.sshPrivateKeyPath)
+                        // Extracts the context of the scm operations
+                        def scmOperationContext = scmService.scmOperationContext(authContext.username, authContext.getRoles().toList(), params.project)
+                        // Extracts the user's configured key (with variables or without them)
+                        def userSshKeyPath = scmService.loadScmConfig(params.project, 'import')?.config?.sshPrivateKeyPath
+                        // Merges the context and the path to extand variables if there are any
+                        def userExpandedSshKeyPath = scmService.expandVariablesInScmConfiguredPath(scmOperationContext, userSshKeyPath)
+                        // Validate of the user have rights to access the key
+                        def userHasPathAccessToSshKey = storageService.hasPath(authContext, userExpandedSshKeyPath)
                         if( !userHasPathAccessToSshKey ){
                             results.warning = "Failed to update SCM Import status; user don't have access rights to SCM's configured key."
                             log.error("Failed to update SCM Import status; user don't have access rights to SCM's configured key.")

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1617,6 +1617,9 @@ class ScmService {
      * @return
      */
     def expandVariablesInScmConfiguredPath(ScmOperationContext context, String path) {
+        if( !context.userInfo.userName ){
+            return path
+        }
         expand(expand(path, context.userInfo), [project: context.frameworkProject])
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1611,7 +1611,6 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         where:
             enabled | count
             true    | 1
-            false   | 0
     }
 
     def "SCM NOT disabled when an unauthorized user request status and import is enabled"(){

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1574,6 +1574,10 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         controller.storageService = Mock(StorageService)
         def project = 'test'
         def scmConfig = Mock(ScmPluginConfigData)
+        def userAndRolesAuthContext = Mock(UserAndRolesAuthContext){
+            it.getRoles() >> new HashSet<String>(Arrays.asList("role1", "role2"))
+            it.username >> 'test'
+        }
 
         when:
         request.method = 'POST'
@@ -1594,6 +1598,7 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN,
                                                                                AuthConstants.ACTION_IMPORT,
                                                                                 AuthConstants.ACTION_SCM_IMPORT]) >> true
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_) >> userAndRolesAuthContext
         1 * controller.scmService.projectHasConfiguredExportPlugin(project) >> false
         1 * controller.scmService.projectHasConfiguredImportPlugin(project) >> true
         2 * controller.scmService.loadScmConfig(project,'import') >> scmConfig
@@ -1614,52 +1619,6 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         where:
             enabled | count
             true    | 1
-    }
-
-    def "SCM NOT disabled when an unauthorized user request status and import is enabled"(){
-        given:
-        controller.frameworkService = Mock(FrameworkService){
-            isClusterModeEnabled() >> true
-        }
-        controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)
-        controller.aclFileManagerService = Mock(AclFileManagerService)
-        controller.scheduledExecutionService = Mock(ScheduledExecutionService)
-        controller.scmService = Mock(ScmService)
-        controller.storageService = Mock(StorageService) {
-            it.hasPath() >> false
-        }
-        def project = 'test'
-        def scmConfig = Mock(ScmPluginConfigData)
-
-        when:
-        request.method = 'POST'
-        request.JSON = []
-        request.format = 'json'
-        params.project = project
-        controller.listExport()
-
-        then:
-        1 * controller.scheduledExecutionService.listWorkflows(_,_) >> [schedlist : []]
-        1 * controller.scheduledExecutionService.finishquery(_,_,_) >> [max: 20,
-                                                                        offset:0,
-                                                                        paginateParams:[:],
-                                                                        displayParams:[:]]
-        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN,
-                                                                                          AuthConstants.ACTION_EXPORT,
-                                                                                          AuthConstants.ACTION_SCM_EXPORT]) >> true
-        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN,
-                                                                                          AuthConstants.ACTION_IMPORT,
-                                                                                          AuthConstants.ACTION_SCM_IMPORT]) >> true
-        1 * controller.scmService.projectHasConfiguredExportPlugin(project) >> false
-        1 * controller.scmService.projectHasConfiguredImportPlugin(project) >> true
-        1 * controller.scmService.loadScmConfig(project,'import') >> scmConfig
-        1 * controller.storageService.hasPath(_,_) >> false
-        0 * controller.scmService.initProject(project,'export')
-        0 * controller.scmService.initProject(project,'import')
-
-        0 * controller.scmService.disablePlugin(_,_,_)
-        response.json.warning !== null
-
     }
 
     def "Expanded path variable in SCM ssh key"(){

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1614,9 +1614,8 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
             false   | 0
     }
 
-    def "SCM disabled when an unauthorized user request status and import is enabled"(){
+    def "SCM NOT disabled when an unauthorized user request status and import is enabled"(){
         given:
-        def unauthorizedMessage = "[SCM disabled] User don't have permissions to the configuration key. Please refer to the system's SCM key owner or administrator for further actions."
         controller.frameworkService = Mock(FrameworkService){
             isClusterModeEnabled() >> true
         }
@@ -1651,13 +1650,13 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
                                                                                           AuthConstants.ACTION_SCM_IMPORT]) >> true
         1 * controller.scmService.projectHasConfiguredExportPlugin(project) >> false
         1 * controller.scmService.projectHasConfiguredImportPlugin(project) >> true
-        2 * controller.scmService.loadScmConfig(project,'import') >> scmConfig
+        1 * controller.scmService.loadScmConfig(project,'import') >> scmConfig
         1 * controller.storageService.hasPath(_,_) >> false
         0 * controller.scmService.initProject(project,'export')
         0 * controller.scmService.initProject(project,'import')
 
-        1 * controller.scmService.disablePlugin(_,_,_)
-        response.json.warning == unauthorizedMessage
+        0 * controller.scmService.disablePlugin(_,_,_)
+        response.json.warning !== null
 
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1699,16 +1699,15 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         def scmUserInfo = Mock(ScmUserInfo){
             it.getUserName() >> 'test'
         }
-        def scmOperationContext = ScmOperationContextBuilder.builder()
-                .frameworkProject(project)
-                .userInfo(scmUserInfo)
-                .build()
+        def scmOperationContext = Mock(ScmOperationContext){
+            it.getUserInfo() >> scmUserInfo
+        }
         def scmService = Mock(ScmService){
-            it.scmOperationContext(_,_,_) >> scmOperationContext
+            it.scmOperationContext(_,_,project) >> scmOperationContext
             it.projectHasConfiguredExportPlugin(project) >> false
             it.projectHasConfiguredImportPlugin(project) >> true
             it.loadScmConfig(_,_) >> scmConfig
-//            it.expandVariablesInScmConfiguredPath(_,_) >> 'keys/test/testKey.key'
+            it.expandVariablesInScmConfiguredPath(_,_) >> 'keys/test/testKey.key'
         }
         controller.scmService = scmService
 
@@ -1720,7 +1719,7 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         controller.listExport()
 
         then:
-        response.json == 'hey'
+        1 * controller.scmService.expandVariablesInScmConfiguredPath(_,_)
 
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -34,9 +34,7 @@ import com.dtolabs.rundeck.core.authorization.providers.Policy
 import com.dtolabs.rundeck.core.authorization.providers.PolicyCollection
 import com.dtolabs.rundeck.core.authorization.providers.Validator
 import com.dtolabs.rundeck.core.common.IFramework
-import com.dtolabs.rundeck.core.storage.StorageTree
 import com.dtolabs.rundeck.plugins.scm.ScmOperationContext
-import com.dtolabs.rundeck.plugins.scm.ScmOperationContextBuilder
 import com.dtolabs.rundeck.plugins.scm.ScmUserInfo
 import com.dtolabs.rundeck.server.AuthContextEvaluatorCacheManager
 import grails.test.hibernate.HibernateSpec


### PR DESCRIPTION
# RSE-418 Fix: Expanded SCM Path Variables in MenuController
If the user has variables to be expanded in the ssh key path configured for the plugin, [this](https://github.com/rundeck/rundeck/pull/8295/files) validation doesn't detect the variables.

# The Problem
No variables expansion in MenuController before the validation to load the plugin or not.

# The Fix
Building context and expanding variables before the access rights validation.

## Implications
[this](https://github.com/rundeck/rundeck/pull/8295) have to be merged first.