### PR TITLE
Fix npe error when wrong runner token is presented

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
@@ -85,7 +85,7 @@ class SetUserInterceptor {
             Set<String> roles = lookupTokenRoles(foundToken, servletContext)
             String user = foundToken?.getOwnerName()
 
-            if(request.getAttribute(RUNNER_RQ_ATTRIB) && foundToken.type == AuthTokenType.RUNNER) {
+            if(request.getAttribute(RUNNER_RQ_ATTRIB) && foundToken?.type == AuthTokenType.RUNNER) {
                 isRunnerToken = true
             }
 


### PR DESCRIPTION
Fix an error in which providing a wrong runner token would bleed NPEs in the service log instead of failing with a comprehensive error message.