### PR TITLE
RUN-1851 split PluginInfo into 2 components (vue 3 conversion)

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/PluginDetails.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/PluginDetails.vue
@@ -1,0 +1,84 @@
+<template>
+  <div>
+    <span
+        :class="descriptionCss"
+        v-if="showDescription"
+        style="margin-left: 5px"
+    >
+      {{ shortDescription }}
+    </span>
+    <details
+        class="more-info details-reset"
+        :class="extendedCss"
+        v-if="showDescription && showExtended && extraDescription"
+    >
+      <summary>
+        More...
+        <span class="more-indicator-verbiage more-info-icon">
+          <i class="glyphicon glyphicon-chevron-right" />
+        </span>
+        <span class="less-indicator-verbiage more-info-icon">
+          <i class="glyphicon glyphicon-chevron-down" />
+        </span>
+      </summary>
+
+      {{ extraDescription }}
+    </details>
+  </div>
+</template>
+
+<script lang="ts">
+import {defineComponent} from 'vue'
+
+export default defineComponent({
+  name: "PluginDetails",
+  props: {
+    showDescription: {
+      type: Boolean,
+      default: true,
+      required: false,
+    },
+    showExtended: {
+      type: Boolean,
+      default: true,
+      required: false,
+    },
+    description: {
+      type: String,
+      default: "",
+      required: false,
+    },
+    descriptionCss: {
+      type: String,
+      default: "",
+      required: false,
+    },
+    extendedCss: {
+      type: String,
+      default: "text-muted",
+      required: false,
+    },
+  },
+  computed: {
+    shortDescription(): string {
+      const desc = this.description;
+      if (desc && desc.indexOf("\n") > 0) {
+        return desc.substring(0, desc.indexOf("\n"));
+      }
+      return desc;
+    },
+    extraDescription(): string | null {
+      const desc = this.description;
+      if (desc && desc.indexOf("\n") > 0) {
+        return desc.substring(desc.indexOf("\n") + 1);
+      }
+      return null;
+    },
+  },
+})
+</script>
+
+
+<style scoped lang="scss">
+
+</style>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/PluginInfo.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/PluginInfo.vue
@@ -8,66 +8,66 @@
       <i :class="'fab fa-'+fabicon" v-else-if="fabicon"></i>
       <i class="rdicon icon-small plugin" v-else></i>
     </span>
-    <span :class="titleCss" v-if="showTitle" style="margin-left: 5px;">{{title}}</span>
-    <span :class="descriptionCss" v-if="showDescription" style="margin-left: 5px;">{{shortDescription}}</span>
-    <details class="more-info details-reset" :class="extendedCss" v-if="showDescription && showExtended && extraDescription">
-        <summary>
-            More...
-            <span class="more-indicator-verbiage more-info-icon"><i class="glyphicon glyphicon-chevron-right"/></span>
-            <span class="less-indicator-verbiage more-info-icon"><i class="glyphicon glyphicon-chevron-down"/></span>
-        </summary>
-
-    {{extraDescription}}
-
-    </details>
+    <span :class="titleCss" v-if="showTitle" style="margin-left: 5px">
+       {{ title }}
+    </span>
+    <PluginDetails
+        :showDescription="showDescription"
+        :showExtended="showExtended"
+        :description="description"
+        :descriptionCss="descriptionCss"
+        :extendedCss="extendedCss"
+    />
 
     <slot name="suffix"></slot>
   </span>
 </template>
 <script lang="ts">
 import {defineComponent} from "vue";
+import PluginDetails from "./PluginDetails.vue";
 
 export default defineComponent({
     name: 'PluginInfo',
     components: {
+      PluginDetails
     },
     props: {
-        'showIcon': {
-            'type': Boolean,
-            'default': true,
-            'required': false
+        showIcon: {
+            type: Boolean,
+            default: true,
+            required: false
         },
-        'showTitle': {
-            'type': Boolean,
-            'default': true,
-            'required': false
+        showTitle: {
+            type: Boolean,
+            default: true,
+            required: false
         },
-        'titleCss':{
+        titleCss:{
             type:String,
             default:'text-strong',
             required:false
         },
-        'showDescription': {
+        showDescription: {
             'type': Boolean,
             'default': true,
             'required': false
         },
-        'descriptionCss':{
+        descriptionCss:{
             type:String,
             default:'',
             required:false
         },
-        'showExtended': {
+        showExtended: {
             'type': Boolean,
             'default': true,
             'required': false
         },
-        'extendedCss':{
+        extendedCss:{
             type:String,
             default:'text-muted',
             required:false
         },
-        'detail': {
+        detail: {
             'type': Object,
             'required': true
         }
@@ -99,20 +99,6 @@ export default defineComponent({
         fabicon() :string{
             return this.providerMeta.fabicon;
         },
-        shortDescription() :string{
-          const desc = this.description
-            if (desc && desc.indexOf("\n") > 0) {
-                return desc.substring(0, desc.indexOf("\n"));
-            }
-            return desc;
-        },
-        extraDescription() :string|null{
-          const desc = this.description
-            if (desc && desc.indexOf("\n") > 0) {
-                return desc.substring(desc.indexOf("\n") + 1);
-            }
-            return null;
-        }
     },
 
 })


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Enhancement - this is the vue 3 version of the PR #8474  - need to split this component into 2 so that can reuse it on the license conversion work to vue

**Describe the solution you've implemented**
Refactor PluginInfo component to extract the description logic to its own component, to increase reusability

