### PR TITLE
Put webpack copied jquery autocomplete asset in the vendor folder.

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/_package-manager/mix-manifest.json
+++ b/rundeckapp/grails-app/assets/javascripts/_package-manager/mix-manifest.json
@@ -4,7 +4,7 @@
     "/vendor/jquery-ui.css": "/vendor/jquery-ui.css",
     "/vendor/jquery-ui-timepicker-addon.js": "/vendor/jquery-ui-timepicker-addon.js",
     "/vendor/knockout.min.js": "/vendor/knockout.min.js",
-    "/jquery.autocomplete.min.js": "/jquery.autocomplete.min.js",
+    "/vendor/jquery.autocomplete.min.js": "/vendor/jquery.autocomplete.min.js",
     "/vendor/knockout-mapping.js": "/vendor/knockout-mapping.js",
     "/vendor/perfect-scrollbar.js": "/vendor/perfect-scrollbar.js",
     "/vendor/perfect-scrollbar.css": "/vendor/perfect-scrollbar.css",

--- a/rundeckapp/grails-app/assets/javascripts/_package-manager/webpack.mix.js
+++ b/rundeckapp/grails-app/assets/javascripts/_package-manager/webpack.mix.js
@@ -8,7 +8,7 @@ mix
     .copy('node_modules/jquery-ui-dist/jquery-ui.css', '../vendor/jquery-ui.css')
     .copy('node_modules/jquery-ui-timepicker-addon/dist/jquery-ui-timepicker-addon.min.js', '../vendor/jquery-ui-timepicker-addon.js')
     .copy('../knockout_3_5_1.js', '../vendor/knockout.min.js')
-    .copy('../jquery_autocomplete_1_3_0.js', '../jquery.autocomplete.min.js')
+    .copy('../jquery_autocomplete_1_3_0.js', '../vendor/jquery.autocomplete.min.js')
     .copy('node_modules/knockout-mapping/dist/knockout.mapping.min.js', '../vendor/knockout-mapping.js')
     .copy('node_modules/perfect-scrollbar/dist/perfect-scrollbar.min.js', '../vendor/perfect-scrollbar.js')
     .copy('node_modules/perfect-scrollbar/css/perfect-scrollbar.css', '../vendor/perfect-scrollbar.css')

--- a/rundeckapp/grails-app/views/scheduledExecution/_jobEditCommon.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_jobEditCommon.gsp
@@ -1,4 +1,4 @@
-<asset:javascript src="jquery.autocomplete.min.js"/>
+<asset:javascript src="vendor/jquery.autocomplete.min.js"/>
 <asset:javascript src="leavePageConfirm.js"/>
 <asset:javascript src="jobEditPage_bundle.js"/>
 <asset:javascript src="util/markdeep.js"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/show.gsp
@@ -27,7 +27,7 @@
 
     <asset:javascript src="scheduledExecution/show.js"/>
     <asset:javascript src="util/markdeep.js"/>
-    <asset:javascript src="jquery.autocomplete.min.js"/>
+    <asset:javascript src="vendor/jquery.autocomplete.min.js"/>
     <asset:javascript src="util/tab-router.js"/>
 
     <asset:stylesheet href="static/css/pages/project-dashboard.css"/>


### PR DESCRIPTION
The jQuery autocomplete js file that is copied by webpack should go in the vendor folder. This change fixes git always showing jquery.autocomplete.min.js as needing to be checked in after a complete gradle build.