### PR TITLE
Update org.dvaske.gradle.git-build-info from 0.8 to 0.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ buildscript {
 }
 
 plugins {
-    id "org.dvaske.gradle.git-build-info" version "0.8"
+    id "org.dvaske.gradle.git-build-info" version "0.9"
     id "com.dorongold.task-tree" version "1.5"
     id "org.ajoberstar.grgit" version "2.2.1"
     id "signing"


### PR DESCRIPTION
Small fixes in this update and use the latest version of plugin.