### PR TITLE
RUN-1759: fix: flaky test: selenium project export form

### DIFF
--- a/test/selenium/src/__tests__/selenium/project-export/form.test.ts
+++ b/test/selenium/src/__tests__/selenium/project-export/form.test.ts
@@ -18,6 +18,7 @@ import {Context} from '@rundeck/testdeck/context'
 import {CreateContext} from '@rundeck/testdeck/test/selenium'
 import {ProjectExportPage,Checkboxes,Radios} from 'pages/projectExport.page'
 import {LoginPage} from 'pages/login.page'
+import {sleep} from '@rundeck/testdeck/async/util'
 
 import {until} from 'selenium-webdriver'
 import '@rundeck/testdeck/test/rundeck'
@@ -83,6 +84,8 @@ describe('projectExport', () => {
     expect(checked).not.toContain(null)
     //click each label
     await Promise.all(labels.map(label=>label.click()))
+
+    await sleep(3000)
 
     let checked2 = await Promise.all(elems.map((elem)=>elem.getAttribute('checked')))
     expect(checked2.length).toBe(Checkboxes.length)


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Attempt to fix flaky test. 

occasionally fails with message:
```
projectExport form checkbox labels work


Error: expect(received).not.toContain(expected) // indexOf

Expected value: not "true"
Received array:     ["true", "true", "true", "true", "true", "true", "true"]
    at Object.<anonymous> (/home/circleci/repo/test/selenium/src/__tests__/selenium/project-export/form.test.ts:89:26)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

**Describe the solution you've implemented**
 Add sleep to let multiple click on label tags to propagate.
