### PR TITLE
RSE-569 Fix: Error importing job definition from 4.5 to 4.13

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -23,6 +23,8 @@ import com.dtolabs.rundeck.core.audit.ResourceTypes
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.UserAndRoles
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import com.dtolabs.rundeck.core.execution.workflow.SequentialWorkflowStrategy
+import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionItem
 import com.dtolabs.rundeck.core.http.ApacheHttpClient
 import com.dtolabs.rundeck.core.jobs.JobLifecycleComponentException
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
@@ -3508,7 +3510,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         if (!workflow.commands || workflow.commands.size() < 1) {
             return null
         }
-        def name = workflow.strategy
+        def name = (workflow.strategy == WorkflowExecutionItem.STEP_FIRST) ? SequentialWorkflowStrategy.PROVIDER_NAME : workflow.strategy
         //validate input values wrt to property definitions
 
         def pluginConfigFactory = frameworkService.pluginConfigFactory(configmap, projectProps)

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3510,7 +3510,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         if (!workflow.commands || workflow.commands.size() < 1) {
             return null
         }
-        def name = (workflow.strategy == WorkflowExecutionItem.STEP_FIRST) ? SequentialWorkflowStrategy.PROVIDER_NAME : workflow.strategy
+        def name = (workflow.strategy.equalsIgnoreCase(WorkflowExecutionItem.STEP_FIRST)) ? SequentialWorkflowStrategy.PROVIDER_NAME : workflow.strategy
         //validate input values wrt to property definitions
 
         def pluginConfigFactory = frameworkService.pluginConfigFactory(configmap, projectProps)

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3510,7 +3510,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         if (!workflow.commands || workflow.commands.size() < 1) {
             return null
         }
-        def name = (workflow.strategy.equalsIgnoreCase(WorkflowExecutionItem.STEP_FIRST)) ? SequentialWorkflowStrategy.PROVIDER_NAME : workflow.strategy
+        def name = (WorkflowExecutionItem.STEP_FIRST.equals(workflow.strategy)) ? SequentialWorkflowStrategy.PROVIDER_NAME : workflow.strategy
         //validate input values wrt to property definitions
 
         def pluginConfigFactory = frameworkService.pluginConfigFactory(configmap, projectProps)

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3510,7 +3510,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         if (!workflow.commands || workflow.commands.size() < 1) {
             return null
         }
-        def name = (WorkflowExecutionItem.STEP_FIRST.equals(workflow.strategy)) ? SequentialWorkflowStrategy.PROVIDER_NAME : workflow.strategy
+        def name = (workflow.strategy == WorkflowExecutionItem.STEP_FIRST) ? SequentialWorkflowStrategy.PROVIDER_NAME : workflow.strategy
         //validate input values wrt to property definitions
 
         def pluginConfigFactory = frameworkService.pluginConfigFactory(configmap, projectProps)


### PR DESCRIPTION
Problem:
Jobs with a "step-first" workflow strategy couldn't be imported. This workflow strategy should be taken for Rundeck as a sequential since they are marked as a synonym.
 
Solution:
Evaluate if the job to be imported has a "step-first"  workflow strategy and replace it with a sequential workflow strategy.