### PR TITLE
RUN-2266: Change label and description of secureExposed option type

### DIFF
--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -389,13 +389,13 @@ form.option.usage.secureAuth.message=Secure authentication option values are not
 form.option.delimiter.description=Delimiter will be used to join all input values. Can be any string: ' ' (space), ',' (comma), etc. Note: do not include quotes.
 form.option.secureInput.description=Secure input values are not stored by Rundeck after use. If the exposed value is used in a script or command then the output log may contain the value.
 form.option.inputType.label=Input Type
-form.option.secureInput.false.label=Plain text
+form.option.secureInput.false.label=Plain Text
 form.option.date.label=Date
 form.option.date.description=The date will pass to your job as a string formatted this way: mm/dd/yy HH:MM
 form.option.secureInput.false.description=Plain text input.
-form.option.secureExposed.true.label=Secure
+form.option.secureExposed.true.label=Plain Text with Password Input
 form.option.secureExposed.false.label=Secure Remote Authentication
-form.option.secureExposed.true.description=Password input, value exposed in scripts and commands.
+form.option.secureExposed.true.description=Plain text with a Password input, value exposed in scripts and commands.
 form.option.secureExposed.false.description=Password input, value not exposed in scripts or commands, used only by Node Executors for authentication.
 
 # API Messages

--- a/rundeckapp/grails-app/i18n/messages_zh_cn.properties
+++ b/rundeckapp/grails-app/i18n/messages_zh_cn.properties
@@ -370,13 +370,13 @@ form.option.usage.secureAuth.message=Secure authentication option values are not
 form.option.delimiter.description=\u5206\u9694\u7B26\u7528\u6765\u8FDE\u63A5\u8F93\u5165\u7684\u503C\uFF0C\u53EF\u4EE5\u4E3A\u4EFB\u4F55\u503C\uFF08\u5F15\u53F7\u9664\u5916\uFF09
 form.option.secureInput.description=Secure input values are not stored by Rundeck after use. If the exposed value is used in a script or command then the output log may contain the value.
 form.option.inputType.label=Input Type
-form.option.secureInput.false.label=Plain text
+form.option.secureInput.false.label=Plain Text
 form.option.date.label=Date
 form.option.date.description=The date will pass to your job as a string formatted this way: mm/dd/yy HH:MM
 form.option.secureInput.false.description=Plain text input.
-form.option.secureExposed.true.label=Secure
+form.option.secureExposed.true.label=Plain Text with Password Input
 form.option.secureExposed.false.label=Secure Remote Authentication
-form.option.secureExposed.true.description=Password input, value exposed in scripts and commands.
+form.option.secureExposed.true.description=Plain text with a Password input, value exposed in scripts and commands.
 form.option.secureExposed.false.description=Password input, value not exposed in scripts or commands, used only by Node Executors for authentication.
 
 # API Messages

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -685,7 +685,7 @@ const messages = {
   "form.option.inputType.label": "Input Type",
   "form.option.defaultStoragePath.present.description":
     "A default value will be loaded from Key Storage",
-  "form.option.secureInput.false.label": "Plain text",
+  "form.option.secureInput.false.label": "Plain Text",
   "form.option.name.label": "Option Name",
   "form.option.valuesType.url.filter.label": "Json Path Filter",
   "form.option.valuesType.url.authType.label": "Authentication Type",
@@ -722,7 +722,7 @@ const messages = {
     "The Remote URL Json Path Filter has an invalid syntax",
   "form.option.valuesType.url.authType.apiKey.label": "API Key",
   "form.option.optionType.text.label": "Text",
-  "form.option.secureExposed.true.label": "Secure",
+  "form.option.secureExposed.true.label": "Plain Text with Password Input",
   "form.option.valuesType.url.filter.description":
     'Filter JSON results using a key path, for example "$.key.path"',
   "form.option.valuesType.url.authentication.tokenInformer.header.label":
@@ -751,7 +751,7 @@ const messages = {
   "form.option.valuesType.url.authentication.tokenInformer.label":
     "Inject key ",
   "form.option.secureExposed.true.description":
-    "Password input, value exposed in scripts and commands.",
+    "Plain text with a Password input, value exposed in scripts and commands.",
   "form.option.dateFormat.title": "Date Format",
   "form.option.label.label": "Option Label",
   "form.option.valuesUrl.description": "A URL to a Remote JSON service.",


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Changes "Secure" to "Plain Text with Password Input"

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
