### PR TITLE
RCLOUD-924: Load additional WorkflowExecutionlistener

### DIFF
--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/execution/WorkflowExecutionListenerTest.java
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/execution/WorkflowExecutionListenerTest.java
@@ -1,0 +1,66 @@
+package com.dtolabs.rundeck.execution;
+
+import com.dtolabs.rundeck.core.common.INodeEntry;
+import com.dtolabs.rundeck.core.execution.ExecutionContext;
+import com.dtolabs.rundeck.core.execution.StatusResult;
+import com.dtolabs.rundeck.core.execution.StepExecutionItem;
+import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext;
+import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionItem;
+import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionListener;
+import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionResult;
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutionResult;
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutor;
+import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepExecutionItem;
+import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepResult;
+
+public class WorkflowExecutionListenerTest implements WorkflowExecutionListener {
+    @Override
+    public void beginWorkflowExecution(StepExecutionContext executionContext, WorkflowExecutionItem item) {
+
+    }
+
+    @Override
+    public void finishWorkflowExecution(WorkflowExecutionResult result, StepExecutionContext executionContext, WorkflowExecutionItem item) {
+
+    }
+
+    @Override
+    public void beginWorkflowItem(int step, StepExecutionItem item) {
+
+    }
+
+    @Override
+    public void beginWorkflowItemErrorHandler(int step, StepExecutionItem item) {
+
+    }
+
+    @Override
+    public void finishWorkflowItem(int step, StepExecutionItem item, StepExecutionResult result) {
+
+    }
+
+    @Override
+    public void finishWorkflowItemErrorHandler(int step, StepExecutionItem item, StepExecutionResult success) {
+
+    }
+
+    @Override
+    public void beginStepExecution(StepExecutor executor, StepExecutionContext context, StepExecutionItem item) {
+
+    }
+
+    @Override
+    public void finishStepExecution(StepExecutor executor, StatusResult result, StepExecutionContext context, StepExecutionItem item) {
+
+    }
+
+    @Override
+    public void beginExecuteNodeStep(ExecutionContext context, NodeStepExecutionItem item, INodeEntry node) {
+
+    }
+
+    @Override
+    public void finishExecuteNodeStep(NodeStepResult result, ExecutionContext context, StepExecutionItem item, INodeEntry node) {
+
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
@@ -1347,7 +1347,7 @@ class LogFileStorageServiceSpec extends Specification implements ServiceUnitTest
         count == 1
     }
 
-    def "countIncompleteStorageRequests"() {
+    def "count IncompleteStorageRequests"() {
         given:
         def serveruuid = 'C9CA0A6D-3F85-4F53-A714-313EB57A4D1F'
         service.frameworkService = Mock(FrameworkService){

--- a/rundeckapp/src/test/resources/META-INF/services/com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionListener
+++ b/rundeckapp/src/test/resources/META-INF/services/com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionListener
@@ -1,0 +1,1 @@
+com.dtolabs.rundeck.execution.WorkflowExecutionListenerTest


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Add a new plugin to log node usage.

Describe the solution you've implemented
A new implementation of WorkflowExecutionListener was created to handle the log creation when an execution ends, and this changes load the new implementation in the multiListener.

Additional context
Jira ticket https://pagerduty.atlassian.net/browse/RCLOUD-922
[Document](https://docs.google.com/document/d/1Se4PHnTGx1rf0PQQYbYfrewLIhmmHmpl84Wn30Astlo/edit#heading=h.zesn33r7rii)