### PR TITLE
RSE-952: Fix: Cluster not retrying execution on another node when owner shutdown

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
@@ -25,6 +25,7 @@ import org.rundeck.app.config.SysConfigProp
 import org.rundeck.util.Sizes
 import org.springframework.beans.factory.InitializingBean
 
+import javax.annotation.PreDestroy
 import java.util.concurrent.TimeUnit
 
 @GrailsCompileStatic
@@ -56,6 +57,11 @@ class ConfigurationService implements InitializingBean, ConfigService {
 
     void setExecutionModeActive(boolean active) {
         executionModeActiveValue = active
+    }
+
+    @PreDestroy
+    void forceInactive(){
+        this.executionModeActive = false
     }
 
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
@@ -19,14 +19,12 @@ package rundeck.services
 import com.dtolabs.rundeck.core.config.RundeckConfigBase
 import grails.compiler.GrailsCompileStatic
 import grails.core.GrailsApplication
-import grails.events.annotation.Subscriber
 import groovy.transform.CompileDynamic
 import org.rundeck.app.config.ConfigService
 import org.rundeck.app.config.SysConfigProp
 import org.rundeck.util.Sizes
 import org.springframework.beans.factory.InitializingBean
 
-import javax.annotation.PreDestroy
 import java.util.concurrent.TimeUnit
 
 @GrailsCompileStatic

--- a/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ConfigurationService.groovy
@@ -19,6 +19,7 @@ package rundeck.services
 import com.dtolabs.rundeck.core.config.RundeckConfigBase
 import grails.compiler.GrailsCompileStatic
 import grails.core.GrailsApplication
+import grails.events.annotation.Subscriber
 import groovy.transform.CompileDynamic
 import org.rundeck.app.config.ConfigService
 import org.rundeck.app.config.SysConfigProp
@@ -57,11 +58,6 @@ class ConfigurationService implements InitializingBean, ConfigService {
 
     void setExecutionModeActive(boolean active) {
         executionModeActiveValue = active
-    }
-
-    @PreDestroy
-    void forceInactive(){
-        this.executionModeActive = false
     }
 
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -227,7 +227,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
     @PreDestroy
     void cleanUp() {
-        configurationService.setExecutionModeActive(false)
+        //configurationService.setExecutionModeActive(false)
         applicationIsShutdown = true;
     }
 

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -227,6 +227,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
     @PreDestroy
     void cleanUp() {
+        configurationService.setExecutionModeActive(false)
         applicationIsShutdown = true;
     }
 

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -228,14 +228,12 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
     @PreDestroy
     void cleanUp() {
-        log.trace("Prev destroy!!!!")
-        configurationService.setExecutionModeActive(false)
         applicationIsShutdown = true;
     }
 
     @Subscriber("rdpro.shutdown")
     void forceInactive(){
-        log.trace("rdpro.shutdown - forceInactive!!!!")
+        log.debug("Enterprise Shutdown Received")
         configurationService.setExecutionModeActive(false)
     }
 
@@ -2265,10 +2263,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         if (!rundeckAuthContextProcessor.authorizeProjectJobAll(authContext, scheduledExecution, [AuthConstants.ACTION_RUN],
                 scheduledExecution.project)) {
             return [success: false, error: 'unauthorized', message: "Unauthorized: Execute Job ${scheduledExecution.extid}"]
-        }
-
-        if(!getExecutionsAreActive()){
-            return [success:false,failed:true,error:'disabled',message:lookupMessage('disabled.execution.run',null)]
         }
 
         if(!scheduledExecutionService.isProjectExecutionEnabled(scheduledExecution.project)){

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -228,11 +228,14 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
     @PreDestroy
     void cleanUp() {
+        log.trace("Prev destroy!!!!")
+        configurationService.setExecutionModeActive(false)
         applicationIsShutdown = true;
     }
 
     @Subscriber("rdpro.shutdown")
     void forceInactive(){
+        log.trace("rdpro.shutdown - forceInactive!!!!")
         configurationService.setExecutionModeActive(false)
     }
 
@@ -2299,6 +2302,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             }
 
             def timeout = 0
+            log.trace("retryExecuteJob: about to schedule new execution retry: ${e.toMap()}")
             def eid = scheduledExecutionService.scheduleTempJob(
                     scheduledExecution,
                     user,
@@ -3133,9 +3137,13 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     loglevel     : execution.loglevel,
                     filter       : execution.filter //TODO: failed nodes?
                 ]
+
+                log.trace(":::::::::saveExecutionState_currentTransaction: About to retry execute job (${scheduledExecution.getJobName()}): ${execution.toMap()}")
                 def result = retryExecuteJob(scheduledExecution, retryContext.authContext,
                                              retryContext.user, input, retryContext.secureOpts,
                                              retryContext.secureOptsExposed, count + 1,execution.id,originalId)
+
+                log.trace("saveExecutionState_currentTransaction: retry execute job (${scheduledExecution.getJobName()} - id: ${execution.id}) result status: ${result}")
                 if (result.success) {
                     execution.retryExecution = result.execution
                 }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -63,6 +63,7 @@ import com.dtolabs.rundeck.plugins.jobs.JobPreExecutionEventImpl
 import com.dtolabs.rundeck.plugins.logging.LogFilterPlugin
 import grails.events.EventPublisher
 import grails.events.annotation.Publisher
+import grails.events.annotation.Subscriber
 import grails.gorm.transactions.NotTransactional
 import grails.gorm.transactions.Transactional
 import grails.web.mapping.LinkGenerator
@@ -227,8 +228,12 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
     @PreDestroy
     void cleanUp() {
-        //configurationService.setExecutionModeActive(false)
         applicationIsShutdown = true;
+    }
+
+    @Subscriber("rdpro.shutdown")
+    void forceInactive(){
+        configurationService.setExecutionModeActive(false)
     }
 
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2296,7 +2296,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             }
 
             def timeout = 0
-            log.trace("retryExecuteJob: about to schedule new execution retry: ${e.toMap()}")
             def eid = scheduledExecutionService.scheduleTempJob(
                     scheduledExecution,
                     user,
@@ -3131,8 +3130,6 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                     loglevel     : execution.loglevel,
                     filter       : execution.filter //TODO: failed nodes?
                 ]
-
-                log.trace(":::::::::saveExecutionState_currentTransaction: About to retry execute job (${scheduledExecution.getJobName()}): ${execution.toMap()}")
                 def result = retryExecuteJob(scheduledExecution, retryContext.authContext,
                                              retryContext.user, input, retryContext.secureOpts,
                                              retryContext.secureOptsExposed, count + 1,execution.id,originalId)

--- a/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobSchedulerService.groovy
@@ -142,6 +142,8 @@ class QuartzJobScheduleManagerService implements JobScheduleManager, Initializin
     Date scheduleJob(final String quartzJobName, final String quartzJobGroup, final Map data, final Date atTime, final boolean pending)
             throws JobScheduleFailure
     {
+        interruptScheduleOnPassiveMode()
+
         data.put('meta.created', Instant.now())
 
         String triggerGroup = pending ? TRIGGER_GROUP_PENDING : quartzJobGroup
@@ -170,6 +172,8 @@ class QuartzJobScheduleManagerService implements JobScheduleManager, Initializin
 
     @Override
     boolean scheduleJobNow(final String quartzJobName, final String quartzJobGroup, final Map data, final boolean pending) throws JobScheduleFailure {
+        interruptScheduleOnPassiveMode()
+
         data.put('meta.created', Instant.now())
 
         String triggerGroup = pending ? TRIGGER_GROUP_PENDING : quartzJobGroup
@@ -284,5 +288,10 @@ class QuartzJobScheduleManagerService implements JobScheduleManager, Initializin
         def ident = scheduledExecutionService.getJobIdent(execution.scheduledExecution, execution)
 
         reschedulePendingJob(ident.jobname, ident.groupname)
+    }
+
+    private void interruptScheduleOnPassiveMode() throws JobScheduleFailure{
+        if(!frameworkService.configurationService.isExecutionModeActive())
+            throw new JobScheduleFailure("Execution mode is PASSIVE")
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/QuartzJobScheduleManagerServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/QuartzJobScheduleManagerServiceSpec.groovy
@@ -1,24 +1,42 @@
 package rundeck.services
 
 import com.dtolabs.rundeck.core.schedule.JobScheduleFailure
-import com.dtolabs.rundeck.core.schedule.JobScheduleManager
 import grails.testing.services.ServiceUnitTest
 import org.grails.spring.beans.factory.InstanceFactoryBean
+import org.quartz.JobKey
 import org.quartz.Scheduler
-import org.quartz.core.QuartzScheduler
 import rundeck.data.quartz.QuartzJobSpecifier
+import rundeck.quartzjobs.ExecutionJob
 import spock.lang.Specification
 
 class QuartzJobScheduleManagerServiceSpec extends Specification implements ServiceUnitTest<QuartzJobScheduleManagerService> {
-    def "interrupt schedule job NOW if executions are disabled"(){
+    def "interrupt schedule job NOW if execution mode is PASSIVE"(){
+        given:
+        defineBeans{
+            quartzScheduler(InstanceFactoryBean, Mock(Scheduler))
+            frameworkService(InstanceFactoryBean, Mock(FrameworkService){
+                configurationService >> Mock(ConfigurationService){
+                    isExecutionModeActive() >> false
+                }
+            })
+        }
         when:
         service.scheduleJobNow('a', 'b', [:], true)
         then:
         JobScheduleFailure e = thrown(JobScheduleFailure)
         e.getMessage() == 'Execution mode is PASSIVE'
-
     }
-    def "interrupt schedule job if executions are disabled"(){
+
+    def "interrupt schedule job if execution mode is PASSIVE"(){
+        given:
+        defineBeans{
+            quartzScheduler(InstanceFactoryBean, Mock(Scheduler))
+            frameworkService(InstanceFactoryBean, Mock(FrameworkService){
+                configurationService >> Mock(ConfigurationService){
+                    isExecutionModeActive() >> false
+                }
+            })
+        }
         when:
         service.scheduleJob('a', 'b', [:], new Date(), true)
         then:
@@ -26,18 +44,55 @@ class QuartzJobScheduleManagerServiceSpec extends Specification implements Servi
         e.getMessage() == 'Execution mode is PASSIVE'
     }
 
-    def setup(){
-        defineBeans {
+    def "schedule job NOW if execution mode is ACTIVE"(){
+        given:
+        defineBeans{
             quartzScheduler(InstanceFactoryBean, Mock(Scheduler))
             frameworkService(InstanceFactoryBean, Mock(FrameworkService){
                 configurationService >> Mock(ConfigurationService){
-                    isExecutionModeActive() >> false
+                    isExecutionModeActive() >> true
                 }
             })
-            scheduledExecutionService(InstanceFactoryBean, Mock(ScheduledExecutionService))
-            quartzJobSpecifier(InstanceFactoryBean, Mock(QuartzJobSpecifier))
         }
+        when:
+        service.scheduleJobNow('a', 'b', [:], true)
+        then:
+        notThrown(JobScheduleFailure)
+        1 * service.quartzScheduler.scheduleJob(_,_)
     }
 
+    def "schedule job if execution mode is ACTIVE"(){
+        given:
+        JobKey jobKey = new JobKey('a', 'b')
+        defineBeans{
+            quartzScheduler(InstanceFactoryBean, Mock(Scheduler){
+                checkExists(jobKey) >> scheduleExists
+            })
+            frameworkService(InstanceFactoryBean, Mock(FrameworkService){
+                configurationService >> Mock(ConfigurationService){
+                    isExecutionModeActive() >> true
+                }
+            })
+        }
+        when:
+        service.scheduleJob(jobKey.getName(), jobKey.getGroup(), [:], new Date(), true)
+        then:
+        notThrown(JobScheduleFailure)
+        scheduleJobCalls * service.quartzScheduler.scheduleJob(_,_)
+        rescheduleJobCalls * service.quartzScheduler.rescheduleJob(_,_)
 
+        where:
+        scheduleExists | rescheduleJobCalls | scheduleJobCalls
+        true           | 1                  | 0
+        false          | 0                  | 1
+    }
+
+    def setup(){
+        defineBeans {
+            scheduledExecutionService(InstanceFactoryBean, Mock(ScheduledExecutionService))
+            quartzJobSpecifier(InstanceFactoryBean, Mock(QuartzJobSpecifier){
+                getJobClass() >> ExecutionJob
+            })
+        }
+    }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/QuartzJobScheduleManagerServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/QuartzJobScheduleManagerServiceSpec.groovy
@@ -1,0 +1,43 @@
+package rundeck.services
+
+import com.dtolabs.rundeck.core.schedule.JobScheduleFailure
+import com.dtolabs.rundeck.core.schedule.JobScheduleManager
+import grails.testing.services.ServiceUnitTest
+import org.grails.spring.beans.factory.InstanceFactoryBean
+import org.quartz.Scheduler
+import org.quartz.core.QuartzScheduler
+import rundeck.data.quartz.QuartzJobSpecifier
+import spock.lang.Specification
+
+class QuartzJobScheduleManagerServiceSpec extends Specification implements ServiceUnitTest<QuartzJobScheduleManagerService> {
+    def "interrupt schedule job NOW if executions are disabled"(){
+        when:
+        service.scheduleJobNow('a', 'b', [:], true)
+        then:
+        JobScheduleFailure e = thrown(JobScheduleFailure)
+        e.getMessage() == 'Execution mode is PASSIVE'
+
+    }
+    def "interrupt schedule job if executions are disabled"(){
+        when:
+        service.scheduleJob('a', 'b', [:], new Date(), true)
+        then:
+        JobScheduleFailure e = thrown(JobScheduleFailure)
+        e.getMessage() == 'Execution mode is PASSIVE'
+    }
+
+    def setup(){
+        defineBeans {
+            quartzScheduler(InstanceFactoryBean, Mock(Scheduler))
+            frameworkService(InstanceFactoryBean, Mock(FrameworkService){
+                configurationService >> Mock(ConfigurationService){
+                    isExecutionModeActive() >> false
+                }
+            })
+            scheduledExecutionService(InstanceFactoryBean, Mock(ScheduledExecutionService))
+            quartzJobSpecifier(InstanceFactoryBean, Mock(QuartzJobSpecifier))
+        }
+    }
+
+
+}


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-952

**Problem:**
When the cluster member that is running an execution is shutdown, the execution is not being retried on any other cluster member (it is retried in the killed one, getting stuck in running state indefinitely) whereas in 4.8, the execution is retried on another cluster member.

**Expected Outcome:**
The running execution in the stopped cluster member gets retried on any other cluster member.

**Proposed Solution:**

Detect the application shutdown subscribing to `rdpro.shutdown` signal annotation to then force the `ConfigurationService` to toggle the execution mode in the current server so that it's not possible to choose it on any further reschedule operation during the shutdown process.

In order to make this work we must move the execution mode validation from `ExecutionService.retryExecuteJob` to the corresponding `JobSchedulerManager` (which is the one that finally schedules the execution):

* ProjobScheduleManager

* QuartzJobScheduleManagerService

_**Not Covered Case**_
In case the job is run through a runner, the execution is still not recovered. A different bug ticket was created to track that specific case.

### Additional Context (current workflow)

When a cluster member is killed during an execution, the execution is interrupted and after saving its state it is rescheduled again following the configured remote execution policy.