### PR TITLE
RUN-2156: don't create a new webhook when already exists in the project

### DIFF
--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -185,10 +185,11 @@ class WebhookService {
         if(saveWebhookRequest.id) {
             hook = webhookDataProvider.getWebhookByUuid(saveWebhookRequest.uuid)
             if (!hook) return [err: "Webhook not found"]
+
+            shouldUpdate = true
             if(saveWebhookRequest.roles && !hookData.importData) {
                 try {
                     rundeckAuthTokenManagerService.updateAuthRoles(authContext, hook.authToken,rundeckAuthTokenManagerService.parseAuthRoles(hookData.roles))
-                    shouldUpdate = true
                     validateNulls(hook, saveWebhookRequest)
                 } catch (Exception e) {
                     return [err: "Failed to update Auth Token roles: "+e.message]

--- a/rundeckapp/src/test/groovy/rundeck/services/WebhookServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/WebhookServiceSpec.groovy
@@ -684,7 +684,7 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
         def result = service.importWebhook(mockUserAuth, definition, false)
 
 
-        then:"should fail"
+        then:"should have 1 webhook"
         def existingWebhooks = service.webhookDataProvider.findAllByProject("Test")
         result == [msg:'Webhook test imported']
         existingWebhooks.size() == 1


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**
bug:
don't create a new webhook when already exists in the project

**Describe the solution you've implemented**

**Describe alternatives you've considered**

**Additional context**
