### PR TITLE
RSE-980: Tests: Job Scm Status Badge Selenium Tests

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginActionsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginActionsSpec.groovy
@@ -10,6 +10,8 @@ import org.rundeck.util.api.scm.httpbody.GitExportSetupRequest
 import org.rundeck.util.api.scm.httpbody.ScmActionPerformRequest
 import org.rundeck.util.api.scm.httpbody.SetupIntegrationResponse
 import org.rundeck.util.api.storage.KeyStorageApiClient
+import org.rundeck.util.common.scm.ScmActionId
+import org.rundeck.util.common.scm.ScmIntegration
 import org.rundeck.util.container.BaseContainer
 import org.rundeck.util.common.jobs.JobUtils
 
@@ -26,7 +28,7 @@ class ScmPluginActionsSpec extends BaseContainer {
 
     def "project scm status must be export needed when having a new job"(){
         given:
-        String integration = 'export'
+        ScmIntegration integration = ScmIntegration.EXPORT
         String projectName = "${PROJECT_NAME}-P1"
         setupProjectArchiveDirectoryResource(projectName, BASE_EXPORT_PROJECT_LOCATION)
         GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(integration).forProject(projectName)
@@ -51,8 +53,8 @@ class ScmPluginActionsSpec extends BaseContainer {
     def "retrieve all input fields on scm action for project with new job"(){
         given:
         String projectName = "${PROJECT_NAME}-P2"
-        String integration = 'export'
-        String actionId = 'project-commit'
+        ScmIntegration integration = ScmIntegration.EXPORT
+        ScmActionId actionId = ScmActionId.PROJECT_COMMIT
         setupProject(projectName)
         GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(integration).forProject(projectName)
         String jobUuid = JobUtils.jobImportFile(projectName, '/test-files/test.xml', client).succeeded.first().id
@@ -150,14 +152,14 @@ class ScmPluginActionsSpec extends BaseContainer {
         IntegrationStatusResponse finalScmStatus = scmClient.callGetIntegrationStatus().response
         verifyAll {
             performActionResult.success
-            performActionResult.message == "SCM ${integration} Action was Successful: ${actionId}"
+            performActionResult.message == "SCM ${integration.name} Action was Successful: ${actionId}"
             finalScmStatus.actions == expectedFinalScmActions
             finalScmStatus.synchState == expectedFinalSynchState
         }
 
         where:
-        integration | actionId          | useAutoPush | expectedFinalSynchState | expectedFinalScmActions
-        'export'    | 'project-commit'  | false       | 'EXPORT_NEEDED'         | ['project-push']
-        'export'    | 'project-commit'  | true        | 'CLEAN'                 | null
+        integration           | actionId          | useAutoPush | expectedFinalSynchState | expectedFinalScmActions
+        ScmIntegration.EXPORT | 'project-commit'  | false       | 'EXPORT_NEEDED'         | ['project-push']
+        ScmIntegration.EXPORT | 'project-commit'  | true        | 'CLEAN'                 | null
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginInputsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginInputsSpec.groovy
@@ -4,6 +4,7 @@ import org.rundeck.util.annotations.APITest
 import org.rundeck.util.annotations.ExcludePro
 import org.rundeck.util.api.scm.GitScmApiClient
 import org.rundeck.util.api.scm.httpbody.ScmPluginInputFieldsResponse
+import org.rundeck.util.common.scm.ScmIntegration
 import org.rundeck.util.container.BaseContainer
 
 @APITest
@@ -31,8 +32,8 @@ class ScmPluginInputsSpec extends BaseContainer {
         inputsResponse.fields.name.containsAll(expectedInputFieldNames)
 
         where:
-        integration | expectedInputFieldNames
-        'import'    | IMPORT_INPUT_FIELD_NAMES
-        'export'    | EXPORT_INPUT_FIELD_NAMES
+        integration           | expectedInputFieldNames
+        ScmIntegration.IMPORT | IMPORT_INPUT_FIELD_NAMES
+        ScmIntegration.EXPORT | EXPORT_INPUT_FIELD_NAMES
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginJobActionInputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginJobActionInputSpec.groovy
@@ -9,6 +9,7 @@ import org.rundeck.util.api.scm.httpbody.GitExportSetupRequest
 import org.rundeck.util.api.scm.httpbody.ScmActionPerformRequest
 import org.rundeck.util.api.scm.httpbody.ScmJobStatusResponse
 import org.rundeck.util.api.scm.httpbody.SetupIntegrationResponse
+import org.rundeck.util.common.scm.ScmIntegration
 import org.rundeck.util.container.BaseContainer
 
 @APITest
@@ -16,7 +17,6 @@ import org.rundeck.util.container.BaseContainer
 class ScmPluginJobActionInputSpec extends BaseContainer {
 
     static final String PROJECT_NAME = "ScmPluginJobActionsInput-project"
-    final String EXPORT_INTEGRATION = "export"
     final String DUMMY_JOB_ID = "383d0599-3ea3-4fa6-ac3a-75a53d6b0000"
     final String JOB_XML_NAME = "job-template-common.xml"
     static final GiteaApiRemoteRepo remoteRepo = new GiteaApiRemoteRepo('repoExample3')
@@ -30,7 +30,7 @@ class ScmPluginJobActionInputSpec extends BaseContainer {
         setupProject(PROJECT_NAME)
         def args =["uuid": DUMMY_JOB_ID]
         JobUtils.jobImportFile(PROJECT_NAME,JobUtils.updateJobFileToImport(JOB_XML_NAME,PROJECT_NAME,args) as String,client)
-        GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(EXPORT_INTEGRATION).forProject(PROJECT_NAME)
+        GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(ScmIntegration.EXPORT).forProject(PROJECT_NAME)
         scmClient.callSetupIntegration(GitExportSetupRequest.defaultRequest().forProject(PROJECT_NAME).withRepo(remoteRepo))
         ScmJobStatusResponse firstStatus = scmClient.callGetJobStatus(DUMMY_JOB_ID).response
         ScmActionPerformRequest actionRequest = new ScmActionPerformRequest([
@@ -46,7 +46,7 @@ class ScmPluginJobActionInputSpec extends BaseContainer {
             firstStatus.actions.size() == 1
             firstStatus.commit == null
             firstStatus.id == DUMMY_JOB_ID
-            firstStatus.integration == EXPORT_INTEGRATION
+            firstStatus.integration == ScmIntegration.EXPORT
             firstStatus.message == "Created"
             firstStatus.project == PROJECT_NAME
             firstStatus.synchState == "CREATE_NEEDED"
@@ -56,7 +56,7 @@ class ScmPluginJobActionInputSpec extends BaseContainer {
             updatedStatus.actions.size() == 0
             updatedStatus.commit.size()== 5
             updatedStatus.id == DUMMY_JOB_ID
-            updatedStatus.integration == EXPORT_INTEGRATION
+            updatedStatus.integration == ScmIntegration.EXPORT
             updatedStatus.message == "No Change"
             updatedStatus.project == PROJECT_NAME
             updatedStatus.synchState == "CLEAN"

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginJobActionsPerformSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginJobActionsPerformSpec.groovy
@@ -8,6 +8,7 @@ import org.rundeck.util.api.scm.gitea.GiteaApiRemoteRepo
 import org.rundeck.util.api.scm.httpbody.GitExportSetupRequest
 import org.rundeck.util.api.scm.httpbody.ScmActionPerformRequest
 import org.rundeck.util.api.scm.httpbody.SetupIntegrationResponse
+import org.rundeck.util.common.scm.ScmIntegration
 import org.rundeck.util.container.BaseContainer
 
 @APITest
@@ -15,7 +16,6 @@ import org.rundeck.util.container.BaseContainer
 class ScmPluginJobActionsPerformSpec extends BaseContainer{
 
     static final String PROJECT_NAME = "ScmPluginJobActionsPerform-project"
-    final String EXPORT_INTEGRATION= "export"
     final String DUMMY_JOB_ID = "383d0599-3ea3-4fa6-ac3a-75a53d6bfdf3"
     final String JOB_XML_NAME = "job-template-common.xml"
     static final GiteaApiRemoteRepo remoteRepo = new GiteaApiRemoteRepo('repoExample4')
@@ -29,7 +29,7 @@ class ScmPluginJobActionsPerformSpec extends BaseContainer{
         setupProject(PROJECT_NAME)
         def args =["uuid": DUMMY_JOB_ID]
         JobUtils.jobImportFile(PROJECT_NAME,JobUtils.updateJobFileToImport(JOB_XML_NAME,PROJECT_NAME,args) as String,client)
-        GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(EXPORT_INTEGRATION).forProject(PROJECT_NAME)
+        GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(ScmIntegration.EXPORT).forProject(PROJECT_NAME)
         scmClient.callSetupIntegration(GitExportSetupRequest.defaultRequest().forProject(PROJECT_NAME).withRepo(remoteRepo))
         ScmActionPerformRequest actionRequest = new ScmActionPerformRequest([
                 input: [ message : "Commit msg example" ],

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginJobDiffSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginJobDiffSpec.groovy
@@ -9,6 +9,7 @@ import org.rundeck.util.api.scm.httpbody.GitExportSetupRequest
 import org.rundeck.util.api.scm.httpbody.ScmActionPerformRequest
 import org.rundeck.util.api.scm.httpbody.ScmJobStatusResponse
 import org.rundeck.util.api.scm.httpbody.SetupIntegrationResponse
+import org.rundeck.util.common.scm.ScmIntegration
 import org.rundeck.util.container.BaseContainer
 
 @APITest
@@ -16,7 +17,6 @@ import org.rundeck.util.container.BaseContainer
 class ScmPluginJobDiffSpec extends BaseContainer {
 
     static final String PROJECT_NAME = "ScmPluginJobActionsInput-project"
-    final String EXPORT_INTEGRATION = "export"
     final String DUMMY_JOB_ID = "383d0599-3ea3-4fa6-ac3a-75a53d6b0000"
     final String JOB_XML_NAME = "job-template-common.xml"
     static final GiteaApiRemoteRepo remoteRepo = new GiteaApiRemoteRepo('repoExample4')
@@ -37,7 +37,7 @@ class ScmPluginJobDiffSpec extends BaseContainer {
                 "uuid": DUMMY_JOB_ID
         ]
         JobUtils.jobImportFile(PROJECT_NAME, JobUtils.updateJobFileToImport(JOB_XML_NAME, PROJECT_NAME, initialArgs) as String, client)
-        GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(EXPORT_INTEGRATION).forProject(PROJECT_NAME)
+        GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(ScmIntegration.EXPORT).forProject(PROJECT_NAME)
         scmClient.callSetupIntegration(GitExportSetupRequest.defaultRequest().forProject(PROJECT_NAME).withRepo(remoteRepo))
         hold(5)
         ScmJobStatusResponse initialStatus = scmClient.callGetJobStatus(DUMMY_JOB_ID).response
@@ -56,7 +56,7 @@ class ScmPluginJobDiffSpec extends BaseContainer {
         initialStatus.actions.size() == 1
         initialStatus.commit == null
         initialStatus.id == DUMMY_JOB_ID
-        initialStatus.integration == EXPORT_INTEGRATION
+        initialStatus.integration == ScmIntegration.EXPORT
         initialStatus.message == "Created"
         initialStatus.project == PROJECT_NAME
         initialStatus.synchState == "CREATE_NEEDED"
@@ -69,7 +69,7 @@ class ScmPluginJobDiffSpec extends BaseContainer {
         updatedStatus.actions.size() == 0
         updatedStatus.commit.size() == 5
         updatedStatus.id == DUMMY_JOB_ID
-        updatedStatus.integration == EXPORT_INTEGRATION
+        updatedStatus.integration == ScmIntegration.EXPORT
         updatedStatus.message == "No Change"
         updatedStatus.project == PROJECT_NAME
         updatedStatus.synchState == "CLEAN"
@@ -90,7 +90,7 @@ class ScmPluginJobDiffSpec extends BaseContainer {
         exportNeededStatus.actions.size() == 1
         exportNeededStatus.commit.size() == 5
         exportNeededStatus.id == DUMMY_JOB_ID
-        exportNeededStatus.integration == EXPORT_INTEGRATION
+        exportNeededStatus.integration == ScmIntegration.EXPORT
         exportNeededStatus.message == "Modified"
         exportNeededStatus.project == PROJECT_NAME
         exportNeededStatus.synchState == "EXPORT_NEEDED"
@@ -105,7 +105,7 @@ class ScmPluginJobDiffSpec extends BaseContainer {
         finalStatus.actions.size() == 0
         finalStatus.commit.size() == 5
         finalStatus.id == DUMMY_JOB_ID
-        finalStatus.integration == EXPORT_INTEGRATION
+        finalStatus.integration == ScmIntegration.EXPORT
         finalStatus.message == "No Change"
         finalStatus.project == PROJECT_NAME
         finalStatus.synchState == "CLEAN"

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginJobStatusSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginJobStatusSpec.groovy
@@ -7,6 +7,7 @@ import org.rundeck.util.api.scm.GitScmApiClient
 import org.rundeck.util.api.scm.gitea.GiteaApiRemoteRepo
 import org.rundeck.util.api.scm.httpbody.GitExportSetupRequest
 import org.rundeck.util.api.scm.httpbody.ScmJobStatusResponse
+import org.rundeck.util.common.scm.ScmIntegration
 import org.rundeck.util.container.BaseContainer
 
 @APITest
@@ -14,7 +15,6 @@ import org.rundeck.util.container.BaseContainer
 class ScmPluginJobStatusSpec extends BaseContainer{
 
     static final String PROJECT_NAME = "ScmPluginJobStatus-project"
-    final String EXPORT_INTEGRATION= "export"
     final String DUMMY_JOB_ID = "383d0599-3ea3-4fa6-ac3a-75a53d611111"
     final String JOB_XML_NAME = "job-template-common.xml"
     static final GiteaApiRemoteRepo remoteRepo = new GiteaApiRemoteRepo('repoExample2')
@@ -28,7 +28,7 @@ class ScmPluginJobStatusSpec extends BaseContainer{
         setupProject(PROJECT_NAME)
         def args =["uuid": DUMMY_JOB_ID]
         JobUtils.jobImportFile(PROJECT_NAME,JobUtils.updateJobFileToImport(JOB_XML_NAME,PROJECT_NAME,args) as String,client)
-        GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(EXPORT_INTEGRATION).forProject(PROJECT_NAME)
+        GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(ScmIntegration.EXPORT).forProject(PROJECT_NAME)
         scmClient.callSetupIntegration(GitExportSetupRequest.defaultRequest().forProject(PROJECT_NAME).withRepo(remoteRepo))
 
         when:
@@ -39,7 +39,7 @@ class ScmPluginJobStatusSpec extends BaseContainer{
             status.actions.size() == 1
             status.commit == null
             status.id == DUMMY_JOB_ID
-            status.integration == EXPORT_INTEGRATION
+            status.integration == ScmIntegration.EXPORT
             status.message == "Created"
             status.project == PROJECT_NAME
             status.synchState == "CREATE_NEEDED"

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginSetupSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginSetupSpec.groovy
@@ -9,6 +9,7 @@ import org.rundeck.util.api.scm.httpbody.ScmPluginsListResponse
 import org.rundeck.util.api.scm.httpbody.ScmProjectConfigResponse
 import org.rundeck.util.api.scm.httpbody.GitExportSetupRequest
 import org.rundeck.util.api.scm.httpbody.SetupIntegrationResponse
+import org.rundeck.util.common.scm.ScmIntegration
 import org.rundeck.util.container.BaseContainer
 
 @APITest
@@ -23,7 +24,7 @@ class ScmPluginSetupSpec extends BaseContainer {
 
     def "should mark corresponding validation errors with 'required' on missing properties"(){
         given:
-        String integration = "export"
+        ScmIntegration integration = ScmIntegration.EXPORT
         String projectName = "${PROJECT_NAME}-P1"
         setupProject(projectName)
         GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(integration).forProject(projectName)
@@ -51,7 +52,7 @@ class ScmPluginSetupSpec extends BaseContainer {
 
     def "should return no errors on valid setup"(){
         given:
-        String integration = "export"
+        ScmIntegration integration = ScmIntegration.EXPORT
         String projectName = "${PROJECT_NAME}-P2"
         setupProject(projectName)
         GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(integration).forProject(projectName)
@@ -68,7 +69,7 @@ class ScmPluginSetupSpec extends BaseContainer {
 
     def "plugin must be present in scm plugins list with enabled false after disabling plugin"(){
         given:
-        String integration = "export"
+        ScmIntegration integration = ScmIntegration.EXPORT
         String projectName = "${PROJECT_NAME}-P3"
         setupProject(projectName)
         GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(integration).forProject(projectName)
@@ -94,7 +95,7 @@ class ScmPluginSetupSpec extends BaseContainer {
 
     def "respond with success false if disabling a non existing plugin"(){
         given:
-        String integration = "export"
+        ScmIntegration integration = ScmIntegration.EXPORT
         String projectName = "${PROJECT_NAME}-P4"
         setupProject(projectName)
         GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(integration).forProject(projectName)
@@ -119,7 +120,7 @@ class ScmPluginSetupSpec extends BaseContainer {
 
     def "disable a plugin that wasn't configured results in response with success false"(){
         given:
-        String integration = "export"
+        ScmIntegration integration = ScmIntegration.EXPORT
         String projectName = "${PROJECT_NAME}-P5"
         setupProject(projectName)
         GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(integration).forProject(projectName)
@@ -136,7 +137,7 @@ class ScmPluginSetupSpec extends BaseContainer {
 
     def "plugin must be present in scm plugins list with enabled true after enabling plugin"(){
         given:
-        String integration = "export"
+        ScmIntegration integration = ScmIntegration.EXPORT
         String projectName = "${PROJECT_NAME}-P6"
         setupProject(projectName)
         GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(integration).forProject(projectName)
@@ -164,7 +165,7 @@ class ScmPluginSetupSpec extends BaseContainer {
 
     def "should return the current  project scm configuration"(){
         given:
-        String integration = "export"
+        ScmIntegration integration = ScmIntegration.EXPORT
         String projectName = "${PROJECT_NAME}-P7"
         setupProject(projectName)
         GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(integration).forProject(projectName)
@@ -215,14 +216,14 @@ class ScmPluginSetupSpec extends BaseContainer {
         }
 
         where:
-        integration | expectedTitle | expectedDescription
-        'export'    | 'Git Export'  | 'Export Jobs to a Git Repository'
-        'import'    | 'Git Import'  | 'Import Jobs from a Git Repository'
+        integration           | expectedTitle | expectedDescription
+        ScmIntegration.EXPORT | 'Git Export'  | 'Export Jobs to a Git Repository'
+        ScmIntegration.IMPORT | 'Git Import'  | 'Import Jobs from a Git Repository'
     }
 
     def "list plugins for non existing integration"() {
         given:
-        String integration = 'invalid'
+        ScmIntegration integration = ScmIntegration.INVALID
         String projectName = "${PROJECT_NAME}-P9"
         setupProject(projectName)
         GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(integration).forProject(projectName)
@@ -233,7 +234,7 @@ class ScmPluginSetupSpec extends BaseContainer {
         then:
         verifyAll {
             scmPlugins.errorCode == 'api.error.invalid.request'
-            scmPlugins.message == 'Invalid API Request: the value "invalid" for parameter "integration" was invalid. It must be in the list: [export, import]'
+            scmPlugins.message == "Invalid API Request: the value \"${integration.name}\" for parameter \"integration\" was invalid. It must be in the list: [export, import]"
         }
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginStatusSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginStatusSpec.groovy
@@ -6,6 +6,7 @@ import org.rundeck.util.api.scm.GitScmApiClient
 import org.rundeck.util.api.scm.gitea.GiteaApiRemoteRepo
 import org.rundeck.util.api.scm.httpbody.IntegrationStatusResponse
 import org.rundeck.util.api.scm.httpbody.GitExportSetupRequest
+import org.rundeck.util.common.scm.ScmIntegration
 import org.rundeck.util.container.BaseContainer
 
 @APITest
@@ -21,7 +22,7 @@ class ScmPluginStatusSpec extends BaseContainer {
 
     def "project scm export status must be clean after setup on empty project"(){
         given:
-        String integration = "export"
+        ScmIntegration integration = ScmIntegration.EXPORT
         GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(integration).forProject(PROJECT_NAME)
 
         GitExportSetupRequest requestBody = GitExportSetupRequest.defaultRequest().forProject(PROJECT_NAME).withRepo(remoteRepo)

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/scm/ScmStatusBadgeSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/scm/ScmStatusBadgeSpec.groovy
@@ -1,0 +1,110 @@
+package org.rundeck.tests.functional.selenium.scm
+
+import org.rundeck.util.common.scm.ScmIntegration
+import org.rundeck.util.gui.scm.ScmStatusBadge
+import org.rundeck.util.gui.pages.jobs.JobShowPage
+import org.rundeck.util.gui.pages.login.LoginPage
+import org.rundeck.util.gui.pages.scm.ConfigureScmPage
+import org.rundeck.util.gui.pages.scm.PerformScmActionPage
+import org.rundeck.util.annotations.SeleniumCoreTest
+import org.rundeck.util.api.scm.GitScmApiClient
+import org.rundeck.util.api.scm.gitea.GiteaApiRemoteRepo
+import org.rundeck.util.api.storage.KeyStorageApiClient
+import org.rundeck.util.container.SeleniumBase
+
+@SeleniumCoreTest
+class ScmStatusBadgeSpec extends SeleniumBase {
+
+    private static String REPO_NAME = "statusBadgeTest"
+    private static String PROJECT_LOCATION = "/projects-import/scm/PScmStatusBadgeTest.rdproject"
+    private static String PROJECT_NAME = 'PScmStatusBadgeTest'
+    private static GitScmApiClient scmApiClient
+
+    @Override
+    def setupSpec() {
+        GiteaApiRemoteRepo repo = new GiteaApiRemoteRepo(REPO_NAME).setupRepo()
+        repo.storeRepoPassInRundeck(new KeyStorageApiClient(clientProvider), "scm/scm.password")
+
+        setupProjectArchiveDirectoryResource(PROJECT_NAME, PROJECT_LOCATION)
+        scmApiClient = new GitScmApiClient(clientProvider).forProject(PROJECT_NAME)
+        scmApiClient.forIntegration(ScmIntegration.EXPORT).callSetEnabledStatusForPlugin(false)
+        scmApiClient.forIntegration(ScmIntegration.IMPORT).callSetEnabledStatusForPlugin(false)
+    }
+
+    def cleanup(){
+        scmApiClient.forIntegration(ScmIntegration.EXPORT).callSetEnabledStatusForPlugin(false)
+        scmApiClient.forIntegration(ScmIntegration.IMPORT).callSetEnabledStatusForPlugin(false)
+    }
+
+    def "job scm import status badge for a newly created job"(){
+        setup:
+        go(LoginPage).login(TEST_USER, TEST_PASS)
+        ConfigureScmPage configureScmPage = go(ConfigureScmPage, PROJECT_NAME)
+        configureScmPage.enableScmImport()
+
+        JobShowPage jobShowPage = page(JobShowPage, PROJECT_NAME).forJob("740791d7-8734-4d8a-a77d-465aa2ccfe63")
+        jobShowPage.go()
+
+        when:
+        ScmStatusBadge scmStatusBadge = jobShowPage.getScmStatusBadge()
+
+        then:
+        scmStatusBadge.iconClasses.containsAll(['glyphicon','glyphicon-question-sign'])
+        scmStatusBadge.badgeText == 'Import Status: Not Tracked'
+        scmStatusBadge.getTooltips() == 'Not Tracked for SCM Import'
+    }
+
+    def "job scm import status badge after import job changes"(){
+        given:
+        go(LoginPage).login(TEST_USER, TEST_PASS)
+        final String jobUuid = "08879a4b-3d0d-427c-9b69-226296ce30af"
+        ConfigureScmPage configureScmPage = go(ConfigureScmPage, PROJECT_NAME)
+        configureScmPage.enableScmExport()
+
+        page(PerformScmActionPage, PROJECT_NAME).commitJobChanges(jobUuid, "message example")
+        configureScmPage.go()
+        configureScmPage.disableScmExport()
+        configureScmPage.enableScmImport()
+
+        JobShowPage jobShowPage = page(JobShowPage, PROJECT_NAME).forJob(jobUuid)
+        jobShowPage.go()
+
+        when:
+        ScmStatusBadge scmStatusBadge = jobShowPage.getScmStatusBadge()
+
+        then:
+        scmStatusBadge.iconClasses.containsAll(['glyphicon','glyphicon-exclamation-sign'])
+        scmStatusBadge.badgeText == 'Import Needed'
+        scmStatusBadge.getTooltips() == 'Import Status: Job changes need to be pulled'
+    }
+
+
+    def "job scm export status badge when job created and after commit"(){
+        given:
+        go(LoginPage).login(TEST_USER, TEST_PASS)
+        final String jobUuid = "1ccd6bc5-63ae-4853-8f00-5fdaad031a24"
+        ConfigureScmPage configureScmPage = go(ConfigureScmPage, PROJECT_NAME)
+        configureScmPage.enableScmExport()
+
+        JobShowPage jobShowPage = page(JobShowPage, PROJECT_NAME).forJob(jobUuid)
+        jobShowPage.go()
+
+        when:
+        ScmStatusBadge scmStatusBadge = jobShowPage.getScmStatusBadge()
+
+        then:
+        scmStatusBadge.iconClasses.containsAll(['glyphicon','glyphicon-exclamation-sign'])
+        scmStatusBadge.badgeText == 'Created'
+        scmStatusBadge.getTooltips() == 'Export Status: New Job, Not yet added to SCM'
+
+        when:
+        page(PerformScmActionPage, PROJECT_NAME).commitJobChanges(jobUuid, "message example")
+        jobShowPage.go()
+        ScmStatusBadge scmStatusBadgeAfterCommit = jobShowPage.getScmStatusBadge()
+
+        then:
+        scmStatusBadgeAfterCommit.iconClasses.containsAll(['glyphicon','glyphicon-ok'])
+        scmStatusBadgeAfterCommit.badgeText == 'No Change'
+        scmStatusBadgeAfterCommit.getTooltips() == 'Export Status: Clean'
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/util/api/scm/GitScmApiClient.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/api/scm/GitScmApiClient.groovy
@@ -11,6 +11,8 @@ import org.rundeck.util.api.scm.httpbody.ScmPluginsListResponse
 import org.rundeck.util.api.scm.httpbody.ScmProjectConfigResponse
 import org.rundeck.util.api.scm.httpbody.GitExportSetupRequest
 import org.rundeck.util.api.scm.httpbody.SetupIntegrationResponse
+import org.rundeck.util.common.scm.ScmActionId
+import org.rundeck.util.common.scm.ScmIntegration
 import org.rundeck.util.container.ClientProvider
 import org.rundeck.util.container.RdClient
 
@@ -24,9 +26,9 @@ class GitScmApiClient {
         this.client = clientProvider.client
     }
 
-    GitScmApiClient forIntegration(String integration){
-        this.integration = integration
-        this.pluginName = "git-${integration}"
+    GitScmApiClient forIntegration(ScmIntegration integration){
+        this.integration = integration.name
+        this.pluginName = "git-${integration.name}"
         return this
     }
 
@@ -47,8 +49,8 @@ class GitScmApiClient {
         return new RundeckResponse(resp, IntegrationStatusResponse)
     }
 
-    RundeckResponse<ScmActionInputFieldsResponse> callGetFieldsForAction(String actionId) {
-        Response resp = client.doGet("/project/${project}/scm/${integration}/action/${actionId}/input")
+    RundeckResponse<ScmActionInputFieldsResponse> callGetFieldsForAction(ScmActionId actionId) {
+        Response resp = client.doGet("/project/${project}/scm/${integration}/action/${actionId.name}/input")
 
         return new RundeckResponse(resp, ScmActionInputFieldsResponse)
     }

--- a/functional-test/src/test/groovy/org/rundeck/util/api/scm/gitea/GiteaApiRemoteRepo.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/api/scm/gitea/GiteaApiRemoteRepo.groovy
@@ -31,8 +31,9 @@ class GiteaApiRemoteRepo {
                 .build()
     }
 
-    void setupRepo(){
+    GiteaApiRemoteRepo setupRepo(){
         doPost(CREATE_REPO_ENDPOINT, new CreateRepoRequest(name: this.repoName))
+        return this
     }
 
     private Response doPost(final String path, final Object body = null){
@@ -62,7 +63,7 @@ class GiteaApiRemoteRepo {
     /**
      *
      * @param client
-     * @param path
+     * @param path including the key name but not the "keys/" prefix
      * @return true if successful
      */
     Response storeRepoPassInRundeck(KeyStorageApiClient client, String path){

--- a/functional-test/src/test/groovy/org/rundeck/util/api/scm/httpbody/IntegrationStatusResponse.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/api/scm/httpbody/IntegrationStatusResponse.groovy
@@ -1,6 +1,7 @@
 package org.rundeck.util.api.scm.httpbody
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import org.rundeck.util.common.scm.ScmIntegration
 
 class IntegrationStatusResponse {
     @JsonProperty
@@ -17,4 +18,8 @@ class IntegrationStatusResponse {
 
     @JsonProperty
     String synchState
+
+    ScmIntegration getIntegration(){
+        return ScmIntegration.getEnum(integration)
+    }
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/api/scm/httpbody/ScmActionInputFieldsResponse.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/api/scm/httpbody/ScmActionInputFieldsResponse.groovy
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.rundeck.util.api.scm.httpbody.common.InputField
+import org.rundeck.util.common.scm.ScmActionId
+import org.rundeck.util.common.scm.ScmIntegration
 
 class ScmActionInputFieldsResponse {
     @JsonProperty
@@ -26,6 +28,15 @@ class ScmActionInputFieldsResponse {
 
     @JsonProperty
     List<ExportItems> exportItems
+
+    ScmIntegration getIntegration(){
+        ScmIntegration.getEnum(integration)
+    }
+
+    ScmActionId getActionId(){
+        ScmActionId.getEnum(actionId)
+    }
+
 
     static class ImportItems extends CommonItems {
         @JsonProperty

--- a/functional-test/src/test/groovy/org/rundeck/util/api/scm/httpbody/ScmJobStatusResponse.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/api/scm/httpbody/ScmJobStatusResponse.groovy
@@ -1,6 +1,7 @@
 package org.rundeck.util.api.scm.httpbody
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import org.rundeck.util.common.scm.ScmIntegration
 
 class ScmJobStatusResponse {
 
@@ -24,4 +25,8 @@ class ScmJobStatusResponse {
 
     @JsonProperty
     String synchState
+
+    ScmIntegration getIntegration(){
+        ScmIntegration.getEnum(integration)
+    }
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/api/scm/httpbody/ScmPluginInputFieldsResponse.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/api/scm/httpbody/ScmPluginInputFieldsResponse.groovy
@@ -2,6 +2,7 @@ package org.rundeck.util.api.scm.httpbody
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import org.rundeck.util.api.scm.httpbody.common.InputField
+import org.rundeck.util.common.scm.ScmIntegration
 
 class ScmPluginInputFieldsResponse {
 
@@ -13,4 +14,8 @@ class ScmPluginInputFieldsResponse {
 
     @JsonProperty
     List<InputField> fields
+
+    ScmIntegration getIntegration(){
+        return ScmIntegration.getEnum(integration)
+    }
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/api/scm/httpbody/ScmPluginsListResponse.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/api/scm/httpbody/ScmPluginsListResponse.groovy
@@ -3,6 +3,7 @@ package org.rundeck.util.api.scm.httpbody
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import okhttp3.Response
+import org.rundeck.util.common.scm.ScmIntegration
 
 class ScmPluginsListResponse {
 
@@ -11,6 +12,10 @@ class ScmPluginsListResponse {
 
     @JsonProperty
     List<ScmPlugin> plugins
+
+    ScmIntegration getIntegration(){
+        ScmIntegration.getEnum(integration)
+    }
 
     static class ScmPlugin {
         @JsonProperty

--- a/functional-test/src/test/groovy/org/rundeck/util/api/scm/httpbody/ScmProjectConfigResponse.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/api/scm/httpbody/ScmProjectConfigResponse.groovy
@@ -1,6 +1,7 @@
 package org.rundeck.util.api.scm.httpbody
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import org.rundeck.util.common.scm.ScmIntegration
 
 class ScmProjectConfigResponse {
     @JsonProperty
@@ -17,4 +18,8 @@ class ScmProjectConfigResponse {
 
     @JsonProperty
     String type
+
+    ScmIntegration getIntegration(){
+        ScmIntegration.getEnum(integration)
+    }
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/common/scm/ScmActionId.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/scm/ScmActionId.groovy
@@ -9,8 +9,8 @@ enum ScmActionId {
     }
 
     static ScmActionId getEnum(String value) {
-        ScmActionId action = valueOf(value.toUpperCase(Locale.ENGLISH))
-        if(action.name == value) return action
+        for(ScmActionId v : values())
+            if(v.name == value) return v
         throw new IllegalArgumentException()
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/common/scm/ScmActionId.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/scm/ScmActionId.groovy
@@ -9,8 +9,8 @@ enum ScmActionId {
     }
 
     static ScmActionId getEnum(String value) {
-        for(ScmActionId v : values())
-            if(v.name.equalsIgnoreCase(value)) return v
+        ScmActionId action = valueOf(value.toUpperCase(Locale.ENGLISH))
+        if(action.name == value) return action
         throw new IllegalArgumentException()
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/common/scm/ScmActionId.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/scm/ScmActionId.groovy
@@ -1,0 +1,16 @@
+package org.rundeck.util.common.scm
+
+enum ScmActionId {
+    JOB_COMMIT("job-commit"),
+    PROJECT_COMMIT("project-commit")
+    final String name
+    ScmActionId(String name){
+        this.name = name
+    }
+
+    static ScmActionId getEnum(String value) {
+        for(ScmActionId v : values())
+            if(v.name.equalsIgnoreCase(value)) return v
+        throw new IllegalArgumentException()
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/util/common/scm/ScmIntegration.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/scm/ScmIntegration.groovy
@@ -10,8 +10,8 @@ enum ScmIntegration {
     }
 
     static ScmIntegration getEnum(String value) {
-        for(ScmIntegration v : values())
-            if(v.name.equalsIgnoreCase(value)) return v
+        ScmIntegration action = valueOf(value.toUpperCase(Locale.ENGLISH))
+        if(action.name == value) return action
         throw new IllegalArgumentException()
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/common/scm/ScmIntegration.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/scm/ScmIntegration.groovy
@@ -1,0 +1,17 @@
+package org.rundeck.util.common.scm
+
+enum ScmIntegration {
+    IMPORT("import"),
+    EXPORT("export"),
+    INVALID("asddsa")
+    final String name
+    ScmIntegration(String name){
+        this.name = name
+    }
+
+    static ScmIntegration getEnum(String value) {
+        for(ScmIntegration v : values())
+            if(v.name.equalsIgnoreCase(value)) return v
+        throw new IllegalArgumentException()
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/util/common/scm/ScmIntegration.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/scm/ScmIntegration.groovy
@@ -10,8 +10,8 @@ enum ScmIntegration {
     }
 
     static ScmIntegration getEnum(String value) {
-        ScmIntegration action = valueOf(value.toUpperCase(Locale.ENGLISH))
-        if(action.name == value) return action
+        for(ScmIntegration v : values())
+            if(v.name == value) return v
         throw new IllegalArgumentException()
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
@@ -135,7 +135,8 @@ abstract class BaseContainer extends Specification implements ClientProvider {
             [
                 importConfig      : true,
                 importACL         : true,
-                importNodesSources: true
+                importNodesSources: true,
+                importScm: true
             ]
         )
     }

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobShowPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobShowPage.groovy
@@ -5,6 +5,7 @@ import org.openqa.selenium.By
 import org.openqa.selenium.WebElement
 import org.rundeck.util.container.SeleniumContext
 import org.rundeck.util.gui.pages.BasePage
+import org.rundeck.util.gui.scm.ScmStatusBadge
 
 /**
  * Job show page
@@ -43,6 +44,7 @@ class JobShowPage extends BasePage{
     By jobSearchSubmitBy = By.cssSelector('#jobs_filters form #jobs_filters_footer input[type="submit"][name="_action_jobs"]')
 
     String loadPath = "/job/show"
+    private String project
 
     JobShowPage(final SeleniumContext context) {
         super(context)
@@ -50,7 +52,17 @@ class JobShowPage extends BasePage{
 
     JobShowPage(final SeleniumContext context, String project) {
         super(context)
+        this.project = project
         this.loadPath = "/project/$project/jobs"
+    }
+
+    JobShowPage forJob(String jobUuid){
+        this.loadPath = "/project/$project/job/show/$jobUuid"
+        return this
+    }
+
+    ScmStatusBadge getScmStatusBadge(){
+        return new ScmStatusBadge(this)
     }
 
     void validatePage() {

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/scm/ConfigureScmPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/scm/ConfigureScmPage.groovy
@@ -1,0 +1,74 @@
+package org.rundeck.util.gui.pages.scm
+
+import org.openqa.selenium.By
+import org.openqa.selenium.NoSuchElementException
+import org.openqa.selenium.StaleElementReferenceException
+import org.openqa.selenium.WebElement
+import org.openqa.selenium.support.ui.ExpectedConditions
+import org.openqa.selenium.support.ui.WebDriverWait
+import org.rundeck.util.gui.pages.BasePage
+import org.rundeck.util.container.SeleniumContext
+
+import java.time.Duration
+
+class ConfigureScmPage extends BasePage{
+
+    String loadPath
+
+    ConfigureScmPage(SeleniumContext context, String project) {
+        super(context)
+        loadPath = "/project/${project}/scm"
+    }
+
+    @Override
+    void validatePage() {
+        if(!loadPath)
+            throw new IllegalStateException("Load path not set")
+        if (!driver.currentUrl.endsWith(loadPath)) {
+            throw new IllegalStateException("Couldn't browse Configure SCM Page. Expected: ${loadPath} Actual: ${driver.currentUrl}")
+        }
+    }
+
+    void disableScmExport() {
+        toggleSCM(false, true)
+    }
+
+    void disableScmImport() {
+        toggleSCM(false, false)
+    }
+
+    void enableScmImport() {
+        toggleSCM(true, false)
+    }
+
+    void enableScmExport() {
+        toggleSCM(true, true)
+    }
+
+    private void toggleSCM(boolean enable, boolean export) {
+        String action = enable ? "enable" : "disable"
+        String oppositeAction = !enable ? "enable" : "disable"
+        String integration = export ? "export" : "import"
+        By dataTargetValueBy = By.xpath("//span[@data-target='#${action}Plugin${integration}']")
+        By oppositeDataTargetValueBy = By.xpath("//span[@data-target='#${oppositeAction}Plugin${integration}']")
+
+        new WebDriverWait(driver, Duration.ofSeconds(15))
+                    .ignoring(StaleElementReferenceException.class)
+                    .until(ExpectedConditions.or(
+                            ExpectedConditions.elementToBeClickable(dataTargetValueBy),
+                            ExpectedConditions.elementToBeClickable(oppositeDataTargetValueBy)
+                    ))
+
+        WebElement toggleButton = null
+        try{
+            toggleButton = driver.findElement(dataTargetValueBy)
+        } catch (NoSuchElementException ignored){}
+
+
+        if(toggleButton){
+            toggleButton.click()
+            waitForModal(1)
+            byAndWait(modalField).findElement(By.xpath(".//input[@type='submit'][@value='Yes']")).click()
+        }
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/scm/PerformScmActionPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/scm/PerformScmActionPage.groovy
@@ -1,0 +1,74 @@
+package org.rundeck.util.gui.pages.scm
+
+import org.openqa.selenium.By
+import org.openqa.selenium.NoSuchElementException
+import org.openqa.selenium.StaleElementReferenceException
+import org.openqa.selenium.WebElement
+import org.openqa.selenium.support.ui.ExpectedConditions
+import org.openqa.selenium.support.ui.WebDriverWait
+
+import org.rundeck.util.common.scm.ScmIntegration
+import org.rundeck.util.container.SeleniumContext
+import org.rundeck.util.common.scm.ScmActionId
+import org.rundeck.util.gui.pages.BasePage
+import org.rundeck.util.common.WaitingTime
+
+import java.time.Duration
+
+class PerformScmActionPage extends BasePage {
+
+    String loadPath
+    private static final String PERFORM_ACTION_URL_PART = "performAction?actionId="
+    private static final ScmIntegration INTEGRATION_FOR_COMMIT = ScmIntegration.EXPORT
+    private static final By INFO_MESSAGE_BOX_LOCATOR = By.cssSelector(".alert.alert-info")
+    private static final By ERROR_MESSAGE_BOX_LOCATOR = By.cssSelector(".alert.alert-danger")
+
+    PerformScmActionPage(SeleniumContext context, String project) {
+        super(context)
+        loadPath = "/project/${project}"
+    }
+
+    String commitJobChanges(String jobUuid, String commitMessage, boolean shouldWaitAfterCommit = true){
+        loadPath += "/job/${jobUuid}/scm/${INTEGRATION_FOR_COMMIT.name}/${PERFORM_ACTION_URL_PART}${ScmActionId.JOB_COMMIT.name}"
+        super.go()
+
+        driver.findElement(By.name("pluginProperties.message")).sendKeys(commitMessage)
+        driver.findElement(By.name("submit")).click()
+
+        String resultText = waitForResultMessageBox().getText()
+
+        if(shouldWaitAfterCommit)
+            Thread.sleep(WaitingTime.MODERATE.milliSeconds)
+
+        return resultText
+    }
+
+    private WebElement waitForResultMessageBox(){
+        new WebDriverWait(driver, Duration.ofSeconds(15))
+                .ignoring(StaleElementReferenceException.class)
+                .until(ExpectedConditions.or(
+                        ExpectedConditions.elementToBeClickable(ERROR_MESSAGE_BOX_LOCATOR),
+                        ExpectedConditions.elementToBeClickable(INFO_MESSAGE_BOX_LOCATOR))
+                )
+
+        try {
+            return driver.findElement(INFO_MESSAGE_BOX_LOCATOR)
+        } catch(NoSuchElementException ignored){
+            return driver.findElement(ERROR_MESSAGE_BOX_LOCATOR)
+        }
+    }
+
+    /**
+     * Cannot go since it doesn't have a defined loadpath until the action method is called
+     */
+    @Override
+    void go() {
+    }
+
+    @Override
+    void validatePage() {
+        if (!driver.currentUrl.endsWith(loadPath)) {
+            throw new IllegalStateException("Couldn't browse Perform SCM Action Page. Expected: ${loadPath} Actual: ${driver.currentUrl}")
+        }
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/scm/ScmStatusBadge.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/scm/ScmStatusBadge.groovy
@@ -1,0 +1,31 @@
+package org.rundeck.util.gui.scm
+
+import org.openqa.selenium.By
+import org.openqa.selenium.WebElement
+import org.openqa.selenium.support.ui.ExpectedConditions
+import org.openqa.selenium.support.ui.WebDriverWait
+import org.rundeck.util.gui.pages.jobs.JobShowPage
+
+import java.time.Duration
+
+class ScmStatusBadge {
+    final List iconClasses
+    final String badgeText
+    final String tooltips
+    static final By elementSelector = By.xpath("//*[@id='jobInfo_']/span[2]/span")
+    static final String loadingFromServerText = "Loading Scm Data"
+    static final String tooltipsAttribute = "title"
+
+    ScmStatusBadge(JobShowPage jobShowPage){
+        new WebDriverWait(jobShowPage.driver, Duration.ofSeconds(10)).until(
+                ExpectedConditions.not(
+                        ExpectedConditions.textToBe(elementSelector, loadingFromServerText)
+                )
+        )
+
+        WebElement statusBadge = jobShowPage.driver.findElement(elementSelector)
+        this.tooltips = statusBadge.getAttribute(tooltipsAttribute)
+        this.badgeText = statusBadge.getText()
+        this.iconClasses = statusBadge.findElement(By.tagName("i")).getAttribute("class").split(" ")
+    }
+}

--- a/functional-test/src/test/resources/projects-import/scm/PScmStatusBadgeTest.rdproject/rundeck-PScmStatusBadgeTest/files/etc/project.properties
+++ b/functional-test/src/test/resources/projects-import/scm/PScmStatusBadgeTest.rdproject/rundeck-PScmStatusBadgeTest/files/etc/project.properties
@@ -1,0 +1,7 @@
+#Exported configuration
+#Wed Jan 31 18:08:12 ART 2024
+project.name=PScmStatusBadgeTest
+project.ssh-authentication=privateKey
+resources.source.1.type=local
+service.FileCopier.default.provider=sshj-scp
+service.NodeExecutor.default.provider=sshj-ssh

--- a/functional-test/src/test/resources/projects-import/scm/PScmStatusBadgeTest.rdproject/rundeck-PScmStatusBadgeTest/files/etc/scm-export.properties
+++ b/functional-test/src/test/resources/projects-import/scm/PScmStatusBadgeTest.rdproject/rundeck-PScmStatusBadgeTest/files/etc/scm-export.properties
@@ -1,0 +1,23 @@
+#Exported configuration
+#Wed Jan 31 18:08:12 ART 2024
+flagToReturnProcess=true
+scm.export.config._createBranch=
+scm.export.config.baseBranch=master
+scm.export.config.branch=master
+scm.export.config.committerEmail=email-example
+scm.export.config.committerName=committer-example
+scm.export.config.dir=%PROJECT_BASEDIR%/ScmExport
+scm.export.config.exportUuidBehavior=preserve
+scm.export.config.fetchAutomatically=true
+scm.export.config.format=yaml
+scm.export.config.gitPasswordPath=keys/scm/scm.password
+scm.export.config.pathTemplate=${job.id}.${config.format}
+scm.export.config.pullAutomatically=false
+scm.export.config.sshPrivateKeyPath=
+scm.export.config.strictHostKeyChecking=no
+scm.export.config.url=http\://rundeckgitea@gitea\:3000/rundeckgitea/statusBadgeTest.git
+scm.export.enabled=true
+scm.export.roles.0=admin
+scm.export.roles.count=1
+scm.export.type=git-export
+scm.export.username=admin

--- a/functional-test/src/test/resources/projects-import/scm/PScmStatusBadgeTest.rdproject/rundeck-PScmStatusBadgeTest/files/etc/scm-import.properties
+++ b/functional-test/src/test/resources/projects-import/scm/PScmStatusBadgeTest.rdproject/rundeck-PScmStatusBadgeTest/files/etc/scm-import.properties
@@ -1,0 +1,20 @@
+#Exported configuration
+#Wed Jan 31 18:08:12 ART 2024
+scm.import.config.branch=master
+scm.import.config.dir=%PROJECT_BASEDIR%/ScmImport
+scm.import.config.fetchAutomatically=true
+scm.import.config.filePattern=.*\\.yaml
+scm.import.config.format=yaml
+scm.import.config.gitPasswordPath=keys/scm/scm.password
+scm.import.config.importUuidBehavior=preserve
+scm.import.config.pathTemplate=${job.id}.${config.format}
+scm.import.config.pullAutomatically=true
+scm.import.config.sshPrivateKeyPath=
+scm.import.config.strictHostKeyChecking=no
+scm.import.config.url=http\://rundeckgitea@gitea\:3000/rundeckgitea/statusBadgeTest.git
+scm.import.config.useFilePattern=true
+scm.import.enabled=false
+scm.import.roles.0=admin
+scm.import.roles.count=1
+scm.import.type=git-import
+scm.import.username=admin

--- a/functional-test/src/test/resources/projects-import/scm/PScmStatusBadgeTest.rdproject/rundeck-PScmStatusBadgeTest/jobs/job-08879a4b-3d0d-427c-9b69-226296ce30af.xml
+++ b/functional-test/src/test/resources/projects-import/scm/PScmStatusBadgeTest.rdproject/rundeck-PScmStatusBadgeTest/jobs/job-08879a4b-3d0d-427c-9b69-226296ce30af.xml
@@ -1,0 +1,23 @@
+<joblist>
+  <job>
+    <defaultTab>nodes</defaultTab>
+    <description></description>
+    <executionEnabled>true</executionEnabled>
+    <id>08879a4b-3d0d-427c-9b69-226296ce30af</id>
+    <loglevel>INFO</loglevel>
+    <name>job-to-be-exported-then-imported</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <plugins />
+    <scheduleEnabled>true</scheduleEnabled>
+    <sequence keepgoing='false' strategy='node-first'>
+      <command>
+        <node-step-plugin type='exec-command'>
+          <configuration>
+            <entry key='adhocRemoteString' value='ls' />
+          </configuration>
+        </node-step-plugin>
+      </command>
+    </sequence>
+    <uuid>08879a4b-3d0d-427c-9b69-226296ce30af</uuid>
+  </job>
+</joblist>

--- a/functional-test/src/test/resources/projects-import/scm/PScmStatusBadgeTest.rdproject/rundeck-PScmStatusBadgeTest/jobs/job-1ccd6bc5-63ae-4853-8f00-5fdaad031a24.xml
+++ b/functional-test/src/test/resources/projects-import/scm/PScmStatusBadgeTest.rdproject/rundeck-PScmStatusBadgeTest/jobs/job-1ccd6bc5-63ae-4853-8f00-5fdaad031a24.xml
@@ -1,0 +1,23 @@
+<joblist>
+  <job>
+    <defaultTab>nodes</defaultTab>
+    <description></description>
+    <executionEnabled>true</executionEnabled>
+    <id>1ccd6bc5-63ae-4853-8f00-5fdaad031a24</id>
+    <loglevel>INFO</loglevel>
+    <name>job-created-export</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <plugins />
+    <scheduleEnabled>true</scheduleEnabled>
+    <sequence keepgoing='false' strategy='node-first'>
+      <command>
+        <node-step-plugin type='exec-command'>
+          <configuration>
+            <entry key='adhocRemoteString' value='ls' />
+          </configuration>
+        </node-step-plugin>
+      </command>
+    </sequence>
+    <uuid>1ccd6bc5-63ae-4853-8f00-5fdaad031a24</uuid>
+  </job>
+</joblist>

--- a/functional-test/src/test/resources/projects-import/scm/PScmStatusBadgeTest.rdproject/rundeck-PScmStatusBadgeTest/jobs/job-740791d7-8734-4d8a-a77d-465aa2ccfe63.xml
+++ b/functional-test/src/test/resources/projects-import/scm/PScmStatusBadgeTest.rdproject/rundeck-PScmStatusBadgeTest/jobs/job-740791d7-8734-4d8a-a77d-465aa2ccfe63.xml
@@ -1,0 +1,23 @@
+<joblist>
+  <job>
+    <defaultTab>nodes</defaultTab>
+    <description></description>
+    <executionEnabled>true</executionEnabled>
+    <id>740791d7-8734-4d8a-a77d-465aa2ccfe63</id>
+    <loglevel>INFO</loglevel>
+    <name>job-created-import</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <plugins />
+    <scheduleEnabled>true</scheduleEnabled>
+    <sequence keepgoing='false' strategy='node-first'>
+      <command>
+        <node-step-plugin type='exec-command'>
+          <configuration>
+            <entry key='adhocRemoteString' value='ls' />
+          </configuration>
+        </node-step-plugin>
+      </command>
+    </sequence>
+    <uuid>740791d7-8734-4d8a-a77d-465aa2ccfe63</uuid>
+  </job>
+</joblist>


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-980
Depends On: https://github.com/rundeck/rundeck/pull/8877

The following tests were added to validate the scm status badge shown next to the job name on the job detail page `(/project/<project_name>/job/show/<job_uuid>`) when having scm import or export plugins enabled:

`"job scm import status badge for a newly created job"`: Having only scm import enabled, when clicking on a newly created job, the following status badge is shown:
![image](https://github.com/rundeck/rundeck/assets/49494423/83c4807b-b7a7-4d8f-a053-1fff3d2ad51f)


`"job scm import status badge after import job changes"`: When exporting changes of an edited job, after enabling only the scm import plugin, the status badge must be the following
![image](https://github.com/rundeck/rundeck/assets/49494423/ff45fd6a-0161-45d4-8d90-d5b1cc1c69d4)


`"job scm export status badge when job created and after commit"`: the status badge must be the following when having only scm export enabled:
![image](https://github.com/rundeck/rundeck/assets/49494423/96027ae1-3fd0-4074-a8e6-741868e8540b)

And after exporting:
![image](https://github.com/rundeck/rundeck/assets/49494423/754c585b-6d98-4dbb-b044-a75ca6c2bae7)

