### PR TITLE
RSE-812: Fix: not importing logs from s3logstore

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/plugins/logging/ExecutionFileStoragePlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/logging/ExecutionFileStoragePlugin.java
@@ -57,4 +57,8 @@ public interface ExecutionFileStoragePlugin extends ExecutionFileStorage {
         return false;
     }
 
+    default String getConfiguredPathTemplate(){
+        return null;
+    }
+
 }

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -47,7 +47,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
     Date dateCompleted
     String status
     String outputfilepath
-    Integer execIdForLogStore
+    Long execIdForLogStore
     String failedNodeList
     String succeededNodeList
     String abortedby
@@ -215,16 +215,24 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
         extraMetadata ? asJsonMap(extraMetadata) : [:]
     }
 
-    Integer getExecIdForLogStore(){
-        return execIdForLogStore ? execIdForLogStore : id
+    Long getExecIdForLogStore(){
+        if(!execIdForLogStore) {
+            if (isRemoteOutputfilepath()) {
+                final int extMarkPos = 'ext:'.length()
+                execIdForLogStore = Long.parseLong(outputfilepath.substring(extMarkPos, outputfilepath.indexOf(':', extMarkPos)))
+            } else
+                execIdForLogStore = id
+        }
+        return execIdForLogStore
     }
 
     String getOutputfilepath(){
-        return isRemoteOutputfilepath() ? outputfilepath.substring('ext:'.length()) : outputfilepath
+        final int extMarkPos = 'ext:'.length()
+        return isRemoteOutputfilepath() ? outputfilepath.substring(outputfilepath.indexOf(':', extMarkPos) + 1) : outputfilepath
     }
 
     boolean isRemoteOutputfilepath(){
-        return this.outputfilepath.startsWith('ext:')
+        return this.outputfilepath?.startsWith('ext:')
     }
 
     void setExtraMetadataMap(Map config) {
@@ -409,7 +417,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
         exec.dateCompleted=data.dateCompleted
         exec.status=data.status
         exec.outputfilepath = data.outputfilepath
-        exec.execIdForLogStore = data.execIdForLogStore
+        exec.execIdForLogStore = data.execIdForLogStore ? Long.parseLong(data.execIdForLogStore as String) : null
         exec.failedNodeList = data.failedNodeList
         exec.succeededNodeList = data.succeededNodeList
         exec.abortedby = data.abortedby

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -47,6 +47,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
     Date dateCompleted
     String status
     String outputfilepath
+    Integer execIdForLogStore
     String failedNodeList
     String succeededNodeList
     String abortedby
@@ -68,7 +69,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
     boolean serverNodeUUIDChanged = false
 
     static hasOne = [logFileStorageRequest: LogFileStorageRequest]
-    static transients = ['executionState', 'customStatusString', 'userRoles', 'extraMetadataMap', 'serverNodeUUIDChanged']
+    static transients = ['executionState', 'customStatusString', 'userRoles', 'extraMetadataMap', 'serverNodeUUIDChanged', 'execIdForLogStore']
     static constraints = {
         importFrom SharedExecutionConstraints
         importFrom SharedNodeConfigConstraints
@@ -214,6 +215,18 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
         extraMetadata ? asJsonMap(extraMetadata) : [:]
     }
 
+    Integer getExecIdForLogStore(){
+        return execIdForLogStore ? execIdForLogStore : id
+    }
+
+    String getOutputfilepath(){
+        return isRemoteOutputfilepath() ? outputfilepath.substring('ext:'.length()) : outputfilepath
+    }
+
+    boolean isRemoteOutputfilepath(){
+        return this.outputfilepath.startsWith('ext:')
+    }
+
     void setExtraMetadataMap(Map config) {
         extraMetadata = config ? serializeJsonMap(config) : null
     }
@@ -322,6 +335,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
         map.dateCompleted=dateCompleted
         map.status=status
         map.outputfilepath=outputfilepath
+        map.execIdForLogStore = getExecIdForLogStore()
         map.failedNodeList = failedNodeList
         map.succeededNodeList = succeededNodeList
         map.abortedby=abortedby
@@ -395,6 +409,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
         exec.dateCompleted=data.dateCompleted
         exec.status=data.status
         exec.outputfilepath = data.outputfilepath
+        exec.execIdForLogStore = data.execIdForLogStore
         exec.failedNodeList = data.failedNodeList
         exec.succeededNodeList = data.succeededNodeList
         exec.abortedby = data.abortedby

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -65,6 +65,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
     Long retryOriginalId
     Long retryPrevId
     String extraMetadata
+    private static final String REMOTE_LOG_FILEPATH_PREFIX = 'ext:'
 
     boolean serverNodeUUIDChanged = false
 
@@ -221,7 +222,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
     Long getExecIdForLogStore(){
         if(!execIdForLogStore) {
             if (isRemoteOutputfilepath()) {
-                final int extMarkPos = 'ext:'.length()
+                final int extMarkPos = REMOTE_LOG_FILEPATH_PREFIX.length()
                 execIdForLogStore = Long.parseLong(outputfilepath.substring(extMarkPos, outputfilepath.indexOf(':', extMarkPos)))
             } else
                 execIdForLogStore = id
@@ -233,7 +234,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
      * @return the path for the log ( must check {@link #isRemoteOutputfilepath()} to validate where the path is located)
      */
     String getOutputfilepath(){
-        final int extMarkPos = 'ext:'.length()
+        final int extMarkPos = REMOTE_LOG_FILEPATH_PREFIX.length()
         return isRemoteOutputfilepath() ? outputfilepath.substring(outputfilepath.indexOf(':', extMarkPos) + 1) : outputfilepath
     }
 
@@ -241,7 +242,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
      * @return true if the outputfilepath corresponds to a path in a remote storage
      */
     boolean isRemoteOutputfilepath(){
-        return this.outputfilepath?.startsWith('ext:')
+        return this.outputfilepath?.startsWith(REMOTE_LOG_FILEPATH_PREFIX)
     }
 
     void setExtraMetadataMap(Map config) {

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -215,6 +215,9 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
         extraMetadata ? asJsonMap(extraMetadata) : [:]
     }
 
+    /**
+     * @return the execution id used to store the log files (might differ from execId since execId changes after imports)
+     */
     Long getExecIdForLogStore(){
         if(!execIdForLogStore) {
             if (isRemoteOutputfilepath()) {
@@ -226,11 +229,17 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
         return execIdForLogStore
     }
 
+    /**
+     * @return the path for the log ( must check {@link #isRemoteOutputfilepath()} to validate where the path is located)
+     */
     String getOutputfilepath(){
         final int extMarkPos = 'ext:'.length()
         return isRemoteOutputfilepath() ? outputfilepath.substring(outputfilepath.indexOf(':', extMarkPos) + 1) : outputfilepath
     }
 
+    /**
+     * @return true if the outputfilepath corresponds to a path in a remote storage
+     */
     boolean isRemoteOutputfilepath(){
         return this.outputfilepath?.startsWith('ext:')
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -987,6 +987,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             jobcontext.filter = execution.filter
         }
         jobcontext.execid = execution.id.toString()
+        jobcontext.outputfilepath = execution.outputfilepath
+        jobcontext.execIdForLogStore = execution.getExecIdForLogStore().toString()
+        jobcontext.isRemoteFilePath = execution.isRemoteOutputfilepath().toString()
         jobcontext.executionUuid = execution.uuid
         jobcontext.execDateCompleted = execution.dateCompleted
         jobcontext.executionType = execution.executionType

--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -1373,6 +1373,10 @@ class LogFileStorageService
         return null
     }
 
+    /**
+     * @param projectName of the desired project to get the storage path for logs
+     * @return the value of the framework property "framework.plugin.ExecutionFileStorage.<file-storage-plugin>.path"
+     */
     String getStorePathForProject(String projectName){
         PropertyResolverFactory.Factory resolverFactory = frameworkService.getFrameworkPropertyResolverFactory(projectName)
         String pluginName = getConfiguredPluginName()
@@ -1386,12 +1390,27 @@ class LogFileStorageService
         return storePath
     }
 
+    /**
+     * Expands the pathTemplate using the execution context
+     * @param execution
+     * @param pathTemplate
+     * @return the expanded path using the execution context
+     */
     String getRemotePathForExecutionFromPathTemplate(Execution execution, String pathTemplate){
         Map<String, String> execCtx = ExecutionService.exportContextForExecution(execution,grailsLinkGenerator)
 
         return expandPath(pathTemplate, execCtx)
     }
 
+    /**
+     * Expand a path given a context:
+     * Done by replacing keys between "${}" in the pathFormat using the corresponding values from the context.
+     * Eg: ${job.execId} will be replaced with content of context['job.execId']
+     *
+     * @param pathFormat eg: path/to/${job.execId}
+     * @param context from which variable values are extracted
+     * @return an expanded path
+     */
     static String expandPath(String pathFormat, Map<String, String> context) {
         String result = pathFormat.replaceAll("^/+", "");
         if (null != context) {

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -203,8 +203,8 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
             if (statefile && statefile.isFile()) {
                 zip.file "state-${exec.id}.state.json", statefile
             }
-        } else if (remotePath != null){
-            logfilepath = "ext:${exec.isRemoteOutputfilepath() ? exec.outputfilepath : logFileStorageService.getRemotePathForExecutionFromPathTemplate(exec, remotePath)}"
+        } else if (remotePath != null){ // if there's a configured remote storage
+            logfilepath = "ext:${exec.getExecIdForLogStore()}:${exec.isRemoteOutputfilepath() ? exec.outputfilepath : logFileStorageService.getRemotePathForExecutionFromPathTemplate(exec, remotePath)}"
         }
 
         //convert map to xml

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -191,14 +191,14 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
         new ProducedExecutionFile(localFile: localfile, fileDeletePolicy: ExecutionFile.DeletePolicy.ALWAYS)
     }
 
-    def exportExecution(ZipBuilder zip, Execution exec, String name, String remotePath = null) throws ProjectServiceException {
+    def exportExecution(ZipBuilder zip, Execution exec, String name, String remotePathTemplate = null) throws ProjectServiceException {
         File logfile = loggingService.getLogFileForExecution(exec)
         String logfilepath = null
         if (logfile && logfile.isFile()) {
             logfilepath = "output-${exec.id}.rdlog"
             zip.file logfilepath, logfile
-        } else if (remotePath != null){ // if there's a configured remote storage
-            logfilepath = "ext:${exec.getExecIdForLogStore()}:${exec.isRemoteOutputfilepath() ? exec.outputfilepath : logFileStorageService.getRemotePathForExecutionFromPathTemplate(exec, remotePath)}"
+        } else if (remotePathTemplate != null){ // if there's a configured remote storage
+            logfilepath = "ext:${exec.getExecIdForLogStore()}:${exec.isRemoteOutputfilepath() ? exec.outputfilepath : logFileStorageService.getRemotePathForExecutionFromPathTemplate(exec, remotePathTemplate)}"
         }
         //convert map to xml
         zip.file("$name") { Writer writer ->
@@ -1747,7 +1747,7 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
                 String oldOutputFilePath = e.outputfilepath
                 if (oldOutputFilePath) {
                     if(e.isRemoteOutputfilepath()){
-                        log.warn("Log file for imported execution ${e.id} is not present in archive. This logs will be loaded when accessed if the path Its path \"${e.outputfilepath}\" is present in configured log storage")
+                        log.warn("Log file for imported execution \"${e.id}\" is not present in archive. This logs will be loaded when accessed if its path \"${e.outputfilepath}\" is present in configured log storage")
                     } else if (execout[oldOutputFilePath]) {
                         File oldfile = execout[oldOutputFilePath]
                         //move to appropriate location and update outputfilepath

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -923,8 +923,11 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
                         dir('executions/') {
                             //export executions
                             //export execution logs
-                            String remotePathTemplate = logFileStorageService.getStorePathForProject(project.getName())
+                            String remotePathTemplate = null
                             execs.each { Execution exec ->
+                                if(remotePathTemplate == null)
+                                    remotePathTemplate = logFileStorageService.getStorePathTemplateForExecution(exec)
+
                                 exportExecution zip, exec, "execution-${exec.id}.xml", remotePathTemplate
 
                                 jobfilerecords.addAll JobFileRecord.findAllByExecution(exec)

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -191,6 +191,18 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
         new ProducedExecutionFile(localFile: localfile, fileDeletePolicy: ExecutionFile.DeletePolicy.ALWAYS)
     }
 
+    /**
+     * Generates log files for the given execution.
+     * output-<execId>.rdlog containing the log output
+     * state-<execId>.state.json containing the execution state
+     * <name>.xml containing the summary of the execution
+     * @param zip builder to pack the execution
+     * @param exec execution to export
+     * @param name of the target xml file
+     * @param remotePathTemplate configured path for remote log storage
+     *
+     * @throws ProjectServiceException
+     */
     def exportExecution(ZipBuilder zip, Execution exec, String name, String remotePathTemplate = null) throws ProjectServiceException {
         File logfile = loggingService.getLogFileForExecution(exec)
         String logfilepath = null

--- a/rundeckapp/src/integration-test/groovy/rundeck/ExecutionIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/ExecutionIntegrationSpec.groovy
@@ -46,4 +46,32 @@ class ExecutionIntegrationSpec extends Specification{
             e.errors.getFieldError('execution').code=='unique'
 
     }
+
+    def "the execid for logstore will be the same as the Id if the output filepath is not external or take it from the outputfilepath"() {
+        given:
+        def e1 = new Execution(
+                serverNodeUUID: 'uuid-example',
+                dateStarted: new Date(),
+                dateCompleted: new Date(),
+                failedNodeList: null,
+                succeededNodeList: null,
+                project: "test",
+                user: "user",
+                status: 'true'
+        )
+        e1.outputfilepath = outputFilePath
+        e1.id = execId
+
+        when:
+        Long returnedExecIdForStorage = e1.getExecIdForLogStore()
+
+        then:
+        returnedExecIdForStorage == expectedIdForLogStorage
+
+        where:
+        execId | outputFilePath            | expectedIdForLogStorage
+        5      | 'ext:11:path/to/file.log' | 11
+        5      | 'path/to/file.log'        | 5
+
+    }
 }

--- a/rundeckapp/src/integration-test/groovy/rundeck/ExecutionIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/ExecutionIntegrationSpec.groovy
@@ -46,32 +46,4 @@ class ExecutionIntegrationSpec extends Specification{
             e.errors.getFieldError('execution').code=='unique'
 
     }
-
-    def "the execid for logstore will be the same as the Id if the output filepath is not external or take it from the outputfilepath"() {
-        given:
-        def e1 = new Execution(
-                serverNodeUUID: 'uuid-example',
-                dateStarted: new Date(),
-                dateCompleted: new Date(),
-                failedNodeList: null,
-                succeededNodeList: null,
-                project: "test",
-                user: "user",
-                status: 'true'
-        )
-        e1.outputfilepath = outputFilePath
-        e1.id = execId
-
-        when:
-        Long returnedExecIdForStorage = e1.getExecIdForLogStore()
-
-        then:
-        returnedExecIdForStorage == expectedIdForLogStorage
-
-        where:
-        execId | outputFilePath            | expectedIdForLogStorage
-        5      | 'ext:11:path/to/file.log' | 11
-        5      | 'path/to/file.log'        | 5
-
-    }
 }

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionSpec.groovy
@@ -85,4 +85,89 @@ class ExecutionSpec extends Specification implements DataTest {
             e.errors.getFieldError('execution').code=='unique'
 
     }
+
+    def "the execid for logstore will be the same as the Id if the output filepath is not external or take it from the outputfilepath"() {
+        given:
+        def e1 = new Execution(
+                serverNodeUUID: 'uuid-example',
+                dateStarted: new Date(),
+                dateCompleted: new Date(),
+                failedNodeList: null,
+                succeededNodeList: null,
+                project: "test",
+                user: "user",
+                status: 'true'
+        )
+        e1.outputfilepath = outputFilePath
+        e1.id = execId
+
+        when:
+        Long returnedExecIdForStorage = e1.getExecIdForLogStore()
+
+        then:
+        returnedExecIdForStorage == expectedIdForLogStorage
+
+        where:
+        execId | outputFilePath            | expectedIdForLogStorage
+        5      | 'ext:11:path/to/file.log' | 11
+        5      | 'path/to/file.log'        | 5
+
+    }
+
+    def "should return true if the outputfilepath starts with \"ext:\""(){
+        given:
+        def e1 = new Execution(
+                serverNodeUUID: 'uuid-example',
+                dateStarted: new Date(),
+                dateCompleted: new Date(),
+                failedNodeList: null,
+                succeededNodeList: null,
+                project: "test",
+                user: "user",
+                status: 'true'
+        )
+        e1.outputfilepath = outputFilePath
+        e1.id = 1
+
+        when:
+        boolean isRemote = e1.isRemoteOutputfilepath()
+
+        then:
+        isRemote == exepected
+
+        where:
+        outputFilePath            | exepected
+        'ext:11:path/to/file.log' | true
+        'ext-11:path/to/file.log' | false
+        'path/to/file.log'        | false
+    }
+
+    def "should return the outputfilepath without any internal marking like \"ext:\""(){
+        given:
+        def e1 = new Execution(
+                serverNodeUUID: 'uuid-example',
+                dateStarted: new Date(),
+                dateCompleted: new Date(),
+                failedNodeList: null,
+                succeededNodeList: null,
+                project: "test",
+                user: "user",
+                status: 'true'
+        )
+        e1.outputfilepath = outputFilePath
+        e1.id = 1
+
+        when:
+        String filePath = e1.getOutputfilepath()
+
+        then:
+        filePath == exepected
+
+        where:
+        outputFilePath               | exepected
+        'ext:11:path/to/file.log'    | 'path/to/file.log'
+        'path2/to2/file2.log'        | 'path2/to2/file2.log'
+        'ext:15:path2/to2/file2.log' | 'path2/to2/file2.log'
+    }
+
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
@@ -1497,6 +1497,31 @@ class LogFileStorageServiceSpec extends Specification implements ServiceUnitTest
 
     }
 
+    def "should expand the path template correctly"(){
+        given:
+        def e = new Execution(dateStarted: new Date(),
+                dateCompleted: new Date(),
+                user: 'user1',
+                project: projectName,
+                serverNodeUUID: serverUUID
+        )
+        e.id = execId
+
+        Map<String, String> execCtx = ExecutionService.exportContextForExecution(e, Mock(LinkGenerator))
+
+        when:
+        String expandedPath = LogFileStorageService.expandPath(pathTemplate, execCtx)
+
+        then:
+        expectedExpandedPath == expandedPath
+
+        where:
+
+        execId | projectName      | serverUUID               | pathTemplate                                      | expectedExpandedPath
+        67     | 'projectExample' | 'some-other-server-uuid' | 'rootDir/logs/${job.project}/${job.execid}.log'   | "rootDir/logs/${projectName}/${execId}.log"
+        67     | 'projectExample' | 'some-other-server-uuid' |'rootDir/logs/${job.execid}/${job.serverUUID}.log' | "rootDir/logs/${execId}/${serverUUID}.log"
+    }
+
     def "should bring the path property from the defined log storage plugin"(){
         given:
         service.configurationService=Mock(ConfigurationService){

--- a/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
@@ -21,11 +21,15 @@ import com.dtolabs.rundeck.core.execution.ExecutionReference
 import com.dtolabs.rundeck.core.execution.logstorage.ExecutionFileState
 import com.dtolabs.rundeck.core.logging.ExecutionFileStorageException
 import com.dtolabs.rundeck.core.logging.ExecutionFileStorageOptions
+import com.dtolabs.rundeck.core.plugins.DescribedPlugin
+import com.dtolabs.rundeck.core.plugins.configuration.Description
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolver
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolverFactory
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
+import com.dtolabs.rundeck.core.plugins.configuration.PropertyUtil
 import com.dtolabs.rundeck.plugins.logging.ExecutionFileStoragePlugin
 import com.dtolabs.rundeck.core.plugins.ConfiguredPlugin
+import com.dtolabs.rundeck.server.plugins.services.ExecutionFileStoragePluginProviderService
 import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import org.rundeck.app.data.providers.logstorage.GormLogFileStorageRequestProvider
@@ -1466,5 +1470,68 @@ class LogFileStorageServiceSpec extends Specification implements ServiceUnitTest
         results.size() == 1
         results[0].pluginName == 'blah3'
 
+    }
+
+    def "should return correctly expanded path given a path template and execution"(){
+        given:
+        def e = new Execution(dateStarted: new Date(),
+                dateCompleted: new Date(),
+                user: 'user1',
+                project: projectName,
+                serverNodeUUID: serverUUID
+        )
+        e.id = execId
+        service.grailsLinkGenerator = Mock(LinkGenerator)
+
+        when:
+        String expandedPath = service.getRemotePathForExecutionFromPathTemplate(e, pathTemplate)
+
+        then:
+        expectedExpandedPath == expandedPath
+
+        where:
+
+        execId | projectName      | serverUUID               | pathTemplate                                      | expectedExpandedPath
+        67     | 'projectExample' | 'some-other-server-uuid' | 'rootDir/logs/${job.project}/${job.execid}.log'   | "rootDir/logs/${projectName}/${execId}.log"
+        67     | 'projectExample' | 'some-other-server-uuid' |'rootDir/logs/${job.execid}/${job.serverUUID}.log' | "rootDir/logs/${execId}/${serverUUID}.log"
+
+    }
+
+    def "should bring the path property from the defined log storage plugin"(){
+        given:
+        service.configurationService=Mock(ConfigurationService){
+            getString('execution.logs.fileStoragePlugin',_) >> pluginName
+        }
+
+        def pluginDescription = Mock(Description) {
+            getProperties() >> [PropertyUtil.string('path','path','path',true,logStoragePluginPath)]
+        }
+        PropertyResolver propertyResolver = Mock(PropertyResolver){
+            resolvePropertyValue('path', _) >> logStoragePluginPath
+        }
+        def propertyResolverFactory = Mock(PropertyResolverFactory.Factory){
+            create(_, pluginDescription) >> propertyResolver
+        }
+        service.frameworkService = Mock(FrameworkService){
+            getFrameworkPropertyResolverFactory(projectName) >> propertyResolverFactory
+        }
+        service.pluginService = Mock(PluginService) {
+            getPluginDescriptor(pluginName, _) >> Mock(DescribedPlugin){
+                getDescription() >> pluginDescription
+            }
+        }
+
+        service.executionFileStoragePluginProviderService = Mock(ExecutionFileStoragePluginProviderService)
+
+        when:
+        String returnedStoragePath = service.getStorePathForProject(projectName)
+
+        then:
+        logStoragePluginPath == returnedStoragePath
+
+        where:
+        pluginName = 'log-storage-name-example'
+        projectName = 'projectExample'
+        logStoragePluginPath = 'rootDir/logs/${job.project}/${job.execid}.log'
     }
 }


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-438

#### Problem
Not exporting logs if they are not present in the file system even if they are in the configured remote log storage

_**STR**_
1. Have an instance with a configured remote log storage
2. Create a Project with a job and run it a couple of times
3. remove some log files from the server file system (`<RDECK_HOME>/var/logs/rundeck/<PROJECT_NAME>/job/<JOB_UUID>/logs`)
4. Export the project and import it from another instance that has the same log storage configured.

_**Actual Behavior**_
* Error message shows up: some executions (the ones removed in step **3**) couldn't be loaded
![image](https://github.com/rundeck-plugins/rundeck-s3-log-plugin/assets/49494423/e9c4cf61-0fc5-4e1c-954b-daf34fda204b)

_**Expected behavior**_
* No error should be displayed and execution logs should be loaded afterwards from remote log storage when accessed

#### Solution
* When exporting an execution if this is not present in the FS, the server will look for a configured log storage plugin for the execution's project and generate the path for the specific execution in the configured log storage using the format: `ext:<exec-id>:<path-to-resource-in-remote-storage>`

* When importing executions that have a remote output filepath, a log warning is displayed from the ProjectService: _"Log file for imported execution "<EXEC_ID>" is not present in archive. This logs will be loaded when accessed if its path "<OUTPUT_FILEPATH>" is present in configured log storage"_

* Once the execution is accessed, the log storage plugin is initialized with the execution context that now has 3 more variables: `outputfilepath`, `isRemoteFilePath` and `execIdForLogStore`. Plugins can now use the `outputfilepath` variable to get the execution log in case the `isRemoteFilePath` is `true` (meaning the file path can not be generated using the configured path). Besides, `execIdForLogStore` stores the original execution id that can be used to validate file metadata.

* If the plugin doesn't support this behavior the server will behave as usual, not retrieving the log file (and responding with "Workflow state and log output is not available" message).

