### PR TITLE
RUN-2314: fix log event metadata may be incorrect

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/logging/internal/DefaultLogEvent.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/logging/internal/DefaultLogEvent.java
@@ -64,8 +64,10 @@ public class DefaultLogEvent implements LogEvent{
         this.datetime = event.getDatetime();
         this.message = event.getMessage();
         this.eventType = event.getEventType();
-        defaultMetadata.putAll(event.getMetadata() != null ? event.getMetadata() : new HashMap<String,String>());
-        this.metadata=defaultMetadata;
+        this.metadata = new HashMap<>(defaultMetadata);
+        if (event.getMetadata() != null) {
+            this.metadata.putAll(event.getMetadata());
+        }
     }
 
     static DefaultLogEvent with(LogEvent event, Map<String,String> metadata) {

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/logging/FSStreamingLogWriterSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/logging/FSStreamingLogWriterSpec.groovy
@@ -1,0 +1,62 @@
+package com.dtolabs.rundeck.app.internal.logging
+
+import com.dtolabs.rundeck.core.logging.LogEvent
+import com.dtolabs.rundeck.core.logging.LogLevel
+import com.dtolabs.rundeck.core.logging.internal.DefaultLogEvent
+import com.dtolabs.rundeck.core.logging.internal.OutputLogFormat
+import spock.lang.Specification
+
+class FSStreamingLogWriterSpec extends Specification {
+
+    def "test writing logs with default meta"() {
+        given:
+            def output = new ByteArrayOutputStream()
+            def outformat = Mock(OutputLogFormat)
+            def writer = new FSStreamingLogWriter(output, [a: 'b'], outformat)
+
+        when:
+            writer.openStream()
+            writer.addEvent(
+                Stub(LogEvent) {
+                    getEventType() >> 'log'
+                    getLoglevel() >> LogLevel.NORMAL
+                    getMessage() >> "msg1"
+                    getDatetime() >> new Date()
+                    getMetadata() >> [c: 'd']
+                }
+            )
+            writer.addEvent(
+                Stub(LogEvent) {
+                    getEventType() >> 'log'
+                    getLoglevel() >> LogLevel.NORMAL
+                    getMessage() >> "msg2"
+                    getDatetime() >> new Date()
+                    getMetadata() >> [x: 'y']
+                }
+            )
+            writer.close()
+            def result = new String(output.toByteArray(), "UTF-8")
+
+        then:
+            1 * outformat.outputBegin() >> "begin"
+            1 * outformat.outputEvent(
+                {
+                    it instanceof DefaultLogEvent
+                    it.getMessage() == 'msg1'
+                    it.getMetadata() == [a: 'b', c: 'd']
+                }
+            ) >> "event1"
+            1 * outformat.outputEvent(
+                {
+                    it instanceof DefaultLogEvent
+                    it.getMessage() == 'msg2'
+                    it.getMetadata() == [a: 'b', x: 'y']
+                }
+            ) >> "event2"
+            0 * outformat.outputEvent(*_)
+            1 * outformat.outputFinish() >> "finish"
+
+
+            result == 'begin\nevent1\nevent2\nfinish\n'
+    }
+}


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Fix: log event metadata may be incorrect.  If e.g. "key value data" log filter is used, and "log output" is checked, the metadata used to log the output in JSON format can become copied to other log output lines.  This surfaces as an exception in the server log:

```
ERROR controllers.ExecutionController - Failed converting data type class java.lang.String(application/json) with plugins: [json-data-view, log-data-table-view]
```

**Describe the solution you've implemented**
Fix: metadata should not merge with previous lines

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
