### PR TITLE
RUN-2019: project config plugin validation issue from API request

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
@@ -2209,6 +2209,7 @@ key2=value'''
         //parse config data
         def config=null
         def configProps=new Properties()
+        def errors=[]
         if (request.format in ['text']) {
             def error=null
             try{
@@ -2517,6 +2518,7 @@ Authorization required: `configure` access for `project` resource type or `admin
         }
         def respFormat = apiService.extractResponseFormat(request, response, allowedFormats)
         def value_=null
+        def errors=[]
         if(request.format in ['text']){
            value_ = request.inputStream.text
         }else{
@@ -2547,7 +2549,8 @@ Authorization required: `configure` access for `project` resource type or `admin
             propValueBefore = new Properties([(key_): ''])
         }
 
-        Properties projProp = new Properties([(key_): value_])
+        Map currentProps = frameworkService.getFrameworkProject(project.name).getProjectProperties()
+        Properties projProp = new Properties(currentProps + [(key_): value_])
 
         //validate plugin property values
         def projectScopedConfigs = frameworkService.discoverScopedConfiguration(projProp, "project.plugin")

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
@@ -2549,11 +2549,14 @@ Authorization required: `configure` access for `project` resource type or `admin
             propValueBefore = new Properties([(key_): ''])
         }
 
+        Map prop = [(key_): value_]
         Map currentProps = frameworkService.getFrameworkProject(project.name).getProjectProperties()
-        Properties projProp = new Properties(currentProps + [(key_): value_])
+        Properties mergedProjProps = new Properties(currentProps + prop)
+
+        Properties projProp = new Properties(prop)
 
         //validate plugin property values
-        def projectScopedConfigs = frameworkService.discoverScopedConfiguration(projProp, "project.plugin")
+        def projectScopedConfigs = frameworkService.discoverScopedConfiguration(mergedProjProps, "project.plugin")
         projectScopedConfigs.each { String svcName, Map<String, Map<String, String>> providers ->
             final pluginDescriptions = pluginService.listPluginDescriptions(svcName)
             providers.each { String provider, Map<String, String> providerConfig ->

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectController2Spec.groovy
@@ -26,6 +26,7 @@ import com.dtolabs.rundeck.core.plugins.configuration.AbstractBaseDescription
 import com.dtolabs.rundeck.core.plugins.configuration.Description
 import com.dtolabs.rundeck.core.plugins.configuration.Property
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyUtil
+import com.dtolabs.rundeck.core.plugins.configuration.Validator
 import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import groovy.mock.interceptor.MockFor
@@ -1202,7 +1203,7 @@ class ProjectController2Spec extends Specification implements ControllerUnitTest
 
         given:
             controller.apiService=Mock(ApiService)
-            Map prop = ["project.plugin.provider1.prop1": "value1"]
+            Map prop = ["project.plugin.provider1.prop1": inputValue]
             Map currentProps = ["project.plugin.provider1.prop1": "value0", "project.plugin.provider1.prop2": "value2"]
             Properties mergedProjProps = new Properties(currentProps + prop)
             controller.frameworkService =Mock(FrameworkService){
@@ -1212,7 +1213,7 @@ class ProjectController2Spec extends Specification implements ControllerUnitTest
                     getProjectProperties()>>["project.plugin.provider1.prop1": "value0", "project.plugin.provider1.prop2": "value2"]
                 }
                 discoverScopedConfiguration(mergedProjProps, 'project.plugin')>>[
-                    'svcName': ["provider1": ["prop1": "value1", "prop2": "value2"]]
+                    'svcName': ["provider1": ["prop1": inputValue, "prop2": "value2"]]
                 ]
             }
 
@@ -1257,7 +1258,7 @@ class ProjectController2Spec extends Specification implements ControllerUnitTest
                 1 * project(_, _) >> Mock(AuthorizingProject) {
                     1 * getResource() >> Stub(IRundeckProject){
                         getName()>>'test1'
-                        getProperty('prop1') >>> [null, 'value1']
+                        getProperty('prop1') >>> [null, inputValue]
                     }
                     0*_(*_)
                 }
@@ -1277,16 +1278,27 @@ class ProjectController2Spec extends Specification implements ControllerUnitTest
             request.api_version = 11
             params.project = 'test1'
             params.keypath = 'project.plugin.provider1.prop1'
-            request.setContent('{"key":"project.plugin.provider1.prop1","value":"value1"}'.bytes)
+            request.setContent(('{"key":"project.plugin.provider1.prop1","value":"' + inputValue + '"}').bytes)
             request.format='JSON'
             request.method='PUT'
         when:
             controller.apiProjectConfigKeyPut()
         then:
-            assertEquals HttpServletResponse.SC_OK, response.status
             with(controller.frameworkService) {
-                1 * validateDescription(desc, "", ["prop1": "value1", "prop2": "value2"])>>[valid:true]
+                1 * validateDescription(desc, "", ["prop1": inputValue, "prop2": "value2"])>>[valid: valid, report: reportError]
             }
+            with(controller.apiService){
+                (valid ? 0 : 1) * renderErrorFormat(_, [
+                        status: HttpServletResponse.SC_BAD_REQUEST,
+                        message:["provider1 configuration was invalid: " + reportError?.errors],
+                        format: 'JSON'
+                ])
+            }
+
+        where:
+        inputValue     | valid | reportError
+        "value1"       | true  | null
+        "invalidValue" | false | Validator.buildReport().error("project.plugin.provider1.prop1", "Invalid value for prop1").build()
 
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ProjectController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ProjectController2Spec.groovy
@@ -1140,6 +1140,10 @@ class ProjectController2Spec extends Specification implements ControllerUnitTest
             controller.apiService=Mock(ApiService)
             controller.frameworkService =Mock(FrameworkService){
                 updateFrameworkProjectConfig(_, ["prop1": "value1"],_)>> [success: true]
+                getFrameworkProject('test1')>>Mock(IRundeckProject){
+                    getName()>>'test1'
+                    getProjectProperties()>>["prop1": "value1"]
+                }
             }
 
             controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
When an individual project config is updated the config property is validating isolated and it is not considering the others current settings. It cause validation error for required properties

**Describe the solution you've implemented**
Now all the current settings is loaded before validation