### PR TITLE
 CircleCI: Removes dependency on ECR for docker image management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,11 +259,6 @@ jobs:
       - run-build-step:
           step-name: Verify Build
           command: rundeck_verify_build
-#      - run-build-step:
-#          step-name: Build Testdeck docker image
-#          command: |
-#            testdeck_build_rdtest
-#            testdeck_push_rdtest
       - persist_to_workspace:
           root: ~/workspace
           paths:
@@ -274,8 +269,6 @@ jobs:
             - grails-*/build
             - rundeck-storage/rundeck-*/build
             - rundeck-authz/rundeck-*/build
-      #            - rundeckapp/grails-spa/packages/ui-trellis/build
-      #            - rundeckapp/grails-spa/packages/ui-trellis/node_modules
       - run-build-step:
           step-name: Collect Artifacts
           command: collect_build_artifacts
@@ -477,7 +470,7 @@ jobs:
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
-          step-name: Build images
+          step-name: Build test images
           command: testdeck_build_rdtest
       - run-build-step:
           step-name: Run Test
@@ -505,7 +498,7 @@ jobs:
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
-          step-name: Pull images
+          step-name: Build test images
           command: testdeck_build_rdtest
       - run-build-step:
           step-name: Run Test
@@ -542,7 +535,7 @@ jobs:
           at: ~/workspace
       - run-build-step:
           step-name: Pull Rundeck Image
-          command: testdeck_pull_rundeck
+          command: rundeck_pull_image
       - run-build-step:
           step-name: Test
           command: |
@@ -582,7 +575,7 @@ jobs:
           at: ~/workspace
       - run-build-step:
           step-name: Pull images
-          command: testdeck_pull_rundeck
+          command: rundeck_pull_image
       - run-build-step:
           step-name: Runs gradle test task << parameters.gradle-task >>
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,11 +259,11 @@ jobs:
       - run-build-step:
           step-name: Verify Build
           command: rundeck_verify_build
-      - run-build-step:
-          step-name: Build Testdeck docker image
-          command: |
-            testdeck_build_rdtest
-            testdeck_push_rdtest
+#      - run-build-step:
+#          step-name: Build Testdeck docker image
+#          command: |
+#            testdeck_build_rdtest
+#            testdeck_push_rdtest
       - persist_to_workspace:
           root: ~/workspace
           paths:
@@ -389,38 +389,6 @@ jobs:
           step-name: Publish to Sonatype
           command: packaging_publish_maven
 
-  test-gradle-functional:
-    <<: *job-defaults
-    executor:
-      name: machine-builder
-      docker_layer_caching: true
-      resource_class: medium
-    parameters:
-      test-image:
-        description: Test image tag
-        default: "rundeck/testdeck"
-        type: string
-      gradle-task:
-        type: string
-    steps:
-      - checkout
-      - install-build-dependencies
-      - restore-build-cache
-      - attach_workspace:
-          at: ~/workspace
-      - run-build-step:
-          step-name: Pull images
-          command: testdeck_pull_rundeck
-      - run-build-step:
-          step-name: Runs gradle test task << parameters.gradle-task >>
-          command: |
-            TEST_IMAGE=<< parameters.test-image >>
-            GRADLE_TASK=<< parameters.gradle-task >>
-            rundeck_gradle_functional_tests
-      - collect-gradle-tests
-      - store_artifacts:
-          path: ~/workspace/functional-test/build/test-results/images
-
   # Publish all packages to packagecloud
   packaging-publish:
     <<: *job-defaults
@@ -509,8 +477,8 @@ jobs:
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
-          step-name: Pull images
-          command: testdeck_pull_rdtest
+          step-name: Build images
+          command: testdeck_build_rdtest
       - run-build-step:
           step-name: Run Test
           command: << parameters.command >>
@@ -538,7 +506,7 @@ jobs:
           at: ~/workspace
       - run-build-step:
           step-name: Pull images
-          command: testdeck_pull_rdtest
+          command: testdeck_build_rdtest
       - run-build-step:
           step-name: Run Test
           command: << parameters.command >>
@@ -592,6 +560,39 @@ jobs:
           destination: images
       - store_test_results:
           path: << parameters.workdir >>/test_out
+
+  test-gradle-functional:
+    <<: *job-defaults
+    executor:
+      name: machine-builder
+      docker_layer_caching: true
+      resource_class: medium
+    parameters:
+      test-image:
+        description: Test image tag
+        default: "rundeck/testdeck"
+        type: string
+      gradle-task:
+        type: string
+    steps:
+      - checkout
+      - install-build-dependencies
+      - restore-build-cache
+      - attach_workspace:
+          at: ~/workspace
+      - run-build-step:
+          step-name: Pull images
+          command: testdeck_pull_rundeck
+      - run-build-step:
+          step-name: Runs gradle test task << parameters.gradle-task >>
+          command: |
+            TEST_IMAGE=<< parameters.test-image >>
+            GRADLE_TASK=<< parameters.gradle-task >>
+            rundeck_gradle_functional_tests
+      - collect-gradle-tests
+      - store_artifacts:
+          path: ~/workspace/functional-test/build/test-results/images
+
 
 
 #### WORKFLOWS ####

--- a/scripts/circleci/build-functions.sh
+++ b/scripts/circleci/build-functions.sh
@@ -20,7 +20,7 @@ rundeck_docker_build() {
     #Build image
     ./gradlew ${GRADLE_BASE_OPTS} officialBuild -Penvironment=${ENV} -PdockerRepository=${DOCKER_REPO} -PdockerTags=latest,SNAPSHOT
 
-    docker tag "${DOCKER_REPO}:latest" "${ECR_REPO}:${ECR_IMAGE_TAG}"
+    docker tag "${DOCKER_REPO}:latest" "${DOCKER_CI_REPO}:${DOCKER_IMAGE_BUILD_TAG}"
 
     # CircleCI tag builds do not have a branch set
     if [[ -n "${RUNDECK_BRANCH_CLEAN}" ]]; then
@@ -31,9 +31,9 @@ rundeck_docker_build() {
 }
 
 rundeck_docker_push() {
-    docker_ecr_login
+    docker_login
 
-    docker push "${ECR_REPO}:${ECR_IMAGE_TAG}"
+    docker push "${DOCKER_CI_REPO}:${DOCKER_IMAGE_BUILD_TAG}"
 
     # CircleCI tag builds do not have a branch set
     if [[ -n "${RUNDECK_BRANCH_CLEAN}" ]]; then

--- a/scripts/circleci/local-overrides.sh
+++ b/scripts/circleci/local-overrides.sh
@@ -18,11 +18,6 @@ testdeck_pull_rdtest() {
 
 }
 
-testdeck_pull_rundeck() {
-    echo "!!! [testdeck_pull_rdtest] ran but OVERRIDEN locally !!!"
-    docker tag "${ECR_REPO}:${ECR_IMAGE_TAG}" rundeck/testdeck
-}
-
 
 fetch_ci_shared_resources() {
     echo "!!! [fetch_ci_shared_resources] ran but OVERRIDEN locally !!!"

--- a/scripts/circleci/setup.sh
+++ b/scripts/circleci/setup.sh
@@ -38,6 +38,7 @@ export DOCKER_PASSWORD=${DOCKER_PASSWORD:-}
 # DockerHub
 export DOCKER_REPO=${DOCKER_REPO:-"rundeck/rundeck"}
 export DOCKER_CI_REPO=${DOCKER_CI_REPO:-"rundeck/ci"}
+export DOCKER_IMAGE_BUILD_TAG=ci-build-${RUNDECK_BUILD_NUMBER}
 
 # Set Twistlock env and map with Circle ENV.
 export TWISTLOCK_USER=${TWISTLOCK_USER:-${TL_USER:-}}
@@ -45,11 +46,6 @@ export TWISTLOCK_PASSWORD=${TWISTLOCK_PASSWORD:-${TL_PASS:-}}
 export TWISTLOCK_CONSOLE_URL=${TWISTLOCK_CONSOLE_URL:-${TL_CONSOLE_URL:-}}
 
 # AWS Config
-export ECR_REGISTRY=481311893001.dkr.ecr.us-west-2.amazonaws.com
-export ECR_REPO=${ECR_REGISTRY}/rundeck/rundeck
-export ECR_TEST_REPO=${ECR_REGISTRY}/rundeck/rdtest
-export ECR_IMAGE_PREFIX=${ECR_IMAGE_PREFIX:-"circle"}
-export ECR_IMAGE_TAG=${ECR_IMAGE_PREFIX}-build-${RUNDECK_BUILD_NUMBER}
 export S3_CI_SHARED_RESOURCES="s3://rundeck-ci-resources/shared/resources"
 
 # Import functions

--- a/scripts/circleci/testdeck-functions.sh
+++ b/scripts/circleci/testdeck-functions.sh
@@ -14,23 +14,23 @@ testdeck_build_rdtest() {
         build_rdtest_docker
     )
 
-    docker tag rdtest:latest "${ECR_TEST_REPO}:${ECR_IMAGE_TAG}"
+#    docker tag rdtest:latest "${ECR_TEST_REPO}:${ECR_IMAGE_TAG}"
 
 }
 
-testdeck_push_rdtest() {
+#testdeck_push_rdtest() {
+#
+#    # Tag and push to be used as cache source in later test builds
+#    docker_ecr_login
+#    docker push "${ECR_TEST_REPO}:${ECR_IMAGE_TAG}"
+#
+#}
 
-    # Tag and push to be used as cache source in later test builds
-    docker_ecr_login
-    docker push "${ECR_TEST_REPO}:${ECR_IMAGE_TAG}"
-
-}
-
-testdeck_pull_rdtest() {
-   docker_ecr_login
-   docker pull "${ECR_TEST_REPO}:${ECR_IMAGE_TAG}"
-   docker tag "${ECR_TEST_REPO}:${ECR_IMAGE_TAG}" rdtest:latest
-}
+#testdeck_pull_rdtest() {
+#   docker_ecr_login
+#   docker pull "${ECR_TEST_REPO}:${ECR_IMAGE_TAG}"
+#   docker tag "${ECR_TEST_REPO}:${ECR_IMAGE_TAG}" rdtest:latest
+#}
 
 
 testdeck_pull_rundeck() {

--- a/scripts/circleci/testdeck-functions.sh
+++ b/scripts/circleci/testdeck-functions.sh
@@ -14,30 +14,6 @@ testdeck_build_rdtest() {
         build_rdtest_docker
     )
 
-#    docker tag rdtest:latest "${ECR_TEST_REPO}:${ECR_IMAGE_TAG}"
-
-}
-
-#testdeck_push_rdtest() {
-#
-#    # Tag and push to be used as cache source in later test builds
-#    docker_ecr_login
-#    docker push "${ECR_TEST_REPO}:${ECR_IMAGE_TAG}"
-#
-#}
-
-#testdeck_pull_rdtest() {
-#   docker_ecr_login
-#   docker pull "${ECR_TEST_REPO}:${ECR_IMAGE_TAG}"
-#   docker tag "${ECR_TEST_REPO}:${ECR_IMAGE_TAG}" rdtest:latest
-#}
-
-
-testdeck_pull_rundeck() {
-    docker_ecr_login
-
-    docker pull "${ECR_REPO}:${ECR_IMAGE_TAG}"
-    docker tag "${ECR_REPO}:${ECR_IMAGE_TAG}" rundeck/testdeck
 }
 
 testdeck_selenium_test() {


### PR DESCRIPTION
Changes docker images management to not use ecr anymore and rely only on the images already published to dockerhub.