### PR TITLE
RUN-2127: Optimize HTML attributes for password manager autofill

### DIFF
--- a/rundeckapp/grails-app/views/user/login.gsp
+++ b/rundeckapp/grails-app/views/user/login.gsp
@@ -110,7 +110,7 @@
               </div>
             </g:if>
             <div class="col-md-4 col-sm-6 col-md-offset-4 col-sm-offset-3">
-              <form action="${g.createLink(uri:"/j_security_check")}" method="post" class="form " role="form" onsubmit="return onLoginClicked()">
+              <form action="${g.createLink(uri:"/j_security_check")}" method="post" class="form " role="form" onsubmit="return onLoginClicked()" data-form-type=”login”>
                 <div class="card" data-background="color" data-color="blue">
                   <div class="card-header">
                     <h3 class="card-title">
@@ -176,12 +176,12 @@
                     </g:if>
                     <div class="form-group">
                         <label for="login"><g:message code="user.login.username.label"/></label>
-                        <input type="text" name="j_username" id="login" class="form-control input-no-border" autofocus="true"/>
+                        <input type="text" name="j_username" id="login" class="form-control input-no-border" autofocus="true" data-form-type=”username”/>
                     </div>
 
                     <div class="form-group">
                         <label for="password"><g:message code="user.login.password.label"/></label>
-                        <input type="password" name="j_password" id="password" class="form-control input-no-border" autocomplete="off"/>
+                        <input type="password" name="j_password" id="password" class="form-control input-no-border" autocomplete="off" data-form-type=”password”/>
                     </div>
                         <div class="card-footer text-center">
                             <button type="submit" id="btn-login" class="btn btn-fill btn-wd btn-primary"><g:message code="user.login.login.button"/></button>


### PR DESCRIPTION
This change allows password managers (such as Dashlane) to autofill username and password (this is mostly a UX enhancement proposal).

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
