### PR TITLE
RSE-724: Keep "allGroups" in true by default.

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
@@ -262,7 +262,7 @@ public class JettyCachingLdapLoginModule extends AbstractLoginModule {
 
     protected boolean _nestedGroups;
 
-    protected boolean _allGroups = false;
+    protected boolean _allGroups = true;
 
     /**
      * timeout for LDAP read


### PR DESCRIPTION
Keep the value true to fetch all groups in LDAP. If there is an error, just change it to false.