### PR TITLE
CircleCI: Store generated rpm and deb as build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,6 +486,9 @@ jobs:
           step-name: Test Packages
           command: packaging_test_packages
       - save-build-cache
+      - store_artifacts:
+          path: ~/workspace/packaging/packaging/build/distributions
+
 
 
   # Run Testdeck job on docker executor.


### PR DESCRIPTION
Add generated packages as build artifacts so they can be downloaded from circleci.