### PR TITLE
RUN-1821: fix: docker tag used for twistlock check

### DIFF
--- a/scripts/circle-helpers.sh
+++ b/scripts/circle-helpers.sh
@@ -219,7 +219,8 @@ twistlock_scan() {
     elif [[ "${CIRCLE_BRANCH}" = "main" ]] ; then
         export RUNDECK_IMAGE_TAG="rundeck/rundeck:SNAPSHOT"
     else
-        export RUNDECK_IMAGE_TAG="rundeck/ci:$CIRCLE_BRANCH"
+        IMG_TAG=$(echo $CIRCLE_BRANCH | tr '/' '-')
+        export RUNDECK_IMAGE_TAG="rundeck/ci:$IMG_TAG"
     fi
 
     echo "==> Scan Image: $RUNDECK_IMAGE_TAG"


### PR DESCRIPTION
replace / char in branch name to set correct docker tag

**Is this a bugfix, or an enhancement? Please describe.**
Fix: twistlock checks try to pull incorrect docker image if branch name contains `/` char