### PR TITLE
RSE-406::Flag to enable/disable search for more than 1000 users

### DIFF
--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModuleTest.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModuleTest.groovy
@@ -708,6 +708,7 @@ class JettyCachingLdapLoginModuleTest extends Specification {
             stringRoles = [role1, role2, nestedRole1]
             module._nestedGroups = true
             module.rolesPerPage = 1000
+            module._allGroups = true
         } else {
             stringRoles = [role1, role2]
             module.rolesPerPage = 1000

--- a/rundeckapp/src/test/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModuleTest2.java
+++ b/rundeckapp/src/test/java/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModuleTest2.java
@@ -463,6 +463,13 @@ public class JettyCachingLdapLoginModuleTest2 {
                 eq(module._roleMemberFilter),
                 any(SearchControls.class)
             )).thenReturn(allRolesSearchResults);
+
+            when(rootContext.search(
+                    eq(module._roleBaseDn),
+                    eq(module._roleMemberFilter),
+                    any(SearchControls.class)
+            )).thenReturn(allRolesSearchResults);
+
             when(allRolesSearchResults.nextElement()).thenReturn(
                 role1SearchResult,
                 role2SearchResult,


### PR DESCRIPTION
Depends and continue: https://github.com/rundeck/rundeck/commit/be518d9c4863dfcff5922e1d460e358e9466cb65

This flag is created with the intention of controlling if we want to obtain all the user's groups and those that come by default. Due to the large number of groups a user can have (example: 500k groups), it may reduce performance when logging in.

## Describe New Flag Functionality
LDAP: error code 4 - Sizelimit Exceeded when you activated the nestedGroups option and you had a large number of groups.
**New**: `allGroups` flag to enable/disable if getting all groups or default. Flag is **false** by default.

## With:
Flag: `allGroups` in `false`:

<img width="1400" alt="image" src="https://github.com/rundeck/rundeck/assets/91557307/a2c5739b-7c46-4744-b135-45895fdf0910">

#### It could only bring a maximum of 991 users, which had 1014 configured.

## And:
Flag: `allGroups` in `true`:

<img width="1403" alt="image" src="https://github.com/rundeck/rundeck/assets/91557307/fe875e53-cd00-4311-b3c7-cb9f5dcaf63a">

#### All 1014 members can be obtained..