### PR TITLE
Testdeck Fix: go edit nodes flaky tests

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/project/NodesSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/tests/project/NodesSpec.groovy
@@ -1,5 +1,6 @@
 package org.rundeck.tests.functional.selenium.tests.project
 
+import org.rundeck.tests.functional.selenium.pages.home.HomePage
 import org.rundeck.tests.functional.selenium.pages.login.LoginPage
 import org.rundeck.tests.functional.selenium.pages.project.NodeSourcePage
 import org.rundeck.util.annotations.SeleniumCoreTest
@@ -16,10 +17,14 @@ class NodesSpec extends SeleniumBase {
         setup:
             def loginPage = go LoginPage
             def nodeSourcePage = page NodeSourcePage
+            def menuPage = page HomePage
         when:
             loginPage.login(TEST_USER, TEST_PASS)
+            menuPage.validatePage()
+            menuPage.goProjectHome(SELENIUM_BASIC_PROJECT)
             nodeSourcePage.loadPath = "/project/${SELENIUM_BASIC_PROJECT}/nodes/sources"
             nodeSourcePage.go("/project/${SELENIUM_BASIC_PROJECT}/nodes/sources")
+
         then:
             nodeSourcePage.waitForElementVisible nodeSourcePage.newNodeSourceButton
             nodeSourcePage.newNodeSourceButton != null


### PR DESCRIPTION
# Changes Made
- Instead of going directly from login page to a project path, we validate the home and then navigate to project home before loading a specific path. 