### PR TITLE
RSE-430 Fix: HTTP Strict Transport Security (HSTS) Header Not Used

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -327,6 +327,9 @@ public class RundeckConfigBase {
         @Data
         public static class Servlet {
             Map<String,Object> initParams;
+            Integer stsMaxAgeSeconds;
+            Boolean stsIncludeSubdomains;
+
         }
     }
 

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -865,9 +865,6 @@ beans={
         initParams = configParams?.toProperties()?.collectEntries {
             [it.key.toString(), it.value.toString()]
         }
-        //stsMaxAgeSeconds = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsMaxAgeSeconds",Integer.class,-1)
-        //stsIncludeSubdomains = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsIncludeSubdomains",Boolean.class,false)
-
         useForwardHeaders = useForwardHeadersConfig ?: Boolean.getBoolean('rundeck.jetty.connector.forwarded')
     }
 

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -868,10 +868,9 @@ beans={
         useForwardHeaders = useForwardHeadersConfig ?: Boolean.getBoolean('rundeck.jetty.connector.forwarded')
     }
 
-    jettyServletHstsCustomizer(JettyServletHstsCustomizer) {
-        stsMaxAgeSeconds = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsMaxAgeSeconds",Integer.class,-1)
-        stsIncludeSubdomains = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsIncludeSubdomains",Boolean.class,false)
-    }
+    def stsMaxAgeSeconds = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsMaxAgeSeconds",Integer.class,-1)
+    def stsIncludeSubdomains = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsIncludeSubdomains",Boolean.class,false)
+    jettyServletHstsCustomizer(JettyServletHstsCustomizer,stsMaxAgeSeconds,stsIncludeSubdomains)
 
     rundeckAuthSuccessEventListener(RundeckAuthSuccessEventListener) {
         frameworkService = ref('frameworkService')
@@ -879,7 +878,7 @@ beans={
 
     if(grailsApplication.config.getProperty("rundeck.security.syncLdapUser",Boolean.class,false)) {
         rundeckJaasAuthenticationSuccessEventListener(RundeckJaasAuthenticationSuccessEventListener) {
-            configurationService = ref('configurationService')
+            configurationService = ref('configurationService')4e3r
         }
     }
 

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -864,10 +864,8 @@ beans={
         initParams = configParams?.toProperties()?.collectEntries {
             [it.key.toString(), it.value.toString()]
         }
-        def stsMaxAgeSecondsConfig = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsMaxAgeSeconds",Integer.class)
-        def stsIncludeSubdomainsConfig = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsIncludeSubdomains",Boolean.class)
-        stsMaxAgeSeconds = stsMaxAgeSecondsConfig
-        stsIncludeSubdomains = stsIncludeSubdomainsConfig
+        stsMaxAgeSeconds = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsMaxAgeSeconds",Integer.class,-1)
+        stsIncludeSubdomains = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsIncludeSubdomains",Boolean.class,false)
 
         useForwardHeaders = useForwardHeadersConfig ?: Boolean.getBoolean('rundeck.jetty.connector.forwarded')
     }

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -864,6 +864,10 @@ beans={
         initParams = configParams?.toProperties()?.collectEntries {
             [it.key.toString(), it.value.toString()]
         }
+        def stsMaxAgeSecondsConfig = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsMaxAgeSeconds",Integer.class)
+        def stsIncludeSubdomainsConfig = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsIncludeSubdomains",Boolean.class)
+        stsMaxAgeSeconds = stsMaxAgeSecondsConfig
+        stsIncludeSubdomains = stsIncludeSubdomainsConfig
 
         useForwardHeaders = useForwardHeadersConfig ?: Boolean.getBoolean('rundeck.jetty.connector.forwarded')
     }

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -878,7 +878,7 @@ beans={
 
     if(grailsApplication.config.getProperty("rundeck.security.syncLdapUser",Boolean.class,false)) {
         rundeckJaasAuthenticationSuccessEventListener(RundeckJaasAuthenticationSuccessEventListener) {
-            configurationService = ref('configurationService')4e3r
+            configurationService = ref('configurationService')
         }
     }
 

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -167,6 +167,7 @@ import rundeckapp.init.PluginCachePreloader
 import rundeckapp.init.RundeckConfigReloader
 import rundeckapp.init.RundeckExtendedMessageBundle
 import rundeckapp.init.servlet.JettyServletContainerCustomizer
+import rundeckapp.init.servlet.JettyServletHstsCustomizer
 
 import javax.security.auth.login.Configuration
 
@@ -864,10 +865,15 @@ beans={
         initParams = configParams?.toProperties()?.collectEntries {
             [it.key.toString(), it.value.toString()]
         }
-        stsMaxAgeSeconds = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsMaxAgeSeconds",Integer.class,-1)
-        stsIncludeSubdomains = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsIncludeSubdomains",Boolean.class,false)
+        //stsMaxAgeSeconds = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsMaxAgeSeconds",Integer.class,-1)
+        //stsIncludeSubdomains = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsIncludeSubdomains",Boolean.class,false)
 
         useForwardHeaders = useForwardHeadersConfig ?: Boolean.getBoolean('rundeck.jetty.connector.forwarded')
+    }
+
+    jettyServletHstsCustomizer(JettyServletHstsCustomizer) {
+        stsMaxAgeSeconds = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsMaxAgeSeconds",Integer.class,-1)
+        stsIncludeSubdomains = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsIncludeSubdomains",Boolean.class,false)
     }
 
     rundeckAuthSuccessEventListener(RundeckAuthSuccessEventListener) {

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -54,7 +54,6 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
     }
 }
 
-
 /**
  * Set init params for the WebAppContext
  */

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -50,7 +50,7 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
             }
         })
         factory.addConfigurations(new JettyConfigPropsInitParameterConfiguration(initParams))
-        factory.useForwardHeaders = useForwardHeaders
+        factory.useForwardHeaders=useForwardHeaders
     }
 }
 

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -17,9 +17,6 @@ package rundeckapp.init.servlet
 
 import com.dtolabs.rundeck.core.init.CustomWebAppInitializer
 import org.eclipse.jetty.server.Handler
-import org.eclipse.jetty.server.HttpConfiguration
-import org.eclipse.jetty.server.HttpConnectionFactory
-import org.eclipse.jetty.server.SecureRequestCustomizer
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ContextHandler
 import org.eclipse.jetty.webapp.AbstractConfiguration
@@ -39,27 +36,12 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
      */
     Map<String, String> initParams = [:]
     Boolean useForwardHeaders
-    Boolean sniHostCheck = false
-    long stsMaxAgeSeconds
-    Boolean stsIncludeSubdomains
 
-    /**
-     * Applies customizations such as adding a SecureRequestCustomizer
-     * for SSL configurations and setting the maximum form keys for the handlers.
-     *
-     * @param factory the Jetty servlet web server factory to customize
-     */
     @Override
     void customize(final JettyServletWebServerFactory factory) {
         factory.addServerCustomizers(new JettyServerCustomizer() {
             @Override
             void customize(Server server) {
-                server.getConnectors().each { connector ->
-                    HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration()
-                    if(checkSSL(config)){
-                        config.addCustomizer(new SecureRequestCustomizer(sniHostCheck, stsMaxAgeSeconds, stsIncludeSubdomains))
-                    }
-                }
                 for (Handler handler : server.getHandlers()) {
                     if (handler instanceof ContextHandler) {
                         ((ContextHandler) handler).setMaxFormKeys(2000)
@@ -69,18 +51,6 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
         })
         factory.addConfigurations(new JettyConfigPropsInitParameterConfiguration(initParams))
         factory.useForwardHeaders = useForwardHeaders
-    }
-
-    /**
-     * Checks if SSL is enabled in the HTTP configuration.
-     *
-     * @param httpConfig the HTTP configuration to check
-     * @return true if SSL is enabled, false otherwise
-     */
-    static boolean checkSSL(HttpConfiguration httpConfig) {
-        int securePort = httpConfig.getSecurePort()
-        boolean isSslEnabled = (securePort > 0)
-        return isSslEnabled
     }
 }
 

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletHstsCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletHstsCustomizer.groovy
@@ -12,7 +12,6 @@ public class JettyServletHstsCustomizer implements JettyServerCustomizer {
     long stsMaxAgeSeconds
     Boolean stsIncludeSubdomains
 
-
     /**
      * Customizes the given server by adding a secure request customizer for SSL configurations
      *
@@ -34,9 +33,15 @@ public class JettyServletHstsCustomizer implements JettyServerCustomizer {
      * @param httpConfig the HTTP configuration to check
      * @return true if SSL is enabled, false otherwise
      */
-    static boolean checkSSL(HttpConfiguration httpConfig) {
+    public static boolean checkSSL(HttpConfiguration httpConfig) {
         int securePort = httpConfig.getSecurePort()
         boolean isSslEnabled = (securePort > 0)
         return isSslEnabled
     }
+
+    JettyServletHstsCustomizer( long stsMaxAgeSeconds, Boolean stsIncludeSubdomains) {
+        this.stsMaxAgeSeconds = stsMaxAgeSeconds
+        this.stsIncludeSubdomains = stsIncludeSubdomains
+    }
+
 }

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletHstsCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletHstsCustomizer.groovy
@@ -14,7 +14,6 @@ public class JettyServletHstsCustomizer implements JettyServerCustomizer {
 
     /**
      * Customizes the given server by adding a secure request customizer for SSL configurations
-     *
      * @param server The server to customize.
      */
     @Override
@@ -29,7 +28,6 @@ public class JettyServletHstsCustomizer implements JettyServerCustomizer {
 
     /**
      * Checks if SSL is enabled in the HTTP configuration.
-     *
      * @param httpConfig the HTTP configuration to check
      * @return true if SSL is enabled, false otherwise
      */

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletHstsCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletHstsCustomizer.groovy
@@ -32,9 +32,7 @@ public class JettyServletHstsCustomizer implements JettyServerCustomizer {
      * @return true if SSL is enabled, false otherwise
      */
     public static boolean checkSSL(HttpConfiguration httpConfig) {
-        int securePort = httpConfig.getSecurePort()
-        boolean isSslEnabled = (securePort > 0)
-        return isSslEnabled
+        return (httpConfig.getSecurePort() > 0)
     }
 
     JettyServletHstsCustomizer( long stsMaxAgeSeconds, Boolean stsIncludeSubdomains) {

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletHstsCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletHstsCustomizer.groovy
@@ -1,0 +1,42 @@
+package rundeckapp.init.servlet;
+
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.springframework.boot.web.embedded.jetty.JettyServerCustomizer;
+
+public class JettyServletHstsCustomizer implements JettyServerCustomizer {
+
+    Boolean sniHostCheck = false
+    long stsMaxAgeSeconds
+    Boolean stsIncludeSubdomains
+
+
+    /**
+     * Customizes the given server by adding a secure request customizer for SSL configurations
+     *
+     * @param server The server to customize.
+     */
+    @Override
+    public void customize(Server server) {
+        server.getConnectors().each { connector ->
+            HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).getHttpConfiguration()
+            if(checkSSL(config)){
+                config.addCustomizer(new SecureRequestCustomizer(sniHostCheck, stsMaxAgeSeconds, stsIncludeSubdomains))
+            }
+        }
+    }
+
+    /**
+     * Checks if SSL is enabled in the HTTP configuration.
+     *
+     * @param httpConfig the HTTP configuration to check
+     * @return true if SSL is enabled, false otherwise
+     */
+    static boolean checkSSL(HttpConfiguration httpConfig) {
+        int securePort = httpConfig.getSecurePort()
+        boolean isSslEnabled = (securePort > 0)
+        return isSslEnabled
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeckapp/init/servlet/JettyServletHstsCustomizerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/init/servlet/JettyServletHstsCustomizerSpec.groovy
@@ -1,0 +1,58 @@
+package rundeckapp.init.servlet
+
+import org.eclipse.jetty.server.ServerConnector
+import spock.lang.Specification
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.HttpConfiguration
+
+import org.eclipse.jetty.server.HttpConnectionFactory
+import org.eclipse.jetty.server.SecureRequestCustomizer
+
+
+
+
+class JettyServletHstsCustomizerSpec extends Specification {
+
+    def "customize jetty server to add hsts header to static assets"() {
+
+        given:"a server"
+        Server server = new Server()
+        HttpConfiguration httpsConfig = new HttpConfiguration()
+        httpsConfig.securePort = 443
+        ServerConnector httpConnector = new ServerConnector(server, new HttpConnectionFactory(httpsConfig))
+        server.setConnectors(new ServerConnector[] { httpConnector })
+        JettyServletHstsCustomizer jettyServletHstsCustomizer = new JettyServletHstsCustomizer(stsMaxAgeSeconds,stsIncludeSubdomains)
+
+        when:"applying a customization"
+        jettyServletHstsCustomizer.customize(server)
+
+        then:"server should be obtained with customization values applied"
+        def secureRequestCustomizer = httpsConfig.getCustomizer(SecureRequestCustomizer)
+        stsMaxAgeSeconds == secureRequestCustomizer.stsMaxAge
+        stsIncludeSubdomains == secureRequestCustomizer.stsIncludeSubDomains
+
+        where:
+        stsMaxAgeSeconds | stsIncludeSubdomains
+        31536000l        | true
+        31536000l        | false
+        12345            | true
+    }
+
+    def "evaluate if ssl is enabled"(){
+
+        given:"an HttpConfiguration with a secure port enabled"
+        HttpConfiguration httpsConfig = new HttpConfiguration()
+        httpsConfig.securePort = 443
+        def stsMaxAgeSeconds = 31536000l
+        def stsIncludeSubdomains = true
+        JettyServletHstsCustomizer jettyServletHstsCustomizer = new JettyServletHstsCustomizer(stsMaxAgeSeconds,stsIncludeSubdomains)
+
+        when:"evaluating if isSslEnabled"
+        def isSslEnabled= jettyServletHstsCustomizer.checkSSL(httpsConfig)
+
+        then:"isSslEnabled should be true"
+        isSslEnabled
+    }
+
+
+}


### PR DESCRIPTION
Problem:
HSTS headers were not being applied to the assets path because the doFilterInternal method from the RundeckSecurityHeadersFilter class was unable to apply the headers to those paths since they were outside of its scope.

Solution:
Delegate the HSTS to the embedded Jetty server by adding a SecureRequestCustomizer