### PR TITLE
RUN-1940: info widget should appear before loading finishes

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/rundeck-info/RundeckInfo.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/rundeck-info/RundeckInfo.vue
@@ -26,7 +26,7 @@
         <div v-if="latest" class="rundeck-info-widget__group" style="border-top: solid 1px grey;">
             <div class="rundeck-info-widget__heading">Latest Release</div>
             <div class="rundeck-info-widget__latest">
-                <RundeckVersion :app="false" :logo="false" :number="latest.full" :tag="latest.tag"/>
+                <RundeckVersion :logo="false" :number="latest.full" :tag="latest.tag"/>
             </div>
         </div>
         <div class="rundeck-info-widget__group" style="display: flex; flex-direction: column-reverse; flex-grow: 1;">

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/rundeck-info/RundeckInfo.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/rundeck-info/RundeckInfo.vue
@@ -7,13 +7,13 @@
                     <PagerdutyLogo v-else/>
                 </a>
             </div>
-            <div class="rundeck-info-widget__header">
-                <RundeckVersion :app="false" :logo="false" :title="appInfo.title" :logocss="appInfo.logocss" :number="version.number" :tag="version.tag"/>
+            <div class="rundeck-info-widget__header" v-if="version && appInfo">
+                <RundeckVersion :logo="false" :title="appInfo.title" :logocss="appInfo.logocss" :number="version.number" :tag="version.tag"/>
             </div>
-            <div>
+            <div v-if="version && version.icon && version.color">
                 <VersionDisplay :text="`${version.name} ${version.color} ${version.icon}`" :icon="version.icon" :color="version.color" />
             </div>
-            <div>
+            <div v-if="server">
                 <span class="server-display">
                     <ServerDisplay
                         :name="server.name"
@@ -58,20 +58,16 @@ export default defineComponent({
     },
     props: {
         version: {
-            type: Object as PropType<VersionInfo>,
-            required: true
+            type: Object as PropType<VersionInfo>
         },
         latest: {
-            type: Object as PropType<Release>,
-            required: true
+            type: Object as PropType<Release>
         },
         server: {
-            type: Object as PropType<ServerInfo>,
-            required: true
+            type: Object as PropType<ServerInfo>
         },
         appInfo: {
-            type: Object as PropType<AppInfo>,
-            required: true
+            type: Object as PropType<AppInfo>
         }
     },
     methods: {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/rundeck-info/RundeckInfoWidget.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/rundeck-info/RundeckInfoWidget.vue
@@ -9,7 +9,8 @@
 
 
 <script lang="ts">
-import {defineComponent} from 'vue'
+import {RootStore} from '../../../stores/RootStore'
+import {defineComponent, inject} from 'vue'
 import InfoDisplay from './RundeckInfo.vue'
 
 export default defineComponent({
@@ -17,21 +18,17 @@ export default defineComponent({
     components: {
         InfoDisplay
     },
-    data() {
-        return {
-            system: window._rundeck.rootStore.system,
-            releases: window._rundeck.rootStore.releases,
-            loaded: false
-        }
+    setup() {
+      let {system, releases} = inject('rootStore') as RootStore
+      return {system, releases}
     },
     async mounted() {
-        await this.releases.load()
         try {
             await Promise.all([
+                this.releases.load(),
                 this.system.load(),
             ])
         } catch(e) {}
-        this.loaded = true
     }
 })
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/rundeck-info/RundeckInfoWidget.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/rundeck-info/RundeckInfoWidget.vue
@@ -1,5 +1,5 @@
 <template>
-    <InfoDisplay v-if="loaded" 
+    <InfoDisplay
         :version="system.versionInfo"
         :latest="releases.releases[0]"
         :server="system.serverInfo"

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/Releases.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/Releases.ts
@@ -12,8 +12,10 @@ export class Releases {
 
     @Serial
     async load() {
+        if (this.releases.length >= 1) {
+            return
+        }
         const results = await axios.get<Array<ApiRelease>>('https://api.rundeck.com/news/v1/release')
-
         results.data.forEach(r => {
             this.releases.push(Release.FromApi(r))
         })

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/System.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/System.ts
@@ -11,7 +11,7 @@ export class SystemStore {
     serverInfo?: ServerInfo
     appInfo: AppInfo
 
-    loaded = ref<boolean>(false)
+    loaded = false
 
     constructor(readonly root: RootStore, readonly client: RundeckClient) {
         this.versionInfo = new VersionInfo()
@@ -29,7 +29,7 @@ export class SystemStore {
 
     @Serial
     async load() {
-        if (this.loaded.value)
+        if (this.loaded)
             return
 
         const resp = await this.client.systemInfoGet()
@@ -42,7 +42,7 @@ export class SystemStore {
             resp.system!.rundeckProperty!.node!,
             resp.system!.rundeckProperty!.serverUUID!)
 
-        this.loaded.value = true
+        this.loaded = true
     }
 }
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
- [x] fix: info widget shows a single pixel dot while it is loading some data, which can be slow

secondary fixes:
- [x] system info and release info do not need to reload every time the widget is shown
- [x] fix use of boolean loaded prop in systemStore
