### PR TITLE
RUN-2069: Update default node filter indicator

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeCard.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeCard.vue
@@ -139,55 +139,11 @@
               <h5 class="column-title text-uppercase text-strong">
                 {{ $t("filters") }}
               </h5>
-
-              <ul class="list-unstyled">
-                <li>
-                  <a
-                      class="nodefilterlink btn btn-default btn-xs"
-                      @click.prevent="saveFilter({filter: '.*'})"
-                  >
-                    {{ $t("all.nodes") }} {{ nodeSummary? nodeSummary.totalCount! : 0 }}
-                  </a>
-                  <div class="btn-group" style="margin-left: 4px">
-                    <button
-                        type="button"
-                        class="btn btn-default btn-xs btn-simple dropdown-toggle"
-                        style="padding: 0 5px"
-                        title="Filter Actions"
-                        data-toggle="dropdown"
-                        aria-expanded="false"
-                    >
-                      <span class="caret"></span>
-                    </button>
-                    <ul class="dropdown-menu" role="menu">
-                      <li>
-                        <a
-                            href="#"
-                            @click="
-                            isDefaultFilter
-                              ? removeDefaultFilter
-                              : setDefaultFilter
-                          "
-                        >
-                          <i
-                              class="glyphicon"
-                              :class="[
-                              isDefaultFilter
-                                ? 'glyphicon-ban-circle'
-                                : 'glyphicon-filter',
-                            ]"
-                          ></i>
-                          {{
-                            isDefaultFilter
-                                ? $t("remove.all.nodes.as.default.filter")
-                                : $t("set.all.nodes.as.default.filter")
-                          }}
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                </li>
-              </ul>
+              <node-default-filter-dropdown
+                :node-summary="nodeSummary"
+                :is-default-filter="isDefaultFilter"
+                @filter="saveFilter"
+              />
             </div>
           </div>
         </div>
@@ -225,21 +181,26 @@
 
 <script lang="ts">
 import {defineComponent, PropType} from "vue";
-import axios from "axios";
 import { _genUrl } from "@/app/utilities/genUrl";
-import { getAppLinks } from "@/library";
+import {getAppLinks, getRundeckContext} from "@/library";
 import NodeFilterLink from "@/app/components/job/resources/NodeFilterLink.vue";
-import { getRundeckContext } from "../../../../../build/pack";
 import NodeTable from "@/app/components/job/resources/NodeTable.vue";
 import {getExecutionMode, getNodes, getNodeSummary} from "@/app/components/job/resources/services/nodeServices";
+import {NodeSummary} from "@/app/components/job/resources/types/nodeTypes";
+import NodeDefaultFilterDropdown from "@/app/components/job/resources/NodeDefaultFilterDropdown.vue";
 
 export default defineComponent({
   name: "NodeCard",
   components: {
+    NodeDefaultFilterDropdown,
     NodeTable,
     NodeFilterLink,
   },
   props: {
+    project: {
+      type: String,
+      required: true,
+    },
     runAuthorized: {
       type: Boolean,
       required: true,
@@ -256,7 +217,8 @@ export default defineComponent({
   data() {
     return {
       nodeSet: {},
-      nodeSummary: {},
+      nodeSummary: {} as NodeSummary,
+      eventBus: getRundeckContext().eventBus,
       allCount: null as number | null,
       total: 0,
       executionMode: null,
@@ -313,6 +275,10 @@ export default defineComponent({
     async fetchNodeSummary() {
       try {
         this.nodeSummary = await getNodeSummary();
+        this.nodeSummary = {
+          ...this.nodeSummary,
+          ...this.nodeFilterStore.loadStoredProjectNodeFilters(this.project),
+        }
       } catch(e) {
         this.error = "Node Summary: request failed: " + e.message;
       }
@@ -363,19 +329,6 @@ export default defineComponent({
         this.loading = false;
       }
     },
-    async setDefaultFilter() {
-      // TODO: finish this - need to find out wth is the selectedFilterName for default
-      // this.nodeFilterStore.setStoredDefaultFilter(
-      //   this.project,
-      //   this.selectedFilterName
-      // );
-      // this.nodeSummary.defaultFilter = this.selectedFilterName;
-    },
-    async removeDefaultFilter() {
-      // this.nodeFilterStore.removeStoredDefaultFilter(this.project);
-      // this.nodeSummary.defaultFilter = null;
-    },
-
     runCommand() {
       if (this.runAuthorized) {
         document.location = _genUrl(getAppLinks().frameworkAdhoc, {
@@ -407,11 +360,19 @@ export default defineComponent({
     await this.fetchNodeSummary();
     await this.fetchExecutionMode();
     await this.fetchNodes();
+
+    if(this.nodeSummary.defaultFilter){
+      let filterToEmit = this.nodeSummary.defaultFilter;
+      if(filterToEmit !== ".*"){
+        filterToEmit = this.nodeSummary.filters.filter(f => f.filterName === this.nodeSummary.defaultFilter)[0]
+      }
+      this.saveFilter(filterToEmit);
+    }
+    this.eventBus.on('nodefilter:savedFilters:changed',this.fetchNodeSummary)
   },
   watch: {
     nodeFilterStore: {
       async handler(newValue) {
-
         if (newValue.selectedFilter === '' && this.hideAll) {
           this.filterAll = true;
         }else if(newValue.selectedFilter ===".*"){

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeDefaultFilterDropdown.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeDefaultFilterDropdown.vue
@@ -1,0 +1,148 @@
+<template>
+  <ul class="list-unstyled">
+    <li>
+      <dropdown>
+        <a
+            class="nodefilterlink btn btn-default btn-xs"
+            @click.prevent="saveFilter({ filter: '.*' })"
+        >
+          {{ $t("all.nodes") }} {{ nodeSummary? nodeSummary.totalCount! : 0 }}
+        </a>
+        <btn size="xs" title="Filter Actions" class="dropdown-toggle">
+          <span class="caret"></span>
+        </btn>
+        <template #dropdown>
+          <li>
+            <a
+                role="button"
+                @click.prevent="toggleDefaultFilter"
+            >
+              <i
+                  class="glyphicon"
+                  :class="[
+                  isDefaultFilter ? 'glyphicon-ban-circle' : 'glyphicon-filter',
+                ]"
+              />
+              {{
+                isDefaultFilter
+                    ? $t("remove.all.nodes.as.default.filter")
+                    : $t("set.all.nodes.as.default.filter")
+              }}
+            </a>
+          </li>
+        </template>
+      </dropdown>
+    </li>
+    <li v-for="i in nodeSummary.filters">
+      <dropdown>
+        <a
+          class="nodefilterlink btn btn-default btn-xs"
+          :data-node-filter-name="i.filterName"
+          :data-node-filter="i.filter"
+          :title="i.filter"
+          :href="linkForFilterName(i)"
+          @click.prevent="saveFilter(i)"
+        >
+          {{ i.filterName }}
+        </a>
+        <btn size="xs" title="Filter Actions" class="dropdown-toggle">
+          <span class="caret"></span>
+        </btn>
+        <template #dropdown>
+          <li>
+            <a role="button" @click="deleteFilterConfirm(i)">
+              <i class="glyphicon glyphicon-remove"></i>
+              {{ $t("delete.this.filter.ellipsis") }}
+            </a>
+          </li>
+          <li v-if="i.filterName !== nodeSummary.defaultFilter">
+            <a role="button" @click="setDefault(i)">
+              <i class="glyphicon glyphicon-filter"></i>
+              {{ $t("set.as.default.filter") }}
+            </a>
+          </li>
+          <li v-else>
+            <a role="button" @click="removeDefault()">
+              <i class="glyphicon glyphicon-ban-circle"></i>
+              {{ $t("remove.default.filter") }}
+            </a>
+          </li>
+        </template>
+      </dropdown>
+    </li>
+  </ul>
+  <div v-if="!nodeSummary.filters || nodeSummary.filters.length < 1">
+    {{ $t("none") }}
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from "vue";
+import { NodeSummary } from "@/app/components/job/resources/types/nodeTypes";
+import { StoredFilter } from "@/library/stores/NodeFilterLocalstore";
+import { _genUrl } from "@/app/utilities/genUrl";
+import { getRundeckContext } from "@/library";
+
+export default defineComponent({
+  name: "NodeDefaultFilterDropdown",
+  props: {
+    isDefaultFilter: {
+      type: Boolean,
+      required: true,
+    },
+    nodeSummary: {
+      type: Object as PropType<NodeSummary>,
+      required: true,
+    },
+  },
+  emits: ["filter"],
+  data() {
+    return {
+      rundeckContext: getRundeckContext(),
+    };
+  },
+  computed: {
+    nodesBaseUrl() {
+      return (
+        this.rundeckContext.rdBase +
+        "/project/" +
+        this.rundeckContext.projectName +
+        "/nodes"
+      );
+    },
+    eventBus() {
+      return this.rundeckContext.eventBus;
+    },
+  },
+  methods: {
+    saveFilter(selectedFilter: object) {
+      this.$emit("filter", selectedFilter);
+    },
+    linkForFilterName(filter: StoredFilter) {
+      return _genUrl(this.nodesBaseUrl, { filter: filter.filter });
+    },
+    setDefaultAll() {
+      this.eventBus.emit("nodefilter:action:setDefaultAll");
+    },
+    setDefault(filter: StoredFilter) {
+      this.eventBus.emit("nodefilter:action:setDefault", filter.filterName);
+    },
+    removeDefault() {
+      this.eventBus.emit("nodefilter:action:removeDefault");
+    },
+    deleteFilterConfirm(filter: StoredFilter) {
+      this.eventBus.emit(
+        "nodefilter:action:deleteSavedFilter",
+        filter.filterName
+      );
+    },
+    toggleDefaultFilter() {
+      if(this.isDefaultFilter) {
+        this.removeDefault();
+      } else {
+        this.setDefaultAll();
+      }
+    }
+  },
+});
+</script>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeFilterInput.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeFilterInput.vue
@@ -413,6 +413,8 @@ export default defineComponent({
       this.outputValue = this.modelValue
       if (this.selectedFilterName && this.selectedFilterName !== this.matchedFilter) {
         this.selectedFilterName = ''
+      } else if (this.matchedFilter) {
+        this.selectedFilterName = this.matchedFilter
       }
     },
     filterName() {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/types/nodeTypes.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/types/nodeTypes.ts
@@ -1,0 +1,13 @@
+import {ProjectFilters} from "../../../../../library/stores/NodeFilterLocalstore";
+
+interface Tag {
+    count: number,
+    tag: string
+}
+
+interface NodeSummary extends ProjectFilters {
+    tags?: Tag[],
+    totalCount?: number,
+}
+
+export { NodeSummary, Tag }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.ts
@@ -136,7 +136,7 @@ function init() {
                     components: { FilterInputComp, NodeCard },
                     methods: {
                         updateNodeFilter(val: any) {
-                            const filterName = val.filter || val
+                            const filterName = val && val.filter? val.filter : val
                             this.nodeFilterStore.setSelectedFilter(filterName)
                         }
                     },
@@ -160,6 +160,7 @@ function init() {
                                     :node-filter-store="nodeFilterStore"
                                     :job-create-authorized="itemData.jobCreateAuthorized"
                                     :run-authorized="itemData.runAuthorized"
+                                    :project="project"
                                     @filter="updateNodeFilter"
                                 >
                                 </node-card>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -382,7 +382,7 @@ const messages = {
     "resource.metadata.entity.tags":"Tags",
     filters: "Filters",
     "all.nodes": "All Nodes",
-    "delete.this.filter.ellipsis": "Delete this Filter &hellip;",
+    "delete.this.filter.ellipsis": "Delete this Filter ...",
     "enter.a.filter": "Enter a Filter",
     "remove.all.nodes.as.default.filter": "Remove All Nodes as Default Filter",
     "set.all.nodes.as.default.filter": "Set All Nodes as Default Filter",
@@ -392,7 +392,7 @@ const messages = {
     "node.changes.success": "Node changes were saved successfully.",
     "node.changes.notsaved": "Node changes were not saved.",
     "node.remoteEdit.edit": "Edit node:",
-    "node.remoteEdit.continue": "Continue&hellip;",
+    "node.remoteEdit.continue": "Continue...",
     "node": "Node",
     "this.will.select.both.nodes": "This will select both nodes.",
     "node.metadata.hostname": "Hostname",
@@ -414,6 +414,7 @@ const messages = {
     "default.paginate.next": "+",
     "jump.to": "Jump to",
     "per.page": "Per Page",
+    "remove.default.filter": "Remove Default Filter",
 }
 
 export default messages;


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Follow up of two tickets, #8558 and #8688 , adding the possibility to save filters as default.

How to test:
- on nodes page, type the filter to search nodes and save it as a new filter (by clicking on the arrow on the right side of the word 'nodes');
- upon saving, you'll see under 'filters' tab in the node summary, ie:
![Screenshot 2023-11-24 at 1 20 08 PM](https://github.com/rundeck/rundeck/assets/139791797/c7caf008-69cc-4443-9df7-964157997b0a)
- then click on the small arrow on the right side of the name and mark it as 'default filter'
** Important: at this point there's no visual feedback that it worked, but you can see that it's the new default filter by either looking at localstorage OR by refreshing the page OR by clicking again the same menu on the right side of the filter where you've clicked before**


