### PR TITLE
Fix: Plugin config data was not being exported

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/PluginStep.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/PluginStep.groovy
@@ -75,6 +75,7 @@ class PluginStep extends WorkflowStep{
             commandExec.description = this.description
             commandExec.errorHandler = this.errorHandler
             commandExec.keepgoingOnSuccess = this.keepgoingOnSuccess
+            commandExec.pluginConfigData = this.pluginConfigData
             return commandExec.toMap()
         }
 

--- a/rundeckapp/src/test/groovy/rundeck/PluginStepTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/PluginStepTests.groovy
@@ -56,7 +56,7 @@ class PluginStepTests  extends Specification implements DataTest{
 
     def testToMapKeepCompatibilityWithOldBuiltInTypes(){
         when:
-        PluginStep t = new PluginStep(type: type,configuration: pluginConfig,nodeStep: true, keepgoingOnSuccess: true, pluginConfigData: "{'key1': 'value1'}")
+        PluginStep t = new PluginStep(type: type,configuration: pluginConfig,nodeStep: true, keepgoingOnSuccess: true, pluginConfigData: '{"key1": "value1"}')
         then:
         Map configMap = t.toMap()
         assertEquals(true, !!configMap.keepgoingOnSuccess)

--- a/rundeckapp/src/test/groovy/rundeck/PluginStepTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/PluginStepTests.groovy
@@ -56,7 +56,7 @@ class PluginStepTests  extends Specification implements DataTest{
 
     def testToMapKeepCompatibilityWithOldBuiltInTypes(){
         when:
-        PluginStep t = new PluginStep(type: type,configuration: pluginConfig,nodeStep: true, keepgoingOnSuccess: true, pluginConfigData: ['key1': 'value1'])
+        PluginStep t = new PluginStep(type: type,configuration: pluginConfig,nodeStep: true, keepgoingOnSuccess: true, pluginConfigData: "{'key1': 'value1'}")
         then:
         Map configMap = t.toMap()
         assertEquals(true, !!configMap.keepgoingOnSuccess)

--- a/rundeckapp/src/test/groovy/rundeck/PluginStepTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/PluginStepTests.groovy
@@ -56,22 +56,26 @@ class PluginStepTests  extends Specification implements DataTest{
 
     def testToMapKeepCompatibilityWithOldBuiltInTypes(){
         when:
-        PluginStep t = new PluginStep(type: type,configuration: pluginConfig,nodeStep: true, keepgoingOnSuccess: true)
+        PluginStep t = new PluginStep(type: type,configuration: pluginConfig,nodeStep: true, keepgoingOnSuccess: true, pluginConfigData: ['key1': 'value1'])
         then:
         Map configMap = t.toMap()
         assertEquals(true, !!configMap.keepgoingOnSuccess)
         assertNull(configMap.errorHandler)
         if(type == ExecCommand.EXEC_COMMAND_TYPE) {
             assertEquals('adhocRemoteString', configMap.exec)
+            assertEquals(['key1': 'value1'], configMap.plugins)
         }else if(type == ScriptCommand.SCRIPT_COMMAND_TYPE) {
             assertEquals('adhocLocalString', configMap.script)
+            assertEquals(['key1': 'value1'], configMap.plugins)
         }else if(type == ScriptFileCommand.SCRIPT_FILE_COMMAND_TYPE) {
             assertEquals('adhocFilepath', configMap.scriptfile)
+            assertEquals(['key1': 'value1'], configMap.plugins)
         }else{
             assertEquals(pluginConfig, configMap.configuration)
             assertEquals(null, configMap.script)
             assertEquals(null, configMap.exec)
             assertEquals(null, configMap.scriptfile)
+            assertEquals(['key1': 'value1'], configMap.plugins)
         }
 
         where:


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Plugin config data was not being exported

**Describe the solution you've implemented**
Include config data when exporting old built-in plugins 

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
