### PR TITLE
RUN-1830: Script plugins, skip exceptions for key storage conversion

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPlugin.java
@@ -441,6 +441,8 @@ public abstract class AbstractDescribableScriptPlugin implements Describable {
             filter = renderingOptions.get(StringRenderingConstants.STORAGE_FILE_META_FILTER_KEY).toString();
         }
         boolean clearValue = isValueConversionFailureRemove(renderingOptions);
+        boolean ignoreKeyPathConversion = isValueConversionFailureIgnore(renderingOptions);
+
         try {
             Resource<ResourceMeta> resource = storageTree.getResource(propValue);
             ResourceMeta contents = resource.getContents();
@@ -464,6 +466,10 @@ public abstract class AbstractDescribableScriptPlugin implements Describable {
             contents.writeContent(byteArrayOutputStream);
             data.put(name, new String(byteArrayOutputStream.toByteArray()));
         } catch (StorageException | IOException e) {
+            if(ignoreKeyPathConversion){
+                return;
+            }
+
             if(clearValue) {
                 data.remove(name);
                 return;
@@ -518,6 +524,13 @@ public abstract class AbstractDescribableScriptPlugin implements Describable {
         );
     }
 
+    private boolean isValueConversionFailureIgnore(final Map<String, Object> renderingOptions) {
+        return StringRenderingConstants.VALUE_CONVERSION_FAILURE_SKIP.equals(
+                renderingOptions.get(
+                        StringRenderingConstants.VALUE_CONVERSION_FAILURE_KEY
+                )
+        );
+    }
 
     @Override
     public Description getDescription() {

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/StringRenderingConstants.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/StringRenderingConstants.java
@@ -27,6 +27,8 @@ public class StringRenderingConstants {
     public static final String VALUE_CONVERSION_KEY = "valueConversion";
     public static final String VALUE_CONVERSION_FAILURE_KEY = "valueConversionFailure";
     public static final String VALUE_CONVERSION_FAILURE_REMOVE = "remove";
+
+    public static final String VALUE_CONVERSION_FAILURE_SKIP = "skip";
     public static final String INSTANCE_SCOPE_NODE_ATTRIBUTE_KEY = "instance-scope-node-attribute";
     public static final String STORAGE_PATH_ROOT_KEY = "storage-path-root";
     public static final String STORAGE_FILE_META_FILTER_KEY = "storage-file-meta-filter";

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/BaseScriptPluginSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/BaseScriptPluginSpec.groovy
@@ -406,6 +406,78 @@ class BaseScriptPluginSpec extends Specification {
 
     }
 
+    @Unroll
+    def "key storage value not found and return original value"() {
+        given:
+        def node = new NodeEntryImpl('anode')
+
+        def pluginMeta = [
+                (BaseScriptPlugin.SETTING_MERGE_ENVIRONMENT): false,
+                config                                      :
+                        [
+                                [
+                                        type            : 'String',
+                                        name            : 'c',
+                                        renderingOptions: [
+                                                (StringRenderingConstants.VALUE_CONVERSION_KEY)        : 'STORAGE_PATH_AUTOMATIC_READ',
+                                                (StringRenderingConstants.VALUE_CONVERSION_FAILURE_KEY): StringRenderingConstants.VALUE_CONVERSION_FAILURE_SKIP,
+                                        ]
+                                ]
+                        ]
+        ]
+        File tempFile = File.createTempFile("test", "zip");
+        tempFile.deleteOnExit()
+        File basedir = File.createTempFile("test", "dir");
+        basedir.deleteOnExit()
+
+        ScriptPluginProvider provider = Mock(ScriptPluginProvider) {
+            getName() >> 'test1'
+            getDefaultMergeEnvVars() >> false
+            getMetadata() >> pluginMeta
+            getArchiveFile() >> tempFile
+            getScriptFile() >> tempFile
+            getContentsBasedir() >> basedir
+        }
+        String[] emptyArray = []
+
+        ScriptExecHelper helper = Mock(ScriptExecHelper) {
+            1 * createScriptArgs(_, null, _, null, false, _) >> emptyArray
+        }
+
+        def storageTree = Mock(StorageTree)
+
+        TestScriptPlugin plugin = new TestScriptPlugin(provider, framework)
+
+        plugin.scriptExecHelper = helper
+        PluginStepContext context = Mock(PluginStepContext) {
+            getFrameworkProject() >> PROJECT_NAME
+            getDataContext() >> new BaseDataContext([:])
+            getLogger() >> Mock(PluginLogger)
+            getExecutionContext() >> Mock(ExecutionContext) {
+                getFramework() >> framework
+                getFrameworkProject() >> PROJECT_NAME
+
+                getStorageTree() >> storageTree
+            }
+        }
+
+        def config = [a: 'b', c: 'somevalue']
+
+        when:
+        def result = plugin.runPluginScript(context, null, null, framework, config)
+
+        then:
+        1 * plugin.scriptExecHelper.runLocalCommand(_, {
+            it.RD_CONFIG_A == 'b' && it.RD_CONFIG_C == 'somevalue'
+        }, _, null, null
+        ) >> 0
+
+        1 * storageTree.getResource(_) >> {
+            throw new StorageException("Not found", StorageException.Event.READ, PathUtil.asPath('somevalue'))
+        }
+
+    }
+
     def "create secret bundle"() {
         given:
         def node = new NodeEntryImpl('anode')


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Script plugins, where a key storage selector is used for a field, have the option to retrieve values from the key storage and use the raw password.

**Describe the solution you've implemented**
add a way to skip exceptions for key storage conversion failure and use the original value

**Describe alternatives you've considered**

**Additional context**
