### PR TITLE
RUN-2107: Use a fixed version of go for remco in Docker Image

### DIFF
--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -1,13 +1,13 @@
 # Build remco from specific commit
 ##################################
-FROM golang:1.20.7 as remco
+FROM golang:1.19.12 as remco
 ENV REMCO_VERSION=0.12.4
 
 RUN go install github.com/HeavyHorst/remco/cmd/remco@v$REMCO_VERSION
 
 # Build base container
 ######################
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -4,7 +4,6 @@ FROM golang:1.20.7 as remco
 ENV REMCO_VERSION=0.12.4
 
 RUN go install github.com/HeavyHorst/remco/cmd/remco@v$REMCO_VERSION
-RUN remco --version
 
 # Build base container
 ######################

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -1,13 +1,13 @@
 # Build remco from specific commit
 ##################################
-FROM golang:1.19.12 as remco
+FROM golang:1.21.5 as remco
 ENV REMCO_VERSION=0.12.4
 
 RUN go install github.com/HeavyHorst/remco/cmd/remco@v$REMCO_VERSION
 
 # Build base container
 ######################
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.20.7 as remco
 ENV REMCO_VERSION=0.12.4
 
 RUN go install github.com/HeavyHorst/remco/cmd/remco@v$REMCO_VERSION
-
+RUN remco --version
 
 # Build base container
 ######################
@@ -51,8 +51,6 @@ RUN curl -sSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}
 
 # Install Remco
 COPY --from=remco /go/bin/remco /usr/local/bin/remco
-RUN chmod +x /usr/local/bin/remco
-
 
 USER rundeck
 

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -1,3 +1,11 @@
+# Build remco from specific commit
+##################################
+FROM golang:1.20.7 as remco
+ENV REMCO_VERSION=0.12.4
+
+RUN go install github.com/HeavyHorst/remco/cmd/remco@v$REMCO_VERSION
+
+
 # Build base container
 ######################
 FROM ubuntu:22.04
@@ -42,14 +50,9 @@ RUN curl -sSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}
     chmod +x /tini
 
 # Install Remco
-ENV REMCO_VERSION=0.12.4
-RUN curl -ssL "https://github.com/HeavyHorst/remco/releases/download/v${REMCO_VERSION}/remco_${REMCO_VERSION}_linux_amd64.zip" -o remco.zip && \
-    echo 'c7eae0db823660f8cf0c0ccba1beebec64ee1c2e5b6b66ca3d20208cbcb70962  remco.zip' > remco.zip.sha && \
-    sha256sum -c remco.zip.sha && \
-    unzip remco.zip && \
-    cp remco_linux /usr/local/bin/remco && \
-    chmod +x /usr/local/bin/remco && \
-    rm remco.zip remco.zip.sha
+COPY --from=remco /go/bin/remco /usr/local/bin/remco
+RUN chmod +x /usr/local/bin/remco
+
 
 USER rundeck
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
install a fixed version of Goland for Remco for CVE issue

**Describe the solution you've implemented**
In this way, we can control the Goland version instead depending on the version used by Remco

**Describe alternatives you've considered**

**Additional context**
