### PR TITLE
Fix liquidbase checksum error

### DIFF
--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -3,7 +3,8 @@ databaseChangeLog = {
         property name: "boolean.type", value: "BOOLEAN", dbms: "postgresql,h2"
         property name: "boolean.type", value: "NUMBER(1, 0)", dbms: "oracle"
 
-        property name: "bytearray.type", value: "longblob", dbms: "mysql,mariadb"
+        property name: "bytearray.type", value: "blob", dbms: "mysql,mariadb"
+        property name: "bytearray_new.type", value: "longblob", dbms: "mysql,mariadb"
         property name: "bytearray.type", value: "blob", dbms: "oracle,h2"
         property name: "bytearray.type", value: "bytea", dbms: "postgresql"
         property name: "bytearray.type", value: "varbinary(max)", dbms: "mssql"

--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -3,9 +3,8 @@ databaseChangeLog = {
         property name: "boolean.type", value: "BOOLEAN", dbms: "postgresql,h2"
         property name: "boolean.type", value: "NUMBER(1, 0)", dbms: "oracle"
 
-        property name: "bytearray.type", value: "blob", dbms: "mysql,mariadb"
+        property name: "bytearray.type", value: "blob", dbms: "mysql,oracle,mariadb,h2"
         property name: "bytearray_new.type", value: "longblob", dbms: "mysql,mariadb"
-        property name: "bytearray.type", value: "blob", dbms: "oracle,h2"
         property name: "bytearray.type", value: "bytea", dbms: "postgresql"
         property name: "bytearray.type", value: "varbinary(max)", dbms: "mssql"
 

--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -4,7 +4,6 @@ databaseChangeLog = {
         property name: "boolean.type", value: "NUMBER(1, 0)", dbms: "oracle"
 
         property name: "bytearray.type", value: "blob", dbms: "mysql,oracle,mariadb,h2"
-        property name: "bytearray_new.type", value: "longblob", dbms: "mysql,mariadb"
         property name: "bytearray.type", value: "bytea", dbms: "postgresql"
         property name: "bytearray.type", value: "varbinary(max)", dbms: "mssql"
 

--- a/rundeckapp/grails-app/migrations/core/Storage.groovy
+++ b/rundeckapp/grails-app/migrations/core/Storage.groovy
@@ -46,7 +46,7 @@ databaseChangeLog = {
         }
         grailsChange {
             change {
-                sql.execute("ALTER TABLE storage MODIFY data longblob;")
+                modifyDataType(tableName: 'storage', columnName: 'data', newDataType: '${bytearray_new.type}')
             }
             rollback {
             }

--- a/rundeckapp/grails-app/migrations/core/Storage.groovy
+++ b/rundeckapp/grails-app/migrations/core/Storage.groovy
@@ -46,7 +46,7 @@ databaseChangeLog = {
         }
         grailsChange {
             change {
-                modifyDataType(tableName: 'storage', columnName: 'data', newDataType: '${bytearray_new.type}')
+                sql.execute("ALTER TABLE storage MODIFY data longblob;")
             }
             rollback {
             }


### PR DESCRIPTION
Fixes error introduced in: https://github.com/rundeck/rundeck/pull/8690
Rundeck-tester pipeline: https://app.circleci.com/pipelines/github/rundeckpro/rundeck-tester/7233/workflows/f71d0902-f77a-4265-a0a3-965f8ea18cbf

#### Problem
There was the following column definition in changeset  `core/Storage.groovy::3.4.0-2`:
`column(name: "data", type: 'blob')`

And after the merged PR, for `mariadb` and `mysql` dbms:
`column(name: "data", type: 'longblob')`


This resulted in a different checksum for the changeset that creates the table:

```
Liquibase.exception.ValidationFailedException: Validation Failed:
     1 changesets check sum
          core/Storage.groovy::3.4.0-23::rundeckuser (generated) was: 8:9e0a3ed272a5f3ba2cd4767e8715aca5 but is now: 8:1b5259deaa6f5ffbeca82ae99143c53e

```

#### Solution
Use a different property to hold the longblob datatype and modify datatype after creation
