### PR TITLE
RUN-2260: Fix: spinner always shown in nextUi jobs list

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/gui/scm/ScmStatusBadge.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/scm/ScmStatusBadge.groovy
@@ -13,7 +13,7 @@ class ScmStatusBadge {
     final String badgeText
     final String tooltips
     static final By elementSelector = By.xpath("//*[@id='jobInfo_']/span[2]/span")
-    static final String loadingFromServerText = "Loading Scm Data"
+    static final String loadingFromServerText = "Loading SCM Status..."
     static final String tooltipsAttribute = "title"
 
     ScmStatusBadge(JobShowPage jobShowPage){

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/browse/tests/JobScmStatus.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/browse/tests/JobScmStatus.spec.ts
@@ -1,0 +1,45 @@
+import { mount, VueWrapper } from "@vue/test-utils";
+import JobScmStatus from "../tree/JobScmStatus.vue";
+
+jest.mock("@/library/rundeckService.ts", () => ({
+  getRundeckContext: jest.fn().mockImplementation(() => ({
+    eventBus: { on: jest.fn(), emit: jest.fn() },
+    rdBase: "http://localhost:4440",
+  })),
+}));
+const mountJobScmStatus = async (props: any): Promise<VueWrapper<any>> => {
+  const wrapper = mount(JobScmStatus, {
+    props,
+    global: {
+      mocks: {
+        $t: jest.fn().mockImplementation((msg) => msg),
+        $tc: jest.fn().mockImplementation((msg) => msg),
+      },
+    },
+  });
+
+  // Wait for the next Vue tick to allow for asynchronous rendering
+  await wrapper.vm.$nextTick();
+
+  return wrapper;
+};
+
+describe("JobScmStatus", () => {
+  it("no content if there is no scm status", async () => {
+    const wrapper = await mountJobScmStatus({ itemData: {} });
+
+    let detail = wrapper.findAll("*");
+    expect(detail.length).toBe(0);
+    expect(wrapper.text()).toEqual("");
+  });
+  it("spinner icon shown if loading prop is true", async () => {
+    const wrapper = await mountJobScmStatus({ itemData: {}, loading: true });
+
+    let detail = wrapper.findAll("span > i");
+    expect(detail.length).toBe(1);
+    expect(detail[0].classes()).toContain("fas");
+    expect(detail[0].classes()).toContain("fa-spinner");
+    expect(detail[0].classes()).toContain("fa-pulse");
+    expect(wrapper.text()).toEqual("");
+  });
+});

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/browse/tree/JobScmStatus.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/browse/tree/JobScmStatus.vue
@@ -1,5 +1,5 @@
 <template>
-  <span v-if="!dataReady">
+  <span v-if="loading">
     <i class="fas fa-spinner fa-pulse"></i>
     <span v-if="showText">{{ $t("job.scm.status.loading.message") }}</span>
   </span>
@@ -41,7 +41,7 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
-    dataReady: {
+    loading: {
       type: Boolean,
       default: false,
     },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/browse/tree/JobScmStatus.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/browse/tree/JobScmStatus.vue
@@ -79,7 +79,7 @@ export default defineComponent({
       )?.data;
     },
     job(): JobBrowseItem | undefined {
-      return this.itemData?.job;
+      return this.itemData?.job || {};
     },
     displayText() {
       if (!this.showText) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/browse/tree/JobScmStatus.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/browse/tree/JobScmStatus.vue
@@ -1,13 +1,13 @@
 <template>
   <span v-if="!dataReady">
-      <i class="fas fa-spinner fa-pulse"></i>
-      <span v-if="showText">Loading Scm Data</span>
+    <i class="fas fa-spinner fa-pulse"></i>
+    <span v-if="showText">Loading Scm Data</span>
   </span>
   <template v-if="jobSynchState">
     <span :title="jobText" class="scm_status">
       <span :class="jobClass">
         <i :class="jobIcon" class="glyphicon"></i>
-        {{displayText}}
+        {{ displayText }}
       </span>
     </span>
   </template>
@@ -21,7 +21,6 @@ import {
 import { JobBrowseItem, JobBrowseMeta } from "@/library/types/jobs/JobBrowse";
 import { defineComponent, inject } from "vue";
 import { ScmTextUtilities } from "@/library/utilities/scm/scmTextUtilities";
-import {$} from "vue/macros";
 
 export default defineComponent({
   name: "JobScmStatus",
@@ -32,25 +31,25 @@ export default defineComponent({
     },
     showText: {
       type: Boolean,
-      default: false
+      default: false,
     },
     showClean: {
       type: Boolean,
-      default: false
+      default: false,
     },
     showExport: {
       type: Boolean,
-      default: true
+      default: true,
     },
     dataReady: {
       type: Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
-  data(){
+  data() {
     return {
-      scmUtilities: new ScmTextUtilities(this.$t)
-    }
+      scmUtilities: new ScmTextUtilities(this.$t),
+    };
   },
   setup() {
     return {
@@ -83,22 +82,25 @@ export default defineComponent({
       return this.itemData?.job;
     },
     displayText() {
-      if(!this.showText){
-        return ""
+      if (!this.showText) {
+        return "";
       }
-      if(this.exportSynchState && (this.showClean || this.exportSynchState))
-        return this.scmUtilities.exportDisplayText(this.exportSynchState)
+      if (this.exportSynchState && (this.showClean || this.exportSynchState))
+        return this.scmUtilities.exportDisplayText(this.exportSynchState);
 
-      return this.scmUtilities.importDisplayText(this.importSynchState)
+      return this.scmUtilities.importDisplayText(this.importSynchState);
     },
     jobClass() {
-      return this.scmUtilities.jobScmStatusIconClass(this.jobSynchState)
+      return this.scmUtilities.jobScmStatusIconClass(this.jobSynchState);
     },
     jobIcon() {
-      return this.scmUtilities.jobScmStatusIcon(this.jobSynchState)
+      return this.scmUtilities.jobScmStatusIcon(this.jobSynchState);
     },
     jobText() {
-      return this.scmUtilities.jobScmDescription(this.exportSynchState, this.importSynchState)
+      return this.scmUtilities.jobScmDescription(
+        this.exportSynchState,
+        this.importSynchState,
+      );
     },
   },
   methods: {},

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/browse/tree/JobScmStatus.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/browse/tree/JobScmStatus.vue
@@ -1,7 +1,7 @@
 <template>
   <span v-if="!dataReady">
     <i class="fas fa-spinner fa-pulse"></i>
-    <span v-if="showText">Loading Scm Data</span>
+    <span v-if="showText">{{ $t("job.scm.status.loading.message") }}</span>
   </span>
   <template v-if="jobSynchState">
     <span :title="jobText" class="scm_status">

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/head/scm/scm-status-badge.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/head/scm/scm-status-badge.ts
@@ -1,47 +1,58 @@
-import {defineComponent, markRaw, provide, reactive, ref} from 'vue'
-import {getRundeckContext} from '../../../../../library'
+import { defineComponent, markRaw, provide, reactive, ref } from "vue";
+import { getRundeckContext } from "../../../../../library";
 
-import moment from 'moment'
-import JobScmStatus from '@/app/pages/job/browse/tree/JobScmStatus.vue'
+import moment from "moment";
+import JobScmStatus from "@/app/pages/job/browse/tree/JobScmStatus.vue";
 
 function init() {
-    const rootStore = getRundeckContext().rootStore;
-    const page = rootStore.jobPageStore
-    const jobPageStore = reactive(page);
+  const rootStore = getRundeckContext().rootStore;
+  const page = rootStore.jobPageStore;
+  const jobPageStore = reactive(page);
 
-    moment.locale(getRundeckContext().locale||'en_US')
+  moment.locale(getRundeckContext().locale || "en_US");
 
-    rootStore.ui.addItems([
-        {
-            section: "job-head",
-            location: "job-status-badge",
-            visible: true,
-            widget: markRaw(
-                defineComponent({
-                    name: "JobHeadScmStatusBadge",
-                    components: { JobScmStatus },
-                    props: ["itemData"],
-                    setup(props){
-                        let scmItemData = reactive({ job: { job: true, groupPath: "", id: props.itemData.jobUuid, meta: undefined } })
-                        let dataReady = ref(false)
+  rootStore.ui.addItems([
+    {
+      section: "job-head",
+      location: "job-status-badge",
+      visible: true,
+      widget: markRaw(
+        defineComponent({
+          name: "JobHeadScmStatusBadge",
+          components: { JobScmStatus },
+          props: ["itemData"],
+          setup(props) {
+            let scmItemData = reactive({
+              job: {
+                job: true,
+                groupPath: "",
+                id: props.itemData.jobUuid,
+                meta: undefined,
+              },
+            });
+            let dataReady = ref(false);
 
-                        jobPageStore.getJobBrowser().loadJobMeta(scmItemData.job.id).then(jobMeta => {
-                            scmItemData.job.meta = jobMeta
-                            dataReady.value = true
-                        })
+            jobPageStore
+              .getJobBrowser()
+              .loadJobMeta(scmItemData.job.id)
+              .then((jobMeta) => {
+                scmItemData.job.meta = jobMeta;
+                dataReady.value = true;
+              });
 
-                        return { scmItemData, dataReady }
-                    },
-                    template: `<job-scm-status
+            return { scmItemData, dataReady };
+          },
+          template: `<job-scm-status
                         :itemData="scmItemData"
                         :show-clean="true"
                         :show-text="true"
                         :show-export="false"
                         :data-ready="dataReady"
-                    />`
-                })),
-        },
-    ]);
+                    />`,
+        }),
+      ),
+    },
+  ]);
 }
 
-window.addEventListener('DOMContentLoaded', init)
+window.addEventListener("DOMContentLoaded", init);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/head/scm/scm-status-badge.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/head/scm/scm-status-badge.ts
@@ -30,24 +30,24 @@ function init() {
                 meta: undefined,
               },
             });
-            let dataReady = ref(false);
+            let loading = ref(true);
 
             jobPageStore
               .getJobBrowser()
               .loadJobMeta(scmItemData.job.id)
               .then((jobMeta) => {
                 scmItemData.job.meta = jobMeta;
-                dataReady.value = true;
+                loading.value = false;
               });
 
-            return { scmItemData, dataReady };
+            return { scmItemData, loading };
           },
           template: `<job-scm-status
                         :itemData="scmItemData"
                         :show-clean="true"
                         :show-text="true"
                         :show-export="false"
-                        :data-ready="dataReady"
+                        :loading="loading"
                     />`,
         }),
       ),

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -605,6 +605,7 @@ const messages = {
   "job.toggle.scm.confirm.on": "Enable all SCM configured plugins?",
   "job.toggle.scm.confirm.off": "Disable all SCM configured plugins?",
   "job.toggle.scm.button.label.on": "Enable SCM",
+  "job.scm.status.loading.message": "Loading SCM Status...",
   "page.section.Activity.for.jobs": "Activity for Jobs",
   "widget.theme.title": "Theme",
   "widget.nextUi.title": "Enable Next UI",


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Fix: SCM status spinner is always shown for jobs in the next UI job list screen 

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
