### PR TITLE
RUN-1840: propagate status result to log filter complete method

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionServiceImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionServiceImpl.java
@@ -111,7 +111,7 @@ public class ExecutionServiceImpl implements ExecutionService {
                 result = executor.executeWorkflowStep(context, item);
             } finally {
                 if (null != pluginLogging) {
-                    pluginLogging.end();
+                    pluginLogging.end(result);
                 }
             }
         } finally {
@@ -207,7 +207,7 @@ public class ExecutionServiceImpl implements ExecutionService {
                 result = interpreter.executeNodeStep(nodeContext, item, node);
             } finally {
                 if (null != pluginLogging) {
-                    pluginLogging.end();
+                    pluginLogging.end(result);
                 }
             }
             if (!result.isSuccess()) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/logging/LoggingManagerImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/logging/LoggingManagerImpl.java
@@ -16,10 +16,7 @@
 
 package com.dtolabs.rundeck.core.logging;
 
-import com.dtolabs.rundeck.core.execution.ExecutionContext;
-import com.dtolabs.rundeck.core.execution.ExecutionLogger;
-import com.dtolabs.rundeck.core.execution.HasLoggingFilterConfiguration;
-import com.dtolabs.rundeck.core.execution.StepExecutionItem;
+import com.dtolabs.rundeck.core.execution.*;
 import com.dtolabs.rundeck.core.plugins.PluginConfiguration;
 import com.dtolabs.rundeck.core.plugins.SimplePluginProviderLoader;
 import com.dtolabs.rundeck.plugins.ServiceNameConstants;
@@ -142,12 +139,14 @@ public class LoggingManagerImpl implements LoggingManager {
         }
 
         @Override
-        public <T> T runWith(final Supplier<T> supplier) {
+        public <T extends StatusResult> T runWith(final Supplier<T> supplier) {
             begin();
+            T result = null;
             try {
-                return supplier.get();
+                result = supplier.get();
+                return result;
             } finally {
-                end();
+                end(result);
             }
         }
 
@@ -162,10 +161,10 @@ public class LoggingManagerImpl implements LoggingManager {
 
 
         @Override
-        public void end() {
+        public void end(StatusResult result) {
             if (pluginsAdded) {
                 writer.removeOverride();
-                pluginFilteredStreamingLogWriter.close();
+                pluginFilteredStreamingLogWriter.finish(result);
             }else{
                 writer.removeOverride();
             }

--- a/core/src/main/java/com/dtolabs/rundeck/core/logging/PluginFilteredStreamingLogWriter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/logging/PluginFilteredStreamingLogWriter.java
@@ -21,6 +21,7 @@ import com.dtolabs.rundeck.core.data.DataContext;
 import com.dtolabs.rundeck.core.data.MultiDataContext;
 import com.dtolabs.rundeck.core.execution.ExecutionContext;
 import com.dtolabs.rundeck.core.execution.ExecutionLogger;
+import com.dtolabs.rundeck.core.execution.StatusResult;
 import com.dtolabs.rundeck.core.execution.workflow.SharedOutputContext;
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin;
 
@@ -237,8 +238,16 @@ public class PluginFilteredStreamingLogWriter extends FilterStreamingLogWriter {
 
     @Override
     public void close() {
+        finish(null);
+    }
+
+    /**
+     * Called when logging is completed
+     * @param result status of the enclosed action, may be null if an error occurred
+     */
+    public void finish(StatusResult result) {
         for (LogFilterPlugin plugin : plugins) {
-            plugin.complete(myLoggingContext);
+            plugin.complete(myLoggingContext, result);
         }
     }
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/logging/PluginLoggingManager.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/logging/PluginLoggingManager.java
@@ -16,6 +16,7 @@
 
 package com.dtolabs.rundeck.core.logging;
 
+import com.dtolabs.rundeck.core.execution.StatusResult;
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin;
 
 import java.util.function.Supplier;
@@ -38,10 +39,10 @@ public interface PluginLoggingManager {
     /**
      * End using the plugins
      */
-    void end();
+    void end(StatusResult result);
 
     /**
      * Run a function by wrapping the call with a begin/end using try/finally
      */
-    <T> T runWith(Supplier<T> supplier);
+    <T extends StatusResult> T runWith(Supplier<T> supplier);
 }

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/logging/LogFilterPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/logging/LogFilterPlugin.java
@@ -17,6 +17,7 @@
 package com.dtolabs.rundeck.plugins.logging;
 
 import com.dtolabs.rundeck.core.execution.ExecutionContext;
+import com.dtolabs.rundeck.core.execution.StatusResult;
 import com.dtolabs.rundeck.core.logging.*;
 
 import java.util.Map;
@@ -47,8 +48,18 @@ public interface LogFilterPlugin {
      * Called when the current step/node output is complete, optional
      *
      * @param context the context for the plugin
+     * @deprecated use {@link #complete(PluginLoggingContext, StatusResult)}
      */
     default void complete(PluginLoggingContext context) {
 
+    }
+    /**
+     * Called when the current step/node output is complete, optional
+     *
+     * @param context the context for the plugin
+     * @param result the status of the step/workflow, may be null if an error occurred
+     */
+    default void complete(PluginLoggingContext context, StatusResult result) {
+        complete(context);
     }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/logging/PluginFilteredStreamingLogWriterSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/logging/PluginFilteredStreamingLogWriterSpec.groovy
@@ -18,6 +18,7 @@ package com.dtolabs.rundeck.core.logging
 
 import com.dtolabs.rundeck.core.execution.ExecutionContext
 import com.dtolabs.rundeck.core.execution.ExecutionLogger
+import com.dtolabs.rundeck.core.execution.StatusResult
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -256,9 +257,46 @@ class PluginFilteredStreamingLogWriterSpec extends Specification {
         writer.close()
 
         then:
-        1 * plugin1.complete(!null)
-        1 * plugin2.complete(!null)
-        1 * plugin3.complete(!null)
+        1 * plugin1.complete(!null,null)
+        1 * plugin2.complete(!null,null)
+        1 * plugin3.complete(!null,null)
 
+    }
+
+    @Unroll
+    def "finish completes all plugins with status"() {
+        given:
+        def sink = Mock(StreamingLogWriter)
+        def context = Mock(ExecutionContext)
+        def logger = Mock(ExecutionLogger)
+        def writer = new PluginFilteredStreamingLogWriter(sink, context, logger)
+
+
+        LogFilterPlugin plugin1 = Mock(LogFilterPlugin)
+        LogFilterPlugin plugin2 = Mock(LogFilterPlugin)
+        LogFilterPlugin plugin3 = Mock(LogFilterPlugin)
+
+
+        writer.addPlugin(plugin1)
+        writer.addPlugin(plugin2)
+        writer.addPlugin(plugin3)
+
+        when:
+        writer.finish(result)
+
+        then:
+        1 * plugin1.complete(!null,result)
+        1 * plugin2.complete(!null,result)
+        1 * plugin3.complete(!null,result)
+
+        where:
+            result <<[
+                null,
+                new Finished(success:true),
+                new Finished(success:false)
+            ]
+    }
+    static class Finished implements StatusResult{
+        boolean success
     }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
allows log filter plugins to know the result status of the step or workflow they are applied to

**Describe the solution you've implemented**
add status result to the LogFilterPlugin `complete` method

**Additional context**
RUN-1840
