### PR TITLE
Update circle-ci to install node before openAPI validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -430,6 +430,7 @@ jobs:
     executor: gradle-docker
     steps:
       - checkout
+      - install-node
       - setup_remote_docker:
           version: 20.10.14
       - attach_workspace:


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Circle ci is failing on openAPI validation due to mismatch on the node version. 

**Describe the solution you've implemented**
Add install node to openAPI job.

**Additional context**
before:
![image](https://github.com/rundeck/rundeck/assets/139791797/b95ed16e-bf34-4fb9-a1d1-2df24f230608)
after:
![image](https://github.com/rundeck/rundeck/assets/139791797/0f50d2a9-9ab6-43ca-a3f0-f4b584e02545)
