### PR TITLE
RSE-521:Fix: When clicking "Save" button at webhook can't copy the genereated string

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/webhooks/views/WebhooksView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/webhooks/views/WebhooksView.vue
@@ -378,12 +378,7 @@ export default observer(Vue.extend({
         this.setValidation(true)
         this.dirty = false
         await this.rootStore.webhooks.refresh(this.projectName)
- 
-        const currentHooks = this.rootStore.webhooks.webhooksByUuid._data
-        const curHooksArrMap = Array.from(currentHooks.values());
-        const curHookByUUID = curHooksArrMap[curHooksArrMap.length - 1].value.uuid;
-  
-        this.select(this.rootStore.webhooks.webhooksByUuid.get(curHookByUUID))
+        this.select(webhook)
       }
     },
     handleCancel() {


### PR DESCRIPTION
# When clicking "Save" button at webhook can't copy the genereated string

When there is more than one webhook (it doesn't matter what type) and you click on any saved webhook except the bottom one, clicking "Regenerate" then "Save" immediately loads the bottom webhook, so the regenerated string is not visible for long enough to copy it.

[RSE-521](https://pagerduty.atlassian.net/browse/RSE-521)

# Fix

For some reason, after saving the webhook config, the selection was going to the last one in the list by default. So instead of doing that, we are sending now the selected webhook so the generated code can be copied.

<img width="1645" alt="image" src="https://github.com/rundeck/rundeck/assets/29233418/cf3fe983-a85b-45ec-92ec-e5c33fe0f198">


[RSE-521]: https://pagerduty.atlassian.net/browse/RSE-521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ