### PR TITLE
RUN-1741: Reduce ubuntu base dockerfile size

### DIFF
--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -2,49 +2,54 @@
 ######################
 FROM ubuntu:20.04
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
-## BASH
-RUN echo "dash dash/sh boolean false" | debconf-set-selections \
-    && dpkg-reconfigure dash
+# Set Bash as default shell
+RUN echo "dash dash/sh boolean false" | debconf-set-selections && \
+    dpkg-reconfigure dash
 
-## General package configuration
-RUN set -euxo pipefail \
-    && sed -i -e 's#http://\(archive\|security\)#mirror://mirrors#' -e 's#/ubuntu/#/mirrors.txt#' /etc/apt/sources.list \
-    && apt-get -y update && apt-get upgrade -y && apt-get -y --no-install-recommends install \
+# General package configuration
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get -y --no-install-recommends install \
         acl \
         curl \
         gnupg2 \
         ssh-client \
         sudo \
-        openjdk-11-jdk-headless \
+        openjdk-11-jre-headless \
         uuid-runtime \
         wget \
-        unzip \
-    && rm -rf /var/lib/apt/lists/* \
-    # Setup rundeck user
-    && adduser --gid 0 --shell /bin/bash --home /home/rundeck --gecos "" --disabled-password rundeck \
-    && chmod 0775 /home/rundeck \
-    && passwd -d rundeck \
-    && addgroup rundeck sudo \
-    && chmod g+w /etc/passwd
+        unzip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-# Add Tini
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
-RUN gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
- && gpg --batch --verify /tini.asc /tini
-RUN chmod +x /tini
+# Setup rundeck user
+RUN adduser --gid 0 --shell /bin/bash --home /home/rundeck --gecos "" --disabled-password rundeck && \
+    chmod 0775 /home/rundeck && \
+    passwd -d rundeck && \
+    addgroup rundeck sudo && \
+    chmod g+w /etc/passwd
 
-RUN curl --request GET -sL \
-    --url 'https://github.com/HeavyHorst/remco/releases/download/v0.12.3/remco_0.12.3_linux_amd64.zip'\
-    --output 'remco.zip'
-RUN echo '45f7073e02ce967e9bdc1e4f4a0b5c52b48a3085be4c2b9d04c912f839439c24  remco.zip' > remco.zip.sha
-RUN sha256sum -c remco.zip.sha
-RUN unzip remco.zip && cp remco_linux /usr/local/bin/remco
+# Install Tini
+ENV TINI_VERSION=0.19.0
+RUN curl -sSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini -o /tini && \
+    curl -sSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini.asc -o /tini.asc && \
+    gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
+    gpg --batch --verify /tini.asc /tini && \
+    chmod +x /tini
+
+# Install Remco
+ENV REMCO_VERSION=0.12.3
+RUN curl -ssL "https://github.com/HeavyHorst/remco/releases/download/v${REMCO_VERSION}/remco_${REMCO_VERSION}_linux_amd64.zip" -o remco.zip && \
+    echo '45f7073e02ce967e9bdc1e4f4a0b5c52b48a3085be4c2b9d04c912f839439c24  remco.zip' > remco.zip.sha && \
+    sha256sum -c remco.zip.sha && \
+    unzip remco.zip && \
+    cp remco_linux /usr/local/bin/remco && \
+    chmod +x /usr/local/bin/remco && \
+    rm remco.zip remco.zip.sha
 
 USER rundeck
 


### PR DESCRIPTION
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".

**Is this a bugfix, or an enhancement? Please describe.**
This is an enhancement to reduce the ubuntu base dockerfile without breaking compatibility with existing users of the container image.

**Describe the solution you've implemented**
Over time the container image for rundeck/PAOP has grown. When possible a smaller image is preferable as it takes up less disk space and starts up faster when run.

There are several tweaks that have been made to reduce the image size:
- Download, install and delete extra remco zip files in one RUN command. This saves ~8MB
- use openjdk-11-jre-headless instead of openjdk-11-jdk-headless since we are only running java not building it in the container. This saves ~234MB of space.
- Include apt-get clean, I didn't see any space savings but its good to include to remove package install caches

As well as a few general best practices and formatting for the Dockerfile. These are not directly saving space so I can split this in a separate PR if thats wanted.
- Added some clarifying comments around the bash being set as default. Honestly I'm not sure why it doesn't use dash but I assume there is a good reason for this?
- Removed set -exuo pipefail as there are no pipes and its an unusual use of set. I have never seen this done ever in any dockerfile so I'm really unsure what the benefit is here as the Dockerfile will already fail to build if any RUN command returns an error code.
- Removed switching to apt mirrors. I can understand why this may have been done in the past due to maybe ubuntu apt servers being down, but using anything but the official mirrors is a bit concerning as those are likely better secured/monitored than mirrors. This would make more sense if apt was being called in realtime during the application execution but during the build process it would simply be rebuilt again if there were apt problems. Again not something I have ever seen reviewing hundreds of Dockerfiles.
- Split out the user creation commands from apt install. There is no real reason for them to be grouped together that I can discern and this improves readability.
- Use curl to pull tini as using ADD is generally discouraged these days
- Added ENV TOOL_VERSION for remco and tini. This allows tools like dependabot to monitor and update these potentially, and its general best practice. Also just nice to be able to run ENV in a running container and see tool versions.
- General formatting to make it easier to read and follow

**Describe alternatives you've considered**
Could leave the dockerfile as is, it is working in production.

**Additional context**
Add any other context or screenshots about the change here.
