### PR TITLE
RUN-1765: BaseReport migration

### DIFF
--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -115,4 +115,5 @@ databaseChangeLog = {
         include file: 'core/WorkflowWorkflowStepPrimaryKey.groovy'
         include file: 'core/OptionRemoveValues.groovy'
         include file: 'core/DBChangelogPrimaryKey.groovy'
+        include file: 'core/BaseReportSpi.groovy'
 }

--- a/rundeckapp/grails-app/migrations/core/BaseReport.groovy
+++ b/rundeckapp/grails-app/migrations/core/BaseReport.groovy
@@ -83,28 +83,4 @@ databaseChangeLog = {
             column(name: "filter_applied", type: '${text.type}')
         }
     }
-    changeSet(author: "rundeckdev", id: "Add-job-uuid-to-base-report") {
-        preConditions(onFail: "MARK_RAN") {
-            not {
-                columnExists(tableName: "base_report", columnName: 'job_uuid')
-            }
-        }
-        addColumn(tableName: "base_report") {
-            column(name: 'job_uuid', type: '${varchar255.type}')
-        }
-    }
-
-    changeSet(author: "rundeckdev", id: "Populate-base-report-job-uuid") {
-        preConditions(onFail: "MARK_RAN") {
-            tableExists(tableName: "base_report")
-            tableExists(tableName: "execution")
-            tableExists(tableName: "scheduled_execution")
-        }
-        sql("update base_report\n" +
-                "set job_uuid =\n" +
-                "        (select scheduled_execution.uuid\n" +
-                "         from scheduled_execution\n" +
-                "                  inner join execution ON execution.scheduled_execution_id = scheduled_execution.id\n" +
-                "         WHERE base_report.execution_id = execution.id)")
-    }
 }

--- a/rundeckapp/grails-app/migrations/core/BaseReportSpi.groovy
+++ b/rundeckapp/grails-app/migrations/core/BaseReportSpi.groovy
@@ -1,0 +1,28 @@
+databaseChangeLog = {
+    changeSet(author: "rundeckdev", id: "Add-job-uuid-to-base-report") {
+        preConditions(onFail: "MARK_RAN") {
+            not {
+                columnExists(tableName: "base_report", columnName: 'job_uuid')
+            }
+        }
+        addColumn(tableName: "base_report") {
+            column(name: 'job_uuid', type: '${varchar255.type}')
+        }
+    }
+
+    changeSet(author: "rundeckdev", id: "Populate-base-report-job-uuid") {
+        preConditions(onFail: "MARK_RAN") {
+            tableExists(tableName: "base_report")
+            tableExists(tableName: "execution")
+            tableExists(tableName: "scheduled_execution")
+            columnExists(tableName: "base_report", columnName: 'execution_id')
+
+        }
+        sql("update base_report\n" +
+                "set job_uuid =\n" +
+                "        (select scheduled_execution.uuid\n" +
+                "         from scheduled_execution\n" +
+                "                  inner join execution ON execution.scheduled_execution_id = scheduled_execution.id\n" +
+                "         WHERE base_report.execution_id = execution.id)")
+    }
+}


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Fix failing migration
**Describe the solution you've implemented**
Move the migration that uses the column execution_id from the table base_report after it's created, also a precondition was added to check if the column exists.

**Additional context**
Jira ticket https://pagerduty.atlassian.net/browse/RUN-1765
