### PR TITLE
Fix Node Wizard in Vue UI

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-nodes-config/ProjectNodePage.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-nodes-config/ProjectNodePage.vue
@@ -57,7 +57,7 @@
                       <div class="help-block">
                         {{ $t("modifiable.node.sources.will.appear.here") }}
                       </div>
-                      <div class="project-plugin-config-vue">
+                      <div>
                         <writeable-project-node-sources
                           :event-bus="rundeckContext.eventBus"
                           class="list-group"


### PR DESCRIPTION
The node wizard functionality was broken in https://github.com/rundeck/rundeck/pull/8898. An additional vue app was being created that was messing with the ability to determine if any sources were writeable, this fixes that