### PR TITLE
RUN-1922: include all validation data in validateJobDefinition map

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -2457,6 +2457,14 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         //v10
         failed |= validateDefinitionComponents(importedJob, params, validation)
         //v11
+        if(failed){
+            scheduledExecution.errors.fieldErrors.each{err->
+                validation.put(
+                    err.field,
+                    [reason: messageSource.getMessage(err, Locale.default), value: err.rejectedValue?.toString()]
+                )
+            }
+        }
 
         !failed
     }

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -151,6 +151,9 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
             }
             validateImportedJob(_)>>new Validator.ReportSet(true,[:])
         }
+        service.messageSource = Mock(MessageSource) {
+            getMessage(_, _) >> { it[0].toString() }
+        }
         TEST_UUID1
     }
     def "blank email notification"() {
@@ -909,6 +912,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         results.failed
         results.scheduledExecution.errors.hasFieldErrors('workflow')
         results.scheduledExecution.workflow.commands[0].errors.hasFieldErrors(fieldName)
+        results.validation.workflow != null
 
         where:
         cmd                                           | fieldName
@@ -1469,6 +1473,10 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
             validateImportedJob(_)>>new Validator.ReportSet(true,[:])
         }
         service.jobStatsDataProvider = new GormJobStatsDataProvider()
+
+        service.messageSource = Mock(MessageSource) {
+            getMessage(_, _) >> { it[0].toString() }
+        }
         uuid
     }
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Adds additional validation data to the validation map response when validating a job, instead of just logging the errors