### PR TITLE
RUN-1873: remove unstylish border from notifications

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/runstrap/_media.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/runstrap/_media.scss
@@ -1,5 +1,4 @@
 .media {
-  border-bottom: 1px solid var(--medium-gray);
   padding-bottom: 30px;
   margin-top: 30px;
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
fix style for notification toasts, remove an extraneous border style.

before:
<img width="322" alt="Screenshot 2023-08-03 at 9 11 32 AM" src="https://github.com/rundeck/rundeck/assets/55603/0459d089-62bd-483c-b00b-3adbad997889">

after:
<img width="333" alt="Screenshot 2023-08-03 at 9 11 22 AM" src="https://github.com/rundeck/rundeck/assets/55603/d0e1b4b7-9e7e-4ea5-b604-99fdc502fb9e">
