### PR TITLE
RSE-774 Fix: Users logged from LDAP are duplicate

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -900,6 +900,7 @@ beans={
     if(grailsApplication.config.getProperty("rundeck.security.syncLdapUser",Boolean.class,false)) {
         rundeckJaasAuthenticationSuccessEventListener(RundeckJaasAuthenticationSuccessEventListener) {
             configurationService = ref('configurationService')
+            userService = ref("userService")
         }
     }
 

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/SetUserInterceptor.groovy
@@ -183,9 +183,6 @@ class SetUserInterceptor {
             }
         }
         subject.principals.addAll(roleset.collect{new Group(it)})
-        def user = userService.findOrCreateUser(principal.name)
-        session.filterPref=UserService.parseKeyValuePref(user?.filterPref)
-
         subject
     }
 

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
@@ -3,6 +3,7 @@ package org.rundeck.app.data.providers
 
 import grails.compiler.GrailsCompileStatic
 import grails.gorm.DetachedCriteria
+import groovy.transform.Synchronized
 import groovy.transform.TypeCheckingMode
 import groovy.util.logging.Slf4j
 import org.hibernate.StaleStateException
@@ -47,6 +48,7 @@ class GormUserDataProvider implements UserDataProvider {
 
     @Override
     @Transactional
+    @Synchronized
     User findOrCreateUser(String login) throws DataAccessException {
         User user = User.findByLogin(login)
         if (!user) {
@@ -59,18 +61,10 @@ class GormUserDataProvider implements UserDataProvider {
         return user
     }
 
-    static User getUserByLoginOrCreate(String login) {
-        User user = User.findByLogin(login)
-        if (!user) {
-            user = new User(login: login)
-        }
-        return user
-    }
-
     @Override
     @Transactional
     User registerLogin(String login, String sessionId) throws DataAccessException {
-        User user = getUserByLoginOrCreate(login)
+        User user = findOrCreateUser(login)
         user.lastLogin = new Date()
         user.lastLoggedHostName = frameworkService.getServerHostname()
         user.lastSessionId = null
@@ -94,7 +88,7 @@ class GormUserDataProvider implements UserDataProvider {
     @Override
     @Transactional
     User registerLogout(String login) throws DataAccessException {
-        User user = getUserByLoginOrCreate(login)
+        User user = findOrCreateUser(login)
         user.lastLogout = new Date()
         if (!user.save(flush: true)) {
             throw new DataAccessException("unable to save user: ${user}, ${user.errors.allErrors.join(',')}")

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
@@ -48,7 +48,6 @@ class GormUserDataProvider implements UserDataProvider {
 
     @Override
     @Transactional
-    @Synchronized
     User findOrCreateUser(String login) throws DataAccessException {
         User user = User.findByLogin(login)
         if (!user) {

--- a/rundeckapp/src/main/groovy/org/rundeck/security/RundeckJaasAuthenticationSuccessEventListener.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/RundeckJaasAuthenticationSuccessEventListener.groovy
@@ -34,6 +34,7 @@ class RundeckJaasAuthenticationSuccessEventListener implements ApplicationListen
     EventBusAware {
     private static final Logger LOG = LoggerFactory.getLogger(RundeckJaasAuthenticationSuccessEventListener)
     ConfigurationService configurationService
+    UserService userService
 
     @Override
     void onApplicationEvent(final JaasAuthenticationSuccessEvent event) {
@@ -56,16 +57,12 @@ class RundeckJaasAuthenticationSuccessEventListener implements ApplicationListen
                 LOG.debug("Last Name: " + lastNamePrincipal?.name)
                 LOG.debug("Email: " + emailPrincipal?.name)
 
-                eventBus.
-                    notify(
-                        UserService.G_EVENT_LOGIN_PROFILE_CHANGE,
-                        new UserService.UserProfileData(
-                            username: username,
-                            lastName: lastNamePrincipal?.name,
-                            firstName: firstNamePrincipal?.name,
-                            email: emailPrincipal?.name
-                        )
-                    )
+                userService.updateUserProfile(
+                        username,
+                        lastNamePrincipal?.name,
+                        firstNamePrincipal?.name,
+                        emailPrincipal?.name
+                )
             }
         } catch(Exception ex) {
             LOG.error("Unable to update user profile from LDAP.",ex)

--- a/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
@@ -74,7 +74,7 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
     def "Should throw error on registerLogin with bad login"() {
         setup:
         provider.configurationService = Mock(ConfigurationService) {
-            1 * getBoolean(UserService.SESSION_ID_ENABLED, false) >> false
+            0 * getBoolean(UserService.SESSION_ID_ENABLED, false) >> false
         }
         provider.frameworkService = Mock(FrameworkService) {
             getServerHostname() >> { "server" }

--- a/rundeckapp/src/test/groovy/org/rundeck/security/RundeckJaasAuthenticationSuccessEventListenerTest.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/security/RundeckJaasAuthenticationSuccessEventListenerTest.groovy
@@ -48,6 +48,9 @@ class RundeckJaasAuthenticationSuccessEventListenerTest extends Specification im
 
         then:
         0 * listener.eventBus.notify(*_)
+        listener.userService = Mock(UserService) {
+            0 * updateUserProfile({it == _},{it == _},{it == _},{it == _}) >> {}
+        }
 
     }
 
@@ -69,7 +72,10 @@ class RundeckJaasAuthenticationSuccessEventListenerTest extends Specification im
         listener.onApplicationEvent(new JaasAuthenticationSuccessEvent(new JaasAuthenticationToken(username,null,loginContext)))
 
         then:
-        1 * listener.eventBus.notify(
+        listener.userService = Mock(UserService) {
+            1 * updateUserProfile({it == username},{it == last},{it == first},{it == email}) >> {}
+        }
+        0 * listener.eventBus.notify(
             UserService.G_EVENT_LOGIN_PROFILE_CHANGE,
             {
                 it.username == username
@@ -100,6 +106,9 @@ class RundeckJaasAuthenticationSuccessEventListenerTest extends Specification im
         listener.onApplicationEvent(new JaasAuthenticationSuccessEvent(new UsernamePasswordAuthenticationToken("un","pwd")))
 
         then:
+        listener.userService = Mock(UserService) {
+            0 * updateUserProfile({it == _},{it == _},{it == _},{it == _}) >> {}
+        }
         0 * listener.eventBus.notify(*_)
         noExceptionThrown()
     }

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/SetUserInterceptorSpec.groovy
@@ -73,6 +73,8 @@ class SetUserInterceptorSpec extends Specification implements InterceptorUnitTes
         allowed
         request.subject.principals.find { it instanceof Username }?.name == username
         request.subject.principals.findAll { it instanceof Group }.collect { it.name } == roles
+        0 * userServiceMock.findOrCreateUser(_)
+        0 * userServiceMock.parseKeyValuePref(_)
 
         where:
         username   | roles
@@ -120,6 +122,8 @@ class SetUserInterceptorSpec extends Specification implements InterceptorUnitTes
         then:
         allowed == expected
         flash.loginErrorCode==code
+        0 * userServiceMock.findOrCreateUser(_)
+        0 * userServiceMock.parseKeyValuePref(_)
 
         where:
         requiredRole | username | groups            | expected | code
@@ -164,6 +168,8 @@ class SetUserInterceptorSpec extends Specification implements InterceptorUnitTes
         interceptor.request.userPrincipal = new Username("User")
         interceptor.request.remoteUser = "User"
         boolean allowed = interceptor.before()
+        0 * userServiceMock.findOrCreateUser(_)
+        0 * userServiceMock.parseKeyValuePref(_)
 
         then:
         allowed == userAllowed
@@ -321,6 +327,8 @@ class SetUserInterceptorSpec extends Specification implements InterceptorUnitTes
         interceptor.params.authtoken = "123"
         interceptor.request.api_version = 41
         boolean allowed = interceptor.before()
+        0 * userServiceMock.findOrCreateUser(_)
+        0 * userServiceMock.parseKeyValuePref(_)
 
         then:
         allowed

--- a/rundeckapp/src/test/groovy/rundeck/services/UserServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/UserServiceSpec.groovy
@@ -123,7 +123,7 @@ class UserServiceSpec extends Specification implements ServiceUnitTest<UserServi
         String login = "user~name"
         String sessionId = "willErrSessionId"
         provider.configurationService = Mock(ConfigurationService) {
-            1 * getBoolean(UserService.SESSION_ID_ENABLED, false) >> false
+            0 * getBoolean(UserService.SESSION_ID_ENABLED, false) >> false
         }
         provider.frameworkService = Mock(FrameworkService) {
             getServerHostname() >> { "server" }
@@ -136,7 +136,7 @@ class UserServiceSpec extends Specification implements ServiceUnitTest<UserServi
 
         then:
         !user.id
-        errMsg.startsWith("unable to save user: rundeck.User")
+        errMsg.startsWith("unable to save user: user~name")
     }
 
     def "registerLogout"(){
@@ -163,7 +163,7 @@ class UserServiceSpec extends Specification implements ServiceUnitTest<UserServi
 
         then:
         !user.id
-        errMsg.startsWith("unable to save user: rundeck.User")
+        errMsg.startsWith("unable to save user: user~name")
     }
 
     def "findWithFilters basic"() {


### PR DESCRIPTION
Problem:
When accessing Rundeck for the first time if the users had configured the rundeck.security.syncLdapUser=true property users were duplicated on the RDUSER table.

Solution:
On the SetUserInterceptor remove code that was causing a duplicated register, this part of the code wasn't necessary since the user is already being created on the RundeckJaasAuthenticationSuccessEventListener.groovy.

The use of the method getUserByLoginOrCreate was replaced by findOrCreateUser since both methods had the same logic