### PR TITLE
Fix issue with showing referenced execution data in gsp layer

### DIFF
--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/execution/ReferencedExecutionDataProvider.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/execution/ReferencedExecutionDataProvider.java
@@ -2,6 +2,7 @@ package org.rundeck.app.data.providers.v1.execution;
 
 import org.rundeck.app.data.model.v1.execution.RdReferencedExecution;
 import org.rundeck.app.data.model.v1.job.JobData;
+import org.rundeck.app.data.model.v1.job.JobDataSummary;
 import org.rundeck.app.data.providers.v1.DataProvider;
 
 import java.util.List;
@@ -9,8 +10,8 @@ import java.util.List;
 public interface ReferencedExecutionDataProvider extends DataProvider {
     Long updateOrCreateReference(Long refId, String jobUuid, Long execId, String status);
     RdReferencedExecution findByJobUuid(String jobUuid);
-    List<Long> parentList(String jobUuid, int max);
-    List executionProjectList(String jobUuid, int max);
+    List<JobDataSummary> parentJobSummaries(String jobUuid, int max);
+    List<String> executionProjectList(String jobUuid, int max);
     int countByJobUuid(String jobUuid);
     int countByJobUuidAndStatus(String jobUuid, String status);
     void deleteByExecutionId(Long id);

--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/job/JobDataProvider.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/job/JobDataProvider.java
@@ -2,6 +2,7 @@ package org.rundeck.app.data.providers.v1.job;
 
 import org.rundeck.app.data.model.v1.DeletionResult;
 import org.rundeck.app.data.model.v1.job.JobData;
+import org.rundeck.app.data.model.v1.job.JobDataSummary;
 import org.rundeck.app.data.model.v1.page.Page;
 import org.rundeck.spi.data.DataAccessException;
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -73,6 +73,7 @@ import org.rundeck.app.components.RundeckJobDefinitionManager
 import org.rundeck.app.components.jobs.ImportedJob
 import org.rundeck.app.data.model.v1.user.RdUser
 import org.rundeck.app.data.providers.v1.execution.ReferencedExecutionDataProvider
+import org.rundeck.app.data.providers.v1.job.JobDataProvider
 import org.rundeck.app.spi.AuthorizedServicesProvider
 import org.rundeck.core.auth.AuthConstants
 import org.rundeck.core.auth.access.NotFound
@@ -118,6 +119,7 @@ class ScheduledExecutionController  extends ControllerBase{
     RundeckJobDefinitionManager rundeckJobDefinitionManager
     AuthorizedServicesProvider rundeckAuthorizedServicesProvider
     ConfigurationService configurationService
+    JobDataProvider jobDataProvider
     ReferencedExecutionDataProvider referencedExecutionDataProvider
 
 
@@ -430,7 +432,7 @@ class ScheduledExecutionController  extends ControllerBase{
         }
 
 
-        def parentList = referencedExecutionDataProvider.parentList(scheduledExecution.uuid,10)
+        def parentList = referencedExecutionDataProvider.parentJobSummaries(scheduledExecution.uuid,10)
         def isReferenced = parentList?.size()>0
 
         def pluginDescriptions=[:]
@@ -1392,7 +1394,7 @@ Since: V14''',
             return
         }
         if(request.method=='POST') {
-            def isReferenced = referencedExecutionDataProvider.parentList(scheduledExecution.uuid,1)?.size()>0
+            def isReferenced = referencedExecutionDataProvider.countByJobUuid(scheduledExecution.uuid)>0
             withForm {
                 def result = scheduledExecutionService.deleteScheduledExecutionById(
                         jobid,

--- a/rundeckapp/grails-app/domain/rundeck/ReferencedExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ReferencedExecution.groovy
@@ -3,6 +3,7 @@ package rundeck
 import com.dtolabs.rundeck.app.support.DomainIndexHelper
 import org.hibernate.sql.JoinType
 import org.rundeck.app.data.model.v1.execution.RdReferencedExecution
+import org.rundeck.app.data.model.v1.job.JobDataSummary
 
 class ReferencedExecution implements RdReferencedExecution{
     String jobUuid
@@ -25,36 +26,25 @@ class ReferencedExecution implements RdReferencedExecution{
         }
     }
 
-    static List<ScheduledExecution> parentList(ScheduledExecution se, int max = 0){
+    static List<JobDataSummary> parentJobSummaries(String jobUuid, int max = 0){
         return createCriteria().list(max: (max!=0)?max:null) {
             createAlias('execution', 'e', JoinType.LEFT_OUTER_JOIN)
             isNotNull( 'e.scheduledExecution')
-            eq("jobUuid", se.uuid)
+            eq("jobUuid", jobUuid)
             projections {
                 distinct('e.scheduledExecution')
             }
-        } as List<ScheduledExecution>
+        }*.toJobDataSummary()
     }
 
-    static List executionProjectList(ScheduledExecution se, int max = 0){
+    static List<String> executionProjectList(String jobUuid, int max = 0){
         return createCriteria().list(max: (max!=0)?max:null) {
             createAlias('execution', 'e', JoinType.LEFT_OUTER_JOIN)
-            eq("jobUuid", se.uuid)
+            eq("jobUuid", jobUuid)
             projections {
                 groupProperty('e.project', "project")
             }
-        }
-    }
-
-    static List<Long> parentListScheduledExecutionId(ScheduledExecution se, int max = 0){
-        return createCriteria().list(max: (max!=0)?max:null) {
-            createAlias('execution', 'e', JoinType.LEFT_OUTER_JOIN)
-            isNotNull( 'e.scheduledExecution')
-            eq("jobUuid", se.uuid)
-            projections {
-                distinct('e.scheduledExecution.id')
-            }
-        } as List<Long>
+        } as List<String>
     }
 
     Serializable getExecutionId(){

--- a/rundeckapp/grails-app/views/scheduledExecution/_jobActionButton.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_jobActionButton.gsp
@@ -255,7 +255,7 @@ jQuery(function(){
                                     <g:each var="job" in="${parentList}">
                                         <li>
                                         <span class=" wfitem jobtype" title="">
-                                        <g:link controller="scheduledExecution" action="show" id="${job.extid}">
+                                        <g:link controller="scheduledExecution" action="show" id="${job.uuid}">
                                             <i class="glyphicon glyphicon-book"></i>
                                             ${(job.groupPath?job.groupPath+'/':'')+job.jobName+(scheduledExecution.project!=job.project?' ('+job.project+')':'')}
                                         </g:link>

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormJobQueryProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormJobQueryProvider.groovy
@@ -186,10 +186,6 @@ class GormJobQueryProvider implements JobQueryProvider {
         return idlist
     }
 
-    def JobDataSummary toSummary(ScheduledExecution se) {
-
-    }
-
 
     static class GormPage<T> implements Page<T> {
         List<T> results = []

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormReferencedExecutionDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormReferencedExecutionDataProvider.groovy
@@ -1,10 +1,12 @@
 package org.rundeck.app.data.providers
 
 import org.rundeck.app.data.model.v1.execution.RdReferencedExecution
+import org.rundeck.app.data.model.v1.job.JobDataSummary
 import org.rundeck.app.data.providers.v1.execution.ReferencedExecutionDataProvider
 import rundeck.Execution
 import rundeck.ReferencedExecution
 import rundeck.ScheduledExecution
+import rundeck.services.JobSchedulerService
 
 class GormReferencedExecutionDataProvider implements ReferencedExecutionDataProvider{
     @Override
@@ -28,15 +30,13 @@ class GormReferencedExecutionDataProvider implements ReferencedExecutionDataProv
     }
 
     @Override
-    List<Long> parentList(String jobUuid, int max) {
-        def se = ScheduledExecution.findByUuid(jobUuid)
-        return ReferencedExecution.parentListScheduledExecutionId(se, max)
+    List<JobDataSummary> parentJobSummaries(String jobUuid, int max) {
+        return ReferencedExecution.parentJobSummaries(jobUuid, max)
     }
 
     @Override
-    List executionProjectList(String jobUuid, int max = 0) {
-        def se = ScheduledExecution.findByUuid(jobUuid)
-        return ReferencedExecution.executionProjectList(se, max)
+    List<String> executionProjectList(String jobUuid, int max = 0) {
+        return ReferencedExecution.executionProjectList(jobUuid, max)
     }
 
     @Override

--- a/rundeckapp/src/test/groovy/rundeck/ReferencedExecutionSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ReferencedExecutionSpec.groovy
@@ -60,7 +60,7 @@ class ReferencedExecutionSpec extends RundeckHibernateSpec
         def re = new ReferencedExecution(jobUuid: "000000",execution: exec).save()
 
         when:
-        List l = ReferencedExecution.executionProjectList(se)
+        List l = ReferencedExecution.executionProjectList(se.uuid)
 
         then:
         l.size() == 1
@@ -138,7 +138,7 @@ class ReferencedExecutionSpec extends RundeckHibernateSpec
         def executionIdList = [[executionId: exec.id, project: exec.project], [executionId: exec2.id, project: exec2.project]]
 
         when:
-        List l = ReferencedExecution.executionProjectList(se, max)
+        List l = ReferencedExecution.executionProjectList(se.uuid, max)
 
         then:
         l.size() == sizeList
@@ -205,11 +205,11 @@ class ReferencedExecutionSpec extends RundeckHibernateSpec
         def re = new ReferencedExecution(jobUuid: "000000",execution: exec).save()
 
         when:
-        List l = ReferencedExecution.parentList(se)
+        List l = ReferencedExecution.parentJobSummaries(se.uuid)
 
         then:
         l.size() == 1
-        l.getAt(0).equals(seb)
+        l[0].uuid == seb.uuid
     }
 
     def "parent list with max result"(){
@@ -298,11 +298,11 @@ class ReferencedExecutionSpec extends RundeckHibernateSpec
         def re2 = new ReferencedExecution(jobUuid: "000000",execution: exec2).save()
 
         when:
-        List l = ReferencedExecution.parentList(se, max)
+        List l = ReferencedExecution.parentJobSummaries(se.uuid, max)
 
         then:
         l.size() == sizeList
-        l*.toString() == result
+        l.collect {s-> "${s.groupPath}/${s.jobName} - null".toString()} == result
 
         where:
         max  | sizeList | result


### PR DESCRIPTION
The SPI changes for ReferencedExecution broke a gsp that tried to list the parent job info for a referenced job.
