### PR TITLE
RSE-712 Fix: Map Different Required Authorizing Roles

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -437,6 +437,7 @@ public class RundeckConfigBase {
         Boolean useHMacRequestTokens;
         Boolean syncLdapUser;
         String requiredRole;
+        String requiredRoles;
         String jaasRolePrefix;
         Boolean syncOauthUser = Boolean.valueOf(false);
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -437,7 +437,6 @@ public class RundeckConfigBase {
         Boolean useHMacRequestTokens;
         Boolean syncLdapUser;
         String requiredRole;
-        String requiredRoles;
         String jaasRolePrefix;
         Boolean syncOauthUser = Boolean.valueOf(false);
 

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
@@ -22,7 +22,6 @@ import javax.security.auth.Subject
 import javax.servlet.ServletContext
 import javax.servlet.http.HttpServletRequest
 import java.util.stream.Collectors
-import java.util.stream.IntStream
 
 class SetUserInterceptor {
     public static final String RUNNER_RQ_ATTRIB = "runnerRq"

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
@@ -129,10 +129,10 @@ class SetUserInterceptor {
         def requiredRoles = getRequiredRolesFromProps()
         if( requiredRoles.size() ){
             def requestGroups = request?.subject?.principals?.findAll { it instanceof Group } as List<Group>
-            def requestRoles = requestGroups.stream()
+            List<String> requestRoles = requestGroups.stream()
             .map{it.getName()}
-            .collect(Collectors.toList()) as List<String>
-            def matchedRoles = new ArrayList<String>(requiredRoles);
+            .collect(Collectors.toList())
+            List<String> matchedRoles = new ArrayList<>(requiredRoles)
             matchedRoles.retainAll(requestRoles)
             if( !matchedRoles.size() ){
                 log.error("User ${request.remoteUser} must have an allowed role to log in.")
@@ -288,12 +288,10 @@ class SetUserInterceptor {
      * */
     @CompileStatic
     private List<String> getRequiredRolesFromProps(){
-        def rolesFromProps = [] as List<String>
-        def requiredRoles = configurationService.getString("security.requiredRole","")
+        List<String> rolesFromProps = []
+        String requiredRoles = configurationService.getString("security.requiredRole","")
         if( requiredRoles ){
-            List<String> allowedHostnames = requiredRoles.split(",").collect( it -> it.trim())
-            allowedHostnames.stream().filter {position -> !position.isEmpty()}
-                    .forEach {rolesFromProps << it}
+            rolesFromProps = requiredRoles.split(",").collect( it -> it.trim())
         }
         return rolesFromProps
     }

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
@@ -289,15 +289,11 @@ class SetUserInterceptor {
     @CompileStatic
     private List<String> getRequiredRolesFromProps(){
         def rolesFromProps = [] as List<String>
-        def requiredSingularRole = configurationService.getString("security.requiredRole","")
-        if( requiredSingularRole ){
-            rolesFromProps << requiredSingularRole
-        }
-        def requiredPluralRoles = configurationService.getString("security.requiredRoles","")
-        if( requiredPluralRoles ){
-            List<String> allowedHostnames = requiredPluralRoles.split(",").collect( it -> it.trim())
+        def requiredRoles = configurationService.getString("security.requiredRole","")
+        if( requiredRoles ){
+            List<String> allowedHostnames = requiredRoles.split(",").collect( it -> it.trim())
             allowedHostnames.stream().filter {position -> !position.isEmpty()}
-            .forEach {rolesFromProps << it}
+                    .forEach {rolesFromProps << it}
         }
         return rolesFromProps
     }

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
@@ -21,7 +21,6 @@ import webhooks.Webhook
 import javax.security.auth.Subject
 import javax.servlet.ServletContext
 import javax.servlet.http.HttpServletRequest
-import java.util.function.Function
 import java.util.stream.Collectors
 
 class SetUserInterceptor {

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
@@ -171,9 +171,11 @@ class SetUserInterceptorSpec extends Specification implements InterceptorUnitTes
         commaSeparatedUserRoles | groups           | userAllowed | code
         "admin"                 |["admin", "user"] | true        | null
         "user"                  |["admin", "user"] | true        | null
-        "admin,user"            |["admin"]         | true        | null
+        "user    "              |["admin", "user"] | true        | null
+        "    user    "          |["admin", "user"] | true        | null
+        "admin, user"           |["admin"]         | true        | null
         "admin,user"            |["admin", "user"] | true        | null
-        "admin,user"            |["allowed"]       | false       | 'user.not.allowed'
+        "admin,user,other"      |["allowed"]       | false       | 'user.not.allowed'
         "admin,user"            |["anyOfThem"]     | false       | 'user.not.allowed'
 
     }

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
@@ -153,8 +153,7 @@ class SetUserInterceptorSpec extends Specification implements InterceptorUnitTes
         }
 
         interceptor.configurationService = Mock(ConfigurationService) {
-             getString("security.requiredRole","")>>soleRequiredRole
-             getString("security.requiredRoles","")>>commaSeparatedUserRoles
+             getString("security.requiredRole","")>>commaSeparatedUserRoles
         }
 
         when:
@@ -169,14 +168,13 @@ class SetUserInterceptorSpec extends Specification implements InterceptorUnitTes
         flash.loginErrorCode==code
 
         where:
-        soleRequiredRole | commaSeparatedUserRoles | groups           | userAllowed | code
-        ''               | ""                      |["admin", "user"] | true        | null
-        'admin'          | ""                      |["admin", "user"] | true        | null
-        'user'           | ""                      |["admin"]         | false       | 'user.not.allowed'
-        ''               | "admin,user"            |["admin"]         | true        | null
-        ''               | "admin,user"            |["admin", "user"] | true        | null
-        'allowed'        | "admin,user"            |["allowed"]       | true        | null
-        'allowed'        | "admin,user"            |["anyOfThem"]     | false       | 'user.not.allowed'
+        commaSeparatedUserRoles | groups           | userAllowed | code
+        "admin"                 |["admin", "user"] | true        | null
+        "user"                  |["admin", "user"] | true        | null
+        "admin,user"            |["admin"]         | true        | null
+        "admin,user"            |["admin", "user"] | true        | null
+        "admin,user"            |["allowed"]       | false       | 'user.not.allowed'
+        "admin,user"            |["anyOfThem"]     | false       | 'user.not.allowed'
 
     }
 


### PR DESCRIPTION
# RSE-712 Fix: Map Different Required Authorizing Roles
As a solution to Runner authorization issues, we expanded the capability to map "required" roles to allow connections.

## The Problem
When the property ```rundeck.security.requiredRole``` is set, the interceptor 'SetUserInterceptor.groovy' acts as a filter and check if the role received in request matches with the role named in the property; when the runner attempts to connect to rundeck's server, only one role ("_runner") is extracted from the connection token, that caused [this issue](https://pagerduty.atlassian.net/browse/RSE-712)

## The Solution
Adding other property to add comma separated roles in order to map other roles as well.

## To QA :white_check_mark: 
STR Previous Behavior (4.15):
1. Enable the runner management and add the property ```rundeck.security.requiredRole=yourRole```
2. Create a project
3. Create a runner and assign it to created project
4. Install the runner in a external environment (docker in the same network)
5. As soon you got ready rundeck server and runner you must see ''Rundeck API token authorization failed. Please check your Rundeck Runner Api token." error in runner console.

Solution:
:heavy_check_mark: Add the plural property: ```rundeck.security.requiredRoles=yourRoleHere,_runner``` and restart rundeck server