### PR TITLE
RSE-934: Migrate API to New testdeck

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/container/SeleniumBase.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/SeleniumBase.groovy
@@ -38,6 +38,7 @@ class SeleniumBase extends BaseContainer implements WebDriver, SeleniumContext {
             options.addArguments("--disable-extensions")
             options.addArguments("--disable-popup-blocking")
             options.addArguments("--disable-default-apps")
+            options.addArguments("--disable-blink-features=AutomationControlled")
             _driver = new ChromeDriver(options)
         }
         return _driver


### PR DESCRIPTION
A connection pool is added to control the stream when turning clusters on and off.
Also, option `--disable-blink-features=AutomationControlled` is added