### PR TITLE
RSE-937: Fix replace token for command plugin

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapter.java
@@ -40,6 +40,7 @@ import com.dtolabs.rundeck.plugins.step.NodeStepPlugin;
 import com.dtolabs.rundeck.plugins.step.PluginStepContext;
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder;
 import org.rundeck.app.spi.Services;
+import org.rundeck.core.execution.ExecCommand;
 import org.rundeck.core.execution.ScriptCommand;
 import org.rundeck.core.execution.ScriptFileCommand;
 import org.slf4j.Logger;
@@ -202,7 +203,7 @@ public class NodeStepPluginAdapter implements NodeStepExecutor, Describable, Dyn
         }
         if (null != instanceConfiguration) {
             CustomFieldsAdapter customFieldsAdapter = CustomFieldsAdapter.create(description);
-            if(!Arrays.asList(ScriptFileCommand.SCRIPT_FILE_COMMAND_TYPE, ScriptCommand.SCRIPT_COMMAND_TYPE).contains((item.getNodeStepType()))) //Those types are handled by its plugins
+            if(!Arrays.asList(ScriptFileCommand.SCRIPT_FILE_COMMAND_TYPE, ScriptCommand.SCRIPT_COMMAND_TYPE, ExecCommand.EXEC_COMMAND_TYPE).contains((item.getNodeStepType()))) //Those types are handled by its plugins
             {
                 instanceConfiguration = SharedDataContextUtils.replaceDataReferences(
                         instanceConfiguration,

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapterSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepPluginAdapterSpec.groovy
@@ -38,6 +38,7 @@ import com.dtolabs.rundeck.plugins.step.StepPlugin
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.rundeck.core.execution.ExecCommand
 import org.rundeck.core.execution.ScriptCommand
 import org.rundeck.core.execution.ScriptFileCommand
 import spock.lang.Specification
@@ -218,6 +219,7 @@ class NodeStepPluginAdapterSpec extends Specification {
         data | expect                                                        | nodeStepType
         [:] | [a: 'b', c: '${option.c}', d: 'something "xyz${option.p}qws"'] | ScriptCommand.SCRIPT_COMMAND_TYPE
         [:] | [a: 'b', c: '${option.c}', d: 'something "xyz${option.p}qws"'] | ScriptFileCommand.SCRIPT_FILE_COMMAND_TYPE
+        [:] | [a: 'b', c: '${option.c}', d: 'something "xyz${option.p}qws"'] | ExecCommand.EXEC_COMMAND_TYPE
         [:] | [a: 'b', c: '', d: 'something "xyzqws"']                       | 'someothertype'
     }
 

--- a/plugins/script-node-step-plugin/src/main/groovy/org/rundeck/plugin/scriptnodestep/CommandNodeStepPlugin.groovy
+++ b/plugins/script-node-step-plugin/src/main/groovy/org/rundeck/plugin/scriptnodestep/CommandNodeStepPlugin.groovy
@@ -1,6 +1,8 @@
 package org.rundeck.plugin.scriptnodestep
 
 import com.dtolabs.rundeck.core.common.INodeEntry
+import com.dtolabs.rundeck.core.data.SharedDataContextUtils
+import com.dtolabs.rundeck.core.dispatcher.ContextView
 import com.dtolabs.rundeck.core.dispatcher.DataContextUtils
 import com.dtolabs.rundeck.core.execution.ExecArgList
 import com.dtolabs.rundeck.core.plugins.PluginException
@@ -29,11 +31,23 @@ class CommandNodeStepPlugin extends ScriptProxyRunner implements NodeStepPlugin,
     void executeNodeStep(PluginStepContext context, Map<String, Object> configuration, INodeEntry entry) throws NodeStepException {
         boolean featureQuotingBackwardCompatible = Boolean.valueOf(context.getExecutionContext().getIFramework()
                 .getPropertyRetriever().getProperty("rundeck.feature.quoting.backwardCompatible"));
+
         def arr = OptsUtil.burst(adhocRemoteString)
+
+        def result = SharedDataContextUtils.replaceDataReferencesInObject(
+                arr,
+                ContextView.node(entry.getNodename()),
+                ContextView::nodeStep,
+                null,
+                context.getExecutionContext().getSharedDataContext(),
+                false,
+                true
+        ) as String[]
+
         NodeExecutorResult nodeExecutorResult =  context.getFramework().getExecutionService().executeCommand(
                 context.getExecutionContext(),
                 ExecArgList.fromStrings(featureQuotingBackwardCompatible, DataContextUtils
-                .stringContainsPropertyReferencePredicate, arr),
+                .stringContainsPropertyReferencePredicate, result),
                 entry
         );
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
The replacement of tokens is occurring before the plugin is executed considering each word of an option as a separate argument

**Describe the solution you've implemented**
The fix make the replacement only in the command plugin so it can consider each word of an option as the same argument

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
