### PR TITLE
RSE-341: Fix: Jobs GUI Slowness Improvements :turtle: 

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -584,6 +584,7 @@ public class RundeckConfigBase {
         String helpLink;
         String helpLinkName;
         Boolean workflowGraph;
+        Boolean showInlineJobSchedules;
         Boolean realJobTree;
         String logoSmall;
         Integer matchedNodesMaxCount;

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3790,20 +3790,36 @@ if executed in cluster mode.
         }
     }
 
+    /**
+     * Returns a boolean flag depending if there were at least one SCM integration enabled.
+     * @return true/false
+     * */
     def scmEnabled(){
         def project = params.project
+        def scmEnabled = true
         if( project && !scmService.projectHasConfiguredExportPlugin(project) && !scmService.projectHasConfiguredImportPlugin(project) ){
-            render(
-                    contentType: 'application/json', text:
-                    (
-                            [scmEnabled: false]
-                    ) as JSON
-            )
+            scmEnabled = false
         }
         render(
                 contentType: 'application/json', text:
                 (
-                        [scmEnabled: true]
+                        [scmEnabled: scmEnabled]
+                ) as JSON
+        )
+    }
+
+    /**
+     * Returns a boolean flag depending on user's configuration for the inline job schedules
+     * renderization in job's page.
+     * @return true/false
+     * */
+    def jobMenuInlineJobSchedulesEnabled(){
+        def showInlineJobSchedules
+        showInlineJobSchedules = configurationService.getBoolean('gui.showInlineJobSchedules', true)
+        render(
+                contentType: 'application/json', text:
+                (
+                        [showInlineJobSchedules: showInlineJobSchedules]
                 ) as JSON
         )
     }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3790,6 +3790,24 @@ if executed in cluster mode.
         }
     }
 
+    def scmEnabled(){
+        def project = params.project
+        if( project && !scmService.projectHasConfiguredExportPlugin(project) && !scmService.projectHasConfiguredImportPlugin(project) ){
+            render(
+                    contentType: 'application/json', text:
+                    (
+                            [scmEnabled: false]
+                    ) as JSON
+            )
+        }
+        render(
+                contentType: 'application/json', text:
+                (
+                        [scmEnabled: true]
+                ) as JSON
+        )
+    }
+
     def listExport(){
         UserAndRolesAuthContext authContext
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3797,7 +3797,7 @@ if executed in cluster mode.
     def scmEnabled(){
         def project = params.project
         def scmEnabled = true
-        if( project && !scmService.projectHasConfiguredExportPlugin(project) && !scmService.projectHasConfiguredImportPlugin(project) ){
+        if( project && (!scmService.projectHasConfiguredExportPlugin(project) && !scmService.projectHasConfiguredImportPlugin(project)) ){
             scmEnabled = false
         }
         render(

--- a/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
+++ b/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
@@ -300,6 +300,7 @@ class UrlMappings {
         "/menu/acls/save"(controller: 'menu', action: 'saveSystemAclFile')
         "/menu/acls/delete/$id**"(controller: 'menu', action: 'deleteSystemAclFile')
         "/menu/storage/$resourcePath**"(controller: 'menu', action: 'storage')
+        "/menu/jobMenuInlineJobSchedulesEnabled"(controller: 'menu', action: 'jobMenuInlineJobSchedulesEnabled')
         "/storage/access/keys/$resourcePath**"(controller: 'storage', action: 'keyStorageAccess')
         "/storage/access/keys"(controller: 'storage', action: 'keyStorageAccess')
         "/storage/upload/keys"(controller: 'storage', action: 'keyStorageUpload')

--- a/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
+++ b/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
@@ -259,6 +259,7 @@ class UrlMappings {
         "/project/$project/history"(controller: 'reports', action: 'index')
         "/project/$project/jobs/$groupPath**"(controller: 'menu', action: 'jobs')
         "/project/$project?/jobs"(controller: 'menu', action: 'jobs')
+        "/project/scm/enabled"(controller: 'menu', action: 'scmEnabled')
         "/project/$project/job/show/$id/$fullName**"(controller: 'scheduledExecution', action: 'show')
         "/project/$project/job/show/$id"(controller: 'scheduledExecution', action: 'show')
         "/project/$project/job/upload"(controller: 'scheduledExecution'){

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -322,28 +322,44 @@ search
             var pageParams = loadJsonData('pageParams');
             var nextScheduled = loadJsonData('nextScheduled');
 
+            // Call only if atleast one of the SCM integrations is enabled
             jQuery.ajax({
                 dataType:'json',
-                type: "POST",
-                url: appLinks.scmjobs,
-                data: JSON.stringify(nextScheduled),
+                type: "GET",
+                url: _genUrl('/project/scm/enabled'),
+                data: {project: pageParams.project},
                 contentType: 'application/json; charset=utf-8',
                 success:function(data,status,xhr){
-                    bulkeditor.scmExportEnabled(data.scmExportEnabled);
-                    bulkeditor.scmStatus(data.scmStatus);
-                    bulkeditor.scmExportStatus(data.scmExportStatus);
-                    bulkeditor.scmExportActions(data.scmExportActions);
-                    bulkeditor.scmExportRenamed(data.scmExportRenamed);
+                    console.log(`This is the data: `)
+                    console.log(data)
+                    if( !data.scmEnabled ){
+                        bulkeditor.scmDone(true);
+                    }else{
+                        jQuery.ajax({
+                            dataType:'json',
+                            type: "POST",
+                            url: appLinks.scmjobs,
+                            data: JSON.stringify(nextScheduled),
+                            contentType: 'application/json; charset=utf-8',
+                            success:function(data,status,xhr){
+                                bulkeditor.scmExportEnabled(data.scmExportEnabled);
+                                bulkeditor.scmStatus(data.scmStatus);
+                                bulkeditor.scmExportStatus(data.scmExportStatus);
+                                bulkeditor.scmExportActions(data.scmExportActions);
+                                bulkeditor.scmExportRenamed(data.scmExportRenamed);
 
-                    bulkeditor.scmImportEnabled(data.scmImportEnabled);
-                    bulkeditor.scmImportJobStatus(data.scmImportJobStatus);
-                    bulkeditor.scmImportStatus(data.scmImportStatus);
-                    bulkeditor.scmImportActions(data.scmImportActions);
-                    if( data.warning !== undefined ){
-                        showError(data.warning)
+                                bulkeditor.scmImportEnabled(data.scmImportEnabled);
+                                bulkeditor.scmImportJobStatus(data.scmImportJobStatus);
+                                bulkeditor.scmImportStatus(data.scmImportStatus);
+                                bulkeditor.scmImportActions(data.scmImportActions);
+                                if( data.warning !== undefined ){
+                                    showError(data.warning)
+                                }
+
+                                bulkeditor.scmDone(true);
+                            }
+                        });
                     }
-
-                    bulkeditor.scmDone(true);
                 }
             });
             const filtersData=loadJsonData('jobFiltersJson')

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -322,7 +322,7 @@ search
             var pageParams = loadJsonData('pageParams');
             var nextScheduled = loadJsonData('nextScheduled');
 
-            // Call only if atleast one of the SCM integrations is enabled
+            // Call only if one of the SCM integrations is enabled
             jQuery.ajax({
                 dataType:'json',
                 type: "GET",

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -1487,9 +1487,17 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)
         controller.aclFileManagerService = Mock(AclFileManagerService)
         controller.scheduledExecutionService = Mock(ScheduledExecutionService)
+        def mockImportScmConfig = Mock(ScmPluginConfigData){
+            it.getEnabled() >> importIntegrationEnabled
+        }
+        def mockExportScmConfig = Mock(ScmPluginConfigData){
+            it.getEnabled() >> exportIntegrationEnabled
+        }
         controller.scmService = Mock(ScmService){
-            it.projectHasConfiguredImportPlugin(project) >> importEnabled
-            it.projectHasConfiguredExportPlugin(project) >> exportEnabled
+            it.projectHasConfiguredImportPlugin(project) >> importConfigured
+            it.loadScmConfig(project,ScmService.IMPORT) >> mockImportScmConfig
+            it.loadScmConfig(project,ScmService.EXPORT) >> mockExportScmConfig
+            it.projectHasConfiguredExportPlugin(project) >> exportConfigured
         }
 
         when:
@@ -1502,10 +1510,13 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         response.json.scmEnabled == scmEnabled
 
         where:
-        importEnabled | exportEnabled | scmEnabled
-        true          | true          | true
-        true          | false         | true
-        false         | false         | false
+        importConfigured | exportConfigured | importIntegrationEnabled | exportIntegrationEnabled  | scmEnabled
+        true             | true             | true                     | true                      | true
+        true             | true             | false                    | true                      | true
+        true             | true             | true                     | false                     | true
+        true             | true             | false                    | false                     | false
+        true             | false            | false                    | false                     | false
+        false            | false            | false                    | false                     | false
 
     }
 


### PR DESCRIPTION
# RSE-341 Fix: Jobs GUI Slowness Improvements :turtle: 
User reported a GUI slowness with 3000+ jobs in jobs menu.

# Use Case
The 3000+ jobs were delaying the calls to the API in render time, so we investigated and identified two major calls marked as "slow", there were "skippable" in certain cases.

# The Calls
![image](https://github.com/rundeck/rundeck/assets/81827734/c7a1fa66-fc16-4f58-9285-697330bf2e59)
1. "listExport" for the SCM status even if any of the SCM integrations were enabled.
2. "job schedules" for the in line job schedules per job "small widget with the schedules".

# The fix
Prevented the calls:
1. The SCM was prevented if the user don't have any integrations enabled
2. The job schedules is prevented by an user property ```rundeck.gui.showInlineJobSchedules``` in config

Related with:
https://github.com/rundeckpro/rundeckpro/pull/3054