### PR TITLE
backport: use latest chromedriver

### DIFF
--- a/test/selenium/.npmrc
+++ b/test/selenium/.npmrc
@@ -1,1 +1,1 @@
-chromedriver_version=113.0.5672.63
+chromedriver_version=LATEST


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
backport #8441 to 4.15
