### PR TITLE
RSE-979 Fix: Remove dependency from rd-api-client

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -93,6 +93,7 @@ dependencies {
         "org.yaml:snakeyaml:${snakeyamlVersion}",
         'com.squareup.retrofit2:retrofit:2.9.0',
         'com.squareup.retrofit2:converter-jackson:2.9.0',
+        'com.squareup.retrofit2:converter-jaxb:2.9.0',
         'javax.servlet:javax.servlet-api:4.0.1'
 
 

--- a/core/src/main/java/com/dtolabs/rundeck/net/api/RundeckApi.java
+++ b/core/src/main/java/com/dtolabs/rundeck/net/api/RundeckApi.java
@@ -1,0 +1,38 @@
+package com.dtolabs.rundeck.net.api;
+import okhttp3.RequestBody;
+import retrofit2.Call;
+import retrofit2.http.*;
+import com.dtolabs.rundeck.net.model.ProjectImportStatus;
+
+import java.util.Map;
+
+
+/**
+ * Interface for Rundeck API using retrofit annotations
+ */
+@SuppressWarnings("JavaDoc")
+public interface RundeckApi {
+
+    /**
+     * Import project archive (&lt;=v18)
+     *
+     * @param project project
+     *
+     * @return archive response
+     */
+    @Headers("Accept: application/json")
+    @PUT("project/{project}/import")
+    Call<ProjectImportStatus> importProjectArchive(
+            @Path("project") String project,
+            @Query("jobUuidOption") String jobUuidOption,
+            @Query("importExecutions") Boolean importExecutions,
+            @Query("importConfig") Boolean importConfig,
+            @Query("importACL") Boolean importACL,
+            @Query("importScm") Boolean importScm,
+            @Query("importWebhooks") Boolean importWebhooks,
+            @Query("whkRegenAuthTokens") Boolean whkRegenAuthTokens,
+            @Query("importNodesSources") Boolean importNodesSources,
+            @QueryMap Map<String,String> params,
+            @Body RequestBody body
+    );
+}

--- a/core/src/main/java/com/dtolabs/rundeck/net/api/RundeckClient.java
+++ b/core/src/main/java/com/dtolabs/rundeck/net/api/RundeckClient.java
@@ -17,11 +17,10 @@ public class RundeckClient {
 
     public static final String APPLICATION_ZIP = "application/zip";
     public static final MediaType MEDIA_TYPE_ZIP = MediaType.parse(APPLICATION_ZIP);
-
     private final RundeckApi rundeckApi;
+    private final Retrofit retrofit;
 
     public RundeckClient(String url, String apiToken) {
-        Retrofit retrofit;
         OkHttpClient.Builder okhttp = new OkHttpClient.Builder();
         okhttp.addInterceptor(chain -> chain.proceed(chain.request().newBuilder().header("X-Rundeck-Auth-Token", apiToken).build()));
         final String apiBaseUrl;
@@ -35,7 +34,11 @@ public class RundeckClient {
                 .build();
 
         rundeckApi = retrofit.create(RundeckApi.class);
+    }
 
+    public RundeckClient(RundeckApi rundeckApi, Retrofit retrofit){
+        this.rundeckApi = rundeckApi;
+        this.retrofit = retrofit;
     }
     public Response<ProjectImportStatus> importProjectArchive(
             String projectName,
@@ -78,5 +81,8 @@ public class RundeckClient {
             return baseUrl + "/";
         }
         return baseUrl;
+    }
+    public Retrofit getRetrofit() {
+        return retrofit;
     }
 }

--- a/core/src/main/java/com/dtolabs/rundeck/net/api/RundeckClient.java
+++ b/core/src/main/java/com/dtolabs/rundeck/net/api/RundeckClient.java
@@ -1,0 +1,82 @@
+package com.dtolabs.rundeck.net.api;
+
+import com.dtolabs.rundeck.net.model.ProjectImportStatus;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import java.io.IOException;
+import java.util.Map;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+import retrofit2.converter.jaxb.JaxbConverterFactory;
+
+import okhttp3.OkHttpClient;
+
+
+public class RundeckClient {
+
+    public static final String APPLICATION_ZIP = "application/zip";
+    public static final MediaType MEDIA_TYPE_ZIP = MediaType.parse(APPLICATION_ZIP);
+
+    private final RundeckApi rundeckApi;
+
+    public RundeckClient(String url, String apiToken) {
+        Retrofit retrofit;
+        OkHttpClient.Builder okhttp = new OkHttpClient.Builder();
+        okhttp.addInterceptor(chain -> chain.proceed(chain.request().newBuilder().header("X-Rundeck-Auth-Token", apiToken).build()));
+        final String apiBaseUrl;
+        apiBaseUrl = buildApiUrlForVersion(url, 39);
+
+        retrofit = new Retrofit.Builder()
+                .baseUrl(apiBaseUrl)
+                .client(okhttp.build())
+                .addConverterFactory(JacksonConverterFactory.create())
+                .addConverterFactory(JaxbConverterFactory.create())
+                .build();
+
+        rundeckApi = retrofit.create(RundeckApi.class);
+
+    }
+    public Response<ProjectImportStatus> importProjectArchive(
+            String projectName,
+            String jobUuidOption,
+            Boolean importExecutions,
+            Boolean importConfig,
+            Boolean importACL,
+            Boolean importScm,
+            Boolean importWebhooks,
+            Boolean whkRegenAuthTokens,
+            Boolean importNodesSources,
+            Map<String,String> params,
+            RequestBody requestBody
+    ) throws IOException {
+
+        return rundeckApi.importProjectArchive(
+                projectName,
+                jobUuidOption,
+                importExecutions,
+                importConfig,
+                importACL,
+                importScm,
+                importWebhooks,
+                whkRegenAuthTokens,
+                importNodesSources,
+                params,
+                requestBody
+        ).execute();
+    }
+
+    private static String buildApiUrlForVersion(String baseUrl, final int apiVers) {
+        if (!baseUrl.matches("^.*/api/\\d+/?$")) {
+            return normalizeUrlPath(baseUrl) + "api/" + (apiVers) + "/";
+        }
+        return normalizeUrlPath(baseUrl);
+    }
+
+    private static String normalizeUrlPath(String baseUrl) {
+        if (!baseUrl.matches(".*/$")) {
+            return baseUrl + "/";
+        }
+        return baseUrl;
+    }
+}

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -80,12 +80,6 @@ configurations {
     runtimeClasspath {
         extendsFrom developmentOnly
     }
-    pluginLibs
-
-    //declare implementation to extend from pluginLibs so it inherits the dependencies
-    implementation {
-        extendsFrom pluginLibs
-    }
 
     implementation.exclude module: "spring-boot-starter-tomcat"
     implementation.exclude module: "spring-boot-cli"
@@ -111,12 +105,6 @@ sourceSets {
 dependencies {
     //Rundeck plugin dependencies
     pluginFiles project.findProperty('bundledPlugins')?:[]
-    pluginLibs("org.rundeck.api:rd-api-client:2.0.5"){
-        exclude group: 'javax.xml.bind'
-        exclude group: 'com.fasterxml.jackson.core'
-        exclude group: 'com.fasterxml.jackson.dataformat'
-        exclude group: 'jakarta.xml.bind', module: 'jakarta.xml.bind-api'
-    }
 
     testImplementation group: 'com.squareup.retrofit2', name: 'retrofit-mock', version: '2.9.0'
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
@@ -27,7 +27,9 @@ import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.core.common.ProjectManager
-import org.rundeck.client.api.model.ProjectImportStatus
+import com.dtolabs.rundeck.net.api.RundeckApi
+import com.dtolabs.rundeck.net.api.RundeckClient
+import com.dtolabs.rundeck.net.model.ProjectImportStatus
 import com.dtolabs.rundeck.util.ZipBuilder
 import grails.async.Promises
 import grails.events.bus.EventBus
@@ -53,8 +55,6 @@ import org.rundeck.app.components.project.ProjectComponent
 import rundeck.data.report.SaveReportRequestImpl
 import org.rundeck.app.data.providers.GormExecReportDataProvider
 import org.rundeck.app.services.ExecutionFile
-import org.rundeck.client.util.Client
-import org.rundeck.client.api.RundeckApi
 import org.rundeck.core.auth.AuthConstants
 import org.slf4j.Logger
 import retrofit2.Call
@@ -1812,6 +1812,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
     def "should result success and no error msgs when export to another instance is success"() {
         given:
         ProjectArchiveParams exportArchiveParams = new ProjectArchiveParams([
+                targetproject:'project-target',
                 project : 'project-target',
                 preserveuuid : 'preserve',
                 exportExecutions : true,
@@ -1843,6 +1844,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
 
         ProjectArchiveParams exportArchiveParams = new ProjectArchiveParams([
                 project : 'project-target',
+                targetproject:'project-target',
                 preserveuuid : 'preserve',
                 exportExecutions : true,
                 exportConfigs : true,
@@ -3276,8 +3278,8 @@ abstract class MockRundeckApi implements RundeckApi{
     }
 
 
-    Client<RundeckApi> getRundeckClient(){
-        return new Client<>(this, retrofit,null, null, 0, false, null)
+    RundeckClient getRundeckClient(){
+        return new RundeckClient(this, retrofit)
     }
 
     private void setupRetrofit(){


### PR DESCRIPTION
Related to 
https://pagerduty.atlassian.net/browse/RSE-401

Problem: A dependency on the rd-api-client external repository was introduced on this PR, https://github.com/rundeck/rundeck/pull/8504

Solution: Revert changes that removed the RundeckApi and create a new RundeckClient to allow to export projects to other instances via API without depending on the rd-api-client