### PR TITLE
RUN-2005: fix log viewer progress bar

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
@@ -602,6 +602,7 @@ export default defineComponent({
 }
 
 .execution-log__settings {
+  align-self: stretch;
   display: flex;
   align-items: center;
   position: sticky;


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
With vue 3 migration, Logviewer isn't rendering the progress bar with full width.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
added 'align-self: stretch' to force the flex div to occupy full width.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

before:
![image](https://github.com/rundeck/rundeck/assets/139791797/5d5e7cc0-a115-4ac9-9ba1-c6a4207705eb)


after:
![image](https://github.com/rundeck/rundeck/assets/139791797/3c4906bf-d5b7-46a0-8ab7-b072f3049a6a)

