### PR TITLE
RCLOUD-1118: Project and Storage usage of unique value for fetch

### DIFF
--- a/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/storage/StorageDataProvider.java
+++ b/rundeck-data-model/src/main/java/org/rundeck/app/data/providers/v1/storage/StorageDataProvider.java
@@ -1,13 +1,11 @@
 package org.rundeck.app.data.providers.v1.storage;
 
-import org.rundeck.app.data.model.v1.page.Pageable;
 import org.rundeck.app.data.model.v1.storage.RundeckStorage;
 import org.rundeck.app.data.providers.v1.DataProvider;
 import org.rundeck.spi.data.DataAccessException;
 import org.rundeck.storage.api.Path;
 
 import java.io.Serializable;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -39,18 +37,18 @@ public interface StorageDataProvider extends DataProvider {
      *
      * @param metadata RundeckStorage metadata
      * @param data RundeckStorage attributes
-     * @param id id
+     * @param storage RundeckStorage base data
      * @throws DataAccessException on error
      */
-    void update(final Serializable id, final RundeckStorage data, Map<String, String> metadata) throws DataAccessException;
+    void update(final RundeckStorage storage, final RundeckStorage data, Map<String, String> metadata) throws DataAccessException;
 
     /**
      * Removes a RundeckStorage
      *
-     * @param id of the RundeckStorage
+     * @param storage RundeckStorage data
      * @throws DataAccessException on error
      */
-    void delete(final Serializable id) throws DataAccessException;
+    void delete(final RundeckStorage storage) throws DataAccessException;
 
     /**
      * Finds a RundeckStorage based on namespace, directory and name
@@ -75,9 +73,7 @@ public interface StorageDataProvider extends DataProvider {
      * Checks if a Rundeck Storage exists with a given path, namespace, name and directory
      *
      * @param ns, namespace
-     * @param path
-     * @param name
-     * @param dir
+     * @param path Path for storage
      * @return true if a RundeckStorage exists, otherwise false
      */
     boolean hasPath(final String ns, final Path path);
@@ -86,7 +82,7 @@ public interface StorageDataProvider extends DataProvider {
      * Checks if a Rundeck Storage exists in a given directory path
      *
      * @param ns, namespace
-     * @param path
+     * @param path Path for storage
      * @return true if a RundeckStorage exists, otherwise false
      */
     boolean hasDirectory(final String ns, final Path path);
@@ -95,7 +91,7 @@ public interface StorageDataProvider extends DataProvider {
      * Finds all RundeckStorages in a directory
      *
      * @param ns, namespace
-     * @param path
+     * @param path Path for storage
      * @return List of RundeckStorages
      */
     List<RundeckStorage> listDirectory(String ns, Path path);
@@ -104,7 +100,7 @@ public interface StorageDataProvider extends DataProvider {
      * Finds all RundeckStorages in a directory subdirectories
      *
      * @param ns, namespace
-     * @param path
+     * @param path Path for storage
      * @return List of RundeckStorages
      */
     List<RundeckStorage> listDirectorySubdirs(final String ns, final Path path);

--- a/rundeckapp/grails-app/services/rundeck/services/DbStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/DbStorageService.groovy
@@ -213,7 +213,7 @@ class DbStorageService implements NamespacedStorage{
         if (!storage1) {
             throw StorageException.deleteException(path, "Not found")
         }
-        storageDataProvider.delete(storage1.getId())
+        storageDataProvider.delete(storage1)
         return true
     }
 
@@ -238,7 +238,7 @@ class DbStorageService implements NamespacedStorage{
     protected RundeckStorage saveStorage(RundeckStorage storage, ResourceMeta content,String namespace, Path path, String event) {
         def id = storage?.id
         def retry = true
-        RundeckStorage saved=null;
+        RundeckStorage saved=null
         def data = content.getInputStream().bytes
         def saveStorage={
             try {
@@ -254,7 +254,7 @@ class DbStorageService implements NamespacedStorage{
                 storageBuilder.setData( data)
                 try {
                     if (id) {
-                        storageDataProvider.update(id, storageBuilder, content.meta)
+                        storageDataProvider.update(storage, storageBuilder, content.meta)
 
                     } else {
                         id = storageDataProvider.create(storageBuilder)
@@ -269,7 +269,7 @@ class DbStorageService implements NamespacedStorage{
                 }
 
                 retry = false
-                return true;
+                return true
             } catch (org.springframework.dao.ConcurrencyFailureException e) {
                 if (!retry) {
                     throw new StorageException("Failed to save content at path ${path}: content was modified", e,
@@ -280,7 +280,7 @@ class DbStorageService implements NamespacedStorage{
                     Thread.sleep(1000)
                 }
             }
-            return false;
+            return false
         }
         try{
             if(!saveStorage()){

--- a/rundeckapp/grails-app/services/rundeck/services/data/StorageDataService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/data/StorageDataService.groovy
@@ -8,6 +8,7 @@ interface StorageDataService {
     Storage get(Serializable id)
     void delete(Serializable id)
     Storage save(Storage storage)
+    Storage findByNamespaceAndDirAndName(String namespace, String dir, String name)
     List<Storage> findAllByNamespaceAndDir(String namespace, String dir, Map args)
 
 }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormProjectDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormProjectDataProvider.groovy
@@ -51,7 +51,7 @@ class GormProjectDataProvider implements RundeckProjectDataProvider {
 
     @Override
     void update(final Serializable id, final RdProject data) throws DataAccessException {
-        def project = projectDataService.get(id)
+        def project = projectDataService.getByName(data.name)
         if (!project) {
             throw new DataAccessException("Not found: project with ID: ${id}")
         }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/storage/GormStorageDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/storage/GormStorageDataProvider.groovy
@@ -32,68 +32,71 @@ class GormStorageDataProvider implements StorageDataProvider {
 
     @Override
     Long create(RundeckStorage data) throws DataAccessException {
-
-        def parent = PathUtil.parentPath(data.getPath())
-        String dir = parent?parent.path:''
-        String name = data.getPath().name
-        Storage s = new Storage(namespace: data.getNamespace(),
-                                name: name,
-                                dir: dir,
-                                data: data.getData())
-        s.setStorageMeta(data.getStorageMeta())
-        try {
-            if (storageDataService.save(s)) {
-                return s.getId()
-            } else {
-                log.warn(s.errors.allErrors.collect { messageSource.getMessage(it, null) }.join(","))
-                throw new DataAccessException(s.errors.allErrors.collect { messageSource.getMessage(it, null) }.join(","))
+        Storage.withTransaction {
+            def parent = PathUtil.parentPath(data.getPath())
+            String dir = parent ? parent.path : ''
+            String name = data.getPath().name
+            Storage s = new Storage(namespace: data.getNamespace(),
+                    name: name,
+                    dir: dir,
+                    data: data.getData())
+            s.setStorageMeta(data.getStorageMeta())
+            try {
+                if (storageDataService.save(s)) {
+                    return s.getId()
+                } else {
+                    log.warn(s.errors.allErrors.collect { messageSource.getMessage(it, null) }.join(","))
+                    throw new DataAccessException(s.errors.allErrors.collect { messageSource.getMessage(it, null) }.join(","))
+                }
+            } catch (Exception e) {
+                throw new DataAccessException("Failed to create storage: ${name}: ${e}", e)
             }
-        } catch (Exception e) {
-            throw new DataAccessException("Failed to create storage: ${name}: ${e}", e)
         }
     }
 
     @Override
     void update(final RundeckStorage source, final RundeckStorage data, Map<String, String> metadata) throws DataAccessException {
-        def sourceParent = PathUtil.parentPath(source.getPath())
-        String sourceDir = sourceParent?sourceParent.path:''
-        String sourceName = source.getPath().name
-        Storage storage = storageDataService.findByNamespaceAndDirAndName(source.namespace, sourceDir, sourceName)
-        if (!storage) {
-            throw new DataAccessException("Not found: storage with ID: ${source.id}")
-        }
-        def parent = PathUtil.parentPath(data.getPath())
-        String dir = parent?parent.path:''
-        String name = data.getPath().name
-        Map<String, String> existingMeta = storage.storageMeta?:[:]
-        storage.storageMeta = existingMeta + metadata
-
-        storage.namespace = data.getNamespace()
-        storage.name = name
-        storage.dir = dir
-        storage.data= data.getData()
-        storage.lastUpdated = new Date()
-
-         try {
-             storage.save(flush: true)
-        } catch (Exception e) {
-            throw new DataAccessException("Error: could not update project ${source.id}: ${e}", e)
+        Storage.withTransaction {
+            def sourceParent = PathUtil.parentPath(source.getPath())
+            String sourceDir = sourceParent ? sourceParent.path : ''
+            String sourceName = source.getPath().name
+            Storage storage = storageDataService.findByNamespaceAndDirAndName(source.namespace, sourceDir, sourceName)
+            if (!storage) {
+                throw new DataAccessException("Not found: storage with ID: ${source.id}")
+            }
+            def parent = PathUtil.parentPath(data.getPath())
+            String dir = parent ? parent.path : ''
+            String name = data.getPath().name
+            Map<String, String> existingMeta = storage.storageMeta ?: [:]
+            storage.storageMeta = existingMeta + metadata
+            storage.namespace = data.getNamespace()
+            storage.name = name
+            storage.dir = dir
+            storage.data = data.getData()
+            storage.lastUpdated = new Date()
+            try {
+                storage.save(flush: true)
+            } catch (Exception e) {
+                throw new DataAccessException("Error: could not update project ${source.id}: ${e}", e)
+            }
         }
     }
 
     @Override
     void delete(final RundeckStorage source) throws DataAccessException {
-        def sourceParent = PathUtil.parentPath(source.getPath())
-        String sourceDir = sourceParent?sourceParent.path:''
-        String sourceName = source.getPath().name
-        def storage = storageDataService.findByNamespaceAndDirAndName(source.namespace, sourceDir, sourceName)
-        if (!storage) {
-            throw new DataAccessException("Not found: storage with ID: ${source.id}")
-        }
-        try {
-            storage.delete(flush:true)
-         } catch (Exception e) {
-            throw new DataAccessException("Could not delete storage ${source.id}: ${e}", e)
+        Storage.withTransaction {
+            def sourceParent = PathUtil.parentPath(source.getPath())
+            String sourceDir = sourceParent ? sourceParent.path : ''
+            String sourceName = source.getPath().name
+            def storage = storageDataService.findByNamespaceAndDirAndName(source.namespace, sourceDir, sourceName)
+            if (!storage) {
+                throw new DataAccessException("Not found: storage with ID: ${source.id}")
+            }
+            try {
+                storage.delete(flush: true)
+            } catch (Exception e) {
+                throw new DataAccessException("Could not delete storage ${source.id}: ${e}", e)
+            }
         }
     }
     List<RundeckStorage> findAllByNamespaceAndDir(String namespace, String path) {

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/storage/GormStorageDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/storage/GormStorageDataProvider.groovy
@@ -121,7 +121,7 @@ class GormStorageDataProvider implements StorageDataProvider {
             cache(false)
         }
         found?.refresh()
-        found as RundeckStorage
+        found
     }
 
     @Override

--- a/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormStorageDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormStorageDataProviderSpec.groovy
@@ -66,14 +66,14 @@ class GormStorageDataProviderSpec extends Specification implements DataTest{
                                         .build()
 
         Long storageId = provider.create(data)
-
+        def storage = provider.getData(storageId)
         def oldStorageName = provider.getData(storageId).path.name
         SimpleStorageBuilder updateData =  SimpleStorageBuilder.builder()
                 .data('def'.bytes)
                 .path(PathUtil.asPath("updated"))
                 .namespace("changed")
                 .build()
-        provider.update(storageId, updateData, [def: 'abc'])
+        provider.update(storage, updateData, [def: 'abc'])
         def storage1 = provider.getData(storageId)
 
         then:
@@ -89,7 +89,7 @@ class GormStorageDataProviderSpec extends Specification implements DataTest{
         def storage = new Storage(data: 'abc1'.bytes, name: 'abc', dir: '', storageMeta: [abc: 'xyz1']).save(flush:true)
         new Storage(data: 'abc2'.bytes, name: 'abc', dir: 'xyz', storageMeta: [abc: 'xyz2']).save(flush:true)
 
-        provider.delete(storage.id)
+        provider.delete(storage)
         def store1 = Storage.findByNamespaceAndDirAndName(null,'', 'abc')
         then:
         store1 == null
@@ -109,6 +109,7 @@ class GormStorageDataProviderSpec extends Specification implements DataTest{
         def res1 = provider.listDirectorySubdirs(null, PathUtil.asPath(''))
         then:
         res1.size() == 5
+        res1.contains(storage1)
     }
 
     def "list Directory"() {
@@ -126,5 +127,6 @@ class GormStorageDataProviderSpec extends Specification implements DataTest{
         res1.size() == 0
         res2 != null
         res2.size() == 4
+        res2.contains(storage1)
     }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Enhancement. 
As we moved away from the gorm implementation, a way to fetch project and storage withouth the id is needed. 
There is also a need to create transactions when writing to the database
**Describe the solution you've implemented**
For project `name` is a unique value, for storage is a combination of `namespace`, `dir` and `name`. So every use of `id` was changed for the entire entity so we have flexiblity for fetching.
`withTransaction` blocks where added when writing to the database