### PR TITLE
Run redocli command using npx command for open api tests

### DIFF
--- a/scripts/circleci/helper-functions.sh
+++ b/scripts/circleci/helper-functions.sh
@@ -119,7 +119,7 @@ openapi_tests() {
     mv WEB-INF/classes/META-INF/swagger/rundeck-api.yml openapi/
 
     # Redocly OpenAPI Linting
-    npx -y redocly lint \
+    npx -y @redocly/cli lint \
         openapi/rundeck-api.yml \
         --skip-rule=operation-4xx-response \
         --skip-rule=no-invalid-media-type-examples

--- a/scripts/circleci/helper-functions.sh
+++ b/scripts/circleci/helper-functions.sh
@@ -119,8 +119,7 @@ openapi_tests() {
     mv WEB-INF/classes/META-INF/swagger/rundeck-api.yml openapi/
 
     # Redocly OpenAPI Linting
-    npm install @redocly/cli -g
-    redocly lint \
+    npx -y redocly lint \
         openapi/rundeck-api.yml \
         --skip-rule=operation-4xx-response \
         --skip-rule=no-invalid-media-type-examples


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Other PR got issue with npm command related to permissions to install packages in the global node modules in circleci

**Describe the solution you've implemented**
Remove the npm command and execute redocli package using npx command for open api tests
