### PR TITLE
RCLOUD-909: BaseReport JobUuid adjustments

### DIFF
--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/model/v1/report/RdExecReport.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/model/v1/report/RdExecReport.java
@@ -21,4 +21,5 @@ public interface RdExecReport{
     String getSucceededNodeList();
     String getFailedNodeList();
     String getFilterApplied();
+    String getJobUuid();
 }

--- a/rundeckapp/grails-app/domain/rundeck/ExecReport.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ExecReport.groovy
@@ -34,6 +34,7 @@ class ExecReport extends BaseReport implements RdExecReport{
     String succeededNodeList
     String failedNodeList
     String filterApplied
+    String jobUuid
 
     static mapping = {
         adhocScript type: 'text'
@@ -59,6 +60,7 @@ class ExecReport extends BaseReport implements RdExecReport{
         succeededNodeList(nullable:true,blank:true)
         failedNodeList(nullable:true,blank:true)
         filterApplied(nullable:true,blank:true)
+        jobUuid(nullable:true)
 
     }
 
@@ -70,7 +72,8 @@ class ExecReport extends BaseReport implements RdExecReport{
             'abortedByUser',
             'succeededNodeList',
             'failedNodeList',
-            'filterApplied'
+            'filterApplied',
+            'jobUuid'
     ]
     def Map toMap(){
         def map = this.properties.subMap(exportProps)
@@ -131,7 +134,8 @@ class ExecReport extends BaseReport implements RdExecReport{
                 actionType: status,
                 failedNodeList: failedList,
                 succeededNodeList: succeededList,
-                filterApplied: exec.filter
+                filterApplied: exec.filter,
+                jobUuid: exec.scheduledExecution?.uuid
         ])
     }
     static ExecReport fromMap(Map map) {

--- a/rundeckapp/grails-app/migrations/core/BaseReport.groovy
+++ b/rundeckapp/grails-app/migrations/core/BaseReport.groovy
@@ -93,21 +93,8 @@ databaseChangeLog = {
             column(name: 'job_uuid', type: '${varchar255.type}')
         }
     }
-        changeSet(author: "rundeckdev", id: "Populate-base-report-job-uuid", dbms: "!mssql") {
-        preConditions(onFail: "MARK_RAN") {
-            tableExists(tableName: "base_report")
-            tableExists(tableName: "execution")
-            tableExists(tableName: "scheduled_execution")
-        }
-        sql("update base_report br\n" +
-                "set job_uuid =\n" +
-                "        (select se.uuid\n" +
-                "         from scheduled_execution se\n" +
-                "                  inner join execution ex ON ex.scheduled_execution_id = se.id\n" +
-                "         WHERE br.execution_id = ex.id)")
-    }
 
-    changeSet(author: "rundeckdev", id: "Populate-base-report-job-uuid-mssql", dbms: "mssql") {
+    changeSet(author: "rundeckdev", id: "Populate-base-report-job-uuid") {
         preConditions(onFail: "MARK_RAN") {
             tableExists(tableName: "base_report")
             tableExists(tableName: "execution")

--- a/rundeckapp/grails-app/migrations/core/BaseReport.groovy
+++ b/rundeckapp/grails-app/migrations/core/BaseReport.groovy
@@ -83,4 +83,41 @@ databaseChangeLog = {
             column(name: "filter_applied", type: '${text.type}')
         }
     }
+    changeSet(author: "rundeckdev", id: "Add-job-uuid-to-base-report") {
+        preConditions(onFail: "MARK_RAN") {
+            not {
+                columnExists(tableName: "base_report", columnName: 'job_uuid')
+            }
+        }
+        addColumn(tableName: "base_report") {
+            column(name: 'job_uuid', type: '${varchar255.type}')
+        }
+    }
+        changeSet(author: "rundeckdev", id: "Populate-base-report-job-uuid", dbms: "!mssql") {
+        preConditions(onFail: "MARK_RAN") {
+            tableExists(tableName: "base_report")
+            tableExists(tableName: "execution")
+            tableExists(tableName: "scheduled_execution")
+        }
+        sql("update base_report br\n" +
+                "set job_uuid =\n" +
+                "        (select se.uuid\n" +
+                "         from scheduled_execution se\n" +
+                "                  inner join execution ex ON ex.scheduled_execution_id = se.id\n" +
+                "         WHERE br.execution_id = ex.id)")
+    }
+
+    changeSet(author: "rundeckdev", id: "Populate-base-report-job-uuid-mssql", dbms: "mssql") {
+        preConditions(onFail: "MARK_RAN") {
+            tableExists(tableName: "base_report")
+            tableExists(tableName: "execution")
+            tableExists(tableName: "scheduled_execution")
+        }
+        sql("update base_report\n" +
+                "set job_uuid =\n" +
+                "        (select scheduled_execution.uuid\n" +
+                "         from scheduled_execution\n" +
+                "                  inner join execution ON execution.scheduled_execution_id = scheduled_execution.id\n" +
+                "         WHERE base_report.execution_id = execution.id)")
+    }
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityList.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityList.vue
@@ -301,9 +301,9 @@
                   <span v-else>
                     {{rpt.executionString}}
                   </span>
-                  <span v-if="query.jobIdFilter && rpt.jobId && query.jobIdFilter !==rpt.jobId && query.jobIdFilter !=='!null' && rpt.jobUuid" class="text-secondary">
+                  <span v-if="query.jobIdFilter && rpt.jobUuid && query.jobIdFilter !==rpt.jobUuid && query.jobIdFilter !=='!null'" class="text-secondary">
                     <i class="fas fa-arrow-circle-right-alt"></i>
-                    {{rpt.jobUuid}}
+                    {{$t('Referenced')}}
                   </span>
 
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityList.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityList.vue
@@ -301,9 +301,9 @@
                   <span v-else>
                     {{rpt.executionString}}
                   </span>
-                  <span v-if="query.jobIdFilter && rpt.jobId && query.jobIdFilter !==rpt.jobId && query.jobIdFilter !=='!null'" class="text-secondary">
+                  <span v-if="query.jobIdFilter && rpt.jobId && query.jobIdFilter !==rpt.jobId && query.jobIdFilter !=='!null' && rpt.jobUuid" class="text-secondary">
                     <i class="fas fa-arrow-circle-right-alt"></i>
-                    {{$t('Referenced')}}
+                    {{rpt.jobUuid}}
                   </span>
 
 

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormExecReportDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormExecReportDataProvider.groovy
@@ -51,6 +51,7 @@ class GormExecReportDataProvider implements ExecReportDataProvider {
     @Override
     SaveReportResponse saveReport(SaveReportRequest saveReportRequest) {
         ExecReport execReport = new ExecReport()
+        Execution execution = Execution.get(saveReportRequest.executionId)
         execReport.executionId = saveReportRequest.executionId
         execReport.jobId = saveReportRequest.jobId
         execReport.adhocExecution = saveReportRequest.adhocExecution
@@ -70,6 +71,7 @@ class GormExecReportDataProvider implements ExecReportDataProvider {
         execReport.message = saveReportRequest.message
         execReport.dateStarted = saveReportRequest.dateStarted
         execReport.dateCompleted = saveReportRequest.dateCompleted
+        execReport.jobUuid = execution.scheduledExecution?.uuid
         boolean isUpdated = execReport.save(flush: true)
         String errors = execReport.errors.allErrors.collect { messageSource.getMessage(it,null) }.join(",")
         return new SaveReportResponseImpl(report: execReport, isSaved: isUpdated, errors: errors)

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
@@ -2328,6 +2328,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
   <succeededNodeList />
   <failedNodeList />
   <filterApplied />
+  <jobUuid>test-job-uuid</jobUuid>
 </report>'''
     /**
      * uses deprecated jcExecId
@@ -2388,6 +2389,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
             dateStarted: new Date(0),
             dateCompleted: new Date(3600000),
             message: 'Report message',
+            jobUuid: se.uuid,
             )
         assertNotNull exec.save()
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Currently the BaseReport/ExecReport data has a soft reference to the internal ScheduleExecution id. A migration needs to be written to look up the internal ScheduledExecution id and put in a job uuid instead. 

**Describe the solution you've implemented**
A new column was added to the base_report table to reference the jobUuid, and the proper adjustments were made to save execReports and then list execReports.

**Additional context**
Jira ticket here https://pagerduty.atlassian.net/browse/RCLOUD-909
