### PR TITLE
RSE-693: Fix stuck log output

### DIFF
--- a/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
@@ -57,15 +57,8 @@
       </div>
     </div>
     <div class="row row-space">
-      <div class="col-sm-3">
+      <div class="col-sm-6">
           <strong><g:message code="execution.show.mode.column.node" /></strong>
-      </div>
-      <div class="col-sm-3">
-          <div class="vue-ui-socket">
-              <div>
-                  <ui-socket section="job-runner-execution-column" location="section-title-column" :event-bus="EventBus"/>
-              </div>
-          </div>
       </div>
       <div class="col-sm-2 col-sm-offset-2">
           <strong><g:message code="start.time" /></strong>
@@ -78,20 +71,12 @@
   <div data-bind="foreach: activeNodes()">
     <div class="wfnodestate" data-bind="css: { open: expanded() }, attr: { 'data-node': name } ">
       <div class="row wfnodeoverall action" data-bind="click: toggleExpand">
-          <div class="col-sm-3  nodectx"
+          <div class="col-sm-6  nodectx"
                data-bind="attr: { title: name }, css: { 'auto-caret-container': expanded() } ">
               <div class="execstate nodename action isnode" data-bind="attr: { 'data-execstate': summaryState }, css: { active: expanded() }">
                   <i class="auto-caret text-muted"></i>
                   <i class="fas fa-hdd"></i>
                   <span data-bind="text: name"></span>
-              </div>
-          </div>
-
-          <div class="col-sm-3">
-              <div class="vue-ui-socket" vue-socket-on="vue-ui-socket-node-added">
-                  <div>
-                      <ui-socket section="job-runner-execution" location="top" :event-bus="EventBus" />
-                  </div>
               </div>
           </div>
 

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -1101,19 +1101,6 @@ search
         "execution": loadJsonData('execDataJSON')
     })
 
-    const observer = new MutationObserver(function(mutations_list) {
-        mutations_list.forEach(function(mutation) {
-            mutation.addedNodes.forEach(function(added_node) {
-                if(added_node.className == 'wfnodestate' && added_node.getElementsByClassName('vue-ui-socket')?.length > 0) {
-                    var eventKOProcessed = new Event('vue-ui-socket-node-added');
-                    window.dispatchEvent(eventKOProcessed)
-                    observer.disconnect();
-                }
-            });
-        });
-    })
-    observer.observe(document.querySelector("#nodeflowstate"), { subtree: true, childList: true });
-
     function init() {
         var execInfo=loadJsonData('execInfoJSON');
         var workflowData=loadJsonData('workflowDataJSON');


### PR DESCRIPTION
**Issue:** When running a job with too many nodes (like 700) to dispatch it, rundeck would get stuck when trying to show the log output page.

**Solution:** Remove non working functionality that tried to attach the runner id associated to the node (also removes the "runned id" column)