### PR TITLE
RUN-3748: Add possibility to translate group name of plugins

### DIFF
--- a/rundeckapp/grails-app/views/framework/_pluginConfigPropertiesInputs.gsp
+++ b/rundeckapp/grails-app/views/framework/_pluginConfigPropertiesInputs.gsp
@@ -100,7 +100,12 @@
       <g:if test="${isSecondary}">
           <details ${hasValue ? 'open' : ''} class="details-reset more-info">
               <summary class="${groupTitleCss?:''}">
-                  ${group != '-' ? group : defaultGroupName}
+                  <stepplugin:message
+                          service="${service}"
+                          name="${provider}"
+                          code="${messagePrefix?:''}property.secondary.${group}.groupName"
+                          messagesType="${messagesType}"
+                          default="${group != '-' ? group : defaultGroupName}"/>
                   <span class="more-indicator-verbiage more-info-icon"><g:icon name="chevron-right"/></span>
                   <span class="less-indicator-verbiage more-info-icon"><g:icon name="chevron-down"/></span>
               </summary>
@@ -130,7 +135,14 @@
 
       </g:if>
       <g:else>
-          <div class="${groupTitleCss?:''}">${group!='-'?group:defaultGroupName}</div>
+          <div class="${groupTitleCss?:''}">
+              <stepplugin:message
+                      service="${service}"
+                      name="${provider}"
+                      code="${messagePrefix?:''}property.primary.${group}.groupName"
+                      messagesType="${messagesType}"
+                      default="${group != '-' ? group : defaultGroupName}"/>
+          </div>
 
           <div>
               <g:each in="${groupProps}" var="prop">


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is an enhancement to translating plugin group names

**Describe the solution you've implemented**
In order to help with translations, I added the possibility of translating group names in plugins

```properties
property.[primary|secondary].[group].groupName
```

For translate primary groups, you need to put in your plugin:

```properties
property.primary.My\ Amazing\ Group.groupName=Any example here
```

For the secondary, just change the `primary` word

```properties
property.secondary.My\ Wonderful\ Group.groupName=Any example here
```

**Describe alternatives you've considered**

**Additional context**
