### PR TITLE
RUN-1853: Fix: Button border width causes misaligned input group on hi-dpi screen

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/runstrap/_variables.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/runstrap/_variables.scss
@@ -189,7 +189,7 @@ $line-height-general:          1.4em !default;
 $line-height:                 36px !default;
 $line-height-lg:              54px !default;
 
-$border-thin:                1.5px !default;
+$border-thin:                1px !default;
 $border-thick:               2px !default;
 
 $border-radius-top:        10px 10px 0 0 !default;


### PR DESCRIPTION
1.5px border width does not match with 1px border width on inputs and input-group-addon elements, causing a 1px alignment issue

**Is this a bugfix, or an enhancement? Please describe.**
fix a misalignment in input group with both input-group-addon and input-group-btn sections.

This border width is used in only two places, the `.input-group-btn .btn` and a pagination element.
