### PR TITLE
RSE-765 Fix: File System keys unreachable in Rundeck

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -7,4 +7,4 @@ rundeck:
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.2"
   - "com.github.rundeck-plugins:multiline-regex-datacapture-filter:1.1.0"
   - "com.github.rundeck-plugins:attribute-match-node-enhancer:v0.1.5"
-  - "com.github.rundeck-plugins:sshj-plugin:v0.1.8"
+  - "com.github.rundeck-plugins:sshj-plugin:v0.1.9"


### PR DESCRIPTION
Problem: A in the sshj-plugin has modified how private keys are used by the SSHClient, as a consequence of this change, private keys stored in the filesystem have become inaccessible to Rundeck, resulting in failed node authentication.

Solution

Changes were made directly on the sshj plugin PR: https://github.com/rundeck-plugins/sshj-plugin/pull/20

The auth method was adapted to take in count the location of the key. If the private key is stored in Rundeck (AKA key storage), the current behavior will remain the same to avoid generating a temporary key. If the private key is located at a filesystem path, it will be loaded into the SSHClient, allowing it to authenticate again.