### PR TITLE
Fix flaky test

### DIFF
--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -6078,6 +6078,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
     def "metrics data from criteria result"(){
         given:
+            TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
             def critresult=[
                 count:3,
                 durationMax: new Long(1L),


### PR DESCRIPTION
Force UTC timezone for test that requires the timezone to be UTC to work correctly
