### PR TITLE
RUN-2126: Bug/fix behavior when remotevalues reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 *.iml
 /db/
 /lib/
-/bin/
+**/*/bin/
 **/node_modules
 **/build
 **/*/build

--- a/rundeckapp/grails-app/assets/javascripts/menu/joboptions.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/joboptions.js
@@ -195,37 +195,18 @@ function Option(data) {
         if (self.hasRemote()) {
             //when remote values are loaded, set the multivalue entries with them
             self.remoteValues.subscribe(function (newval) {
-                var temp = [];
-                if(!self.enforced()) {
-                    //preserve the editable values
-                    temp = ko.utils.arrayFilter(self.multiValueList(),function (val) {
-                        return val.editable();
-                    });
-                }
+                var new_values = [];
+
                 ko.utils.arrayForEach(newval, function (val) {
-                    var selected = testselected(val.value());
-                    var hasselected = self.selectedMultiValues() && self.selectedMultiValues().length > 0;
-                    var found = ko.utils.arrayFirst(self.multiValueList(),function (oval) {
-                        return oval.value()==val.value() && oval.editable();
-                    });
-                    if(found){
-                        found.label(val.label());
-                        found.editable(false);
-                        found.selected(true);
-                        temp.push(found);
-                    }else {
-                        temp.push(self.createMultivalueEntry({
-                            label: val.label(),
-                            value: val.value(),
-                            selected: selected || (!hasselected && val.selected()),
-                            editable: false,
-                            multival: true
-                        }));
-                    }
+                    new_values.push(self.createMultivalueEntry({
+                        label: val.label(),
+                        value: val.value(),
+                        selected: testselected(val.value()) || val.selected(),
+                        editable: false,
+                        multival: true
+                    }));
                 });
-                var multiselected=self.selectedMultiValues();
-                self.multiValueList(temp);
-                addExtraSelected(multiselected);
+                self.multiValueList(new_values);
             });
         } else {
             addExtraSelected(self.selectedMultiValues());


### PR DESCRIPTION
I messed up this one: [https://github.com/rundeck/rundeck/pull/8657](https://github.com/rundeck/rundeck/pull/8657)
So here we go again.
------

Is this a bugfix, or an enhancement? Please describe.
Bugfix: https://github.com/rundeck/rundeck/issues/8587

Describe the solution you've implemented
cleanup if(remote()) function in jobOptions.
It now only showes the values loaded remote to not mixup values from previous remote calls

Describe alternatives you've considered
fix doublication check, but this would not fix the behavior that there are values from an old call.

Additional context
I dont wanted to push the 3000 files from the **/bin folders.

