### PR TITLE
Migrate AWS SDK for JavaScript v2 APIs to v3

### DIFF
--- a/test/selenium/package.json
+++ b/test/selenium/package.json
@@ -25,7 +25,6 @@
     "@types/tmp": "0.0.33",
     "@types/uuid": "^3.4.6",
     "@types/yargs": "^11.0.0",
-    "aws-sdk": "^2.318.0",
     "axios": "^0.18.0",
     "chalk": "^2.4.1",
     "chromedriver": ">109",

--- a/test/selenium/src/pages/systemAcls.page.ts
+++ b/test/selenium/src/pages/systemAcls.page.ts
@@ -2,7 +2,6 @@ import { By, WebElementPromise } from 'selenium-webdriver'
 
 import { Page } from '@rundeck/testdeck/page'
 import { Context } from '@rundeck/testdeck/context'
-import { integer } from 'aws-sdk/clients/cloudfront'
 
 export const Elems = {
     uploadBtn: By.css('#storage_acl_upload_btn'),
@@ -68,7 +67,7 @@ export class SystemAclsPage extends Page {
     async getDeleteModal() {
         return this.ctx.driver.findElement(Elems.deleteModal)
     }
-    async getActionDropdown(index: integer) {
+    async getActionDropdown(index: number) {
         let list = await this.getStoredPoliciesCardList()
         let div = list.findElement(By.css("div:nth-of-type(" + (index + 1) + ")"))
         return div.findElement(By.css(" a[data-toggle='dropdown']"))

--- a/test/testdeck/src/context.ts
+++ b/test/testdeck/src/context.ts
@@ -34,7 +34,7 @@ export class Context {
     }
 
     friendlyTestName() {
-        return this.currentTestName.toLowerCase().replace(/ /g, '_')
+        return this.currentTestName.toLowerCase().replace(/ /g, '_');
     }
 
     async screenshot() {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

It's an upgrade of dependencies.

From AWS SDK for JavaScript v2 [README](https://github.com/aws/aws-sdk-js):
> We are formalizing our plans to make the Maintenance Announcement (Phase 2) for AWS SDK for JavaScript v2 in 2023.

**Describe the solution you've implemented**

This PR migrates AWS SDK for JavaScript v2 APIs to v3 using [aws-sdk-js-codemod](https://www.npmjs.com/package/aws-sdk-js-codemod).

```console
$ npx aws-sdk-js-codemod@0.26.3 -t v2-to-v3 **/*.ts
```

**Describe alternatives you've considered**

N/A