### PR TITLE
RSE-941: Unexpected Default Value Field for Options

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/jobs/JobCreatePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/jobs/JobCreatePage.groovy
@@ -55,6 +55,8 @@ class JobCreatePage extends BasePage {
     By formValidationAlertBy = By.cssSelector('#page_job_edit > div.list-group-item > div.alert.alert-danger')
     By sessionSectionBy = By.xpath("//div[contains(@class, 'opt_sec_nexp_disabled')]")
     By secureInputTypeBy = By.xpath("//input[contains(@value, 'secureExposed')]")
+    By storagePathInput = By.name("defaultStoragePath")
+    By defaultValueInput = By.id("opt_defaultValue")
     By optionOpenKeyStorageBy = By.cssSelector(".btn.btn-default.obs-select-storage-path")
     By optionCloseKeyStorageBy = By.xpath("//button[@class='btn btn-sm btn-default']")
     By optionUndoBy = By.xpath("//*[@id='optundoredo']/div/span[1]")
@@ -311,6 +313,14 @@ class JobCreatePage extends BasePage {
 
     WebElement getSecureInputTypeRadio() {
         el secureInputTypeBy
+    }
+
+    WebElement getStoragePathInput(){
+        el storagePathInput
+    }
+
+    WebElement getDefaultValueInput(){
+        el defaultValueInput
     }
 
     WebElement getOptionOpenKeyStorageButton() {

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/jobs/JobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/jobs/JobsSpec.groovy
@@ -245,6 +245,25 @@ class JobsSpec extends SeleniumBase {
             jobCreatePage.createJobButton.click()
     }
 
+    def "No default value field shown in secure job option section"() {
+        when:
+        def jobCreatePage = go JobCreatePage, SELENIUM_BASIC_PROJECT
+        then:
+        jobCreatePage.fillBasicJob 'a job with option secure'
+        jobCreatePage.optionButton.click()
+        jobCreatePage.optionName 0 sendKeys 'seleniumOption1'
+        jobCreatePage.waitForElementVisible jobCreatePage.separatorOption
+        jobCreatePage.sessionSectionLabel.isDisplayed()
+        jobCreatePage.secureInputTypeRadio.click()
+        jobCreatePage.storagePathInput.sendKeys("test")
+        jobCreatePage.secureInputTypeRadio.click()
+        jobCreatePage.storagePathInput.clear()
+        jobCreatePage.secureInputTypeRadio.click()
+
+        expect:
+        !jobCreatePage.defaultValueInput.isDisplayed()
+    }
+
     def "job option revert all"() {
         when:
             def jobCreatePage = go JobCreatePage, SELENIUM_BASIC_PROJECT

--- a/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
@@ -268,7 +268,6 @@ form.option.valuesType.url.authType.bearerToken.label
                     <wdgt:action targetSelector="#opt_defaultValue" clear="true"/>
                 </wdgt:eventHandler>
                 <wdgt:eventHandler for="defaultStoragePath_${storagePathKey}" state="empty" inline="true" oneway="true" frequency="2" >
-                    <wdgt:action targetSelector=".opt_keystorage_disabled" visible="true"/>
                     <wdgt:action targetSelector=".opt_keystorage_enabled" visible="false"/>
                 </wdgt:eventHandler>
             </div>


### PR DESCRIPTION
# RSE-941: Unexpected Default Value Field for Options
There is a wrong “Default Value“ field appearing in the job option section of job definition UI, when user write something in the “Storage“ input value and the remove it:
![image](https://github.com/rundeck/rundeck/assets/81827734/344dccdc-35fa-420b-914e-e1b7385c4078)

## Expected Outcome:
The “Default Value“ input must not be rendered if the secure option is selected.

## Proposed Solution:

In file “rundeckpro/rundeck/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp“, aprox line: 270 there is an event handler that yields the behavior of the bug:

```groovy
<wdgt:eventHandler for="defaultStoragePath_${storagePathKey}" state="empty" inline="true" oneway="true" frequency="2" >
    <wdgt:action targetSelector=".opt_keystorage_disabled" visible="true"/> <-------- THIS LINE
    <wdgt:action targetSelector=".opt_keystorage_enabled" visible="false"/>
</wdgt:eventHandler>
```

One hypothesis is that this line, was mistakenly leaved there, so removing it will solve the issue.
