### PR TITLE
Update remote docker to use default version for release/4.17.x branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,7 +321,6 @@ jobs:
       - install-java
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 20.10.14
       - run:
           name: Build
           command: |
@@ -430,8 +429,7 @@ jobs:
     steps:
       - checkout
       - install-node
-      - setup_remote_docker:
-          version: 20.10.14
+      - setup_remote_docker
       - attach_workspace:
           at: artifacts
       - run:
@@ -459,8 +457,7 @@ jobs:
         type: string
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.14
+      - setup_remote_docker
       - fetch-common-artifacts
       - run:
           name: Test
@@ -653,8 +650,7 @@ jobs:
       - checkout
       - install-node
       - restore-gradle-cache
-      - setup_remote_docker:
-          version: 20.10.14
+      - setup_remote_docker
       - fetch-common-artifacts
       - fetch-ci-resources
       - run:


### PR DESCRIPTION
Backport of https://github.com/rundeck/rundeck/pull/8977. Changes introduced since made the solution required different.