### PR TITLE
RCLOUD-1110: Add models for creating job and execution reference objects.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,8 +56,7 @@ dependencies {
     api project(":rundeck-authz:rundeck-authz-api")
     api project(":rundeck-authz:rundeck-authz-core")
     api project(":rundeck-authz:rundeck-authz-yaml")
-
-    api "org.rundeck:rundeck-data-models:1.0.4"
+    api "org.rundeck:rundeck-data-models:1.0.5"
 
     api ('com.google.guava:guava:32.0.1-jre') {
         exclude group:'org.codehaus.mojo', module: 'animal-sniffer-annotations'

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/execution/RdExecution.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/execution/RdExecution.groovy
@@ -15,6 +15,7 @@ import rundeck.data.validation.shared.SharedServerNodeUuidConstraints
 
 @JsonIgnoreProperties(["errors","executionState"])
 class RdExecution implements ExecutionData, Validateable {
+    Serializable internalId
     String uuid = UUID.randomUUID().toString()
     String jobUuid
     Date dateStarted

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/execution/reference/ExecutionReferenceImpl.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/execution/reference/ExecutionReferenceImpl.groovy
@@ -1,0 +1,38 @@
+package rundeck.data.execution.reference
+
+import com.dtolabs.rundeck.core.execution.ExecutionReference
+import com.dtolabs.rundeck.core.jobs.JobReference
+
+class ExecutionReferenceImpl implements ExecutionReference {
+    String project
+    String options
+    String filter
+    String id
+    String uuid
+    String retryOriginalId
+    String retryPrevId
+    String retryNextId
+    JobReference job
+    Date dateStarted
+    Date dateCompleted
+    String status
+    String succeededNodeList
+    String failedNodeList
+    String targetNodes
+    String adhocCommand
+    Map metadata
+    boolean scheduled
+    String executionType
+
+    @Override
+    String toString() {
+        return "ExecutionReference{" +
+                "id='" + id + '\'' +
+                "uuid='" + uuid + '\'' +
+                ", status='" + status + '\'' +
+                ", filter='" + filter + '\'' +
+                ", options='" + options + '\'' +
+                ", job='" + job + '\'' +
+                '}';
+    }
+}

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/job/reference/JobReferenceImpl.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/job/reference/JobReferenceImpl.groovy
@@ -1,0 +1,30 @@
+package rundeck.data.job.reference
+
+import com.dtolabs.rundeck.core.jobs.JobReference
+
+
+class JobReferenceImpl implements JobReference {
+    String id
+    String project
+    String jobName
+    String groupPath
+    String serverUUID
+    String originalQuartzJobName
+    String originalQuartzGroupName
+
+    @Override
+    String getJobAndGroup() {
+        null != groupPath ? groupPath + '/' + jobName : jobName
+    }
+
+    @Override
+    public String toString() {
+        return "JobReference{" +
+                "id='" + id + '\'' +
+                ", project='" + project + '\'' +
+                ", jobName='" + jobName + '\'' +
+                ", groupPath='" + groupPath + '\'' +
+                ", version='" + version + '\'' +
+                '}';
+    }
+}

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/job/reference/JobRevReferenceImpl.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/job/reference/JobRevReferenceImpl.groovy
@@ -1,0 +1,18 @@
+package rundeck.data.job.reference
+
+import com.dtolabs.rundeck.core.jobs.JobRevReference
+
+class JobRevReferenceImpl extends JobReferenceImpl implements JobRevReference {
+    Long version
+
+    @Override
+    public String toString() {
+        return "JobReference{" +
+                "id='" + id + '\'' +
+                ", project='" + project + '\'' +
+                ", jobName='" + jobName + '\'' +
+                ", groupPath='" + groupPath + '\'' +
+                ", version='" + version + '\'' +
+                '}';
+    }
+}

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/util/ExecutionDataUtil.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/util/ExecutionDataUtil.groovy
@@ -1,7 +1,10 @@
 package rundeck.data.util
 
+import com.dtolabs.rundeck.core.execution.ExecutionReference
+import com.dtolabs.rundeck.core.jobs.JobReference
 import org.rundeck.app.data.model.v1.execution.ExecutionData
 import rundeck.data.constants.ExecutionConstants
+import rundeck.data.execution.reference.ExecutionReferenceImpl
 
 class ExecutionDataUtil {
 
@@ -30,5 +33,32 @@ class ExecutionDataUtil {
                                                  ExecutionConstants.EXECUTION_QUEUED,
                                                  ExecutionConstants.EXECUTION_SCHEDULED,
                                                  ExecutionConstants.AVERAGE_DURATION_EXCEEDED])
+    }
+
+    public static ExecutionReference createExecutionReference(ExecutionData executionData, JobReference jobRef = null, String targetNodes = null) {
+        String adhocCommand = null
+        if(!jobRef) {
+            adhocCommand = executionData.workflow.steps.get(0).summarize()
+        }
+        return new ExecutionReferenceImpl(
+                project: executionData.project,
+                id: executionData.internalId.toString(),
+                uuid: executionData.uuid,
+                retryOriginalId: executionData.retryOriginalId?.toString(),
+                retryPrevId: executionData.retryPrevId?.toString(),
+                retryNextId: executionData.retryExecutionId?.toString(),
+                options: executionData.argString,
+                filter: executionData.nodeConfig?.filter,
+                job: jobRef,
+                adhocCommand: adhocCommand,
+                dateStarted: executionData.dateStarted,
+                status: executionData.status,
+                succeededNodeList: executionData.succeededNodeList,
+                failedNodeList: executionData.failedNodeList,
+                targetNodes: targetNodes,
+                metadata: executionData.extraMetadataMap,
+                scheduled: executionData.executionType in ['scheduled','user-scheduled'],
+                executionType: executionData.executionType
+        )
     }
 }

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/util/ExecutionDataUtil.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/util/ExecutionDataUtil.groovy
@@ -42,7 +42,7 @@ class ExecutionDataUtil {
         }
         return new ExecutionReferenceImpl(
                 project: executionData.project,
-                id: executionData.internalId.toString(),
+                id: executionData.internalId?.toString(),
                 uuid: executionData.uuid,
                 retryOriginalId: executionData.retryOriginalId?.toString(),
                 retryPrevId: executionData.retryPrevId?.toString(),

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/util/JobDataUtil.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/util/JobDataUtil.groovy
@@ -1,0 +1,15 @@
+package rundeck.data.util
+
+import com.dtolabs.rundeck.core.jobs.JobReference
+import org.rundeck.app.data.model.v1.job.JobData
+import rundeck.data.job.reference.JobReferenceImpl
+
+class JobDataUtil {
+    static JobReference asJobReference(JobData job) {
+        return new JobReferenceImpl(id: job.uuid,
+                jobName: job.jobName,
+                groupPath: job.groupPath,
+                project: job.project,
+                serverUUID: job.serverNodeUUID)
+    }
+}

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/validation/shared/SharedExecutionConstraints.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/validation/shared/SharedExecutionConstraints.groovy
@@ -3,6 +3,7 @@ package rundeck.data.validation.shared
 import grails.validation.Validateable
 
 class SharedExecutionConstraints implements Validateable {
+    Serializable internalId
     String jobUuid
     String argString
     String status
@@ -23,6 +24,7 @@ class SharedExecutionConstraints implements Validateable {
     String retryDelay
 
     static constraints = {
+        internalId(nullable: true)
         jobUuid(nullable:true)
         argString(nullable:true)
         dateStarted(nullable:true)

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/events/RdExecutionCompleteEvent.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/events/RdExecutionCompleteEvent.groovy
@@ -1,0 +1,8 @@
+package rundeck.events
+
+class RdExecutionCompleteEvent {
+    String state
+    String executionUuid
+    Map nodeStatus
+    Map context
+}

--- a/grails-rundeck-data-shared/src/test/groovy/rundeck/data/util/ExecutionDataUtilSpec.groovy
+++ b/grails-rundeck-data-shared/src/test/groovy/rundeck/data/util/ExecutionDataUtilSpec.groovy
@@ -2,6 +2,8 @@ package rundeck.data.util
 
 import rundeck.data.constants.ExecutionConstants
 import rundeck.data.execution.RdExecution
+import rundeck.data.job.RdJob
+import rundeck.data.job.RdNodeConfig
 import spock.lang.Specification
 
 class ExecutionDataUtilSpec extends Specification {
@@ -45,5 +47,46 @@ class ExecutionDataUtilSpec extends Specification {
         "custom"                                                   | true
         "other"                                                    | true
 
+    }
+
+    def "create execution reference"() {
+        given:
+        def jobData = new RdJob(uuid: UUID.randomUUID().toString(),
+                                jobName: "test",
+                                groupPath: "test",
+                                project: "test"
+        )
+        def execution = new RdExecution(internalId: 1L,
+                                    uuid: UUID.randomUUID().toString(),
+                                    jobUuid: jobData.uuid,
+                                    project: jobData.project,
+                                    dateStarted: new Date(1024,1,1),
+                                    dateCompleted: new Date(1024,1,2),
+                                    status: "completed",
+                                    succeededNodeList: "node1,node2",
+                                    failedNodeList: "node3",
+                                    executionType: "scheduled",
+                                    nodeConfig: new RdNodeConfig(filter: "tag: gold")
+        )
+
+
+        when:
+        def execRef = ExecutionDataUtil.createExecutionReference(execution, JobDataUtil.asJobReference(jobData))
+
+        then:
+        execRef.project == execution.project
+        execRef.id == execution.internalId.toString()
+        execRef.project == execution.project
+        execRef.job.project == jobData.project
+        execRef.job.id == jobData.uuid
+        execRef.job.jobName == jobData.jobName
+        execRef.job.groupPath == jobData.groupPath
+        execRef.adhocCommand == null
+        execRef.filter == execution.nodeConfig.filter
+        execRef.dateStarted == execution.dateStarted
+        execRef.status == execution.status
+        execRef.succeededNodeList == execution.succeededNodeList
+        execRef.failedNodeList == execution.failedNodeList
+        execRef.executionType == execution.executionType
     }
 }

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -170,6 +170,10 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
         }
     }
 
+    Serializable getInternalId() {
+        return id
+    }
+
     @Override
     Serializable getRetryExecutionId() {
         return retryExecution?.id

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionEventsService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionEventsService.groovy
@@ -18,6 +18,9 @@ package rundeck.services
 
 import grails.events.annotation.Subscriber
 import grails.gorm.transactions.Transactional
+import rundeck.Execution
+import rundeck.ScheduledExecution
+import rundeck.events.RdExecutionCompleteEvent
 import rundeck.services.events.ExecutionCompleteEvent
 
 @Transactional
@@ -31,6 +34,11 @@ class ExecutionEventsService {
     @Subscriber
     def executionComplete(ExecutionCompleteEvent e) {
         logFileStorageService.submitForStorage(e.execution)
+    }
+
+    @Subscriber
+    def executionComplete(RdExecutionCompleteEvent e) {
+        logFileStorageService.submitForStorage(e.executionUuid)
     }
     /**
      * Checkpoint during job execution to allow partiallog storage

--- a/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/LogFileStorageService.groovy
@@ -771,6 +771,13 @@ class LogFileStorageService
      * Submit asynchronous request to store log files for the execution
      * @param e
      */
+    void submitForStorage(String executionUuid) {
+        submitForStorage(Execution.findByUuid(executionUuid))
+    }
+    /**
+     * Submit asynchronous request to store log files for the execution
+     * @param e
+     */
     void submitForStorage(Execution e) {
         def plugin = getConfiguredPluginForExecution(e, frameworkService.getFrameworkPropertyResolverFactory(e.project))
         if(null==plugin || !pluginSupportsStorage(plugin)){

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/ExecutionToRdExecutionConverter.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/ExecutionToRdExecutionConverter.groovy
@@ -8,6 +8,7 @@ class ExecutionToRdExecutionConverter {
     static RdExecution convert(Execution e) {
         if(!e) return null
         RdExecution re = new RdExecution()
+        re.internalId = e.internalId
         re.uuid = e.uuid
         re.jobUuid = e.jobUuid
         re.status = e.status

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/ExecutionToRdExecutionConverterSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/ExecutionToRdExecutionConverterSpec.groovy
@@ -38,6 +38,7 @@ class ExecutionToRdExecutionConverterSpec extends Specification implements DataT
         RdExecution rdExecution = converter.convert(execution)
 
         then:
+        rdExecution.internalId == execution.id
         rdExecution.uuid == execution.uuid
         rdExecution.jobUuid == execution.jobUuid
         rdExecution.workflow.steps.size() == execution.workflow.commands.size()

--- a/rundeckapp/src/test/groovy/rundeck/services/ExecutionEventsServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ExecutionEventsServiceSpec.groovy
@@ -1,0 +1,20 @@
+package rundeck.services
+
+import grails.testing.gorm.DataTest
+import grails.testing.services.ServiceUnitTest
+import rundeck.events.RdExecutionCompleteEvent
+import spock.lang.Specification
+
+class ExecutionEventsServiceSpec extends Specification implements ServiceUnitTest<ExecutionEventsService>, DataTest {
+    def "On RdExecutionCompleteEvent"() {
+        given:
+        service.logFileStorageService = Mock(LogFileStorageService)
+
+        when:
+        service.executionComplete(new RdExecutionCompleteEvent(executionUuid: '123'))
+
+        then:
+        1 * service.logFileStorageService.submitForStorage('123')
+
+    }
+}


### PR DESCRIPTION
Add models for creating job and execution reference objects.
Support new execution completion event that doesn't require an Execution domain class.