### PR TITLE
Avoid parallel execution of runNpmBuild tasks

### DIFF
--- a/rundeckapp/grails-spa/build.gradle
+++ b/rundeckapp/grails-spa/build.gradle
@@ -39,6 +39,7 @@ task noop() {
 
 tasks.register("runNpmBuild", NpmTask) {
     // dependsOn configurations.uiTrellis
+    dependsOn ':rundeckapp:grails-spa:packages:ui-trellis:runNpmBuild'
 
     // inputs.files(configurations.uiTrellis.allArtifacts)
     // inputs.file 'packages/ui-trellis/build/package/rundeck-ui-trellis.tgz'

--- a/scripts/circleci/build-functions.sh
+++ b/scripts/circleci/build-functions.sh
@@ -7,10 +7,6 @@ rundeck_war_build() {
     echo "NPM=$(npm -version)"
     echo "Node=$(node --version)"
     echo "Groovy=$(groovy --version)"
-    echo "== Launch SPA build =="
-    # It appears npm has issues with parallel builds, so we build grails-spa first without parallelism.
-    ./gradlew -Penvironment="${ENV}" ${GRADLE_BASE_OPTS} -x check --no-parallel --max-workers 1 \
-        rundeckapp:grails-spa:build runNpmBuild
 
     echo "== Launch War build =="
     ./gradlew -Penvironment="${ENV}" ${GRADLE_BUILD_OPTS} publishToMavenLocal build -x check


### PR DESCRIPTION
Avoid parallel execution of runNpmBuild tasks to prevent npm build errors, while still allowing gradle parallel builds