### PR TITLE
RUN-1709: Sets SameSite cookie policy to Lax as default to allow OAuth2 SSO flows

### DIFF
--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -335,7 +335,7 @@ server:
             persistent: false
             cookie:
                 http-only: true
-                same-site: "Strict"
+                same-site: "Lax"
             tracking-modes: 'cookie'
 rundeck:
     web:


### PR DESCRIPTION
Sets SameSite cookie policy to Lax as default to allow correct OAuth2 SSO flows