### PR TITLE
RSE-846 & RSE-774 Fix: Users logged in rundeck from LDAP are duplicate

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -552,6 +552,7 @@ public class RundeckConfigBase {
     public static class RundeckLoginConfig {
         LocalLogin localLogin;
         String redirectUri;
+        Boolean nameCaseSensitiveEnabled = false;
     }
 
     @Data

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
@@ -246,7 +246,7 @@ class GormUserDataProvider implements UserDataProvider {
 
     @Override
     RdUser findByLogin(String login) {
-        return User.findByLoginIlike(login)
+        return isLoginNameCaseSensitiveEnabled() ? User.findByLogin(login) : User.findByLoginIlike(login)
     }
 
     @Override

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
@@ -216,14 +216,8 @@ class GormUserDataProvider implements UserDataProvider {
         def response = new UserFilteredResponse()
         response.setShowLoginStatus(showLoginStatus)
 
-        if (isLoginNameCaseSensitiveEnabled()){
-            response.setUsers(users)
-            response.setTotalRecords(totalRecords)
-        }
-        else{
-            response.setUsers(getUserListIgnoringCases(users))
-            response.setTotalRecords(getUserListIgnoringCases(users).size())
-        }
+        response.setUsers(users)
+        response.setTotalRecords(totalRecords)
         return response
     }
 
@@ -320,22 +314,6 @@ class GormUserDataProvider implements UserDataProvider {
      */
     def getSessionIdRegisterMethod() {
         configurationService.getString(SESSION_ID_METHOD, 'hash')
-    }
-
-    static def getUserListIgnoringCases( List<RdUser> users){
-
-        def uniqueLogin = [:]
-
-        def userList = users.findAll { user ->
-            def loginLowerCase = user.login.toLowerCase()
-            if (!uniqueLogin[loginLowerCase]) {
-                uniqueLogin[loginLowerCase] = true
-                true
-            } else {
-                false
-            }
-        }
-        return userList
     }
 
     def isLoginNameCaseSensitiveEnabled(){

--- a/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
@@ -9,11 +9,9 @@ import rundeck.services.ConfigurationService
 import rundeck.services.FrameworkService
 import rundeck.services.UserService
 import rundeck.services.data.UserDataService
-import spock.lang.Stepwise
 import spock.lang.Unroll
 import testhelper.RundeckHibernateSpec
 
-@Stepwise
 class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest {
     GormUserDataProvider provider = new GormUserDataProvider()
 
@@ -27,7 +25,7 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
     def "Find or create User"() {
         given:
         User savedUser = new User(login: "saved")
-        1 * savedUser.save()
+        savedUser.save()
         when:
         User user = provider.findOrCreateUser(login)
         then:
@@ -59,7 +57,7 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
         User savedUser = new User(login: "saved")
         savedUser.save()
         when:
-        User user = provider.registerLogin(login.toUpperCase(), sessionId)
+        User user = provider.registerLogin(login, sessionId)
         then:
         user.getLogin() == login
         user.getLastLogin()

--- a/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
@@ -9,9 +9,11 @@ import rundeck.services.ConfigurationService
 import rundeck.services.FrameworkService
 import rundeck.services.UserService
 import rundeck.services.data.UserDataService
+import spock.lang.Stepwise
 import spock.lang.Unroll
 import testhelper.RundeckHibernateSpec
 
+@Stepwise
 class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest {
     GormUserDataProvider provider = new GormUserDataProvider()
 
@@ -25,7 +27,7 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
     def "Find or create User"() {
         given:
         User savedUser = new User(login: "saved")
-        savedUser.save()
+        1 * savedUser.save()
         when:
         User user = provider.findOrCreateUser(login)
         then:
@@ -57,7 +59,7 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
         User savedUser = new User(login: "saved")
         savedUser.save()
         when:
-        User user = provider.registerLogin(login, sessionId)
+        User user = provider.registerLogin(login.toUpperCase(), sessionId)
         then:
         user.getLogin() == login
         user.getLastLogin()
@@ -115,7 +117,7 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
         when:
         provider.updateUserProfile(login, lastName, firstName, email)
         then:
-        User user = User.findByLogin(login)
+        User user = provider.findOrCreateUser(login.toUpperCase())
         user.id
         user.getLogin() == login
         user.getLastName() == lastName
@@ -225,7 +227,7 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
         where:
         login   | expect
         "login" | false
-        "saved" | true
+        "SAVED" | true
     }
 
     def "Should list all by order by login"() {
@@ -272,7 +274,7 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
         !result == !found
         where:
         login   | found
-        "user"  | true
+        "USER"  | true
         "admin" | false
     }
 

--- a/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
@@ -335,7 +335,7 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
         result.get(2).getLogin() == "admin"
     }
 
-    def "Should find user by login"() {
+    def "Should find user by login case insensitive"() {
         given:
         User u = new User(login: "user")
         u.save()
@@ -346,8 +346,33 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
         where:
         login   | found
         "USER"  | true
+        "User"  | true
+        "USer"  | true
         "admin" | false
     }
+
+    def "Should find user by login case sensitive"() {
+        given:
+        User u = new User(login: "usernameTest")
+        u.save()
+        provider.configurationService = Mock(ConfigurationService) {
+            getBoolean("login.nameCaseSensitiveEnabled",false) >> true
+        }
+        when:
+        def result = provider.findByLogin(login)
+        then:
+        !result == !found
+
+        where:
+        login           | found
+        "usernameTest"  | true
+        "nonExisting"   | false
+        "usernametest"  | false
+        "UsernametesT"  | false
+        "useRnaMetest"  | false
+    }
+
+
 
     def "Should build user"() {
         given:

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -107,6 +107,9 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         service.execReportDataProvider = providerExec
         service.referencedExecutionDataProvider = referencedExecutionDataProvider
         service.jobStatsDataProvider = new GormJobStatsDataProvider()
+        provider.configurationService = Mock(ConfigurationService) {
+            getBoolean("login.nameCaseSensitiveEnabled",false) >> true
+        }
     }
 
     private Map createJobParams(Map overrides = [:]) {

--- a/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
@@ -69,6 +69,9 @@ class ScmServiceSpec extends Specification implements ServiceUnitTest<ScmService
         mockDataService(UserDataService)
         GormUserDataProvider provider = new GormUserDataProvider()
         service.userDataProvider = provider
+        provider.configurationService = Mock(ConfigurationService) {
+            getBoolean("login.nameCaseSensitiveEnabled", false) >> true
+        }
     }
 
     class TestCloseable implements Closeable {


### PR DESCRIPTION
Related to:
https://pagerduty.atlassian.net/browse/RSE-864
https://pagerduty.atlassian.net/browse/RSE-774

Problems:
When accessing Rundeck for the first time if the users had configured the rundeck.security.syncLdapUser=true property users were duplicated on the RDUSER table.

The username on rundeck is case sensitive while usernames un LDAP are case insensitive this difference generated duplicated users on the RDUSER table since.

Solutions:
On the SetUserInterceptor remove code that was causing a duplicated register, this part of the code wasn't necessary since the user is already being created on the RundeckJaasAuthenticationSuccessEventListener.groovy.

The use of the method getUserByLoginOrCreate was replaced by findOrCreateUser since both methods had the same logic.

A new feature flag was added to the config.properties
rundeck.login.nameCaseSensitiveEnabled
By default this flag will be false meaning that username on login will case insensitive.