### PR TITLE
RUN-2211: Fix: restore class to java core library

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/utils/SSHAgentProcess.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/utils/SSHAgentProcess.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.rundeck.plugins.jsch.util;
+package com.dtolabs.rundeck.core.utils;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/ExtSSHExec.java
+++ b/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/ExtSSHExec.java
@@ -25,7 +25,7 @@
 
 package org.rundeck.plugins.jsch.net;
 
-import org.rundeck.plugins.jsch.util.SSHAgentProcess;
+import com.dtolabs.rundeck.core.utils.SSHAgentProcess;
 import com.dtolabs.rundeck.plugins.PluginLogger;
 import com.jcraft.jsch.*;
 import org.apache.tools.ant.BuildException;

--- a/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/ExtScp.java
+++ b/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/ExtScp.java
@@ -16,7 +16,7 @@
 
 package org.rundeck.plugins.jsch.net;
 
-import org.rundeck.plugins.jsch.util.SSHAgentProcess;
+import com.dtolabs.rundeck.core.utils.SSHAgentProcess;
 import com.dtolabs.rundeck.plugins.PluginLogger;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;

--- a/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/SSHTaskBuilder.java
+++ b/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/net/SSHTaskBuilder.java
@@ -26,7 +26,7 @@ package org.rundeck.plugins.jsch.net;
 import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.dispatcher.DataContextUtils;
 import com.dtolabs.rundeck.core.utils.FileUtils;
-import org.rundeck.plugins.jsch.util.SSHAgentProcess;
+import com.dtolabs.rundeck.core.utils.SSHAgentProcess;
 import com.dtolabs.rundeck.plugins.PluginLogger;
 import com.dtolabs.utils.Streams;
 import com.jcraft.jsch.JSch;

--- a/plugins/jsch-plugin/src/test/java/org/rundeck/plugins/jsch/net/TestSSHTaskBuilder.java
+++ b/plugins/jsch-plugin/src/test/java/org/rundeck/plugins/jsch/net/TestSSHTaskBuilder.java
@@ -25,7 +25,7 @@ package org.rundeck.plugins.jsch.net;
 
 import com.dtolabs.rundeck.core.cli.CLIUtils;
 import com.dtolabs.rundeck.core.common.NodeEntryImpl;
-import org.rundeck.plugins.jsch.util.SSHAgentProcess;
+import com.dtolabs.rundeck.core.utils.SSHAgentProcess;
 import com.dtolabs.rundeck.plugins.PluginLogger;
 
 import junit.framework.TestCase;


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**

Fixes #8925 
Restore class removed from rundeck-core library

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
