### PR TITLE
RUN-1923: fix: short description not shown for node/workflow steps in workflow step create picker

### DIFF
--- a/rundeckapp/grails-app/views/execution/_wfAddStep.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfAddStep.gsp
@@ -125,7 +125,8 @@
                             </span>
                             <span>-
                             <g:render template="/scheduledExecution/description"
-                                      model="[description: stepplugin.messageText(
+                                      model="[firstLineOnly:true,
+                                              description: stepplugin.messageText(
                                               service: 'WorkflowNodeStep',
                                               name: typedesc.name,
                                               code: 'plugin.description',
@@ -174,7 +175,8 @@
                             </span>
                             <span>-
                                 <g:render template="/scheduledExecution/description"
-                                          model="[description:
+                                          model="[firstLineOnly:true,
+                                                  description:
                                                           stepplugin.messageText(
                                                                   service: 'WorkflowStep',
                                                                   name: typedesc.name,


### PR DESCRIPTION
If a step plugin has extended description content, the first line is not shown in the list of plugins when adding a new step to a workflow.

- [x] specify firstLineOnly to show the first line

before:
![Screenshot 2023-09-01 at 11 20 40 AM](https://github.com/rundeck/rundeck/assets/55603/698563f2-6570-4aa8-9611-22290326c78b)


after:

![Screenshot 2023-09-01 at 11 19 40 AM](https://github.com/rundeck/rundeck/assets/55603/4352b950-1474-4881-9c08-f33c18557004)

RUN-1923
