### PR TITLE
RSE-892: Fix: Node wizard and resourceyaml sources cannot store +4K lines of node entries 

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -70,6 +70,7 @@ import grails.converters.JSON
 import grails.converters.XML
 import grails.web.servlet.mvc.GrailsParameterMap
 import org.rundeck.core.projects.ProjectPluginListConfigurable
+import org.rundeck.storage.api.StorageException
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
 import org.springframework.http.HttpStatus
@@ -2900,7 +2901,7 @@ Since: v23''',
                     }
                 }
             }
-        } catch (IOException exc){
+        } catch (IOException | StorageException exc){
             log.error("Failed to store Resource model data for node source[${source.index}] (type:${source.type}) in project ${project}",exc)
             exc.printStackTrace()
             error = exc

--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -3,10 +3,10 @@ databaseChangeLog = {
         property name: "boolean.type", value: "BOOLEAN", dbms: "postgresql,h2"
         property name: "boolean.type", value: "NUMBER(1, 0)", dbms: "oracle"
 
-        property name: "bytearray.type", value: "longblob", dbms: "mysql,mariadb" // 2^32 - 1
-        property name: "bytearray.type", value: "blob", dbms: "oracle,h2" // 4 GB - 1
-        property name: "bytearray.type", value: "bytea", dbms: "postgresql"  //max field size of -> 1GB
-        property name: "bytearray.type", value: "varbinary(max)", dbms: "mssql" // 2^31 -1 B -> 2GB
+        property name: "bytearray.type", value: "longblob", dbms: "mysql,mariadb"
+        property name: "bytearray.type", value: "blob", dbms: "oracle,h2"
+        property name: "bytearray.type", value: "bytea", dbms: "postgresql"
+        property name: "bytearray.type", value: "varbinary(max)", dbms: "mssql"
 
         property name: "int.type", value: "INT", dbms: "mysql, mssql,h2,mariadb"
         property name: "int.type", value: "INTEGER", dbms: "postgresql"

--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -4,8 +4,7 @@ databaseChangeLog = {
         property name: "boolean.type", value: "NUMBER(1, 0)", dbms: "oracle"
 
         property name: "bytearray.type", value: "longblob", dbms: "mysql,mariadb" // 2^32 - 1
-        property name: "bytearray.type", value: "blob", dbms: "oracle" // 4 GB - 1
-        property name: "bytearray.type", value: "blob(1M)", dbms: "h2" // 1M
+        property name: "bytearray.type", value: "blob", dbms: "oracle,h2" // 4 GB - 1
         property name: "bytearray.type", value: "bytea", dbms: "postgresql"  //max field size of -> 1GB
         property name: "bytearray.type", value: "varbinary(max)", dbms: "mssql" // 2^31 -1 B -> 2GB
 

--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -3,9 +3,11 @@ databaseChangeLog = {
         property name: "boolean.type", value: "BOOLEAN", dbms: "postgresql,h2"
         property name: "boolean.type", value: "NUMBER(1, 0)", dbms: "oracle"
 
-        property name: "bytearray.type", value: "blob", dbms: "mysql,oracle,mariadb,h2"
-        property name: "bytearray.type", value: "bytea", dbms: "postgresql"
-        property name: "bytearray.type", value: "varbinary(max)", dbms: "mssql"
+        property name: "bytearray.type", value: "longblob", dbms: "mysql,mariadb" // 2^32 - 1
+        property name: "bytearray.type", value: "blob", dbms: "oracle" // 4 GB - 1
+        property name: "bytearray.type", value: "blob(1M)", dbms: "h2" // 1M
+        property name: "bytearray.type", value: "bytea", dbms: "postgresql"  //max field size of -> 1GB
+        property name: "bytearray.type", value: "varbinary(max)", dbms: "mssql" // 2^31 -1 B -> 2GB
 
         property name: "int.type", value: "INT", dbms: "mysql, mssql,h2,mariadb"
         property name: "int.type", value: "INTEGER", dbms: "postgresql"

--- a/rundeckapp/grails-app/migrations/core/Storage.groovy
+++ b/rundeckapp/grails-app/migrations/core/Storage.groovy
@@ -40,7 +40,6 @@ databaseChangeLog = {
         }
     }
 
-    final int DATA_FIELD_MAX_SIZE_BYTES = 1000000
     changeSet(author: "rundeckuser (generated)", id: "migrate-storage-data-column-to-longblob-1", dbms: "mysql,mariadb") {
         preConditions(onFail: "MARK_RAN") {
             tableExists(tableName: "storage")
@@ -50,64 +49,6 @@ databaseChangeLog = {
                 sql.execute("ALTER TABLE storage MODIFY data longblob;")
             }
             rollback {
-            }
-        }
-    }
-    changeSet(author: "rundeckuser (generated)", id: "data-col-max-size-to-1MB-1", dbms: "mysql,mariadb,postgresql,h2") {
-        preConditions(onFail: "MARK_RAN") {
-            and {
-                tableExists(tableName: "storage")
-                or {
-                    and {
-                        dbms(type: 'mysql,mariadb')
-                        sqlCheck(expectedResult: '0', "select count(*) from INFORMATION_SCHEMA.CHECK_CONSTRAINTS where CONSTRAINT_NAME = 'storage_data_col_max_size_1M'")//MYSQL
-                    }
-                    and{
-                        dbms(type: 'postgresql')
-                        sqlCheck(expectedResult: '0', "select count(*) from pg_constraint where conname = 'storage_data_col_max_size_1m'")//POSTGRES
-                    }
-                    and{
-                        dbms(type: 'h2')
-                        sqlCheck(expectedResult: '0', "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_NAME = 'STORAGE_DATA_COL_MAX_SIZE_1M'")//H2
-                    }
-                }
-            }
-        }
-        grailsChange{
-            change{
-                sql.execute("ALTER TABLE storage ADD CONSTRAINT storage_data_col_max_size_1M CHECK (octet_length(data) < " + DATA_FIELD_MAX_SIZE_BYTES + ");")
-            }
-            rollback{
-            }
-        }
-    }
-    changeSet(author: "rundeckuser (generated)", id: "data-col-max-size-to-1MB-1", dbms: "mssql") {
-        preConditions(onFail: "MARK_RAN") {
-            and{
-                tableExists(tableName: "storage")
-                sqlCheck(expectedResult: '0', "select count(*) from sys.check_constraints where name = 'storage_data_col_max_size_1M'")
-            }
-        }
-        grailsChange{
-            change{
-                sql.execute("ALTER TABLE storage ADD CONSTRAINT storage_data_col_max_size_1M CHECK(DATALENGTH(data) < " + DATA_FIELD_MAX_SIZE_BYTES + ");")
-            }
-            rollback{
-            }
-        }
-    }
-    changeSet(author: "rundeckuser (generated)", id: "data-col-max-size-to-1M-1", dbms: "oracle") {
-        preConditions(onFail: "MARK_RAN") {
-            and{
-                tableExists(tableName: "storage")
-                sqlCheck(expectedResult: '0', "SELECT COUNT(*) FROM all_constraints WHERE CONSTRAINT_NAME = 'STORAGE_DATA_COL_MAX_SIZE_1M'")
-            }
-        }
-        grailsChange{
-            change{
-                sql.execute("ALTER TABLE storage ADD CONSTRAINT STORAGE_DATA_COL_MAX_SIZE_1M CHECK (lengthb(data) < " + DATA_FIELD_MAX_SIZE_BYTES + ")")
-            }
-            rollback{
             }
         }
     }

--- a/rundeckapp/grails-app/migrations/core/Storage.groovy
+++ b/rundeckapp/grails-app/migrations/core/Storage.groovy
@@ -100,7 +100,7 @@ databaseChangeLog = {
         preConditions(onFail: "MARK_RAN") {
             and{
                 tableExists(tableName: "storage")
-                sqlCheck(expectedResult: '0', "SELECT COUNT(*) FROM all_constraints WHERE CONSTRAINT_NAME LIKE '%STORAGE_DATA_COL_MAX_SIZE_1M%'")
+                sqlCheck(expectedResult: '0', "SELECT COUNT(*) FROM all_constraints WHERE CONSTRAINT_NAME = 'STORAGE_DATA_COL_MAX_SIZE_1M'")
             }
         }
         grailsChange{

--- a/rundeckapp/grails-app/migrations/core/Storage.groovy
+++ b/rundeckapp/grails-app/migrations/core/Storage.groovy
@@ -39,4 +39,54 @@ databaseChangeLog = {
             }
         }
     }
+
+    final int DATA_FIELD_MAX_SIZE_BYTES = 1000000
+    changeSet(author: "rundeckuser (generated)", id: "migrate-storage-data-column-to-longblob-1", dbms: "mysql,mariadb") {
+        preConditions(onFail: "MARK_RAN") {
+            tableExists(tableName: "storage")
+        }
+        grailsChange {
+            change {
+                sql.execute("ALTER TABLE storage MODIFY data longblob;")
+            }
+            rollback {
+            }
+        }
+    }
+    changeSet(author: "rundeckuser (generated)", id: "data-col-max-size-to-1MB-1", dbms: "mysql,mariadb,postgresql,h2") {
+        preConditions(onFail: "MARK_RAN") {
+            tableExists(tableName: "storage")
+        }
+        grailsChange{
+            change{
+                sql.execute("ALTER TABLE storage ADD CONSTRAINT storage_data_col_max_size_1M CHECK (octet_length(data) < " + DATA_FIELD_MAX_SIZE_BYTES + ");")
+            }
+            rollback{
+            }
+        }
+    }
+    changeSet(author: "rundeckuser (generated)", id: "data-col-max-size-to-1MB-1", dbms: "mssql") {
+        preConditions(onFail: "MARK_RAN") {
+            tableExists(tableName: "storage")
+        }
+        grailsChange{
+            change{
+                sql.execute("ALTER TABLE storage ADD CONSTRAINT storage_data_col_max_size_1M CHECK(DATALENGTH(data) < " + DATA_FIELD_MAX_SIZE_BYTES + ");")
+            }
+            rollback{
+            }
+        }
+    }
+    changeSet(author: "rundeckuser (generated)", id: "data-col-max-size-to-1M-1", dbms: "oracle") {
+        preConditions(onFail: "MARK_RAN") {
+            tableExists(tableName: "storage")
+        }
+        grailsChange{
+            change{
+                sql.execute("ALTER TABLE storage ADD CONSTRAINT storage_data_col_max_size_1M CHECK(length(data) < " + DATA_FIELD_MAX_SIZE_BYTES + ");")
+            }
+            rollback{
+            }
+        }
+    }
 }

--- a/rundeckapp/grails-app/migrations/core/Storage.groovy
+++ b/rundeckapp/grails-app/migrations/core/Storage.groovy
@@ -55,7 +55,23 @@ databaseChangeLog = {
     }
     changeSet(author: "rundeckuser (generated)", id: "data-col-max-size-to-1MB-1", dbms: "mysql,mariadb,postgresql,h2") {
         preConditions(onFail: "MARK_RAN") {
-            tableExists(tableName: "storage")
+            and {
+                tableExists(tableName: "storage")
+                or {
+                    and {
+                        dbms(type: 'mysql,mariadb')
+                        sqlCheck(expectedResult: '0', "select count(*) from INFORMATION_SCHEMA.CHECK_CONSTRAINTS where CONSTRAINT_NAME = 'storage_data_col_max_size_1M'")//MYSQL
+                    }
+                    and{
+                        dbms(type: 'postgresql')
+                        sqlCheck(expectedResult: '0', "select count(*) from pg_constraint where conname = 'storage_data_col_max_size_1m'")//POSTGRES
+                    }
+                    and{
+                        dbms(type: 'h2')
+                        sqlCheck(expectedResult: '0', "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_NAME = 'STORAGE_DATA_COL_MAX_SIZE_1M'")//H2
+                    }
+                }
+            }
         }
         grailsChange{
             change{
@@ -67,7 +83,10 @@ databaseChangeLog = {
     }
     changeSet(author: "rundeckuser (generated)", id: "data-col-max-size-to-1MB-1", dbms: "mssql") {
         preConditions(onFail: "MARK_RAN") {
-            tableExists(tableName: "storage")
+            and{
+                tableExists(tableName: "storage")
+                sqlCheck(expectedResult: '0', "select count(*) from sys.check_constraints where name = 'storage_data_col_max_size_1M'")
+            }
         }
         grailsChange{
             change{
@@ -79,11 +98,14 @@ databaseChangeLog = {
     }
     changeSet(author: "rundeckuser (generated)", id: "data-col-max-size-to-1M-1", dbms: "oracle") {
         preConditions(onFail: "MARK_RAN") {
-            tableExists(tableName: "storage")
+            and{
+                tableExists(tableName: "storage")
+                sqlCheck(expectedResult: '0', "SELECT COUNT(*) FROM all_constraints WHERE CONSTRAINT_NAME LIKE '%STORAGE_DATA_COL_MAX_SIZE_1M%'")
+            }
         }
         grailsChange{
             change{
-                sql.execute("ALTER TABLE storage ADD CONSTRAINT storage_data_col_max_size_1M CHECK(length(data) < " + DATA_FIELD_MAX_SIZE_BYTES + ");")
+                sql.execute("ALTER TABLE storage ADD CONSTRAINT STORAGE_DATA_COL_MAX_SIZE_1M CHECK (lengthb(data) < " + DATA_FIELD_MAX_SIZE_BYTES + ")")
             }
             rollback{
             }


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-744

#### Problem:

In 3.3.x it was possible to add a resource yaml node resource with more than 4000 lines and since 3.4.0, when db changes were moved to be managed with liquibase, servers with mysql started showing the following error message in the nodes page after saving a node source like so:

And the service log showing a stacktrace with this caused-by message:

`Caused by: org.rundeck.storage.api.StorageException: Failed to save content at path projects/P/etc/project.properties: validation error: Data too long for column 'data' at row 1`

This happens because after migrating to liquibase, the type for data was set to blob while in previous versions was longblob. A fragment of the Storage table changeset:

```
column( name: "data", type: '${bytearray.type}')
property name: "bytearray.type", value: "blob", dbms: "mysql,oracle,mariadb,h2"
```

#### Expected Outcome:
The node source should be added and the nodes loaded the same as in versions < 3.4

#### Proposed Solution:

* Add a new changeset for the Storage table to migrate the data column from blob to longblob as in previous versions.

* Add Storage exception errors to the gui error response payload