### PR TITLE
Fix hibernate user session on scm context

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
@@ -239,7 +239,9 @@ class GormUserDataProvider implements UserDataProvider {
 
     @Override
     RdUser findByLogin(String login) {
-        return User.findByLogin(login)
+        User.withNewSession {
+            return User.findByLogin(login)
+        }
     }
 
     @Override

--- a/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
@@ -265,7 +265,7 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
     def "Should find user by login"() {
         given:
         User u = new User(login: "user")
-        u.save()
+        u.save(flush: true)
         when:
         def result = provider.findByLogin(login)
         then:

--- a/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
@@ -699,7 +699,7 @@ class ScmServiceSpec extends Specification implements ServiceUnitTest<ScmService
 
     def "lookup user profile, with User found"() {
         given:
-        new User(login: 'bob', firstName: 'a', lastName: 'b', email: 'test@test.com').save()
+        new User(login: 'bob', firstName: 'a', lastName: 'b', email: 'test@test.com').save(flush: true)
 
         when:
         def info = service.lookupUserInfo('bob')


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Bugfix for session not handled properly when context is Scm 
**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Use hibernate capabilities to attach a User query in the thread again
**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
I didn't consider any other option
**Additional context**
<!-- Add any other context or screenshots about the change here. -->
Usage of `findByLogin` does not require further writes so no problem with return value not being attached to the context