### PR TITLE
RUN-2032: Percentage in number showing in progress bar instead of undefined%

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityList.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityList.vue
@@ -288,7 +288,6 @@
               class="dateStarted date"
               colspan="2"
             >
-              <!--getting vue warning: Invalid prop: type check failed for prop "modelValue".Converted :value to :modelValue-->
               <progress-bar
                 v-if="exec.status === 'scheduled'"
                 :modelValue="100"
@@ -297,7 +296,6 @@
                 label
                 :label-text="
                   $t('job.execution.starting.0', [
-                    // if exec.dateStarted is null or undefined,it doesn't throw an error but instead returns undefined
                     runningStartedDisplay(exec.dateStarted?.date) || 'N/A',
                   ])
                 "
@@ -802,24 +800,6 @@ export default defineComponent({
       }
       return 0;
     },
-
-    // Below code makes the progress bar reach closer to 100%
-    /* jobDurationPercentage(exec: Execution) {
-      if (
-        exec.job &&
-        exec.job.averageDuration &&
-        exec.dateStarted &&
-        exec.dateStarted.date
-      ) {
-        const now = moment();
-        const startDate = moment(exec.dateStarted.date);
-        const diff = now.diff(startDate);
-        const percentage = Math.floor((diff / exec.job.averageDuration) * 100);
-        return Math.min(percentage, 100);
-      }
-      return 0;
-    },
-    */
 
     runningStartedDisplay(date: string) {
       if (!date) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityList.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityList.vue
@@ -796,7 +796,10 @@ export default defineComponent({
         exec.dateStarted.date
       ) {
         const diff = moment().diff(moment(exec.dateStarted.date));
-        return Math.floor(100 * (diff / exec.job.averageDuration));
+        return Math.min(
+          Math.floor((diff / exec.job.averageDuration) * 100),
+          100,
+        );
       }
       return 0;
     },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityList.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityList.vue
@@ -288,21 +288,23 @@
               class="dateStarted date"
               colspan="2"
             >
+              <!--getting vue warning: Invalid prop: type check failed for prop "modelValue".Converted :value to :modelValue-->
               <progress-bar
                 v-if="exec.status === 'scheduled'"
-                :value="100"
+                :modelValue="100"
                 striped
                 type="default"
                 label
                 :label-text="
                   $t('job.execution.starting.0', [
-                    runningStartedDisplay(exec.dateStarted.date),
+                    // if exec.dateStarted is null or undefined,it doesn't throw an error but instead returns undefined
+                    runningStartedDisplay(exec.dateStarted?.date) || 'N/A',
                   ])
                 "
               ></progress-bar>
               <progress-bar
                 v-else-if="exec.status === 'queued'"
-                :value="100"
+                :modelValue="100"
                 striped
                 type="default"
                 label
@@ -310,7 +312,7 @@
               ></progress-bar>
               <progress-bar
                 v-else-if="exec.job && exec.job.averageDuration"
-                :value="jobDurationPercentage(exec)"
+                :modelValue="jobDurationPercentage(exec)"
                 striped
                 active
                 type="info"
@@ -319,7 +321,7 @@
               ></progress-bar>
               <progress-bar
                 v-else-if="exec.dateStarted.date"
-                :value="100"
+                :modelValue="100"
                 striped
                 active
                 type="info"
@@ -327,7 +329,6 @@
                 :label-text="$t('running')"
               ></progress-bar>
             </td>
-
             <td class="user text-right" style="white-space: nowrap">
               <em>{{ $t("by") }}</em>
               {{ exec.user }}
@@ -801,6 +802,25 @@ export default defineComponent({
       }
       return 0;
     },
+
+    // Below code makes the progress bar reach closer to 100%
+    /* jobDurationPercentage(exec: Execution) {
+      if (
+        exec.job &&
+        exec.job.averageDuration &&
+        exec.dateStarted &&
+        exec.dateStarted.date
+      ) {
+        const now = moment();
+        const startDate = moment(exec.dateStarted.date);
+        const diff = now.diff(startDate);
+        const percentage = Math.floor((diff / exec.job.averageDuration) * 100);
+        return Math.min(percentage, 100);
+      }
+      return 0;
+    },
+    */
+
     runningStartedDisplay(date: string) {
       if (!date) {
         return "";

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityList.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityList.vue
@@ -296,7 +296,7 @@
                 label
                 :label-text="
                   $t('job.execution.starting.0', [
-                    runningStartedDisplay(exec.dateStarted?.date) || 'N/A',
+                    runningStartedDisplay(exec.dateStarted.date),
                   ])
                 "
               ></progress-bar>


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
"undefined%" message appears in the progress bar instead of percentage. Fixed it to make it shows the percentage in number. 

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
