### PR TITLE
RSE-1024: Fixed test that was using a method that was moved to jobUtils

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/export_import/JobsImportSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/export_import/JobsImportSpec.groovy
@@ -208,7 +208,7 @@ class JobsImportSpec extends BaseContainer {
             """
         def path = JobUtils.generateFileToImport(job, "xml")
         when:
-        def result = jobImportFile(PROJECT_NAME, path)
+        def result = JobUtils.jobImportFile(PROJECT_NAME, path, client)
         then:
         verifyAll {
             result.succeeded[0].id == "28a1fc62-92a1-4a45-bbc3-02a8b0f46af8"


### PR DESCRIPTION
After merging this PR: https://github.com/rundeck/rundeck/pull/8924
a test started to fail because it was using a method that was moved to `JobUtils`