### PR TITLE
RSE-954 Fix: Wrong Value Used as Secure Option

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/jobs/JobEditPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/jobs/JobEditPage.groovy
@@ -1,0 +1,55 @@
+package org.rundeck.tests.functional.selenium.pages.jobs
+
+import groovy.transform.CompileStatic
+import org.openqa.selenium.By
+import org.openqa.selenium.WebElement
+import org.rundeck.tests.functional.selenium.pages.BasePage
+import org.rundeck.util.container.SeleniumContext
+
+/**
+ * Job upload page
+ */
+@CompileStatic
+class JobEditPage extends BasePage {
+
+    private static final String secureOptionSelectors = 'optdetail opt-detail-ext autohilite autoedit'
+    private static final String secureOptionDefaultValueId = 'opt_defaultValue'
+    private static final String secureOptionDefaultValueHelpSelector = 'help-block'
+
+    String loadPath
+    By workflowTab = By.cssSelector('#job_edit_tabs > li > a[href=\'#tab_workflow\']')
+    By secureOptionSpan = By.xpath("//span[@class='${secureOptionSelectors}']")
+    By defaultValueInput = By.id(secureOptionDefaultValueId)
+    By secureOptionDefaultValueHelpDiv = By.xpath("//span[@class='${secureOptionDefaultValueHelpSelector}']")
+
+    JobEditPage(final SeleniumContext context) {
+        super(context)
+    }
+
+    void loadPathToEditByUuid(String projectName, String jobUuid) {
+        loadPath = "/project/${projectName}/job/edit/${jobUuid}"
+    }
+
+    void validatePage() {
+        if (!driver.currentUrl.contains(loadPath)) {
+            throw new IllegalStateException("Not on job edit page: " + driver.currentUrl)
+        }
+    }
+
+    WebElement workflowTabElement(){
+        el workflowTab
+    }
+
+    WebElement secureOptionSpanElement(){
+        el secureOptionSpan
+    }
+
+    WebElement defaultValueInputElement(){
+        el defaultValueInput
+    }
+
+    WebElement secureOptionDefaultValueHelpElement(){
+        el secureOptionDefaultValueHelpDiv
+    }
+
+}

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/jobs/JobEditPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/jobs/JobEditPage.groovy
@@ -7,7 +7,7 @@ import org.rundeck.tests.functional.selenium.pages.BasePage
 import org.rundeck.util.container.SeleniumContext
 
 /**
- * Job upload page
+ * Job edit page
  */
 @CompileStatic
 class JobEditPage extends BasePage {

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/jobs/JobUploadPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/jobs/JobUploadPage.groovy
@@ -1,0 +1,50 @@
+package org.rundeck.tests.functional.selenium.pages.jobs
+
+import groovy.transform.CompileStatic
+import org.openqa.selenium.By
+import org.openqa.selenium.WebElement
+import org.rundeck.tests.functional.selenium.pages.BasePage
+import org.rundeck.util.container.SeleniumContext
+
+/**
+ * Job upload page
+ */
+@CompileStatic
+class JobUploadPage extends BasePage {
+
+    private static final String fileInputName = "xmlBatch"
+    private static final String formUploadButtonId = "uploadFormUpload"
+    private static final String jobUploadInfoSelectors = 'alert alert-info'
+
+    String loadPath
+    By fileInput = By.name(fileInputName)
+    By formUploadButton = By.id(formUploadButtonId)
+    By jobUploadInfoDiv = By.xpath("//div[@class='${jobUploadInfoSelectors}']")
+
+    JobUploadPage(final SeleniumContext context) {
+        super(context)
+    }
+
+    void loadPathToUploadPage(String projectName) {
+        loadPath = "/project/${projectName}/job/upload"
+    }
+
+    void validatePage() {
+        if (!driver.currentUrl.contains(loadPath)) {
+            throw new IllegalStateException("Not on job upload page: " + driver.currentUrl)
+        }
+    }
+
+    WebElement fileInputElement(){
+        el fileInput
+    }
+
+    WebElement fileUploadButtonElement(){
+        el formUploadButton
+    }
+
+    WebElement jobUploadInfoDivElement(){
+        el jobUploadInfoDiv
+    }
+
+}

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/jobs/JobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/jobs/JobsSpec.groovy
@@ -1,9 +1,11 @@
 package org.rundeck.tests.functional.selenium.tests.jobs
 
 import org.rundeck.tests.functional.selenium.pages.jobs.JobCreatePage
+import org.rundeck.tests.functional.selenium.pages.jobs.JobEditPage
 import org.rundeck.tests.functional.selenium.pages.jobs.JobListPage
 import org.rundeck.tests.functional.selenium.pages.jobs.JobShowPage
 import org.rundeck.tests.functional.selenium.pages.jobs.JobTab
+import org.rundeck.tests.functional.selenium.pages.jobs.JobUploadPage
 import org.rundeck.tests.functional.selenium.pages.jobs.StepType
 import org.rundeck.tests.functional.selenium.pages.login.LoginPage
 import org.rundeck.tests.functional.selenium.pages.profile.UserProfilePage
@@ -262,6 +264,52 @@ class JobsSpec extends SeleniumBase {
 
         expect:
         !jobCreatePage.defaultValueInput.isDisplayed()
+    }
+
+    def "Upload job definition with secure options + default values, get info"() {
+        setup:
+        def uploadJobDefinitionPage = page JobUploadPage
+        uploadJobDefinitionPage.loadPathToUploadPage(SELENIUM_BASIC_PROJECT)
+        def tempYamlText = "- defaultTab: nodes\n  description: ''\n  executionEnabled: true\n  id: c19d5338-770b-493f-8125-bfa4634515bb\n  loglevel: INFO\n  name: test\n  nodeFilterEditable: false\n  options:\n  - name: secure_opt\n    secure: true\n    value: anything\n    valueExposed: true\n  plugins:\n    ExecutionLifecycle: {}\n  scheduleEnabled: true\n  schedules: []\n  sequence:\n    commands:\n    - exec: echo 'asd'\n    keepgoing: false\n    strategy: node-first\n  uuid: c19d5338-770b-493f-8125-bfa4634515bb"
+        def tempFile = File.createTempFile("temp", ".yaml")
+        tempFile.text = tempYamlText
+        tempFile.deleteOnExit()
+
+        when:
+        uploadJobDefinitionPage.go()
+        uploadJobDefinitionPage.fileInputElement().sendKeys(tempFile.getAbsolutePath())
+        uploadJobDefinitionPage.fileUploadButtonElement().click()
+        uploadJobDefinitionPage.waitForElementVisible(uploadJobDefinitionPage.jobUploadInfoDivElement())
+
+        then:
+        uploadJobDefinitionPage.jobUploadInfoDivElement().isDisplayed()
+    }
+
+    def "Upload job definition with secure options + default values, get info"() {
+        setup:
+        def uploadJobDefinitionPage = page JobUploadPage
+        uploadJobDefinitionPage.loadPathToUploadPage(SELENIUM_BASIC_PROJECT)
+
+        def tempYamlText = "- defaultTab: nodes\n  description: ''\n  executionEnabled: true\n  id: c19d5338-770b-493f-8125-bfa4634515bb\n  loglevel: INFO\n  name: test\n  nodeFilterEditable: false\n  options:\n  - name: secure_opt\n    secure: true\n    value: anything\n    valueExposed: true\n  plugins:\n    ExecutionLifecycle: {}\n  scheduleEnabled: true\n  schedules: []\n  sequence:\n    commands:\n    - exec: echo 'asd'\n    keepgoing: false\n    strategy: node-first\n  uuid: c19d5338-770b-493f-8125-bfa4634515bb"
+        def tempFile = File.createTempFile("temp", ".yaml")
+        tempFile.text = tempYamlText
+        tempFile.deleteOnExit()
+
+        def jobEditPage = page JobEditPage
+        jobEditPage.loadPathToEditByUuid(SELENIUM_BASIC_PROJECT, 'c19d5338-770b-493f-8125-bfa4634515bb')
+
+        when:
+        uploadJobDefinitionPage.go()
+        uploadJobDefinitionPage.fileInputElement().sendKeys(tempFile.getAbsolutePath())
+        uploadJobDefinitionPage.fileUploadButtonElement().click()
+        jobEditPage.go()
+        jobEditPage.workflowTabElement().click()
+        jobEditPage.secureOptionSpanElement().click()
+
+        then:
+        jobEditPage.defaultValueInputElement().isDisplayed()
+        jobEditPage.secureOptionDefaultValueHelpElement().isDisplayed()
+
     }
 
     def "job option revert all"() {

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/jobs/JobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/jobs/JobsSpec.groovy
@@ -285,7 +285,7 @@ class JobsSpec extends SeleniumBase {
         uploadJobDefinitionPage.jobUploadInfoDivElement().isDisplayed()
     }
 
-    def "Upload job definition with secure options + default values, get info"() {
+    def "Secure options with default values, hint in the definition form"() {
         setup:
         def uploadJobDefinitionPage = page JobUploadPage
         uploadJobDefinitionPage.loadPathToUploadPage(SELENIUM_BASIC_PROJECT)

--- a/rundeckapp/grails-app/assets/javascripts/optionEditKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/optionEditKO.js
@@ -82,6 +82,9 @@ function OptionEditor(data) {
     self.shouldShowDefaultValue = ko.computed(function(){
         return self.checkForOldSecureOptionsWithDefaultValues() ? self.checkForOldSecureOptionsWithDefaultValues() : JSON.parse(self.showDefaultValue());
     });
+    self.disableIfSecureAndHasDefaultValue = ko.computed(function(){
+        return self.checkForOldSecureOptionsWithDefaultValues();
+    })
     self.shouldShowDefaultStorage = ko.computed(function(){
         return !JSON.parse(self.showDefaultValue());
     });

--- a/rundeckapp/grails-app/assets/javascripts/optionEditKO.js
+++ b/rundeckapp/grails-app/assets/javascripts/optionEditKO.js
@@ -25,6 +25,7 @@ function OptionEditor(data) {
     self.showDefaultValue = ko.observable(data.showDefaultValue);
     self.defaultValue = ko.observable(data.defaultValue);
     self.optionType = ko.observable(data.optionType);
+    self.isSecure = ko.observable(data.isSecure);
     self.name = ko.observable(data.name);
     self.bashVarPrefix= data.bashVarPrefix? data.bashVarPrefix:'';
     self.enforceType = ko.observable(data.enforceType);
@@ -75,8 +76,11 @@ function OptionEditor(data) {
         self.showDefaultValue(showDefaultValueInput);
         return true;
     };
+    self.checkForOldSecureOptionsWithDefaultValues = ko.computed(function(){
+        return self.isSecure() ? JSON.parse(self.isSecure() && self.defaultValue() != null) : false;
+    })
     self.shouldShowDefaultValue = ko.computed(function(){
-        return JSON.parse(self.showDefaultValue());
+        return self.checkForOldSecureOptionsWithDefaultValues() ? self.checkForOldSecureOptionsWithDefaultValues() : JSON.parse(self.showDefaultValue());
     });
     self.shouldShowDefaultStorage = ko.computed(function(){
         return !JSON.parse(self.showDefaultValue());

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -910,6 +910,7 @@ ScheduledExecution.property.description.description=The first line of the descri
   and everything following that will be rendered in a separate tab using [Markdeep](https://casual-effects.com/markdeep).
 ScheduledExecution.property.description.plain.description=The description will be shown in plain text
 Option.property.description.description=The description will be rendered with Markdown.
+Option.secure.deafault.warning=Please replace the default value with a storage path to avoid security issues.
 delete.this.job=Delete this Job
 delete.all.executions.of.this.job=Delete all executions of this Job
 Delete=Delete

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -1314,7 +1314,8 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
                                 null,
                                 [:],
                                 authContext,
-                                validateJobref
+                                validateJobref,
+                                execerrors
                         )
 
                         scheduledExecutionService.issueJobChangeEvents(results.jobChangeEvents)

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -1314,8 +1314,7 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
                                 null,
                                 [:],
                                 authContext,
-                                validateJobref,
-                                execerrors
+                                validateJobref
                         )
 
                         scheduledExecutionService.issueJobChangeEvents(results.jobChangeEvents)

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1850,7 +1850,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         )
     }
     /**
-     * Returns the secure options with default values (deprecated as of version 3.x.x).
+     * Returns the secure options with default values (deprecated as of version 3.4.x).
      *
      * @param importedJob
      * @return list with the names of secure options with default values

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -2757,6 +2757,9 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             EditOptsController._validateOption(origopt, userDataProvider, scheduledExecution, null,null, scheduledExecution.scheduled)
             fileUploadService.validateFileOptConfig(origopt)
 
+            // If a secure option has a default value AND a storage path set, remove the default value.
+            cleanSecureOptionIfHasDefaultValueAndStoragePath(origopt)
+
             if (origopt.errors.hasErrors() || !origopt.validate(deepValidate: false)) {
                 failed = true
                 origopt.discard()
@@ -2772,6 +2775,22 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             }
         }
         return failed
+    }
+
+    /**
+     * Removes the deprecated default value from option if there is a storage path set in the definition
+     * to avoid security issues.
+     *
+     * @param option
+     */
+    @CompileStatic
+    public void cleanSecureOptionIfHasDefaultValueAndStoragePath(Option option){
+        if( option.secureInput ){
+            if( option.defaultValue != null && option.defaultStoragePath != null ){
+                log.info("Overriding old default value of secure input: ${option.name} with storage key.")
+                option.defaultValue = null
+            }
+        }
     }
 
     @CompileStatic

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1850,7 +1850,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         )
     }
     /**
-     * Returns the secure options with default values (deprecated as of version 3.4.x).
+     * Returns the secure options with default values (deprecated as of version 3.4.x) .
      *
      * @param importedJob
      * @return list with the names of secure options with default values

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1850,21 +1850,20 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         )
     }
     /**
-     * Checks if the imported job has secure options with default values (deprecated as of version 3.x.X) and
-     * populates a waring to the user.
+     * Returns the secure options with default values (deprecated as of version 3.x.x).
      *
      * @param importedJob
-     * @return secure options with default values
+     * @return list with the names of secure options with default values
      */
     def getSecureOptionsWithDefaultValues(ImportedJob<ScheduledExecution> importedJob){
         def options = importedJob.job.options
-        def optionsWithSecureOptsAndDefaultValues = new ArrayList<String>()
+        def secureOptionsWithDefaultValues = new ArrayList<Option>()
         options.each { option -> {
             if( option.secureInput && (option.defaultValue != null || !option.defaultValue.isEmpty()) ){
-                optionsWithSecureOptsAndDefaultValues << option.name
+                secureOptionsWithDefaultValues << option
             }
         }}
-        return optionsWithSecureOptsAndDefaultValues
+        return secureOptionsWithDefaultValues
     }
 
     /**
@@ -1941,8 +1940,12 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 scheduledExecution = result.scheduledExecution
                 def secureOptionsWithDefaultValues = getSecureOptionsWithDefaultValues(importedJob)
                 if( secureOptionsWithDefaultValues.size() ){
+                    String optionsNamesInAString = secureOptionsWithDefaultValues.stream()
+                            .map(Option::getName)
+                            .collect(Collectors.joining(", "))
+
                     msgs << "Job: ${jobdata.jobName}, " +
-                            "has secure options: [${String.join(", ", secureOptionsWithDefaultValues)}] set with default values," +
+                            "has secure options: [${optionsNamesInAString}] set with default values," +
                             " please consider overriding this values with a storage key path to avoid security issues."
                 }
                 if (!success) {
@@ -2778,7 +2781,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     }
 
     /**
-     * Removes the deprecated default value from option if there is a storage path set in the definition
+     * Removes the deprecated default value from secure option if there is a storage path set in the definition
      * to avoid security issues.
      *
      * @param option

--- a/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
@@ -219,7 +219,6 @@ form.option.valuesType.url.authType.bearerToken.label
                                    data-bind="value: defaultValue"
                             />
             </div>
-
         </div>
 
         <div class="opt_sec_enabled form-group ${hasErrors(bean: option, field: 'defaultStoragePath', 'has-error')}"
@@ -1022,6 +1021,7 @@ form.option.valuesType.url.authType.bearerToken.label
           var editor=new OptionEditor({name:"${option?.name}",
           bashVarPrefix:'${DataContextUtils.ENV_VAR_PREFIX}',
           optionType:"${option?.optionType}",
+          isSecure: "${option?.secureInput}",
           enforceType:currentEnforceType,
           defaultValue:"${option?.defaultValue}",
           showDefaultValue:"${!option?.secureInput && !option?.isDate}",

--- a/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_optEdit.gsp
@@ -208,16 +208,22 @@ form.option.valuesType.url.authType.bearerToken.label
         <!-- ko if: !isFileType() -->
         <div class="form-group ${hasErrors(bean: option, field: 'defaultValue', 'has-error')} opt_keystorage_disabled"
              data-bind="visible: shouldShowDefaultValue">
-            <label class="col-sm-2 control-label"><g:message code="form.option.defaultValue.label" /></label>
+            <label class="col-sm-2 control-label"><g:message code="form.option.defaultValue.label"/></label>
+
             <div class="col-sm-10">
-                            <input type="text"
-                                   class="form-control"
-                                   name="defaultValue"
-                                   id="opt_defaultValue"
-                                   size="40"
-                                   placeholder="Default value"
-                                   data-bind="value: defaultValue"
-                            />
+                <input type="text"
+                       class="form-control"
+                       name="defaultValue"
+                       id="opt_defaultValue"
+                       size="40"
+                       placeholder="Default value"
+                       data-bind="value: defaultValue, attr: {'disabled' : disableIfSecureAndHasDefaultValue()}"/>
+
+                <div class="help-block" data-bind="visible: disableIfSecureAndHasDefaultValue">
+                    <g:message code="Option.secure.deafault.warning"/>
+                    <i class="glyphicon glyphicon-warning-sign"></i>
+                </a>
+                </div>
             </div>
         </div>
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -5099,6 +5099,24 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
             !job.errors.hasErrors()
     }
 
+    def "Option validation removes the default value from a secure option if the definition has a storage path set"(){
+        given:
+        def opt2 = new Option(
+                name: 'opt2',
+                required: false,
+                description: 'monkey',
+                enforced: false,
+                secureInput: true,
+                defaultValue: "default",
+                defaultStoragePath: "keys/keypath/key.key"
+        )
+        when:
+        service.cleanSecureOptionIfHasDefaultValueAndStoragePath(opt2)
+
+        then:
+        opt2.defaultValue == null
+    }
+
     def "validate definition options should have errors for option"() {
         given:
             def opt2 = new Option(name: 'opt2', required: true, description: 'monkey', enforced: false)

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -2754,7 +2754,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
 
     def "load jobs with secure options that has default values, get a message"(){
         given:
-        def userHint = "Job: testUploadErrorHandlers, has secure options: [secure_opt] set with default values, please consider overriding this values with a storage key path to avoid security issues."
+        def userHint = "Job: testUploadErrorHandlers, has secure options: [secure_opt, secure_opt2] set with default values, please consider overriding this values with a storage key path to avoid security issues."
         setupDoUpdate()
         service.rundeckAuthContextProcessor.authorizeProjectJobAny(_,_,_,_) >> true
         service.fileUploadService = Mock(FileUploadService)
@@ -2769,7 +2769,12 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
                                 name: 'secure_opt',
                                 secureInput: true,
                                 defaultValue: 'default'
-                        )
+                        ),
+                        new Option(
+                                name: 'secure_opt2',
+                                secureInput: true,
+                                defaultValue: 'default'
+                        ),
                 ],
                 workflow: new Workflow(commands: [
                         new CommandExec(adhocExecution: true, adhocRemoteString: "echo test")


### PR DESCRIPTION
# RSE-954 Fix: Wrong Value Used as Secure Option
- When users has a secure option with default value, they cannot get the storage path to override the default value
- They cannot see in the GUI the default value, nor modify it

# The Problem
1. As of 3.4.x users cannot input default values for secure options because the field is hidden.
2. By execution parameter, the option's value has predominance over other values.

# The Solutions
- [x] At job definition's import time, we inform the user about all the secure options with wrong default value and suggest to override it.
![image](https://github.com/rundeck/rundeck/assets/81827734/6eaa7ac6-5604-4315-b2bf-51cb5ee46201)


- [x] In the job's option definition UI, we show the default value as a disabled input, and a small message suggesting to override the default value as well.
![image](https://github.com/rundeck/rundeck/assets/81827734/6f89861f-d32b-4383-9b9b-4d2fba456ede)
- [x] When the user provides a key storage value and update the job, the option validator will remove the default value and the execution services will use the storage value in the future.*

*: To stop and prevent security issues since the default value prints as a plain text string in a exported YAML or XML definition.