### PR TITLE
Fix flaky tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,61 +505,12 @@ jobs:
           command: << parameters.command >>
 
 
-  # Run Testdeck job on machine executor.
-  testdeck:
-    <<: *job-defaults
-    executor:
-      name: machine-builder
-      docker_layer_caching: true
-      resource_class: << parameters.resource_class >>
-
-    parameters:
-      resource_class:
-        type: string
-        default: medium
-      workdir:
-        description: Working directory
-        type: string
-        default: .
-      command:
-        description: Command that will execute the docker tests
-        type: string
-
-    steps:
-
-      - checkout
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
-      - install-testdeck-dependencies
-      - attach_workspace:
-          at: ~/workspace
-      - run-build-step:
-          step-name: Pull Rundeck Image
-          command: rundeck_pull_image
-      - run-build-step:
-          step-name: Test
-          command: |
-            cd << parameters.workdir >>
-            ./bin/deck bootstrap
-            << parameters.command >>
-      - run-build-step:
-          step-name: Print Logs
-          when: always
-          command: |
-            cd << parameters.workdir >>
-            ./bin/deck cluster logs
-      - store_artifacts:
-          path: << parameters.workdir >>/test_out/images
-          destination: images
-      - store_test_results:
-          path: << parameters.workdir >>/test_out
-
   test-gradle-functional:
     <<: *job-defaults
     executor:
       name: machine-builder
       docker_layer_caching: true
-      resource_class: medium
+      resource_class: << parameters.resource_class >>
     parameters:
       test-image:
         description: Test image tag
@@ -567,6 +518,9 @@ jobs:
         type: string
       gradle-task:
         type: string
+      resource_class:
+        type: string
+        default: medium
     steps:
       - checkout
       - install-build-dependencies
@@ -733,6 +687,7 @@ workflows:
       - test-gradle-functional:
           name: New Selenium Test
           gradle-task: seleniumCoreTest
+          resource_class: large
           <<: *require-build
           <<: *slack-defaults
       - test-gradle-functional:

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/BasePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/BasePage.groovy
@@ -29,6 +29,7 @@ abstract class BasePage {
     BasePage(final SeleniumContext context) {
         this.context = context
         this.context.driver.manage().window().setSize(new Dimension(1200, 1050))
+        this.context.driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30))
     }
 
     abstract String getLoadPath()
@@ -36,7 +37,7 @@ abstract class BasePage {
      * Go to the page and validate
      */
     void go() {
-        if (loadPath) {
+        if (loadPath && !loadPath.empty) {
             implicitlyWait 2000
             driver.get(context.client.baseUrl + loadPath)
             validatePage()

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/BasePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/BasePage.groovy
@@ -29,7 +29,7 @@ abstract class BasePage {
     BasePage(final SeleniumContext context) {
         this.context = context
         this.context.driver.manage().window().setSize(new Dimension(1200, 1050))
-        this.context.driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30))
+        this.context.driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10))
     }
 
     abstract String getLoadPath()
@@ -37,6 +37,14 @@ abstract class BasePage {
      * Go to the page and validate
      */
     void go() {
+        if (loadPath && !loadPath.empty) {
+            implicitlyWait 2000
+            driver.get(context.client.baseUrl + loadPath)
+            validatePage()
+        }
+    }
+
+    void go(String loadPath) {
         if (loadPath && !loadPath.empty) {
             implicitlyWait 2000
             driver.get(context.client.baseUrl + loadPath)
@@ -66,7 +74,7 @@ abstract class BasePage {
     }
 
     void waitForElementToBeClickable(By locator) {
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(60))
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(30))
         wait.until {
             WebDriver d ->
                 def elementLocator = d.findElement(locator)
@@ -75,17 +83,17 @@ abstract class BasePage {
     }
 
     void waitForElementToBeClickable(WebElement locator) {
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(60))
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(30))
         wait.until { ExpectedConditions.elementToBeClickable(locator) }
     }
 
     void waitForTextToBePresentInElement(WebElement locator, String text) {
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(60))
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(30))
         wait.until { ExpectedConditions.textToBePresentInElement(locator, text) }
     }
 
     boolean waitForElementAttributeToChange(WebElement locator, String attribute, String valueCompare) {
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(60))
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(30))
         wait.until {
             WebDriver d ->
                 def elementLocator = locator.getAttribute(attribute)

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/jobs/JobCreatePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/jobs/JobCreatePage.groovy
@@ -67,7 +67,9 @@ class JobCreatePage extends BasePage {
     By ansibleBinariesPathBy = By.name("pluginConfig.ansible-binaries-dir-path")
     By autocompleteSuggestionsBy = By.cssSelector("div[class='autocomplete-suggestions']")
     By wfUndoButtonBy = By.xpath("//*[@id='wfundoredo']/div/span[1]")
+    By wfUndoButtonLinkBy = By.xpath("//*[@class='btn btn-xs btn-default act_undo flash_undo']")
     By wfRedoButtonBy = By.xpath("//*[@id='wfundoredo']/div/span[2]")
+    By wfRedoButtonLinkBy = By.xpath("//*[@class='btn btn-xs btn-default act_redo flash_undo']")
     By wfRevertAllButtonBy = By.xpath("//*[@id='wfundoredo']/div/span[3]")
     By revertWfConfirmBy = By.xpath('//*[starts-with(@id,"popover")]/div[2]/span[2]')
     By listWorkFlowItemBy = By.xpath("//*[starts-with(@id,'wfitem_')]")
@@ -371,8 +373,16 @@ class JobCreatePage extends BasePage {
         el wfUndoButtonBy
     }
 
+    WebElement getWfUndoButtonLink() {
+        el wfUndoButtonLinkBy
+    }
+
     WebElement getWfRedoButton() {
         el wfRedoButtonBy
+    }
+
+    WebElement getWfRedoButtonLink() {
+        el wfRedoButtonLinkBy
     }
 
     WebElement getWfRevertAllButton() {

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/execution/CommandSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/execution/CommandSpec.groovy
@@ -27,6 +27,7 @@ class CommandSpec extends SeleniumBase {
             commandPage.filterNodeButton.click()
             commandPage.waitForElementToBeClickable commandPage.commandTextField
             commandPage.commandTextField.click()
+            commandPage.waitForElementAttributeToChange commandPage.commandTextField, 'disabled', null
             commandPage.commandTextField.sendKeys "echo running test && sleep 45"
             commandPage.runButton.click()
             commandPage.waitForElementAttributeToChange commandPage.runningExecutionStateButton, 'data-execstate', 'RUNNING'
@@ -45,6 +46,7 @@ class CommandSpec extends SeleniumBase {
             commandPage.filterNodeButton.click()
             commandPage.waitForElementToBeClickable commandPage.commandTextField
             commandPage.commandTextField.click()
+            commandPage.waitForElementAttributeToChange commandPage.commandTextField, 'disabled', null
             commandPage.commandTextField.sendKeys "echo running test && sleep 45"
             commandPage.runButton.click()
             commandPage.runningButtonLink().click()
@@ -64,7 +66,8 @@ class CommandSpec extends SeleniumBase {
             commandPage.filterNodeButton.click()
             commandPage.waitForElementToBeClickable commandPage.commandTextField
             commandPage.commandTextField.click()
-            commandPage.commandTextField.sendKeys "echo running test '" + this.class.name + "'"
+            commandPage.waitForElementAttributeToChange commandPage.commandTextField, 'disabled', null
+            commandPage.commandTextField.sendKeys "echo running test '" + this.class.name.toString() + "'"
             commandPage.runButton.click()
             def href = commandPage.runningButtonLink().getAttribute("href")
             commandPage.driver.get href
@@ -86,7 +89,8 @@ class CommandSpec extends SeleniumBase {
             commandPage.filterNodeButton.click()
             commandPage.waitForElementToBeClickable commandPage.commandTextField
             commandPage.commandTextField.click()
-            commandPage.commandTextField.sendKeys "echo running test '" + this.class.name + "'"
+            commandPage.waitForElementAttributeToChange commandPage.commandTextField, 'disabled', null
+            commandPage.commandTextField.sendKeys "echo running test '" + this.class.name.toString() + "'"
             commandPage.runButton.click()
             def href = commandPage.runningButtonLink().getAttribute("href")
             commandPage.driver.get href + "#output"
@@ -108,7 +112,8 @@ class CommandSpec extends SeleniumBase {
             commandPage.filterNodeButton.click()
             commandPage.waitForElementToBeClickable commandPage.commandTextField
             commandPage.commandTextField.click()
-            commandPage.commandTextField.sendKeys "echo running test '" + this.class.name + "'"
+            commandPage.waitForElementAttributeToChange commandPage.commandTextField, 'disabled', null
+            commandPage.commandTextField.sendKeys "echo running test '" + this.class.name.toString() + "'"
             commandPage.runButton.click()
             def href = commandPage.runningButtonLink().getAttribute("href")
             commandPage.driver.get href + "#output"
@@ -132,7 +137,8 @@ class CommandSpec extends SeleniumBase {
             commandPage.filterNodeButton.click()
             commandPage.waitForElementToBeClickable commandPage.commandTextField
             commandPage.commandTextField.click()
-            commandPage.commandTextField.sendKeys "echo running test '" + this.class.name + "'"
+            commandPage.waitForElementAttributeToChange commandPage.commandTextField, 'disabled', null
+            commandPage.commandTextField.sendKeys "echo running test '" + this.class.name.toString() + "'"
             commandPage.runButton.click()
             def href = commandPage.runningButtonLink().getAttribute("href")
             commandPage.driver.get href

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/jobs/JobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/jobs/JobsSpec.groovy
@@ -237,6 +237,7 @@ class JobsSpec extends SeleniumBase {
             jobCreatePage.executeScript "arguments[0].scrollIntoView(true);", jobCreatePage.saveOptionButton
             jobCreatePage.saveOptionButton.click()
             jobCreatePage.waitFotOptLi 1
+            jobCreatePage.waitForElementAttributeToChange jobCreatePage.optionUndoButton, 'disabled', null
             jobCreatePage.optionUndoButton.click()
         expect:
             jobCreatePage.waitForOptionsToBe 1, 0
@@ -284,6 +285,7 @@ class JobsSpec extends SeleniumBase {
             jobCreatePage.saveOptionButton.click()
             jobCreatePage.waitFotOptLi 1
             jobCreatePage.executeScript "window.location.hash = '#optundoredo'"
+            jobCreatePage.waitForElementAttributeToChange jobCreatePage.optionUndoButton, 'disabled', null
             jobCreatePage.optionUndoButton
             jobCreatePage.optionRevertAllButton.click()
             jobCreatePage.optionConfirmRevertAllButton.click()
@@ -316,8 +318,10 @@ class JobsSpec extends SeleniumBase {
             jobCreatePage.saveOptionButton.click()
             jobCreatePage.waitFotOptLi 1
             jobCreatePage.executeScript "window.location.hash = '#optundoredo'"
+            jobCreatePage.waitForElementAttributeToChange jobCreatePage.optionUndoButton, 'disabled', null
             jobCreatePage.optionUndoButton.click()
             jobCreatePage.waitForElementToBeClickable jobCreatePage.optionRedoButton
+            jobCreatePage.waitForElementAttributeToChange jobCreatePage.optionRedoButton, 'disabled', null
             jobCreatePage.optionRedoButton.click()
         expect:
             !(jobCreatePage.optionLis 0 isEmpty())

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/jobs/JobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/jobs/JobsSpec.groovy
@@ -367,9 +367,10 @@ class JobsSpec extends SeleniumBase {
             jobCreatePage.fillBasicJob 'a job with workflow undo-redo test'
             jobCreatePage.addSimpleCommandStepButton.click()
             jobCreatePage.addSimpleCommandStep 'echo selenium test 2', 1
-            jobCreatePage.wfUndoButton.click()
-            jobCreatePage.waitForElementToBeClickable jobCreatePage.wfRedoButton
-            jobCreatePage.wfRedoButton.click()
+            jobCreatePage.waitForElementToBeClickable jobCreatePage.wfUndoButtonLink
+            jobCreatePage.wfUndoButtonLink.click()
+            jobCreatePage.waitForElementToBeClickable jobCreatePage.wfRedoButtonLink
+            jobCreatePage.wfRedoButtonLink.click()
             jobCreatePage.waitForNumberOfElementsToBe jobCreatePage.listWorkFlowItemBy, 2
         expect:
             jobCreatePage.workFlowList.size() == 2

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/jobs/JobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/jobs/JobsSpec.groovy
@@ -321,7 +321,7 @@ class JobsSpec extends SeleniumBase {
             jobCreatePage.waitForElementAttributeToChange jobCreatePage.optionUndoButton, 'disabled', null
             jobCreatePage.optionUndoButton.click()
             jobCreatePage.waitForElementToBeClickable jobCreatePage.optionRedoButton
-            jobCreatePage.waitForElementAttributeToChange jobCreatePage.optionRedoButton, 'disabled', null
+            sleep 1000
             jobCreatePage.optionRedoButton.click()
         expect:
             !(jobCreatePage.optionLis 0 isEmpty())

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/project/NodesSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/project/NodesSpec.groovy
@@ -18,7 +18,7 @@ class NodesSpec extends SeleniumBase {
             def nodeSourcePage = page NodeSourcePage
         when:
             loginPage.login(TEST_USER, TEST_PASS)
-            nodeSourcePage.loadPath += "/project/${SELENIUM_BASIC_PROJECT}/nodes/sources"
+            nodeSourcePage.loadPath = "/project/${SELENIUM_BASIC_PROJECT}/nodes/sources"
             nodeSourcePage.go()
         then:
             nodeSourcePage.waitForElementVisible nodeSourcePage.newNodeSourceButton

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/project/NodesSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/project/NodesSpec.groovy
@@ -19,7 +19,7 @@ class NodesSpec extends SeleniumBase {
         when:
             loginPage.login(TEST_USER, TEST_PASS)
             nodeSourcePage.loadPath = "/project/${SELENIUM_BASIC_PROJECT}/nodes/sources"
-            nodeSourcePage.go()
+            nodeSourcePage.go("/project/${SELENIUM_BASIC_PROJECT}/nodes/sources")
         then:
             nodeSourcePage.waitForElementVisible nodeSourcePage.newNodeSourceButton
             nodeSourcePage.newNodeSourceButton != null


### PR DESCRIPTION
The flaky tests of:
`go to edit nodes`
`job workflow undo redo`
`job option simple redo`
`job option revert all`
`job option undo redo`
The old testdeck configuration for selenium is removed