### PR TITLE
RUN-2015: Fix: flickering execution log view

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
@@ -558,10 +558,6 @@ export default defineComponent({
   transition: none !important;
 }
 
-.execution-log__node-chunk * {
-  transition: all 0.3s ease;
-}
-
 .execution-log__node-chunk {
   contain: layout;
   flex: 1;


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**
Bug: when scrolling log output, the lines flicker and jump around.


**Describe the solution you've implemented**
Remove css transition that affects log line dom elements


**Additional context**
version 4.17.0
