### PR TITLE
RUN-1905: Inject storage filter and fieldId to Vue

### DIFF
--- a/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
+++ b/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
@@ -332,7 +332,9 @@
         %{-- selector for accessible storage --}%
         <g:set var="storageRoot" value="${prop.renderingOptions?.(StringRenderingConstants.STORAGE_PATH_ROOT_KEY)?:'/'}"/>
         <g:set var="storageFilter" value="${prop.renderingOptions?.(StringRenderingConstants.STORAGE_FILE_META_FILTER_KEY)?:''}"/>
-        <div class="vue-ui-socket">
+        <div class="vue-ui-socket"
+             for="${enc(attr: fieldid)}"
+             data-storage-filter="${enc(attr:storageFilter)}">
             <ui-socket section="plugin-runner-key-selector" location="main"
                        :event-bus="eventBus"
                        :socket-data="{ storageFilter: '${enc(attr:storageFilter)}', fieldId: '${enc(attr:fieldid)}' }"

--- a/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
+++ b/rundeckapp/grails-app/views/framework/_pluginConfigPropertyFormField.gsp
@@ -333,7 +333,7 @@
         <g:set var="storageRoot" value="${prop.renderingOptions?.(StringRenderingConstants.STORAGE_PATH_ROOT_KEY)?:'/'}"/>
         <g:set var="storageFilter" value="${prop.renderingOptions?.(StringRenderingConstants.STORAGE_FILE_META_FILTER_KEY)?:''}"/>
         <div class="vue-ui-socket"
-             for="${enc(attr: fieldid)}"
+             data-field-id="${enc(attr: fieldid)}"
              data-storage-filter="${enc(attr:storageFilter)}">
             <ui-socket section="plugin-runner-key-selector" location="main"
                        :event-bus="eventBus"


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Enhancement to make NodeExecutor configuration use the Runner Key Storage Selector component.
And fix some Vue3 migration issues.
