### PR TITLE
RSE-700::Fix empty values key value data for nixy steps local command

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPlugin.java
@@ -159,14 +159,15 @@ public abstract class AbstractDescribableScriptPlugin implements Describable {
 
 
                     final Object blankIfUnexpandedValue = itemmeta.get(CONFIG_BLANK_IF_UNEXPANDED);
-                    final boolean blankIfUnexpanded;
-                    if (blankIfUnexpandedValue instanceof Boolean) {
-                        blankIfUnexpanded = (Boolean) blankIfUnexpandedValue;
-                    } else {
-                        blankIfUnexpanded = blankIfUnexpandedValue instanceof String && Boolean.parseBoolean((String) blankIfUnexpandedValue);
+                    if (blankIfUnexpandedValue != null) {
+                        final boolean blankIfUnexpanded;
+                        if (blankIfUnexpandedValue instanceof Boolean) {
+                            blankIfUnexpanded = (Boolean) blankIfUnexpandedValue;
+                        } else {
+                            blankIfUnexpanded = blankIfUnexpandedValue instanceof String && Boolean.parseBoolean((String) blankIfUnexpandedValue);
+                        }
+                        pbuild.blankIfUnexpandable(blankIfUnexpanded);
                     }
-
-                    pbuild.blankIfUnexpandable(blankIfUnexpanded);
 
 
                     final Object defObj = itemmeta.get(CONFIG_DEFAULT);


### PR DESCRIPTION
## Describe Bug:
Jobs using nixy that were worked on 4.8 stopped working properly on 4.14.x and 4.15.x

**My Rundeck detail**

Rundeck version: [ 4.8.0 , 4.14 ]

install type: [ deb, war ]

OS Name/version: [ ubuntu 20, ubuntu 22, macOs, windows]

DB Type/version: [ Mariadb, H2 ]

**To Reproduce**  

Steps to reproduce the behavior:

1- Install rundeck 4.8 and upload the yaml that I leave here. 

2- Run that job and you will see that the output is ok

3- Install rundeck 4.14 and do the same

4- You will see that the jobs failed

<img width="1429" alt="image" src="https://github.com/rundeck/rundeck/assets/91557307/2303808e-aad3-4943-be5d-8f3bcf7aedb6">

**Expected behavior**  

We expected that the Nixy plugin works fine on both versions.

## Solution
If the value obtained from the metadata, field: `blankIfUnexpandable`, is different from null, the value obtained is used only. Set the value to false or keep the default value in true.

<img width="1422" alt="image" src="https://github.com/rundeck/rundeck/assets/91557307/75725586-107e-4765-b0fc-da64b5670ddb">

