### PR TITLE
RUN-2179: Keep job definitions created in 5.x working in previous versions

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/WorkflowController.groovy
@@ -789,7 +789,7 @@ class WorkflowController extends ControllerBase {
                 if (params.nodeStep instanceof String) {
                     item.nodeStep = params.nodeStep == 'true'
                 }
-            } else if([ExecCommand.EXEC_COMMAND_TYPE, ScriptCommand.SCRIPT_COMMAND_TYPE, ScriptFileCommand.SCRIPT_FILE_COMMAND_TYPE].contains(params.type)){
+            } else if(PluginStep.isOldBuiltInType(params.type)){
                 item = PluginStep.fromMap(params)
             } else {
                 item = new CommandExec(params)

--- a/rundeckapp/grails-app/domain/rundeck/PluginStep.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/PluginStep.groovy
@@ -17,6 +17,9 @@
 package rundeck
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.rundeck.core.execution.ExecCommand
+import org.rundeck.core.execution.ScriptCommand
+import org.rundeck.core.execution.ScriptFileCommand
 
 class PluginStep extends WorkflowStep{
     Boolean nodeStep = false
@@ -60,8 +63,21 @@ class PluginStep extends WorkflowStep{
         pluginConfigData(type: 'text')
     }
 
+    static isOldBuiltInType(String type) {
+        return [ExecCommand.EXEC_COMMAND_TYPE, ScriptCommand.SCRIPT_COMMAND_TYPE, ScriptFileCommand.SCRIPT_FILE_COMMAND_TYPE].contains(type)
+    }
+
     public Map toMap() {
         def map=[type: type, nodeStep:nodeStep]
+
+        if(isOldBuiltInType(this.type)){//keep job defs compatibility with old Rundeck versions prior to 5.x
+            CommandExec commandExec = new CommandExec(this.configuration)
+            commandExec.description = this.description
+            commandExec.errorHandler = this.errorHandler
+            commandExec.keepgoingOnSuccess = this.keepgoingOnSuccess
+            return commandExec.toMap()
+        }
+
         if(this.configuration){
             map.put('configuration',this.configuration)
         }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
After refactoring built-in plugins, the jobs definitions was changed make them incompatible on previous versions

**Describe the solution you've implemented**
Keep the job definitions as before the refactoring so that the jobs definitions will looks like the same as before refactoring

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
