### PR TITLE
RUN-1975: fix: execution mode is not retained after config refresh

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
@@ -26,9 +26,13 @@ class ConfigurationService implements InitializingBean {
     static transactional = false
     def grailsApplication
     private Map<String, Object> appCfg = new HashMap<>()
+    private Boolean executionModeActiveValue
 
     boolean isExecutionModeActive() {
-        getAppConfig()?.executionMode == 'active'
+        if (null == executionModeActiveValue) {
+            executionModeActiveValue = getAppConfig()?.executionMode == 'active'
+        }
+        return executionModeActiveValue
     }
 
     public Map<String, Object> getAppConfig() {
@@ -44,7 +48,7 @@ class ConfigurationService implements InitializingBean {
     }
 
     void setExecutionModeActive(boolean active) {
-        getAppConfig().executionMode = (active ? 'active' : 'passive')
+        executionModeActiveValue = active
     }
     String getString(String property) {
         getString(property,null)

--- a/rundeckapp/src/test/groovy/rundeck/services/ConfigurationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ConfigurationServiceSpec.groovy
@@ -43,6 +43,24 @@ class ConfigurationServiceSpec extends Specification implements ServiceUnitTest<
         !service.executionModeActive
     }
 
+    void "executionMode remains passive after config reload"() {
+        when:
+            grailsApplication.config.clear()
+            grailsApplication.config.rundeck.executionMode = beginMode
+            service.setAppConfig(grailsApplication.config.rundeck)
+        then:
+            service.executionModeActive == expected
+        when:
+            grailsApplication.config.rundeck.executionMode = changedMode
+            service.setAppConfig(grailsApplication.config.rundeck)
+        then:
+            service.executionModeActive == expected
+        where:
+            beginMode | changedMode | expected
+            'passive' | 'active'    | false
+            'active'  | 'passive'   | true
+    }
+
     void "get string present"() {
         when:
         grailsApplication.config.clear()

--- a/rundeckapp/src/test/groovy/rundeck/services/ConfigurationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ConfigurationServiceSpec.groovy
@@ -43,7 +43,7 @@ class ConfigurationServiceSpec extends Specification implements ServiceUnitTest<
         !service.executionModeActive
     }
 
-    void "executionMode remains passive after config reload"() {
+    void "executionMode remains the same after config reload"() {
         when:
             grailsApplication.config.clear()
             grailsApplication.config.rundeck.executionMode = beginMode


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Fix: execution mode state is not retained after config refresh

**Describe the solution you've implemented**
Don't rely on config value, which may have been reloaded from disk.  The execution mode should persist in memory instead.
