### PR TITLE
RUN-1912: update ansible plugin to 3.2.7

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 rundeck:
   plugins: # Extra plugins to bundle
-  - "com.github.rundeck-plugins:ansible-plugin:3.2.5"
+  - "com.github.rundeck-plugins:ansible-plugin:3.2.7"
   - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.8"
   - "com.github.rundeck-plugins:py-winrm-plugin:2.1.2"
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.2"


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
upgrade ansible plugin

- add key storage support for resource model
- implement ProxySecretBundleCreator to share keys with the runner
- project and framework mapping were missing for the new property ANSIBLE_BINARIES_DIR_PATH

**Describe the solution you've implemented**

**Describe alternatives you've considered**

**Additional context**
