### PR TITLE
RUN-2213: fix: resolve critical CVE by updating `org.postgresql:postgresql` to 42.7.2

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -250,7 +250,7 @@ dependencies {
     runtimeOnly "com.h2database:h2:2.2.220"
     runtimeOnly 'com.microsoft.sqlserver:mssql-jdbc:9.4.0.jre8'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:2.7.0'
-    runtimeOnly 'org.postgresql:postgresql:42.3.8'
+    runtimeOnly 'org.postgresql:postgresql:42.7.2'
     runtimeOnly 'org.rundeck.hibernate:rundeck-oracle-dialect:1.0.0'
 
     runtimeOnly "org.springframework:spring-jcl:${springVersion}"


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Fixes critical `org.postgresql:postgresql` vulnerability:
- CVE-2024-1597 (CRITICAL)

**Describe the solution you've implemented**
Bumped the version number.

**Describe alternatives you've considered**
N/A

**Additional context**

Trivy scan before:

```bash
├─────────────────────────────────────────────────────────────┼──────────────────┼──────────┤          ├───────────────────────┼────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.postgresql:postgresql (rundeck.war)                     │ CVE-2024-1597    │ CRITICAL │          │ 42.3.8                │ 42.7.2, 42.6.1, 42.5.5, 42.4.4, 42.3.9, 42.2.8 │ SQL injection in pgjdbc                                      │
│                                                             │                  │          │          │                       │                                                │ https://avd.aquasec.com/nvd/cve-2024-1597                    │
├─────────────────────────────────────────────────────────────┼──────────────────┼──────────┤          ├───────────────────────┼────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤

```

Would it be possible to backport this to 4.17.x? Thanks in advance!