### PR TITLE
RUN-2134: Attach change event listener on mount instead of watch

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/AceEditorVue.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/AceEditorVue.vue
@@ -39,7 +39,6 @@ export default defineComponent({
                 // @ts-ignore
                 this.editor!.getSession().setValue(this.resolveValue(val) ,1)
                 this.contentBackup = this.resolveValue(val)
-                this.attachChangeEventToEditor()
             }
         },
         theme: function (newTheme): void {
@@ -88,6 +87,7 @@ export default defineComponent({
         if (this.options)
             editor.setOptions(this.options)
         this.observeDarkMode()
+        this.attachChangeEventToEditor()
     },
     beforeUnmount: function() {
         this.editor!.destroy()


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
AceEditorVue was only adding a change listener in case the initial content wasn't the same as the backupContent (an empty string). This works fine for scenarios where the editor already starts populated, but for readme and message of the day, where there's no content until the first save, this was a problem as the lack of listeners would prevent the content from being properly updated and saved.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Moved the call for adding the event listener from modelValue watcher to the mounted hook.  

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
How to test:
* Create a project
* Navigate to Project Settings, either "Edit README" or "Edit Message of the Day" pages
* Attempt to save a message
