### PR TITLE
Rcloud-665: execution to spi

### DIFF
--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/constants/ExecutionConstants.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/constants/ExecutionConstants.groovy
@@ -1,0 +1,19 @@
+package rundeck.data.constants
+
+class ExecutionConstants {
+    public static String EXECUTION_RUNNING = "running"
+    public static String EXECUTION_SUCCEEDED = "succeeded"
+    public static String EXECUTION_FAILED = "failed"
+    public static String EXECUTION_ABORTED = "aborted"
+    public static String EXECUTION_TIMEDOUT = "timedout"
+    public static String EXECUTION_FAILED_WITH_RETRY = "failed-with-retry"
+    public static String EXECUTION_STATE_OTHER = "other"
+    public static String EXECUTION_SCHEDULED = "scheduled"
+    public static String EXECUTION_MISSED = "missed"
+    public static String EXECUTION_QUEUED = "queued"
+    public static String AVERAGE_DURATION_EXCEEDED = "average-duration-exceeded"
+
+    public static String ABORT_PENDING = "pending"
+    public static String ABORT_ABORTED = "aborted"
+    public static String ABORT_FAILED = "failed"
+}

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/execution/RdExecution.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/execution/RdExecution.groovy
@@ -1,0 +1,78 @@
+package rundeck.data.execution
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import grails.validation.Validateable
+import org.rundeck.app.data.model.v1.execution.ExecutionData
+import rundeck.data.constants.ExecutionConstants
+import rundeck.data.job.RdNodeConfig
+import rundeck.data.job.RdOrchestrator
+import rundeck.data.job.RdWorkflow
+import rundeck.data.util.ExecutionDataUtil
+import rundeck.data.validation.shared.SharedExecutionConstraints
+import rundeck.data.validation.shared.SharedNodeConfigConstraints
+import rundeck.data.validation.shared.SharedProjectNameConstraints
+import rundeck.data.validation.shared.SharedServerNodeUuidConstraints
+
+@JsonIgnoreProperties(["errors"])
+class RdExecution implements ExecutionData, Validateable {
+    String uuid = UUID.randomUUID().toString()
+    String jobUuid
+    Date dateStarted
+    Date dateCompleted
+    String project
+    String argString
+    String status
+    String loglevel
+    String outputfilepath
+    String failedNodeList
+    String succeededNodeList
+    String abortedby
+    boolean cancelled
+    Boolean timedOut=false
+    String timeout
+    String retry
+    String retryDelay
+
+    String executionType
+    Integer retryAttempt=0
+    Boolean willRetry=false
+    String user
+    List<String> userRoles
+    String serverNodeUUID
+    Integer nodeThreadcount=1
+    Long logFileStorageRequestId
+    Long retryExecutionId
+    Long retryOriginalId
+    Long retryPrevId
+    String extraMetadata
+
+    RdWorkflow workflow
+    RdOrchestrator orchestrator
+    RdNodeConfig nodeConfig
+
+    boolean serverNodeUUIDChanged = false //transient
+
+    static constraints = {
+        importFrom SharedProjectNameConstraints
+        importFrom SharedExecutionConstraints
+        importFrom SharedServerNodeUuidConstraints
+        importFrom SharedNodeConfigConstraints
+        logFileStorageRequestId(nullable:true)
+        workflow(nullable:true)
+        orchestrator(nullable: true)
+        retryExecutionId(nullable: true)
+        retryOriginalId(nullable: true)
+        retryPrevId(nullable: true)
+        extraMetadata(nullable: true)
+    }
+
+    @Override
+    String getExecutionState() {
+        return ExecutionDataUtil.getExecutionState(this)
+    }
+
+    @Override
+    boolean statusSucceeded(){
+        return getExecutionState()== ExecutionConstants.EXECUTION_SUCCEEDED
+    }
+}

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/execution/RdExecution.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/execution/RdExecution.groovy
@@ -13,7 +13,7 @@ import rundeck.data.validation.shared.SharedNodeConfigConstraints
 import rundeck.data.validation.shared.SharedProjectNameConstraints
 import rundeck.data.validation.shared.SharedServerNodeUuidConstraints
 
-@JsonIgnoreProperties(["errors"])
+@JsonIgnoreProperties(["errors","executionState"])
 class RdExecution implements ExecutionData, Validateable {
     String uuid = UUID.randomUUID().toString()
     String jobUuid
@@ -44,7 +44,7 @@ class RdExecution implements ExecutionData, Validateable {
     Long retryExecutionId
     Long retryOriginalId
     Long retryPrevId
-    String extraMetadata
+    Map<String, Object> extraMetadataMap
 
     RdWorkflow workflow
     RdOrchestrator orchestrator
@@ -59,11 +59,12 @@ class RdExecution implements ExecutionData, Validateable {
         importFrom SharedNodeConfigConstraints
         logFileStorageRequestId(nullable:true)
         workflow(nullable:true)
+        nodeConfig(nullable: true)
         orchestrator(nullable: true)
         retryExecutionId(nullable: true)
         retryOriginalId(nullable: true)
         retryPrevId(nullable: true)
-        extraMetadata(nullable: true)
+        extraMetadataMap(nullable: true)
     }
 
     @Override

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/execution/RdExecutionDataSummary.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/execution/RdExecutionDataSummary.groovy
@@ -1,0 +1,15 @@
+package rundeck.data.execution
+
+import org.rundeck.app.data.model.v1.execution.ExecutionDataSummary
+
+class RdExecutionDataSummary implements ExecutionDataSummary {
+    String uuid
+    String jobUuid
+    String project
+    String status
+    String executionType
+    String executionState
+    Date dateStarted
+    Date dateCompleted
+    String serverNodeUUID
+}

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/job/RdWorkflowStep.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/job/RdWorkflowStep.groovy
@@ -37,4 +37,9 @@ class RdWorkflowStep implements WorkflowStepData, PluginProviderConfiguration, V
         return pluginType
     }
 
+    @Override
+    @JsonIgnore
+    String summarize() {
+        return "implement summarization"
+    }
 }

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/paging/RdPageable.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/paging/RdPageable.groovy
@@ -1,9 +1,15 @@
 package rundeck.data.paging
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import grails.validation.Validateable
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
 import org.rundeck.app.data.model.v1.page.Pageable
 import org.rundeck.app.data.model.v1.page.SortOrder
 
+@ToString
+@EqualsAndHashCode
+@JsonIgnoreProperties(["errors"])
 class RdPageable implements Pageable, Validateable {
     Integer max = 200
     Integer offset = 0

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/util/ExecutionDataUtil.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/util/ExecutionDataUtil.groovy
@@ -1,0 +1,34 @@
+package rundeck.data.util
+
+import org.rundeck.app.data.model.v1.execution.ExecutionData
+import rundeck.data.constants.ExecutionConstants
+
+class ExecutionDataUtil {
+
+    public static String getExecutionState(ExecutionData e) {
+        return e.cancelled ? ExecutionConstants.EXECUTION_ABORTED :
+                (null == e.dateCompleted && e.status == ExecutionConstants.EXECUTION_QUEUED) ? ExecutionConstants.EXECUTION_QUEUED :
+                        null != e.dateStarted && e.dateStarted.getTime() > System.currentTimeMillis() ? ExecutionConstants.EXECUTION_SCHEDULED :
+                                (null == e.dateCompleted && e.status!=ExecutionConstants.AVERAGE_DURATION_EXCEEDED) ? ExecutionConstants.EXECUTION_RUNNING :
+                                        (e.status == ExecutionConstants.AVERAGE_DURATION_EXCEEDED) ? ExecutionConstants.AVERAGE_DURATION_EXCEEDED:
+                                                (e.status in ['true', 'succeeded']) ? ExecutionConstants.EXECUTION_SUCCEEDED :
+                                                        e.cancelled ? ExecutionConstants.EXECUTION_ABORTED :
+                                                                e.willRetry ? ExecutionConstants.EXECUTION_FAILED_WITH_RETRY :
+                                                                        e.timedOut ? ExecutionConstants.EXECUTION_TIMEDOUT :
+                                                                                (e.status == 'missed') ? ExecutionConstants.EXECUTION_MISSED :
+                                                                                        (e.status in ['false', 'failed']) ? ExecutionConstants.EXECUTION_FAILED :
+                                                                                                isCustomStatusString(e.status) ? ExecutionConstants.EXECUTION_STATE_OTHER : e.status.toLowerCase()
+
+    }
+
+    public static boolean isCustomStatusString(String value){
+        null!=value && !(value.toLowerCase() in [ExecutionConstants.EXECUTION_TIMEDOUT,
+                                                 ExecutionConstants.EXECUTION_FAILED_WITH_RETRY,
+                                                 ExecutionConstants.EXECUTION_ABORTED,
+                                                 ExecutionConstants.EXECUTION_SUCCEEDED,
+                                                 ExecutionConstants.EXECUTION_FAILED,
+                                                 ExecutionConstants.EXECUTION_QUEUED,
+                                                 ExecutionConstants.EXECUTION_SCHEDULED,
+                                                 ExecutionConstants.AVERAGE_DURATION_EXCEEDED])
+    }
+}

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/validation/shared/SharedExecutionConstraints.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/validation/shared/SharedExecutionConstraints.groovy
@@ -1,0 +1,45 @@
+package rundeck.data.validation.shared
+
+import grails.validation.Validateable
+
+class SharedExecutionConstraints implements Validateable {
+    String jobUuid
+    String argString
+    String status
+    String userRoleList
+    Date dateStarted
+    Date dateCompleted
+    String outputfilepath
+    String loglevel
+    String failedNodeList
+    String succeededNodeList
+    String abortedby
+    Boolean timedOut=false
+    String executionType
+    Integer retryAttempt=0
+    Boolean willRetry
+    String timeout
+    String retry
+    String retryDelay
+
+    static constraints = {
+        jobUuid(nullable:true)
+        argString(nullable:true)
+        dateStarted(nullable:true)
+        dateCompleted(nullable:true)
+        userRoleList(nullable: true)
+        outputfilepath(nullable:true)
+        loglevel(nullable:true)
+        status(nullable:true)
+        failedNodeList(nullable:true, blank:true)
+        succeededNodeList(nullable:true, blank:true)
+        abortedby(nullable:true, blank:true)
+        timedOut(nullable: true)
+        executionType(nullable: true, maxSize: 30)
+        retryAttempt(nullable: true)
+        willRetry(nullable: true)
+        timeout(maxSize: 256, blank: true, nullable: true,)
+        retry(maxSize: 256, blank: true, nullable: true,matches: /^\d+$/)
+        retryDelay(nullable:true)
+    }
+}

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/validation/shared/SharedServerNodeUuidConstraints.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/validation/shared/SharedServerNodeUuidConstraints.groovy
@@ -1,0 +1,16 @@
+package rundeck.data.validation.shared
+
+import grails.validation.Validateable
+
+class SharedServerNodeUuidConstraints implements Validateable {
+    String serverNodeUUID
+
+    static constraints = {
+        serverNodeUUID(maxSize: 36, size:36..36, blank: true, nullable: true, validator: { val, obj ->
+            if (null == val) return true;
+            try { return null!= UUID.fromString(val) } catch (IllegalArgumentException e) {
+                return false
+            }
+        })
+    }
+}

--- a/grails-rundeck-data-shared/src/test/groovy/rundeck/data/util/ExecutionDataUtilSpec.groovy
+++ b/grails-rundeck-data-shared/src/test/groovy/rundeck/data/util/ExecutionDataUtilSpec.groovy
@@ -1,0 +1,49 @@
+package rundeck.data.util
+
+import rundeck.data.constants.ExecutionConstants
+import rundeck.data.execution.RdExecution
+import spock.lang.Specification
+
+class ExecutionDataUtilSpec extends Specification {
+
+    def "test getExecutionState method"() {
+        expect:
+        ExecutionDataUtil.getExecutionState(executionData) == expectedExecutionState
+
+        where:
+        executionData                    | expectedExecutionState
+        new RdExecution(cancelled: true) | ExecutionConstants.EXECUTION_ABORTED
+        new RdExecution(status: ExecutionConstants.EXECUTION_QUEUED)      | ExecutionConstants.EXECUTION_QUEUED
+        new RdExecution(dateStarted: new Date(System.currentTimeMillis()+5000)) | ExecutionConstants.EXECUTION_SCHEDULED
+        new RdExecution(dateCompleted: null, status: ExecutionConstants.AVERAGE_DURATION_EXCEEDED) | ExecutionConstants.AVERAGE_DURATION_EXCEEDED
+        new RdExecution(dateCompleted: null, status: "running")           | ExecutionConstants.EXECUTION_RUNNING
+        new RdExecution(dateCompleted: new Date(),status: "succeeded")    | ExecutionConstants.EXECUTION_SUCCEEDED
+        new RdExecution(dateCompleted: new Date(), cancelled: true)       | ExecutionConstants.EXECUTION_ABORTED
+        new RdExecution(dateCompleted: new Date(),willRetry: true)        | ExecutionConstants.EXECUTION_FAILED_WITH_RETRY
+        new RdExecution(dateCompleted: new Date(),timedOut: true)         | ExecutionConstants.EXECUTION_TIMEDOUT
+        new RdExecution(dateCompleted: new Date(),status: "missed")       | ExecutionConstants.EXECUTION_MISSED
+        new RdExecution(dateCompleted: new Date(),status: "failed")       | ExecutionConstants.EXECUTION_FAILED
+        new RdExecution(dateCompleted: new Date(),status: "custom")       | ExecutionConstants.EXECUTION_STATE_OTHER
+
+        // Add more test cases as needed
+    }
+
+    def "test isCustomStatusString method"() {
+        expect:
+        ExecutionDataUtil.isCustomStatusString(value) == expectedResult
+
+        where:
+        value                                                      | expectedResult
+        ExecutionConstants.EXECUTION_TIMEDOUT                      | false
+        ExecutionConstants.EXECUTION_FAILED_WITH_RETRY             | false
+        ExecutionConstants.EXECUTION_ABORTED                       | false
+        ExecutionConstants.EXECUTION_SUCCEEDED                     | false
+        ExecutionConstants.EXECUTION_FAILED                        | false
+        ExecutionConstants.EXECUTION_QUEUED                        | false
+        ExecutionConstants.EXECUTION_SCHEDULED                     | false
+        ExecutionConstants.AVERAGE_DURATION_EXCEEDED               | false
+        "custom"                                                   | true
+        "other"                                                    | true
+
+    }
+}

--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/model/v1/execution/ExecutionData.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/model/v1/execution/ExecutionData.java
@@ -1,25 +1,49 @@
 package org.rundeck.app.data.model.v1.execution;
 
+import org.rundeck.app.data.model.v1.job.config.NodeConfig;
+import org.rundeck.app.data.model.v1.job.orchestrator.OrchestratorData;
+import org.rundeck.app.data.model.v1.job.workflow.WorkflowData;
+
 import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
 
 public interface ExecutionData {
+    String getUuid();
+    String getJobUuid();
     String getProject();
+    String getArgString();
+    String getUser();
+    List<String> getUserRoles();
+    String getLoglevel();
+    String getTimeout();
+    String getRetry();
+    String getRetryDelay();
     String getStatus();
+    Date getDateStarted();
+    Date getDateCompleted();
     String getOutputfilepath();
     String getFailedNodeList();
     String getSucceededNodeList();
     String getAbortedby();
     String getExecutionType();
-    String getUserRoleList();
     String getServerNodeUUID();
     String getExtraMetadata();
     Integer getRetryAttempt();
     Integer getNodeThreadcount();
+    Serializable getRetryExecutionId();
     Serializable getRetryOriginalId();
     Serializable getRetryPrevId();
+    Serializable getLogFileStorageRequestId();
     boolean isCancelled();
     Boolean getTimedOut();
     Boolean getWillRetry();
+    NodeConfig getNodeConfig();
+    WorkflowData getWorkflow();
+    OrchestratorData getOrchestrator();
+
+    //transient methods
+    String getExecutionState();
     boolean isServerNodeUUIDChanged();
-    String getNodeInclude();
+    boolean statusSucceeded();
 }

--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/model/v1/execution/ExecutionData.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/model/v1/execution/ExecutionData.java
@@ -7,6 +7,7 @@ import org.rundeck.app.data.model.v1.job.workflow.WorkflowData;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 public interface ExecutionData {
     String getUuid();
@@ -28,7 +29,6 @@ public interface ExecutionData {
     String getAbortedby();
     String getExecutionType();
     String getServerNodeUUID();
-    String getExtraMetadata();
     Integer getRetryAttempt();
     Integer getNodeThreadcount();
     Serializable getRetryExecutionId();
@@ -41,9 +41,11 @@ public interface ExecutionData {
     NodeConfig getNodeConfig();
     WorkflowData getWorkflow();
     OrchestratorData getOrchestrator();
+    Map<String,Object> getExtraMetadataMap();
 
     //transient methods
     String getExecutionState();
     boolean isServerNodeUUIDChanged();
     boolean statusSucceeded();
+
 }

--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/model/v1/execution/ExecutionDataSummary.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/model/v1/execution/ExecutionDataSummary.java
@@ -1,0 +1,13 @@
+package org.rundeck.app.data.model.v1.execution;
+
+import java.util.Date;
+
+public interface ExecutionDataSummary {
+    String getUuid();
+    String getJobUuid();
+    String getProject();
+    String getStatus();
+    Date getDateStarted();
+    Date getDateCompleted();
+    String getServerNodeUUID();
+}

--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/model/v1/job/workflow/WorkflowStepData.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/model/v1/job/workflow/WorkflowStepData.java
@@ -50,4 +50,6 @@ public interface WorkflowStepData {
      * @return A map keyed by the plugin name, and the value being the configuration data for that plugin
      */
     Map<String,Object> getPluginConfig();
+
+    String summarize();
 }

--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/execution/ExecutionDataProvider.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/execution/ExecutionDataProvider.java
@@ -2,10 +2,13 @@ package org.rundeck.app.data.providers.v1.execution;
 
 import org.rundeck.app.data.model.v1.DeletionResult;
 import org.rundeck.app.data.model.v1.execution.ExecutionData;
+import org.rundeck.app.data.model.v1.execution.ExecutionDataSummary;
+import org.rundeck.app.data.model.v1.page.Pageable;
 import org.rundeck.app.data.providers.v1.DataProvider;
 import org.rundeck.spi.data.DataAccessException;
 
 import java.io.Serializable;
+import java.util.List;
 
 public interface ExecutionDataProvider extends DataProvider {
     /**
@@ -36,4 +39,12 @@ public interface ExecutionDataProvider extends DataProvider {
      * @return result of the delete operation
      */
     DeletionResult delete(String uuid);
+
+    /**
+     *
+     * @param jobUuid
+     * @param pageable
+     * @return a list of executions for the given job uuid
+     */
+    List<ExecutionDataSummary> findAllExecutionsByJob(String jobUuid, Pageable pageable);
 }

--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/execution/ExecutionDataProvider.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/execution/ExecutionDataProvider.java
@@ -1,0 +1,39 @@
+package org.rundeck.app.data.providers.v1.execution;
+
+import org.rundeck.app.data.model.v1.DeletionResult;
+import org.rundeck.app.data.model.v1.execution.ExecutionData;
+import org.rundeck.app.data.providers.v1.DataProvider;
+import org.rundeck.spi.data.DataAccessException;
+
+import java.io.Serializable;
+
+public interface ExecutionDataProvider extends DataProvider {
+    /**
+     * Get execution data
+     * @param id - the internal database id of the execution
+     * @return execution data
+     */
+    ExecutionData get(Serializable id);
+
+    /**
+     * Get execution data
+     * @param uuid - the uuid of the execution
+     * @return execution data
+     */
+    ExecutionData getByUuid(String uuid);
+
+    /**
+     * Save execution data
+     * @param execution
+     * @return the saved execution data object
+     * @throws DataAccessException
+     */
+    ExecutionData save(ExecutionData execution) throws DataAccessException;
+
+    /**
+     *
+     * @param uuid execution uuid
+     * @return result of the delete operation
+     */
+    DeletionResult delete(String uuid);
+}

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -112,6 +112,7 @@ import org.rundeck.app.components.JobYAMLFormat
 import org.rundeck.app.data.providers.GormExecReportDataProvider
 import org.rundeck.app.data.options.DefaultJobOptionUrlExpander
 import org.rundeck.app.data.options.DefaultRemoteJsonOptionRetriever
+import org.rundeck.app.data.providers.GormExecutionDataProvider
 import org.rundeck.app.data.providers.GormJobStatsDataProvider
 import org.rundeck.app.data.providers.GormPluginMetaDataProvider
 import org.rundeck.app.data.providers.GormProjectDataProvider
@@ -922,6 +923,7 @@ beans={
     execReportDataProvider(GormExecReportDataProvider)
     webhookDataProvider(GormWebhookDataProvider)
     jobDataProvider(GormJobDataProvider)
+    executionDataProvider(GormExecutionDataProvider)
     pluginMetaDataProvider(GormPluginMetaDataProvider)
     referencedExecutionDataProvider(GormReferencedExecutionDataProvider)
     jobStatsDataProvider(GormJobStatsDataProvider)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/RdExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/RdExecutionController.groovy
@@ -1,0 +1,78 @@
+package rundeck.controllers
+
+import com.dtolabs.rundeck.core.authorization.AuthContext
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import groovy.transform.CompileStatic
+import org.rundeck.app.authorization.AppAuthContextProcessor
+import org.rundeck.app.data.exception.DataValidationException
+import org.rundeck.app.data.validation.ValidationResponse
+import org.rundeck.core.auth.AuthConstants
+import org.rundeck.core.auth.app.RundeckAccess
+import org.rundeck.core.auth.web.RdAuthorizeExecution
+import org.rundeck.core.auth.web.RdAuthorizeProject
+import org.springframework.context.MessageSource
+import rundeck.Execution
+import rundeck.data.execution.RdExecution
+import rundeck.data.job.RdJob
+import rundeck.services.RdExecutionService
+
+class RdExecutionController extends ControllerBase {
+
+    static ObjectMapper mapper = new ObjectMapper()
+    static {
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
+    }
+
+    AppAuthContextProcessor rundeckAuthContextProcessor
+    RdExecutionService rdExecutionService
+    MessageSource messageSource
+
+    @RdAuthorizeExecution(RundeckAccess.Execution.AUTH_APP_READ_OR_VIEW)
+    def get() {
+        response.contentType = "application/json;utf-8"
+        def job = rdExecutionService.getExecutionByUuid(params.id)
+        if(job) {
+            render mapper.writeValueAsString(job)
+        } else {
+            response.status = 404
+        }
+    }
+
+    @CompileStatic
+    def save() {
+        response.contentType = "application/json;utf-8"
+
+        try {
+            RdExecution execution = mapper.readValue(request.inputStream, RdExecution)
+            render mapper.writeValueAsString(rdExecutionService.saveExecutionData(execution))
+        } catch(InvalidFormatException ife) {
+            response.status = 400
+            render mapper.writeValueAsString([error: ife.message])
+        } catch(DataValidationException dvex) {
+            response.status = 400
+            render mapper.writeValueAsString(new ValidationResponse().createFrom(messageSource, dvex.target))
+        }
+    }
+
+
+    def delete() {
+        response.contentType = "application/json;utf-8"
+        def e = rdExecutionService.getExecutionByUuid(params.id)
+        if(!e) {
+            response.status = 404
+            return
+        }
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
+        if (!rundeckAuthContextProcessor.authorizeApplicationResourceAny(
+                authContext,
+                rundeckAuthContextProcessor.authResourceForProject(e.project),
+                [AuthConstants.ACTION_DELETE_EXECUTION, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]
+        )) {
+            renderUnauthorized("Unauthorized API call")
+        }
+        render mapper.writeValueAsString(rdExecutionService.delete(params.id))
+    }
+
+}

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/RdExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/RdExecutionController.groovy
@@ -42,32 +42,6 @@ class RdExecutionController extends ControllerBase {
         }
     }
 
-    @GrailsCompileStatic
-    def save() {
-        response.contentType = "application/json;utf-8"
-
-        try {
-            RdExecution execution = mapper.readValue(request.inputStream, RdExecution)
-            AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject((Subject)session.getAttribute("subject"))
-            if (!rundeckAuthContextProcessor.authorizeProjectResourceAny(
-                    authContext,
-                    AuthConstants.RESOURCE_TYPE_JOB,
-                    [AuthConstants.ACTION_RUN, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
-                    execution.project
-            )) {
-                throw new UnauthorizedAccess(AuthConstants.ACTION_RUN, AuthConstants.TYPE_JOB, execution.uuid)
-            }
-            render mapper.writeValueAsString(rdExecutionService.saveExecutionData(execution))
-        } catch(JsonMappingException ife) {
-            response.status = 400
-            render mapper.writeValueAsString([error: ife.message])
-        } catch(DataValidationException dvex) {
-            response.status = 400
-            render mapper.writeValueAsString(new ValidationResponse().createFrom(messageSource, dvex.target))
-        }
-    }
-
-
     def delete() {
         response.contentType = "application/json;utf-8"
         def e = rdExecutionService.getExecutionByUuid(params.id)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/RdExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/RdExecutionController.groovy
@@ -2,21 +2,23 @@ package rundeck.controllers
 
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.exc.InvalidFormatException
-import groovy.transform.CompileStatic
+import grails.compiler.GrailsCompileStatic
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.app.data.exception.DataValidationException
 import org.rundeck.app.data.validation.ValidationResponse
 import org.rundeck.core.auth.AuthConstants
+import org.rundeck.core.auth.access.UnauthorizedAccess
 import org.rundeck.core.auth.app.RundeckAccess
 import org.rundeck.core.auth.web.RdAuthorizeExecution
-import org.rundeck.core.auth.web.RdAuthorizeProject
+import org.rundeck.core.auth.web.RdAuthorizeJob
 import org.springframework.context.MessageSource
-import rundeck.Execution
 import rundeck.data.execution.RdExecution
-import rundeck.data.job.RdJob
+import rundeck.data.paging.RdPageable
 import rundeck.services.RdExecutionService
+
+import javax.security.auth.Subject
 
 class RdExecutionController extends ControllerBase {
 
@@ -40,14 +42,23 @@ class RdExecutionController extends ControllerBase {
         }
     }
 
-    @CompileStatic
+    @GrailsCompileStatic
     def save() {
         response.contentType = "application/json;utf-8"
 
         try {
             RdExecution execution = mapper.readValue(request.inputStream, RdExecution)
+            AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject((Subject)session.getAttribute("subject"))
+            if (!rundeckAuthContextProcessor.authorizeProjectResourceAny(
+                    authContext,
+                    AuthConstants.RESOURCE_TYPE_JOB,
+                    [AuthConstants.ACTION_RUN, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+                    execution.project
+            )) {
+                throw new UnauthorizedAccess(AuthConstants.ACTION_RUN, AuthConstants.TYPE_JOB, execution.uuid)
+            }
             render mapper.writeValueAsString(rdExecutionService.saveExecutionData(execution))
-        } catch(InvalidFormatException ife) {
+        } catch(JsonMappingException ife) {
             response.status = 400
             render mapper.writeValueAsString([error: ife.message])
         } catch(DataValidationException dvex) {
@@ -70,9 +81,18 @@ class RdExecutionController extends ControllerBase {
                 rundeckAuthContextProcessor.authResourceForProject(e.project),
                 [AuthConstants.ACTION_DELETE_EXECUTION, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]
         )) {
-            renderUnauthorized("Unauthorized API call")
+            throw new UnauthorizedAccess(AuthConstants.ACTION_DELETE_EXECUTION, AuthConstants.TYPE_EXECUTION, e.uuid)
         }
         render mapper.writeValueAsString(rdExecutionService.delete(params.id))
+    }
+
+    @RdAuthorizeJob(RundeckAccess.Job.AUTH_APP_READ_OR_VIEW)
+    def listForJob() {
+        response.contentType = "application/json;utf-8"
+        RdPageable pageable = new RdPageable()
+        if(params.max) pageable.max = params.max.toInteger()
+        if(params.offset) pageable.offset = params.offset.toInteger()
+        render mapper.writeValueAsString(rdExecutionService.listExecutionsForJob(params.id, pageable))
     }
 
 }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/RdJobController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/RdJobController.groovy
@@ -1,10 +1,15 @@
 package rundeck.controllers
 
+import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import groovy.transform.CompileStatic
 import org.rundeck.app.data.exception.DataValidationException
+import org.rundeck.core.auth.AuthConstants
+import org.rundeck.core.auth.access.UnauthorizedAccess
+import org.rundeck.core.auth.app.RundeckAccess
+import org.rundeck.core.auth.web.RdAuthorizeJob
 import rundeck.data.job.RdJob
 import org.rundeck.app.data.validation.ValidationResponse
 import org.springframework.context.MessageSource
@@ -12,6 +17,7 @@ import rundeck.data.job.query.RdJobQueryInput
 import rundeck.services.RdJobService
 
 import javax.persistence.EntityNotFoundException
+import javax.security.auth.Subject
 
 class RdJobController extends ControllerBase {
 
@@ -25,6 +31,7 @@ class RdJobController extends ControllerBase {
 
     def editpage() {}
 
+    @RdAuthorizeJob(RundeckAccess.Job.AUTH_APP_READ_OR_VIEW)
     def get() {
         response.contentType = "application/json;utf-8"
         def job = rdJobService.getJobByIdOrUuid(params.id)
@@ -42,6 +49,15 @@ class RdJobController extends ControllerBase {
 
         try {
             RdJob job = mapper.readValue(request.inputStream, RdJob)
+            AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject((Subject)session.getAttribute("subject"))
+            if (!rundeckAuthContextProcessor.authorizeProjectResourceAny(
+                    authContext,
+                    AuthConstants.RESOURCE_TYPE_JOB,
+                    [AuthConstants.ACTION_CREATE, AuthConstants.ACTION_UPDATE, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+                    job.project
+            )) {
+                throw new UnauthorizedAccess("create or update", AuthConstants.TYPE_JOB, job.uuid)
+            }
             render mapper.writeValueAsString(rdJobService.saveJob(job))
         } catch(InvalidFormatException ife) {
             response.status = 400
@@ -55,8 +71,22 @@ class RdJobController extends ControllerBase {
 
     def delete() {
         response.contentType = "application/json;utf-8"
+        def job = rdJobService.getJobByUuid(params.id)
+        if(!job) {
+            response.status = 404
+            return
+        }
         try {
-            render mapper.writeValueAsString(rdJobService.delete(params.id))
+            AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject((Subject)session.getAttribute("subject"))
+            if (!rundeckAuthContextProcessor.authorizeProjectResourceAny(
+                    authContext,
+                    AuthConstants.RESOURCE_TYPE_JOB,
+                    [AuthConstants.ACTION_DELETE, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+                    job.project
+            )) {
+                throw new UnauthorizedAccess(AuthConstants.ACTION_DELETE, AuthConstants.TYPE_JOB, job.uuid)
+            }
+            render mapper.writeValueAsString(rdJobService.delete(job.uuid))
         } catch(EntityNotFoundException ex) {
             response.status = 404
             render mapper.writeValueAsString(["err":ex.message])

--- a/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
+++ b/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
@@ -43,6 +43,11 @@ class UrlMappings {
 
         "/api/$api_version/executions/delete"(controller: 'execution', action: 'apiExecutionDeleteBulk')
 
+        "/api/$api_version/incubator/execution/$id?"(controller: 'rdExecution') {
+            action = [GET: 'get', POST: 'save', DELETE: 'delete']
+        }
+        "/api/$api_version/incubator/executions"(controller: 'rdExecution', action: "list")
+
         "/api/$api_version/incubator/job/$id?"(controller: 'rdJob') {
             action = [GET: 'get', POST: 'save', DELETE: 'delete']
         }

--- a/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
+++ b/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
@@ -44,7 +44,7 @@ class UrlMappings {
         "/api/$api_version/executions/delete"(controller: 'execution', action: 'apiExecutionDeleteBulk')
 
         "/api/$api_version/incubator/execution/$id?"(controller: 'rdExecution') {
-            action = [GET: 'get', POST: 'save', DELETE: 'delete']
+            action = [GET: 'get', DELETE: 'delete']
         }
         "/api/$api_version/incubator/executions/$id"(controller: 'rdExecution', action: "listForJob")
 

--- a/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
+++ b/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
@@ -46,13 +46,13 @@ class UrlMappings {
         "/api/$api_version/incubator/execution/$id?"(controller: 'rdExecution') {
             action = [GET: 'get', POST: 'save', DELETE: 'delete']
         }
-        "/api/$api_version/incubator/executions"(controller: 'rdExecution', action: "list")
+        "/api/$api_version/incubator/executions/$id"(controller: 'rdExecution', action: "listForJob")
 
         "/api/$api_version/incubator/job/$id?"(controller: 'rdJob') {
             action = [GET: 'get', POST: 'save', DELETE: 'delete']
         }
 
-        "/api/$api_version/incubator/jobs"(controller: 'rdJob', action: "list")
+        "/api/$api_version/incubator/jobs"(controller: 'rdJob', action: "query")
 
         "/api/$api_version/job/$id"(controller: 'scheduledExecution') {
             action = [GET: 'apiJobExport', DELETE: 'apiJobDelete']

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -26,6 +26,8 @@ import com.dtolabs.rundeck.util.XmlParserUtil
 import com.fasterxml.jackson.core.JsonParseException
 import grails.gorm.DetachedCriteria
 import org.rundeck.app.data.model.v1.execution.ExecutionData
+import org.rundeck.app.data.model.v1.execution.ExecutionDataSummary
+import rundeck.data.execution.RdExecutionDataSummary
 import rundeck.data.job.RdNodeConfig
 import rundeck.data.validation.shared.SharedExecutionConstraints
 import rundeck.data.validation.shared.SharedNodeConfigConstraints
@@ -510,6 +512,20 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
 
     void beforeUpdate() {
         serverNodeUUIDChanged = this.isDirty('serverNodeUUID')
+    }
+
+    ExecutionDataSummary toSummary() {
+        return new RdExecutionDataSummary(
+                uuid: this.uuid,
+                jobUuid: this.jobUuid,
+                project: this.project,
+                status: this.status,
+                executionType: this.executionType,
+                executionState: this.executionState,
+                dateStarted: this.dateStarted,
+                dateCompleted: this.dateCompleted,
+                serverNodeUUID: this.serverNodeUUID
+        )
     }
 }
 

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -24,11 +24,13 @@ import com.dtolabs.rundeck.core.execution.ExecutionReference
 import com.dtolabs.rundeck.core.jobs.JobReference
 import com.dtolabs.rundeck.util.XmlParserUtil
 import com.fasterxml.jackson.core.JsonParseException
-import com.google.gson.Gson
 import grails.gorm.DetachedCriteria
-import groovy.json.JsonOutput
-import org.grails.datastore.mapping.query.api.BuildableCriteria
 import org.rundeck.app.data.model.v1.execution.ExecutionData
+import rundeck.data.job.RdNodeConfig
+import rundeck.data.validation.shared.SharedExecutionConstraints
+import rundeck.data.validation.shared.SharedNodeConfigConstraints
+import rundeck.data.validation.shared.SharedProjectNameConstraints
+import rundeck.data.validation.shared.SharedServerNodeUuidConstraints
 import rundeck.services.ExecutionService
 import rundeck.services.execution.ExecutionReferenceImpl
 
@@ -37,6 +39,8 @@ import rundeck.services.execution.ExecutionReferenceImpl
 */
 class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionData {
     ScheduledExecution scheduledExecution
+    String uuid = UUID.randomUUID().toString()
+    String jobUuid
     Date dateStarted
     Date dateCompleted
     String status
@@ -51,7 +55,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
     Integer retryAttempt=0
     Boolean willRetry=false
     Execution retryExecution
-    Orchestrator orchestrator;
+    Orchestrator orchestrator
     String userRoleList
     String serverNodeUUID
     Integer nodeThreadcount=1
@@ -64,64 +68,21 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
     static hasOne = [logFileStorageRequest: LogFileStorageRequest]
     static transients = ['executionState', 'customStatusString', 'userRoles', 'extraMetadataMap', 'serverNodeUUIDChanged']
     static constraints = {
-        project(matches: FrameworkResource.VALID_RESOURCE_NAME_REGEX, validator:{val,Execution obj->
+        importFrom SharedExecutionConstraints
+        importFrom SharedNodeConfigConstraints
+        importFrom SharedServerNodeUuidConstraints
+        project(matches: FrameworkResource.VALID_RESOURCE_NAME_REGEX, validator:{ val, Execution obj->
             if(obj.scheduledExecution && obj.scheduledExecution.project!=val){
                 return 'job.project.mismatch.error'
             }
         })
         logFileStorageRequest(nullable:true)
         workflow(nullable:true)
-        argString(nullable:true)
-        dateStarted(nullable:true)
-        dateCompleted(nullable:true)
-        status(nullable:true)
-        outputfilepath(nullable:true)
         scheduledExecution(nullable:true)
-        loglevel(nullable:true)
-        nodeInclude(nullable:true)
-        nodeExclude(nullable:true)
-        nodeIncludeName(nullable:true)
-        nodeExcludeName(nullable:true)
-        nodeIncludeTags(nullable:true)
-        nodeExcludeTags(nullable:true)
-        nodeIncludeOsName(nullable:true)
-        nodeExcludeOsName(nullable:true)
-        nodeIncludeOsFamily(nullable:true)
-        nodeExcludeOsFamily(nullable:true)
-        nodeIncludeOsArch(nullable:true)
-        nodeExcludeOsArch(nullable:true)
-        nodeIncludeOsVersion(nullable:true)
-        nodeExcludeOsVersion(nullable:true)
-        nodeExcludePrecedence(nullable:true)
-        nodeKeepgoing(nullable:true)
-        doNodedispatch(nullable:true)
-        nodeThreadcount(nullable:true)
-        nodeRankOrderAscending(nullable: true)
-        nodeRankAttribute(nullable: true)
-        orchestrator(nullable: true);
-        failedNodeList(nullable:true, blank:true)
-        succeededNodeList(nullable:true, blank:true)
-        abortedby(nullable:true, blank:true)
-        serverNodeUUID(maxSize: 36, size:36..36, blank: true, nullable: true, validator: { val, obj ->
-            if (null == val) return true;
-            try { return null!= UUID.fromString(val) } catch (IllegalArgumentException e) {
-                return false
-            }
-        })
-        timeout(maxSize: 256, blank: true, nullable: true,)
-        retry(maxSize: 256, blank: true, nullable: true,matches: /^\d+$/)
-        timedOut(nullable: true)
-        executionType(nullable: true, maxSize: 30)
-        retryAttempt(nullable: true)
+        orchestrator(nullable: true)
         retryExecution(nullable: true)
-        willRetry(nullable: true)
-        nodeFilterEditable(nullable: true)
-        userRoleList(nullable: true)
-        retryDelay(nullable:true)
-        successOnEmptyNodeFilter(nullable: true)
         retryOriginalId(nullable: true)
         retryPrevId(nullable: true)
-        excludeFilterUncheck(nullable: true)
         extraMetadata(nullable: true)
     }
 
@@ -203,6 +164,45 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
         }
     }
 
+    @Override
+    Serializable getRetryExecutionId() {
+        return retryExecution?.id
+    }
+
+    @Override
+    Serializable getLogFileStorageRequestId() {
+        return logFileStorageRequest?.id
+    }
+
+    RdNodeConfig getNodeConfig() {
+        new RdNodeConfig(
+                nodeInclude : nodeInclude,
+                nodeExclude : nodeExclude,
+                nodeIncludeName : nodeIncludeName,
+                nodeExcludeName : nodeExcludeName,
+                nodeIncludeTags : nodeIncludeTags,
+                nodeExcludeTags : nodeExcludeTags,
+                nodeIncludeOsName : nodeIncludeOsName,
+                nodeExcludeOsName : nodeExcludeOsName,
+                nodeIncludeOsFamily : nodeIncludeOsFamily,
+                nodeExcludeOsFamily : nodeExcludeOsFamily,
+                nodeIncludeOsArch : nodeIncludeOsArch,
+                nodeExcludeOsArch : nodeExcludeOsArch,
+                nodeIncludeOsVersion : nodeIncludeOsVersion,
+                nodeExcludeOsVersion : nodeExcludeOsVersion,
+                nodeExcludePrecedence : nodeExcludePrecedence,
+                successOnEmptyNodeFilter: successOnEmptyNodeFilter,
+                filter: filter,
+                filterExclude: filterExclude,
+                excludeFilterUncheck: excludeFilterUncheck,
+                nodeKeepgoing : nodeKeepgoing,
+                doNodedispatch : doNodedispatch,
+                nodeRankAttribute : nodeRankAttribute,
+                nodeRankOrderAscending : nodeRankOrderAscending,
+                nodeFilterEditable : nodeFilterEditable,
+                nodeThreadcount : nodeThreadcount
+        )
+    }
 
     public String toString() {
         return "Workflow execution: ${workflow}"

--- a/rundeckapp/grails-app/domain/rundeck/PluginStep.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/PluginStep.groovy
@@ -104,7 +104,7 @@ class PluginStep extends WorkflowStep{
     static void updateFromMap(PluginStep ce, Map data) {
         ce.nodeStep=data.nodeStep
         ce.type=data.type
-        ce.setConfiguration(data)
+        ce.setConfiguration(data.configuration)
 
         ce.keepgoingOnSuccess = !!data.keepgoingOnSuccess
         ce.description=data.description?.toString()

--- a/rundeckapp/grails-app/domain/rundeck/PluginStep.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/PluginStep.groovy
@@ -104,7 +104,7 @@ class PluginStep extends WorkflowStep{
     static void updateFromMap(PluginStep ce, Map data) {
         ce.nodeStep=data.nodeStep
         ce.type=data.type
-        ce.configuration=data.configuration
+        ce.setConfiguration(data)
 
         ce.keepgoingOnSuccess = !!data.keepgoingOnSuccess
         ce.description=data.description?.toString()

--- a/rundeckapp/grails-app/migrations/core/Execution.groovy
+++ b/rundeckapp/grails-app/migrations/core/Execution.groovy
@@ -1,3 +1,4 @@
+import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import liquibase.statement.core.UpdateStatement
 
 databaseChangeLog = {
@@ -175,6 +176,22 @@ databaseChangeLog = {
         }
 
     }
+
+    changeSet(author: "rundeckdev", id: "4.x-add-uuid-and-job-uuid-indexes") {
+        preConditions(onFail: "MARK_RAN"){
+            not {
+                indexExists(indexName: "execution_uuid_idx", tableName: "execution")
+                indexExists(indexName: "execution_job_uuid_idx", tableName: "execution")
+            }
+        }
+        createIndex(indexName: "execution_uuid_idx", tableName: "execution") {
+            column(name: "uuid")
+        }
+        createIndex(indexName: "execution_job_uuid_idx", tableName: "execution") {
+            column(name: "job_uuid")
+        }
+    }
+
     changeSet(author: "rundeckdev", id: "4.x-populate-job-uuid") {
         preConditions(onFail: "MARK_RAN") {
             tableExists(tableName: "execution")

--- a/rundeckapp/grails-app/migrations/core/Execution.groovy
+++ b/rundeckapp/grails-app/migrations/core/Execution.groovy
@@ -191,32 +191,4 @@ databaseChangeLog = {
             column(name: "job_uuid")
         }
     }
-
-    changeSet(author: "rundeckdev", id: "4.x-populate-job-uuid") {
-        preConditions(onFail: "MARK_RAN") {
-            tableExists(tableName: "execution")
-            tableExists(tableName: "scheduled_execution")
-        }
-        sql("update execution set job_uuid = (select scheduled_execution.uuid from scheduled_execution where scheduled_execution.id = execution.scheduled_execution_id) where job_uuid is null")
-    }
-    changeSet(author: "rundeckuser (generated)", failOnError:"true", id: "all-executions-have-uuids") {
-        preConditions(onFail: 'MARK_RAN') {
-            columnExists(tableName: "execution", columnName: 'uuid')
-        }
-        grailsChange {
-            change {
-                def updates = []
-                sql.eachRow("select id from execution") {
-
-                    updates.add(new UpdateStatement(null,null,"execution")
-                            .addNewColumnValue("uuid",UUID.randomUUID().toString())
-                            .setWhereClause("id = '${it.id}'"))
-                }
-
-                sqlStatements(updates)
-            }
-            rollback {
-            }
-        }
-    }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2153,6 +2153,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
         // Abandon the transient ScheduledExecution entity instance.
         execution.scheduledExecution = null
+        execution.jobUuid = null
 
         if(execution.workflow){
             if(!execution.workflow.save(flush:true)){
@@ -2566,6 +2567,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         }
 
         execution.scheduledExecution=se
+        execution.jobUuid=se.uuid
 
         // If there is a preExecutionCheckError, put that error into the execution's extraMetadataMap.
         if(!beforeExecutionResult?.isSuccessful() && beforeExecutionResult?.isTriggeredByJobEvent(JobPreExecutionEvent)) {

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3004,6 +3004,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         def boolean execSaved = false
         def Execution execution = Execution.get(exId)
         execution.properties = props
+        if(!execution.uuid) {
+            execution.uuid = UUID.randomUUID().toString()
+        }
         if (props.failedNodes) {
             execution.failedNodeList = props.failedNodes.join(",")
         }
@@ -3013,6 +3016,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
         if (schedId) {
             scheduledExecution = ScheduledExecution.findByUuid(schedId)
+            if(!execution.jobUuid) execution.jobUuid = scheduledExecution.uuid
         }
 
         //check the final status of succeeded nodes

--- a/rundeckapp/grails-app/services/rundeck/services/RdExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/RdExecutionService.groovy
@@ -1,0 +1,22 @@
+package rundeck.services
+
+import org.rundeck.app.data.model.v1.DeletionResult
+import org.rundeck.app.data.model.v1.execution.ExecutionData
+import org.rundeck.app.data.providers.v1.execution.ExecutionDataProvider
+
+class RdExecutionService {
+
+    ExecutionDataProvider executionDataProvider
+
+    ExecutionData getExecutionByUuid(String uuid) {
+        executionDataProvider.getByUuid(uuid)
+    }
+
+    ExecutionData saveExecutionData(ExecutionData executionData) {
+        executionDataProvider.save(executionData)
+    }
+
+    DeletionResult delete(String id) {
+        return executionDataProvider.delete(id)
+    }
+}

--- a/rundeckapp/grails-app/services/rundeck/services/RdExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/RdExecutionService.groovy
@@ -2,6 +2,8 @@ package rundeck.services
 
 import org.rundeck.app.data.model.v1.DeletionResult
 import org.rundeck.app.data.model.v1.execution.ExecutionData
+import org.rundeck.app.data.model.v1.execution.ExecutionDataSummary
+import org.rundeck.app.data.model.v1.page.Pageable
 import org.rundeck.app.data.providers.v1.execution.ExecutionDataProvider
 
 class RdExecutionService {
@@ -18,5 +20,9 @@ class RdExecutionService {
 
     DeletionResult delete(String id) {
         return executionDataProvider.delete(id)
+    }
+
+    List<ExecutionDataSummary> listExecutionsForJob(String jobUuid, Pageable pageable) {
+        executionDataProvider.findAllExecutionsByJob(jobUuid, pageable)
     }
 }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/domain/execution/AppAuthorizingExecution.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/domain/execution/AppAuthorizingExecution.groovy
@@ -61,7 +61,11 @@ class AppAuthorizingExecution extends BaseAuthorizingIdResource<Execution, Proje
         if (identifier.project) {
             found = Execution.findByIdAndProject(identifier.id.toLong(), identifier.project)
         } else {
-            found = Execution.get(identifier.id.toLong())
+            try {
+                found = Execution.get(identifier.id.toLong())
+            } catch(NumberFormatException ignored) {
+                found = Execution.findByUuid(identifier.id)
+            }
         }
         Optional.ofNullable(found)
     }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/ExecutionFromRdExecutionUpdater.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/ExecutionFromRdExecutionUpdater.groovy
@@ -41,7 +41,7 @@ class ExecutionFromRdExecutionUpdater {
         }
         e.retryOriginalId = re.retryOriginalId
         e.retryPrevId = re.retryPrevId
-        e.extraMetadata = re.extraMetadata
+        e.setExtraMetadataMap(re.extraMetadataMap)
         e.abortedby = re.abortedby
         e.cancelled = re.cancelled
         e.timedOut = re.timedOut
@@ -62,6 +62,7 @@ class ExecutionFromRdExecutionUpdater {
     }
 
     static void updateNodeConfig(Execution e, RdNodeConfig nodeConfig) {
+        if(!nodeConfig) return
         e.nodeInclude = nodeConfig.nodeInclude
         e.nodeIncludeName = nodeConfig.nodeIncludeName
         e.nodeIncludeTags = nodeConfig.nodeIncludeTags

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/ExecutionFromRdExecutionUpdater.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/ExecutionFromRdExecutionUpdater.groovy
@@ -1,0 +1,91 @@
+package org.rundeck.app.data.job.converters
+
+import rundeck.Execution
+import rundeck.LogFileStorageRequest
+import rundeck.Orchestrator
+import rundeck.ScheduledExecution
+import rundeck.Workflow
+import rundeck.data.execution.RdExecution
+import rundeck.data.job.RdNodeConfig
+import rundeck.data.job.RdOrchestrator
+
+class ExecutionFromRdExecutionUpdater {
+    static void update(Execution e, RdExecution re) {
+        e.uuid = re.uuid
+        if(!e.id && !e.uuid) e.uuid = UUID.randomUUID().toString()
+        if(re.jobUuid && (!e.scheduledExecution || e.scheduledExecution?.uuid != re.jobUuid)) {
+            e.scheduledExecution = ScheduledExecution.findByUuid(re.jobUuid)
+        }
+        e.jobUuid = re.jobUuid
+        e.status = re.status
+        e.dateStarted = re.dateStarted
+        e.dateCompleted = re.dateCompleted
+        e.executionType = re.executionType
+        e.project = re.project
+        e.argString = re.argString
+        e.user = re.user
+        e.timeout = re.timeout
+        e.retry = re.retry
+        e.retryDelay = re.retryDelay
+        e.setUserRoles(re.userRoles)
+        e.outputfilepath = re.outputfilepath
+        e.failedNodeList = re.failedNodeList
+        e.succeededNodeList = re.succeededNodeList
+        e.serverNodeUUID = re.serverNodeUUID
+        e.nodeThreadcount = re.nodeThreadcount
+        if(re.logFileStorageRequestId && e.logFileStorageRequestId != re.logFileStorageRequestId) {
+            e.logFileStorageRequest = LogFileStorageRequest.get(re.logFileStorageRequestId)
+        }
+        if(re.retryExecutionId && e.retryExecutionId != re.retryExecutionId) {
+            e.retryExecution = Execution.get(re.retryExecutionId)
+        }
+        e.retryOriginalId = re.retryOriginalId
+        e.retryPrevId = re.retryPrevId
+        e.extraMetadata = re.extraMetadata
+        e.abortedby = re.abortedby
+        e.cancelled = re.cancelled
+        e.timedOut = re.timedOut
+        updateNodeConfig(e, re.nodeConfig)
+        if(!e.workflow) e.workflow = new Workflow(commands:[])
+        WorkflowUpdater.updateWorkflow(e.workflow, re.workflow)
+        updateOrchestrator(e, re.orchestrator)
+    }
+
+    static updateOrchestrator(Execution e, RdOrchestrator rdo) {
+        if(!e.orchestrator && !rdo) return
+        if(e.orchestrator && !rdo) {
+            e.orchestrator = null
+            return
+        }
+        if(!e.orchestrator) e.orchestrator = new Orchestrator()
+        OrchestratorUpdater.updateOrchestrator(e.orchestrator, rdo)
+    }
+
+    static void updateNodeConfig(Execution e, RdNodeConfig nodeConfig) {
+        e.nodeInclude = nodeConfig.nodeInclude
+        e.nodeIncludeName = nodeConfig.nodeIncludeName
+        e.nodeIncludeTags = nodeConfig.nodeIncludeTags
+        e.nodeIncludeOsName = nodeConfig.nodeIncludeOsName
+        e.nodeIncludeOsArch = nodeConfig.nodeIncludeOsArch
+        e.nodeIncludeOsFamily = nodeConfig.nodeIncludeOsFamily
+        e.nodeIncludeOsVersion = nodeConfig.nodeIncludeOsVersion
+        e.nodeExclude = nodeConfig.nodeExclude
+        e.nodeExcludeName = nodeConfig.nodeExcludeName
+        e.nodeExcludeTags = nodeConfig.nodeExcludeTags
+        e.nodeExcludeOsName = nodeConfig.nodeExcludeOsName
+        e.nodeExcludeOsArch = nodeConfig.nodeExcludeOsArch
+        e.nodeExcludeOsFamily = nodeConfig.nodeExcludeOsFamily
+        e.nodeExcludeOsVersion = nodeConfig.nodeExcludeOsVersion
+        e.nodeExcludePrecedence = nodeConfig.nodeExcludePrecedence
+        e.successOnEmptyNodeFilter = nodeConfig.successOnEmptyNodeFilter
+        e.nodeKeepgoing = nodeConfig.nodeKeepgoing
+        e.doNodedispatch = nodeConfig.doNodedispatch
+        e.nodeRankAttribute = nodeConfig.nodeRankAttribute
+        e.nodeRankOrderAscending = nodeConfig.nodeRankOrderAscending
+        e.nodeFilterEditable = nodeConfig.nodeFilterEditable
+        e.nodeThreadcount = nodeConfig.nodeThreadcount
+        e.filter = nodeConfig.filter
+        e.filterExclude = nodeConfig.filterExclude
+        e.excludeFilterUncheck = nodeConfig.excludeFilterUncheck
+    }
+}

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/ExecutionToRdExecutionConverter.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/ExecutionToRdExecutionConverter.groovy
@@ -1,0 +1,42 @@
+package org.rundeck.app.data.job.converters
+
+import rundeck.Execution
+import rundeck.data.execution.RdExecution
+
+class ExecutionToRdExecutionConverter {
+    static RdExecution convert(Execution e) {
+        if(!e) return null
+        RdExecution re = new RdExecution()
+        re.uuid = e.uuid
+        re.jobUuid = e.jobUuid
+        re.status = e.status
+        re.dateStarted = e.dateStarted
+        re.dateCompleted = e.dateCompleted
+        re.executionType = e.executionType
+        re.project = e.project
+        re.argString = e.argString
+        re.user = e.user
+        re.timeout = e.timeout
+        re.retry = e.retry
+        re.retryDelay = e.retryDelay
+        re.userRoles = e.userRoles
+        re.outputfilepath = e.outputfilepath
+        re.failedNodeList = e.failedNodeList
+        re.succeededNodeList = e.succeededNodeList
+        re.serverNodeUUID = e.serverNodeUUID
+        re.nodeThreadcount = e.nodeThreadcount
+        re.logFileStorageRequestId = e.logFileStorageRequestId as Long
+        re.retryExecutionId = e.retryExecutionId as Long
+        re.retryOriginalId = e.retryOriginalId
+        re.retryPrevId = e.retryPrevId
+        re.extraMetadata = e.extraMetadata
+        re.abortedby = e.abortedby
+        re.cancelled = e.cancelled
+        re.timedOut = e.timedOut
+        re.nodeConfig = e.nodeConfig
+        re.workflow = WorkflowToRdWorkflowConverter.convertWorkflow(e.workflow)
+        re.orchestrator = OrchestratorToRdOrchestratorConverter.convertOrchestrator(e.orchestrator)
+        return re
+
+    }
+}

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/ExecutionToRdExecutionConverter.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/ExecutionToRdExecutionConverter.groovy
@@ -1,5 +1,6 @@
 package org.rundeck.app.data.job.converters
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import rundeck.Execution
 import rundeck.data.execution.RdExecution
 
@@ -17,6 +18,8 @@ class ExecutionToRdExecutionConverter {
         re.argString = e.argString
         re.user = e.user
         re.timeout = e.timeout
+        re.retryAttempt = e.retryAttempt
+        re.willRetry = e.willRetry
         re.retry = e.retry
         re.retryDelay = e.retryDelay
         re.userRoles = e.userRoles
@@ -29,7 +32,7 @@ class ExecutionToRdExecutionConverter {
         re.retryExecutionId = e.retryExecutionId as Long
         re.retryOriginalId = e.retryOriginalId
         re.retryPrevId = e.retryPrevId
-        re.extraMetadata = e.extraMetadata
+        re.extraMetadataMap = e.extraMetadataMap
         re.abortedby = e.abortedby
         re.cancelled = e.cancelled
         re.timedOut = e.timedOut

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/OrchestratorToRdOrchestratorConverter.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/OrchestratorToRdOrchestratorConverter.groovy
@@ -1,0 +1,15 @@
+package org.rundeck.app.data.job.converters
+
+import rundeck.Orchestrator
+import rundeck.data.job.RdOrchestrator
+
+class OrchestratorToRdOrchestratorConverter {
+
+    static RdOrchestrator convertOrchestrator(Orchestrator o) {
+        if(!o) return null
+        RdOrchestrator orchestrator = new RdOrchestrator()
+        orchestrator.type = o.type
+        orchestrator.configuration = o.configuration
+        return orchestrator
+    }
+}

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/OrchestratorUpdater.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/OrchestratorUpdater.groovy
@@ -1,0 +1,14 @@
+package org.rundeck.app.data.job.converters
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import rundeck.Orchestrator
+import rundeck.data.job.RdOrchestrator
+
+class OrchestratorUpdater {
+    static ObjectMapper mapper = new ObjectMapper()
+
+    static void updateOrchestrator(Orchestrator orchestrator, RdOrchestrator rdo) {
+        orchestrator.type = rdo.type
+        orchestrator.content = mapper.writeValueAsString(rdo.configuration)
+    }
+}

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/ScheduledExecutionToJobConverter.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/ScheduledExecutionToJobConverter.groovy
@@ -58,9 +58,9 @@ class ScheduledExecutionToJobConverter {
         job.nodeConfig = se.nodeConfig
         job.optionSet = convertJobOptionSet(se)
         job.notificationSet = convertNotificationSet(se)
-        job.workflow = convertWorkflow(se.workflow)
+        job.workflow = WorkflowToRdWorkflowConverter.convertWorkflow(se.workflow)
         if(se.scheduled) job.schedule = se.schedule
-        job.orchestrator = convertOrchestrator(se.orchestrator)
+        job.orchestrator = OrchestratorToRdOrchestratorConverter.convertOrchestrator(se.orchestrator)
         job.pluginConfigMap = se.getPluginConfigMap()
         addJobComponents(job)
         return job
@@ -75,52 +75,6 @@ class ScheduledExecutionToJobConverter {
             }
             ((JobComponentDataImportExport)componentDef).exportToJobData(job)
         }
-    }
-
-    static RdOrchestrator convertOrchestrator(Orchestrator o) {
-        if(!o) return null
-        RdOrchestrator orchestrator = new RdOrchestrator()
-        orchestrator.type = o.type
-        orchestrator.configuration = o.configuration
-        return orchestrator
-    }
-
-    static RdWorkflow convertWorkflow(Workflow w) {
-        def wkf = new RdWorkflow()
-        wkf.threadcount = w.threadcount
-        wkf.keepgoing = w.keepgoing
-        wkf.strategy = w.strategy
-        wkf.pluginConfigMap = w.pluginConfigMap
-        wkf.steps = w.commands.collect { step -> convertWorkflowStep(step) }
-        return wkf
-    }
-
-    static RdWorkflowStep convertWorkflowStep(WorkflowStep wstep) {
-        if(!wstep) return null
-        def rds = new RdWorkflowStep()
-        rds.description = wstep.description
-        rds.keepgoingOnSuccess = wstep.keepgoingOnSuccess
-        rds.pluginConfig = wstep.pluginConfig
-        rds.errorHandler = convertWorkflowStep(wstep.errorHandler)
-        if(wstep instanceof PluginStep) {
-            def pstep = (PluginStep)wstep
-            rds.configuration = pstep.configuration
-        } else if(wstep instanceof JobExec) {
-            def jrstep = (JobExec)wstep
-            rds.configuration = new HashMap<>(jrstep.toMap())
-            rds.configuration.remove("plugins")
-            rds.configuration.remove("description")
-            rds.configuration.remove("keepgoingOnSuccess")
-        } else if(wstep instanceof CommandExec) {
-            def cstep = (CommandExec)wstep
-            rds.configuration = new HashMap<>(cstep.toMap()) as Map<String, Object>
-            rds.configuration.remove("plugins")
-            rds.configuration.remove("description")
-            rds.configuration.remove("keepgoingOnSuccess")
-        }
-        rds.nodeStep = wstep.nodeStep
-        rds.pluginType = wstep.getPluginType()
-        return rds
     }
 
     static TreeSet<RdOption> convertJobOptionSet(ScheduledExecution se) {

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/WorkflowToRdWorkflowConverter.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/WorkflowToRdWorkflowConverter.groovy
@@ -1,0 +1,50 @@
+package org.rundeck.app.data.job.converters
+
+import rundeck.CommandExec
+import rundeck.JobExec
+import rundeck.PluginStep
+import rundeck.Workflow
+import rundeck.WorkflowStep
+import rundeck.data.job.RdWorkflow
+import rundeck.data.job.RdWorkflowStep
+
+class WorkflowToRdWorkflowConverter {
+
+    static RdWorkflow convertWorkflow(Workflow w) {
+        def wkf = new RdWorkflow()
+        wkf.threadcount = w.threadcount
+        wkf.keepgoing = w.keepgoing
+        wkf.strategy = w.strategy
+        wkf.pluginConfigMap = w.pluginConfigMap
+        wkf.steps = w.commands.collect { step -> convertWorkflowStep(step) }
+        return wkf
+    }
+
+    static RdWorkflowStep convertWorkflowStep(WorkflowStep wstep) {
+        if(!wstep) return null
+        def rds = new RdWorkflowStep()
+        rds.description = wstep.description
+        rds.keepgoingOnSuccess = wstep.keepgoingOnSuccess
+        rds.pluginConfig = wstep.pluginConfig
+        rds.errorHandler = convertWorkflowStep(wstep.errorHandler)
+        if(wstep instanceof PluginStep) {
+            def pstep = (PluginStep)wstep
+            rds.configuration = pstep.configuration
+        } else if(wstep instanceof JobExec) {
+            def jrstep = (JobExec)wstep
+            rds.configuration = new HashMap<>(jrstep.toMap())
+            rds.configuration.remove("plugins")
+            rds.configuration.remove("description")
+            rds.configuration.remove("keepgoingOnSuccess")
+        } else if(wstep instanceof CommandExec) {
+            def cstep = (CommandExec)wstep
+            rds.configuration = new HashMap<>(cstep.toMap()) as Map<String, Object>
+            rds.configuration.remove("plugins")
+            rds.configuration.remove("description")
+            rds.configuration.remove("keepgoingOnSuccess")
+        }
+        rds.nodeStep = wstep.nodeStep
+        rds.pluginType = wstep.getPluginType()
+        return rds
+    }
+}

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/WorkflowUpdater.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/WorkflowUpdater.groovy
@@ -6,13 +6,14 @@ import rundeck.PluginStep
 import rundeck.ScheduledExecution
 import rundeck.Workflow
 import rundeck.WorkflowStep
+import rundeck.data.constants.WorkflowStepConstants
 import rundeck.data.job.RdWorkflow
 import rundeck.data.job.RdWorkflowStep
 
 class WorkflowUpdater {
 
     static void updateWorkflow(Workflow wkf, RdWorkflow rdw) {
-        if(!wkf) return
+        if(!wkf || !rdw) return
         wkf.threadcount = rdw.threadcount
         wkf.keepgoing = rdw.keepgoing
         wkf.strategy = rdw.strategy
@@ -34,7 +35,7 @@ class WorkflowUpdater {
     }
 
     static WorkflowStep createWorkflowStep(RdWorkflowStep step) {
-        if(step.pluginType == "builtin-jobref") return new JobExec()
+        if(step.pluginType == WorkflowStepConstants.TYPE_JOB_REF) return new JobExec()
         else if(step.pluginType.startsWith("builtin-")) return new CommandExec()
         return new PluginStep()
     }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/WorkflowUpdater.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/WorkflowUpdater.groovy
@@ -1,0 +1,57 @@
+package org.rundeck.app.data.job.converters
+
+import rundeck.CommandExec
+import rundeck.JobExec
+import rundeck.PluginStep
+import rundeck.ScheduledExecution
+import rundeck.Workflow
+import rundeck.WorkflowStep
+import rundeck.data.job.RdWorkflow
+import rundeck.data.job.RdWorkflowStep
+
+class WorkflowUpdater {
+
+    static void updateWorkflow(Workflow wkf, RdWorkflow rdw) {
+        if(!wkf) return
+        wkf.threadcount = rdw.threadcount
+        wkf.keepgoing = rdw.keepgoing
+        wkf.strategy = rdw.strategy
+        wkf.pluginConfigMap = rdw.pluginConfigMap
+        //remove all previous steps
+        for(int x = 0; x < wkf.commands.size(); x++) {
+            def cmd = wkf.commands[x]
+            wkf.removeFromCommands(cmd)
+            cmd.delete()
+        }
+        rdw.steps.each { rdstep ->
+            def wfstep = createWorkflowStep(rdstep)
+            wkf.addToCommands(wfstep)
+            updateWorkflowStep(wfstep, rdstep)
+            wfstep.save(failOnError:true)
+        }
+        wkf.save(failOnError:true)
+
+    }
+
+    static WorkflowStep createWorkflowStep(RdWorkflowStep step) {
+        if(step.pluginType == "builtin-jobref") return new JobExec()
+        else if(step.pluginType.startsWith("builtin-")) return new CommandExec()
+        return new PluginStep()
+    }
+
+    static void updateWorkflowStep(WorkflowStep step, RdWorkflowStep rdstep) {
+        if(step instanceof JobExec) {
+            def jstep = (JobExec)step
+            JobExec.updateFromMap(jstep, rdstep.configuration)
+            jstep.nodeStep = rdstep.nodeStep
+        } else if(step instanceof CommandExec) {
+            def cstep = (CommandExec)step
+            CommandExec.updateFromMap(cstep, rdstep.configuration)
+        } else if(step instanceof PluginStep) {
+            def pstep = (PluginStep)step
+            PluginStep.updateFromMap(pstep, rdstep.configuration)
+            pstep.nodeStep = rdstep.nodeStep
+            pstep.type = rdstep.pluginType
+        }
+    }
+}

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormExecutionDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormExecutionDataProvider.groovy
@@ -1,0 +1,86 @@
+package org.rundeck.app.data.providers
+
+import grails.gorm.transactions.Transactional
+import groovy.transform.CompileStatic
+import groovy.transform.TypeCheckingMode
+import groovy.util.logging.Log4j2
+import org.rundeck.app.data.exception.DataValidationException
+import org.rundeck.app.data.job.converters.ExecutionFromRdExecutionUpdater
+import org.rundeck.app.data.job.converters.ExecutionToRdExecutionConverter
+import org.rundeck.app.data.model.v1.DeletionResult
+import org.rundeck.app.data.model.v1.execution.ExecutionData
+import org.rundeck.app.data.providers.v1.execution.ExecutionDataProvider
+import org.rundeck.spi.data.DataAccessException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.context.request.RequestContextHolder
+import rundeck.Execution
+import rundeck.data.execution.RdExecution
+import rundeck.services.ExecutionService
+import rundeck.services.FrameworkService
+
+@Transactional
+@Log4j2
+class GormExecutionDataProvider implements ExecutionDataProvider {
+
+    @Autowired
+    ExecutionService executionService
+    @Autowired
+    FrameworkService frameworkService
+
+    @Override
+    ExecutionData get(Serializable id) {
+        return ExecutionToRdExecutionConverter.convert(Execution.get(id))
+    }
+
+    @Override
+    ExecutionData getByUuid(String uuid) {
+        return ExecutionToRdExecutionConverter.convert(Execution.findByUuid(uuid))
+    }
+
+    @Override
+    ExecutionData save(ExecutionData edata) throws DataAccessException {
+        Execution e = edata.uuid ? Execution.findByUuid(edata.uuid) : null
+        if(!e) {
+            e = new Execution()
+        }
+        RdExecution rdExec = (RdExecution)edata
+        if(!rdExec.validate()) {
+            throw new DataValidationException(rdExec)
+        }
+        ExecutionFromRdExecutionUpdater.update(e, rdExec)
+        return ExecutionToRdExecutionConverter.convert(e.save(failOnError:true, flush: true))
+    }
+
+    @Override
+    DeletionResult delete(String uuid) {
+        DeleteExecutionResult result = new DeleteExecutionResult()
+        result.id = uuid
+        def e = Execution.findByUuid(uuid)
+        if(!e) {
+            result.error = "Execution with id: ${uuid} not found"
+            return
+        }
+        try {
+            def authCtx = frameworkService.userAuthContext(getSession())
+            def _result = executionService.deleteExecution(e, authCtx, authCtx.username)
+            result.success = _result.success
+            result.error = _result.error
+        } catch(Exception ex) {
+            log.error("Execution Deletion Failed", ex)
+            result.error = "Failed to delete execution."
+        }
+        return result
+    }
+
+    @CompileStatic(TypeCheckingMode.SKIP)
+    def getSession() {
+        RequestContextHolder.currentRequestAttributes().getSession()
+    }
+
+    static class DeleteExecutionResult implements DeletionResult {
+        String dataType = "Execution"
+        String id
+        boolean success
+        String error
+    }
+}

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormExecutionDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormExecutionDataProvider.groovy
@@ -9,6 +9,8 @@ import org.rundeck.app.data.job.converters.ExecutionFromRdExecutionUpdater
 import org.rundeck.app.data.job.converters.ExecutionToRdExecutionConverter
 import org.rundeck.app.data.model.v1.DeletionResult
 import org.rundeck.app.data.model.v1.execution.ExecutionData
+import org.rundeck.app.data.model.v1.execution.ExecutionDataSummary
+import org.rundeck.app.data.model.v1.page.Pageable
 import org.rundeck.app.data.providers.v1.execution.ExecutionDataProvider
 import org.rundeck.spi.data.DataAccessException
 import org.springframework.beans.factory.annotation.Autowired
@@ -70,6 +72,11 @@ class GormExecutionDataProvider implements ExecutionDataProvider {
             result.error = "Failed to delete execution."
         }
         return result
+    }
+
+    @Override
+    List<ExecutionDataSummary> findAllExecutionsByJob(String jobUuid, Pageable pageable) {
+        return Execution.findAllByJobUuid(jobUuid, [offset: pageable.offset, max: pageable.max, sort: 'dateStarted', order:'desc'])*.toSummary()
     }
 
     @CompileStatic(TypeCheckingMode.SKIP)

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/ExecutionFromRdExecutionUpdaterSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/ExecutionFromRdExecutionUpdaterSpec.groovy
@@ -1,0 +1,76 @@
+package org.rundeck.app.data.job.converters
+
+import grails.testing.gorm.DataTest
+import rundeck.CommandExec
+import rundeck.Execution
+import rundeck.ScheduledExecution
+import rundeck.Workflow
+import rundeck.data.constants.WorkflowStepConstants
+import rundeck.data.execution.RdExecution
+import rundeck.data.job.RdWorkflow
+import rundeck.data.job.RdWorkflowStep
+import spock.lang.Specification
+import testhelper.TestDomainFactory
+
+class ExecutionFromRdExecutionUpdaterSpec extends Specification implements DataTest {
+
+    def setupSpec() {
+        mockDomains(Execution, ScheduledExecution, Workflow, CommandExec)
+    }
+
+    def "should update Execution from RdExecution"() {
+        given:
+        ScheduledExecution job = TestDomainFactory.createJob()
+        Execution e = new Execution()
+        RdExecution re = new RdExecution()
+
+        def serverUUID = UUID.randomUUID().toString()
+        def startDate = new Date(123,06,15, 5,0)
+        def completeDate = new Date(123,06,15, 5,0)
+        re.uuid = "test-uuid"
+        re.jobUuid = job.uuid
+        re.status = "test-status"
+        re.dateStarted = startDate
+        re.dateCompleted = completeDate
+        re.outputfilepath = "file://log/file"
+        re.failedNodeList = "node1"
+        re.succeededNodeList = "node2"
+        re.abortedby = "tester"
+        re.cancelled = true
+        re.timedOut = true
+        re.executionType = "user"
+        re.userRoles = ["admin","user"]
+        re.serverNodeUUID = serverUUID
+        re.user = "tester"
+        re.nodeThreadcount = 5
+        re.retryOriginalId = 123L
+        re.retryPrevId = 122L
+        re.extraMetadataMap = [msg:"ok"]
+        re.workflow = new RdWorkflow(steps: [new RdWorkflowStep(pluginType: WorkflowStepConstants.TYPE_COMMAND, configuration: [exec: "echo hello"])])
+
+        when:
+        ExecutionFromRdExecutionUpdater.update(e, re)
+
+        then:
+        e.uuid == "test-uuid"
+        e.scheduledExecution == job
+        e.jobUuid == job.uuid
+        e.status == "test-status"
+        e.dateStarted == startDate
+        e.dateCompleted == completeDate
+        e.workflow.steps.size() == 1
+        e.failedNodeList == "node1"
+        e.succeededNodeList == "node2"
+        e.abortedby == "tester"
+        e.cancelled
+        e.timedOut
+        e.user == "tester"
+        e.userRoleList == '["admin","user"]'
+        e.serverNodeUUID == serverUUID
+        e.nodeThreadcount == 5
+        e.retryOriginalId == 123L
+        e.retryPrevId == 122L
+        e.extraMetadataMap == re.extraMetadataMap
+    }
+
+}

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/ExecutionToRdExecutionConverterSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/ExecutionToRdExecutionConverterSpec.groovy
@@ -1,0 +1,68 @@
+package org.rundeck.app.data.job.converters
+
+import grails.testing.gorm.DataTest
+import rundeck.CommandExec
+import rundeck.Execution
+import rundeck.Workflow
+import rundeck.data.execution.RdExecution
+import spock.lang.Specification
+import spock.lang.Unroll
+import testhelper.TestDomainFactory
+
+class ExecutionToRdExecutionConverterSpec extends Specification implements DataTest {
+
+    def setupSpec() {
+        mockDomains(Execution, Workflow, CommandExec)
+    }
+
+    ExecutionToRdExecutionConverter converter = new ExecutionToRdExecutionConverter()
+
+    def "should return null when converting null Execution object"() {
+        when:
+        RdExecution rdExecution = converter.convert(null)
+
+        then:
+        rdExecution == null
+    }
+
+    @Unroll
+    def "should convert Execution to RdExecution #property"() {
+        given:
+        Execution execution = TestDomainFactory.createExecution(
+                uuid: UUID.randomUUID().toString(),
+                jobUuid: UUID.randomUUID().toString(),
+                "${property}": value
+        )
+
+        when:
+        RdExecution rdExecution = converter.convert(execution)
+
+        then:
+        rdExecution.uuid == execution.uuid
+        rdExecution.jobUuid == execution.jobUuid
+        rdExecution.workflow.steps.size() == execution.workflow.commands.size()
+        rdExecution."${property}" == value
+
+
+        where:
+        property            | value
+        "argString"         | "argValue"
+        "user"              | "testuser"
+        "dateStarted"       | new Date()
+        "dateCompleted"     | new Date()
+        "status"            | "running"
+        "outputfilepath"    | "file:///the/log/file"
+        "failedNodeList"    | "failer"
+        "succeededNodeList" | "succeeder"
+        "abortedby"         | "tester"
+        "cancelled"         | true
+        "timedOut"          | true
+        "executionType"     | "user"
+        "retryAttempt"      | 5
+        "willRetry"         | true
+        "serverNodeUUID"    | UUID.randomUUID().toString()
+        "nodeThreadcount"   | 10
+        "retryOriginalId"   | 145L
+        "retryPrevId"       | 140L
+    }
+}

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/OrchestratorToRdOrchestratorConverterSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/OrchestratorToRdOrchestratorConverterSpec.groovy
@@ -1,0 +1,31 @@
+package org.rundeck.app.data.job.converters
+
+import rundeck.Orchestrator
+import rundeck.data.job.RdOrchestrator
+import spock.lang.Specification
+
+class OrchestratorToRdOrchestratorConverterSpec extends Specification {
+    def "should return null when input is null"() {
+        given:
+        OrchestratorToRdOrchestratorConverter converter = new OrchestratorToRdOrchestratorConverter()
+
+        when:
+        RdOrchestrator result = converter.convertOrchestrator(null)
+
+        then:
+        result == null
+    }
+
+    def "should return RdOrchestrator with type and configuration when input is valid"() {
+        given:
+        OrchestratorToRdOrchestratorConverter converter = new OrchestratorToRdOrchestratorConverter()
+        Orchestrator input = new Orchestrator(type: "limitRun", configuration: [key: "value"])
+
+        when:
+        RdOrchestrator result = converter.convertOrchestrator(input)
+
+        then:
+        result.type == input.type
+        result.configuration == input.configuration
+    }
+}

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/WorkflowToRdWorkflowConverterSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/WorkflowToRdWorkflowConverterSpec.groovy
@@ -1,0 +1,90 @@
+package org.rundeck.app.data.job.converters
+
+import grails.testing.gorm.DataTest
+import rundeck.CommandExec
+import rundeck.JobExec
+import rundeck.PluginStep
+import rundeck.Workflow
+import rundeck.WorkflowStep
+import rundeck.data.constants.WorkflowStepConstants
+import rundeck.data.job.RdWorkflow
+import rundeck.data.job.RdWorkflowStep
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class WorkflowToRdWorkflowConverterSpec extends Specification implements DataTest {
+
+    def "setupSpec"() {
+        mockDomains(Workflow, JobExec, CommandExec, PluginStep)
+    }
+
+    def "test updateWorkflow method"() {
+        given:
+        Workflow wkf = new Workflow(commands: [])
+        RdWorkflow rdw = new RdWorkflow()
+        rdw.threadcount = 5
+        rdw.keepgoing = true
+        rdw.strategy = "parallel"
+        rdw.pluginConfigMap = [key1: "value1", key2: "value2"]
+        RdWorkflowStep step1 = new RdWorkflowStep()
+        step1.pluginType = WorkflowStepConstants.TYPE_JOB_REF
+        step1.nodeStep = true
+        step1.configuration = [jobref:[name:"job1",group:"grp1","uuid":"jobuuid"]]
+        RdWorkflowStep step2 = new RdWorkflowStep()
+        step2.pluginType = WorkflowStepConstants.TYPE_COMMAND
+        step2.nodeStep = true
+        step2.configuration = [exec:"echo hello"]
+        RdWorkflowStep step3 = new RdWorkflowStep()
+        step3.pluginType = "custom-plugin"
+        step3.nodeStep = true
+        step3.configuration = [plugincfg:"val1"]
+        rdw.steps = [step1, step2, step3]
+
+        when:
+        WorkflowUpdater.updateWorkflow(wkf, rdw)
+
+        then:
+        wkf.threadcount == 5
+        wkf.keepgoing == true
+        wkf.strategy == "parallel"
+        wkf.pluginConfigMap == [key1: "value1", key2: "value2"]
+        wkf.commands.size() == 3
+        wkf.commands[0] instanceof JobExec
+        wkf.commands[1] instanceof CommandExec
+        wkf.commands[2] instanceof PluginStep
+        wkf.commands[0].jobName == step1.configuration.jobref.name
+        wkf.commands[0].jobGroup == step1.configuration.jobref.group
+        wkf.commands[0].uuid == step1.configuration.jobref.uuid
+        wkf.commands[1].adhocRemoteString == step2.configuration.exec
+        wkf.commands[2].configuration.plugincfg == step3.configuration.plugincfg
+    }
+
+    def "test createWorkflowStep method"() {
+        when:
+        WorkflowStep step1 = WorkflowUpdater.createWorkflowStep(new RdWorkflowStep(pluginType: "builtin-jobref"))
+        WorkflowStep step2 = WorkflowUpdater.createWorkflowStep(new RdWorkflowStep(pluginType: "builtin-command"))
+        WorkflowStep step3 = WorkflowUpdater.createWorkflowStep(new RdWorkflowStep(pluginType: "custom-plugin"))
+
+        then:
+        step1 instanceof JobExec
+        step2 instanceof CommandExec
+        step3 instanceof PluginStep
+    }
+
+//    @Unroll
+//    def "test updateWorkflowStep method for #stepType"() {
+//        given:
+//        WorkflowStep step
+//        RdWorkflowStep rdstep = new RdWorkflowStep()
+//        rdstep.configuration = [key1: "value1", key2: "value2"]
+//
+//        when:
+//        WorkflowUpdater.updateWorkflowStep(step, rdstep)
+//
+//        then:
+//        step.configuration == rdstep.configuration
+//
+//        where:
+//        stepType << [JobExec, CommandExec, PluginStep]
+//    }
+}

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/WorkflowUpdaterSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/WorkflowUpdaterSpec.groovy
@@ -1,8 +1,6 @@
 package org.rundeck.app.data.job.converters
 
 import grails.testing.gorm.DataTest
-import liquibase.pro.packaged.C
-import liquibase.pro.packaged.W
 import rundeck.CommandExec
 import rundeck.JobExec
 import rundeck.PluginStep

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/WorkflowUpdaterSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/WorkflowUpdaterSpec.groovy
@@ -1,0 +1,103 @@
+package org.rundeck.app.data.job.converters
+
+import grails.testing.gorm.DataTest
+import liquibase.pro.packaged.C
+import liquibase.pro.packaged.W
+import rundeck.CommandExec
+import rundeck.JobExec
+import rundeck.PluginStep
+import rundeck.Workflow
+import rundeck.WorkflowStep
+import rundeck.data.constants.WorkflowStepConstants
+import rundeck.data.job.RdWorkflow
+import rundeck.data.job.RdWorkflowStep
+import spock.lang.Specification
+
+class WorkflowUpdaterSpec extends Specification implements DataTest {
+
+    def "setupSpec"() {
+        mockDomains(Workflow, JobExec, CommandExec, PluginStep)
+    }
+
+    def "should not update workflow when both Workflow and RdWorkflow objects are null"() {
+        when:
+        WorkflowUpdater.updateWorkflow(wkf, rdw)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        wkf             | rdw
+        null            | null
+        new Workflow()  | null
+        null            | new RdWorkflow()
+    }
+
+    def "update Workflow with RdWorkflow"() {
+        given:
+        Workflow wkf = new Workflow(commands: [])
+        RdWorkflow rdw = new RdWorkflow(
+                threadcount: 2,
+                keepgoing: true,
+                strategy: "parallel",
+                pluginConfigMap: [key: "value"],
+                steps: [
+                        new RdWorkflowStep(pluginType: "builtin-jobref", configuration: [jobref:[name:"jobname"]]),
+                        new RdWorkflowStep(pluginType: "builtin-command", configuration: [exec:"echo hello"]),
+                        new RdWorkflowStep(pluginType: "custom-plugin", nodeStep: false, configuration: [configuration:[key1:"val1"]])
+                ]
+        )
+
+        when:
+        WorkflowUpdater.updateWorkflow(wkf, rdw)
+
+        then:
+        wkf.threadcount == 2
+        wkf.keepgoing == true
+        wkf.strategy == "parallel"
+        wkf.pluginConfigMap == [key: "value"]
+        wkf.commands.size() == 3
+    }
+
+    def "should create JobExec workflow step when RdWorkflowStep has pluginType 'builtin-jobref'"() {
+        given:
+        RdWorkflowStep rdstep = new RdWorkflowStep(pluginType: WorkflowStepConstants.TYPE_JOB_REF)
+
+        when:
+        WorkflowStep step = WorkflowUpdater.createWorkflowStep(rdstep)
+
+        then:
+        step instanceof JobExec
+    }
+
+    def "should create CommandExec workflow step when RdWorkflowStep has pluginType  'builtin-*' that is not a job ref"() {
+        given:
+        RdWorkflowStep rdstep = new RdWorkflowStep(pluginType: pluginType)
+
+        when:
+        WorkflowStep step = WorkflowUpdater.createWorkflowStep(rdstep)
+
+        then:
+        step instanceof CommandExec
+
+        where:
+        _ | pluginType
+        _ | WorkflowStepConstants.TYPE_COMMAND
+        _ | WorkflowStepConstants.TYPE_SCRIPT
+        _ | WorkflowStepConstants.TYPE_SCRIPT_FILE
+        _ | WorkflowStepConstants.TYPE_SCRIPT_URL
+
+    }
+
+    def "should create PluginStep workflow step when RdWorkflowStep has custom pluginType"() {
+        given:
+        RdWorkflowStep rdstep = new RdWorkflowStep(pluginType: "custom-plugin")
+
+        when:
+        WorkflowStep step = WorkflowUpdater.createWorkflowStep(rdstep)
+
+        then:
+        step instanceof PluginStep
+    }
+
+}

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecutionDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecutionDataProviderSpec.groovy
@@ -1,0 +1,110 @@
+package org.rundeck.app.data.providers
+
+import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import grails.testing.gorm.DataTest
+import rundeck.CommandExec
+import rundeck.Execution
+import rundeck.JobExec
+import rundeck.PluginStep
+import rundeck.Workflow
+import rundeck.data.constants.WorkflowStepConstants
+import rundeck.data.execution.RdExecution
+import rundeck.data.job.RdWorkflow
+import rundeck.data.job.RdWorkflowStep
+import rundeck.data.paging.RdPageable
+import rundeck.services.ExecutionService
+import rundeck.services.FrameworkService
+import spock.lang.Specification
+import testhelper.TestDomainFactory
+
+import javax.servlet.http.HttpSession
+
+class GormExecutionDataProviderSpec extends Specification implements DataTest {
+    GormExecutionDataProvider provider = new GormExecutionDataProvider()
+
+    def setupSpec() {
+        mockDomains(Execution, Workflow, CommandExec, PluginStep, JobExec)
+    }
+    def "Get"() {
+        given:
+        String uuid = UUID.randomUUID().toString()
+        Execution e = TestDomainFactory.createExecution(uuid: uuid)
+
+        when:
+        def actual = provider.get(e.id)
+
+        then:
+        actual.uuid == uuid
+    }
+
+    def "GetByUuid"() {
+        given:
+        String uuid = UUID.randomUUID().toString()
+        Execution e = TestDomainFactory.createExecution(uuid: uuid)
+
+        when:
+        def actual = provider.getByUuid(uuid)
+
+        then:
+        actual.uuid == uuid
+        actual.status == e.status
+    }
+
+    def "Save"() {
+        given:
+        String uuid = UUID.randomUUID().toString()
+        Date now = new Date()
+        RdExecution rdex = new RdExecution()
+        rdex.uuid = uuid
+        rdex.project = 'test'
+        rdex.user = 'tester'
+        rdex.dateStarted = now
+        rdex.status = 'running'
+        rdex.workflow = new RdWorkflow(steps: [new RdWorkflowStep(pluginType: WorkflowStepConstants.TYPE_COMMAND, configuration: [exec:"echo hello"])])
+
+        when:
+        def actual = provider.save(rdex)
+
+        then:
+        actual.uuid == uuid
+        actual.dateStarted == now
+        actual.workflow.steps[0].configuration.exec == "echo hello"
+    }
+
+    def "Delete"() {
+        given:
+        provider.metaClass.getSession = { Mock(HttpSession) }
+        provider.frameworkService = Mock(FrameworkService) {
+            1 * userAuthContext(_) >> Mock(UserAndRolesAuthContext)
+        }
+        provider.executionService = Mock(ExecutionService) {
+            1 * deleteExecution(_,_,_) >> [success: true]
+        }
+        Execution e = TestDomainFactory.createExecution()
+
+        when:
+        def result = provider.delete(e.uuid)
+
+        then:
+        result.id == e.uuid
+        result.dataType == "Execution"
+    }
+
+    def "FindAllExecutionsByJob"() {
+        given:
+        String jobUuid = UUID.randomUUID().toString()
+        String uuid1 = UUID.randomUUID().toString()
+        String uuid2 = UUID.randomUUID().toString()
+        def e1 = TestDomainFactory.createExecution(uuid: uuid1, jobUuid: jobUuid)
+        def e2 = TestDomainFactory.createExecution(uuid: uuid2, jobUuid: jobUuid)
+
+        when:
+        def results = provider.findAllExecutionsByJob(jobUuid, new RdPageable())
+
+        then:
+        results.size() == 2
+        results.find {it.uuid == uuid1 }
+        results.find {it.uuid == uuid2 }
+    }
+
+}

--- a/rundeckapp/src/test/groovy/rundeck/controllers/RdExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/RdExecutionControllerSpec.groovy
@@ -30,52 +30,6 @@ class RdExecutionControllerSpec extends Specification implements ControllerUnitT
         response.status == 200
     }
 
-    def "test save method - valid execution"() {
-        given:
-        def execution = new RdExecution()
-        request.json = execution
-
-        when:
-        controller.save()
-
-        then:
-        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_) >> Mock(UserAndRolesAuthContext)
-        1 * controller.rundeckAuthContextProcessor.authorizeProjectResourceAny(_, _, _, _) >> true
-        1 * controller.rdExecutionService.saveExecutionData(_) >> execution
-        response.contentType == "application/json;utf-8"
-        response.status == 200
-        response.contentAsString
-    }
-
-    def "test save method - invalid format"() {
-        given:
-        request.json = [invalid:"data"]
-
-        when:
-        controller.save()
-
-        then:
-        response.contentType == "application/json;utf-8"
-        response.status == 400
-
-    }
-
-    def "test save method - data validation exception"() {
-        given:
-        def execution = new RdExecution() // Create a dummy execution for testing
-        request.json = execution
-
-        when:
-        controller.save()
-
-        then:
-        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_) >> Mock(UserAndRolesAuthContext)
-        1 * controller.rundeckAuthContextProcessor.authorizeProjectResourceAny(_, _, _, _) >> true
-        1 * controller.rdExecutionService.saveExecutionData(_) >> { throw new DataValidationException(execution)}
-        response.contentType == "application/json;utf-8"
-        response.status == 400
-    }
-
     def "test delete method"() {
         given:
         def executionId = "123"

--- a/rundeckapp/src/test/groovy/rundeck/controllers/RdExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/RdExecutionControllerSpec.groovy
@@ -1,0 +1,114 @@
+package rundeck.controllers
+
+import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
+import grails.testing.gorm.DataTest
+import grails.testing.web.controllers.ControllerUnitTest
+import org.rundeck.app.authorization.AppAuthContextProcessor
+import org.rundeck.app.data.exception.DataValidationException
+import org.rundeck.app.data.providers.GormExecutionDataProvider
+import org.springframework.context.MessageSource
+import rundeck.data.execution.RdExecution
+import rundeck.data.paging.RdPageable
+import rundeck.services.RdExecutionService
+import spock.lang.Specification
+
+class RdExecutionControllerSpec extends Specification implements ControllerUnitTest<RdExecutionController>, DataTest {
+
+    def setup() {
+        controller.rdExecutionService = Mock(RdExecutionService)
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor)
+        controller.messageSource = Mock(MessageSource)
+    }
+
+    def "test get method"() {
+        when:
+        controller.get()
+
+        then:
+        1 * controller.rdExecutionService.getExecutionByUuid(_) >> new RdExecution()
+        response.contentType == "application/json;utf-8"
+        response.status == 200
+    }
+
+    def "test save method - valid execution"() {
+        given:
+        def execution = new RdExecution()
+        request.json = execution
+
+        when:
+        controller.save()
+
+        then:
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_) >> Mock(UserAndRolesAuthContext)
+        1 * controller.rundeckAuthContextProcessor.authorizeProjectResourceAny(_, _, _, _) >> true
+        1 * controller.rdExecutionService.saveExecutionData(_) >> execution
+        response.contentType == "application/json;utf-8"
+        response.status == 200
+        response.contentAsString
+    }
+
+    def "test save method - invalid format"() {
+        given:
+        request.json = [invalid:"data"]
+
+        when:
+        controller.save()
+
+        then:
+        response.contentType == "application/json;utf-8"
+        response.status == 400
+
+    }
+
+    def "test save method - data validation exception"() {
+        given:
+        def execution = new RdExecution() // Create a dummy execution for testing
+        request.json = execution
+
+        when:
+        controller.save()
+
+        then:
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_) >> Mock(UserAndRolesAuthContext)
+        1 * controller.rundeckAuthContextProcessor.authorizeProjectResourceAny(_, _, _, _) >> true
+        1 * controller.rdExecutionService.saveExecutionData(_) >> { throw new DataValidationException(execution)}
+        response.contentType == "application/json;utf-8"
+        response.status == 400
+    }
+
+    def "test delete method"() {
+        given:
+        def executionId = "123"
+        params.id = executionId
+
+        when:
+        controller.delete()
+
+        then:
+        1 * controller.rdExecutionService.getExecutionByUuid(executionId) >> new RdExecution()
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_) >> Mock(UserAndRolesAuthContext)
+        1 * controller.rundeckAuthContextProcessor.authorizeApplicationResourceAny(_, _, _) >> true
+        1 * controller.rdExecutionService.delete(executionId) >> new GormExecutionDataProvider.DeleteExecutionResult()
+        response.contentType == "application/json;utf-8"
+        response.status == 200
+    }
+
+    def "test listForJob method"() {
+        given:
+        def jobId = "job-uuid"
+        def pageable = new RdPageable()
+        pageable.max = 10
+        pageable.offset = 1
+        params.id = jobId
+        params.max = pageable.max
+        params.offset = pageable.offset
+
+        when:
+        controller.listForJob()
+
+        then:
+        1 * controller.rdExecutionService.listExecutionsForJob(jobId, pageable) >> []
+        response.contentType == "application/json;utf-8"
+        response.status == 200
+    }
+}

--- a/rundeckapp/src/test/groovy/testhelper/TestDomainFactory.groovy
+++ b/rundeckapp/src/test/groovy/testhelper/TestDomainFactory.groovy
@@ -1,0 +1,33 @@
+package testhelper
+
+import rundeck.CommandExec
+import rundeck.Execution
+import rundeck.ScheduledExecution
+import rundeck.Workflow
+
+class TestDomainFactory {
+
+    static ScheduledExecution createJob(Map<String,Object> params = [:]) {
+        def job = new ScheduledExecution(uuid: UUID.randomUUID().toString(), jobName: "test job", groupPath: "testgroup", project:"one")
+        job.workflow = createWorkflow()
+        params.each { k, v -> job[k] = v }
+        return job.save(failOnError: true)
+    }
+
+    static Execution createExecution(Map<String,Object> params = [:]) {
+        Execution e = new Execution()
+        e.project = "test"
+        e.user = "tester"
+        e.dateStarted = new Date()
+        e.status = 'running'
+        e.workflow = createWorkflow()
+        params.each { k, v -> e[k] = v }
+        return e.save(failOnError: true)
+    }
+
+    static Workflow createWorkflow(Map<String, Object> params = [:]) {
+        def w = new Workflow(commands: [new CommandExec(adhocRemoteString: "echo hello")])
+        params.each { k, v -> w[k] = v }
+        return w.save(failOnError: true)
+    }
+}


### PR DESCRIPTION
Add SPI for Execution data.

The data SPI adds a uuid to all executions, and associates jobs to execution by a jobUuid column. This allows non-gorm implementations of execution data to associate executions and jobs.

This PR should be fairly safe as it only adds new classes and interfaces and does not significantly change any code that uses the Execution domain class directly.

This PR also adds new incubator endpoints for accessing the new execution data structure. 