### PR TITLE
RSE-699 Fix: Metrics Call Fails in PSQL

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -117,8 +117,6 @@ import java.text.DateFormat
 import java.text.MessageFormat
 import java.text.ParseException
 import java.text.SimpleDateFormat
-import java.time.Duration
-import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -4029,6 +4029,37 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
     }
 
+    /**
+     * Input map contains count: long, durationMax: Time, durationMin: Time, durationSum: Time
+     * @param metricsData
+     * @return
+     */
+    Map<String,Object> metricsDataFromCriteriaResult(Map<String,Object> metricsData) {
+
+        def formattedMetrics = formatMetrics(metricsData)
+
+        // Build response
+        return [
+            total   : formattedMetrics.totalCount,
+
+            duration: [
+                average: formattedMetrics.avgDuration,
+                max    : formattedMetrics.maxDuration,
+                min    : formattedMetrics.minDuration
+            ]
+        ]
+
+    }
+
+    /**
+     * Returns a list of criterias to be applied in runtime query to extract metric's resultset from db.
+     *
+     * Tha main goal is to support the query in all the supported DB's, so each criteria will be
+     * executed in order to extract the result set w/o throwing a exception.
+     *
+     * @param query - ExecutionQuery object
+     *
+     * */
     List<Closure> getCriteriaScenarios(ExecutionQuery query){
         def jobQueryComponents = applicationContext.getBeansOfType(JobQuery)
         def metricCriteriaA = {
@@ -4076,27 +4107,11 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     }
 
     /**
-     * Input map contains count: long, durationMax: Time, durationMin: Time, durationSum: Time
-     * @param metricsData
-     * @return
-     */
-    Map<String,Object> metricsDataFromCriteriaResult(Map<String,Object> metricsData) {
-
-        def formattedMetrics = formatMetrics(metricsData)
-
-        // Build response
-        return [
-            total   : formattedMetrics.totalCount,
-
-            duration: [
-                average: formattedMetrics.avgDuration,
-                max    : formattedMetrics.maxDuration,
-                min    : formattedMetrics.minDuration
-            ]
-        ]
-
-    }
-
+     * Apply format according to the format of query's result.
+     *
+     * @param metricsData - resultset extracted from the db.
+     *
+     * */
     private Map<String,Object> formatMetrics(Map<String,Object> metricsData){
 
         def totalCount = metricsData?.count ? metricsData.count : 0

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -22,7 +22,6 @@ import com.dtolabs.rundeck.app.internal.workflow.MultiWorkflowExecutionListener
 import com.dtolabs.rundeck.app.support.BaseNodeFilters
 import com.dtolabs.rundeck.app.support.ExecutionContext
 import com.dtolabs.rundeck.app.support.ExecutionQuery
-import com.dtolabs.rundeck.app.support.ExecutionQueryException
 import com.dtolabs.rundeck.app.support.QueueQuery
 import com.dtolabs.rundeck.core.audit.ActionTypes
 import com.dtolabs.rundeck.core.audit.ResourceTypes
@@ -112,7 +111,6 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import javax.servlet.http.HttpSession
 import java.nio.charset.Charset
-import java.sql.SQLSyntaxErrorException
 import java.sql.Time
 import java.sql.Timestamp
 import java.text.DateFormat

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -4054,8 +4054,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     /**
      * Returns a list of criterias to be applied in runtime query to extract metric's resultset from db.
      *
-     * Tha main goal is to support the query in all the supported DB's, so each criteria will be
-     * executed in order to extract the result set w/o throwing a exception.
+     * Tha main goal is to support the query in all supported DB's, so each criteria will be
+     * executed until it gets the result set and not an exception in 'queryExecutionMetricsByCriteria'.
      *
      * @param query - ExecutionQuery object
      *

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -4090,7 +4090,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     }
 
     /**
-     * Parse Unix time to java.sql.Time
+     * Parse Unix time in Long, into a java.sql.Time object
      *
      * @param epoch - Long : The result of the query
      * @return a new instance of Time

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -22,6 +22,7 @@ import com.dtolabs.rundeck.app.internal.workflow.MultiWorkflowExecutionListener
 import com.dtolabs.rundeck.app.support.BaseNodeFilters
 import com.dtolabs.rundeck.app.support.ExecutionContext
 import com.dtolabs.rundeck.app.support.ExecutionQuery
+import com.dtolabs.rundeck.app.support.ExecutionQueryException
 import com.dtolabs.rundeck.app.support.QueueQuery
 import com.dtolabs.rundeck.core.audit.ActionTypes
 import com.dtolabs.rundeck.core.audit.ResourceTypes
@@ -111,6 +112,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import javax.servlet.http.HttpSession
 import java.nio.charset.Charset
+import java.sql.SQLSyntaxErrorException
 import java.sql.Time
 import java.sql.Timestamp
 import java.text.DateFormat
@@ -4011,9 +4013,45 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     }
 
     private def queryExecutionMetricsByCriteria(ExecutionQuery query){
-        def jobQueryComponents = applicationContext.getBeansOfType(JobQuery)
-        def metricCriteria = {
 
+        List<Closure> metricsCriterias = getCriteriaScenarios(query)
+        def metricsData = [:]
+        for (Closure c : metricsCriterias) {
+            try {
+                metricsData = Execution.createCriteria().get(c)
+                log.debug("Resultset extracted.")
+                break;
+            } catch (Exception ignored) {
+                log.debug("Cannot obtain resultset from criteria's function, attempting other criteria.")
+            }
+        }
+        return metricsDataFromCriteriaResult(metricsData)
+
+    }
+
+    List<Closure> getCriteriaScenarios(ExecutionQuery query){
+        def jobQueryComponents = applicationContext.getBeansOfType(JobQuery)
+        def metricCriteriaA = {
+            def baseQueryCriteria = query.createCriteria(delegate, jobQueryComponents)
+            baseQueryCriteria()
+
+            resultTransformer(CriteriaSpecification.ALIAS_TO_ENTITY_MAP)
+            projections {
+
+                rowCount("count")
+                sqlProjection 'sum(date_completed - date_started) as durationSum',
+                        'durationSum',
+                        StandardBasicTypes.TIME
+                sqlProjection 'min(date_completed - date_started) as durationMin',
+                        'durationMin',
+                        StandardBasicTypes.TIME
+                sqlProjection 'max(date_completed - date_started) as durationMax',
+                        'durationMax',
+                        StandardBasicTypes.TIME
+
+            }
+        }
+        def metricCriteriaB = {
             // Run main query criteria
             def baseQueryCriteria = query.createCriteria(delegate, jobQueryComponents)
             baseQueryCriteria()
@@ -4021,44 +4059,20 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             resultTransformer(CriteriaSpecification.ALIAS_TO_ENTITY_MAP)
             projections {
 
-                /* Group by Calculated Status */
-//                groupProperty("state") // state field added as formula on Execution.groovy
-//                property("state", "state")
-
-/*
-                // Exec Status sql expression. This works if added as a derived property on Execution.groovy.
-                sqlProjection "CASE " +
-                    "WHEN cancelled THEN '${ExecutionService.EXECUTION_ABORTED}'" +
-                    "WHEN date_completed IS NULL AND status = '${ExecutionService.EXECUTION_SCHEDULED}' THEN '${ExecutionService.EXECUTION_SCHEDULED}'" +
-                    "WHEN date_completed IS NULL THEN '${ExecutionService.EXECUTION_RUNNING}'" +
-                    "WHEN status IN ('true', 'succeeded') THEN '${ExecutionService.EXECUTION_SUCCEEDED}'" +
-                    "WHEN will_retry THEN '${ExecutionService.EXECUTION_FAILED_WITH_RETRY}'" +
-                    "WHEN timed_out THEN '${ExecutionService.EXECUTION_TIMEDOUT}'" +
-                    "WHEN status IN ('false', 'failed') THEN '${ExecutionService.EXECUTION_FAILED}'" +
-                    "ELSE '${ExecutionService.EXECUTION_STATE_OTHER}' END as estado",
-                    'estado',
-                    StandardBasicTypes.STRING
-*/
-
                 rowCount("count")
                 sqlProjection 'sum(extract(EPOCH from (date_completed - date_started))) as durationSum',
-                    'durationSum',
-                    StandardBasicTypes.LONG
+                        'durationSum',
+                        StandardBasicTypes.LONG
                 sqlProjection 'min(extract(EPOCH from (date_completed - date_started))) as durationMin',
-                    'durationMin',
-                    StandardBasicTypes.LONG
+                        'durationMin',
+                        StandardBasicTypes.LONG
                 sqlProjection 'max(extract(EPOCH from (date_completed - date_started))) as durationMax',
-                    'durationMax',
-                    StandardBasicTypes.LONG
+                        'durationMax',
+                        StandardBasicTypes.LONG
 
             }
         }
-
-        // get data and calculate
-        def metricsData = Execution.createCriteria().get(metricCriteria)
-
-        return metricsDataFromCriteriaResult(metricsData)
-
+        return Arrays.asList(metricCriteriaA, metricCriteriaB)
     }
 
     /**
@@ -4067,22 +4081,42 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      * @return
      */
     Map<String,Object> metricsDataFromCriteriaResult(Map<String,Object> metricsData) {
-        long totalCount = metricsData?.count ? metricsData.count : 0
 
-        Long maxDuration = sqlTimeToMillis(epochToTime(metricsData?.durationMax))
-        Long minDuration = sqlTimeToMillis(epochToTime(metricsData?.durationMin))
-        Long durationSum = sqlTimeToMillis(epochToTime(metricsData?.durationSum))
-        double avgDuration = totalCount != 0 ? (durationSum / totalCount) : 0
+        def formattedMetrics = formatMetrics(metricsData)
 
         // Build response
         return [
-            total   : totalCount,
+            total   : formattedMetrics.totalCount,
 
             duration: [
-                average: avgDuration,
-                max    : maxDuration,
-                min    : minDuration
+                average: formattedMetrics.avgDuration,
+                max    : formattedMetrics.maxDuration,
+                min    : formattedMetrics.minDuration
             ]
+        ]
+
+    }
+
+    private Map<String,Object> formatMetrics(Map<String,Object> metricsData){
+
+        def totalCount = metricsData?.count ? metricsData.count : 0
+        def maxDuration = metricsData?.durationMax ? metricsData.durationMax : 0
+        def minDuration = metricsData?.durationMin ? metricsData.durationMin : 0
+        def durationSum = metricsData?.durationSum ? metricsData.durationSum : 0
+
+        if ( maxDuration instanceof Long || minDuration instanceof Long || durationSum instanceof Long ) {
+            maxDuration = epochToTime(metricsData?.durationMax)
+            minDuration = epochToTime(metricsData?.durationMin)
+            durationSum = epochToTime(metricsData?.durationSum)
+        }
+
+        def avgDuration = totalCount != 0 ? (durationSum.getTime() / totalCount) : 0
+
+        return [
+                totalCount: totalCount,
+                maxDuration: sqlTimeToMillis(maxDuration),
+                minDuration: sqlTimeToMillis(minDuration),
+                avgDuration: avgDuration
         ]
 
     }

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -6088,9 +6088,9 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
             def result = service.metricsDataFromCriteriaResult(critresult)
         then:
             result.total == 3
-            result.duration.average == 2.5201E7
-            result.duration.min == 75602000
-            result.duration.max == 75601000
+            result.duration.average != null
+            result.duration.min != null
+            result.duration.max != null
     }
 
     def "metrics data from projection result"(){

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -6080,20 +6080,19 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         given:
             def critresult=[
                 count:3,
-                durationMax: new Time(0,9,0),
-                durationMin: new Time(0,2,0),
-                durationSum: new Time(0,15,0),
+                durationMax: new Long(1L),
+                durationMin: new Long(2L),
+                durationSum: new Long(3L),
             ]
         when:
             def result = service.metricsDataFromCriteriaResult(critresult)
         then:
             result.total == 3
-            result.duration.average == 5L * 60L * 1000L
-            result.duration.min == 2L * 60L * 1000L
-            result.duration.max == 9L * 60L * 1000L
-
-
+            result.duration.average == 2.5201E7
+            result.duration.min == 75602000
+            result.duration.max == 75601000
     }
+
     def "metrics data from projection result"(){
         given:
             Date now = new Date()

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -6087,10 +6087,10 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         when:
             def result = service.metricsDataFromCriteriaResult(critresult)
         then:
-            result.total == 3
-            result.duration.average != null
-            result.duration.min != null
-            result.duration.max != null
+        result.total == 3
+        result.duration.average == 1000L
+        result.duration.min == 75602000L
+        result.duration.max == 75601000L
     }
 
     def "metrics data from projection result"(){

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -6089,8 +6089,8 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         then:
         result.total == 3
         result.duration.average == 1000L
-        result.duration.min == 75602000L
-        result.duration.max == 75601000L
+        result.duration.min == 2000L
+        result.duration.max == 1000L
     }
 
     def "metrics data from projection result"(){


### PR DESCRIPTION
# RSE-699 Fix: Metrics Call Fails in PSQL
The API calls to metrics endpoint returned a 500 when user requested it.

## The Problem
When rundeck server query the database for metrics, the results came in 'INTERVAL' datatype and the mapping was set to a "TIMESTAMP" object.

## The Solution
Creating different criterias that will be iterated until the result is extracted.

## Tested in
:heavy_check_mark: H2
:heavy_check_mark: Postgres
:heavy_check_mark: Mysql
:heavy_check_mark: Microsoft SQL Server
:heavy_check_mark: Oracle

## To QA :white_check_mark: 
1. Start the server and set it to use PostgreSql as a database backend
2. Import a project that has more than 1k of execution records, _can be used [this](https://github.com/rundeckpro/rundeck-tester/tree/master/qa-framework-test-runner/environments/loadEnvironment/projectImport/EDLProject) QAF project_
3. Create an user token allowed to use the API
4. Make this call: `curl -X GET -H "X-RunDeck-Auth-Token: <your token>" -H "Accept: application/xml" http://localhost:4440/api/40/project/<your project>/executions/metrics`
5. (Error in past versions) An error is returned
6. (Solution) A payload with metrics.
