### PR TITLE
RUN-2059: prevent markdown-view from applying its default theme

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/notifications/NotificationsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/notifications/NotificationsEditor.vue
@@ -46,7 +46,7 @@
 
                   <popover :title="$t('scheduledExecution.property.notifyAvgDurationThreshold.label')" target="#jobAvgInfoBtn">
                     <template v-slot:popover>
-                      <VMarkdownView class="markdown-body" :content="$t('scheduledExecution.property.notifyAvgDurationThreshold.description')"/>
+                      <VMarkdownView class="markdown-body" :content="$t('scheduledExecution.property.notifyAvgDurationThreshold.description')" mode=""/>
                     </template>
                   </popover>
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropEdit.vue
@@ -350,7 +350,7 @@
               <span class="less-indicator-verbiage btn-link btn-xs">Less </span>
           </summary>
 
-          <VMarkdownView class="markdown-body" :content="extraDescription" />
+          <VMarkdownView class="markdown-body" :content="extraDescription" mode="" />
 
       </details>
       <div class="help-block" v-else>{{prop.desc}}</div>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/ExtendedDescription.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/ExtendedDescription.vue
@@ -7,7 +7,7 @@
               <span class="less-indicator-verbiage btn-link btn-xs">Less </span>
           </summary>
           <div class="more-info-content">
-            <VMarkdownView class="markdown-body" mode="light" :content="extraDescription"/>
+            <VMarkdownView class="markdown-body" mode="" :content="extraDescription"/>
           </div>
       </details>
       <span :class="basicCss" v-else>{{text}}</span>


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Bugfix for RUN-2059

**Describe the solution you've implemented**
By default, the markdown view component uses a light theme (defined by the prop mode) that overrides the CSS from the project. While the component has a built-in dark theme as well, the simplest solution is not to apply any of them and let the project's CSS style them, as the built-in dark theme is also very different from the project's style.

Before:
![image](https://github.com/rundeck/rundeck/assets/139791797/60676fd4-bc95-4b0f-a4e7-f48145cdf2b4)

After:
![image](https://github.com/rundeck/rundeck/assets/139791797/d6ddf2f9-f1a8-48f8-be78-c684c8381738)
