### PR TITLE
Remove tomcat tests from circleci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -685,16 +685,6 @@ workflows:
           command: bash test/run-docker-tests.sh
           <<: *require-build
           <<: *slack-defaults
-      - test-docker:
-          name: Tomcat 8 API Test
-          command: bash test/run-docker-tomcat-tests.sh 8-jdk11
-          <<: *require-build
-          <<: *slack-defaults
-      - test-docker:
-          name: Tomcat 9 API Test
-          command: bash test/run-docker-tomcat-tests.sh 9-jdk11
-          <<: *require-build
-          <<: *slack-defaults
       - test-machine:
           name: API Test
           command: DOCKER_COMPOSE_SPEC=docker-compose-api-mysql.yaml bash test/run-docker-api-tests.sh
@@ -744,17 +734,5 @@ workflows:
       - test-gradle-functional:
           name: New API Test
           gradle-task: apiTest
-          <<: *require-build
-          <<: *slack-defaults
-      - test-gradle-functional:
-          name: New API Test Tomcat 8
-          test-image: 8-jdk11
-          gradle-task: tomcatTest
-          <<: *require-build
-          <<: *slack-defaults
-      - test-gradle-functional:
-          name: New API Test Tomcat 9
-          test-image: 9-jdk11
-          gradle-task: tomcatTest
           <<: *require-build
           <<: *slack-defaults


### PR DESCRIPTION
Remove tomcat tests as is not longer supported since 5.0