### PR TITLE
Selenium Testdeck's "auto scroll on log viewer page..." Flaky Test Fix

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
@@ -374,7 +374,7 @@ class JobExecutionSpec extends BaseContainer {
         assert enabledJobsResponse.successful
 
         // Necessary since the api needs to breathe after enable execs
-        Thread.sleep(WaitingTime.LOW.milliSeconds)
+        Thread.sleep(WaitingTime.MODERATE.milliSeconds)
 
         def jobExecResponseFor1AfterEnable = JobUtils.executeJob(job1Id, client)
         assert jobExecResponseFor1AfterEnable.successful
@@ -391,6 +391,9 @@ class JobExecutionSpec extends BaseContainer {
         then:
         parsedExecutionsResponseForExecution1AfterEnable.executions.size() == 2
         parsedExecutionsResponseForExecution2AfterEnable.executions.size() == 2
+
+        cleanup:
+        deleteProject(projectName)
     }
 
     def "test-job-flip-scheduleEnabled-bulk"(){
@@ -442,7 +445,7 @@ class JobExecutionSpec extends BaseContainer {
         then:
         job2Detail?.executionEnabled
 
-        Thread.sleep(WaitingTime.LOW.milliSeconds) // As the original test says
+        Thread.sleep(WaitingTime.MODERATE.milliSeconds) // As the original test says
 
         when: "TEST: bulk job schedule disable"
         Object idList = [
@@ -469,6 +472,9 @@ class JobExecutionSpec extends BaseContainer {
         then:
         job1DetailAfterEnable?.scheduleEnabled
         job2DetailAfterEnable?.scheduleEnabled
+
+        cleanup:
+        deleteProject(projectName)
 
     }
 

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
@@ -374,7 +374,7 @@ class JobExecutionSpec extends BaseContainer {
         assert enabledJobsResponse.successful
 
         // Necessary since the api needs to breathe after enable execs
-        Thread.sleep(WaitingTime.MODERATE.milliSeconds)
+        Thread.sleep(WaitingTime.LOW.milliSeconds)
 
         def jobExecResponseFor1AfterEnable = JobUtils.executeJob(job1Id, client)
         assert jobExecResponseFor1AfterEnable.successful
@@ -392,8 +392,6 @@ class JobExecutionSpec extends BaseContainer {
         parsedExecutionsResponseForExecution1AfterEnable.executions.size() == 2
         parsedExecutionsResponseForExecution2AfterEnable.executions.size() == 2
 
-        cleanup:
-        deleteProject(projectName)
     }
 
     def "test-job-flip-scheduleEnabled-bulk"(){
@@ -445,7 +443,7 @@ class JobExecutionSpec extends BaseContainer {
         then:
         job2Detail?.executionEnabled
 
-        Thread.sleep(WaitingTime.MODERATE.milliSeconds) // As the original test says
+        Thread.sleep(WaitingTime.LOW.milliSeconds) // As the original test says
 
         when: "TEST: bulk job schedule disable"
         Object idList = [
@@ -472,9 +470,6 @@ class JobExecutionSpec extends BaseContainer {
         then:
         job1DetailAfterEnable?.scheduleEnabled
         job2DetailAfterEnable?.scheduleEnabled
-
-        cleanup:
-        deleteProject(projectName)
 
     }
 

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
@@ -391,7 +391,6 @@ class JobExecutionSpec extends BaseContainer {
         then:
         parsedExecutionsResponseForExecution1AfterEnable.executions.size() == 2
         parsedExecutionsResponseForExecution2AfterEnable.executions.size() == 2
-
     }
 
     def "test-job-flip-scheduleEnabled-bulk"(){

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutputSpec.groovy
@@ -1,7 +1,6 @@
 package org.rundeck.tests.functional.selenium
 
 import org.openqa.selenium.By
-import org.openqa.selenium.WebElement
 import org.rundeck.tests.functional.selenium.pages.*
 import org.rundeck.tests.functional.selenium.pages.home.HomePage
 import org.rundeck.tests.functional.selenium.pages.login.LoginPage

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutputSpec.groovy
@@ -41,7 +41,7 @@ class LogViewerOutputSpec extends SeleniumBase{
 
         then: "The user view must follow up to the last log output."
         !firstLogLine.isDisplayed() // First line is not reachable or visible by user
-        lastLogLine.isDisplayed() // And the last line does
+        lastLogLine.isDisplayed() // And the last line is
 
     }
 

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutputSpec.groovy
@@ -39,7 +39,7 @@ class LogViewerOutputSpec extends SeleniumBase{
         def firstLogLine = jobShowPage.el(By.xpath("//span[contains(text(),'log output 1')]"))
         def lastLogLine = jobShowPage.el(By.xpath("//span[contains(text(),'log output 50')]"))
 
-        then: "The user view must be the last log output."
+        then: "The user view must follow up to the last log output."
         !firstLogLine.isDisplayed() // First line is not reachable or visible by user
         lastLogLine.isDisplayed() // And the last line does
 

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/LogViewerOutputSpec.groovy
@@ -12,14 +12,15 @@ import org.rundeck.util.setup.NavLinkTypes
 @SeleniumCoreTest
 class LogViewerOutputSpec extends SeleniumBase{
 
+    private static final def longOutPutProjectName = "test-long-job-output"
+
     def setupSpec(){
-        setupProjectArchiveDirectoryResource("test-long-job-output", "/projects-import/long-job-output-project")
+        setupProjectArchiveDirectoryResource(longOutPutProjectName, "/projects-import/long-job-output-project")
     }
 
     def "auto scroll on log viewer page show last input"() {
 
         given:
-        def projectName = "test-long-job-output"
         def loginPage = page LoginPage
         def sideBar = page SideBarPage
         def projectHomePage = page HomePage
@@ -29,7 +30,7 @@ class LogViewerOutputSpec extends SeleniumBase{
         loginPage.go()
         loginPage.login(TEST_USER, TEST_PASS)
         projectHomePage.validatePage()
-        projectHomePage.goProjectHome(projectName)
+        projectHomePage.goProjectHome(longOutPutProjectName)
         sideBar.goTo(NavLinkTypes.JOBS)
         jobShowPage.goToJob("f44481c4-159d-4176-869b-e4a9bd898fe5")
         jobShowPage.getRunJobBtn().click()
@@ -59,7 +60,7 @@ class LogViewerOutputSpec extends SeleniumBase{
         loginPage.go()
         loginPage.login(TEST_USER, TEST_PASS)
         projectHomePage.validatePage()
-        projectHomePage.goProjectHome("AutoFollowTest")
+        projectHomePage.goProjectHome(longOutPutProjectName)
         sideBar.goTo(NavLinkTypes.JOBS)
         jobListPage.getCreateJobLink().click()
         jobCreatePage.getJobNameField().sendKeys("loop job")

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/JobShowPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/pages/JobShowPage.groovy
@@ -9,7 +9,6 @@ import org.rundeck.util.container.SeleniumContext
 import java.time.Duration
 
 class JobShowPage extends BasePage{
-    By jobUuidText = By.cssSelector('#subtitlebar > div > div.subtitle-head-item.flex-item-auto > section > div > div')
     static final String PAGE_PATH = "/job/show"
     String loadPath = PAGE_PATH
     By runJobBtn = By.id("execFormRunButton")
@@ -29,7 +28,6 @@ class JobShowPage extends BasePage{
 
     void waitForLogOutput (By logOutput, Integer number, Integer seconds){
         new WebDriverWait(driver, Duration.ofSeconds(seconds)).until(ExpectedConditions.numberOfElementsToBeMoreThan(logOutput,number))
-
     }
 
     void validatePage() {
@@ -38,7 +36,7 @@ class JobShowPage extends BasePage{
         }
     }
 
-    WebElement getJobUuidText(){
-        el jobUuidText
+    void goToJob(String jobUuidText){
+        go(PAGE_PATH + "/$jobUuidText")
     }
 }

--- a/functional-test/src/test/resources/projects-import/long-job-output-project/rundeck-longOutput/jobs/job-f44481c4-159d-4176-869b-e4a9bd898fe5.xml
+++ b/functional-test/src/test/resources/projects-import/long-job-output-project/rundeck-longOutput/jobs/job-f44481c4-159d-4176-869b-e4a9bd898fe5.xml
@@ -1,0 +1,26 @@
+<joblist>
+  <job>
+    <defaultTab>nodes</defaultTab>
+    <description></description>
+    <executionEnabled>true</executionEnabled>
+    <id>f44481c4-159d-4176-869b-e4a9bd898fe5</id>
+    <loglevel>INFO</loglevel>
+    <name>long output job</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <plugins />
+    <scheduleEnabled>true</scheduleEnabled>
+    <schedules />
+    <sequence keepgoing='false' strategy='node-first'>
+      <command>
+        <script><![CDATA[#!/bin/bash
+
+for (( i=1; i<=50; i++ ))
+do
+    echo "log output $i"
+done]]></script>
+        <scriptargs />
+      </command>
+    </sequence>
+    <uuid>f44481c4-159d-4176-869b-e4a9bd898fe5</uuid>
+  </job>
+</joblist>


### PR DESCRIPTION
# Improvements Done
1. Replaced time-expensive selenium based project and job creation for a preset project
2. Added more log lines without sleep in-between to force the user's window re-location
3. Switched the test goal to assert if the last log line is displayed and rendered to the view.