### PR TITLE
RUN-2031: remove AVERAGE_DURATION_EXCEEDED execution status

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -274,8 +274,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
         return cancelled ? ExecutionService.EXECUTION_ABORTED :
             (null == dateCompleted && status == ExecutionService.EXECUTION_QUEUED) ? ExecutionService.EXECUTION_QUEUED :
                 null != dateStarted && dateStarted.getTime() > System.currentTimeMillis() ? ExecutionService.EXECUTION_SCHEDULED :
-                    (null == dateCompleted && status!=ExecutionService.AVERAGE_DURATION_EXCEEDED) ? ExecutionService.EXECUTION_RUNNING :
-                        (status == ExecutionService.AVERAGE_DURATION_EXCEEDED) ? ExecutionService.AVERAGE_DURATION_EXCEEDED:
+                    (null == dateCompleted) ? ExecutionService.EXECUTION_RUNNING :
                             (status in ['true', 'succeeded']) ? ExecutionService.EXECUTION_SUCCEEDED :
                                 cancelled ? ExecutionService.EXECUTION_ABORTED :
                                     willRetry ? ExecutionService.EXECUTION_FAILED_WITH_RETRY :
@@ -301,8 +300,7 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
                                                  ExecutionService.EXECUTION_SUCCEEDED,
                                                  ExecutionService.EXECUTION_FAILED,
                                                  ExecutionService.EXECUTION_QUEUED,
-                                                 ExecutionService.EXECUTION_SCHEDULED,
-                                                 ExecutionService.AVERAGE_DURATION_EXCEEDED])
+                                                 ExecutionService.EXECUTION_SCHEDULED])
     }
 
     // various utility methods helpful to the presentation layer

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -424,9 +424,6 @@ class ExecutionJob implements InterruptableJob {
             def duration = System.currentTimeMillis() - startTime
             if(!avgNotificationSent && jobAverageDurationFinal>0){
                 if(duration > jobAverageDurationFinal){
-                    if(execmap.execution){
-                        execmap.execution.status=ExecutionService.AVERAGE_DURATION_EXCEEDED
-                    }
                     runContext.executionService.avgDurationExceeded(
                             execmap.scheduledExecution.uuid,
                             [

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1462,7 +1462,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     public static String EXECUTION_SCHEDULED = "scheduled"
     public static String EXECUTION_MISSED = "missed"
     public static String EXECUTION_QUEUED = "queued"
-    public static String AVERAGE_DURATION_EXCEEDED = "average-duration-exceeded"
 
     public static String ABORT_PENDING = "pending"
     public static String ABORT_ABORTED = "aborted"

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -314,14 +314,18 @@ public class NotificationService implements ApplicationContextAware{
                             (ExecutionService.EXECUTION_SUCCEEDED):'SUCCESS',
                             (ExecutionService.EXECUTION_TIMEDOUT):'TIMEDOUT',
                             (ExecutionService.EXECUTION_MISSED):'MISSED',
-                            (ExecutionService.EXECUTION_FAILED_WITH_RETRY):'FAILED WITH RETRY',
-                            (ExecutionService.AVERAGE_DURATION_EXCEEDED):'AVERAGE DURATION EXCEEDED',
+                            (ExecutionService.EXECUTION_FAILED_WITH_RETRY):'FAILED WITH RETRY'
                     ]
+
+                    String eventStatus = statMsg[state]
+                    if(trigger=='avgduration'){
+                        eventStatus='AVERAGE DURATION EXCEEDED'
+                    }
 
                     def execMap = null
                     Map context = null
                     (context, execMap) = generateNotificationContext(content.execution, content, source)
-                    context = DataContextUtils.addContext("notification", [trigger: trigger, eventStatus: statMsg[state]], context)
+                    context = DataContextUtils.addContext("notification", [trigger: trigger, eventStatus: eventStatus], context)
 
                     def destarr=[]
                     def destrecipients=mailConfig.recipients

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionTest.groovy
@@ -173,10 +173,6 @@ class ExecutionTest extends Specification implements DataTest  {
         se.status = "any string"
         then:
         assertEquals(ExecutionService.EXECUTION_STATE_OTHER,se.executionState)
-        when:
-        se.status ="average-duration-exceeded"
-        then:
-        assertEquals(ExecutionService.AVERAGE_DURATION_EXCEEDED,se.executionState)
     }
 
     void testIsCustomStatusString() {
@@ -198,7 +194,6 @@ class ExecutionTest extends Specification implements DataTest  {
         ExecutionService.EXECUTION_FAILED               | false
         ExecutionService.EXECUTION_QUEUED               | false
         ExecutionService.EXECUTION_SCHEDULED            | false
-        ExecutionService.AVERAGE_DURATION_EXCEEDED      | false
         "CUSTOM STRING"                                 | true
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
@@ -710,6 +710,7 @@ class ExecutionJobSpec extends Specification implements DataTest {
                 dateCompleted: null,
                 project: se.project,
                 user: 'bob',
+                status: ExecutionService.EXECUTION_RUNNING,
                 workflow: new Workflow(commands: [new CommandExec(
                         [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
                 )]
@@ -779,6 +780,7 @@ class ExecutionJobSpec extends Specification implements DataTest {
             latch.countDown()
         }
         result != null
+        se.executions.status.get(0) == ExecutionService.EXECUTION_RUNNING
     }
 
     def "scheduled job quartz checking the same format of dates"() {

--- a/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
@@ -779,7 +779,6 @@ class ExecutionJobSpec extends Specification implements DataTest {
             latch.countDown()
         }
         result != null
-        se.executions.status.get(0) == ExecutionService.AVERAGE_DURATION_EXCEEDED
     }
 
     def "scheduled job quartz checking the same format of dates"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -537,7 +537,6 @@ class NotificationServiceSpec extends Specification implements ServiceUnitTest<N
                     getDataContext() >> new BaseDataContext([globals: [testmail: 'bob@example.com']])
                 }
         ]
-        content.execution.status = ExecutionService.AVERAGE_DURATION_EXCEEDED
 
         job.notifications = [
                 new Notification(


### PR DESCRIPTION

**Describe the solution you've implemented**
- remove AVERAGE_DURATION_EXCEEDED execution status added in https://github.com/rundeck/rundeck/pull/8156
- that AVERAGE_DURATION_EXCEEDED status produces an issue checking if the execution finishing using the API 
- add the fix to send the right subject in the email AVERAGE_DURATION_EXCEEDED notification 

**Describe alternatives you've considered**

**Additional context**
