### PR TITLE
RUN-2270: Fix docker image ignoring value of JVM_MAX_RAM_PERCENTAGE

### DIFF
--- a/docker/official/lib/entry.sh
+++ b/docker/official/lib/entry.sh
@@ -71,7 +71,6 @@ if [[ -n "${EXEC_CMD}" ]] ; then
 fi
 
 exec java \
-    -XX:+UnlockExperimentalVMOptions \
     -XX:MaxRAMPercentage="${JVM_MAX_RAM_PERCENTAGE}" \
     -Dlog4j.configurationFile="${HOME}/server/config/log4j2.properties" \
     -Dlogging.config="file:${HOME}/server/config/log4j2.properties" \

--- a/docker/official/lib/includes/100_defaults.sh
+++ b/docker/official/lib/includes/100_defaults.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 # Hard-coded default for OSS so scheduler is not confused; set manually for multi-node deployments
 RUNDECK_SERVER_UUID="${RUNDECK_SERVER_UUID:-a14bc3e6-75e8-4fe4-a90d-a16dcc976bf6}"
 
-JVM_MAX_RAM_PERCENTAGE="${JVM_MAX_RAM_FRACTION:-75}"
+JVM_MAX_RAM_PERCENTAGE="${JVM_MAX_RAM_PERCENTAGE:-75}"


### PR DESCRIPTION
The docker official image is ignoring the value set at the `JVM_MAX_RAM_PERCENTAGE` environment variable when setting the value for the `-XX:MaxRAMPercentage` argument, but instead is incorrectly used the value of the deprecated `JVM_MAX_RAM_FRACTION` env variable.

This could potentially mislead administrators into think the rundeck container is using less memory than what is using in reality, as the final value for `MaxRAMPercentage` will be 75% regardless of the value of `JVM_MAX_RAM_PERCENTAGE`