### PR TITLE
RUN-1973 Fix webhook update to keep auth config

### DIFF
--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -179,7 +179,7 @@ class WebhookService {
     }
 
     def saveHook(UserAndRolesAuthContext authContext, def hookData) {
-        RdWebhook hook
+        RdWebhook hook = null
         SaveWebhookRequest saveWebhookRequest = mapperSaveRequest(hookData)
         boolean shouldUpdate = false
         if(saveWebhookRequest.id) {
@@ -211,6 +211,8 @@ class WebhookService {
             saveWebhookRequest.setAuthConfigJson(mapper.writeValueAsString(new AuthorizationHeaderAuthenticator.Config(secret:generatedSecureString.sha256())))
         } else if(hookData.useAuth == false) {
             saveWebhookRequest.setAuthConfigJson(null)
+        } else if(shouldUpdate && hookData.useAuth == true && hookData.regenAuth == false) {
+            saveWebhookRequest.setAuthConfigJson(hook?.authConfigJson)
         }
 
         if(hookData.enabled != null) saveWebhookRequest.setEnabled(hookData.enabled)


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
The authConfigJson property is lost when updating a webhook

**Describe the solution you've implemented**
It checks if the webhook uses authorization header and is a update method, if so the webhook keeps the authConfigJson prop