### PR TITLE
RUN-1902: Add execution context for log filter plugins

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/logging/PluginFilteredStreamingLogWriter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/logging/PluginFilteredStreamingLogWriter.java
@@ -23,6 +23,7 @@ import com.dtolabs.rundeck.core.execution.ExecutionContext;
 import com.dtolabs.rundeck.core.execution.ExecutionLogger;
 import com.dtolabs.rundeck.core.execution.workflow.SharedOutputContext;
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin;
+import lombok.Getter;
 
 import java.io.IOException;
 import java.util.*;
@@ -55,7 +56,8 @@ public class PluginFilteredStreamingLogWriter extends FilterStreamingLogWriter {
                 directLogger,
                 context.getDataContextObject(),
                 context.getPrivateDataContextObject(),
-                context.getSharedDataContext()
+                context.getSharedDataContext(),
+                context
         );
     }
 
@@ -243,41 +245,20 @@ public class PluginFilteredStreamingLogWriter extends FilterStreamingLogWriter {
     }
 
     private static class MyLoggingContext implements PluginLoggingContext {
-        SharedOutputContext outputContext;
+        @Getter SharedOutputContext outputContext;
         ExecutionLogger logger;
-        DataContext dataContext;
-        DataContext privateDataContext;
-        MultiDataContext<ContextView, DataContext> sharedDataContext;
-
-        /**
-         * Return data context set
-         *
-         * @return map of data contexts keyed by name
-         */
-        public DataContext getDataContext() {
-            return dataContext;
-        }
-
-        /**
-         * @return the scoped context data keyed by scope
-         */
-        public MultiDataContext<ContextView, DataContext> getSharedDataContext() {
-            return sharedDataContext;
-        }
-
-        /**
-         * @return the data context in the private scope
-         */
-        public DataContext getPrivateDataContext() {
-            return privateDataContext;
-        }
+        @Getter DataContext dataContext;
+        @Getter DataContext privateDataContext;
+        @Getter MultiDataContext<ContextView, DataContext> sharedDataContext;
+        @Getter ExecutionContext executionContext;
 
         MyLoggingContext(
                 final SharedOutputContext outputContext,
                 final ExecutionLogger logger,
                 final DataContext dataContext,
                 final DataContext privateDataContext,
-                final MultiDataContext<ContextView, DataContext> sharedDataContext
+                final MultiDataContext<ContextView, DataContext> sharedDataContext,
+                ExecutionContext executionContext
         )
         {
             this.outputContext = outputContext;
@@ -285,6 +266,7 @@ public class PluginFilteredStreamingLogWriter extends FilterStreamingLogWriter {
             this.dataContext = dataContext;
             this.privateDataContext = privateDataContext;
             this.sharedDataContext = sharedDataContext;
+            this.executionContext=executionContext;
         }
 
         @Override
@@ -302,10 +284,6 @@ public class PluginFilteredStreamingLogWriter extends FilterStreamingLogWriter {
             logger.event(eventType, message, eventMeta);
         }
 
-        @Override
-        public SharedOutputContext getOutputContext() {
-            return outputContext;
-        }
     }
 
     void addPlugin(final LogFilterPlugin plugin) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/logging/PluginLoggingContext.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/logging/PluginLoggingContext.java
@@ -19,6 +19,7 @@ package com.dtolabs.rundeck.core.logging;
 import com.dtolabs.rundeck.core.dispatcher.ContextView;
 import com.dtolabs.rundeck.core.data.DataContext;
 import com.dtolabs.rundeck.core.data.MultiDataContext;
+import com.dtolabs.rundeck.core.execution.ExecutionContext;
 import com.dtolabs.rundeck.core.execution.ExecutionLogger;
 import com.dtolabs.rundeck.core.execution.workflow.SharedOutputContext;
 
@@ -51,4 +52,6 @@ public interface PluginLoggingContext extends ExecutionLogger {
      * @return the data context in the private scope
      */
     public DataContext getPrivateDataContext();
+
+    public ExecutionContext getExecutionContext();
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/logging/PluginFilteredStreamingLogWriterSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/logging/PluginFilteredStreamingLogWriterSpec.groovy
@@ -256,9 +256,9 @@ class PluginFilteredStreamingLogWriterSpec extends Specification {
         writer.close()
 
         then:
-        1 * plugin1.complete(!null)
-        1 * plugin2.complete(!null)
-        1 * plugin3.complete(!null)
+        1 * plugin1.complete({ it.executionContext==context })
+        1 * plugin2.complete({ it.executionContext==context })
+        1 * plugin3.complete({ it.executionContext==context })
 
     }
 }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Extends the PluginLoggingContext to include the full Execution Context
