### PR TITLE
Fix RUN-1883: selecting correct webhook when it's saving a new one

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/webhooks/views/WebhooksView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/webhooks/views/WebhooksView.vue
@@ -378,7 +378,11 @@ export default observer(Vue.extend({
         this.setValidation(true)
         this.dirty = false
         await this.rootStore.webhooks.refresh(this.projectName)
-        this.select(webhook)
+        const currentHooks = this.rootStore.webhooks.webhooksByUuid._data
+        const curHooksArrMap = Array.from(currentHooks.values());
+        const curHookByUUID = curHooksArrMap[curHooksArrMap.length - 1].value.uuid;
+
+        this.select(webhook.new ? this.rootStore.webhooks.webhooksByUuid.get(curHookByUUID) : webhook)
       }
     },
     handleCancel() {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
The fix for #8453 caused a new issue when creating a new webhook showing `undefined` in the webhook URL

**Describe the solution you've implemented**
It checks if it is creating a new webhook. If so, it will keep the previous behavior to select the new item created. If not, it will keep the current selection