### PR TITLE
RUN-2248: Fix: don't include UI timezone data in schedules json

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/SchedulesEditorSection.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/SchedulesEditorSection.vue
@@ -6,7 +6,7 @@
       :event-bus="eventBus"
       :use-crontab-string="useCrontabString"
     />
-    <json-embed :output-data="updatedData" field-name="schedulesJsonData" />
+    <json-embed :output-data="outputData" field-name="schedulesJsonData" />
   </div>
 </template>
 
@@ -29,10 +29,13 @@ export default {
       rdBase: null,
       schedulesData: {},
       updatedData: null,
+      outputData: {},
     };
   },
   watch: {
     updatedData() {
+      const { timeZones, ...other } = this.updatedData;
+      this.outputData = other;
       window.jobWasEdited();
     },
   },
@@ -44,6 +47,8 @@ export default {
       if (rundeck && rundeck.data) {
         this.schedulesData = rundeck.data.schedulesData;
         this.updatedData = Object.assign({}, this.schedulesData);
+        const { timeZones, ...other } = this.updatedData;
+        this.outputData = other;
       }
     }
   },


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**
Fix a minor bug in the job editor Schedules UI: timezone data used by the GUI is included in the json data sent to the server.

**Describe the solution you've implemented**
Remove the timeZones from the json

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<img width="1111" alt="Screenshot 2024-03-14 at 3 10 29 PM" src="https://github.com/rundeck/rundeck/assets/55603/31a6532d-427b-490f-9e0f-d5f9ce02dd23">
