### PR TITLE
RSE-919: Fix whale logs crashing browser

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/ExecutionOutput.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/ExecutionOutput.ts
@@ -127,7 +127,7 @@ export class ExecutionOutput {
             },
             queryParameters: {
                 offset: offset.toString(),
-                maxlines: maxLines
+                maxlines: maxLines.toString()
             }
         }).then(response => {
             if (response.status != 200) {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Even showing whale logs message the browser is crashing when trying open output logs

**Describe the solution you've implemented**
Maxline parameter was not sent to server to prevent download the log output
