### PR TITLE
RSE-934: Migrate api new testdeck - config the cluster environment

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
@@ -36,6 +36,11 @@ abstract class BaseContainer extends Specification implements ClientProvider {
                     RdClient clientWithToken(String token) {
                         return RdClient.create(System.getenv("TEST_RUNDECK_URL"), token)
                     }
+
+                    @Override
+                    RdClient getClusterClient() {
+                        return RdClient.create("http://localhost:4440", "admintoken")
+                    }
                 }
             }
         } else if (DEFAULT_DOCKERFILE_LOCATION != null && !DEFAULT_DOCKERFILE_LOCATION.isEmpty() && CLIENT_PROVIDER == null && DEFAULT_CLUSTER_PATH == null){
@@ -95,6 +100,7 @@ abstract class BaseContainer extends Specification implements ClientProvider {
     }
 
     RdClient _client
+    RdClient _clientSecond
     @Override
     RdClient getClient() {
         if (null == _client) {
@@ -106,6 +112,11 @@ abstract class BaseContainer extends Specification implements ClientProvider {
     RdClient createClient() {
         return clientProvider.getClient()
     }
+
+    RdClient createSecondClient() {
+        return clientProvider.getClusterClient()
+    }
+
     Map<String, RdClient> tokenProviders = [:]
 
     @Override
@@ -114,6 +125,14 @@ abstract class BaseContainer extends Specification implements ClientProvider {
             tokenProviders[token] = clientProvider.clientWithToken(token)
         }
         return tokenProviders[token]
+    }
+
+    @Override
+    RdClient getClusterClient() {
+        if (null == _clientSecond) {
+            _clientSecond = createSecondClient()
+        }
+        return _clientSecond
     }
 
     void startEnvironment() {
@@ -143,6 +162,10 @@ abstract class BaseContainer extends Specification implements ClientProvider {
 
     <T> T get(String path, Class<T> clazz) {
         return client.get(path, clazz)
+    }
+
+    <T> T getSecondCluster(String path, Class<T> clazz) {
+        return clusterClient.get(path, clazz)
     }
 
     Response doPost(String path, Object body = null) {

--- a/functional-test/src/test/groovy/org/rundeck/util/container/ClientProvider.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/ClientProvider.groovy
@@ -4,4 +4,6 @@ interface ClientProvider {
     RdClient getClient()
 
     RdClient clientWithToken(String token)
+
+    RdClient getClusterClient()
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdClient.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdClient.groovy
@@ -12,6 +12,7 @@ import okhttp3.Response
 import okhttp3.ResponseBody
 import org.jetbrains.annotations.NotNull
 
+import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 
 @CompileStatic
@@ -30,6 +31,9 @@ class RdClient {
         new RdClient(
                 baseUrl,
                 new OkHttpClient.Builder().
+                        connectTimeout(30, TimeUnit.SECONDS).
+                        writeTimeout(30, TimeUnit.SECONDS).
+                        readTimeout(60, TimeUnit.SECONDS).
                         addInterceptor(new HeaderInterceptor("X-Rundeck-Auth-token", apiToken)).
                         build()
         )

--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdClient.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdClient.groovy
@@ -31,9 +31,6 @@ class RdClient {
         new RdClient(
                 baseUrl,
                 new OkHttpClient.Builder().
-                        connectTimeout(30, TimeUnit.SECONDS).
-                        writeTimeout(30, TimeUnit.SECONDS).
-                        readTimeout(60, TimeUnit.SECONDS).
                         addInterceptor(new HeaderInterceptor("X-Rundeck-Auth-token", apiToken)).
                         build()
         )

--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdClusterDockerContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdClusterDockerContainer.groovy
@@ -33,7 +33,7 @@ class RdClusterDockerContainer extends DockerComposeContainer<RdClusterDockerCon
         withRemoveImages(RemoveImages.ALL)
         waitingFor(DEFAULT_SERVICES_TO_EXPOSE,
                 Wait.forLogMessage(".*Grails application running.*", 1)
-                        .withStartupTimeout(Duration.ofMinutes(5)))
+                        .withStartupTimeout(Duration.ofMinutes(10)))
     }
 
     @Override

--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdClusterDockerContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdClusterDockerContainer.groovy
@@ -1,0 +1,52 @@
+package org.rundeck.util.container
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.testcontainers.containers.DockerComposeContainer
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.images.builder.ImageFromDockerfile
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList
+
+import java.nio.file.Paths
+import java.time.Duration
+
+@CompileStatic
+@Slf4j
+class RdClusterDockerContainer extends DockerComposeContainer<RdClusterDockerContainer> implements ClientProvider {
+
+    public static final String DEFAULT_SERVICES_TO_EXPOSE = System.getenv("TEST_RUNDECK_CONTAINERS_SERVICE") ?: 'rundeck-1:rundeck-2'
+    private static final String STATIC_TOKEN = System.getenv("TEST_RUNDECK_CONTAINER_TOKEN") ?: 'admintoken'
+    private static final String CONTEXT_PATH = System.getenv("TEST_RUNDECK_CONTAINER_CONTEXT") ?: '/rundeck'
+    private static final Integer DEFAULT_PORT = System.getenv("TEST_RUNDECK_CONTAINER_PORT")?.toInteger() ?: 4440
+    public static final String RUNDECK_IMAGE = System.getenv("TEST_IMAGE") ?: System.getProperty("TEST_IMAGE")
+    public static final String LICENSE_LOCATION = System.getenv("LICENSE_LOCATION")
+
+    RdClusterDockerContainer(URI dockerFileLocation) {
+        super(new File(dockerFileLocation))
+        withExposedService(DEFAULT_SERVICES_TO_EXPOSE.split(":")[0], DEFAULT_PORT,
+                Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(10)))
+        withEnv("TEST_IMAGE", RUNDECK_IMAGE)
+        withEnv("LICENSE_LOCATION", LICENSE_LOCATION)
+        withLogConsumer(DEFAULT_SERVICES_TO_EXPOSE.split(":")[0], new Slf4jLogConsumer(log))
+        waitingFor(DEFAULT_SERVICES_TO_EXPOSE.split(":")[0],
+                Wait.forLogMessage(".*Grails application running.*", 1)
+                        .withStartupTimeout(Duration.ofMinutes(5)))
+    }
+
+    @Override
+    void close() {
+        super.close()
+    }
+
+    RdClient getClient() {
+        clientWithToken(STATIC_TOKEN)
+    }
+
+    RdClient clientWithToken(String token) {
+        def host = getServiceHost(DEFAULT_SERVICES_TO_EXPOSE.split(":")[0], DEFAULT_PORT)
+        def port = getServicePort(DEFAULT_SERVICES_TO_EXPOSE.split(":")[0], DEFAULT_PORT)
+        RdClient.create("http://$host:$port", token)
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdClusterDockerContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdClusterDockerContainer.groovy
@@ -25,15 +25,14 @@ class RdClusterDockerContainer extends DockerComposeContainer<RdClusterDockerCon
     RdClusterDockerContainer(URI dockerFileLocation) {
         super(new File(dockerFileLocation))
         withExposedService(DEFAULT_SERVICES_TO_EXPOSE, DEFAULT_PORT,
-                Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(10)))
+                Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(15)))
         withEnv("TEST_IMAGE", RUNDECK_IMAGE)
         withEnv("LICENSE_LOCATION", LICENSE_LOCATION)
         withLogConsumer(DEFAULT_SERVICES_TO_EXPOSE, new Slf4jLogConsumer(log))
-        withRemoveVolumes(true)
-        withRemoveImages(RemoveImages.ALL)
         waitingFor(DEFAULT_SERVICES_TO_EXPOSE,
-                Wait.forLogMessage(".*Grails application running.*", 1)
-                        .withStartupTimeout(Duration.ofMinutes(10)))
+                Wait.forHttp("/api/14/system/info")
+                        .forStatusCodeMatching(it -> it >= 200 && it < 500 && it != 404)
+                        .withStartupTimeout(Duration.ofMinutes(15)))
     }
 
     @Override

--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdContainer.groovy
@@ -52,6 +52,10 @@ class RdContainer extends DockerComposeContainer<RdContainer> implements ClientP
         RdClient.create("http://${getServiceHost(DEFAULT_SERVICE_TO_EXPOSE,DEFAULT_PORT)}:${getServicePort(DEFAULT_SERVICE_TO_EXPOSE,DEFAULT_PORT)}${CONTEXT_PATH}", token)
     }
 
+    RdClient getClusterClient() {
+        RdClient.create("http://localhost:4440", STATIC_TOKEN)
+    }
+
     @Override
     void close() {
         super.close()

--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdDockerContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdDockerContainer.groovy
@@ -54,4 +54,8 @@ class RdDockerContainer extends GenericContainer<RdDockerContainer> implements C
     RdClient clientWithToken(String token) {
         RdClient.create("http://${host}:${firstMappedPort}${CONTEXT_PATH}", token)
     }
+
+    RdClient getClusterClient() {
+        RdClient.create("http://localhost:4440", STATIC_TOKEN)
+    }
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/container/SeleniumBase.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/SeleniumBase.groovy
@@ -38,6 +38,7 @@ class SeleniumBase extends BaseContainer implements WebDriver, SeleniumContext {
             options.addArguments("--disable-extensions")
             options.addArguments("--disable-popup-blocking")
             options.addArguments("--disable-default-apps")
+            options.addArguments("--disable-blink-features=AutomationControlled")
             _driver = new ChromeDriver(options)
         }
         return _driver


### PR DESCRIPTION
This PR adds a new environment to build rundeck using cluster reading the same DB and then use it like:` @ClusterTest `annotation.