### PR TITLE
RSE-776 Fix: Server Error while Metrics Request

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -74,7 +74,6 @@ import org.hibernate.JDBCException
 import org.hibernate.StaleObjectStateException
 import org.hibernate.criterion.CriteriaSpecification
 import org.hibernate.type.StandardBasicTypes
-import org.jsoup.select.Collector
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.app.auth.types.AuthorizingProject
 import org.rundeck.app.data.model.v1.job.JobData

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -74,6 +74,7 @@ import org.hibernate.JDBCException
 import org.hibernate.StaleObjectStateException
 import org.hibernate.criterion.CriteriaSpecification
 import org.hibernate.type.StandardBasicTypes
+import org.jsoup.select.Collector
 import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.app.auth.types.AuthorizingProject
 import org.rundeck.app.data.model.v1.job.JobData
@@ -128,6 +129,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 import java.util.regex.Pattern
+import java.util.stream.Collectors
 
 /**
  * Coordinates Command executions via Ant Project objects
@@ -4241,10 +4243,13 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
         def avgDuration = totalCount != 0 ? (durationSum.getTime() / totalCount) : 0
 
+        def maxDurationToMillis = maxDuration != 0 ? sqlTimeToMillis(maxDuration) : 0
+        def minDurationToMillis = minDuration != 0 ? sqlTimeToMillis(minDuration) : 0
+
         return [
                 totalCount: totalCount,
-                maxDuration: sqlTimeToMillis(maxDuration),
-                minDuration: sqlTimeToMillis(minDuration),
+                maxDuration: maxDurationToMillis,
+                minDuration: minDurationToMillis,
                 avgDuration: avgDuration
         ]
 
@@ -4285,12 +4290,19 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      */
     Map<String,Object> metricsDataFromProjectionResult(List<Map<String, Timestamp>> result) {
         List<Long> timeSpent = result?.collect { Map<String, Timestamp> dataResult ->
-            dataResult.dateCompleted.getTime() - dataResult.dateStarted.getTime()
+            if( dataResult.dateCompleted != null ){
+                return dataResult.dateCompleted.getTime() - dataResult.dateStarted.getTime()
+            }
+            return null // null if there are running execs (date_completed == null)
         }
+        def timeSpentWithoutRunningExecs = timeSpent
+                .stream()
+                .filter {it -> it != null}
+                .collect(Collectors.toList())
         def totalCount = result?.size()
-        Long maxDuration = timeSpent?.max()
-        Long minDuration = timeSpent?.min()
-        double avgDuration = totalCount != 0 ? (timeSpent?.sum() / totalCount) : 0
+        Long maxDuration = timeSpentWithoutRunningExecs?.max()
+        Long minDuration = timeSpentWithoutRunningExecs?.min()
+        double avgDuration = totalCount != 0 ? (timeSpentWithoutRunningExecs?.sum() / totalCount) : 0
 
         return  [
             total   : totalCount,

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -6126,6 +6126,33 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
             result.duration.max == 9L * 60L * 1000L
     }
 
+    def "metrics from projection results no errors if null dateCompleted is extracted"(){
+        given:
+        Date now = new Date()
+        Date dateStarted1 = now
+        Date dateStarted2 = now
+        Date dateStarted3 = now
+        Date dateCompleted = now
+        use (TimeCategory) {
+            dateStarted1 = now - 9.minute
+            dateStarted2 = now - 4.minute
+            dateStarted3 = now - 2.minute
+        }
+        def projresult = [
+                [dateStarted: new Timestamp(dateStarted1.time), dateCompleted: null],
+                [dateStarted: new Timestamp(dateStarted2.time), dateCompleted: new Timestamp(dateCompleted.time)],
+                [dateStarted: new Timestamp(dateStarted3.time), dateCompleted: new Timestamp(dateCompleted.time)]
+        ]
+        when:
+        def result = service.metricsDataFromProjectionResult(projresult)
+        then:
+        noExceptionThrown()
+        result.total == 3
+        result.duration.average == 120000.0
+        result.duration.min == 120000
+        result.duration.max == 240000
+    }
+
     def "load additional listener"(){
         when:
             def result = service.loadAdditionalListeners([])


### PR DESCRIPTION
## The Problem
When a execution is running the 'date_completed' data needed to make metrics calculations, is null.

## The Fix
If 'date_completed' is null, we exclude the calculation of that particular execution from the metrics.