### PR TITLE
RUN-2265: Ui:Next: remove duplicated backslash on nextUi for menu/home

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/HomeActionsMenu.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/HomeActionsMenu.vue
@@ -69,18 +69,18 @@ export default defineComponent({
       return [
         {
           show: this.isAdmin,
-          link: `${getRundeckContext().rdBase}/project/${this.project.name}/configure`,
+          link: `${getRundeckContext().rdBase}project/${this.project.name}/configure`,
           text: "edit.configuration",
         },
         {
           show: this.createPermissions,
-          link: `${getRundeckContext().rdBase}/project/${this.project.name}/job/create`,
+          link: `${getRundeckContext().rdBase}project/${this.project.name}/job/create`,
           icon: "glyphicon-plus",
           text: "new.job.button.label",
         },
         {
           show: this.createPermissions,
-          link: `${getRundeckContext().rdBase}/project/${this.project.name}/job/upload`,
+          link: `${getRundeckContext().rdBase}project/${this.project.name}/job/upload`,
           icon: "glyphicon-upload",
           text: "upload.definition.button.label",
         },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/HomeBrowserItem.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/HomeBrowserItem.vue
@@ -13,7 +13,7 @@
         />
         <a
           :id="`project${index}`"
-          :href="createLink(`/?project=${project.name}`)"
+          :href="createLink(`?project=${project.name}`)"
           class="link-hover text-inverse project_list_item_link link-quiet"
         >
           <span class="h5" :class="{ 'display-block': project.label }">
@@ -63,7 +63,7 @@
       <!--      TODO: ADJUST THIS SECTION ONCE ACTIVITY IS REFACTORED -->
       <div class="col-sm-6 col-md-2 text-center">
         <a
-          :href="createLink(`/project/${project.name}/activity`)"
+          :href="createLink(`project/${project.name}/activity`)"
           class="as-block link-hover link-block-padded text-inverse"
           :class="{ 'text-secondary': project.execCount < 1 }"
           data-toggle="popover"
@@ -116,9 +116,7 @@
         <a
           v-if="project.failedCount > 0"
           class="text-warning"
-          :href="
-            createLink(`/project/${project.name}/activity?statFilter=fail`)
-          "
+          :href="createLink(`project/${project.name}/activity?statFilter=fail`)"
         >
           <span>
             {{ project.failedCount

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/tests/HomeActionsMenu.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/tests/HomeActionsMenu.spec.ts
@@ -11,7 +11,7 @@ const defaultMeta: AuthzMeta = {
 jest.mock("@/library", () => ({
   getRundeckContext: jest
     .fn()
-    .mockReturnValue({ rdBase: "http://localhost:4440" }),
+    .mockReturnValue({ rdBase: "http://localhost:4440/" }),
 }));
 
 const mountHomeActionsMenu = async (): Promise<VueWrapper<any>> => {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/tests/HomeBrowserItem.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/tests/HomeBrowserItem.spec.ts
@@ -12,7 +12,7 @@ const dropdownStub = {
 jest.mock("@/library", () => ({
   getRundeckContext: jest
     .fn()
-    .mockReturnValue({ rdBase: "http://localhost:4440" }),
+    .mockReturnValue({ rdBase: "http://localhost:4440/" }),
 }));
 
 const projectData = {


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Bugfix: remove extra backslash added when concatenating URLs in the UI:Next: for menu/home

**Describe the solution you've implemented**
Just remove extra backslash

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
