### PR TITLE
RUN-36: Fix loading storage plugins to load plugin group settings

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/storage/StorageTreeFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/storage/StorageTreeFactory.java
@@ -343,7 +343,7 @@ public class StorageTreeFactory {
         ConfiguredPlugin<T> configured = getPluginRegistry().retainConfigurePluginByName(
                 pluginType,
                 service,
-                PropertyResolverFactory.createResolver(
+                PropertyResolverFactory.pluginPrefixedScoped(
                         PropertyResolverFactory.instanceRetriever(config),
                         null,
                         getPropertyLookup()


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Plugin group settings isn't loaded for storage plugins

**Describe the solution you've implemented**
Changed property resolver on storage tree factory to get framework property using the correct property prefix
