### PR TITLE
RSE-721: fixes job deletion of an scheduled job

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -200,6 +200,11 @@ class ScheduledExecution extends ExecutionContext implements JobData, EmbeddedJs
         withProject { project ->
             eq 'project', project
         }
+        findByUUID{ uuid ->
+            eq 'uuid', uuid
+            cache false
+            setUniqueResult true
+        }
     }
 
 

--- a/rundeckapp/src/main/groovy/rundeck/services/ScheduledExecutionDeletedException.java
+++ b/rundeckapp/src/main/groovy/rundeck/services/ScheduledExecutionDeletedException.java
@@ -1,0 +1,9 @@
+package rundeck.services;
+
+public class ScheduledExecutionDeletedException extends Exception{
+
+    public ScheduledExecutionDeletedException(String s) {
+        super(s);
+    }
+
+}


### PR DESCRIPTION
**Issue:** whenever an scheduled job was deleted on a cluster member different than the owner, the job would still be running on quartz but throwing exception each time that it tried to run

`[2023-07-31T11:34:00,029] ERROR quartzjobs.ExecutionJob [quartzScheduler_Worker-5] - Unable to start Job execution: No row with the given identifier exists: [rundeck.ScheduledExecution#13]
org.hibernate.ObjectNotFoundException: No row with the given identifier exists: [rundeck.ScheduledExecution#13]
	at org.hibernate.boot.internal.StandardEntityNotFoundDelegate.handleEntityNotFound(StandardEntityNotFoundDelegate.java:28) ~[hibernate-core-5.4.24.Final.jar!/:5.4.24.Final]
	at org.hibernate.event.internal.DefaultLoadEventListener.load(DefaultLoadEventListener.java:216) ~[hibernate-core-5.4.24.Final.jar!/:5.4.24.Final]
	at org.hibernate.event.internal.DefaultLoadEventListener.proxyOrLoad(DefaultLoadEventListener.java:332) ~[hibernate-core-5.4.24.Final.jar!/:5.4.24.Final]`

**Solution:** 

1. Change the query to get the job definition to not use the cache
2. If the job does not exist it will throw an exception and the job will get removed from quartz