### PR TITLE
RSE-886: Fix: Job option description too long

### DIFF
--- a/rundeckapp/grails-app/views/framework/_jobOptionsKO.gsp
+++ b/rundeckapp/grails-app/views/framework/_jobOptionsKO.gsp
@@ -139,9 +139,9 @@ data for configuring remote option cascading/dependencies
                     </span>
                 </div>
 
-                <div class="col-sm-10 col-sm-offset-2">
+                <div class="col-sm-10 col-sm-offset-2" style="max-width: 950px">
                     %{--<span class="help-block" data-bind="text: description"></span>--}%
-                    <span class="help-block" data-bind="html: descriptionHtml"></span>
+                    <span class="help-block text-break" data-bind="html: descriptionHtml"></span>
                 </div>
 
                 <div class="col-sm-10 col-sm-offset-2" data-bind="if: hasError">

--- a/rundeckapp/grails-app/views/framework/_jobOptionsKO.gsp
+++ b/rundeckapp/grails-app/views/framework/_jobOptionsKO.gsp
@@ -139,7 +139,7 @@ data for configuring remote option cascading/dependencies
                     </span>
                 </div>
 
-                <div class="col-sm-10 col-sm-offset-2" style="max-width: 950px">
+                <div class="col-sm-10 col-sm-offset-2" style="max-width: 80vw">
                     %{--<span class="help-block" data-bind="text: description"></span>--}%
                     <span class="help-block text-break" data-bind="html: descriptionHtml"></span>
                 </div>

--- a/rundeckapp/grails-app/views/scheduledExecution/_optView.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optView.gsp
@@ -34,7 +34,7 @@
                 <g:icon name="lock"/>
             </g:if>
         </span>
-        <span class="opt-desc"><g:strip>${option.description}</g:strip></span>
+        <span class="desc" style="word-wrap:break-word; border: 1px dashed red; max-width: 900px; display: block; margin-bottom: 5px"><g:strip>${option.description}</g:strip></span>
     </span>
     <g:if test="${option.optionValues}">
         <g:set var="opts" value="${option.optionValues}"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_optView.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optView.gsp
@@ -23,7 +23,7 @@
 <g:set var="rkey" value="${g.rkey()}"/>
 
 <span id="opt_${rkey}" class="optview">
-    <span class="optdetail ${edit?'autohilite autoedit':''}" title="${edit?'Click to edit':''}">
+    <span class="optdetail opt-detail-ext ${edit?'autohilite autoedit':''}" title="${edit?'Click to edit':''}">
         <g:if test="${option.optionType=='file'}">
             <g:icon name="file"/>
         </g:if>

--- a/rundeckapp/grails-app/views/scheduledExecution/_optView.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optView.gsp
@@ -34,7 +34,7 @@
                 <g:icon name="lock"/>
             </g:if>
         </span>
-        <span class="desc"><g:strip>${option.description}</g:strip></span>
+        <span class="opt-desc"><g:strip>${option.description}</g:strip></span>
     </span>
     <g:if test="${option.optionValues}">
         <g:set var="opts" value="${option.optionValues}"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/_optView.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optView.gsp
@@ -34,7 +34,7 @@
                 <g:icon name="lock"/>
             </g:if>
         </span>
-        <span class="desc" style="word-wrap:break-word; border: 1px dashed red; max-width: 900px; display: block; margin-bottom: 5px"><g:strip>${option.description}</g:strip></span>
+        <span class="opt-desc"><g:strip>${option.description}</g:strip></span>
     </span>
     <g:if test="${option.optionValues}">
         <g:set var="opts" value="${option.optionValues}"/>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/pages/jobs.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/pages/jobs.scss
@@ -146,6 +146,11 @@
     white-space: nowrap;
     height: 16px;
     line-height: 16px;
+    position:relative;
+    top: 2px;
+    display: inline-block;
+    padding-bottom: 5px;
+    min-height: 17px
   }
 
   .enforceSet {
@@ -160,7 +165,10 @@
   }
 
   .opt-desc {
-    overflow-wrap: break-word !important;
+    overflow:hidden;
+    text-overflow: ellipsis;
+    max-width: 100px;
+    margin-top: 5px;
   }
 
   .enforceSet span.any,

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/pages/jobs.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/pages/jobs.scss
@@ -146,6 +146,9 @@
     white-space: nowrap;
     height: 16px;
     line-height: 16px;
+  }
+
+  .opt-detail-ext {
     position:relative;
     top: 2px;
     display: inline-block;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/pages/jobs.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/pages/jobs.scss
@@ -159,6 +159,10 @@
     line-height: 16px;
   }
 
+  .opt-desc {
+    overflow-wrap: break-word !important;
+  }
+
   .enforceSet span.any,
   .opt.item .enforceSet span.enforced,
   .opt.item .enforceSet span.regex {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/pages/jobs.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/pages/jobs.scss
@@ -141,7 +141,7 @@
   //   }
   .optdetail {
     /*float:left;*/
-    width: 540px;
+    width: 650px;
     overflow: hidden;
     white-space: nowrap;
     height: 16px;
@@ -149,7 +149,6 @@
     position:relative;
     top: 2px;
     display: inline-block;
-    padding-bottom: 5px;
     min-height: 17px
   }
 
@@ -167,7 +166,6 @@
   .opt-desc {
     overflow:hidden;
     text-overflow: ellipsis;
-    max-width: 100px;
     margin-top: 5px;
   }
 


### PR DESCRIPTION
### ❌ Issue:
Job option description is affected by an overflow due to long texts without spaces. This behaviour occurs on Job page and Edit Job page.

### ✅ Fix:
Adding css style on these pages to avoid the overflow from its DOM element.