### PR TITLE
RUN-1766:Fix: Key Storage Making Call to List Keys Twice

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageView.vue
@@ -582,7 +582,6 @@ export default Vue.extend({
 
       this.loadUpPath();
       this.loadKeys();
-      console.log("NEWEST!!!!")
     },
     showUpPath() {
       if (this.upPath != this.rootPath) {


### PR DESCRIPTION
the check parent dir method is the same as load keys. this removed that method and the single call to it that was resulting in duplicate calls to the backend to list the keys