### PR TITLE
RUN-1962 Fix logViewer regression

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="execution-log__node-chunk" v-if="entries && entries.length > 0">
+  <div class="execution-log__node-chunk" v-if="entryOutputs && entryOutputs.length > 0">
     <DynamicScroller :items="entryOutputs"
-                     :min-item-size="21"
+                     :min-item-size="2"
                      :key="nodeChunkKey"
                      class="scroller execution-log__chunk"
                      key-field="lineNumber"

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
@@ -519,7 +519,7 @@ export default defineComponent({
     flattenObj(obj = {}) {
       return Object.keys(obj || {}).reduce((acc, cur) => {
         if (typeof obj[cur] === 'object') {
-          acc = { ...acc, ...this.crushObj(obj[cur])}
+          acc = { ...acc, ...this.flattenObj(obj[cur])}
         } else { acc[cur] = obj[cur] }
         return acc
       }, {})

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
@@ -382,7 +382,7 @@ export default defineComponent({
     },
     saveConfig() {
       // flattening nested objects to save to local storage
-      let flattenedSettings = this.crushObj({...this.settings})
+      let flattenedSettings = this.flattenObj({...this.settings})
       localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(flattenedSettings))
     },
     addScrollBlocker() {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Bug introduced with vue 3 migration, where logs weren't showing at runtime

**Describe the solution you've implemented**
Removed mobx observer and use vue computed properties instead. Also, fix small issue with saving configs (as settings has nested objects);

Will make a PR on pro to fix the error with 'addUiMessages'
