### PR TITLE
RUN-2192: Make max log size configurable (whale log limit)

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/LogViewerOutputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/LogViewerOutputSpec.groovy
@@ -1,6 +1,7 @@
 package org.rundeck.tests.functional.selenium.jobs
 
 import org.openqa.selenium.By
+import org.rundeck.util.gui.pages.execution.ExecutionShowPage
 import org.rundeck.util.gui.pages.home.HomePage
 import org.rundeck.util.gui.pages.jobs.JobShowPage
 import org.rundeck.util.gui.pages.login.LoginPage
@@ -85,6 +86,7 @@ class LogViewerOutputSpec extends SeleniumBase{
         def sideBar = page SideBarPage
         def projectHomePage = page HomePage
         def jobShowPage = page JobShowPage
+        def executionShowPage = page ExecutionShowPage
 
         when: "We run the job to have multiple lines in log output"
         loginPage.go()
@@ -94,9 +96,9 @@ class LogViewerOutputSpec extends SeleniumBase{
         sideBar.goTo(NavLinkTypes.JOBS)
         jobShowPage.goToJob("1f0306cd-e123-44f3-8977-9e52edad8ce7")
         jobShowPage.getRunJobBtn().click()
-        jobShowPage.getLogOutputBtn().click()
+        executionShowPage.validateStatus 'SUCCEEDED'
+        executionShowPage.getLink 'Log Output' click()
         def showWarningMessage = jobShowPage.waitForElementVisible(By.xpath("//div[contains(@class, 'execution-log__warning')]")).isDisplayed()
-
         then:
         verifyAll {
             showWarningMessage

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/LogViewerOutputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/LogViewerOutputSpec.groovy
@@ -79,7 +79,7 @@ class LogViewerOutputSpec extends SeleniumBase{
         }
     }
 
-    def "doesnt show whale log warning message if maxLogSize is set"() {
+    def "show whale log warning message"() {
 
         given:
         def loginPage = page LoginPage
@@ -105,7 +105,7 @@ class LogViewerOutputSpec extends SeleniumBase{
         }
     }
 
-    def "show whale log warning message"() {
+    def "doesnt show whale log warning message if maxLogSize is set"() {
 
         given:
         def loginPage = page LoginPage
@@ -121,7 +121,7 @@ class LogViewerOutputSpec extends SeleniumBase{
         projectHomePage.validatePage()
         projectHomePage.goProjectHome(longOutPutProjectName)
         sideBar.goTo(NavLinkTypes.JOBS)
-        jobShowPage.goToJob("1f0306cd-e123-44f3-8977-9e52edad8ce7")
+        jobShowPage.goToJob("1f0306cd-e123-44f3-8977-9e52edad8ce8")
         jobShowPage.getRunJobBtn().click()
         executionShowPage.validateStatus 'SUCCEEDED'
         executionShowPage.go()

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/LogViewerOutputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/LogViewerOutputSpec.groovy
@@ -129,7 +129,7 @@ class LogViewerOutputSpec extends SeleniumBase{
         def showWarningMessage = jobShowPage.waitForElementVisible(By.xpath("//div[contains(@class, 'execution-log__warning')]")).isDisplayed()
         then:
         verifyAll {
-            showWarningMessage
+            !showWarningMessage
         }
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/LogViewerOutputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/LogViewerOutputSpec.groovy
@@ -77,4 +77,29 @@ class LogViewerOutputSpec extends SeleniumBase{
             selectedLine
         }
     }
+
+    def "show whale log warning message"() {
+
+        given:
+        def loginPage = page LoginPage
+        def sideBar = page SideBarPage
+        def projectHomePage = page HomePage
+        def jobShowPage = page JobShowPage
+
+        when: "We run the job to have multiple lines in log output"
+        loginPage.go()
+        loginPage.login(TEST_USER, TEST_PASS)
+        projectHomePage.validatePage()
+        projectHomePage.goProjectHome(longOutPutProjectName)
+        sideBar.goTo(NavLinkTypes.JOBS)
+        jobShowPage.goToJob("1f0306cd-e123-44f3-8977-9e52edad8ce7")
+        jobShowPage.getRunJobBtn().click()
+        jobShowPage.getLogOutputBtn().click()
+        def showWarningMessage = jobShowPage.waitForElementVisible(By.xpath("//div[contains(@class, 'execution-log__warning')]")).isDisplayed()
+
+        then:
+        verifyAll {
+            showWarningMessage
+        }
+    }
 }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/LogViewerOutputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/LogViewerOutputSpec.groovy
@@ -126,10 +126,10 @@ class LogViewerOutputSpec extends SeleniumBase{
         executionShowPage.validateStatus 'SUCCEEDED'
         executionShowPage.go()
         executionShowPage.getLink 'Log Output' click()
-        def showWarningMessage = jobShowPage.waitForElementVisible(By.xpath("//div[contains(@class, 'execution-log__warning')]")).isDisplayed()
+        def showWarningMessage = jobShowPage.waitForElementVisible(By.xpath("//div[contains(@class, 'execution-log__line')]")).isDisplayed()
         then:
         verifyAll {
-            !showWarningMessage
+            showWarningMessage
         }
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/LogViewerOutputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/LogViewerOutputSpec.groovy
@@ -79,7 +79,7 @@ class LogViewerOutputSpec extends SeleniumBase{
         }
     }
 
-    def "show whale log warning message"() {
+    def "doesnt show whale log warning message if maxLogSize is set"() {
 
         given:
         def loginPage = page LoginPage
@@ -97,6 +97,34 @@ class LogViewerOutputSpec extends SeleniumBase{
         jobShowPage.goToJob("1f0306cd-e123-44f3-8977-9e52edad8ce7")
         jobShowPage.getRunJobBtn().click()
         executionShowPage.validateStatus 'SUCCEEDED'
+        executionShowPage.getLink 'Log Output' click()
+        def showWarningMessage = jobShowPage.waitForElementVisible(By.xpath("//div[contains(@class, 'execution-log__warning')]")).isDisplayed()
+        then:
+        verifyAll {
+            showWarningMessage
+        }
+    }
+
+    def "show whale log warning message"() {
+
+        given:
+        def loginPage = page LoginPage
+        def sideBar = page SideBarPage
+        def projectHomePage = page HomePage
+        def jobShowPage = page JobShowPage
+        def executionShowPage = page ExecutionShowPage
+        executionShowPage.setLoadPath("/execution/show/1?maxLogSize=5000000")
+
+        when: "We run the job to have multiple lines in log output"
+        loginPage.go()
+        loginPage.login(TEST_USER, TEST_PASS)
+        projectHomePage.validatePage()
+        projectHomePage.goProjectHome(longOutPutProjectName)
+        sideBar.goTo(NavLinkTypes.JOBS)
+        jobShowPage.goToJob("1f0306cd-e123-44f3-8977-9e52edad8ce7")
+        jobShowPage.getRunJobBtn().click()
+        executionShowPage.validateStatus 'SUCCEEDED'
+        executionShowPage.go()
         executionShowPage.getLink 'Log Output' click()
         def showWarningMessage = jobShowPage.waitForElementVisible(By.xpath("//div[contains(@class, 'execution-log__warning')]")).isDisplayed()
         then:

--- a/functional-test/src/test/resources/projects-import/long-job-output-project/rundeck-longOutput/jobs/job-1f0306cd-e123-44f3-8977-9e52edad8ce7.xml
+++ b/functional-test/src/test/resources/projects-import/long-job-output-project/rundeck-longOutput/jobs/job-1f0306cd-e123-44f3-8977-9e52edad8ce7.xml
@@ -1,0 +1,30 @@
+<joblist>
+  <job>
+    <defaultTab>nodes</defaultTab>
+    <description></description>
+    <executionEnabled>true</executionEnabled>
+    <id>1f0306cd-e123-44f3-8977-9e52edad8ce7</id>
+    <loglevel>INFO</loglevel>
+    <name>output job</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <plugins />
+    <runnerSelector>
+      <runnerFilterMode>LOCAL</runnerFilterMode>
+      <runnerFilterType>LOCAL_RUNNER</runnerFilterType>
+    </runnerSelector>
+    <scheduleEnabled>true</scheduleEnabled>
+    <schedules />
+    <sequence keepgoing='false' strategy='node-first'>
+      <command>
+        <script><![CDATA[#!/bin/bash
+
+for (( i=1; i<=25000; i++ ))
+do
+    echo "--------------------------------------- test a very long output $i ---------------------------------------"
+done]]></script>
+        <scriptargs />
+      </command>
+    </sequence>
+    <uuid>1f0306cd-e123-44f3-8977-9e52edad8ce7</uuid>
+  </job>
+</joblist>

--- a/functional-test/src/test/resources/projects-import/long-job-output-project/rundeck-longOutput/jobs/job-1f0306cd-e123-44f3-8977-9e52edad8ce8.xml
+++ b/functional-test/src/test/resources/projects-import/long-job-output-project/rundeck-longOutput/jobs/job-1f0306cd-e123-44f3-8977-9e52edad8ce8.xml
@@ -3,7 +3,7 @@
     <defaultTab>nodes</defaultTab>
     <description></description>
     <executionEnabled>true</executionEnabled>
-    <id>1f0306cd-e123-44f3-8977-9e52edad8ce7</id>
+    <id>1f0306cd-e123-44f3-8977-9e52edad8ce8</id>
     <loglevel>INFO</loglevel>
     <name>output job</name>
     <nodeFilterEditable>false</nodeFilterEditable>
@@ -25,6 +25,6 @@ done]]></script>
         <scriptargs />
       </command>
     </sequence>
-    <uuid>1f0306cd-e123-44f3-8977-9e52edad8ce7</uuid>
+    <uuid>1f0306cd-e123-44f3-8977-9e52edad8ce8</uuid>
   </job>
 </joblist>

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -266,7 +266,9 @@ class ExecutionController extends ControllerBase{
         def inputFilesMap = inputFiles.collectEntries { [it.uuid, it] }
 
         String max = getGrailsApplication().config.getProperty("rundeck.logviewer.trimOutput", String)
+        String maxLogSizeConfig = getGrailsApplication().config.getProperty("rundeck.logviewer.maxLogSize", String)
         Long trimOutput = Sizes.parseFileSize(max)
+        Long maxLogSize = Sizes.parseFileSize(maxLogSizeConfig)
 
         return loadExecutionViewPlugins() + [
                 scheduledExecution    : e.scheduledExecution ?: null,
@@ -281,7 +283,8 @@ class ExecutionController extends ControllerBase{
                 eprev                 : eprev,
                 inputFilesMap         : inputFilesMap,
                 clusterModeEnabled    : frameworkService.isClusterModeEnabled(),
-                trimOutput            : trimOutput
+                trimOutput            : trimOutput,
+                maxLogSize            : maxLogSize
         ]
     }
 

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -859,7 +859,7 @@ search
                                        class="card-content-full-width"
                                        data-bind="visible: activeTab() === 'output' || activeTab().startsWith('outputL')"
                                   >
-                                      <div class="execution-log-viewer" style="height: 100%" data-execution-id="${execution.id}" data-theme="light" data-follow="true" data-trim-output="${trimOutput}"></div>
+                                      <div class="execution-log-viewer" style="height: 100%" data-execution-id="${execution.id}" data-max-log-size="${maxLogSize}" data-theme="light" data-follow="true" data-trim-output="${trimOutput}"></div>
                                   </div>
 
                               </div>

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -859,7 +859,7 @@ search
                                        class="card-content-full-width"
                                        data-bind="visible: activeTab() === 'output' || activeTab().startsWith('outputL')"
                                   >
-                                      <div class="execution-log-viewer" style="height: 100%" data-execution-id="${execution.id}" data-max-log-size="${maxLogSize}" data-theme="light" data-follow="true" data-trim-output="${trimOutput}"></div>
+                                      <div class="execution-log-viewer" style="height: 100%" data-execution-id="${execution.id}" data-max-log-size="${params.maxLogSize ? params.maxLogSize.toInteger() : maxLogSize}" data-theme="light" data-follow="true" data-trim-output="${trimOutput}"></div>
                                   </div>
 
                               </div>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/main.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/main.js
@@ -80,6 +80,7 @@ function mount(e) {
     :jumpToLine="${jumpToLine || null}"
     ref="viewer"
     ${e.dataset.trimOutput ? `trimOutput="${e.dataset.trimOutput}"` : ""}
+    ${e.dataset.maxLogSize ? `maxLogSize="${e.dataset.maxLogSize}"` : ""}
   />
   `;
   const vue = createApp({


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Add the new configuration `rundeck.logviewer.maxLogSize` to define the max log output size. If the log output is bigger than the configured value, the whale log warning is shown. If no value is provided the default value is same as currently: 3145728 bytes

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
