### PR TITLE
Fixes an broken report when referenced executions are present.

### DIFF
--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/ExecReportDataProvider.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/ExecReportDataProvider.java
@@ -18,9 +18,9 @@ public interface ExecReportDataProvider extends DataProvider{
     List<RdExecReport> findAllByProjectAndExecutionIdInList(String projectName, List<Long> execIds);
     int countByProject(String projectName);
     int countExecutionReports(RdExecQuery execQuery);
-    int countExecutionReportsWithTransaction(RdExecQuery execQuery, boolean isJobs, Long scheduledExecutionId);
+    int countExecutionReportsWithTransaction(RdExecQuery execQuery, boolean isJobs, Long jobId);
     int countAndSaveByStatus();
-    Collection<String> getExecutionReports(RdExecQuery execQuery, boolean isJobs, Long scheduledExecutionId);
+    List<RdExecReport> getExecutionReports(RdExecQuery execQuery, boolean isJobs, Long jobId);
     void deleteByProject(String projectName);
     void deleteWithTransaction(String projectName);
     void deleteAllByExecutionId(Long executionId);


### PR DESCRIPTION
The exec report query needed to be updated after the SPI changes to the referenced execution domain class.