### PR TITLE
RSE-415: Java11 compatibility core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,10 +298,10 @@ commands:
       - run:
           name: Install Java
           command: |
-            sudo add-apt-repository -y ppa:openjdk-r/ppa  
-            sudo apt-get update 
-            sudo apt-get install -y openjdk-8-jdk
-            sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+            sudo apt-get update
+            sudo apt-get install -y openjdk-11-jdk
+            sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+            export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
             sudo apt-get install -y groovy
 
 jobs:
@@ -318,6 +318,7 @@ jobs:
       - checkout
       - install-node
       - restore-gradle-cache
+      - install-java
       - run:
           name: Build
           command: |

--- a/build.gradle
+++ b/build.gradle
@@ -145,6 +145,7 @@ subprojects {
     // set the eclipse project naming convention to rundeck:<path>:<projectName>
     // so it matches the logical hierarchy more closely
     apply plugin: 'eclipse'
+    apply from: "${rootDir}/gradle/java-version.gradle"
     eclipse.project.name = "${project.getParent().eclipse.project.name}:${name}"
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -36,6 +36,9 @@ description = 'The Rundeck Core API project'
 archivesBaseName = 'rundeck-core'
 defaultTasks 'clean'
 apply plugin: "groovy"
+
+apply from: "../gradle/java-version.gradle"
+
 configurations {
      provided
 }
@@ -98,8 +101,8 @@ dependencies {
 
     implementation ("org.apache.httpcomponents:httpcore:4.4.16")
 
-    compileOnly "org.projectlombok:lombok:1.18.20"
-    annotationProcessor "org.projectlombok:lombok:1.18.20"
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     testImplementation 'junit:junit:4.8.1',
         'org.mockito:mockito-all:1.10.19'
 

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/JobOptionImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/JobOptionImpl.java
@@ -42,7 +42,7 @@ public class JobOptionImpl implements JobOption, Comparable {
     @Builder.Default
     private Boolean secureExposed = false;
     private String optionType;
-    @Builder.Default
+
     private JobOptionConfigData configData;
     @Builder.Default
     private Boolean multivalueAllSelected = false;
@@ -100,7 +100,7 @@ public class JobOptionImpl implements JobOption, Comparable {
             }else{
                 builder.valuesListDelimiter = DEFAULT_DELIMITER;
             }
-            builder.valuesList = produceValuesList(builder);
+            builder.valuesList = produceValuesList(builder.build());
             builder.values = null;
         }
         if(option.containsKey("multivalued")){
@@ -133,14 +133,14 @@ public class JobOptionImpl implements JobOption, Comparable {
     }
 
 
-    static private String produceValuesList(JobOptionImplBuilder builder) {
-        if (builder.values != null) {
-            if (builder.valuesListDelimiter == null) {
-                builder.valuesListDelimiter = DEFAULT_DELIMITER;
+    static private String produceValuesList(JobOptionImpl jobOption) {
+        if (jobOption.values != null) {
+            if (jobOption.valuesListDelimiter == null) {
+                jobOption.valuesListDelimiter = DEFAULT_DELIMITER;
             }
-            builder.valuesList = String.join(builder.valuesListDelimiter, builder.values);
-            builder.values = null;
-            return builder.valuesList;
+            jobOption.valuesList = String.join(jobOption.valuesListDelimiter, jobOption.values);
+            jobOption.values = null;
+            return jobOption.valuesList;
         }else{
             return "";
         }

--- a/examples/example-java-execution-lifecyle-plugin/build.gradle
+++ b/examples/example-java-execution-lifecyle-plugin/build.gradle
@@ -3,6 +3,7 @@ defaultTasks 'clean', 'build'
 apply plugin: 'java'
 apply plugin: 'idea'
 sourceCompatibility = 1.8
+targetCompatibility = 1.8
 ext.rundeckPluginVersion = '1.2'
 
 

--- a/examples/example-java-job-lifecycle-plugin/build.gradle
+++ b/examples/example-java-job-lifecycle-plugin/build.gradle
@@ -3,6 +3,7 @@ defaultTasks 'clean','build'
 apply plugin: 'java'
 apply plugin: 'idea'
 sourceCompatibility = 1.8
+targetCompatibility = 1.8
 ext.rundeckPluginVersion= '1.2'
 
 

--- a/examples/example-java-logging-plugins/build.gradle
+++ b/examples/example-java-logging-plugins/build.gradle
@@ -2,7 +2,8 @@ version = '2.0.0-SNAPSHOT'
 defaultTasks 'clean','build'
 apply plugin: 'java'
 apply plugin: 'idea'
-sourceCompatibility = 1.5
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 ext.rundeckPluginVersion= '1.1'
 
 

--- a/examples/example-java-nodeexecutor-plugin/build.gradle
+++ b/examples/example-java-nodeexecutor-plugin/build.gradle
@@ -2,7 +2,8 @@ version = '2.0.2'
 defaultTasks 'clean','build'
 apply plugin: 'java'
 apply plugin: 'idea'
-sourceCompatibility = 1.5
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 ext.rundeckPluginVersion= '1.1'
 
 

--- a/examples/example-java-notification-plugin/build.gradle
+++ b/examples/example-java-notification-plugin/build.gradle
@@ -4,10 +4,9 @@ apply plugin: 'java-library'
 apply plugin: 'idea'
 ext.rundeckPluginVersion= '1.2'
 
-java{
-    sourceCompatibility='VERSION_1_8'
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
-}
 repositories {
     mavenLocal()
     mavenCentral()

--- a/examples/example-java-step-plugin/build.gradle
+++ b/examples/example-java-step-plugin/build.gradle
@@ -2,7 +2,8 @@ version = '1.5.3-SNAPSHOT'
 defaultTasks 'clean','build'
 apply plugin: 'java'
 apply plugin: 'idea'
-sourceCompatibility = 1.5
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 ext.rundeckPluginVersion= '1.1'
 
 

--- a/examples/example-java-storage-converter-plugin/build.gradle
+++ b/examples/example-java-storage-converter-plugin/build.gradle
@@ -2,7 +2,8 @@ version = '2.1.0-SNAPSHOT'
 defaultTasks 'clean','build'
 apply plugin: 'java'
 apply plugin: 'idea'
-sourceCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 ext.rundeckPluginVersion= '1.1'
 
 

--- a/examples/example-java-storage-plugin/build.gradle
+++ b/examples/example-java-storage-plugin/build.gradle
@@ -2,7 +2,8 @@ version = '2.0.3-SNAPSHOT'
 defaultTasks 'clean','build'
 apply plugin: 'java'
 apply plugin: 'idea'
-sourceCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 ext.rundeckPluginVersion= '1.1'
 
 

--- a/examples/json-plugin/build.gradle
+++ b/examples/json-plugin/build.gradle
@@ -2,7 +2,8 @@ version = '1.5-dev'
 defaultTasks 'clean','build'
 apply plugin: 'java'
 apply plugin: 'idea'
-sourceCompatibility = 1.5
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 archivesBaseName = "rundeck-$project.name"
 rundeckPluginVersion= '1.1'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,3 +55,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1024M
 rundeckProBuild=false
+lombokVersion=1.18.20

--- a/gradle/java-version.gradle
+++ b/gradle/java-version.gradle
@@ -1,0 +1,3 @@
+apply plugin: 'java'
+sourceCompatibility = 1.8
+targetCompatibility = 1.8

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -5,10 +5,7 @@ import org.gradle.plugins.signing.Sign
 apply plugin: 'java';
 apply plugin: 'eclipse';
 apply plugin: 'idea';
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
+apply plugin: 'idea';
 
 repositories {
     mavenLocal()

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -5,7 +5,6 @@ import org.gradle.plugins.signing.Sign
 apply plugin: 'java';
 apply plugin: 'eclipse';
 apply plugin: 'idea';
-apply plugin: 'idea';
 
 repositories {
     mavenLocal()

--- a/grails-execution-mode-timer/build.gradle
+++ b/grails-execution-mode-timer/build.gradle
@@ -40,6 +40,7 @@ configurations{
     provided
 }
 
+apply from: "../gradle/java-version.gradle"
 
 dependencies {
 

--- a/grails-metricsweb/build.gradle
+++ b/grails-metricsweb/build.gradle
@@ -17,6 +17,8 @@ apply plugin: "org.grails.grails-plugin"
 apply plugin: "org.grails.grails-gsp"
 apply plugin: "java-library"
 
+apply from: "../gradle/java-version.gradle"
+
 repositories {
     mavenLocal()
     maven { url "https://repo.grails.org/grails/core" }

--- a/grails-persistlocale/build.gradle
+++ b/grails-persistlocale/build.gradle
@@ -15,6 +15,8 @@ apply plugin:"idea"
 apply plugin:"org.grails.grails-plugin"
 apply plugin:"org.grails.grails-gsp"
 
+apply from: "../gradle/java-version.gradle"
+
 repositories {
     mavenLocal()
     maven { url "https://repo.grails.org/grails/core" }

--- a/grails-repository/build.gradle
+++ b/grails-repository/build.gradle
@@ -16,6 +16,8 @@ apply plugin:"org.grails.grails-plugin"
 apply plugin:"org.grails.grails-gsp"
 apply plugin: "java-library"
 
+apply from: "../gradle/java-version.gradle"
+
 repositories {
     mavenLocal()
     maven { url "https://repo.grails.org/grails/core" }

--- a/grails-rundeck-data-shared/build.gradle
+++ b/grails-rundeck-data-shared/build.gradle
@@ -26,6 +26,8 @@ configurations {
     }
 }
 
+apply from: "../gradle/java-version.gradle"
+
 dependencies {
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     implementation "org.springframework.boot:spring-boot-starter-log4j2"

--- a/grails-securityheaders/build.gradle
+++ b/grails-securityheaders/build.gradle
@@ -15,6 +15,8 @@ apply plugin:"idea"
 apply plugin:"org.grails.grails-plugin"
 apply plugin:"org.grails.grails-gsp"
 
+apply from: "../gradle/java-version.gradle"
+
 repositories {
     mavenLocal()
     maven { url "https://repo.grails.org/grails/core" }

--- a/grails-webhooks/build.gradle
+++ b/grails-webhooks/build.gradle
@@ -31,6 +31,8 @@ configurations {
     }
 }
 
+apply from: "../gradle/java-version.gradle"
+
 dependencies {
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     implementation "org.springframework.boot:spring-boot-starter-log4j2"

--- a/grails-webhooks/src/test/groovy/webhooks/WebhookControllerSpec.groovy
+++ b/grails-webhooks/src/test/groovy/webhooks/WebhookControllerSpec.groovy
@@ -30,7 +30,6 @@ import org.rundeck.storage.api.Resource
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import javax.rmi.CORBA.Stub
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 

--- a/plugins/audit-logging-plugin/build.gradle
+++ b/plugins/audit-logging-plugin/build.gradle
@@ -19,6 +19,9 @@ ext.pluginName = 'Audit Logger plugin'
 ext.pluginDescription = 'Write audit events to the service log'
 
 apply plugin: "groovy"
+
+apply from: "../../gradle/java-version.gradle"
+
 configurations{
     pluginLibs
 

--- a/plugins/azure-object-store-plugin/build.gradle
+++ b/plugins/azure-object-store-plugin/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'groovy'
 }
 
+apply from: "../../gradle/java-version.gradle"
+
 ext.pluginClassNames='org.rundeck.plugin.azureobjectstore.AzureObjectStorePlugin'
 ext.pluginName = 'Azure Object Store Plugin'
 ext.pluginDescription = 'Stores data in an Azure Storage compliant object store'

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -26,6 +26,7 @@ ext.rundeckPluginVersion= '1.2'
 subprojects{
 
     apply from: "${projectDir}/../../gradle/java.gradle"
+    apply from: "../../gradle/java-version.gradle"
 
     defaultTasks 'clean','build'
     archivesBaseName = "rundeck-$project.name"

--- a/plugins/copyfile-plugin/build.gradle
+++ b/plugins/copyfile-plugin/build.gradle
@@ -23,6 +23,8 @@ ext.pluginName = 'Copy File Step'
 ext.pluginDescription = 'Copy a file to a destination on a remote node.'
 apply plugin: "groovy"
 
+apply from: "../../gradle/java-version.gradle"
+
 jar {
     manifest {
         attributes 'Rundeck-Plugin-Classnames': pluginClassNames

--- a/plugins/flow-control-plugin/build.gradle
+++ b/plugins/flow-control-plugin/build.gradle
@@ -23,6 +23,8 @@ ext.pluginName = 'Flow Control'
 ext.pluginDescription = 'Control execution flow'
 apply plugin: "groovy"
 
+apply from: "../../gradle/java-version.gradle"
+
 jar {
     manifest {
         attributes 'Rundeck-Plugin-Classnames': pluginClassNames

--- a/plugins/git-plugin/build.gradle
+++ b/plugins/git-plugin/build.gradle
@@ -19,6 +19,9 @@ ext.pluginName = 'Git Plugin'
 ext.pluginDescription = 'Export and Import Jobs with a Git repository'
 
 apply plugin: "groovy"
+
+apply from: "../../gradle/java-version.gradle"
+
 configurations{
     pluginLibs
 

--- a/plugins/jasypt-encryption-plugin/build.gradle
+++ b/plugins/jasypt-encryption-plugin/build.gradle
@@ -30,6 +30,9 @@ configurations{
         extendsFrom pluginLibs
     }
 }
+
+apply from: "../../gradle/java-version.gradle"
+
 repositories {
     mavenLocal()
     maven{ //snapshot dependency

--- a/plugins/job-state-plugin/build.gradle
+++ b/plugins/job-state-plugin/build.gradle
@@ -22,6 +22,9 @@ ext.pluginClassNames = 'org.rundeck.plugin.jobstate.JobStateWorkflowStep'
 ext.pluginName = 'Job State Conditional'
 ext.pluginDescription = 'Evaluate state of another Job'
 apply plugin: 'groovy'
+
+apply from: "../../gradle/java-version.gradle"
+
 dependencies{
 
     testImplementation 'junit:junit:4.8.1',

--- a/plugins/localexec-plugin/build.gradle
+++ b/plugins/localexec-plugin/build.gradle
@@ -31,6 +31,8 @@ apply plugin: 'idea'
 // apply plugin: 'maven'
 apply plugin: 'groovy'
 
+apply from: "../../gradle/java-version.gradle"
+
 dependencies {
 	implementation project(":core")
 

--- a/plugins/object-store-plugin/build.gradle
+++ b/plugins/object-store-plugin/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'groovy'
 }
 
+apply from: "../../gradle/java-version.gradle"
+
 ext.pluginClassNames='org.rundeck.plugin.objectstore.ObjectStorePlugin'
 ext.pluginName = 'Object Store Plugin'
 ext.pluginDescription = 'Stores data in an Amazon S3 compliant object store'

--- a/plugins/orchestrator-plugin/build.gradle
+++ b/plugins/orchestrator-plugin/build.gradle
@@ -18,6 +18,8 @@ ext.pluginClassNames='org.rundeck.plugin.example.MaxPercentageOrchestatorPlugin,
 ext.pluginName = 'Orchestrator Plugin'
 ext.pluginDescription = 'Utility Orchestrator plugins'
 
+apply from: "../../gradle/java-version.gradle"
+
 repositories {
     mavenLocal()
     maven{ //snapshot dependency

--- a/plugins/script-plugin/build.gradle
+++ b/plugins/script-plugin/build.gradle
@@ -22,6 +22,8 @@ ext.pluginClassNames = 'com.dtolabs.rundeck.plugin.script.ScriptFileCopier,com.d
 ext.pluginName = 'Script Execution'
 ext.pluginDescription = 'Delegate command and script execution to another external script'
 
+apply from: "../../gradle/java-version.gradle"
+
 jar {
     manifest {
         attributes 'Rundeck-Plugin-Classnames': pluginClassNames

--- a/plugins/source-refresh-plugin/build.gradle
+++ b/plugins/source-refresh-plugin/build.gradle
@@ -18,6 +18,8 @@ ext.pluginClassNames = 'org.rundeck.plugin.nodes.NodeRefreshWorkflowStep'
 ext.pluginName = 'Node Refresh Plugin'
 ext.pluginDescription = 'Force refresh node list'
 
+apply from: "../../gradle/java-version.gradle"
+
 jar {
     manifest {
         attributes 'Rundeck-Plugin-Classnames': pluginClassNames

--- a/plugins/stub-plugin/build.gradle
+++ b/plugins/stub-plugin/build.gradle
@@ -22,6 +22,8 @@ ext.pluginClassNames = 'com.dtolabs.rundeck.plugin.stub.LogDataStep,com.dtolabs.
 ext.pluginName = 'Stub Execution'
 ext.pluginDescription = 'Mock execution of commands and scripts'
 
+apply from: "../../gradle/java-version.gradle"
+
 jar {
     manifest {
         attributes 'Rundeck-Plugin-Classnames': pluginClassNames

--- a/plugins/upvar-plugin/build.gradle
+++ b/plugins/upvar-plugin/build.gradle
@@ -20,6 +20,7 @@ ext.pluginDescription = 'Uplift variables to global'
 
 apply plugin: 'groovy'
 
+apply from: "../../gradle/java-version.gradle"
 
 dependencies {
 

--- a/rundeck-app-util/build.gradle
+++ b/rundeck-app-util/build.gradle
@@ -3,6 +3,9 @@ apply plugin: "java-library"
 repositories {
     mavenCentral()
 }
+
+apply from: "../gradle/java-version.gradle"
+
 dependencies {
     api project(':core')
     api project(':rundeck-data-model')
@@ -10,8 +13,8 @@ dependencies {
     testImplementation "org.spockframework:spock-core:2.0-groovy-3.0"
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 
-    compileOnly "org.projectlombok:lombok:1.18.24"
-    annotationProcessor "org.projectlombok:lombok:1.18.24"
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 }
 
 ext.description = "Rundeck project ${project.name}"

--- a/rundeck-authz/rundeck-authz-api/build.gradle
+++ b/rundeck-authz/rundeck-authz-api/build.gradle
@@ -1,11 +1,13 @@
 apply plugin: "groovy"
 
+apply from: "../../gradle/java-version.gradle"
+
 dependencies {
     testImplementation "org.codehaus.groovy:groovy-all:${groovyVersion}"
     testImplementation "org.spockframework:spock-core:2.0-groovy-3.0"
 
-    compileOnly "org.projectlombok:lombok:1.18.20"
-    annotationProcessor "org.projectlombok:lombok:1.18.20"
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
 }
 

--- a/rundeck-authz/rundeck-authz-core/build.gradle
+++ b/rundeck-authz/rundeck-authz-core/build.gradle
@@ -1,12 +1,14 @@
 apply plugin: "groovy"
 
+apply from: "../../gradle/java-version.gradle"
+
 dependencies {
     testImplementation "org.codehaus.groovy:groovy-all:${groovyVersion}"
     testImplementation "org.spockframework:spock-core:2.0-groovy-3.0"
     implementation project(':rundeck-authz:rundeck-authz-api')
 
-    compileOnly "org.projectlombok:lombok:1.18.20"
-    annotationProcessor "org.projectlombok:lombok:1.18.20"
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 }
 
 ext.description= "Rundeck project ${project.name}"

--- a/rundeck-authz/rundeck-authz-yaml/build.gradle
+++ b/rundeck-authz/rundeck-authz-yaml/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: "groovy"
 
+apply from: "../../gradle/java-version.gradle"
+
 dependencies {
     testImplementation "org.codehaus.groovy:groovy-all:${groovyVersion}"
     testImplementation "org.spockframework:spock-core:2.0-groovy-3.0"

--- a/rundeck-data-model/build.gradle
+++ b/rundeck-data-model/build.gradle
@@ -3,6 +3,9 @@ apply plugin: "java-library"
 repositories {
     mavenCentral()
 }
+
+apply from: "../gradle/java-version.gradle"
+
 dependencies {
     api project(":rundeck-storage:rundeck-storage-api")
     api 'commons-codec:commons-codec:1.15'
@@ -14,8 +17,8 @@ dependencies {
     testImplementation "org.spockframework:spock-core:2.0-groovy-3.0"
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 
-    compileOnly "org.projectlombok:lombok:1.18.20"
-    annotationProcessor "org.projectlombok:lombok:1.18.20"
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 }
 
 ext.description = "Rundeck project ${project.name}"

--- a/rundeck-storage/build.gradle
+++ b/rundeck-storage/build.gradle
@@ -26,6 +26,8 @@ buildscript {
 subprojects {
     apply plugin: "groovy"
 
+    apply from: "../../gradle/java-version.gradle"
+
     repositories {
         mavenCentral()
     }

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -602,6 +602,7 @@ publishing {
 }
 
 apply from: "${rootDir}/gradle/java.gradle"
+apply from: "../gradle/java-version.gradle"
 
 
 if (project.hasProperty('signing.keyId') && project.hasProperty('signing.password')) {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectController2Spec.groovy
@@ -314,14 +314,14 @@ class ProjectController2Spec extends Specification implements ControllerUnitTest
     @Unroll
     def "renderApiProjectXml hasConfig #hasConfig vers #vers"() {
         given:
-            Properties projProps = new Properties(
+            Map projProps =
                 [
                     'project.description': 'a description',
                     'project.label'      : 'a label',
                     "test.property"      : "value1",
                     "test.property2"     : "value2"
                 ]
-            )
+
             def configDate = new Date()
             def rdProject = Mock(IRundeckProject) {
                 _ * getName() >> 'test1'
@@ -353,10 +353,10 @@ class ProjectController2Spec extends Specification implements ControllerUnitTest
 
             (seeConfig?4:0)== response.config.property.size()
 
-            response.config.property[0].'@key'.text() == (seeConfig?'test.property':'')
-            response.config.property[0].'@value'.text() == (seeConfig?'value1':'')
-            response.config.property[1].'@key'.text() == (seeConfig?'test.property2':'')
-            response.config.property[1].'@value'.text() == (seeConfig?'value2':'')
+            response.config.property[2].'@key'.text() == (seeConfig?'test.property':'')
+            response.config.property[2].'@value'.text() == (seeConfig?'value1':'')
+            response.config.property[3].'@key'.text() == (seeConfig?'test.property2':'')
+            response.config.property[3].'@value'.text() == (seeConfig?'value2':'')
 
             response.label.size()==seeLabel
 


### PR DESCRIPTION
Adds jdk11 compatibility to build and run (still retro compatible with jdk8 for build and run)

Necessary changes made:

1. Explicit source and target compatibility
2. Very minor dependency version changed
3. Circleci config changes to use jdk 11