### PR TITLE
RUN-1864: CyberArk CCP Mode

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageView.vue
@@ -479,7 +479,19 @@ export default defineComponent({
 
         this.loading=false
       }).catch((err: Error) => {
-        this.errorMsg = err.message
+        try {
+          const jsonError = JSON.parse(err.message)
+
+          if(jsonError.message === "Error: Key browsing is not allowed in CCP mode.") {
+            this.errorMsg = `${jsonError.message} If you need to select a key, please type the path of the key with the prefix "${this.rootPath}${this.path}" into the form field. E.g. ${this.rootPath}${this.path}/path/to/the/key`
+          } else {
+            this.errorMsg = jsonError.message
+          }
+          
+        } catch (parseError) {
+          this.errorMsg = err.message
+        }
+
         this.loading=false
       });
     },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageView.vue
@@ -483,7 +483,10 @@ export default defineComponent({
           const jsonError = JSON.parse(err.message)
 
           if(jsonError.message === "Error: Key browsing is not allowed in CCP mode.") {
-            this.errorMsg = `${jsonError.message} If you need to select a key, please type the path of the key with the prefix "${this.rootPath}${this.path}" into the form field. E.g. ${this.rootPath}${this.path}/path/to/the/key`
+            // Generate sample key path string
+            const sampleKeyPath = this.rootPath.endsWith("/") ? `${this.rootPath}${this.path}` : `${this.rootPath}/${this.path}`
+
+            this.errorMsg = `${jsonError.message} If you need to select a key, please type the path of the key with the prefix "${sampleKeyPath}" into the form field. E.g. ${sampleKeyPath}/path/to/the/key`
           } else {
             this.errorMsg = jsonError.message
           }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageView.vue
@@ -486,7 +486,10 @@ export default defineComponent({
             // Generate sample key path string
             const sampleKeyPath = this.rootPath.endsWith("/") ? `${this.rootPath}${this.path}` : `${this.rootPath}/${this.path}`
 
-            this.errorMsg = `${jsonError.message} If you need to select a key, please type the path of the key with the prefix "${sampleKeyPath}" into the form field. E.g. ${sampleKeyPath}/path/to/the/key`
+            // Remove the Error prefix
+            const softenedMessage = jsonError.message.startsWith("Error: ") ? jsonError.message.substring("Error: ".length) : jsonError.message
+
+            this.errorMsg = `${softenedMessage} If you need to select a key, please type the path of the key with the prefix "${sampleKeyPath}" into the form field. E.g. ${sampleKeyPath}/path/to/the/key`
           } else {
             this.errorMsg = jsonError.message
           }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is an enhancement to CyberArk key storage provider plugin. The change refactored the code to make it support different CyberArk working modes. Currently, legacy mode and CCP mode have been implemented. 
The legacy mode keeps the existing business logic.
The CCP mode limits the user's ability to browse the key storage. Only direct key access by the path is allowed.
At the UI side, in CCP mode a warning message will prompt the user to manually type in the path of the key into the form field.


