### PR TITLE
RUN-2024: avoid NPE if UserGroupSourcePlugin returns a null entry

### DIFF
--- a/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
+++ b/rundeck-authz/rundeck-authz-api/src/main/java/com/dtolabs/rundeck/core/authorization/RuleEvaluator.java
@@ -163,7 +163,7 @@ public class RuleEvaluator implements AclRuleSetAuthorization {
             return false;
         }
         for (Object groupName : groups) {
-            if (pattern.matcher(groupName.toString()).matches()) {
+            if (groupName != null && pattern.matcher(groupName.toString()).matches()) {
                 return true;
             }
         }

--- a/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
+++ b/rundeck-authz/rundeck-authz-api/src/test/groovy/com/dtolabs/rundeck/core/authorization/RuleEvaluatorSpec.groovy
@@ -560,6 +560,19 @@ class RuleEvaluatorSpec extends Specification {
 
     }
 
+
+    def "matches any pattern skips null group"() {
+        expect:
+        expect == RuleEvaluator.matchesAnyPatterns(input, pattern)
+        where:
+        input          | pattern | expect
+        [null]         | 'd'     | false
+        [null, 'asdf'] | '..d.'  | true
+        [null, 'asdf'] | '..x.'  | false
+        ['asdf', null] | '..d.'  | true
+        ['asdf', null] | '..x.'  | false
+    }
+
     def "narrow contexts"() {
         given:
 

--- a/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
@@ -178,7 +178,7 @@ class UserService {
             }
         }
 
-        return roles
+        return roles.findAll { it != null }
     }
 
     def getLoginStatus(RdUser user){

--- a/rundeckapp/src/test/groovy/rundeck/services/UserServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/UserServiceSpec.groovy
@@ -230,12 +230,14 @@ class UserServiceSpec extends Specification implements ServiceUnitTest<UserServi
         def roles = service.getUserGroupSourcePluginRoles(userA)
 
         then:
-        roles == groups
+        roles == expect
 
         where:
-        userA | groups
-        "any" | ["one","two"]
-        "any" | []
+        userA | groups           | expect
+        "any" | ["one", "two"]   | ["one", "two"]
+        "any" | []               | []
+        //make sure nulls are filtered
+        "any" | ["a", null, "b"] | ["a", "b"]
     }
 
     def "User Group Source Plugin doesn't process misconfigured plugin"() {


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**
Bug fix, avoid NPE during authorization checks if a UserGroupSourcePlugin result has a null entry.

**Describe the solution you've implemented**
Skip null values
