### PR TITLE
RSE-926: Fix: Active Connection Required, StackOverflow false upload error (s3) on LogFileStorage Service

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/logging/StorageFile.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/logging/StorageFile.java
@@ -47,4 +47,11 @@ public interface StorageFile {
      * @return true if the file is complete
      */
     boolean isComplete();
+
+    /**
+     * @return true if the file is available for streaming
+     */
+    default boolean storageFileExists(){
+        return true;
+    }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/logging/StorageFileTest.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/logging/StorageFileTest.groovy
@@ -1,0 +1,43 @@
+package com.dtolabs.rundeck.core.logging
+
+import spock.lang.Specification
+
+class StorageFileTest extends Specification {
+    def "storage file exists always true by default"() {
+        given:
+        StorageFile storageFileNoDefaultMethodImplemented = new StorageFileImplExmpl()
+
+        when:
+        Boolean storageFileExists = storageFileNoDefaultMethodImplemented.storageFileExists()
+
+        then:
+        storageFileExists == true
+    }
+
+    class StorageFileImplExmpl implements StorageFile{
+        @Override
+        String getFiletype() {
+            return null
+        }
+
+        @Override
+        InputStream getInputStream() {
+            return null
+        }
+
+        @Override
+        long getLength() {
+            return 0
+        }
+
+        @Override
+        Date getLastModified() {
+            return null
+        }
+
+        @Override
+        boolean isComplete() {
+            return false
+        }
+    }
+}

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -765,19 +765,21 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
             g.refreshFormTokensHeader()
 
             logFileStorageService.resumeIncompleteLogStorageAsync(frameworkService.serverUUID,id)
-//            logFileStorageService.resumeCancelledLogStorageAsync(frameworkService.serverUUID)
             def message="Resumed log storage requests"
-            LogFileStorageRequest req=null
+
+            LinkedHashMap<String, Object> requestMap = null
             if(id){
-                req=LogFileStorageRequest.get(id)
+                LogFileStorageRequest req=LogFileStorageRequest.get(id)
+                requestMap = exportRequestMap(req, true, false, null)
             }
+
             withFormat{
                 ajax{
                     render(contentType: 'application/json'){
                         status 'ok'
                         delegate.message message
-                        if(req){
-                            contents exportRequestMap(req, true, false, null)
+                        if(requestMap){
+                            contents requestMap
                         }
                     }
                 }

--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -79,7 +79,6 @@ import java.util.function.Supplier
  * "storageRequests" blocking queue for storage requests
  * "retrievalRequests" blocking queue for retrieval requests
  */
-@Transactional
 class LogFileStorageService
         implements
                 InitializingBean,
@@ -435,20 +434,22 @@ class LogFileStorageService
 
             def files=[:]
             log.debug("Partial: Storage request [ID#${task.id}]: for types: $typelist")
-            Execution execution = Execution.get(execId)
+            Execution.withNewSession {
+                Execution execution = Execution.get(execId)
 
-            files = getExecutionFiles(execution, typelist, true)
-            try {
-                def (didsucceed, failuremap) = storeLogFiles(typelist, task.storage, task.id, files, true)
-                success = didsucceed
-                if(success){
-                    log.debug("Partial: Storage request [ID#${task.id}]: succeeded")
-                }else{
-                    log.debug("Failure: Partial: Storage request [ID#${task.id}]: ${failuremap}")
+                files = getExecutionFiles(execution, typelist, true)
+                try {
+                    def (didsucceed, failuremap) = storeLogFiles(typelist, task.storage, task.id, files, true)
+                    success = didsucceed
+                    if (success) {
+                        log.debug("Partial: Storage request [ID#${task.id}]: succeeded")
+                    } else {
+                        log.debug("Failure: Partial: Storage request [ID#${task.id}]: ${failuremap}")
+                    }
+                } catch (IOException | ExecutionFileStorageException e) {
+                    success = false
+                    log.error("Failure: Partial: Storage request [ID#${task.id}]: ${e.message}", e)
                 }
-            } catch (IOException | ExecutionFileStorageException e) {
-                success = false
-                log.error("Failure: Partial: Storage request [ID#${task.id}]: ${e.message}", e)
             }
             return
         }
@@ -866,28 +867,30 @@ class LogFileStorageService
         log.debug("dequeueIncompleteLogStorage, processing ${taskId}")
         Long invalidId
         String serverUuid
-        LogFileStorageRequestData request = logFileStorageRequestProvider.get(taskId)
-        Execution e = Execution.get(request.executionId)
-        if (!frameworkService.existsFrameworkProject(e.project)) {
-            log.error(
-                "cannot re-queue incomplete log storage request for execution ${e.id}, project does not exist: " + e.project
-            )
-            invalidId = request.id
-            serverUuid = e.serverNodeUUID
-            return
-        }
-        log.debug("re-queueing incomplete log storage request for execution ${e.id}")
-        def plugin = getConfiguredPluginForExecution(e, frameworkService.getFrameworkPropertyResolverFactory(e.project))
-        if (null != plugin && pluginSupportsStorage(plugin)) {
-            //re-queue storage request immediately, pass -1 to skip counter increment
-            storeLogFileAsync(e.id.toString() + ":" + request.filetype, plugin, request, -1)
-        } else {
-            log.error(
-                    "cannot re-queue incomplete log storage request for execution ${e.id}, plugin was not available: ${getConfiguredPluginName()}"
-            )
-        }
-        if (invalidId != null) {
-            cleanupIncompleteLogStorage(serverUuid, invalidId)
+        Execution.withNewSession {
+            LogFileStorageRequestData request = logFileStorageRequestProvider.get(taskId)
+            Execution e = Execution.get(request.executionId)
+            if (!frameworkService.existsFrameworkProject(e.project)) {
+                log.error(
+                        "cannot re-queue incomplete log storage request for execution ${e.id}, project does not exist: " + e.project
+                )
+                invalidId = request.id
+                serverUuid = e.serverNodeUUID
+                return
+            }
+            log.debug("re-queueing incomplete log storage request for execution ${e.id}")
+            def plugin = getConfiguredPluginForExecution(e, frameworkService.getFrameworkPropertyResolverFactory(e.project))
+            if (null != plugin && pluginSupportsStorage(plugin)) {
+                //re-queue storage request immediately, pass -1 to skip counter increment
+                storeLogFileAsync(e.id.toString() + ":" + request.filetype, plugin, request, -1)
+            } else {
+                log.error(
+                        "cannot re-queue incomplete log storage request for execution ${e.id}, plugin was not available: ${getConfiguredPluginName()}"
+                )
+            }
+            if (invalidId != null) {
+                cleanupIncompleteLogStorage(serverUuid, invalidId)
+            }
         }
     }
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/logging/MultiFileStorageRequestImpl.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/logging/MultiFileStorageRequestImpl.groovy
@@ -73,4 +73,9 @@ class StorageFileImpl implements StorageFile {
     Date getLastModified() {
         new Date(file.lastModified())
     }
+
+    @Override
+    boolean storageFileExists() {
+        return file.exists()
+    }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/logging/StorageFileImplTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/logging/StorageFileImplTest.groovy
@@ -1,0 +1,25 @@
+package rundeck.services.logging
+
+import com.dtolabs.rundeck.core.logging.StorageFile
+import spock.lang.Specification
+
+class StorageFileImplTest extends Specification {
+    def "should return false if storage file is not present in FS"() {
+        given:
+        StorageFile storageFile = new StorageFileImpl()
+        storageFile.file = Mock(File){
+            exists() >> fileExistsInFs
+        }
+
+        when:
+        Boolean storageFileExists = storageFile.storageFileExists()
+
+        then:
+        storageFileExists == fileExistsInFs
+
+        where:
+        fileExistsInFs | _
+                  true | _
+                 false | _
+    }
+}


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-926

#### Problem:
When the server is under high load, some log storage requests can fail and if they reach the maximum store attempts, the following error is thrown:
`Exception in thread "LogFileStorageTask695" java.lang.IllegalArgumentException: Active Connection is required`

And even if clicking on re-queue buttons through GUI, the maximum of attempts is reached and the storage requests that initially failed keeps failing over and over 

Customers receive lots of messages like this due to [an internal issue with the grails-data-mapping library](https://github.com/grails/grails-data-mapping/issues/1234), which handles the DomainObject.withNewSession calls (which are used for managing the requests). 

Besides this, when the user clicks on a `requeue` button for a specific storage request, the server requeues the storage request and after that, it tries to build the response `json` content using a `request` object instead of a `serializable`, resulting `500` error on the browser and a `StackOverflow` error on the server.

#### Expected Outcome:
The server should not throw this `Active Connection is Required` error and the server should recover the failed log storage requests when the user clicks on the `requeue` or `requeue all` button on the Log Storage page.

#### Proposed Solution:

* This issue Active Connection is required can be avoided by just removing the `@Transactional` annotation and use `DomainObject.withNewSession` where needed in the `LogFileStorageService` (`dequeueIncompleteLogStorage` and `runStorageRequest` methods). This was taken from suggested changes by @sjrd218 on [this PR](https://github.com/rundeck/rundeck/pull/8519).

* Some log storage requests may fail because the local file doesn’t exist on the file system but was successfully stored in the remote storage, after this, when request is retried it fails because it tries to upload a not existing file. This is fixed by first checking if the file exists on the FS and the log stored in the remote storage for complete file logs.

* For the `StackOverflow` error the solution is to call the `exportRequestMap(storageRequest)` outside the contents closure, providing it with a previously calculated `serializable` object.