### PR TITLE
Add preauthentication logging configs

### DIFF
--- a/docker/official/remco/templates/log4j2.properties
+++ b/docker/official/remco/templates/log4j2.properties
@@ -32,6 +32,11 @@ logger.authorization.name = com.dtolabs.rundeck.core.authorization
 logger.authorization.level = {{ getv("/rundeck/logging/loglevel/authorization", defaultLogLevel) }}
 logger.authorization.additivity = false
 logger.authorization.appenderRef.stdout.ref = audit
+
+logger.preauth.name = org.rundeck.security.RundeckPreauthenticationRequestHeaderFilter
+logger.preauth.level = {{ getv("/rundeck/logging/loglevel/authorization", defaultLogLevel) }}
+logger.preauth.additivity = false
+logger.preauth.appenderRef.stdout.ref = audit
 {% endif %}
 
 logger.audit_events.name = org.rundeck.plugin.audit.AuditLoggerPlugin

--- a/packaging/lib/common/etc/rundeck/log4j2.properties
+++ b/packaging/lib/common/etc/rundeck/log4j2.properties
@@ -279,3 +279,9 @@ logger.springBeanPropertyDescriptor.name = org.springframework.beans.GenericType
 logger.springBeanPropertyDescriptor.level = error
 logger.springBeanPropertyDescriptor.additivity = false
 logger.springBeanPropertyDescriptor.appenderRef.stdout.ref = STDOUT
+
+# Preauthentication only logs at INFO level
+logger.preauth.name = org.rundeck.security.RundeckPreauthenticationRequestHeaderFilter
+logger.preauth.level = info
+logger.preauth.additivity = false
+logger.preauth.appenderRef.stdout.ref = STDOUT

--- a/rundeckapp/templates/config/log4j2.properties.template
+++ b/rundeckapp/templates/config/log4j2.properties.template
@@ -288,3 +288,8 @@ logger.liquibase.name = liquibase
 logger.liquibase.level = info
 logger.liquibase.additivity = false
 logger.liquibase.appenderRef.stdout.ref = STDOUT
+
+logger.preauth.name = org.rundeck.security.RundeckPreauthenticationRequestHeaderFilter
+logger.preauth.level = info
+logger.preauth.additivity = false
+logger.preauth.appenderRef.stdout.ref = STDOUT

--- a/test/docker/dockers/tomcat/log4j2.properties
+++ b/test/docker/dockers/tomcat/log4j2.properties
@@ -244,3 +244,7 @@ logger.jaas.level = debug
 logger.jaas.additivity = false
 logger.jaas.appenderRef.stdout.ref = STDOUT
 
+logger.preauth.name = org.rundeck.security.RundeckPreauthenticationRequestHeaderFilter
+logger.preauth.level = info
+logger.preauth.additivity = false
+logger.preauth.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Enhancement. 

Implements a fix for #9090, as currently this logger is undocumented and difficult for someone without Log4j2 experience to figure out.

**Describe the solution you've implemented**
Add log4j2 configs for preauthentication to all default templates

**Describe alternatives you've considered**
Considered leaving it commented out, but if someone is not using the preauth module it won't make any noise. A future enhancement could be to suppress some of the logging to `DEBUG` level instead, since `INFO` is pretty broad. That would require a code change.

**Additional context**
#5656 has further discussion regarding how difficult it has been to debug preauthentication.
