### PR TITLE
RPL-6: reduce machine resources to its default (medium)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -680,7 +680,6 @@ workflows:
       - test-gradle-functional:
           name: New Selenium Test
           gradle-task: seleniumCoreTest
-          resource_class: large
           <<: *require-build
           <<: *slack-defaults
       - test-gradle-functional:

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/ScheduledJobSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/ScheduledJobSpec.groovy
@@ -70,7 +70,7 @@ class ScheduledJobSpec extends SeleniumBase{
         jobShowPage.validatePage()
         activityPage.loadActivityPageForProject(projectName)
         activityPage.go()
-        Thread.sleep(10000) // Auto refresh doesn't work
+        Thread.sleep(15000) // Auto refresh doesn't work
         activityPage.go()
 
         then:

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/webhook/WebhooksSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/webhook/WebhooksSpec.groovy
@@ -2,6 +2,7 @@ package org.rundeck.tests.functional.selenium.webhook
 
 import org.rundeck.util.annotations.SeleniumCoreTest
 import org.rundeck.util.container.SeleniumBase
+import org.rundeck.util.gui.pages.home.HomePage
 import org.rundeck.util.gui.pages.login.LoginPage
 import org.rundeck.util.gui.pages.webhooks.WebhooksPage
 
@@ -18,9 +19,11 @@ class WebhooksSpec extends SeleniumBase {
         setupProject(projectName)
         def webhookPage = page WebhooksPage
         def loginPage = go LoginPage
+        HomePage homePage = page HomePage
 
         when:
         loginPage.login(TEST_USER, TEST_PASS)
+        homePage.validatePage()
         webhookPage.loadPageForProject(projectName)
         webhookPage.go()
         webhookPage.validatePage()

--- a/functional-test/src/test/groovy/org/rundeck/util/container/SeleniumBase.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/SeleniumBase.groovy
@@ -9,6 +9,8 @@ import org.openqa.selenium.chrome.ChromeOptions
 import org.rundeck.util.spock.extensions.TestResultExtension
 import org.rundeck.util.gui.pages.BasePage
 
+import java.time.Duration
+
 /**
  * Utility Base for selenium test specs
  */
@@ -30,6 +32,7 @@ class SeleniumBase extends BaseContainer implements WebDriver, SeleniumContext {
         if (null == _driver) {
             def prefs = ["download.default_directory": downloadFolder]
             ChromeOptions options = new ChromeOptions()
+            options.setImplicitWaitTimeout(Duration.ofSeconds(5))
             options.setExperimentalOption("prefs", prefs)
             options.addArguments("start-maximized")
             options.addArguments("enable-automation")


### PR DESCRIPTION
This reduces machine resource class for the functional tests from large to medium and increases the implicit wait time for selenium