### PR TITLE
RUN-1917 add strings, adjust _tabsEdit and fix render of tabs

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_tabsEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_tabsEdit.gsp
@@ -39,10 +39,11 @@
                     </a>
                 </li>
                 <li>
-                    <a href="#tab_nodes" data-toggle="tab" class="vue-ui-socket">
-                        <ui-socket section="job-edit-page" location="nodes-tab-title" :event-bus="EventBus">
-                        <g:message code="job.edit.page.tab.nodes.title"/>
-                        </ui-socket>
+                    <a href="#tab_nodes" data-toggle="tab">
+                        <span class="vue-ui-socket">
+                            <ui-socket section="job-edit-page" location="nodes-tab-title" :event-bus="EventBus"></ui-socket>
+                        </span>
+
                         <g:set var="sectionProps" value="${g.jobComponentSectionProperties(section:'nodes',jobComponents:jobComponents)}"/>
 
                         <g:if test="${sectionProps.any{jobComponentValidation?.get(it.name)}}">

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -339,6 +339,21 @@ const messages = {
     "project.nodes.edit.empty.description": "Note: No content was available.",
     "button.action.Cancel": "Cancel",
     "button.action.Save": "Save",
+    'job-edit-page': {
+        'nodes-tab-title': 'Nodes & Runners',
+        'node-dispatch-true-label': 'Dispatch to Nodes through Runner',
+        'node-dispatch-false-label': 'Run on Runner',
+        'section-title': 'Dispatch',
+        'section-title-help': 'Choose the Runner and its selected Nodes'
+    },
+    'job-exec-page': {
+        'nodes-tab-title': 'Runner/Nodes'
+    },
+    JobRunnerEdit: {
+        section: {
+            title: 'Runner Set'
+        }
+    },
 }
 
 export default messages;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/containers/tabs/Tabs.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/containers/tabs/Tabs.vue
@@ -10,12 +10,12 @@
                   }"
           >
             <div class="rdtabs__tab-inner"/></div>
-            <div v-for="(tab, i) in $slots.default()"
+            <div v-for="(tab, i) in tabsWithTitles"
                  :key="tab.title"
                  :class="{
                   'rdtabs__tab': true,
                   'rdtabs__tab-component': true,
-                  'rdtabs__tab--active': i === activeTab,
+                  'rdtabs__tab--active': i === activeTab || tabsWithTitles.length === 1,
                   'rdtabs__tab-previous': i === (activeTab - 1)
                   }"
                  role="tab"
@@ -66,6 +66,12 @@ export default defineComponent({
         selectedIndex: computed(() => this.activeTab),
       }
     },
+    computed: {
+      tabsWithTitles() {
+        // this.$slots.default() isn't handling correctly its content when there's a slot with v-if
+        return this.$slots.default().filter((tab) => tab.props?.title)
+      }
+    },
     methods: {
         selectTab (i) {
             this.activeTab = i
@@ -77,7 +83,7 @@ export default defineComponent({
         },
     },
     mounted () {
-        this.selectTab(0)
+        this.selectTab(this.activeTab)
     },
 })
 </script>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
These changes are necessary to fix the following bugs:

- upon downloading a runner, the section would be rendered empty due to an extra tab being rendered (this.$slots.default isn't reacting on the change of content, therefore it tries to render a tab for 'editing the runner', which shouldn't happen);
- upon editing a job, the node tab wasn't rendering all strings;

will make a second PR on pro

**Describe the solution you've implemented**
- on tabs: changed the template to use a computed property, to ensure that the tabs will match the slots passed;
- add missing strings;