### PR TITLE
Change how the disableContentConversion parameter is cast to boolean

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/ScriptPluginResourceModelSourceFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/ScriptPluginResourceModelSourceFactory.java
@@ -108,7 +108,7 @@ public class ScriptPluginResourceModelSourceFactory extends AbstractDescribableS
         boolean disableContentConversion = false;
 
         if(configuration.containsKey(DISABLE_CONTENT_CONVERSION)){
-            disableContentConversion = (Boolean)configuration.get(DISABLE_CONTENT_CONVERSION);
+            disableContentConversion = Boolean.parseBoolean((String)configuration.get(DISABLE_CONTENT_CONVERSION));
         }
 
         if(!disableContentConversion){

--- a/core/src/main/java/com/dtolabs/rundeck/core/resources/ScriptPluginResourceModelSourceFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/resources/ScriptPluginResourceModelSourceFactory.java
@@ -108,7 +108,7 @@ public class ScriptPluginResourceModelSourceFactory extends AbstractDescribableS
         boolean disableContentConversion = false;
 
         if(configuration.containsKey(DISABLE_CONTENT_CONVERSION)){
-            disableContentConversion = Boolean.parseBoolean((String)configuration.get(DISABLE_CONTENT_CONVERSION));
+            disableContentConversion = Boolean.parseBoolean(configuration.get(DISABLE_CONTENT_CONVERSION).toString());
         }
 
         if(!disableContentConversion){

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/resources/ScriptPluginResourceModelSourceFactorySpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/resources/ScriptPluginResourceModelSourceFactorySpec.groovy
@@ -179,7 +179,7 @@ class ScriptPluginResourceModelSourceFactorySpec  extends Specification{
         Properties configuration = new Properties()
         configuration.put("project",PROJECT_NAME)
         configuration.put("token","keys/token")
-        configuration.put(ScriptPluginResourceModelSourceFactory.DISABLE_CONTENT_CONVERSION, "true")
+        configuration.put(ScriptPluginResourceModelSourceFactory.DISABLE_CONTENT_CONVERSION, disableContentConversion)
 
         TestScriptResourceModel resourceModelProvider = new TestScriptResourceModel()
         resourceModelProvider.name = "test-script-resource-model"
@@ -229,6 +229,11 @@ class ScriptPluginResourceModelSourceFactorySpec  extends Specification{
         resource !=null
         resource.configuration.getProperty("token") != null
         resource.configuration.getProperty("token") == "keys/token"
+
+        where:
+        disableContentConversion| _
+        true| _
+        "true"| _
 
     }
 

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/resources/ScriptPluginResourceModelSourceFactorySpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/resources/ScriptPluginResourceModelSourceFactorySpec.groovy
@@ -179,7 +179,7 @@ class ScriptPluginResourceModelSourceFactorySpec  extends Specification{
         Properties configuration = new Properties()
         configuration.put("project",PROJECT_NAME)
         configuration.put("token","keys/token")
-        configuration.put(ScriptPluginResourceModelSourceFactory.DISABLE_CONTENT_CONVERSION, true)
+        configuration.put(ScriptPluginResourceModelSourceFactory.DISABLE_CONTENT_CONVERSION, "true")
 
         TestScriptResourceModel resourceModelProvider = new TestScriptResourceModel()
         resourceModelProvider.name = "test-script-resource-model"


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
BUG: 
Getting this error using Script Resource Model

`Reason: runtimeException class java.lang.String cannot be cast to class java.lang.Boolean (java.lang.String and java.lang.Boolean are in module java.base of loader 'bootstrap')`


**Describe the solution you've implemented**
Change how the parameter is cast to a boolean

**Describe alternatives you've considered**
This affects script plugins using a runner

**Additional context**
