### PR TITLE
disable gradle build caching from grails-spa build

### DIFF
--- a/rundeckapp/grails-spa/build.gradle
+++ b/rundeckapp/grails-spa/build.gradle
@@ -53,7 +53,7 @@ tasks.register("runNpmBuild", NpmTask) {
     inputs.dir 'packages/ui-trellis/src/app'
 
     outputs.dir(file("$spaBuildDir"))
-    outputs.cacheIf { true }
+    outputs.cacheIf { false }
 
     def npmCommand = System.env.CI ?
       'ci:app:build' :


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
turn off build caching for the grails-spa project