### PR TITLE
fix test image reference for functional test module

### DIFF
--- a/scripts/circleci/build-functions.sh
+++ b/scripts/circleci/build-functions.sh
@@ -56,5 +56,5 @@ rundeck_verify_build() {
 }
 
 rundeck_gradle_functional_tests() {
-    ./gradlew :functional-test:${GRADLE_TASK} -Penvironment="${ENV}" ${GRADLE_BUILD_OPTS} --info
+    TEST_IMAGE=${TEST_IMAGE:-} ./gradlew :functional-test:${GRADLE_TASK} -Penvironment="${ENV}" ${GRADLE_BUILD_OPTS} --info
 }


### PR DESCRIPTION
when running on circleci functional-test was always using snapshot instead of the image generated by the branch