### PR TITLE
RUN-1737: Allow display of request error messages in spacecat 500 page.

### DIFF
--- a/rundeckapp/grails-app/views/5xx.gsp
+++ b/rundeckapp/grails-app/views/5xx.gsp
@@ -67,6 +67,9 @@
             <h3>There was an unexpected error</h3>
             <h4>Please check the service log for more details.</h4>
             <h4>At ${new Date()}</h4>
+            <g:if test="${request.getAttribute('javax.servlet.error.message')}">
+              <h5><g:enc>${request.getAttribute('javax.servlet.error.message')}</g:enc></h5>
+            </g:if>
             <h5><g:enc>${exception?.message}</g:enc></h5>
             <div>
               <h5>


### PR DESCRIPTION
Display the message stored on the request when present in the 500 erro page.