### PR TITLE
RUN-1859: Dark mode updates

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/package.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package.json
@@ -34,7 +34,7 @@
     "@iconfu/svg-inject": "^1.2.3",
     "@popperjs/core": "^2.8.4",
     "@rundeck/client": "^0.2.5",
-    "ace-builds": "^1.4.12",
+    "ace-builds": "^1.23.4",
     "axios": "^0.21.3",
     "core-js": "^3.6.5",
     "markdown-it-vue": "^1.1.6",
@@ -96,7 +96,7 @@
   },
   "peerDependencies": {
     "@rundeck/client": "^0.2.5",
-    "ace-builds": "^1.4.12",
+    "ace-builds": "^1.23.4",
     "mobx": "^5.15.4",
     "mobx-utils": "^5.6.1",
     "mobx-vue": "^2.0.11",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/AceEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/AceEditor.vue
@@ -66,6 +66,8 @@ import 'ace-builds/src-noconflict/mode-sql'
 import 'ace-builds/src-noconflict/mode-xml'
 import 'ace-builds/src-noconflict/mode-yaml'
 import 'ace-builds/src-noconflict/theme-chrome'
+import 'ace-builds/src-noconflict/theme-tomorrow_night'
+import 'ace-builds/src-noconflict/theme-tomorrow_night_eighties'
 
 export default Vue.extend({
   name: 'ace-editor',

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/process-flow.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/process-flow.scss
@@ -9,7 +9,7 @@ div {
 
       li {
         margin-left: 20px;
-        border: 1px solid #cfcfca;
+        border: 1px solid var(--list-item-border-color);
         padding: 10px !important;
         margin-bottom: 10px;
         border-radius: 5px;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/runstrap/_code.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/runstrap/_code.scss
@@ -15,8 +15,8 @@ samp {
 code {
   padding: 2px 4px;
   font-size: 90%;
-  color: $code-color;
-  background-color: $code-bg;
+  color: var(--code-color);
+  background-color: var(--code-bg);
   border-radius: $border-radius-base;
 }
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/runstrap/_input-groups.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/runstrap/_input-groups.scss
@@ -83,7 +83,7 @@
   font-size: $font-size-base;
   font-weight: 400;
   line-height: 1;
-  color: $input-color;
+  color: var(--font-color);
   text-align: center;
   background-color: var(--background-color);
   border: 1px solid var(--input-outline-color);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/runstrap/_variables.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/runstrap/_variables.scss
@@ -1045,8 +1045,6 @@ $close-text-shadow:           0 1px 0 #fff !default;
 //
 //##
 
-$code-color:                  #c7254e !default;
-$code-bg:                     #f9f2f4 !default;
 
 $kbd-color:                   #fff !default;
 $kbd-bg:                      #333 !default;
@@ -1057,6 +1055,15 @@ $pre-border-color:            #ccc !default;
 $pre-scrollable-max-height:   340px !default;
 
 
+:root {
+  --code-color: var(--red-600);
+  --code-bg: var(--grey-200);
+}
+
+*[data-color-theme="dark"] {
+  --code-color: var(--red-100);
+  --code-bg: var(--grey-500);
+}
 //== Type
 //
 //##


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
* Updates the Ace text editor used via Vue to adapt to dark mode
* Updates some styles for dark mode
    * border for list items
    * color/bg for `<code>` 


**Additional context**
Before:
![Screenshot 2023-07-28 at 8 32 24 AM](https://github.com/rundeck/rundeck/assets/55603/a6fc6eeb-b6ae-458d-92ae-11a0b145e633)

After:
![Screenshot 2023-07-28 at 9 01 34 AM](https://github.com/rundeck/rundeck/assets/55603/eb333c80-d7eb-440c-b367-3ebc31e10bf1)

![Screenshot 2023-07-28 at 8 59 50 AM](https://github.com/rundeck/rundeck/assets/55603/773ae8f2-ec62-441d-a7fe-4a54edf045f6)


