### PR TITLE
RUN-1732: fix variable expansion for DYNAMIC_FORM property values

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/data/SharedDataContextUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/data/SharedDataContextUtils.java
@@ -450,21 +450,55 @@ public class SharedDataContextUtils {
             final Map<String,Boolean> blankIfUnexpandedFieldMap
     )
     {
+        return replaceDataReferences(
+                input,
+                currentContext,
+                viewMap,
+                converter,
+                data,
+                failOnUnexpanded,
+                blankIfUnexpandedFieldMap,
+                null,
+                null
+        );
+    }
+    /**
+     * Recursively replace data references in the values in a map which contains either string, collection or Map
+     * values.
+     *
+     * @param input input map
+     * @param data  context data
+     *
+     * @return Map with all string values having references replaced
+     */
+    public static <T extends ViewTraverse<T>> Map<String, Object> replaceDataReferences(
+            final Map<String, Object> input,
+            final T currentContext,
+            final BiFunction<Integer, String, T> viewMap,
+            final Converter<String, String> converter,
+            final MultiDataContext<T, DataContext> data,
+            boolean failOnUnexpanded,
+            final Map<String,Boolean> blankIfUnexpandedFieldMap,
+            final BiFunction<String,Object,Object> inputConverter,
+            final BiFunction<String,Object,Object> outputConverter
+    )
+    {
         final HashMap<String, Object> output = new HashMap<>();
         for (final String s : input.keySet()) {
             Boolean blankIfUnexpanded = blankIfUnexpandedFieldMap.getOrDefault(s,true);
             Object o = input.get(s);
-            output.put(
-                    s,
-                    replaceDataReferencesInObject(o,
-                                                  currentContext,
-                                                  viewMap,
-                                                  converter,
-                                                  data,
-                                                  failOnUnexpanded,
-                                                  blankIfUnexpanded
-                    )
+            if(null!=inputConverter){
+                o = inputConverter.apply(s,o);
+            }
+            Object value = replaceDataReferencesInObject(o,
+                    currentContext,
+                    viewMap,
+                    converter,
+                    data,
+                    failOnUnexpanded,
+                    blankIfUnexpanded
             );
+            output.put(s, outputConverter!=null?outputConverter.apply(s,value):value);
         }
         return output;
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/CustomFieldsAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/CustomFieldsAdapter.java
@@ -1,0 +1,157 @@
+package com.dtolabs.rundeck.core.execution.workflow.steps;
+
+import com.dtolabs.rundeck.core.plugins.configuration.Description;
+import com.dtolabs.rundeck.core.plugins.configuration.Property;
+import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Data;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Assists in converting plugin property values with DYNAMIC_FORM rendering option, so that variable expansion can be
+ * done within the field values of the JSON structure.
+ */
+public class CustomFieldsAdapter {
+    Description description;
+    Set<String> dynamicFormProperties = new HashSet<>();
+    Map<String, CustomFields> tempCustomFields = new HashMap<>();
+
+    /**
+     * Create a new instance
+     *
+     * @param description description
+     * @return instance
+     */
+    public static CustomFieldsAdapter create(final Description description) {
+        return new CustomFieldsAdapter(description);
+    }
+
+    /**
+     * Represents a custom field entry
+     */
+    @Data
+    public static class CustomField {
+        private String key;
+        @JsonInclude(JsonInclude.Include.NON_ABSENT)
+        private String label;
+        private String value;
+        @JsonInclude(JsonInclude.Include.NON_ABSENT)
+        private String desc;
+    }
+
+    /**
+     * Represents a list of custom fields, and contains a Map that holds the key/value pairs for easy lookup
+     */
+    public static class CustomFields {
+        Map<String, String> keyedValues = new HashMap<>();
+        List<CustomField> fields;
+
+        public CustomFields(final List<CustomField> fields) {
+            this.fields = fields;
+            this.fields.forEach(f -> keyedValues.put(f.getKey(), f.getValue()));
+        }
+
+        public void update(Map<String, String> converted) {
+            fields.forEach(f -> f.setValue(converted.get(f.getKey())));
+        }
+    }
+
+    private CustomFieldsAdapter(final Description description) {
+        this.description = description;
+        if (description != null) {
+            dynamicFormProperties =
+                    description.getProperties()
+                            .stream()
+                            .filter(CustomFieldsAdapter::isDynamicFormProperty)
+                            .map(Property::getName)
+                            .collect(Collectors.toCollection(HashSet::new))
+            ;
+        }
+    }
+
+    private static boolean isDynamicFormProperty(final Property p) {
+        Object displayType = p.getRenderingOptions().get(StringRenderingConstants.DISPLAY_TYPE_KEY);
+        return StringRenderingConstants.DisplayType.DYNAMIC_FORM.equals(displayType) ||
+                "DYNAMIC_FORM".equals(displayType);
+    }
+
+    /**
+     * Given a map of converted values, replace the values in the CustomFields object and return the JSON serialized
+     *
+     * @param customFields CustomFields object
+     * @param converted    converted values
+     * @return json serialized string of new value, or null if there is an error
+     */
+    public static String replaceConvertedCustomFieldValues(CustomFields customFields, Map<String, String> converted) {
+        customFields.update(converted);
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.writeValueAsString(customFields.fields);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Parse the input as a JSON representation of an array of CustomFields
+     *
+     * @param input input string
+     * @return CustomFields object, or null if there is an error
+     */
+    public static CustomFields convertJsonCustomFieldValues(String input) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            List<CustomField> list = objectMapper.readValue(
+                    input,
+                    new TypeReference<List<CustomField>>() {
+                    }
+            );
+            return new CustomFields(list);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Given property key, and input value, convert the value if it is a JSON representation of an array of CustomFields
+     *
+     * @param key   property key
+     * @param input input value
+     * @return converted value, or original value if not converted
+     */
+    public Object convertInput(String key, Object input) {
+        if (isDynamicFormProperty(key) && input instanceof String) {
+            CustomFields o = convertJsonCustomFieldValues((String) input);
+            if (o == null) {
+                return input;
+            }
+            tempCustomFields.put(key, o);
+            return o.keyedValues;
+        }
+        return input;
+
+    }
+
+    /**
+     * Given property key, and output value, restore the value back to JSON string
+     *
+     * @param key    property key
+     * @param output output value
+     * @return json serialized string of new value, or original value if not converted
+     */
+    public Object convertOutput(String key, Object output) {
+        if (isDynamicFormProperty(key) && output instanceof Map && tempCustomFields.containsKey(key)) {
+            return replaceConvertedCustomFieldValues(tempCustomFields.get(key), (Map<String, String>) output);
+        }
+        return output;
+    }
+
+    private Boolean isDynamicFormProperty(final String key) {
+        return dynamicFormProperties.contains(key);
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/StepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/StepPluginAdapter.java
@@ -30,7 +30,6 @@ import com.dtolabs.rundeck.core.execution.ConfiguredStepExecutionItem;
 import com.dtolabs.rundeck.core.execution.StepExecutionItem;
 import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext;
 import com.dtolabs.rundeck.core.plugins.configuration.*;
-import com.dtolabs.rundeck.core.storage.StorageTree;
 import com.dtolabs.rundeck.core.utils.Converter;
 import com.dtolabs.rundeck.plugins.ServiceNameConstants;
 import com.dtolabs.rundeck.plugins.step.PluginStepContext;
@@ -41,7 +40,6 @@ import org.rundeck.app.spi.Services;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 
@@ -145,11 +143,13 @@ public class StepPluginAdapter implements StepExecutor, Describable, DynamicProp
         return new StepExecutionResultImpl();
     }
 
+
     public Map<String, Object> createConfig(StepExecutionContext executionContext,
                                   StepExecutionItem item){
         Map<String, Object> instanceConfiguration = getStepConfiguration(item);
         Description description = getDescription();
         Map<String,Boolean> blankIfUnexMap = new HashMap<>();
+        CustomFieldsAdapter customFieldsAdapter = CustomFieldsAdapter.create(description);
         if(description != null) {
             description.getProperties().forEach(p -> {
                 blankIfUnexMap.put(p.getName(), p.isBlankIfUnexpandable());
@@ -163,7 +163,9 @@ public class StepPluginAdapter implements StepExecutor, Describable, DynamicProp
                     null,
                     executionContext.getSharedDataContext(),
                     false,
-                    blankIfUnexMap
+                    blankIfUnexMap,
+                    customFieldsAdapter::convertInput,
+                    customFieldsAdapter::convertOutput
             );
         }
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
@@ -30,6 +30,7 @@ import com.dtolabs.rundeck.core.dispatcher.ContextView;
 import com.dtolabs.rundeck.core.execution.ConfiguredStepExecutionItem;
 import com.dtolabs.rundeck.core.execution.StepExecutionItem;
 import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext;
+import com.dtolabs.rundeck.core.execution.workflow.steps.CustomFieldsAdapter;
 import com.dtolabs.rundeck.core.execution.workflow.steps.PluginStepContextImpl;
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepFailureReason;
 import com.dtolabs.rundeck.core.plugins.configuration.*;
@@ -197,6 +198,7 @@ public class NodeStepPluginAdapter implements NodeStepExecutor, Describable, Dyn
             });
         }
         if (null != instanceConfiguration) {
+            CustomFieldsAdapter customFieldsAdapter = CustomFieldsAdapter.create(description);
             instanceConfiguration = SharedDataContextUtils.replaceDataReferences(
                     instanceConfiguration,
                     ContextView.node(node.getNodename()),
@@ -204,7 +206,9 @@ public class NodeStepPluginAdapter implements NodeStepExecutor, Describable, Dyn
                     null,
                     context.getSharedDataContext(),
                     false,
-                    blankIfUnexMap
+                    blankIfUnexMap,
+                    customFieldsAdapter::convertInput,
+                    customFieldsAdapter::convertOutput
             );
         }
         return instanceConfiguration;

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/CustomFieldsAdapterSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/CustomFieldsAdapterSpec.groovy
@@ -1,0 +1,61 @@
+package com.dtolabs.rundeck.core.execution.workflow.steps
+
+import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants
+import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
+import com.dtolabs.rundeck.plugins.util.PropertyBuilder
+import spock.lang.Specification
+
+class CustomFieldsAdapterSpec extends Specification {
+
+    def "plain field no effect"() {
+        given:
+        def fieldName = 'somefield'
+        def description = DescriptionBuilder.builder().name('APlugin')
+                .property(PropertyBuilder.builder().string(fieldName).build())
+                .build()
+        def adapter = CustomFieldsAdapter.create(description)
+        when:
+        def result = adapter.convertInput(fieldName, inputVal)
+
+        then:
+        result == inputVal
+        when:
+        def out = adapter.convertOutput(fieldName, outputVal)
+
+        then:
+        out == outputVal
+
+        where:
+        inputVal  | outputVal
+        'someval' | 'outval'
+    }
+
+    def "field with DYNAMIC_FORM converts the input from Array of dynamic form entries in JSON"() {
+        given:
+        def fieldName = 'somefield'
+        def description = DescriptionBuilder.builder().name('APlugin')
+                .property(PropertyBuilder.builder().string(fieldName)
+                        .renderingOption(StringRenderingConstants.DISPLAY_TYPE_KEY, StringRenderingConstants.DisplayType.DYNAMIC_FORM)
+                        .build())
+                .build()
+        def adapter = CustomFieldsAdapter.create(description)
+        when:
+        def result = adapter.convertInput(fieldName, inputVal)
+
+        then:
+        result == convertedInput
+
+        when:
+        def outresult = adapter.convertOutput(fieldName, newOutput)
+
+        then:
+        outresult == convertedOutput
+
+
+        where:
+        inputVal = '[{"key":"akey","value":"avalue"},{"key":"bkey","value":"bvalue"}]'
+        convertedInput = [akey: 'avalue', bkey: 'bvalue']
+        newOutput = [akey: 'avalue2', bkey: 'bvalue2 "quoted"']
+        convertedOutput = '[{"key":"akey","value":"avalue2"},{"key":"bkey","value":"bvalue2 \\\"quoted\\\""}]'
+    }
+}

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/StepPluginAdapterSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/StepPluginAdapterSpec.groovy
@@ -12,13 +12,16 @@ import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext
 import com.dtolabs.rundeck.core.plugins.Plugin
 import com.dtolabs.rundeck.core.plugins.configuration.Describable
 import com.dtolabs.rundeck.core.plugins.configuration.Description
+import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants
 import com.dtolabs.rundeck.core.tools.AbstractBaseTest
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.descriptions.PluginProperty
+import com.dtolabs.rundeck.plugins.descriptions.RenderingOption
 import com.dtolabs.rundeck.plugins.step.PluginStepContext
 import com.dtolabs.rundeck.plugins.step.StepPlugin
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder
+import com.fasterxml.jackson.databind.ObjectMapper
 import spock.lang.Specification
 
 class StepPluginAdapterSpec extends Specification {
@@ -113,6 +116,72 @@ class StepPluginAdapterSpec extends Specification {
         [c: 'Z', p: 'Q'] | [a: 'b', c: 'Z', d: 'something "xyzQqws"']
     }
 
+    def "create config with custom fields"(){
+        given: 'context with a plugin using custom field values'
+        def json = new ObjectMapper()
+        framework.frameworkServices = Mock(IFrameworkServices)
+        def optionContext = new BaseDataContext([option: data])
+        def shared = SharedDataContextUtils.sharedContext()
+        shared.merge(ContextView.global(), optionContext)
+        StepExecutionContext context = Mock(StepExecutionContext) {
+            getFramework() >> framework
+            getDataContext() >> optionContext
+            getSharedDataContext() >> shared
+            getFrameworkProject() >> PROJECT_NAME
+        }
+        def plugin = Mock(StepPlugin)
+        def wrap = new Test3Plugin(
+                impl: plugin
+        )
+        def adapter = new StepPluginAdapter(wrap)
+        def customFieldsData = [
+                [
+                        key:'akey',
+                        value:'plain',
+                        desc:'Adesc'
+                ],
+                [
+                        key:'bkey',
+                        value:'some ${option.b} value',
+                        label:'Blabel'
+                ],
+                [
+                        key:'ckey',
+                        value:'${option.c}',
+                        desc:'Cdesc',
+                        label:'Clabel'
+                ],
+                [
+                        key:'dkey',
+                        value:'${option.d}'
+                ],
+        ]
+        def jsonFieldData=json.writeValueAsString(customFieldsData)
+        def config = [customFieldsTest: jsonFieldData]
+        def item = new TestExecItem(
+                type: 'atype',
+                stepConfiguration: config,
+                label: 'a label'
+        )
+        when: 'create config is called'
+        def result = adapter.createConfig(context, item)
+
+        then: 'customFieldsTest value is expanded with correct values inside the json'
+        result['customFieldsTest'] instanceof String
+        List resData = json.readValue(result['customFieldsTest'].toString(), List)
+        resData[0] == [key: 'akey', value: expect['akey'], desc: 'Adesc']
+        resData[1] == [key: 'bkey', value: expect['bkey'], label: 'Blabel']
+        resData[2] == [key: 'ckey', value: expect['ckey'], desc: 'Cdesc', label: 'Clabel']
+        resData[3] == [key: 'dkey', value: expect['dkey']]
+
+        where:
+        data | expect
+        [:] | [akey: 'plain', bkey: 'some  value', ckey: '',dkey:'']
+        [b:'Bval',c:'Cval',d:'Dval\"with quotes\"'] | [akey: 'plain', bkey: 'some Bval value', ckey: 'Cval',dkey:'Dval\"with quotes\"']
+
+
+    }
+
     static class TestPlugin implements StepPlugin, Describable {
         StepPlugin impl
         Description description
@@ -131,6 +200,24 @@ class StepPluginAdapterSpec extends Specification {
                 description = "test",
                 defaultValue = "test")
         private String test
+
+        @Override
+        void executeStep(PluginStepContext context, Map<String, Object> configuration) throws StepException {
+            impl.executeStep(context, configuration)
+        }
+    }
+
+    @Plugin(name = "test3", service = ServiceNameConstants.WorkflowNodeStep)
+    static class Test3Plugin implements StepPlugin {
+        StepPlugin impl
+
+        @PluginProperty(title = "customFieldsTest",
+                description = "test")
+        @RenderingOption(
+                key = StringRenderingConstants.DISPLAY_TYPE_KEY,
+                value = "DYNAMIC_FORM"
+        )
+        private String customFieldsTest
 
         @Override
         void executeStep(PluginStepContext context, Map<String, Object> configuration) throws StepException {

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapterSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapterSpec.groovy
@@ -23,16 +23,21 @@ import com.dtolabs.rundeck.core.dispatcher.ContextView
 import com.dtolabs.rundeck.core.execution.ConfiguredStepExecutionItem
 import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext
 import com.dtolabs.rundeck.core.execution.workflow.WFSharedContext
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepPluginAdapter
 import com.dtolabs.rundeck.core.plugins.Plugin
 import com.dtolabs.rundeck.core.plugins.configuration.Describable
 import com.dtolabs.rundeck.core.plugins.configuration.Description
+import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants
 import com.dtolabs.rundeck.core.tools.AbstractBaseTest
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.descriptions.PluginProperty
+import com.dtolabs.rundeck.plugins.descriptions.RenderingOption
 import com.dtolabs.rundeck.plugins.step.NodeStepPlugin
 import com.dtolabs.rundeck.plugins.step.PluginStepContext
+import com.dtolabs.rundeck.plugins.step.StepPlugin
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder
+import com.fasterxml.jackson.databind.ObjectMapper
 import spock.lang.Specification
 
 /**
@@ -76,6 +81,29 @@ class NodeStepPluginAdapterSpec extends Specification {
                 description = "test",
                 defaultValue = "test")
         private String test
+
+        @Override
+        void executeNodeStep(
+                final PluginStepContext context,
+                final Map<String, Object> configuration,
+                final INodeEntry entry
+        ) throws NodeStepException
+        {
+            impl.executeNodeStep(context, configuration, entry)
+        }
+    }
+
+    @Plugin(name = "test2", service = ServiceNameConstants.WorkflowNodeStep)
+    static class Test3Plugin implements NodeStepPlugin {
+        NodeStepPlugin impl
+
+        @PluginProperty(title = "customFieldsTest",
+                description = "test")
+        @RenderingOption(
+                key = StringRenderingConstants.DISPLAY_TYPE_KEY,
+                value = "DYNAMIC_FORM"
+        )
+        private String customFieldsTest
 
         @Override
         void executeNodeStep(
@@ -145,6 +173,73 @@ class NodeStepPluginAdapterSpec extends Specification {
         [c: 'Z', p: 'Q'] | [a: 'b', c: 'Z', d: 'something "xyzQqws"']
     }
 
+    def "create config with custom fields"(){
+        given: 'a plugin with custom fields'
+
+        def json = new ObjectMapper()
+        framework.frameworkServices = Mock(IFrameworkServices)
+        def optionContext = new BaseDataContext([option: data])
+        def shared = SharedDataContextUtils.sharedContext()
+        shared.merge(ContextView.global(), optionContext)
+        StepExecutionContext context = Mock(StepExecutionContext) {
+            getFramework() >> framework
+            getDataContext() >> optionContext
+            getSharedDataContext() >> shared
+            getFrameworkProject() >> PROJECT_NAME
+        }
+        def node = new NodeEntryImpl('node')
+        def plugin = Mock(NodeStepPlugin)
+        def wrap = new Test3Plugin(
+                impl: plugin
+        )
+        def adapter = new NodeStepPluginAdapter(wrap)
+        def customFieldsData = [
+                [
+                        key:'akey',
+                        value:'plain',
+                        desc:'Adesc'
+                ],
+                [
+                        key:'bkey',
+                        value:'some ${option.b} value',
+                        label:'Blabel'
+                ],
+                [
+                        key:'ckey',
+                        value:'${option.c}',
+                        desc:'Cdesc',
+                        label:'Clabel'
+                ],
+                [
+                        key:'dkey',
+                        value:'${option.d}'
+                ],
+        ]
+        def jsonFieldData=json.writeValueAsString(customFieldsData)
+        def config = [customFieldsTest: jsonFieldData]
+        def item = new TestExecItem(
+                type: 'atype',
+                stepConfiguration: config,
+                label: 'a label'
+        )
+        when: 'create config is called'
+
+        def result = adapter.createConfig(context, item, node)
+
+        then: 'the custom field values inside the json are correct'
+
+        result['customFieldsTest'] instanceof String
+        List resData = json.readValue(result['customFieldsTest'].toString(), List)
+        resData[0] == [key: 'akey', value: expect['akey'], desc: 'Adesc']
+        resData[1] == [key: 'bkey', value: expect['bkey'], label: 'Blabel']
+        resData[2] == [key: 'ckey', value: expect['ckey'], desc: 'Cdesc', label: 'Clabel']
+        resData[3] == [key: 'dkey', value: expect['dkey']]
+
+        where:
+        data | expect
+        [:] | [akey: 'plain', bkey: 'some  value', ckey: '',dkey:'']
+        [b:'Bval',c:'Cval',d:'Dval\"with quotes\"'] | [akey: 'plain', bkey: 'some Bval value', ckey: 'Cval',dkey:'Dval\"with quotes\"']
+    }
     def "expand config vars uses blank from property config"() {
         given:
         framework.frameworkServices = Mock(IFrameworkServices)

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.core.config.Features
 import com.dtolabs.rundeck.core.dispatcher.ContextView
 import com.dtolabs.rundeck.core.dispatcher.DataContextUtils
 import com.dtolabs.rundeck.core.execution.workflow.WorkflowStrategy
+import com.dtolabs.rundeck.core.execution.workflow.steps.CustomFieldsAdapter
 import com.dtolabs.rundeck.core.http.ApacheHttpClient
 import com.dtolabs.rundeck.core.http.HttpClient
 import com.dtolabs.rundeck.core.logging.LogEvent
@@ -565,18 +566,8 @@ public class NotificationService implements ApplicationContextAware{
                     Map context = null
                     (context, execMap) = generateNotificationContext(content.execution, content, source)
 
-                    Map config= n.configuration
-                    if (context && config) {
-                        config = DataContextUtils.replaceDataReferences(config, context)
-                    }
 
-                    config = config?.each {
-                        if(!it.value){
-                            it.value=null
-                        }
-                    }
-
-                    didsend=triggerPlugin(trigger,execMap,n.type, source.project,config, content)
+                    didsend=triggerPlugin(trigger,execMap,n.type, source.project,n.configuration, content,context)
                 }else{
                     log.error("Unsupported notification type: " + n.type);
                 }
@@ -770,8 +761,28 @@ public class NotificationService implements ApplicationContextAware{
      * @param type plugin type
      * @param config user configuration
      */
-    private boolean triggerPlugin(String trigger, Map data,String type, String project, Map config, Map content){
+    private boolean triggerPlugin(String trigger, Map data,String type, String project, Map config, Map content, Map context){
+        if (context && config) {
+            DescribedPlugin described = pluginService.getPluginDescriptor(type, notificationPluginProviderService)
+            if(described?.description) {
+                CustomFieldsAdapter customFieldsAdapter = CustomFieldsAdapter.create(described.description)
+                config = DataContextUtils.replaceDataReferences(
+                        config,
+                        context,
+                        null,
+                        false,
+                        false,
+                        customFieldsAdapter.&convertInput,
+                        customFieldsAdapter.&convertOutput
+                )
+            }
+        }
 
+        config = config?.each {
+            if(!it.value){
+                it.value=null
+            }
+        }
         Map<Class, Object> servicesMap = [:]
         servicesMap.put(KeyStorageTree, content.context.storageTree)
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/DynamicFormPluginProp.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/DynamicFormPluginProp.vue
@@ -237,7 +237,7 @@ export default defineComponent({
       }
     }
 
-    if (this.hasOptions && this.options != null && this.options !== '') {
+    if (this.useOptions && this.options !== null && this.options !== '') {
       const optionsObject = JSON.parse(this.options);
       const options = Object.keys(optionsObject).map((key: any) => {
         const data = optionsObject[key];

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/DynamicFormPluginProp.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/DynamicFormPluginProp.vue
@@ -101,6 +101,13 @@ import VueMultiselect from 'vue-multiselect'
 import { defineComponent} from "vue";
 import { Btn, Alert, Modal} from 'uiv'
 
+interface CustomField{
+  key?:string
+  label?:string
+  value?:string
+  desc?:string
+}
+
 export default defineComponent({
   name: 'DynamicFormPluginProp',
   components: {
@@ -134,7 +141,7 @@ export default defineComponent({
   emits: ['update:modelValue'],
   data() {
     return {
-      customFields: [] as any[],
+      customFields: [] as CustomField[],
       customOptions: [] as any[],
       useOptions: false,
       modalAddField: false,
@@ -150,7 +157,7 @@ export default defineComponent({
       this.modalAddField = true;
     },
     addField() {
-      let field = {} as any;
+      let field = {} as CustomField;
       this.duplicate = false;
 
       if (this.useOptions) {
@@ -200,8 +207,8 @@ export default defineComponent({
       }
     },
     removeField(row: any) {
-      const fields = [] as any;
-      this.customFields.forEach((field: any) => {
+      const fields = [] as CustomField[];
+      this.customFields.forEach((field: CustomField) => {
         if (field.key !== row.key) {
           fields.push(field);
         }
@@ -209,7 +216,7 @@ export default defineComponent({
       this.customFields = fields;
       this.refreshPlugin();
     },
-    changeField(field: any) {
+    changeField(field: CustomField) {
       this.refreshPlugin();
     },
     refreshPlugin() {

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -31,10 +31,16 @@ import com.dtolabs.rundeck.core.logging.StreamingLogReader
 import com.dtolabs.rundeck.core.plugins.ConfiguredPlugin
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
 import com.dtolabs.rundeck.core.plugins.configuration.AcceptsServices
+import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolverFactory
+import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
+import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants
 import com.dtolabs.rundeck.core.storage.StorageTree
 import com.dtolabs.rundeck.core.storage.keys.KeyStorageTree
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.notification.NotificationPlugin
+import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
+import com.dtolabs.rundeck.plugins.util.PropertyBuilder
+import com.fasterxml.jackson.databind.ObjectMapper
 import grails.plugins.mail.MailMessageBuilder
 import grails.plugins.mail.MailService
 import grails.test.hibernate.HibernateSpec
@@ -272,6 +278,93 @@ class NotificationServiceSpec extends Specification implements ServiceUnitTest<N
 
         then:
         1 * service.frameworkService.getProjectPropertyResolver(_)
+
+    }
+
+    def "custom plugin notification dynamic form contents"() {
+        given: 'notification context has some globals values, and a notification config uses a dynamic form field'
+        def (job, execution) = createTestJob()
+        def globalContext=new BaseDataContext([globals:globals])
+        def shared = SharedDataContextUtils.sharedContext()
+        shared.merge(ContextView.global(), globalContext)
+        def content = [
+                execution: execution,
+                context  : Mock(ExecutionContext) {
+                    getDataContext() >> new BaseDataContext([globals:globals])
+                    getSharedDataContext() >> shared
+                }
+        ]
+        def notificationConfig=[
+                testCustomFields:testCustomFieldsConfig
+        ]
+        def json = new ObjectMapper()
+
+        job.notifications = [
+                new Notification(
+                        eventTrigger: 'onstart',
+                        type: 'TestNotificationPlugin',
+                        content: json.writeValueAsString(notificationConfig)
+                )
+        ]
+        job.save()
+        service.frameworkService = Mock(FrameworkService) {
+            _ * getRundeckFramework() >> Mock(Framework) {
+                _ * getWorkflowStrategyService()
+            }
+            _* getPluginControlService(_) >> Mock(PluginControlService)
+
+        }
+
+        service.grailsLinkGenerator = Mock(LinkGenerator) {
+            _ * link(*_) >> 'alink'
+        }
+        service.pluginService = Mock(PluginService)
+        service.executionService = Mock(ExecutionService){
+            getEffectiveSuccessNodeList(_)>>[]
+        }
+
+
+        def fieldName = 'testCustomFields'
+        def desc = DescriptionBuilder.builder().name('TestNotificationPlugin')
+        .property(
+                PropertyBuilder.builder().string(fieldName).renderingOption(
+                        StringRenderingConstants.DISPLAY_TYPE_KEY,
+                        StringRenderingConstants.DisplayType.DYNAMIC_FORM
+                ).build()
+        ).build()
+        def pluginInst = Mock(NotificationPlugin)
+
+        when: 'trigger notification'
+        service.triggerJobNotification('start', job, content)
+
+        then: 'plugin is configured with the dynamic form contents with correct expansion values'
+        1* service.pluginService.getPluginDescriptor('TestNotificationPlugin',_)>>new DescribedPlugin(
+                null,
+                desc,
+                'TestNotificationPlugin',
+                null,
+                null
+        )
+        1 * service.pluginService.configurePlugin('TestNotificationPlugin',_, { PropertyResolverFactory.Factory factory->
+            //assert the factory param matches by resolving the field value
+            factory.create(
+                    ServiceNameConstants.Notification,
+                    desc
+            ).resolvePropertyValue(
+                    fieldName,
+                    PropertyScope.Instance
+            ) == expect
+        },_,_) >> new ConfiguredPlugin(pluginInst, [:])
+        1 * service.frameworkService.getProjectPropertyResolver(_)
+        1 * pluginInst.postNotification(_, _, _)
+
+        where:
+
+        testCustomFieldsConfig         | globals                     || expect
+        'plain text'                   | [:]                         || 'plain text'
+        'expand text ${globals.test1}' | [:]                         || 'expand text ${globals.test1}'
+        'expand text ${globals.test1}' | [test1: 'some value']       || 'expand text some value'
+        'expand text ${globals.test1}' | [test1: 'has "quotes" etc'] || 'expand text has "quotes" etc'
 
     }
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Fix variable expansion in Workflow Step, Node Step and Notification plugins that use the DYNAMIC_FORM rendering option

**Describe the solution you've implemented**
- [x] parse JSON formatted property values that use DYNAMIC_FORM option before expansion, and re-serialize back into json values afterwards

**Additional context**
Variable expansion within a DYNAMIC_FORM plugin property value cannot be done directly since the expanded variable can break the JSON formatting