### PR TITLE
Switch 4.17.x to legacy packaging branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "packaging/packaging"]
 	path = packaging/packaging
 	url = git@github.com:rundeck/packaging.git
-	branch = main
+	branch = release/4.x


### PR DESCRIPTION
Switches the packaging branch to the legacy release branch for after the merging of https://github.com/rundeck/packaging/pull/43