### PR TITLE
Pin chromedriver version for selenium to avoid driver download bug

### DIFF
--- a/test/selenium/.npmrc
+++ b/test/selenium/.npmrc
@@ -1,1 +1,1 @@
-chromedriver_version=LATEST
+chromedriver_version=113.0.5672.63


### PR DESCRIPTION
Google recently changed the way their download urls are structured for their chrome driver. The chromedriver npm package that we use to install the driver doesn't construct the url correctly for the latest version of the 114 driver so it fails. Pinning the driver version used will get around this issue, while either the bug is fixed, or Google populates the old site with the newer drivers.

We should be able to go back to `latest` once the bug has been fixed upstream.