### PR TITLE
RUN-1974: Disable resource model runner selector for only local plugins

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/LocalResourceModelSource.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/LocalResourceModelSource.java
@@ -7,6 +7,7 @@ import com.dtolabs.rundeck.core.common.NodeSetImpl;
 import com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException;
 import com.dtolabs.rundeck.core.plugins.configuration.Description;
 import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants;
+import com.dtolabs.rundeck.plugins.ExecutionEnvironmentConstants;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -127,6 +128,7 @@ public class LocalResourceModelSource implements ResourceModelSource {
                     .description("Custom attributes, in Java properties format")
             )
             .metadata("faicon", "hdd")
+            .metadata(ExecutionEnvironmentConstants.ENVIRONMENT_TYPE_KEY,ExecutionEnvironmentConstants.LOCAL_RUNNER)
         );
     }
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
enhancement: 
There are some plugins like Local Node or Node Wizard that cannot be executed in a remote node. For this case, the best approach would be to disable the runner selector to avoid getting errors trying to run these plugins in a remote runner.

**Describe the solution you've implemented**

**Describe alternatives you've considered**

**Additional context**
