### PR TITLE
RUN-2027: Use Java 17 for tests, Java 11 for build/packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,7 @@ job-defaults: &job-defaults
     CIRCLE_PIPELINE_NUM: << pipeline.number >>
     GRADLE_OPTS: -XX:MaxRAMPercentage=80.0
     JAVA_OPTS: -XX:MaxRAMPercentage=80.0
-    JAVA_HOME: /usr/lib/jvm/zulu11
+    JAVA_HOME: /usr/lib/jvm/zulu17
 
 jobs:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,15 +221,6 @@ commands:
           step-name: Install TestDeck Dependencies
           command: dependencies_testdeck_setup
 
-  reconfigure-java-version:
-    description: Reconfigure Java Version to 17
-    steps:
-      - aws-cli/install
-      - install-node
-      - run-build-step:
-          step-name: Install Java 17
-          command: reconfigure_java_version
-
 
 #### Job Definitions ####
 
@@ -277,6 +268,11 @@ jobs:
       - run-build-step:
           step-name: Verify Build
           command: rundeck_verify_build
+      - run-build-step:
+          step-name: Build Testdeck docker image
+          command: |
+            testdeck_build_rdtest
+            testdeck_push_rdtest
       - persist_to_workspace:
           root: ~/workspace
           paths:
@@ -287,6 +283,8 @@ jobs:
             - grails-*/build
             - rundeck-storage/rundeck-*/build
             - rundeck-authz/rundeck-*/build
+      #            - rundeckapp/grails-spa/packages/ui-trellis/build
+      #            - rundeckapp/grails-spa/packages/ui-trellis/node_modules
       - run-build-step:
           step-name: Collect Artifacts
           command: collect_build_artifacts
@@ -297,7 +295,7 @@ jobs:
 
   # Run Gradle Tests
   test-gradle:
-    <<: *job-defaults-java17
+    <<: *job-defaults-java11
     executor:
       name: docker-builder
     steps:
@@ -400,6 +398,38 @@ jobs:
           step-name: Publish to Sonatype
           command: packaging_publish_maven
 
+  test-gradle-functional:
+    <<: *job-defaults-java11
+    executor:
+      name: machine-builder
+      docker_layer_caching: true
+      resource_class: medium
+    parameters:
+      test-image:
+        description: Test image tag
+        default: "rundeck/testdeck"
+        type: string
+      gradle-task:
+        type: string
+    steps:
+      - checkout
+      - install-build-dependencies
+      - restore-build-cache
+      - attach_workspace:
+          at: ~/workspace
+      - run-build-step:
+          step-name: Pull images
+          command: testdeck_pull_rundeck
+      - run-build-step:
+          step-name: Runs gradle test task << parameters.gradle-task >>
+          command: |
+            TEST_IMAGE=<< parameters.test-image >>
+            GRADLE_TASK=<< parameters.gradle-task >>
+            rundeck_gradle_functional_tests
+      - collect-gradle-tests
+      - store_artifacts:
+          path: ~/workspace/functional-test/build/test-results/images
+
   # Publish all packages to packagecloud
   packaging-publish:
     <<: *job-defaults-java17
@@ -438,7 +468,7 @@ jobs:
 
   # Test packaging
   packaging-test:
-    <<: *job-defaults-java17
+    <<: *job-defaults-java11
     executor:
       name: docker-builder
 
@@ -485,12 +515,11 @@ jobs:
           docker_layer_caching: true
       - checkout
       - install-testdeck-dependencies
-      - reconfigure-java-version
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
-          step-name: Build test images
-          command: testdeck_build_rdtest
+          step-name: Pull images
+          command: testdeck_pull_rdtest
       - run-build-step:
           step-name: Run Test
           command: << parameters.command >>
@@ -514,12 +543,11 @@ jobs:
 
       - checkout
       - install-testdeck-dependencies
-      - reconfigure-java-version
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
-          step-name: Build test images
-          command: testdeck_build_rdtest
+          step-name: Pull images
+          command: testdeck_pull_rdtest
       - run-build-step:
           step-name: Run Test
           command: << parameters.command >>
@@ -551,12 +579,11 @@ jobs:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - install-testdeck-dependencies
-      - reconfigure-java-version
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
           step-name: Pull Rundeck Image
-          command: rundeck_pull_image
+          command: testdeck_pull_rundeck
       - run-build-step:
           step-name: Test
           command: |
@@ -574,39 +601,6 @@ jobs:
           destination: images
       - store_test_results:
           path: << parameters.workdir >>/test_out
-
-  test-gradle-functional:
-    <<: *job-defaults-java11
-    executor:
-      name: machine-builder
-      docker_layer_caching: true
-      resource_class: medium
-    parameters:
-      test-image:
-        description: Test image tag
-        default: "rundeck/testdeck"
-        type: string
-      gradle-task:
-        type: string
-    steps:
-      - checkout
-      - install-build-dependencies
-      - restore-build-cache
-      - attach_workspace:
-          at: ~/workspace
-      - run-build-step:
-          step-name: Pull images
-          command: rundeck_pull_image
-      - run-build-step:
-          step-name: Runs gradle test task << parameters.gradle-task >>
-          command: |
-            TEST_IMAGE=<< parameters.test-image >>
-            GRADLE_TASK=<< parameters.gradle-task >>
-            rundeck_gradle_functional_tests
-      - collect-gradle-tests
-      - store_artifacts:
-          path: ~/workspace/functional-test/build/test-results/images
-
 
 
 #### WORKFLOWS ####
@@ -700,6 +694,16 @@ workflows:
           command: bash test/run-docker-tests.sh
           <<: *require-build
           <<: *slack-defaults
+      - test-docker:
+          name: Tomcat 8 API Test
+          command: bash test/run-docker-tomcat-tests.sh 8-jdk17
+          <<: *require-build
+          <<: *slack-defaults
+      - test-docker:
+          name: Tomcat 9 API Test
+          command: bash test/run-docker-tomcat-tests.sh 9-jdk17
+          <<: *require-build
+          <<: *slack-defaults
       - test-machine:
           name: API Test
           command: DOCKER_COMPOSE_SPEC=docker-compose-api-mysql.yaml bash test/run-docker-api-tests.sh
@@ -735,6 +739,12 @@ workflows:
           command: bash test/run-docker-pam-tests.sh
           <<: *require-build
           <<: *slack-defaults
+      - testdeck:
+          name: Selenium Test
+          workdir: test/selenium
+          command: testdeck_selenium_test
+          <<: *require-build
+          <<: *slack-defaults
       - test-gradle-functional:
           name: New Selenium Test
           gradle-task: seleniumCoreTest
@@ -743,5 +753,17 @@ workflows:
       - test-gradle-functional:
           name: New API Test
           gradle-task: apiTest
+          <<: *require-build
+          <<: *slack-defaults
+      - test-gradle-functional:
+          name: New API Test Tomcat 8
+          test-image: 8-jdk17
+          gradle-task: tomcatTest
+          <<: *require-build
+          <<: *slack-defaults
+      - test-gradle-functional:
+          name: New API Test Tomcat 9
+          test-image: 9-jdk17
+          gradle-task: tomcatTest
           <<: *require-build
           <<: *slack-defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,7 +412,7 @@ jobs:
           at: ~/workspace
       - run-build-step:
           step-name: Pull images
-          command: testdeck_pull_rundeck
+          command: rundeck_pull_image
       - run-build-step:
           step-name: Runs gradle test task << parameters.gradle-task >>
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,15 @@ commands:
           step-name: Install TestDeck Dependencies
           command: dependencies_testdeck_setup
 
+  reconfigure-java-version:
+    description: Reconfigure Java Version to 17
+    steps:
+      - aws-cli/install
+      - install-node
+      - run-build-step:
+          step-name: Install Java 17
+          command: dependencies_reconfigure_java
+
 
 #### Job Definitions ####
 
@@ -476,6 +485,7 @@ jobs:
           docker_layer_caching: true
       - checkout
       - install-testdeck-dependencies
+      - reconfigure-java-version
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
@@ -504,6 +514,7 @@ jobs:
 
       - checkout
       - install-testdeck-dependencies
+      - reconfigure-java-version
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
@@ -540,6 +551,7 @@ jobs:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - install-testdeck-dependencies
+      - reconfigure-java-version
       - attach_workspace:
           at: ~/workspace
       - run-build-step:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,11 +268,6 @@ jobs:
       - run-build-step:
           step-name: Verify Build
           command: rundeck_verify_build
-      - run-build-step:
-          step-name: Build Testdeck docker image
-          command: |
-            testdeck_build_rdtest
-            testdeck_push_rdtest
       - persist_to_workspace:
           root: ~/workspace
           paths:
@@ -283,8 +278,6 @@ jobs:
             - grails-*/build
             - rundeck-storage/rundeck-*/build
             - rundeck-authz/rundeck-*/build
-      #            - rundeckapp/grails-spa/packages/ui-trellis/build
-      #            - rundeckapp/grails-spa/packages/ui-trellis/node_modules
       - run-build-step:
           step-name: Collect Artifacts
           command: collect_build_artifacts
@@ -518,8 +511,8 @@ jobs:
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
-          step-name: Pull images
-          command: testdeck_pull_rdtest
+          step-name: Build test images
+          command: testdeck_build_rdtest
       - run-build-step:
           step-name: Run Test
           command: << parameters.command >>
@@ -546,8 +539,8 @@ jobs:
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
-          step-name: Pull images
-          command: testdeck_pull_rdtest
+          step-name: Build test images
+          command: testdeck_build_rdtest
       - run-build-step:
           step-name: Run Test
           command: << parameters.command >>
@@ -583,7 +576,7 @@ jobs:
           at: ~/workspace
       - run-build-step:
           step-name: Pull Rundeck Image
-          command: testdeck_pull_rundeck
+          command: rundeck_pull_image
       - run-build-step:
           step-name: Test
           command: |
@@ -694,16 +687,6 @@ workflows:
           command: bash test/run-docker-tests.sh
           <<: *require-build
           <<: *slack-defaults
-      - test-docker:
-          name: Tomcat 8 API Test
-          command: bash test/run-docker-tomcat-tests.sh 8-jdk17
-          <<: *require-build
-          <<: *slack-defaults
-      - test-docker:
-          name: Tomcat 9 API Test
-          command: bash test/run-docker-tomcat-tests.sh 9-jdk17
-          <<: *require-build
-          <<: *slack-defaults
       - test-machine:
           name: API Test
           command: DOCKER_COMPOSE_SPEC=docker-compose-api-mysql.yaml bash test/run-docker-api-tests.sh
@@ -739,12 +722,6 @@ workflows:
           command: bash test/run-docker-pam-tests.sh
           <<: *require-build
           <<: *slack-defaults
-      - testdeck:
-          name: Selenium Test
-          workdir: test/selenium
-          command: testdeck_selenium_test
-          <<: *require-build
-          <<: *slack-defaults
       - test-gradle-functional:
           name: New Selenium Test
           gradle-task: seleniumCoreTest
@@ -753,17 +730,5 @@ workflows:
       - test-gradle-functional:
           name: New API Test
           gradle-task: apiTest
-          <<: *require-build
-          <<: *slack-defaults
-      - test-gradle-functional:
-          name: New API Test Tomcat 8
-          test-image: 8-jdk17
-          gradle-task: tomcatTest
-          <<: *require-build
-          <<: *slack-defaults
-      - test-gradle-functional:
-          name: New API Test Tomcat 9
-          test-image: 9-jdk17
-          gradle-task: tomcatTest
           <<: *require-build
           <<: *slack-defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ commands:
 #### Job Definitions ####
 
 # Default job config
-job-defaults: &job-defaults
+job-defaults-java17: &job-defaults-java17
   # Using an absolute path here prevents issues with bash interpolations.
   working_directory: /home/circleci/workspace
   environment:
@@ -234,11 +234,20 @@ job-defaults: &job-defaults
     JAVA_OPTS: -XX:MaxRAMPercentage=80.0
     JAVA_HOME: /usr/lib/jvm/zulu17
 
+job-defaults-java11: &job-defaults-java11
+  # Using an absolute path here prevents issues with bash interpolations.
+  working_directory: /home/circleci/workspace
+  environment:
+    CIRCLE_PIPELINE_NUM: << pipeline.number >>
+    GRADLE_OPTS: -XX:MaxRAMPercentage=80.0
+    JAVA_OPTS: -XX:MaxRAMPercentage=80.0
+    JAVA_HOME: /usr/lib/jvm/zulu11
+
 jobs:
 
   # Build rundeck War
   build-rundeck:
-    <<: *job-defaults
+    <<: *job-defaults-java11
     executor:
       name: docker-builder
       resource_class: large
@@ -279,7 +288,7 @@ jobs:
 
   # Run Gradle Tests
   test-gradle:
-    <<: *job-defaults
+    <<: *job-defaults-java17
     executor:
       name: docker-builder
     steps:
@@ -297,7 +306,7 @@ jobs:
 
   # Run twistlock scan
   twistlock-scan-image:
-    <<: *job-defaults
+    <<: *job-defaults-java17
     executor:
       name: docker-builder
     parameters:
@@ -321,7 +330,7 @@ jobs:
 
   #Openapi tests
   test-openapi:
-    <<: *job-defaults
+    <<: *job-defaults-java17
     executor:
       name: docker-builder
     steps:
@@ -347,7 +356,7 @@ jobs:
 
   # Publish Docker Images
   docker-publish:
-    <<: *job-defaults
+    <<: *job-defaults-java17
     executor:
       name: docker-builder
 
@@ -367,7 +376,7 @@ jobs:
 
   # Publish Maven Packages to sonatype
   maven-publish:
-    <<: *job-defaults
+    <<: *job-defaults-java17
     executor:
       name: docker-builder
 
@@ -384,7 +393,7 @@ jobs:
 
   # Publish all packages to packagecloud
   packaging-publish:
-    <<: *job-defaults
+    <<: *job-defaults-java17
     executor:
       name: docker-builder
 
@@ -420,7 +429,7 @@ jobs:
 
   # Test packaging
   packaging-test:
-    <<: *job-defaults
+    <<: *job-defaults-java17
     executor:
       name: docker-builder
 
@@ -454,7 +463,7 @@ jobs:
 
   # Run Testdeck job on docker executor.
   test-docker:
-    <<: *job-defaults
+    <<: *job-defaults-java17
     executor:
       name: docker-builder
 
@@ -478,7 +487,7 @@ jobs:
 
 
   test-machine:
-    <<: *job-defaults
+    <<: *job-defaults-java17
     executor:
       name: machine-builder
       docker_layer_caching: true
@@ -507,7 +516,7 @@ jobs:
 
   # Run Testdeck job on machine executor.
   testdeck:
-    <<: *job-defaults
+    <<: *job-defaults-java17
     executor:
       name: machine-builder
       docker_layer_caching: true
@@ -555,7 +564,7 @@ jobs:
           path: << parameters.workdir >>/test_out
 
   test-gradle-functional:
-    <<: *job-defaults
+    <<: *job-defaults-java11
     executor:
       name: machine-builder
       docker_layer_caching: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,7 +228,7 @@ commands:
       - install-node
       - run-build-step:
           step-name: Install Java 17
-          command: dependencies_reconfigure_java
+          command: reconfigure_java_version
 
 
 #### Job Definitions ####

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
         gnupg2 \
         ssh-client \
         sudo \
-        openjdk-11-jre-headless \
+        openjdk-17-jre-headless \
         uuid-runtime \
         wget \
         unzip && \

--- a/scripts/circleci/dependencies-functions.sh
+++ b/scripts/circleci/dependencies-functions.sh
@@ -33,7 +33,6 @@ dependencies_build_setup() {
 reconfigure_java_version(){
 
   sudo apt-get remove openjdk-11-jdk-headless
-  sudo apt-get remove zulu11-jdk-headless
   sudo apt-get -y --no-install-recommends install openjdk-17-jdk-headless
   sudo apt-get -y --no-install-recommends install zulu17-jdk-headless
 

--- a/scripts/circleci/dependencies-functions.sh
+++ b/scripts/circleci/dependencies-functions.sh
@@ -33,6 +33,9 @@ dependencies_build_setup() {
 reconfigure_java_version(){
 
   sudo apt-get remove openjdk-11-jdk-headless
+  sudo apt install gnupg ca-certificates curl
+      curl -s https://repos.azul.com/azul-repo.key | sudo gpg --dearmor -o /usr/share/keyrings/azul.gpg
+      echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | sudo tee /etc/apt/sources.list.d/zulu.list
   sudo apt-get -y --no-install-recommends install openjdk-17-jdk-headless
   sudo apt-get -y --no-install-recommends install zulu17-jdk-headless
 

--- a/scripts/circleci/dependencies-functions.sh
+++ b/scripts/circleci/dependencies-functions.sh
@@ -29,17 +29,6 @@ dependencies_build_setup() {
     mkdir -p "$HOME/.gradle"
 }
 
-
-reconfigure_java_version(){
-
-  sudo apt-get remove openjdk-11-jdk-headless
-  sudo apt install gnupg ca-certificates curl
-      curl -s https://repos.azul.com/azul-repo.key | sudo gpg --dearmor -o /usr/share/keyrings/azul.gpg
-      echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | sudo tee /etc/apt/sources.list.d/zulu.list
-  sudo apt-get -y --no-install-recommends install openjdk-17-jdk-headless
-  sudo apt-get -y --no-install-recommends install zulu17-jdk-headless
-
-}
 # Install dependencies needed for packaging
 dependencies_packaging_setup() {
 

--- a/scripts/circleci/dependencies-functions.sh
+++ b/scripts/circleci/dependencies-functions.sh
@@ -46,7 +46,7 @@ dependencies_packaging_setup() {
     dependencies_build_setup
 
     sudo apt-get -y --no-install-recommends install \
-        openjdk-17-jdk-headless \
+        openjdk-11-jdk-headless \
         dpkg \
         xmlstarlet \
         expect \

--- a/scripts/circleci/dependencies-functions.sh
+++ b/scripts/circleci/dependencies-functions.sh
@@ -11,7 +11,7 @@ dependencies_build_setup() {
     echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | sudo tee /etc/apt/sources.list.d/zulu.list
 
     sudo apt-get update
-    sudo apt-get -y --no-install-recommends install zulu11-jdk-headless
+    sudo apt-get -y --no-install-recommends install zulu17-jdk-headless
 
     # Node and aws installed by orb.
 
@@ -35,7 +35,7 @@ dependencies_packaging_setup() {
     dependencies_build_setup
 
     sudo apt-get -y --no-install-recommends install \
-        openjdk-11-jdk-headless \
+        openjdk-17-jdk-headless \
         dpkg \
         xmlstarlet \
         expect \
@@ -52,7 +52,7 @@ dependencies_testdeck_setup() {
     sudo apt-get update
     sudo apt-get -y --no-install-recommends install \
         xmlstarlet \
-        openjdk-11-jdk-headless \
+        openjdk-17-jdk-headless \
         file \
         dpkg \
         jq

--- a/scripts/circleci/dependencies-functions.sh
+++ b/scripts/circleci/dependencies-functions.sh
@@ -29,6 +29,15 @@ dependencies_build_setup() {
     mkdir -p "$HOME/.gradle"
 }
 
+
+reconfigure_java_version(){
+
+  sudo apt-get remove openjdk-11-jdk-headless
+  sudo apt-get remove zulu11-jdk-headless
+  sudo apt-get -y --no-install-recommends install openjdk-17-jdk-headless
+  sudo apt-get -y --no-install-recommends install zulu17-jdk-headless
+
+}
 # Install dependencies needed for packaging
 dependencies_packaging_setup() {
 

--- a/scripts/circleci/dependencies-functions.sh
+++ b/scripts/circleci/dependencies-functions.sh
@@ -11,7 +11,7 @@ dependencies_build_setup() {
     echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | sudo tee /etc/apt/sources.list.d/zulu.list
 
     sudo apt-get update
-    sudo apt-get -y --no-install-recommends install zulu17-jdk-headless
+    sudo apt-get -y --no-install-recommends install zulu11-jdk-headless
 
     # Node and aws installed by orb.
 

--- a/test/docker/dockers/rundeck/Dockerfile
+++ b/test/docker/dockers/rundeck/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get -y update && \
         zip \
         file \
         apt-transport-https \
-        openjdk-11-jdk \
+        openjdk-17-jdk \
         dos2unix
 
 RUN curl -s https://packagecloud.io/install/repositories/pagerduty/rundeck/script.deb.sh | os=any dist=any bash \

--- a/test/docker/dockers/rundeck/scripts/start_rundeck.sh
+++ b/test/docker/dockers/rundeck/scripts/start_rundeck.sh
@@ -80,7 +80,7 @@ cat > $HOME/etc/profile <<END
 RDECK_BASE=$RDECK_BASE
 export RDECK_BASE
 
-JAVA_HOME=${JAVA_HOME:-/usr/lib/jvm/java-11-openjdk-amd64}
+JAVA_HOME=${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}
 export JAVA_HOME
 
 PATH=\$JAVA_HOME/bin:\$RDECK_BASE/tools/bin:\$PATH


### PR DESCRIPTION
Use java 17 for all tests, but use java 11 for build and packaging tests
