### PR TITLE
RSE-1051: Replace api call for fetching execution modes for nodes

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeCard.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeCard.vue
@@ -325,8 +325,11 @@ export default defineComponent({
     async fetchExecutionMode() {
       try {
         const data = await getConfigMetaForExecutionMode(this.project);
+
         // not taking scheduleEnabled into account as commands executed from here are adhoc
-        this.executionMode = data.executionsEnabled ? "active" : "passive";
+        this.executionMode = data[0].data!.executionsEnabled
+          ? "active"
+          : "passive";
       } catch (e) {
         this.error = e.message;
       }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeCard.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeCard.vue
@@ -210,7 +210,7 @@ import { getAppLinks, getRundeckContext } from "@/library";
 import NodeFilterLink from "@/app/components/job/resources/NodeFilterLink.vue";
 import NodeTable from "@/app/components/job/resources/NodeTable.vue";
 import {
-  getExecutionMode,
+  getConfigMetaForExecutionMode,
   getNodes,
   getNodeSummary,
 } from "@/app/components/job/resources/services/nodeServices";
@@ -324,8 +324,9 @@ export default defineComponent({
     },
     async fetchExecutionMode() {
       try {
-        const data = await getExecutionMode();
-        this.executionMode = data.executionMode;
+        const data = await getConfigMetaForExecutionMode(this.project);
+        // not taking scheduleEnabled into account as commands executed from here are adhoc
+        this.executionMode = data.executionsEnabled ? "active" : "passive";
       } catch (e) {
         this.error = e.message;
       }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/services/nodeServices.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/services/nodeServices.ts
@@ -1,15 +1,19 @@
 import axios, { AxiosResponse } from "axios";
 import { _genUrl } from "../../../../utilities/genUrl";
 import { getAppLinks, getRundeckContext } from "../../../../../library";
+import { ConfigMeta } from "../../../home/types/projectTypes";
 
-export async function getExecutionMode(): Promise<any> {
+export async function getConfigMetaForExecutionMode(
+  project: string,
+  meta: string = "config",
+): Promise<ConfigMeta[]> {
   const ctx = getRundeckContext();
   const response = await axios.request({
     method: "GET",
     headers: {
       "x-rundeck-ajax": "true",
     },
-    url: `${ctx.rdBase}api/${ctx.apiVersion}/system/executions/status`,
+    url: `${ctx.rdBase}api/${ctx.apiVersion}/project/${project}/meta?meta=${meta}`,
     validateStatus(status) {
       return status <= 403;
     },


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
On the vue conversion for nodes, the wrong endpoint was used to fetch the execution mode (`/system/executions/status`, which would fetch the system execution status instead of the project's). The issue is that the former endpoint requires permissions, that do not apply to the nodes page.


**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Swapped the endpoint to fetch the project metadata instead and leverage it to determine the execution status. 


**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
Considered reusing getProjectMeta which lives in JobBrowse.ts, but decided against it as the type return and error handling are different.

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

Will add unit tests for this in a later moment, so that can tackle all components in the resources folder. But did test the scenario described on the ticket.
