### PR TITLE
RSE-421: fix: Added a customizer to avoid trace method on root path

### DIFF
--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/BanConfigCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/BanConfigCustomizer.groovy
@@ -1,0 +1,54 @@
+package rundeckapp.init.servlet
+
+import org.eclipse.jetty.http.HttpMethod
+import org.eclipse.jetty.http.HttpStatus
+import org.eclipse.jetty.server.Connector
+import org.eclipse.jetty.server.HttpConfiguration
+import org.eclipse.jetty.server.HttpConnectionFactory
+import org.eclipse.jetty.server.Request
+import org.eclipse.jetty.server.Server
+import org.springframework.boot.web.embedded.jetty.JettyServerCustomizer
+
+/**
+ * Validates jetty configuration to avoid disallowed http methods and paths
+ */
+class BanConfigCustomizer implements JettyServerCustomizer {
+
+    @Override
+    void customize(Server server) {
+
+        server.connectors.each {connector ->
+            HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).httpConfiguration
+            config.addCustomizer(new BanHttpCustomizer([HttpMethod.TRACE]))
+        }
+    }
+}
+
+/**
+ * Includes and validates paths and http methods banned for security reasons
+ */
+class BanHttpCustomizer implements HttpConfiguration.Customizer {
+
+    /**
+     * Banned http methods
+     */
+    final List<HttpMethod> banMethods
+    /**
+     * Banned path
+     */
+    final String banPath = "/"
+
+    BanHttpCustomizer(List<HttpMethod> methods) {
+        this.banMethods = methods
+    }
+
+    @Override
+    void customize(Connector connector, HttpConfiguration channelConfig, Request request) {
+        HttpMethod currentMethod = HttpMethod.fromString(request.method)
+        String currentPath = request.pathInfo
+        if (banMethods.contains(currentMethod) && currentPath == banPath) {
+            request.handled = true
+            request.response.status = HttpStatus.METHOD_NOT_ALLOWED_405
+        }
+    }
+}

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/BanHttpMethodCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/BanHttpMethodCustomizer.groovy
@@ -12,7 +12,7 @@ import org.springframework.boot.web.embedded.jetty.JettyServerCustomizer
 /**
  * Validates jetty configuration to avoid disallowed http methods and paths
  */
-class BanConfigCustomizer implements JettyServerCustomizer {
+class BanHttpMethodCustomizer implements JettyServerCustomizer {
 
     @Override
     void customize(Server server) {
@@ -33,10 +33,6 @@ class BanHttpCustomizer implements HttpConfiguration.Customizer {
      * Banned http methods
      */
     final List<HttpMethod> banMethods
-    /**
-     * Banned path
-     */
-    final String banPath = "/"
 
     BanHttpCustomizer(List<HttpMethod> methods) {
         this.banMethods = methods
@@ -45,8 +41,7 @@ class BanHttpCustomizer implements HttpConfiguration.Customizer {
     @Override
     void customize(Connector connector, HttpConfiguration channelConfig, Request request) {
         HttpMethod currentMethod = HttpMethod.fromString(request.method)
-        String currentPath = request.pathInfo
-        if (banMethods.contains(currentMethod) && currentPath == banPath) {
+        if (banMethods.contains(currentMethod)) {
             request.handled = true
             request.response.status = HttpStatus.METHOD_NOT_ALLOWED_405
         }

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -49,6 +49,7 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
                 }
             }
         })
+        factory.addServerCustomizers(new BanConfigCustomizer())
         factory.addConfigurations(new JettyConfigPropsInitParameterConfiguration(initParams))
         factory.useForwardHeaders=useForwardHeaders
     }

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -49,7 +49,7 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
                 }
             }
         })
-        factory.addServerCustomizers(new BanConfigCustomizer())
+        factory.addServerCustomizers(new BanHttpMethodCustomizer())
         factory.addConfigurations(new JettyConfigPropsInitParameterConfiguration(initParams))
         factory.useForwardHeaders=useForwardHeaders
     }

--- a/rundeckapp/src/test/groovy/rundeckapp/init/servlet/BanConfigCustomizerTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/init/servlet/BanConfigCustomizerTest.groovy
@@ -1,0 +1,50 @@
+package rundeckapp.init.servlet
+
+import org.apache.http.HttpResponse
+import org.apache.http.client.HttpClient
+import org.apache.http.client.methods.HttpTrace
+import org.apache.http.impl.client.HttpClientBuilder
+import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory
+import org.springframework.boot.web.embedded.jetty.JettyWebServer
+import org.springframework.boot.web.server.WebServer
+import org.springframework.boot.web.servlet.ServletContextInitializer
+import spock.lang.Specification
+
+class BanConfigCustomizerTest extends Specification {
+
+    static final String SERVER_URL = "http://localhost"
+    WebServer server
+
+    def "Reject trace http method in root path"() {
+
+        given:
+        JettyServletWebServerFactory factory = new JettyServletWebServerFactory("",port)
+        ServletContextInitializer initializer = Mock(ServletContextInitializer)
+        factory.addServerCustomizers(new BanConfigCustomizer())
+        server = factory.getWebServer(initializer)
+        server.start()
+
+        when:
+        HttpResponse response = initTraceRequest(port, path)
+
+        then:
+        response.statusLine.statusCode == statusCode
+        response.getHeaders("Set-Cookie").length == 0
+
+        where:
+        port | path | statusCode
+        9696 | "/"  | 405
+    }
+
+    def cleanup() {
+        if (server) {
+            server.stop()
+        }
+    }
+
+    private HttpResponse initTraceRequest(int port, String path) {
+        HttpClient httpClient = HttpClientBuilder.create().build()
+        HttpTrace request = new HttpTrace("${SERVER_URL}:${port}${path}")
+        return httpClient.execute(request)
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeckapp/init/servlet/BanConfigCustomizerTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeckapp/init/servlet/BanConfigCustomizerTest.groovy
@@ -5,7 +5,6 @@ import org.apache.http.client.HttpClient
 import org.apache.http.client.methods.HttpTrace
 import org.apache.http.impl.client.HttpClientBuilder
 import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory
-import org.springframework.boot.web.embedded.jetty.JettyWebServer
 import org.springframework.boot.web.server.WebServer
 import org.springframework.boot.web.servlet.ServletContextInitializer
 import spock.lang.Specification
@@ -20,7 +19,7 @@ class BanConfigCustomizerTest extends Specification {
         given:
         JettyServletWebServerFactory factory = new JettyServletWebServerFactory("",port)
         ServletContextInitializer initializer = Mock(ServletContextInitializer)
-        factory.addServerCustomizers(new BanConfigCustomizer())
+        factory.addServerCustomizers(new BanHttpMethodCustomizer())
         server = factory.getWebServer(initializer)
         server.start()
 
@@ -32,8 +31,10 @@ class BanConfigCustomizerTest extends Specification {
         response.getHeaders("Set-Cookie").length == 0
 
         where:
-        port | path | statusCode
-        9696 | "/"  | 405
+        port | path          | statusCode
+        9696 | "/"           | 405
+        9696 | "/rundeck"    | 405
+        9696 | "/user/login" | 405
     }
 
     def cleanup() {


### PR DESCRIPTION
Issue:
it was a problem when it was sent a trace http method to the root path because the app response with a cookie JSESSIONID and this addressed to a security concern.

Fix:
I was added a customizer to jetty to avoid trace http method requests and the response it's a 405 - Method not allowed and without any cookie associated to.