### PR TITLE
Fix: Not showing parent job output on node exec view when having jobref error handler 

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/ExecutionOutput.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/ExecutionOutput.ts
@@ -64,7 +64,10 @@ export class ExecutionOutput {
     constructor(id: string, client: RundeckClient) {
         Object.assign(this, { id, client })
         this.entriesbyNodeCtx = new ObservableGroupMap(this.entries, (e) => {
-            return `${e.node}:${e.stepctx ? JobWorkflow.cleanContextId(e.stepctx) : ''}`
+            let ctx = (e.stepctx === null) || (e.stepctx === undefined) ? '' : JobWorkflow.cleanContextId(e.stepctx)
+            let parsedCtx = ctx ? JobWorkflow.parseContextId(ctx) : null
+            let parentCtx =  (parsedCtx === null)  ? '' : parsedCtx[0]
+            return `${e.node}:${parentCtx}`
         })
         this.entriesByNode = new ObservableGroupMap(this.entries, (e) => `${e.node}`)
     }
@@ -82,8 +85,11 @@ export class ExecutionOutput {
      **/
     getEntriesFiltered(node?: string, stepCtx?: string) {
         if(node){
-            if (stepCtx)
-                return this.entriesbyNodeCtx.get(`${node}:${JobWorkflow.cleanContextId(stepCtx)}`)
+            if (stepCtx) {
+                const ctxArr = JobWorkflow.parseContextId(stepCtx)
+                let ctxStr = (ctxArr !== null && ctxArr.length > 0)? ctxArr[0] : ''
+                return this.entriesbyNodeCtx.get(`${node}:${JobWorkflow.cleanContextId(ctxStr)}`)
+            }
             else
                 return this.entriesByNode.get(node)
         } else


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-438

#### Problem

_**STR**_
1. Create a "child job" that simply runs an echo command
2. Create a "parent" Job with the following:
        Step 1 with a Script Step that prints and exit with status different than 0 (so it always is marked as failed)
        an Error handler for the Step 1 that uses a job reference of the "child job"
3. Run the parent job
4. Go to the nodes view and expand step 1 to see log output

_**Actual Behavior**_
* Only the output of the child job error handler is shown
![image](https://github.com/rundeck/rundeck/assets/49494423/36ba01f4-84c7-411a-bf57-3d19e4d64902)

_**Expected behavior**_
* The output of both the "parent job" and the "child job" error handler should be present in the step node view

#### Solution
The `ExecutionOutput` class has an `entriesbyNodeCtx` map that is only used by the nodes view to render log output, this map now groups all the log entries using the "root" of the stepCtx (if an entry stepCtx is `2/1` then this entry is added to the map with the key `2` )

![image](https://github.com/rundeck/rundeck/assets/49494423/adcdcbba-334d-462e-9d48-f46381cdc9cb)
