### PR TITLE
RUN-2084: job import with JSON format with unsupported version should return expected error

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/jobs/JobImportSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/jobs/JobImportSpec.groovy
@@ -1,0 +1,81 @@
+package org.rundeck.tests.functional.api.jobs
+
+import org.rundeck.util.annotations.APITest
+import org.rundeck.util.container.BaseContainer
+
+@APITest
+class JobImportSpec extends BaseContainer {
+
+    def setupSpec() {
+        startEnvironment()
+        setupProject()
+    }
+    static final List JOB_JSON_MAP = [
+        [
+            "executionEnabled"  : false,
+            "loglevel"          : "INFO",
+            "name"              : "JobImportSpec-testjob1",
+            "nodeFilterEditable": false,
+            "options"           : [
+                [
+                    "label"   : "Option 1",
+                    "name"    : "opt1",
+                    "required": true
+                ],
+            ],
+            "scheduleEnabled"   : true,
+            "schedules"         : [],
+            "sequence"          : [
+                "commands" : [
+                    [
+                        "script": 'echo "${option.opt1}"'
+                    ],
+                ],
+                "keepgoing": false,
+                "strategy" : "node-first"
+            ],
+        ]
+    ]
+
+    def "import job json format fails for version<44"() {
+        given:
+            def client = getClient()
+            client.apiVersion = version
+        when:
+            def response = client.doPost(
+                "/project/${PROJECT_NAME}/jobs/import?dupeOption=update&uuidOption=remove",
+                JOB_JSON_MAP
+            )
+        then:
+            verifyAll {
+                !response.successful
+                response.code() == 400
+                def json = client.jsonValue(response.body(), Map)
+                json.errorCode == 'api.error.api-version.unsupported'
+            }
+        where:
+            version << [14, 43]
+    }
+
+    def "import job json format succeeds for version>=44"() {
+        given:
+            def client = getClient()
+            client.apiVersion = version
+        when:
+            def response = client.doPost(
+                "/project/${PROJECT_NAME}/jobs/import?dupeOption=update&uuidOption=remove",
+                JOB_JSON_MAP
+            )
+        then:
+            verifyAll {
+                response.successful
+                response.code() == 200
+                def json = client.jsonValue(response.body(), Map)
+                json.succeeded != null
+                json.succeeded.size() == 1
+            }
+
+        where:
+            version << [44, 46]
+    }
+}

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -3750,6 +3750,11 @@ Each job entry contains:
         }
         log.debug("ScheduledExecutionController: upload " + params)
         String fileformat = params.format ?:params.fileformat ?: 'xml'
+        if (fileformat && fileformat == 'json' || request.format == 'json') {
+            if (!apiService.requireApi(request, response, ApiVersions.V44)) {
+                return
+            }
+        }
         def parseresult
         def supportedFormats = ['xml', 'yaml']
         if (request.api_version > ApiVersions.V43) {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -3837,7 +3837,7 @@ class ScheduledExecutionControllerSpec extends RundeckHibernateSpec implements C
             controller.apiJobsImportv14()
         then:
             1 * controller.apiService.requireApi(_,_) >> true
-            (format=='json'?1:0) * controller.apiService.requireApi(_,_,43) >> true
+            (format=='json'?1:0) * controller.apiService.requireApi(_,_,44) >> true
             1 * controller.apiService.requireParameters(_, _, ['project']) >> true
             1 * controller.scheduledExecutionService.parseUploadedFile(!null, format) >> [
                 jobset: jobset

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -3778,6 +3778,30 @@ class ScheduledExecutionControllerSpec extends RundeckHibernateSpec implements C
             1 * controller.apiService.requireApi(_,_) >> false
 
     }
+    def "api jobs import format param=json requires v44"() {
+        given:
+            controller.apiService = Mock(ApiService)
+            request.method = 'POST'
+            params.format='json'
+        when:
+            controller.apiJobsImportv14()
+        then:
+            1 * controller.apiService.requireApi(_,_) >> true
+            1 * controller.apiService.requireParameters(_,_,['project']) >> true
+            1 * controller.apiService.requireApi(_,_,44) >> false
+    }
+    def "api jobs import request format=json requires v44"() {
+        given:
+            controller.apiService = Mock(ApiService)
+            request.method = 'POST'
+            request.format='json'
+        when:
+            controller.apiJobsImportv14()
+        then:
+            1 * controller.apiService.requireApi(_,_) >> true
+            1 * controller.apiService.requireParameters(_, _, ['project']) >> true
+            1 * controller.apiService.requireApi(_,_,44) >> false
+    }
     def "api jobs import require project param"() {
         given:
             controller.apiService = Mock(ApiService)
@@ -3813,6 +3837,7 @@ class ScheduledExecutionControllerSpec extends RundeckHibernateSpec implements C
             controller.apiJobsImportv14()
         then:
             1 * controller.apiService.requireApi(_,_) >> true
+            (format=='json'?1:0) * controller.apiService.requireApi(_,_,43) >> true
             1 * controller.apiService.requireParameters(_, _, ['project']) >> true
             1 * controller.scheduledExecutionService.parseUploadedFile(!null, format) >> [
                 jobset: jobset


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**

Fix: if the Job import API is called with JSON job data, but incorrect API version, it returns an unexpected error



**Describe the solution you've implemented**
Return 400 error with "api.error.api-version.unsupported" error code
