### PR TITLE
RCLOUD-1184: cleanup LogFileStorageRequestProvider

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     api project(":rundeck-authz:rundeck-authz-core")
     api project(":rundeck-authz:rundeck-authz-yaml")
 
-    api "org.rundeck:rundeck-data-models:1.0.3"
+    api "org.rundeck:rundeck-data-models:1.0.4"
 
     api ('com.google.guava:guava:32.0.1-jre') {
         exclude group:'org.codehaus.mojo', module: 'animal-sniffer-annotations'

--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -467,7 +467,6 @@ class BootStrap {
                 }
             }
 
-             logFileStorageService.cleanupDuplicates()
              def resumeMode = configurationService.getString(LogFileStorageService.STARTUP_RESUMEMODE, "")
              if ('sync' == resumeMode) {
                  timer("logFileStorageService.resumeIncompleteLogStorage") {

--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -428,6 +428,7 @@ class LogFileStorageService
         def requestId = task.requestId
         def partial = task.partial
         def execId = task.execId
+        def execUuid = task.executionUuid
         List<String> typelist = filetype != '*' ? (filetype.split(',') as List) : []
 
         if (partial) {
@@ -435,7 +436,7 @@ class LogFileStorageService
             def files=[:]
             log.debug("Partial: Storage request [ID#${task.id}]: for types: $typelist")
             Execution.withNewSession {
-                Execution execution = Execution.get(execId)
+                Execution execution = execUuid ? Execution.findByUuid(execUuid) : Execution.get(execId)
 
                 files = getExecutionFiles(execution, typelist, true)
                 try {
@@ -458,7 +459,7 @@ class LogFileStorageService
         failures.remove(requestId)
         long retryMax = 30000
         Execution.withNewSession {
-            Execution execution = Execution.get(execId)
+            Execution execution = execUuid ? Execution.findByUuid(execUuid) : Execution.get(execId)
             def files = getExecutionFiles(execution, typelist, false)
 
             try {

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/logstorage/GormLogFileStorageRequestProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/logstorage/GormLogFileStorageRequestProvider.groovy
@@ -4,12 +4,8 @@ import grails.compiler.GrailsCompileStatic
 import groovy.transform.CompileStatic
 import groovy.transform.TypeChecked
 import groovy.transform.TypeCheckingMode
-import org.hibernate.type.IntegerType
-import org.hibernate.type.LongType
 import org.rundeck.app.data.model.v1.logstorage.LogFileStorageRequestData
 import org.rundeck.app.data.providers.v1.logstorage.LogFileStorageRequestProvider
-import org.rundeck.app.data.providers.v1.logstorage.dto.CompletedStatusLogFileStorageResponse
-import org.rundeck.app.data.providers.v1.logstorage.dto.DuplicateLogFileStorageResponse
 import rundeck.Execution
 import rundeck.LogFileStorageRequest
 
@@ -59,7 +55,7 @@ class GormLogFileStorageRequestProvider implements LogFileStorageRequestProvider
 
     @Override
     LogFileStorageRequestData update(String executionUuid, LogFileStorageRequestData data) throws Exception {
-        var currentLogFileStorage = findByExecutionUuid(executionUuid)
+        var currentLogFileStorage = findLogFileStorageRequestByExecutionUuid(executionUuid)
         currentLogFileStorage.refresh()
         currentLogFileStorage.filetype = data.filetype
         currentLogFileStorage.completed = data.completed
@@ -70,7 +66,7 @@ class GormLogFileStorageRequestProvider implements LogFileStorageRequestProvider
 
     @Override
     LogFileStorageRequestData updateFiletypeAndCompleted(String executionUuid, String filetype, Boolean completed) throws Exception {
-        var currentLogFileStorage = findByExecutionUuid(executionUuid)
+        var currentLogFileStorage = findLogFileStorageRequestByExecutionUuid(executionUuid)
         currentLogFileStorage.refresh()
         currentLogFileStorage.filetype = filetype
         currentLogFileStorage.completed = completed
@@ -79,7 +75,7 @@ class GormLogFileStorageRequestProvider implements LogFileStorageRequestProvider
 
     @Override
     LogFileStorageRequestData updateCompleted(String executionUuid, Boolean completed) throws Exception {
-        var currentLogFileStorage = findByExecutionUuid(executionUuid)
+        var currentLogFileStorage = findLogFileStorageRequestByExecutionUuid(executionUuid)
         currentLogFileStorage.refresh()
         currentLogFileStorage.completed = completed
         return currentLogFileStorage.save(flush:true)
@@ -96,30 +92,13 @@ class GormLogFileStorageRequestProvider implements LogFileStorageRequestProvider
 
     @Override
     @CompileStatic(TypeCheckingMode.SKIP)
-    LogFileStorageRequestData findByExecutionId(Long executionId) {
-        return LogFileStorageRequest.findByExecution(Execution.get(executionId))
+    LogFileStorageRequestData findByExecutionUuid(String executionUuid) {
+        return LogFileStorageRequest.findByExecution(Execution.findByUuid(executionUuid))
     }
 
     @Override
     @TypeChecked(TypeCheckingMode.SKIP)
-    List<DuplicateLogFileStorageResponse> findDuplicates() {
-        def list = LogFileStorageRequest.createCriteria().list {
-            projections{
-                sqlGroupProjection 'execution_id, count(id) as dupecount', 'execution_id having count(execution_id) > 1', ['execution_id', 'dupecount'], [
-                        LongType.INSTANCE, IntegerType.INSTANCE]
-            }
-        }.collect { new DuplicateLogFileStorageResponse(executionId: it[0] as Long, count: it[1] as Long) }
-        return list
-    }
-
-    @Override
-    List<CompletedStatusLogFileStorageResponse> listCompletedStatusByExecutionId(Long executionId) {
-        return LogFileStorageRequest.executeQuery('select org.rundeck.app.data.providers.v1.logstorage.dto.CompletedStatusLogFileStorageResponse(id,completed) from LogFileStorageRequest where execution_id=:eid',[eid:executionId])
-    }
-
-    @Override
-    @TypeChecked(TypeCheckingMode.SKIP)
-    Long countByIncompleteAndClusterNodeNotInExecIds(String serverUUID, Set<Long> skipExecIds) {
+    Long countByIncompleteAndClusterNodeNotInExecUuids(String serverUUID, Set<String> skipExecUuids) {
         return LogFileStorageRequest.createCriteria().get{
             eq('completed',false)
             execution {
@@ -128,9 +107,9 @@ class GormLogFileStorageRequestProvider implements LogFileStorageRequestProvider
                 } else {
                     eq('serverNodeUUID', serverUUID)
                 }
-                if (skipExecIds) {
+                if (skipExecUuids) {
                     not {
-                        inList('id', skipExecIds)
+                        inList('uuid', skipExecUuids)
                     }
                 }
             }
@@ -142,7 +121,7 @@ class GormLogFileStorageRequestProvider implements LogFileStorageRequestProvider
 
     @Override
     @TypeChecked(TypeCheckingMode.SKIP)
-    List<LogFileStorageRequestData> listByIncompleteAndClusterNodeNotInExecIds(String serverUUID, Set<Long> execIds, Map paging) {
+    List<LogFileStorageRequestData> listByIncompleteAndClusterNodeNotInExecUuids(String serverUUID, Set<String> execUuids, Map paging) {
         return LogFileStorageRequest.withCriteria{
             eq('completed',false)
 
@@ -152,9 +131,9 @@ class GormLogFileStorageRequestProvider implements LogFileStorageRequestProvider
                 } else {
                     eq('serverNodeUUID', serverUUID)
                 }
-                if (execIds) {
+                if (execUuids) {
                     not {
-                        inList('id', execIds)
+                        inList('uuid', execUuids)
                     }
                 }
             }
@@ -176,7 +155,7 @@ class GormLogFileStorageRequestProvider implements LogFileStorageRequestProvider
     }
 
     @CompileStatic(TypeCheckingMode.SKIP)
-    LogFileStorageRequest findByExecutionUuid(String executionUuid) {
-        return LogFileStorageRequest.findByExecution(Execution.findByUuid(executionUuid))
+    LogFileStorageRequest findLogFileStorageRequestByExecutionUuid(String uuid) {
+        return LogFileStorageRequest.findByExecution(Execution.findByUuid(uuid))
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/LogFileStorageServiceSpec.groovy
@@ -1671,7 +1671,12 @@ class LogFileStorageServiceSpec extends Specification implements ServiceUnitTest
             LogFileStorageRequest request = new LogFileStorageRequest(filetype: filetype,execution: e,pluginName:'test1',completed: false)
             request.validate()
             request.save(flush:true)
-            def task = [execId: e.id.toString(), file: testfile, storage: testPlugin, filetype: filetype,request:request,requestId:request.id]
+            def task = [file: testfile, storage: testPlugin, filetype: filetype,request:request,requestId:request.id]
+            if(useExecId) {
+                task['execId'] = e.id.toString()
+            } else {
+                task['executionUuid'] = e.uuid
+            }
 
         when:
             def result=service.runStorageRequest(task)
@@ -1689,9 +1694,10 @@ class LogFileStorageServiceSpec extends Specification implements ServiceUnitTest
         cleanup:
             testfile.delete()
         where:
+            useExecId | filetype | storeSuccess
+            true      | 'rdlog'  | false
+            false     | 'rdlog'  | false
 
-             filetype = 'rdlog'
-            storeSuccess=false
 
     }
 


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Cleanup of unused methods

**Describe the solution you've implemented**
Cleanup of some unused methods in the LogFileStorageRequestProvider, along with the removal of the `cleanupDuplicates` method, as duplicates are not possible due to the constraint:
`addUniqueConstraint(columnNames: "execution_id", constraintName: "UC_LOG_FILE_STORAGE_REQUESTEXECUTION_ID_COL", tableName: "log_file_storage_request") `


