### PR TITLE
RSE-445: Fix: execution state in clustermode with nfs logstorage not in sync

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
@@ -387,7 +387,7 @@ class WorkflowService implements ApplicationContextAware,ExecutionFileProducer{
 
         //look for cached local data
         def statemap=stateCache.getIfPresent(e.id)
-        if (statemap) {
+        if (statemap && !configurationService.getBoolean("clusterMode.enabled", false)) {
             statemap=stateMapping.summarize(new HashMap(statemap),nodes,selectedOnly,stepStates)
             return new WorkflowStateFileLoader(workflowState: statemap, state: ExecutionFileState.AVAILABLE)
         }


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-445

#### Problem
The execution state is not synchronized among cluster members when using shared file system log storage because the `<exec_id>.state.json` is generated on execution completion if not using any log storage plugin.

#### Solution 
Keep the `<exec_id>.state.json` files updated on every workflow status change. Also reading the status from the file without using a cache on cluster mode

##### Alternative solution
Create some kind of "file watcher" on the `WorkflowStateFileLoader` to keep the cache updated on every external change of the file. This was discarded for the extra complexity that implies for a little benefit