### PR TITLE
RUN-2017: Fix exception in job start can cause system logs to stop

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/utils/ThreadBoundOutputStream.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/utils/ThreadBoundOutputStream.java
@@ -155,7 +155,12 @@ public class ThreadBoundOutputStream extends FilterOutputStream {
     public static synchronized ThreadBoundOutputStream bindSystemOut() {
         if (null== boundOutPrint) {
             origSystemOut = System.out;
-            final ThreadBoundOutputStream boundOut = new ThreadBoundOutputStream(origSystemOut);
+            final ThreadBoundOutputStream boundOut = new ThreadBoundOutputStream(new FilterOutputStream(origSystemOut){
+                @Override
+                public void close() {
+                    //don't close System.out
+                }
+            });
             boundOutPrint = new ThreadBoundPrintStream(boundOut);
             System.setOut(boundOutPrint);
             return boundOut;
@@ -197,7 +202,12 @@ public class ThreadBoundOutputStream extends FilterOutputStream {
     public static synchronized ThreadBoundOutputStream bindSystemErr() {
         if (null== boundErrPrint) {
             origSystemErr = System.err;
-            final ThreadBoundOutputStream newErr = new ThreadBoundOutputStream(origSystemErr);
+            final ThreadBoundOutputStream newErr = new ThreadBoundOutputStream(new FilterOutputStream(origSystemErr){
+                @Override
+                public void close() {
+                    //don't close System.err
+                }
+            });
             boundErrPrint = new ThreadBoundPrintStream(newErr);
             System.setErr(boundErrPrint);
             return newErr;

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1069,6 +1069,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         }else{
             metricService.markMeter(this.class.name,'executionAdhocStartMeter')
         }
+        boolean logsInstalled=false
         try{
             def jobcontext=exportContextForExecution(execution, grailsLinkGenerator)
             loghandler.openStream()
@@ -1218,7 +1219,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                             logOutFlusher,
                             inputCharset ? Charset.forName(inputCharset) : null
                     )
-            );
+            )
             sysThreadBoundErr.installThreadStream(
                     loggingService.createLogOutputStream(
                             workflowoverride,
@@ -1227,7 +1228,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                             logErrFlusher,
                             inputCharset ? Charset.forName(inputCharset) : null
                     )
-            );
+            )
+            logsInstalled=true
             WorkflowExecutionItem item = executionUtilService.createExecutionItemForWorkflow(execution.workflow)
 
 
@@ -1259,10 +1261,10 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             log.error("Failed while starting execution: ${execution.id}", e)
             loghandler.logError('Failed to start execution: ' + e.getClass().getName() + ": " + e.message)
             metricService.markMeter(this.class.name,'executionJobStartFailedMeter')
-            sysThreadBoundOut.close()
-            sysThreadBoundOut.removeThreadStream()
-            sysThreadBoundErr.close()
-            sysThreadBoundErr.removeThreadStream()
+            if(logsInstalled) {
+                sysThreadBoundOut.removeThreadStream()?.close()
+                sysThreadBoundErr.removeThreadStream()?.close()
+            }
             loghandler.close()
             return null
         }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionUtilService.groovy
@@ -146,10 +146,8 @@ class ExecutionUtilService {
                 }
             }
         } finally {
-            sysThreadBoundOut.close()
-            sysThreadBoundOut.removeThreadStream()
-            sysThreadBoundErr.close()
-            sysThreadBoundErr.removeThreadStream()
+            sysThreadBoundOut.removeThreadStream()?.close()
+            sysThreadBoundErr.removeThreadStream()?.close()
             loghandler.close()
         }
     }


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Bug fix: System logs can stop if an exception is thrown during scheduled job start, e.g. via JobLifecyclePlugin

**Describe the solution you've implemented**
* prevent closing system output streams

