### PR TITLE
RSE-985: Fix inconsistent Execution class constraints.

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -88,6 +88,8 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
         retryOriginalId(nullable: true)
         retryPrevId(nullable: true)
         extraMetadata(nullable: true)
+        uuid(nullable: true)
+        jobUuid(nullable: true)
     }
 
     static mapping = {


### PR DESCRIPTION
`4.17.0` added new columns at the execution table, however the domain object incorrectly is set as non-nullable (gorm's default), preventing the correct update of executions from previous versions that have a null value on those columns.