### PR TITLE
RCLOUD-1066: Transactional write to database for AuthToken and Webhook

### DIFF
--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -50,7 +50,7 @@ class WebhookService {
     static final String TOPIC_RECENT_EVENTS = 'webhook:events:recent'
     static final String TOPIC_DEBUG_EVENTS = 'webhook:events:debug'
 
-    WebhookDataProvider webhookDataProvider;
+    WebhookDataProvider webhookDataProvider
 
     @Autowired
     EventStoreService eventStoreService
@@ -118,7 +118,7 @@ class WebhookService {
                 subsystem: "webhooks",
                 topic: "${eventTopic}:${webhook.uuid}"
         ))
-        return queryResult.totalCount;
+        return queryResult.totalCount
     }
 
     @PackageScope
@@ -183,7 +183,7 @@ class WebhookService {
         SaveWebhookRequest saveWebhookRequest = mapperSaveRequest(hookData)
         boolean shouldUpdate = false
         if(saveWebhookRequest.id) {
-            hook = webhookDataProvider.getWebhook(saveWebhookRequest.id)
+            hook = webhookDataProvider.getWebhookByUuid(saveWebhookRequest.uuid)
             if (!hook) return [err: "Webhook not found"]
             if(saveWebhookRequest.roles && !hookData.importData) {
                 try {
@@ -203,7 +203,7 @@ class WebhookService {
         }
         def whsFound = webhookDataProvider.findAllByNameAndProjectAndUuidNotEqual(saveWebhookRequest.name, saveWebhookRequest.project, saveWebhookRequest.uuid)
         if( whsFound.size() > 0) {
-            return [err: " A Webhook by that name already exists in this project"]
+            return [err: "A Webhook by that name already exists in this project"]
         }
         String generatedSecureString = null
         if(hookData.useAuth == true && hookData.regenAuth == true) {
@@ -332,7 +332,7 @@ class WebhookService {
         try {
             // Deleting all stored debug data for this particular hook from the DB
             deleteWebhookEventsData(hook)
-            webhookDataProvider.delete(hook.id)
+            webhookDataProvider.deleteByUuid(hook.uuid)
             rundeckAuthTokenManagerService.deleteByTokenWithType(authToken, AuthenticationToken.AuthTokenType.WEBHOOK)
             return [msg: "Deleted ${name} webhook"]
         } catch(Exception ex) {
@@ -344,7 +344,11 @@ class WebhookService {
     def importWebhook(UserAndRolesAuthContext authContext, Map hook, boolean regenAuthTokens) {
 
         RdWebhook existing = webhookDataProvider.findByUuidAndProject(hook.uuid, hook.project)
-        if(existing) hook.id = existing.id
+        if(existing) {
+            hook.id = existing.id
+        } else {
+            hook.id = null
+        }
         hook.importData = true
 
         if(!regenAuthTokens && hook.authToken) {
@@ -395,11 +399,11 @@ class WebhookService {
     }
 
     RdWebhook getWebhookByUuid(String uuid) {
-        return webhookDataProvider.getWebhookByUuid(uuid);
+        return webhookDataProvider.getWebhookByUuid(uuid)
     }
 
     RdWebhook getWebhookByToken(String token) {
-        return webhookDataProvider.getWebhookByToken(token);
+        return webhookDataProvider.getWebhookByToken(token)
     }
 
     class Evt extends EventImpl {}

--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/WebhookDataProvider.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/WebhookDataProvider.java
@@ -3,6 +3,7 @@ package org.rundeck.app.data.providers.v1;
 import org.rundeck.app.data.model.v1.webhook.RdWebhook;
 import org.rundeck.app.data.model.v1.webhook.dto.SaveWebhookRequest;
 import org.rundeck.app.data.model.v1.webhook.dto.SaveWebhookResponse;
+import org.rundeck.spi.data.DataAccessException;
 
 import java.util.List;
 
@@ -17,20 +18,21 @@ public interface WebhookDataProvider extends DataProvider {
     List<RdWebhook> findAllByNameAndProjectAndUuidNotEqual(String name, String project, String Uuid);
     Integer countByAuthToken(String authToken);
     Integer countByNameAndProject(String name, String project);
-    void delete(Long id);
+    void delete(Long id) throws DataAccessException;
+    void deleteByUuid(String uuid) throws DataAccessException;
     /**
      * Retrieves SaveWebhookResponse with the result of the webhook creation
      *
      * @param saveWebhookRequest of the webhook to be created
      * @return A SaveWebhookResponse with the result of the webhook creation
      */
-    SaveWebhookResponse createWebhook(SaveWebhookRequest saveWebhookRequest);
+    SaveWebhookResponse createWebhook(SaveWebhookRequest saveWebhookRequest) throws DataAccessException;
     /**
      * Retrieves SaveWebhookResponse with the result of the webhook update
      *
      * @param saveWebhookRequest of the webhook to be updated
      * @return A SaveWebhookResponse with the result of the webhook update
      */
-    SaveWebhookResponse updateWebhook(SaveWebhookRequest saveWebhookRequest);
+    SaveWebhookResponse updateWebhook(SaveWebhookRequest saveWebhookRequest) throws DataAccessException;
 
 }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormWebhookDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormWebhookDataProvider.groovy
@@ -4,14 +4,15 @@ import grails.compiler.GrailsCompileStatic
 import groovy.transform.TypeCheckingMode
 import groovy.util.logging.Slf4j
 import org.rundeck.app.data.model.v1.webhook.dto.SaveWebhookRequest
-import org.rundeck.app.data.model.v1.webhook.dto.SaveWebhookResponse;
+import org.rundeck.app.data.model.v1.webhook.dto.SaveWebhookResponse
 import org.rundeck.app.data.providers.v1.WebhookDataProvider
+import org.rundeck.spi.data.DataAccessException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.MessageSource
 import rundeck.services.data.WebhookDataService
 import webhooks.Webhook
 
-import javax.transaction.Transactional;
+import javax.transaction.Transactional
 
 @GrailsCompileStatic(TypeCheckingMode.SKIP)
 @Slf4j
@@ -46,65 +47,96 @@ class GormWebhookDataProvider implements WebhookDataProvider {
 
     @Override
     Webhook findByUuidAndProject(String uuid, String project) {
-        return Webhook.findByUuidAndProject(uuid, project);
+        return Webhook.findByUuidAndProject(uuid, project)
     }
 
     @Override
     Webhook findByName(String name) {
-        return Webhook.findByName(name);
+        return Webhook.findByName(name)
     }
 
     @Override
     List<Webhook> findAllByProject(String project) {
-        return Webhook.findAllByProject(project);
+        return Webhook.findAllByProject(project)
     }
 
     @Override
     List<Webhook> findAllByNameAndProjectAndUuidNotEqual(String name, String project, String uuid) {
-        return Webhook.findAllByNameAndProjectAndUuidNotEqual(name, project, uuid);
+        return Webhook.findAllByNameAndProjectAndUuidNotEqual(name, project, uuid)
     }
 
     @Override
     Integer countByAuthToken(String authToken) {
-        return Webhook.countByAuthToken(authToken);
+        return Webhook.countByAuthToken(authToken)
     }
 
     @Override
     Integer countByNameAndProject(String name, String project) {
-        return Webhook.countByNameAndProject(name, project);
+        return Webhook.countByNameAndProject(name, project)
     }
 
     @Override
-    void delete(Long id){
-        webhookDataService.delete(id);
+    void delete(Long id) throws DataAccessException {
+        Webhook.withTransaction {
+            try {
+                webhookDataService.delete(id)
+            } catch (Exception e) {
+                throw new DataAccessException("Error: could not delete webhook ${id}: ${e}", e)
+            }
+        }
+    }
+
+    @Override
+    void deleteByUuid(String uuid) throws DataAccessException {
+        Webhook.withTransaction {
+            try {
+                Webhook.findByUuid(uuid)?.delete()
+            } catch (Exception e) {
+                throw new DataAccessException("Error: could not delete webhook ${uuid}: ${e}", e)
+            }
+        }
     }
 
     @Override
     SaveWebhookResponse createWebhook(SaveWebhookRequest saveWebhookRequest) {
-        Webhook hook = new Webhook(uuid: saveWebhookRequest.uuid, name: saveWebhookRequest.name,
-                project: saveWebhookRequest.project, authToken: saveWebhookRequest.authToken,
-                authConfigJson: saveWebhookRequest.authConfigJson, eventPlugin: saveWebhookRequest.eventPlugin,
-                pluginConfigurationJson: saveWebhookRequest.pluginConfigurationJson,
-                enabled: saveWebhookRequest.enabled);
-
-        Boolean isUpdated = hook.save(flush: true)
-        String errors = hook.errors.allErrors.collect { messageSource.getMessage(it,null) }.join(",")
-        return new SaveWebhookResponse(webhook: hook, isSaved: isUpdated, errors: errors);
+        Webhook.withTransaction {
+            Webhook hook = new Webhook(uuid: saveWebhookRequest.uuid, name: saveWebhookRequest.name,
+                    project: saveWebhookRequest.project, authToken: saveWebhookRequest.authToken,
+                    authConfigJson: saveWebhookRequest.authConfigJson, eventPlugin: saveWebhookRequest.eventPlugin,
+                    pluginConfigurationJson: saveWebhookRequest.pluginConfigurationJson,
+                    enabled: saveWebhookRequest.enabled)
+            try {
+                Boolean isUpdated = hook.save(flush: true)
+                String errors = hook.errors.allErrors.collect { messageSource.getMessage(it, null) }.join(",")
+                return new SaveWebhookResponse(webhook: hook, isSaved: isUpdated, errors: errors)
+            } catch (Exception e) {
+                throw new DataAccessException("Error: could not create webhook ${saveWebhookRequest.name}: ${e}", e)
+            }
+        }
     }
 
     @Override
-    SaveWebhookResponse updateWebhook(SaveWebhookRequest saveWebhookRequest) {
-        Webhook hook = getWebhook(saveWebhookRequest.id)
-        hook.setUuid(saveWebhookRequest.uuid)
-        hook.setName(saveWebhookRequest.name)
-        hook.setProject(saveWebhookRequest.project)
-        hook.setAuthToken(saveWebhookRequest.authToken)
-        hook.setAuthConfigJson(saveWebhookRequest.authConfigJson)
-        hook.setEventPlugin(saveWebhookRequest.eventPlugin)
-        hook.setPluginConfigurationJson(saveWebhookRequest.pluginConfigurationJson)
-        hook.setEnabled(saveWebhookRequest.enabled)
-        Boolean isUpdated = hook.save(flush: true)
-        String errors = hook.errors.allErrors.collect { messageSource.getMessage(it,null) }.join(",")
-        return new SaveWebhookResponse(webhook: hook, isSaved: isUpdated, errors: errors);
+    SaveWebhookResponse updateWebhook(SaveWebhookRequest saveWebhookRequest) throws DataAccessException {
+        Webhook.withTransaction {
+            Webhook hook = getWebhookByUuid(saveWebhookRequest.uuid)
+            if (hook == null) {
+                throw new DataAccessException("Error: could not update webhook ${saveWebhookRequest.uuid}")
+            }
+            hook.setUuid(saveWebhookRequest.uuid)
+            hook.setName(saveWebhookRequest.name)
+            hook.setProject(saveWebhookRequest.project)
+            hook.setAuthToken(saveWebhookRequest.authToken)
+            hook.setAuthConfigJson(saveWebhookRequest.authConfigJson)
+            hook.setEventPlugin(saveWebhookRequest.eventPlugin)
+            hook.setPluginConfigurationJson(saveWebhookRequest.pluginConfigurationJson)
+            hook.setEnabled(saveWebhookRequest.enabled)
+            try {
+                Boolean isUpdated = hook.save(flush: true)
+                String errors = hook.errors.allErrors.collect { messageSource.getMessage(it, null) }.join(",")
+                return new SaveWebhookResponse(webhook: hook, isSaved: isUpdated, errors: errors)
+            } catch (Exception e) {
+                throw new DataAccessException("Error: could not update webhook ${saveWebhookRequest.uuid}: ${e}", e)
+            }
+        }
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/WebhookServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/WebhookServiceSpec.groovy
@@ -253,7 +253,7 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
     }
     def "save new webhook token creation unauthorized"() {
         given:
-        Webhook existing = new Webhook(name:"test",project: "Test",authToken: "12345",eventPlugin: "log-webhook-event")
+        Webhook existing = new Webhook(name:"test",project: "Test",authToken: "12345",eventPlugin: "log-webhook-event", uuid: "existing-uuid")
         existing.save()
 
         def mockUserAuth = Mock(UserAndRolesAuthContext) {
@@ -282,7 +282,7 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
         }
 
         when:
-        def result = service.saveHook(mockUserAuth,[id:existing.id,name:"test",project:"Test",user:"webhookUser",roles:"webhook,test,bogus",eventPlugin:"log-webhook-event","config":["cfg1":"val1"]])
+        def result = service.saveHook(mockUserAuth,[id:existing.id, uuid: existing.uuid,name:"test",project:"Test",user:"webhookUser",roles:"webhook,test,bogus",eventPlugin:"log-webhook-event","config":["cfg1":"val1"]])
 
         then:
         result.err ==~ /^Failed to update Auth Token roles: Unauthorized to update roles$/
@@ -620,7 +620,7 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
         def result = service.importWebhook(mockUserAuth, [id: 1, uuid: "d1c6dcf7-dd12-4858-9373-c12639c689d4", name: "test", project: "Test", authToken: "12345", eventPlugin: "log-webhook-event"], false)
 
         then:
-        result == [err:"Unable to import webhoook test. Error: A Webhook by that name already exists in this project"]
+        result == [err:"Unable to import webhoook test. Error:A Webhook by that name already exists in this project"]
 
     }
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Enhancement for threaded write to the database
**Describe the solution you've implemented**
When using the gorm approach as a secondary write there was an issue with the session. By defining the writes as transactional the session will be respected
