### PR TITLE
RUN-1897: enable execution of  script file resource model in a remote runner

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/ScriptResourceModelSource.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/ScriptResourceModelSource.java
@@ -54,11 +54,6 @@ public class ScriptResourceModelSource implements Configurable, ResourceModelSou
     public static final String CONFIG_INTERPRETER_ARGS_QUOTED = "argsQuoted";
 
     public static final String CONFIG_FORMAT = "format";
-    public static final PropertyValidator FILE_VALIDATOR = new PropertyValidator() {
-        public boolean isValid(String value) throws ValidationException {
-            return new File(value).isFile();
-        }
-    };
 
     static Description createDescription(final List<String> formats) {
         return DescriptionBuilder.builder()
@@ -78,7 +73,6 @@ public class ScriptResourceModelSource implements Configurable, ResourceModelSou
                           .title("Script File Path")
                           .description("Path to script file to execute")
                           .required(true)
-                          .validator(FILE_VALIDATOR)
                           .build()
             )
             .property(PropertyBuilder.builder()

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/ScriptResourceModelSource.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/ScriptResourceModelSource.java
@@ -125,10 +125,7 @@ public class ScriptResourceModelSource implements Configurable, ResourceModelSou
             throw new ConfigurationException(CONFIG_FILE + " is required");
         }
         scriptFile = new File(configuration.getProperty(CONFIG_FILE));
-        if (!scriptFile.isFile()) {
-            throw new ConfigurationException(
-                CONFIG_FILE + " does not exist or is not a file: " + scriptFile.getAbsolutePath());
-        }
+
         interpreter = configuration.getProperty(CONFIG_INTERPRETER);
         String args = configuration.getProperty(CONFIG_ARGS);
         if(null != args){
@@ -152,6 +149,13 @@ public class ScriptResourceModelSource implements Configurable, ResourceModelSou
     }
 
     public INodeSet getNodes() throws ResourceModelSourceException {
+
+        //validate file exists
+        if (!scriptFile.isFile()) {
+            throw new ResourceModelSourceException(
+                    CONFIG_FILE + " does not exist or is not a file: " + scriptFile.getAbsolutePath());
+        }
+
         try {
             return ScriptResourceUtil.executeScript(scriptFile,
                                                     null,

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/resources/ScriptResourceModelSourceSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/resources/ScriptResourceModelSourceSpec.groovy
@@ -1,0 +1,25 @@
+package com.dtolabs.rundeck.core.resources
+
+import com.dtolabs.rundeck.core.tools.AbstractBaseTest
+import spock.lang.Specification
+
+class ScriptResourceModelSourceSpec extends Specification{
+
+    def "file not found"(){
+        given:
+        def framework = AbstractBaseTest.createTestFramework()
+        def source = new ScriptResourceModelSource(framework)
+
+        def properties = new Properties()
+        properties.put("project","test")
+        properties.put("file","some/path")
+        properties.put("format","resourcexml")
+        source.configure(properties)
+        when:
+        def result = source.getNodes()
+
+        then:
+        ResourceModelSourceException e = thrown()
+        e.message.contains("file does not exist or is not a file")
+    }
+}


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
remove script file resource model validation to be executed in a remote runner

**Describe the solution you've implemented**

**Describe alternatives you've considered**

**Additional context**
