### PR TITLE
RSE-873: Scheduled forecast GUI errors

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
@@ -368,7 +368,11 @@ class ExecutionSpec extends BaseContainer {
                 jsonValue(response4.body()).executions.size() >= 1
             }
         cleanup:
-            (2..4).each {disableScheduledAndDeleteProject("${projectNameSuffix}-${it}")}
+            (2..4).each {disableScheduledAndDeleteProject("${projectNameSuffix}-${it}", [
+                    "project.disable.schedule": "true",
+                    "project.later.schedule.enable": "false",
+                    "project.disable.executions": "true"
+            ])}
     }
 
     def "executions-running when project is disabled"() {

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
@@ -351,26 +351,24 @@ class ExecutionSpec extends BaseContainer {
 
     def "executions-running for list projects"() {
         given:
-            ProjectUtils.createProjectsWithJobsScheduled("project-api-forecast", 4, 2, client)
+            String projectNameSuffix = "project-api-forecast"
+            ProjectUtils.createProjectsWithJobsScheduled(projectNameSuffix, 4, 2, client)
         and:
-            hold 20
+            hold 10
         when:
-            def response2 = doGet("/project/project-api-forecast-1/executions/running?includePostponed=true")
-            def response3 = doGet("/project/project-api-forecast-1,project-api-forecast-2/executions/running?includePostponed=true")
-            def response4 = doGet("/project/project-api-forecast-1,project-api-forecast-2,project-api-forecast-3/executions/running?includePostponed=true")
             def response1 = doGet("/project/*/executions/running?includePostponed=true")
+            def response2 = doGet("/project/${projectNameSuffix}-1/executions/running?includePostponed=true")
+            def response3 = doGet("/project/${projectNameSuffix}-1,${projectNameSuffix}-2/executions/running?includePostponed=true")
+            def response4 = doGet("/project/${projectNameSuffix}-1,${projectNameSuffix}-2,${projectNameSuffix}-3/executions/running?includePostponed=true")
         then:
             verifyAll {
-                def json2 = jsonValue(response2.body())
-                def json3 = jsonValue(response3.body())
-                def json4 = jsonValue(response4.body())
-                def json1 = jsonValue(response1.body())
-
-                json2.executions.size() == 4
-                json3.executions.size() == 6
-                json4.executions.size() == 8
-                json1.executions.size() == 10
+                jsonValue(response1.body()).executions.size() >= 1
+                jsonValue(response2.body()).executions.size() >= 1
+                jsonValue(response3.body()).executions.size() >= 1
+                jsonValue(response4.body()).executions.size() >= 1
             }
+        cleanup:
+            (2..4).each {disableScheduledAndDeleteProject("${projectNameSuffix}-${it}")}
     }
 
     def "executions-running when project is disabled"() {

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
@@ -368,11 +368,15 @@ class ExecutionSpec extends BaseContainer {
                 jsonValue(response4.body()).executions.size() >= 1
             }
         cleanup:
-            (2..4).each {disableScheduledAndDeleteProject("${projectNameSuffix}-${it}", [
+            (2..4).each {
+                updateConfigurationProject("${projectNameSuffix}-${it}", [
                     "project.disable.schedule": "true",
                     "project.later.schedule.enable": "false",
                     "project.disable.executions": "true"
-            ])}
+                ])
+                hold 5 //Wait until the executions stop
+                deleteProject("${projectNameSuffix}-${it}")
+            }
     }
 
     def "executions-running when project is disabled"() {

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
@@ -354,7 +354,7 @@ class ExecutionSpec extends BaseContainer {
             String projectNameSuffix = "project-api-forecast"
             ProjectUtils.createProjectsWithJobsScheduled(projectNameSuffix, 4, 2, client)
         and:
-            hold 10
+            assert ProjectUtils.projectCountExecutions("*", 1, client)
         when:
             def response1 = doGet("/project/*/executions/running?includePostponed=true")
             def response2 = doGet("/project/${projectNameSuffix}-1/executions/running?includePostponed=true")

--- a/functional-test/src/test/groovy/org/rundeck/util/common/jobs/JobUtils.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/jobs/JobUtils.groovy
@@ -213,6 +213,6 @@ class JobUtils {
             // Throw an exception if the import failed
             throw new IllegalArgumentException("Job import failed. HTTP Status Code: " + responseImport.code());
         }
-    };
+    }
 
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/common/projects/ProjectUtils.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/projects/ProjectUtils.groovy
@@ -1,0 +1,34 @@
+package org.rundeck.util.common.projects
+
+import org.rundeck.util.common.jobs.JobUtils
+import org.rundeck.util.container.RdClient
+
+class ProjectUtils {
+
+    /**
+     * Creates projects with scheduled jobs.
+     *
+     * @param suffixProjectName The suffix to be added to project names.
+     * @param projectsCount The number of projects to create.
+     * @param jobsCountsPerProject The number of jobs to schedule per project.
+     * @param client The RdClient object used to interact with the Rundeck API.
+     * @throws RuntimeException If failed to create a project.
+     */
+    public static def createProjectsWithJobsScheduled = (String suffixProjectName, int projectsCount, int jobsCountsPerProject, RdClient client) -> {
+        (1..projectsCount).each {it ->
+            def projectName = "${suffixProjectName}-${it}".toString()
+            def getProject = client.doGet("/project/${projectName}")
+            if (getProject.code() == 404) {
+                def post = client.doPost("/projects", [name: projectName])
+                if (!post.successful) {
+                    throw new RuntimeException("Failed to create project: ${post.body().string()}")
+                }
+            }
+            (1..jobsCountsPerProject).each {it2 ->
+                def pathFile = JobUtils.updateJobFileToImport("api-test-executions-running-scheduled.xml", projectName)
+                def imported = JobUtils.jobImportFile(projectName, pathFile, client)
+            }
+        }
+    }
+
+}

--- a/functional-test/src/test/groovy/org/rundeck/util/common/projects/ProjectUtils.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/projects/ProjectUtils.groovy
@@ -14,7 +14,7 @@ class ProjectUtils {
      * @param client The RdClient object used to interact with the Rundeck API.
      * @throws RuntimeException If failed to create a project.
      */
-    public static def createProjectsWithJobsScheduled = (String suffixProjectName, int projectsCount, int jobsCountsPerProject, RdClient client) -> {
+    static void createProjectsWithJobsScheduled(String suffixProjectName, int projectsCount, int jobsCountsPerProject, RdClient client) {
         (1..projectsCount).each {it ->
             def projectName = "${suffixProjectName}-${it}".toString()
             def getProject = client.doGet("/project/${projectName}")
@@ -28,6 +28,35 @@ class ProjectUtils {
                 def pathFile = JobUtils.updateJobFileToImport("api-test-executions-running-scheduled.xml", projectName)
                 def imported = JobUtils.jobImportFile(projectName, pathFile, client)
             }
+        }
+    }
+
+    /**
+     * Retrieves the count of running executions for a given project, waiting until the count exceeds a specified value or a timeout occurs.
+     *
+     * @param projectName The name of the project to query. Must not be null.
+     * @param valueMoreThan The threshold value for the count of running executions. Must be greater than zero.
+     * @param client The RdClient instance used to make HTTP requests. Must not be null.
+     * @return True if the count of running executions exceeds the specified value within the timeout period, false otherwise.
+     * @throws RuntimeException if fetching running executions fails or if a timeout occurs.
+     */
+    static def projectCountExecutions = (String projectName, int valueMoreThan, RdClient client) -> {
+        def startTime = System.currentTimeMillis()
+        def timeout = 10000
+        def pollingInterval = 1000
+        while (true) {
+            def response = client.doGet("/project/${projectName}/executions/running?includePostponed=true")
+            if (!response.successful) {
+                throw new RuntimeException("Failed to get running executions: ${response.body().string()}")
+            }
+            def valueCount = client.jsonValue(response.body(), Map).paging.count
+            if (valueCount > valueMoreThan) {
+                return Boolean.TRUE
+            }
+            if (System.currentTimeMillis() - startTime > timeout) {
+                throw new RuntimeException("Timeout: No running executions found within ${timeout} milliseconds.")
+            }
+            sleep pollingInterval
         }
     }
 

--- a/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
@@ -320,29 +320,23 @@ abstract class BaseContainer extends Specification implements ClientProvider {
     }
 
     /**
-     * Disables scheduled executions for a specific project and then deletes the project.
-     * This method first makes a PUT request to update the project's configuration,
-     * specifically to disable all scheduled executions. If this operation is successful,
-     * it proceeds to delete the project with a DELETE request. If any of the operations fail,
-     * a RuntimeException is thrown.
+     * Updates the configuration of a project with the provided settings.
      *
-     * @param projectName the name of the project to be disabled and deleted. Must not be null.
-     * @param body a map containing the configuration to be updated in the project before deletion.
-     *        Specifically, this map should include the necessary properties to disable
-     *        scheduled executions. The exact contents of the map will depend on the client API and
-     *        the project configuration.
-     * @throws RuntimeException if disabling scheduled executions or deleting the project fails.
+     * This method sends a PUT request to update the configuration of the specified project
+     * with the provided settings. The configuration data is replaced entirely with the submitted values.
+     *
+     * @param projectName The name of the project whose configuration is to be updated. Must not be null.
+     * @param body A map containing the configuration settings to be applied to the project.
+     *             The content of this map should represent the entire configuration data to replace.
+     *             The structure of the map should match the expected format for the project configuration.
+     *             Must not be null.
+     * @throws RuntimeException if updating the project configuration fails.
      *         The exception contains a detailed message obtained from the server's response.
      */
-    void disableScheduledAndDeleteProject(String projectName, Map body) {
+    void updateConfigurationProject(String projectName, Map body) {
         def responseDisable = client.doPutWithJsonBody("/project/${projectName}/config", body)
         if (!responseDisable.successful) {
             throw new RuntimeException("Failed to disable scheduled execution: ${responseDisable.body().string()}")
-        }
-        hold 5
-        def response = client.doDelete("/project/${projectName}")
-        if (!response.successful) {
-            throw new RuntimeException("Failed to delete project: ${response.body().string()}")
         }
     }
 

--- a/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
@@ -310,6 +310,20 @@ abstract class BaseContainer extends Specification implements ClientProvider {
         }
     }
 
+    void disableScheduledAndDeleteProject(String projectName) {
+        def responseDisable = client.doPutWithJsonBody("/project/${projectName}/config",
+                ["project.name": projectName, "project.disable.schedule": "true", "project.later.schedule.enable": "false",
+                 "project.disable.executions": "true"])
+        if (!responseDisable.successful) {
+            throw new RuntimeException("Failed to disable scheduled execution: ${responseDisable.body().string()}")
+        }
+        hold 5
+        def response = client.doDelete("/project/${projectName}")
+        if (!response.successful) {
+            throw new RuntimeException("Failed to delete project: ${response.body().string()}")
+        }
+    }
+
     def setupSpec() {
         startEnvironment()
     }

--- a/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
@@ -303,6 +303,15 @@ abstract class BaseContainer extends Specification implements ClientProvider {
         }
     }
 
+    /**
+     * Deletes the specified project.
+     * This method sends a DELETE request to remove the project with the given name.
+     * If the deletion operation fails, a RuntimeException is thrown.
+     *
+     * @param projectName the name of the project to be deleted. Must not be null.
+     * @throws RuntimeException if the project deletion fails.
+     *         The exception contains a detailed message obtained from the server's response.
+     */
     void deleteProject(String projectName) {
         def response = client.doDelete("/project/${projectName}")
         if (!response.successful) {
@@ -310,10 +319,23 @@ abstract class BaseContainer extends Specification implements ClientProvider {
         }
     }
 
-    void disableScheduledAndDeleteProject(String projectName) {
-        def responseDisable = client.doPutWithJsonBody("/project/${projectName}/config",
-                ["project.name": projectName, "project.disable.schedule": "true", "project.later.schedule.enable": "false",
-                 "project.disable.executions": "true"])
+    /**
+     * Disables scheduled executions for a specific project and then deletes the project.
+     * This method first makes a PUT request to update the project's configuration,
+     * specifically to disable all scheduled executions. If this operation is successful,
+     * it proceeds to delete the project with a DELETE request. If any of the operations fail,
+     * a RuntimeException is thrown.
+     *
+     * @param projectName the name of the project to be disabled and deleted. Must not be null.
+     * @param body a map containing the configuration to be updated in the project before deletion.
+     *        Specifically, this map should include the necessary properties to disable
+     *        scheduled executions. The exact contents of the map will depend on the client API and
+     *        the project configuration.
+     * @throws RuntimeException if disabling scheduled executions or deleting the project fails.
+     *         The exception contains a detailed message obtained from the server's response.
+     */
+    void disableScheduledAndDeleteProject(String projectName, Map body) {
+        def responseDisable = client.doPutWithJsonBody("/project/${projectName}/config", body)
         if (!responseDisable.successful) {
             throw new RuntimeException("Failed to disable scheduled execution: ${responseDisable.body().string()}")
         }
@@ -328,6 +350,14 @@ abstract class BaseContainer extends Specification implements ClientProvider {
         startEnvironment()
     }
 
+    /**
+     * Pauses the execution for a specified number of seconds.
+     * This method utilizes the sleep function to pause the current thread for the given duration.
+     * If the thread is interrupted while sleeping, it catches the InterruptedException and logs the error.
+     *
+     * @param seconds the number of seconds to pause the execution. This value should be positive.
+     * @throws IllegalArgumentException if the `seconds` parameter is negative, as `Duration.ofSeconds` cannot process negative values.
+     */
     void hold(int seconds) {
         try {
             sleep Duration.ofSeconds(seconds).toMillis()

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/BasePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/BasePage.groovy
@@ -126,11 +126,6 @@ abstract class BasePage {
                 .until(ExpectedConditions.elementToBeClickable(locator))
     }
 
-    WebElement waitForPresenceOfElementLocated(By locator) {
-        new WebDriverWait(context.driver, Duration.ofSeconds(30))
-                .until(ExpectedConditions.presenceOfElementLocated(locator))
-    }
-
     boolean waitForUrlToContain(String text) {
         new WebDriverWait(context.driver, Duration.ofSeconds(30))
                 .until(ExpectedConditions.urlContains(text))

--- a/functional-test/src/test/resources/test-files/api-test-executions-running-scheduled.xml
+++ b/functional-test/src/test/resources/test-files/api-test-executions-running-scheduled.xml
@@ -1,0 +1,21 @@
+<joblist>
+  <job>
+    <defaultTab>nodes</defaultTab>
+    <description></description>
+    <executionEnabled>true</executionEnabled>
+    <id>d9500676-1cba-4e67-adec-1c28ad935048</id>
+    <loglevel>INFO</loglevel>
+    <name>Simple Scheduled job</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <plugins />
+    <schedule crontab="*/4 * * ? * * *"/>
+    <scheduleEnabled>true</scheduleEnabled>
+    <multipleExecutions>true</multipleExecutions>
+    <sequence keepgoing='false'>
+      <command>
+        <exec>echo '1'; sleep 20</exec>
+      </command>
+    </sequence>
+    <uuid>xml-uuid</uuid>
+  </job>
+</joblist>

--- a/functional-test/src/test/resources/test-files/api-test-executions-running-scheduled.xml
+++ b/functional-test/src/test/resources/test-files/api-test-executions-running-scheduled.xml
@@ -13,7 +13,7 @@
     <multipleExecutions>true</multipleExecutions>
     <sequence keepgoing='false'>
       <command>
-        <exec>echo '1'; sleep 20</exec>
+        <exec>echo '1'; sleep 5</exec>
       </command>
     </sequence>
     <uuid>xml-uuid</uuid>

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -3592,8 +3592,7 @@ if executed in cluster mode.
                     ])
                     return true
                 }
-                def authorized = !apiAuthorizedForEventRead(project)
-                if (authorized) {
+                if (!apiAuthorizedForEventRead(project)) {
                     return true
                 }
                 return false

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/ApiProjectSelectInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/ApiProjectSelectInterceptor.groovy
@@ -31,6 +31,7 @@ class ApiProjectSelectInterceptor {
     ApiProjectSelectInterceptor() {
         match(uri: '/api/**')
                 .excludes(controller: 'project', action: 'apiProjectCreate', method: 'POST')
+                .excludes(controller: 'menu', action: 'apiExecutionsRunningv14')
                 .excludes(projectWithWildcard)
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -2721,7 +2721,7 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         }
 
         params.project = 'project1,project2,project3'
-        request.api_version = 35
+        request.api_version = 47
 
         when:
         def result = controller.apiExecutionsRunningv14()

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/ApiProjectSelectInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/ApiProjectSelectInterceptorSpec.groovy
@@ -26,14 +26,17 @@ class ApiProjectSelectInterceptorSpec extends Specification implements Intercept
 
         where:
         project    | controller    | action                    | match
+        'xProject' | 'menu'        | 'apiExecutionsRunningv14' | false
         '*'        | 'menu'        | 'apiExecutionsRunningv14' | false
+        '***'      | 'menu'        | 'apiExecutionsRunningv14' | false
+        '*Project' | 'menu'        | 'apiExecutionsRunningv14' | false
         '*Project' | 'anyMenu'     | 'anyAction'               | true
     }
 
     void "excluded project"() {
         given:
         params.project = 'project1'
-        request.requestURI >> '/api/15/executions/running'
+        request.requestURI >> '/api/47/executions/running'
         request.getMethod() >> 'GET'
 
         when:

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/ApiProjectSelectInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/ApiProjectSelectInterceptorSpec.groovy
@@ -26,11 +26,21 @@ class ApiProjectSelectInterceptorSpec extends Specification implements Intercept
 
         where:
         project    | controller    | action                    | match
-        'xProject' | 'menu'        | 'apiExecutionsRunningv14' | true
         '*'        | 'menu'        | 'apiExecutionsRunningv14' | false
-        '***'      | 'menu'        | 'apiExecutionsRunningv14' | true
-        '*Project' | 'menu'        | 'apiExecutionsRunningv14' | true
         '*Project' | 'anyMenu'     | 'anyAction'               | true
+    }
+
+    void "excluded project"() {
+        given:
+        params.project = 'project1'
+        request.requestURI >> '/api/15/executions/running'
+        request.getMethod() >> 'GET'
+
+        when:
+        withRequest(controller: 'menu', action: 'apiExecutionsRunningv14')
+
+        then:
+        !interceptor.doesMatch()
     }
 }
 


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This PR addresses a bug related to the Schedule Forecast page.

**Describe the problem**
When selecting more than two projects (but not all) on the Schedule Forecast page and clicking the "search" button, the loading icon remains stuck, and a warning icon appears. This issue stems from the API call to `http://rundeck/api/v/{params.project}/executions/running` where `params.project` is not correctly processed for multiple selected projects.

**Describe the solution you've implemented**
The solution involves two main changes:
1. **Interceptor Exclusion**: Modify the `ApiProjectSelectInterceptor` to include an exclusion for the `apiExecutionsRunningv14()` method, allowing it to bypass pre-validation checks that incorrectly handle multiple projects.
2. **API Method Enhancement**: The `apiExecutionsRunningv14()` method will be updated to:
   - Split the `params.project` string by commas to process each project individually.
   - Validate each project to ensure it exists, is active, and has read authorization.
   - Return appropriate error responses for invalid projects.

**Describe alternatives you've considered**
An alternative approach was to refactor the interceptor validations. However, this would have required significant changes across various API calls and potentially introduced new bugs. The chosen solution minimizes the impact on other components and focuses on addressing the specific issue.

**References**
- Related issue: `fixes #RSE-873`