### PR TITLE
RUN-1735: Add additional DB index to improve performance

### DIFF
--- a/rundeckapp/grails-app/migrations/core/Execution.groovy
+++ b/rundeckapp/grails-app/migrations/core/Execution.groovy
@@ -147,4 +147,16 @@ databaseChangeLog = {
             }
         }
     }
+
+    changeSet(author: "rundeckuser (generated)", id: "4.14.0-add-workflow-id-index") {
+        preConditions(onFail: "MARK_RAN"){
+            not {
+                indexExists(indexName: "execution_workflow_id_idx", tableName: "execution")
+            }
+        }
+
+        createIndex(indexName: "execution_workflow_id_idx", tableName: "execution", unique: false) {
+            column(name: "workflow_id")
+        }
+    }
 }

--- a/rundeckapp/grails-app/migrations/core/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/migrations/core/ScheduledExecution.groovy
@@ -325,4 +325,16 @@ databaseChangeLog = {
         }
         sql("update scheduled_execution_stats stats set job_uuid = (select uuid from scheduled_execution where id = stats.se_id)")
     }
+
+    changeSet(author: "rundeckuser (generated)", id: "4.14.0-add-index-workflow-id"){
+        preConditions(onFail: "MARK_RAN") {
+            not {
+                indexExists(indexName: "scheduled_execution_workflow_id_idx", tableName: "scheduled_execution")
+            }
+        }
+
+        createIndex(indexName: "scheduled_execution_workflow_id_idx", tableName: "scheduled_execution", unique: false) {
+            column(name: "workflow_id")
+        }
+    }
 }

--- a/rundeckapp/grails-app/migrations/core/Workflow.groovy
+++ b/rundeckapp/grails-app/migrations/core/Workflow.groovy
@@ -129,4 +129,16 @@ databaseChangeLog = {
             column(name: "commands_idx", type: '${int.type}')
         }
     }
+
+    changeSet(author: "rundeckuser (generated)", id: "4.14.0-add-index-workflow-workflow-step-id"){
+        preConditions(onFail: "MARK_RAN"){
+            not{
+                indexExists(indexName: "workflow_workflow_step_workflow_step_id_idx", tableName: "workflow_workflow_step")
+            }
+        }
+
+        createIndex(indexName: "workflow_workflow_step_workflow_step_id_idx", tableName: "workflow_workflow_step", unique: false) {
+            column(name: "workflow_step_id")
+        }
+    }
 }

--- a/rundeckapp/grails-app/migrations/core/WorkflowStep.groovy
+++ b/rundeckapp/grails-app/migrations/core/WorkflowStep.groovy
@@ -9,4 +9,16 @@ databaseChangeLog = {
             column(name: "error_handler_id")
         }
     }
+
+    changeSet(author: "rundeckuser (generated)", id: "4.14.0-add-index-error-handler-id"){
+        preConditions(onFail: "MARK_RAN"){
+            not{
+                indexExists(indexName: "workflow_step_error_handler_id_idx", tableName: "workflow_step")
+            }
+        }
+
+        createIndex(indexName: "workflow_step_error_handler_id_idx", tableName: "workflow_step", unique: false) {
+            column(name: "error_handler_id")
+        }
+    }
 }

--- a/rundeckapp/grails-app/migrations/core/WorkflowStep.groovy
+++ b/rundeckapp/grails-app/migrations/core/WorkflowStep.groovy
@@ -9,16 +9,4 @@ databaseChangeLog = {
             column(name: "error_handler_id")
         }
     }
-
-    changeSet(author: "rundeckuser (generated)", id: "4.14.0-add-index-error-handler-id"){
-        preConditions(onFail: "MARK_RAN"){
-            not{
-                indexExists(indexName: "workflow_step_error_handler_id_idx", tableName: "workflow_step")
-            }
-        }
-
-        createIndex(indexName: "workflow_step_error_handler_id_idx", tableName: "workflow_step", unique: false) {
-            column(name: "error_handler_id")
-        }
-    }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Enhancement. By adding additional indexes to improve database performance.

**Additional context**
All ID columns by default have been indexed. We need to create an index for the column that references a foreign table.
This is a request from our clients when they found the added index can improve database performance, especially on deletion executions.
