### PR TITLE
RUN-2114:  Fix replacing data references in script as it uses different tokens to define them

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
@@ -40,11 +40,14 @@ import com.dtolabs.rundeck.plugins.step.NodeStepPlugin;
 import com.dtolabs.rundeck.plugins.step.PluginStepContext;
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder;
 import org.rundeck.app.spi.Services;
+import org.rundeck.core.execution.ScriptCommand;
+import org.rundeck.core.execution.ScriptFileCommand;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -199,17 +202,20 @@ public class NodeStepPluginAdapter implements NodeStepExecutor, Describable, Dyn
         }
         if (null != instanceConfiguration) {
             CustomFieldsAdapter customFieldsAdapter = CustomFieldsAdapter.create(description);
-            instanceConfiguration = SharedDataContextUtils.replaceDataReferences(
-                    instanceConfiguration,
-                    ContextView.node(node.getNodename()),
-                    ContextView::nodeStep,
-                    null,
-                    context.getSharedDataContext(),
-                    false,
-                    blankIfUnexMap,
-                    customFieldsAdapter::convertInput,
-                    customFieldsAdapter::convertOutput
-            );
+            if(!Arrays.asList(ScriptFileCommand.SCRIPT_FILE_COMMAND_TYPE, ScriptCommand.SCRIPT_COMMAND_TYPE).contains((item.getNodeStepType()))) //Those types are handled by its plugins
+            {
+                instanceConfiguration = SharedDataContextUtils.replaceDataReferences(
+                        instanceConfiguration,
+                        ContextView.node(node.getNodename()),
+                        ContextView::nodeStep,
+                        null,
+                        context.getSharedDataContext(),
+                        false,
+                        blankIfUnexMap,
+                        customFieldsAdapter::convertInput,
+                        customFieldsAdapter::convertOutput
+                );
+            }
         }
         return instanceConfiguration;
     }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapterSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapterSpec.groovy
@@ -39,6 +39,7 @@ import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.rundeck.core.execution.ScriptCommand
+import org.rundeck.core.execution.ScriptFileCommand
 import spock.lang.Specification
 
 /**
@@ -201,7 +202,7 @@ class NodeStepPluginAdapterSpec extends Specification {
         def item = new TestExecItem(
                 type: 'atype',
                 stepConfiguration: inputconfig,
-                nodeStepType: ScriptCommand.SCRIPT_COMMAND_TYPE,
+                nodeStepType: nodeStepType,
                 label: 'a label'
         )
         when:
@@ -214,8 +215,10 @@ class NodeStepPluginAdapterSpec extends Specification {
         where:
 
         inputconfig = [a: 'b', c: '${option.c}', d: 'something "xyz${option.p}qws"']
-        data | expect
-        [:] | [a: 'b', c: '${option.c}', d: 'something "xyz${option.p}qws"']
+        data | expect                                                        | nodeStepType
+        [:] | [a: 'b', c: '${option.c}', d: 'something "xyz${option.p}qws"'] | ScriptCommand.SCRIPT_COMMAND_TYPE
+        [:] | [a: 'b', c: '${option.c}', d: 'something "xyz${option.p}qws"'] | ScriptFileCommand.SCRIPT_FILE_COMMAND_TYPE
+        [:] | [a: 'b', c: '', d: 'something "xyzqws"']                       | 'someothertype'
     }
 
     def "create config with custom fields"(){

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapterSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapterSpec.groovy
@@ -38,6 +38,7 @@ import com.dtolabs.rundeck.plugins.step.StepPlugin
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.rundeck.core.execution.ScriptCommand
 import spock.lang.Specification
 
 /**
@@ -171,6 +172,50 @@ class NodeStepPluginAdapterSpec extends Specification {
         [c: 'q'] | [a: 'b', c: 'q', d: 'something "xyzqws"']
         [p: 'Q'] | [a: 'b', c: '', d: 'something "xyzQqws"']
         [c: 'Z', p: 'Q'] | [a: 'b', c: 'Z', d: 'something "xyzQqws"']
+    }
+
+    def "Not expand config vars for script plugins"() {
+        given:
+        framework.frameworkServices = Mock(IFrameworkServices)
+        def optionContext = new BaseDataContext([option: data])
+        def shared = SharedDataContextUtils.sharedContext()
+        shared.merge(ContextView.global(), optionContext)
+        StepExecutionContext context = Mock(StepExecutionContext) {
+            getFramework() >> framework
+            getDataContext() >> optionContext
+            getSharedDataContext() >> shared
+            getFrameworkProject() >> PROJECT_NAME
+        }
+        def node = new NodeEntryImpl('node')
+        def plugin = Mock(NodeStepPlugin)
+        def wrap = new TestPlugin(
+                impl: plugin,
+                description: DescriptionBuilder.builder()
+                        .name('nodetype')
+                        .property(PropertyBuilder.builder().string('a').build())
+                        .property(PropertyBuilder.builder().string('c').build())
+                        .property(PropertyBuilder.builder().string('d').build())
+                        .build()
+        )
+        def adapter = new NodeStepPluginAdapter(wrap)
+        def item = new TestExecItem(
+                type: 'atype',
+                stepConfiguration: inputconfig,
+                nodeStepType: ScriptCommand.SCRIPT_COMMAND_TYPE,
+                label: 'a label'
+        )
+        when:
+        def result = adapter.executeNodeStep(context, item, node)
+
+        then:
+        1 * plugin.executeNodeStep(!null as PluginStepContext, expect, node)
+        result.isSuccess()
+
+        where:
+
+        inputconfig = [a: 'b', c: '${option.c}', d: 'something "xyz${option.p}qws"']
+        data | expect
+        [:] | [a: 'b', c: '${option.c}', d: 'something "xyz${option.p}qws"']
     }
 
     def "create config with custom fields"(){

--- a/plugins/script-node-step-plugin/src/main/groovy/org/rundeck/plugin/scriptnodestep/ScriptNodeStepPlugin.groovy
+++ b/plugins/script-node-step-plugin/src/main/groovy/org/rundeck/plugin/scriptnodestep/ScriptNodeStepPlugin.groovy
@@ -21,8 +21,8 @@ class ScriptNodeStepPlugin extends ScriptProxyRunner implements NodeStepPlugin, 
     public static final String PROVIDER_NAME = "script-node-step-plugin";
 
     @PluginProperty(
-            title = "Enter the entire script to execute",
-            description = "",
+            title = "Script",
+            description = "Enter the entire script to execute",
             required = true
     )
     @RenderingOptions(


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Script inline plugin should use `@` to define data reference to be replace by data.

**Describe the solution you've implemented**
The script input should not be handled by NodeStepPluginAdapter, so it will skip this for script plugin types and let the plugins to handle it 