### PR TITLE
RSE-534 Fix: Cannot Import Jobs with Blank Notification's Config

### DIFF
--- a/rundeckapp/grails-app/utils/rundeck/codecs/JobsXMLCodec.groovy
+++ b/rundeckapp/grails-app/utils/rundeck/codecs/JobsXMLCodec.groovy
@@ -351,9 +351,6 @@ class JobsXMLCodec {
                     if (notifData.type==null) {
                         throw new JobXMLException("${trigger} plugin had blank or missing 'type' attribute")
                     }
-                    if (notifData.configuration==null) {
-                        throw new JobXMLException("${trigger} plugin had blank or missing 'configuration' element")
-                    }
                     convertPluginToMap(notifData)
                     Map plugNotifs = map.notification[trigger].find {notif -> notif.plugin}
                     if(!plugNotifs)  map.notification[trigger].add(['plugin':[notifData]])

--- a/rundeckapp/src/test/groovy/rundeck/JobsXMLCodecTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobsXMLCodecTests.groovy
@@ -6942,12 +6942,8 @@ void testDecodeBasic__no_group(){
 </joblist>
 """
 
-        try {
-            def jobs = JobsXMLCodec.decode(xml0)
-            assertNotNull(jobs)
-        } catch (Exception e) {
-            // Never going to get here but...
-            assertNotEquals("onstart plugin had blank or missing 'configuration' element", e.message)
-        }
+        def jobs = JobsXMLCodec.decode(xml0)
+        assertNotNull(jobs)
+
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/JobsXMLCodecTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobsXMLCodecTests.groovy
@@ -6915,7 +6915,39 @@ void testDecodeBasic__no_group(){
         job.options.getAt("OPTION").getAt("values").size() == 3
     }
 
+    @Test
+    public void "Allow to import jobs with blank notification's config"() {
 
+        // Missing notification config
+        def xml0 = """<joblist>
+    <job>
+    <id>5</id>
+    <name>wait1</name>
+    <description></description>
+    <loglevel>INFO</loglevel>
+    <context>
+        <project>test1</project>
+    </context>
+    <sequence><command><exec>test</exec></command></sequence>
+    <dispatch>
+      <threadcount>1</threadcount>
+      <keepgoing>false</keepgoing>
+    </dispatch>
+    <notification>
+      <onstart>
+        <plugin type='SlackNotification' />
+      </onstart>
+    </notification>
+  </job>
+</joblist>
+"""
 
-
+        try {
+            def jobs = JobsXMLCodec.decode(xml0)
+            assertNotNull(jobs)
+        } catch (Exception e) {
+            // Never going to get here but...
+            assertNotEquals("onstart plugin had blank or missing 'configuration' element", e.message)
+        }
+    }
 }


### PR DESCRIPTION
# RSE-534 Fix: Cannot Import Jobs with Blank Notification's Config

## The Problem
If a import was attempted with a empty notification plugin, configured in a job an error could be seen: 
![image](https://github.com/rundeck/rundeck/assets/81827734/22c51b40-f2a3-4a5b-a58b-4aa69f117a28)

## The Solution
Removing the validation from the xml codec, which was the functionality that was preventing the import.