### PR TITLE
RUN-1917: Add default tab name for Nodes

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_tabsEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_tabsEdit.gsp
@@ -41,7 +41,9 @@
                 <li>
                     <a href="#tab_nodes" data-toggle="tab">
                         <span class="vue-ui-socket">
-                            <ui-socket section="job-edit-page" location="nodes-tab-title" :event-bus="EventBus"></ui-socket>
+                            <ui-socket section="job-edit-page" location="nodes-tab-title" :event-bus="EventBus">
+                                <g:message code="job.edit.page.tab.nodes.title"/>
+                            </ui-socket>
                         </span>
 
                         <g:set var="sectionProps" value="${g.jobComponentSectionProperties(section:'nodes',jobComponents:jobComponents)}"/>


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Bugfix, there is no default value for Nodes tab name, so it displays as an empty string

**Describe the solution you've implemented**
Restored old behavior where value was loaded using gsp

**Additional context**
Old behavior:
<img width="828" alt="imagen" src="https://github.com/rundeck/rundeck/assets/1281392/4031b00c-c2d0-41ae-b5e5-0ded728038e8">

New behavior:
<img width="838" alt="imagen" src="https://github.com/rundeck/rundeck/assets/1281392/b5b3697f-d756-4b30-a218-58ce914153de">
