### PR TITLE
RSE-326: Fix: Error responses including stacktraces

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -395,7 +395,7 @@ public class RundeckConfigBase {
         Enabled pluginGroups = new Enabled(true);
         Enabled vueKeyStorage = new Enabled(true);
         Enabled legacyUi = new Enabled(false);
-
+        Debug debug = new Debug();
 
 
         @Data
@@ -408,6 +408,11 @@ public class RundeckConfigBase {
         @Data
         public static class RepositoryInstalledPlugins {
             String storageTreePath;
+        }
+
+        @Data
+        public static class Debug {
+            Boolean showTracesOnResponse = false;
         }
     }
 

--- a/docker/official/remco/templates/rundeck-config-features.properties
+++ b/docker/official/remco/templates/rundeck-config-features.properties
@@ -19,3 +19,7 @@ rundeck.feature.{{ getv(name, c) }}.defaultEnabled={{ getv(defaultEnabled) }}
     {% set name = printf("/rundeck/features/%s/name", c) -%}
 rundeck.features.{{ getv(name, c) }}.enabled={{ getv(enabled, "false") }}
 {% endfor %}
+
+{% if exists("/rundeck/feature/debug/showTracesOnResponse") %}
+rundeck.feature.debug.showTracesOnResponse = {{ getv("/rundeck/feature/debug/showTracesOnResponse") }}
+{% endif %}

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/InternalErrorsInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/InternalErrorsInterceptor.groovy
@@ -1,0 +1,47 @@
+package rundeck.interceptors
+
+import groovy.transform.CompileStatic
+import org.apache.http.HttpStatus
+
+import javax.servlet.http.HttpServletRequest
+
+/**
+ * Intercept all responses with 5xx status and removes stacktrace data
+ */
+@CompileStatic
+class InternalErrorsInterceptor {
+    private static final String SHOW_TRACES_DEBUG_PROP_NAME = 'rundeck.feature.debug.showTracesOnResponse'
+    private static final String[] EXCEPT_ATTR_NAMES = ['javax.servlet.error.exception', 'exception']
+    int order = HIGHEST_PRECEDENCE + 600
+
+    InternalErrorsInterceptor() {
+        matchAll().excludes {
+            grailsApplication.config.getProperty(SHOW_TRACES_DEBUG_PROP_NAME, 'false') == 'true' ||
+            response == null ||
+            response.getStatus() < HttpStatus.SC_INTERNAL_SERVER_ERROR
+        }
+    }
+
+    boolean after() {
+        HttpServletRequest requestForRendering = request
+
+        for(String exceptionAttrName: EXCEPT_ATTR_NAMES){
+            Throwable serverException = (requestForRendering.getAttribute(exceptionAttrName) as Throwable)
+            if(serverException) {
+                requestForRendering.removeAttribute(exceptionAttrName)
+                cleanStackTraces(serverException)
+                requestForRendering.setAttribute(exceptionAttrName, serverException)
+            }
+        }
+
+        return true
+    }
+
+    static void cleanStackTraces(Throwable exceptionToClean) {
+        Throwable cause = exceptionToClean
+        while (cause?.stackTrace != null && cause.stackTrace.size() > 0 ){
+            cause.setStackTrace(new StackTraceElement[]{})
+            cause = cause.getCause()
+        }
+    }
+}

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/InternalErrorsInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/InternalErrorsInterceptor.groovy
@@ -29,21 +29,23 @@ class InternalErrorsInterceptor {
 
         HttpServletRequest requestForRendering = request
         Enumeration<String> reqAttributes = requestForRendering.getAttributeNames()
+        boolean throwableFound = false
 
         reqAttributes.each { String attributeName ->
             def attribute = requestForRendering.getAttribute(attributeName)
-            if(attribute instanceof Throwable) {
+            if(attribute instanceof Throwable && attribute != null) {
                 Throwable serverException = (attribute as Throwable)
-                if (serverException) {
-                    requestForRendering.removeAttribute(attributeName)
-                    cleanStackTraces(serverException)
-                    requestForRendering.setAttribute(attributeName, serverException)
-                }
+                throwableFound = true
+
+                requestForRendering.removeAttribute(attributeName)
+                cleanStackTraces(serverException)
+                requestForRendering.setAttribute(attributeName, serverException)
             }
         }
 
-        render(view: '/error.gsp')
-        return false
+        if(throwableFound)
+            render(view: '/error.gsp')
+        return !throwableFound
     }
 
     static void cleanStackTraces(Throwable exceptionToClean) {

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/InternalErrorsInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/InternalErrorsInterceptor.groovy
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletRequest
 class InternalErrorsInterceptor {
     private static final String[] EXCEPT_ATTR_NAMES = ['javax.servlet.error.exception', 'exception']
 
-    final ConfigurationService configurationService
+   private final ConfigurationService configurationService
     int order = HIGHEST_PRECEDENCE + 600
 
     @Autowired

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/InternalErrorsInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/InternalErrorsInterceptor.groovy
@@ -49,10 +49,9 @@ class InternalErrorsInterceptor {
     }
 
     static void cleanStackTraces(Throwable exceptionToClean) {
-        Throwable cause = exceptionToClean
-        while (cause?.stackTrace != null && cause.stackTrace.size() > 0 ){
-            cause.setStackTrace(new StackTraceElement[]{})
-            cause = cause.getCause()
+        while (exceptionToClean?.stackTrace != null && exceptionToClean.stackTrace.size() > 0 ){
+            exceptionToClean.setStackTrace(new StackTraceElement[]{})
+            exceptionToClean = exceptionToClean.getCause()
         }
     }
 }

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/InternalErrorsInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/InternalErrorsInterceptor.groovy
@@ -2,22 +2,26 @@ package rundeck.interceptors
 
 import groovy.transform.CompileStatic
 import org.apache.http.HttpStatus
+import org.springframework.beans.factory.annotation.Autowired
+import rundeck.services.ConfigurationService
 
 import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 
 /**
  * Intercept all responses with 5xx status and removes stacktrace data
  */
 @CompileStatic
 class InternalErrorsInterceptor {
-    private static final String SHOW_TRACES_DEBUG_PROP_NAME = 'rundeck.feature.debug.showTracesOnResponse'
     private static final String[] EXCEPT_ATTR_NAMES = ['javax.servlet.error.exception', 'exception']
+
+    final ConfigurationService configurationService
     int order = HIGHEST_PRECEDENCE + 600
 
-    InternalErrorsInterceptor() {
+    @Autowired
+    InternalErrorsInterceptor(ConfigurationService configurationService) {
+        this.configurationService = configurationService
         matchAll().excludes {
-            grailsApplication.config.getProperty(SHOW_TRACES_DEBUG_PROP_NAME, 'false') == 'true' || response == null || response.getStatus() < HttpStatus.SC_INTERNAL_SERVER_ERROR
+            this.configurationService.getBoolean('feature', 'debug', 'showTracesOnResponse', false) || response == null
         }
     }
 

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/InternalErrorsInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/InternalErrorsInterceptor.groovy
@@ -12,9 +12,7 @@ import javax.servlet.http.HttpServletRequest
  */
 @CompileStatic
 class InternalErrorsInterceptor {
-    private static final String[] EXCEPT_ATTR_NAMES = ['javax.servlet.error.exception', 'exception']
-
-   private final ConfigurationService configurationService
+    private final ConfigurationService configurationService
     int order = HIGHEST_PRECEDENCE + 600
 
     @Autowired
@@ -30,13 +28,17 @@ class InternalErrorsInterceptor {
             return true
 
         HttpServletRequest requestForRendering = request
+        Enumeration<String> reqAttributes = requestForRendering.getAttributeNames()
 
-        for (String exceptionAttrName : EXCEPT_ATTR_NAMES) {
-            Throwable serverException = (requestForRendering.getAttribute(exceptionAttrName) as Throwable)
-            if (serverException) {
-                requestForRendering.removeAttribute(exceptionAttrName)
-                cleanStackTraces(serverException)
-                requestForRendering.setAttribute(exceptionAttrName, serverException)
+        reqAttributes.each { String attributeName ->
+            def attribute = requestForRendering.getAttribute(attributeName)
+            if(attribute instanceof Throwable) {
+                Throwable serverException = (attribute as Throwable)
+                if (serverException) {
+                    requestForRendering.removeAttribute(attributeName)
+                    cleanStackTraces(serverException)
+                    requestForRendering.setAttribute(attributeName, serverException)
+                }
             }
         }
 

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/InternalErrorsInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/InternalErrorsInterceptorSpec.groovy
@@ -2,8 +2,7 @@ package rundeck.interceptors
 
 import grails.testing.web.interceptor.InterceptorUnitTest
 import org.apache.http.HttpStatus
-import org.grails.taglib.GrailsTagException
-import org.springframework.context.ApplicationContext
+import rundeck.services.ConfigurationService
 import spock.lang.Specification
 
 class InternalErrorsInterceptorSpec extends Specification implements InterceptorUnitTest<InternalErrorsInterceptor> {
@@ -15,6 +14,11 @@ class InternalErrorsInterceptorSpec extends Specification implements Interceptor
         request.setAttribute(EXCEPT_ATTR_NAMES[0], new Exception("This is a \"${EXCEPT_ATTR_NAMES[0]}\""))
         request.setAttribute(EXCEPT_ATTR_NAMES[1], new Exception("This is a \"${EXCEPT_ATTR_NAMES[1]}\""))
         response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+        defineBeans {
+            configurationService(ConfigurationService) {
+                grailsApplication = grailsApplication
+            }
+        }
 
         when:
         interceptor.after()
@@ -31,7 +35,13 @@ class InternalErrorsInterceptorSpec extends Specification implements Interceptor
         request.setAttribute(EXCEPT_ATTR_NAMES[0], new Exception("This is a \"${EXCEPT_ATTR_NAMES[0]}\""))
         request.setAttribute(EXCEPT_ATTR_NAMES[1], new Exception("This is a \"${EXCEPT_ATTR_NAMES[1]}\""))
         response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)
-        grailsApplication.config.put(SHOW_TRACES_DEBUG_PROP_NAME, 'true')
+        grailsApplication.config.put(SHOW_TRACES_DEBUG_PROP_NAME,true)
+        defineBeans {
+            configurationService(ConfigurationService) {
+                grailsApplication = grailsApplication
+            }
+        }
+
         withRequest(controller:"demo", action: 'index')
 
         then:

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/InternalErrorsInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/InternalErrorsInterceptorSpec.groovy
@@ -1,0 +1,41 @@
+package rundeck.interceptors
+
+import grails.testing.web.interceptor.InterceptorUnitTest
+import org.apache.http.HttpStatus
+import org.grails.taglib.GrailsTagException
+import org.springframework.context.ApplicationContext
+import spock.lang.Specification
+
+class InternalErrorsInterceptorSpec extends Specification implements InterceptorUnitTest<InternalErrorsInterceptor> {
+    private static final String SHOW_TRACES_DEBUG_PROP_NAME = 'rundeck.feature.debug.showTracesOnResponse'
+    private static final String[] EXCEPT_ATTR_NAMES = ['javax.servlet.error.exception', 'exception']
+
+    def "should remove exceptions stacktrace from request by default"() {
+        setup:
+        request.setAttribute(EXCEPT_ATTR_NAMES[0], new Exception("This is a \"${EXCEPT_ATTR_NAMES[0]}\""))
+        request.setAttribute(EXCEPT_ATTR_NAMES[1], new Exception("This is a \"${EXCEPT_ATTR_NAMES[1]}\""))
+        response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+
+        when:
+        interceptor.after()
+
+        then:
+        def e = thrown(Exception)
+        e.message.contains('No tag library found for namespace')
+        (request.getAttribute(EXCEPT_ATTR_NAMES[0]) as Throwable).stackTrace.size() == 0
+        (request.getAttribute(EXCEPT_ATTR_NAMES[1]) as Throwable).stackTrace.size() == 0
+    }
+
+    def "should NOT remove exceptions stacktrace from request on debug property set"() {
+        when:
+        request.setAttribute(EXCEPT_ATTR_NAMES[0], new Exception("This is a \"${EXCEPT_ATTR_NAMES[0]}\""))
+        request.setAttribute(EXCEPT_ATTR_NAMES[1], new Exception("This is a \"${EXCEPT_ATTR_NAMES[1]}\""))
+        response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+        grailsApplication.config.put(SHOW_TRACES_DEBUG_PROP_NAME, 'true')
+        withRequest(controller:"demo", action: 'index')
+
+        then:
+        !interceptor.doesMatch()
+    }
+
+}

--- a/rundeckapp/templates/config/rundeck-config.properties.template
+++ b/rundeckapp/templates/config/rundeck-config.properties.template
@@ -23,4 +23,3 @@ rundeck.security.authorization.preauthenticated.redirectLogout=false
 rundeck.security.authorization.preauthenticated.redirectUrl=/oauth2/sign_in
 
 rundeck.feature.repository.enabled=true
-rundeck.feature.debug.showTracesOnResponse=true

--- a/rundeckapp/templates/config/rundeck-config.properties.template
+++ b/rundeckapp/templates/config/rundeck-config.properties.template
@@ -23,3 +23,4 @@ rundeck.security.authorization.preauthenticated.redirectLogout=false
 rundeck.security.authorization.preauthenticated.redirectUrl=/oauth2/sign_in
 
 rundeck.feature.repository.enabled=true
+rundeck.feature.debug.showTracesOnResponse=true


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-326

#### Problem
When there's an internal error, the responses include information about the internal system (stacktraces).
![image](https://github.com/rundeck/rundeck/assets/49494423/67579e96-a10c-4170-9796-acfcdd93a9b8)
or
![image](https://github.com/rundeck/rundeck/assets/49494423/b3faaa9d-cf33-4959-a746-30b052567cf9)


#### Solution
Use an Interceptor that matches responses with internal server errors and render a default error page for any of them:
![image](https://github.com/rundeck/rundeck/assets/49494423/360e4201-dd26-4b1e-abf6-b448bb985d6f)

##### Previous behavior can be re-enabled for debug:
```
# In rundeck-config.properties to disable the interceptor
rundeck.feature.debug.showTracesOnResponse=false
```

