### PR TITLE
RUN-2155: job output highlight

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutput.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutput.groovy
@@ -72,7 +72,7 @@ class LogViewerOutput extends SeleniumBase{
         jobCreatePage.getTab(JobTab.WORKFLOW).click()
         jobCreatePage.getStepByType(StepName.COMMAND, StepType.NODE).click()
         jobCreatePage.waitForStepToBeShown(By.name("pluginConfig.adhocRemoteString"))
-        jobCreatePage.el(By.name("pluginConfig.adhocRemoteString")).sendKeys("for i in {1..2}; do echo NUMBER \$i; sleep 0.2; done")
+        jobCreatePage.el(By.name("pluginConfig.adhocRemoteString")).sendKeys("for i in {1..60}; do echo NUMBER \$i; sleep 0.2; done")
         jobCreatePage.getSaveStepButton().click()
         jobCreatePage.waitForSavedStep(0)
         jobCreatePage.getCreateButton().click()

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutput.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutput.groovy
@@ -52,4 +52,41 @@ class LogViewerOutput extends SeleniumBase{
 
     }
 
+    def "click on gutter and refresh should highlight correct line"() {
+
+        setup:
+        def loginPage = page LoginPage
+        def sideBar = page SideBarPage
+        def jobListPage = page JobsListPage
+        def jobCreatePage = page JobCreatePage
+        def projectHomePage = page HomePage
+        def jobShowPage = page JobShowPage
+
+        when:
+        loginPage.go()
+        loginPage.login(TEST_USER, TEST_PASS)
+        projectHomePage.goProjectHome("AutoFollowTest")
+        sideBar.goTo(NavLinkTypes.JOBS)
+        jobListPage.getCreateJobLink().click()
+        jobCreatePage.getJobNameField().sendKeys("loop job")
+        jobCreatePage.getTab(JobTab.WORKFLOW).click()
+        jobCreatePage.getStepByType(StepName.COMMAND, StepType.NODE).click()
+        jobCreatePage.waitForStepToBeShown(By.name("pluginConfig.adhocRemoteString"))
+        jobCreatePage.el(By.name("pluginConfig.adhocRemoteString")).sendKeys("for i in {1..2}; do echo NUMBER \$i; sleep 0.2; done")
+        jobCreatePage.getSaveStepButton().click()
+        jobCreatePage.waitForSavedStep(0)
+        jobCreatePage.getCreateButton().click()
+        jobShowPage.getRunJobBtn().click()
+        jobShowPage.getLogOutputBtn().click()
+        jobShowPage.waitForLogOutput(By.xpath("//span[contains(text(),'NUMBER ')]"),3,5)
+        def firstLocation = jobShowPage.el(By.xpath("//span[contains(text(),'NUMBER 1')]")).getLocation()
+        jobShowPage.waitForLogOutput(By.xpath("//span[contains(text(),'NUMBER ')]"),35,40)
+        def finalLocation = jobShowPage.el(By.xpath("//span[contains(text(),'NUMBER 1')]")).getLocation()
+        jobShowPage.el(By.xpath("//span[contains(@class, 'execution-log_gutter-entry')]")).click()
+        driver.navigate().refresh();
+
+        then:
+        def selectedLine = jobShowPage.el(By.xpath("//span[contains(@class, 'execution-log_gutter-entry')]/ancestor::div[3]"))
+        waitForAttributeContains selectedLine, 'class', 'execution-log_gutter-entry--selected'
+    }
 }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutput.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutput.groovy
@@ -84,10 +84,13 @@ class LogViewerOutput extends SeleniumBase{
         lineToClick.click();
         jobShowPage.waitForUrlToContain("#outputL1")
         driver.navigate().refresh();
+//        def href = commandPage.runningButtonLink().getAttribute("href")
+//        jobShowPage.driver.get href + "#outputL1"
+
         jobShowPage.waitForLogOutput(By.xpath("//span[contains(text(),'NUMBER ')]"),3,5)
 
         then:
-        def selectedLine = jobShowPage.waitForElementVisible(By.xpath("//div[contains(@class, 'execution-log_gutter-entry--selected')]"))
+        def selectedLine = jobShowPage.waitForElementVisible(By.xpath("//div[contains(@class, 'execution-log__line--selected')]"))
 
         assert selectedLine != null : "Expected at least one element with the specified class to be present"
     }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutput.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutput.groovy
@@ -72,21 +72,21 @@ class LogViewerOutput extends SeleniumBase{
         jobCreatePage.getTab(JobTab.WORKFLOW).click()
         jobCreatePage.getStepByType(StepName.COMMAND, StepType.NODE).click()
         jobCreatePage.waitForStepToBeShown(By.name("pluginConfig.adhocRemoteString"))
-        jobCreatePage.el(By.name("pluginConfig.adhocRemoteString")).sendKeys("for i in {1..60}; do echo NUMBER \$i; sleep 0.2; done")
+        jobCreatePage.el(By.name("pluginConfig.adhocRemoteString")).sendKeys("for i in {1..6}; do echo NUMBER \$i; sleep 0.5; done")
         jobCreatePage.getSaveStepButton().click()
         jobCreatePage.waitForSavedStep(0)
         jobCreatePage.getCreateButton().click()
         jobShowPage.getRunJobBtn().click()
         jobShowPage.getLogOutputBtn().click()
         jobShowPage.waitForLogOutput(By.xpath("//span[contains(text(),'NUMBER ')]"),3,5)
-        def firstLocation = jobShowPage.el(By.xpath("//span[contains(text(),'NUMBER 1')]")).getLocation()
-        jobShowPage.waitForLogOutput(By.xpath("//span[contains(text(),'NUMBER ')]"),35,40)
-        def finalLocation = jobShowPage.el(By.xpath("//span[contains(text(),'NUMBER 1')]")).getLocation()
-        jobShowPage.el(By.xpath("//span[contains(@class, 'execution-log_gutter-entry')]")).click()
+        def lineToClick = jobShowPage.el(By.xpath("//span[contains(text(),'NUMBER 1')]/ancestor::div[contains(@class, 'execution-log__line')]/div[@class='execution-log__gutter']"))
+
+        lineToClick.click();
+        jobCreatePage.waitForURL("#outputL1")
         driver.navigate().refresh();
 
         then:
-        def selectedLine = jobShowPage.el(By.xpath("//span[contains(@class, 'execution-log_gutter-entry')]/ancestor::div[3]"))
+        def selectedLine = jobShowPage.el(By.xpath("//span[contains(text(),'NUMBER 1')]/ancestor::div[contains(@class, 'execution-log__line')]"))
         selectedLine.getAttribute("class").contains("execution-log_gutter-entry--selected")
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutput.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutput.groovy
@@ -87,6 +87,6 @@ class LogViewerOutput extends SeleniumBase{
 
         then:
         def selectedLine = jobShowPage.el(By.xpath("//span[contains(@class, 'execution-log_gutter-entry')]/ancestor::div[3]"))
-        waitForAttributeContains selectedLine, 'class', 'execution-log_gutter-entry--selected'
+        selectedLine.getAttribute("class").contains("execution-log_gutter-entry--selected")
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutput.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutput.groovy
@@ -84,6 +84,7 @@ class LogViewerOutput extends SeleniumBase{
         lineToClick.click();
         jobShowPage.waitForUrlToContain("#outputL1")
         driver.navigate().refresh();
+        jobShowPage.waitForLogOutput(By.xpath("//span[contains(text(),'NUMBER ')]"),3,5)
 
         then:
         def selectedLine = jobShowPage.waitForElementVisible(By.xpath("//div[contains(@class, 'execution-log_gutter-entry--selected')]"))

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutput.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutput.groovy
@@ -82,11 +82,12 @@ class LogViewerOutput extends SeleniumBase{
         def lineToClick = jobShowPage.el(By.xpath("//span[contains(text(),'NUMBER 1')]/ancestor::div[contains(@class, 'execution-log__line')]/div[@class='execution-log__gutter']"))
 
         lineToClick.click();
-        jobCreatePage.waitForURL("#outputL1")
+        jobShowPage.waitForUrlToContain("#outputL1")
         driver.navigate().refresh();
 
         then:
-        def selectedLine = jobShowPage.el(By.xpath("//span[contains(text(),'NUMBER 1')]/ancestor::div[contains(@class, 'execution-log__line')]"))
-        selectedLine.getAttribute("class").contains("execution-log_gutter-entry--selected")
+        def selectedLine = jobShowPage.waitForElementVisible(By.xpath("//div[contains(@class, 'execution-log_gutter-entry--selected')]"))
+
+        assert selectedLine != null : "Expected at least one element with the specified class to be present"
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/JobCreatePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/JobCreatePage.groovy
@@ -137,9 +137,6 @@ class JobCreatePage extends BasePage {
         new WebDriverWait(driver, Duration.ofSeconds(5)).until(ExpectedConditions.elementToBeClickable(jobAddStepButton))
     }
 
-    void waitForURL(String url){
-        new WebDriverWait(driver, Duration.ofSeconds(5)).until(ExpectedConditions.urlContains(url))
-    }
 }
 
 enum NotificationType {

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/JobCreatePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/JobCreatePage.groovy
@@ -135,7 +135,10 @@ class JobCreatePage extends BasePage {
 
     void waitForAddNewStepBtn(By jobAddStepButton){
         new WebDriverWait(driver, Duration.ofSeconds(5)).until(ExpectedConditions.elementToBeClickable(jobAddStepButton))
+    }
 
+    void waitForURL(String url){
+        new WebDriverWait(driver, Duration.ofSeconds(5)).until(ExpectedConditions.urlContains(url))
     }
 }
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/main.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/main.js
@@ -62,6 +62,11 @@ function mount(e) {
   // Create VueI18n instance with options
   const i18n = initI18n()
 
+  let jumpToLine
+  const line = window.location.hash.split('L')[1]
+  if (line)
+    jumpToLine = parseInt(line)
+
   /**
    * Ant accesses the root Vue instance constructor.
    * Since the viewer is a class component that would make its
@@ -70,6 +75,7 @@ function mount(e) {
   const template = `\
   <LogViewer
     executionId="${e.dataset.executionId}"
+    :jumpToLine="${jumpToLine || null}"
     ref="viewer"
     ${e.dataset.trimOutput ? `trimOutput="${e.dataset.trimOutput}"` : ""}
   />

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
@@ -193,6 +193,11 @@ export default defineComponent({
       }
     },
   },
+  mounted() {
+    if(this.jumpToLine) {
+      this.onSelectLine(this.jumpToLine)
+    }
+  }
 })
 </script>
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
@@ -194,8 +194,9 @@ export default defineComponent({
     },
   },
   mounted() {
-    if(this.jumpToLine) {
-      this.onSelectLine(this.jumpToLine)
+    if (this.jumpToLine && !this.jumped) {
+      this.$emit('line-select', this.jumpToLine)
+      this.$emit('jumped')
     }
   }
 })


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Fix regression, where navigating to a job output with `#outputL[Number]` wouldn't highlight the correct line.

**Describe the solution you've implemented**
Added a check on LogNodeChunk to emit a line-select event on mounted, that will cause the line to be highlighted. 
Also added a test.

