### PR TITLE
RSE-461 Fix: Job Step plugin that uses ${config.*} variables within are no longer resolving

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPlugin.java
@@ -79,6 +79,8 @@ public abstract class AbstractDescribableScriptPlugin implements Describable {
     public static final String CONFIG_RENDERING_OPTIONS = "renderingOptions";
     public static final String SETTING_MERGE_ENVIRONMENT = "mergeEnvironment";
 
+    public static final String CONFIG_BLANK_IF_UNEXPANDED = "blankIfUnexpanded";
+
     private final ScriptPluginProvider provider;
     private final Framework framework;
     Description description;
@@ -154,6 +156,17 @@ public abstract class AbstractDescribableScriptPlugin implements Describable {
                     }
 
                     pbuild.required(required);
+
+
+                    final Object blankIfUnexpandedValue = itemmeta.get(CONFIG_BLANK_IF_UNEXPANDED);
+                    final boolean blankIfUnexpanded;
+                    if (blankIfUnexpandedValue instanceof Boolean) {
+                        blankIfUnexpanded = (Boolean) blankIfUnexpandedValue;
+                    } else {
+                        blankIfUnexpanded = blankIfUnexpandedValue instanceof String && Boolean.parseBoolean((String) blankIfUnexpandedValue);
+                    }
+
+                    pbuild.blankIfUnexpandable(blankIfUnexpanded);
 
 
                     final Object defObj = itemmeta.get(CONFIG_DEFAULT);


### PR DESCRIPTION
# Job Step plugin that uses ${config.*} variables within are no longer resolving

Since version 4.9.0 plugins that used ${config.*} variables, were no longer resolving configured values, replacing aforementioned values with blank strings. 

[RSE-461](https://pagerduty.atlassian.net/browse/RSE-461)

# Fix

There were a field to indicate whether the application needed to resolve the config path, being always true. Meaning we were gonna replace ${config.*} values  for blank.

We added the validation to replace that field for whatever we defined in the plugin configuration.

![image](https://github.com/rundeck/rundeck/assets/29233418/23587e82-2edd-4e19-a23e-d92db70d8a8b)



[RSE-461]: https://pagerduty.atlassian.net/browse/RSE-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ