### PR TITLE
RSE-755 Fix: SCM Disabled in Cluster while Job Plugins Metadata Retrieval

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -56,6 +56,7 @@ import com.dtolabs.rundeck.core.plugins.ValidatedPlugin
 import com.dtolabs.rundeck.server.plugins.services.ScmExportPluginProviderService
 import com.dtolabs.rundeck.server.plugins.services.ScmImportPluginProviderService
 import groovy.transform.CompileStatic
+import org.hibernate.ObjectNotFoundException
 import org.rundeck.app.components.RundeckJobDefinitionManager
 import org.rundeck.app.data.providers.v1.UserDataProvider
 import org.slf4j.Logger
@@ -1578,8 +1579,12 @@ class ScmService {
     }
 
     Map<String, Map> getJobsPluginMeta(String project, String type){
-        List jobsPluginMeta = jobMetadataService.getJobsPluginMeta(project, type)
-        jobsPluginMeta.collectEntries{[it.key.replace("/" + type,""),it.pluginData]}
+        try{
+            List jobsPluginMeta = jobMetadataService.getJobsPluginMeta(project, type)
+            jobsPluginMeta.collectEntries{[it.key.replace("/" + type,""),it.pluginData]}
+        }catch(ObjectNotFoundException ignored){
+            log.debug("No jobs plugin metadata found")
+        }
     }
 
     // check if jobs has the SCM metadata stored in the DB

--- a/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
@@ -1258,6 +1258,35 @@ class ScmServiceSpec extends Specification implements ServiceUnitTest<ScmService
         true        | "1234/scm-export"   | '{"name":"test","groupPath":"test","srcId":"1234"}'     | 1     | "1234"
     }
 
+    def "Call for jobs plugin metadata, no exception thrown"() {
+        given:
+        def project = "test"
+        def scmIntegration = 'scm-import'
+
+        service.pluginConfigService = Mock(PluginConfigService)
+        service.frameworkService = Mock(FrameworkService) {
+            isClusterModeEnabled() >> true
+        }
+        service.storageService = Mock(StorageService)
+        service.pluginService = Mock(PluginService)
+        service.jobEventsService = Mock(JobEventsService)
+        service.jobMetadataService = Mock(JobMetadataService){
+            getJobsPluginMeta(project, scmIntegration) >> List.of()
+        }
+
+
+        PluginMeta importPluginMeta = new PluginMeta()
+        importPluginMeta.key = "1234/scm-import"
+        importPluginMeta.project = project
+        importPluginMeta.jsonData = '{"name":"test","groupPath":"test","srcId":"456"}'
+
+        when:
+        def result = service.getJobsPluginMeta(project,scmIntegration)
+
+        then:
+        noExceptionThrown()
+    }
+
     def "get srcId job export plugin metadata"() {
         given:
         service.pluginConfigService = Mock(PluginConfigService)


### PR DESCRIPTION
# RSE-755 Fix: SCM Disabled in Cluster while Job Plugins Metadata Retrieval
A exception is thrown in cluster when SCM try to get jobs plugin metadata (of no jobs).

## The Problem
No jobs to extract metadata from, so GORM complains with the wrong identifier exception.

## The Fix
Handling exception, and eventually the cluster will rearrange the metadata.