### PR TITLE
RUN-2741: Add LDAP rolePagination config option for docker

### DIFF
--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -24,6 +24,7 @@
         roleMemberAttribute="{{ getv("/rundeck/jaas/ldap/rolememberattribute", "uniqueMember") }}"
         roleObjectClass="{{ getv("/rundeck/jaas/ldap/roleobjectclass", "groupOfUniqueNames") }}"
         rolePrefix="{{ getv("/rundeck/jaas/ldap/roleprefix", "") }}"
+        rolePagination="{{ getv("/rundeck/jaas/ldap/rolepagination", "true") }}"
         cacheDurationMillis="{{ getv("/rundeck/jaas/ldap/cachedurationmillis", "600000") }}"
         reportStatistics="{{ getv("/rundeck/jaas/ldap/reportstatistics", "true") }}"
 {% if exists("/rundeck/jaas/ldap/roleusernamememberattribute") %}


### PR DESCRIPTION
Some LDAP servers don't support pagination in the search queries so that pagination must be disabled to fix `error code 12 - Unavailable Critical Extension` in the LDAP search.

This PR addresses the issue described in #8273 by allowing the user to set the `RUNDECK_JAAS_LDAP_ROLEPAGINATION=false` in the docker based setup if needed.