### PR TITLE
Cleanup: remove unused circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -621,18 +621,6 @@ jobs:
       - test-packages
       - package-cloud-install
 
-  trigger-packaging:
-    <<: *defaults
-    docker:
-      - image: cimg/node:lts
-    resource_class: small
-    steps:
-      - trigger/trigger:
-          debug: true
-          branch: 'main'
-          token: '${CIRCLECI_API_TOKEN}'
-          project-slug: 'gh/rundeck/packaging-core'
-          pipeline-number: '<<pipeline.number>>'
   maven-publish:
     <<: *defaults
     executor:


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
cleanup

remove unused circleci job "trigger-packaging". this is no longer used since converting the packaging build to use a submodule