### PR TITLE
RSE-331: Fix: "Active Connection is required" errors when using s3 log storage

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -290,7 +290,7 @@ class LogFileStorageService
         failedRequests.remove(requestId)
         failures.remove(requestId)
         long retryMax = 30000;
-        LogFileStorageRequest.withNewSession {
+        LogFileStorageRequest.withNewTransaction {
 
             Execution execution = Execution.get(execId)
             def files = getExecutionFiles(execution, typelist, false)


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-331

#### Problem 
_Steps to Reproduce_
Steps to reproduce the behavior:

1- Install rundeck 4.8/4.9 on a cluster mode

2- Add the cluster on an rds mariadb database.

3- Add this remote execution policy 
```
# Forward jobs to other active cluster members automatically
rundeck.clusterMode.remoteExecution.policy=RoundRobin
rundeck.clusterMode.remoteExecution.config.activeOnly=true

# Define additional remote execution profiles
rundeck.clusterMode.remoteExecution.profiles=P1,P2

# Create a profile for running jobs on us-west-2 node only
rundeck.clusterMode.remoteExecution.profile.P1.policy=Preset
rundeck.clusterMode.remoteExecution.profile.P1.config.uuid=ffffccff-c818-456d-87ce-763c499ec196
rundeck.clusterMode.remoteExecution.profile.P1.config.activeOnly=true
rundeck.clusterMode.remoteExecution.profile.P1.projects=P1-only

# Create a profile for running jobs on us-east-2 node only
rundeck.clusterMode.remoteExecution.profile.P2.policy=Preset
rundeck.clusterMode.remoteExecution.profile.P2.config.uuid=aaaa0d78-6e77-4318-82e3-d7e1e5296909
rundeck.clusterMode.remoteExecution.profile.P2.config.activeOnly=true
rundeck.clusterMode.remoteExecution.profile.P2.projects=P2-only
```

4- Create three projects that will depend on the remote execution policy settings. 

5- Add these settings in order to use s3 for the logs
```
rundeck.execution.logs.fileStoragePlugin=com.rundeck.rundeckpro.amazon-s3
rundeck.execution.logs.fileStorage.checkpoint.time.interval=1
rundeck.execution.logs.fileStorage.checkpoint.time.minimum=1
rundeck.execution.logs.fileStorage.checkpoint.fileSize.minimum=0
rundeck.execution.logs.fileStorage.checkpoint.fileSize.increment=0

# additional lines
rundeck.execution.logs.fileStorage.storageRetryCount=20
rundeck.execution.logs.fileStorage.storageRetryDelay=5
rundeck.execution.logs.fileStorage.retrievalRetryDelay=5
rundeck.execution.logs.fileStorage.retrievalRetryCount=20
rundeck.execution.logs.fileStorage.remotePendingDelay=5
rundeck.execution.logs.fileStorage.retrievalTasks.concurrencyLimit=20
rundeck.execution.logs.fileStorage.storageTasks.concurrencyLimit=20
```

6- Run the jobs manually and scheduled

7- See Error
```
[2023-02-07T00:42:11,395] ERROR services.LogFileStorageService - Storage request [ID#38469:*] FAILED 20 attempts, cancelling
Exception in thread "LogFileStorageTask45" java.lang.IllegalArgumentException: Active Connection is required
        at org.springframework.util.Assert.notNull(Assert.java:201)
        at org.springframework.jdbc.datasource.ConnectionHolder.getConnection(ConnectionHolder.java:160)
```

#### Solution
Make `LogFileStorage.runStorageRequest()` not transactional to avoid `Active Connection is required` spring issue