### PR TITLE
RUN-1727: Correct loading indicator text

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageView.vue
@@ -62,7 +62,7 @@
 
       <div class="loading-area text-info " v-if="loading" style="width: 100%; height: 200px; padding: 50px; background-color: #eee;">
         <i class="glyphicon glyphicon-time"></i>
-        {{$t('loading.text')}}
+        {{ "Loading..." }}
       </div>
       <table class="table table-hover table-condensed" v-else>
         <tbody>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Bugfix. Use String literal `Loading...` to replace the malfunction i18n translation. This is a temporary fix, we should implement a i18n solution to fully translate the component.