### PR TITLE
RUN-1947 key storage view does not show error when saving fails

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageEdit.vue
@@ -269,7 +269,7 @@ export default defineComponent({
           this.uploadSetting.errorMsg = 'key aready exists';
           return
         } else {
-          const resp = await rundeckContext.rundeckClient.storageKeyUpdate(fullPath, value, { contentType, inputType: this.uploadSetting.inputType, keyType: this.uploadSetting.keyType })
+          rundeckContext.rundeckClient.storageKeyUpdate(fullPath, value, { contentType, inputType: this.uploadSetting.inputType, keyType: this.uploadSetting.keyType })
             .then((result: any) => {
               this.$emit("finishEditing", result)
             }).catch((err: Error) => {
@@ -279,8 +279,6 @@ export default defineComponent({
               }
               this.uploadSetting.errorMsg = errorMessage;
             });
-
-          this.$emit("finishEditing", resp)
         }
       } else {
         rundeckContext.rundeckClient.storageKeyCreate(fullPath, value, { contentType, inputType: this.uploadSetting.inputType, keyType: this.uploadSetting.keyType })

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageEdit.vue
@@ -218,7 +218,6 @@ export default defineComponent({
       }
     },
     async handleUploadKey() {
-      console.log("handleUploadKey");
       const rundeckContext = getRundeckContext();
 
       let fullPath = this.calcBrowsePath(this.getKeyPath())
@@ -267,7 +266,6 @@ export default defineComponent({
 
       if(exists) {
         if(this.uploadSetting.dontOverwrite) {
-          console.log("aaaa")
           this.uploadSetting.errorMsg = 'key aready exists';
           return
         } else {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
When an error is returned from promise trying to save a new key, it is not shown on the page

**Describe the solution you've implemented**
Change the code to catch result and error message from promise
