### PR TITLE
RUN-2090: fix for ui socket loading in project config page

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/framework/editProject.js
+++ b/rundeckapp/grails-app/assets/javascripts/framework/editProject.js
@@ -44,6 +44,7 @@ function EditProject (data) {
     var self = this
     self.create = ko.observable(data.create || !data.name)
     self.name = ko.observable(data.name)
+    self.loaded = ko.observable(false)
     self.descriptions = {}
     if (data.descriptions) {
         for (let p in data.descriptions) {
@@ -71,4 +72,7 @@ jQuery(function () {
     var projectData = loadJsonData('projectDataJSON')
     window.projectEditor = new EditProject(projectData)
     initKoBind(null, {editProject: projectEditor})
+    //hack to trigger dynamic dom change inside the knockout content,
+    //so mutation observer will always get triggered for it
+    projectEditor.loaded(true)
 })

--- a/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
@@ -306,8 +306,8 @@
             <g:set var="fcopyprefix" value="${serviceDefaults.prefix}.default.config."/>
       <g:if test="${description && description.properties}">
           <g:set var="isSelected" value="${serviceDefaults.selectedType == description.name}"/>
-          <div class=" " id="${enc(attr: nkey) + '_det'}"
-               data-bind="if: defaults['${serviceDefaults.service}'].type()==='${enc(attr: description.name)}'">
+          <div class=" vue-ui-socket-deferred " id="${enc(attr: nkey) + '_det'}"
+               data-bind="if: loaded() && defaults['${serviceDefaults.service}'].type()==='${enc(attr: description.name)}'">
               <hr/>
 
             <g:render template="/framework/pluginConfigPropertiesInputs" model="${[

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/ui/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/ui/main.ts
@@ -9,10 +9,22 @@ import {initI18n, updateLocaleMessages} from "../../utilities/i18n";
 
 const rootStore = getRundeckContext().rootStore
 const EventBus = getRundeckContext().eventBus
-
+const closest = function (elem: Element, className:string): HTMLElement|null {
+  let parent = elem.parentElement;
+  while (parent) {
+    if (parent.classList.contains(className)) {
+      return parent;
+    }
+    parent = parent.parentElement;
+  }
+  return null;
+};
 window.addEventListener('DOMContentLoaded', (() => {
   const elm = document.getElementsByClassName('vue-ui-socket')
   for (const elmElement of elm) {
+    if(closest(elmElement,'vue-ui-socket-deferred')){
+      return
+    }
     const eventName = elmElement.getAttribute("vue-socket-on")
     if(eventName){
       window.addEventListener(eventName, (evt1 => initUiComponentsOnEvent(evt1)))


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
until Project config page can be converted to Vue, this fixes a loading issue for vue content within the knockout managed dom.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
