### PR TITLE
When SaveReportRequest builder hits a deprecated field it should not print a stack trace.

### DIFF
--- a/rundeck-data-model/build.gradle
+++ b/rundeck-data-model/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api 'commons-codec:commons-codec:1.15'
     api 'commons-lang:commons-lang:2.6'
     api "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
+    implementation 'org.slf4j:slf4j-api:1.7.32'
 
     testImplementation "org.codehaus.groovy:groovy-all:${groovyVersion}"
     testImplementation "org.spockframework:spock-core:2.0-groovy-3.0"

--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/model/v1/report/dto/SaveReportRequestImpl.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/model/v1/report/dto/SaveReportRequestImpl.java
@@ -3,14 +3,15 @@ package org.rundeck.app.data.model.v1.report.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.Field;
-import java.util.Date;
-import java.util.Map;
+import java.util.*;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Slf4j
 public class SaveReportRequestImpl implements SaveReportRequest {
     Long executionId;
     Date dateStarted;
@@ -63,8 +64,12 @@ public class SaveReportRequestImpl implements SaveReportRequest {
                     }
                 }
 
-            } catch (NoSuchFieldException | IllegalAccessException e) {
-                e.printStackTrace();
+            } catch (NoSuchFieldException nsfe) {
+                if(!DEPRECATED_FIELD_NAMES.contains(key)) {
+                    log.info("Report builder found unknown field: " + key);
+                }
+            } catch (IllegalAccessException iex) {
+                log.warn("Unable to set field: "+key+" illegal access");
             }
         }
     }
@@ -74,4 +79,5 @@ public class SaveReportRequestImpl implements SaveReportRequest {
         return SaveReportRequest;
     }
 
+    public static final List<String> DEPRECATED_FIELD_NAMES = Arrays.asList("ctxProject","jcJobId","jcExecId","actionType","ctxType","ctxName","ctxCommand","ctxController","maprefUri");
 }

--- a/rundeckapp/grails-app/domain/rundeck/BaseReport.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/BaseReport.groovy
@@ -23,10 +23,14 @@ class BaseReport {
     String node
     String title
     String status
+    @Deprecated
     String actionType
     String project
+    @Deprecated
     String ctxType
+    @Deprecated
     String ctxName
+    @Deprecated
     String maprefUri
     String reportId
     String tags

--- a/rundeckapp/grails-app/domain/rundeck/ExecReport.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ExecReport.groovy
@@ -22,7 +22,9 @@ import org.rundeck.app.data.model.v1.report.RdExecReport
 
 class ExecReport extends BaseReport implements RdExecReport{
 
+    @Deprecated
     String ctxCommand
+    @Deprecated
     String ctxController
     Long executionId
     String jobId


### PR DESCRIPTION
Change logging to info.
Mark deprecated fields in BaseReport and ExecReport