### PR TITLE
RCLOUD-1182:  Configure web request logging

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -336,6 +336,7 @@ public class RundeckConfigBase {
 
         Cookie cookie;
         Jetty jetty;
+        WebLogging logging;
 
         @Data
         public static class Cookie {
@@ -356,6 +357,10 @@ public class RundeckConfigBase {
         }
     }
 
+    @Data
+    public static class WebLogging {
+        List<String> ignorePrefixes;
+    }
     @Data
     public static class RundeckNodeServiceConfig {
 

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/ZZ_TimerInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/ZZ_TimerInterceptor.groovy
@@ -3,6 +3,7 @@ package rundeck.interceptors
 class ZZ_TimerInterceptor {
 
     int order = HIGHEST_PRECEDENCE + 500
+    def configurationService
 
     ZZ_TimerInterceptor() {
         matchAll()
@@ -11,6 +12,11 @@ class ZZ_TimerInterceptor {
     boolean before() { true }
 
     boolean after() {
+        def ignorePrefixes = configurationService.getValue("web.logging.ignorePrefixes", [])
+        String testUri = request[AA_TimerInterceptor._REQ_URI]
+        if(ignorePrefixes.any { testUri.startsWith(it) }) {
+            return true
+        }
         AA_TimerInterceptor.afterRequest(request,response,session)
         true
     }

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/ZZ_TimerInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/ZZ_TimerInterceptorSpec.groovy
@@ -1,0 +1,33 @@
+package rundeck.interceptors
+
+import grails.testing.web.interceptor.InterceptorUnitTest
+import rundeck.services.ConfigurationService
+import spock.lang.Specification
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class ZZ_TimerInterceptorSpec extends Specification implements InterceptorUnitTest<ZZ_TimerInterceptor> {
+    def "After"() {
+        given:
+        boolean afterRequestCalled = false
+        AA_TimerInterceptor.metaClass.static.afterRequest = { HttpServletRequest request, HttpServletResponse response, session ->
+            afterRequestCalled = true
+        }
+        interceptor.configurationService = Mock(ConfigurationService) {
+            getValue(_,_) >> ["/ignore/me"]
+        }
+        request[AA_TimerInterceptor._REQ_URI] = requestForwardURI
+
+        when:
+        boolean result = interceptor.after()
+        then:
+        result
+        expectedAfterRequestCalled == afterRequestCalled
+        where:
+        requestForwardURI   | expectedAfterRequestCalled
+        "/ignore/me/please" | false
+        "/api"              | true
+
+    }
+}


### PR DESCRIPTION
Add ability to configure path prefixes for web requests that should be excluded from web request log

Set`rundeck.web.logging.ignorePrefixes` with a comma separated list of prefixes for web paths that should not be logged by the web request logger.