### PR TITLE
Rse 702 schedule cluster

### DIFF
--- a/grails-execution-mode-timer/grails-app/services/com/rundeck/plugin/UpdateModeProjectService.groovy
+++ b/grails-execution-mode-timer/grails-app/services/com/rundeck/plugin/UpdateModeProjectService.groovy
@@ -1,6 +1,7 @@
 package com.rundeck.plugin
 
 import com.dtolabs.rundeck.core.common.IRundeckProject
+import com.dtolabs.rundeck.core.common.IRundeckProjectConfig
 import com.dtolabs.rundeck.core.plugins.configuration.Property
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyValidator
 import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants
@@ -469,6 +470,7 @@ class UpdateModeProjectService implements ProjectConfigurable {
 
         frameworkService.updateFrameworkProjectConfig(project, projProps, removePrefixes)
         if(reschedule){
+            frameworkService.notifyProjectSchedulingChange(project, isExecutionDisabledNow, isScheduleDisabledNow, active)
             if(active){
                 scheduledExecutionService.rescheduleJobs(frameworkService.isClusterModeEnabled()?frameworkService.getServerUUID():null, project)
             }else{

--- a/grails-execution-mode-timer/src/test/groovy/com/rundeck/plugin/EditProjectControllerSpec.groovy
+++ b/grails-execution-mode-timer/src/test/groovy/com/rundeck/plugin/EditProjectControllerSpec.groovy
@@ -338,5 +338,10 @@ class MockFrameworkService{
         projectList
     }
 
+    void notifyProjectSchedulingChange(String project, boolean oldDisableExec, boolean oldDisableSched, boolean isEnabled){
+
+    }
+
+
 }
 

--- a/grails-execution-mode-timer/src/test/groovy/com/rundeck/plugin/UpdateModeProjectServiceSpec.groovy
+++ b/grails-execution-mode-timer/src/test/groovy/com/rundeck/plugin/UpdateModeProjectServiceSpec.groovy
@@ -334,6 +334,7 @@ class UpdateModeProjectServiceSpec extends Specification implements ServiceUnitT
 
         def mockFrameworkService = new MockFrameworkService()
         mockFrameworkService.setRundeckProject(rundeckProject)
+        mockFrameworkService.notifyProjectSchedulingChange(project,executionLater,scheduleLater,true)
 
         def quartzScheduler = Mock(Scheduler){
             schedule * scheduleJob(_)
@@ -347,6 +348,7 @@ class UpdateModeProjectServiceSpec extends Specification implements ServiceUnitT
         def result = service.editProject(rundeckProject,project,disable, executionLater, scheduleLater)
         then:
         result!=null
+        _ * service.frameworkService.notifyProjectSchedulingChange(_,_,_,_)
 
         where:
         disableExecution  | disableSchedule  | disable | executionLater | scheduleLater| delete | schedule

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -312,7 +312,7 @@ class ExecutionJob implements InterruptableJob {
                 }
             }
 
-            def fwProject = frameworkService.getFrameworkProject(project)
+            def fwProject = frameworkService.getProjectConfigReloaded(project)
             def disableEx = fwProject.getProjectProperties().get("project.disable.executions")
             def disableSe = fwProject.getProjectProperties().get("project.disable.schedule")
             def isProjectExecutionEnabled = ((!disableEx)||disableEx.toLowerCase()!='true')

--- a/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionJobIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionJobIntegrationSpec.groovy
@@ -463,7 +463,7 @@ class ExecutionJobIntegrationSpec extends Specification {
             def proj = Mock(IRundeckProject) {
                 2 * getProjectProperties() >> [:]
             }
-            1 * mockfs.getFrameworkProject(_) >> proj
+            1 * mockfs.getProjectConfigReloaded(_) >> proj
             IFramework fwk = Mock(IFramework)
             1 * mockfs.getRundeckFramework() >> fwk
             def mockAuth = Mock(UserAndRolesAuthContext) {
@@ -647,7 +647,7 @@ class ExecutionJobIntegrationSpec extends Specification {
             def proj = Mock(IRundeckProject) {
                 2 * getProjectProperties() >> [:]
             }
-            1 * mockfs.getFrameworkProject(_) >> proj
+            1 * mockfs.getProjectConfigReloaded(_) >> proj
             IFramework fwk = Mock(IFramework)
             1 * mockfs.getRundeckFramework() >> fwk
             def mockAuth = Mock(UserAndRolesAuthContext) {
@@ -711,7 +711,7 @@ class ExecutionJobIntegrationSpec extends Specification {
             def proj = Mock(IRundeckProject) {
                 2 * getProjectProperties() >> [:]
             }
-            1 * mockfs.getFrameworkProject(_) >> proj
+            1 * mockfs.getProjectConfigReloaded(_) >> proj
             IFramework fwk = Mock(IFramework)
             1 * mockfs.getRundeckFramework() >> fwk
             def mockAuth = Mock(UserAndRolesAuthContext) {

--- a/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
@@ -405,7 +405,7 @@ class ExecutionJobSpec extends Specification implements DataTest {
         def jobSchedulerService = Mock(JobSchedulerService)
         def fs = Mock(FrameworkService) {
             getServerUUID() >> serverUUID
-            getFrameworkProject('AProject') >> Mock(IRundeckProject) {
+            getProjectConfigReloaded('AProject') >> Mock(IRundeckProject) {
                 getProjectProperties() >> [:]
             }
         }
@@ -786,7 +786,7 @@ class ExecutionJobSpec extends Specification implements DataTest {
         def jobSchedulerService = Mock(JobSchedulerService)
         def fs = Mock(FrameworkService) {
             getServerUUID() >> serverUUID
-            getFrameworkProject('AProject')>>Mock(IRundeckProject){
+            getProjectConfigReloaded('AProject')>>Mock(IRundeckProject){
                 getProjectProperties()>>[:]
             }
         }


### PR DESCRIPTION
Problem: Some jobs do not trigger after disabling/enabling the schedule at the project level on the cluster this also happened with Disable Execution Later/Disable Scheduled Later.

Solution: The query that queries the messaging table was modified to sort the retrieved records by ID, avoiding a race condition that caused scheduled jobs not to execute. Also, the project config is now obtained directly from DB and not from the cache avoiding inconsistencies.

A missing notification was added to the cluster communication to notify the "Disable Execution Later" / "Disable Scheduled Later" events.
