### PR TITLE
RUN-2321- Added unit test for saved Filters

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/savedFilters.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/savedFilters.vue
@@ -49,6 +49,7 @@
           <a role="button" @click="selectFilter(filter)">
             {{ filter.filterName }}
             <span v-if="query && filter.filterName === query.filterName"
+            data-testid="checkmark-span"
               >√</span
             >
           </a>
@@ -122,7 +123,7 @@ export default defineComponent({
     },
     deleteFilter() {
       console.log("Before deletion:", this.filters);
-
+      console.log("deleteFilter was called");
       if (!this.query || !this.query.filterName) {
         return;
       }
@@ -171,10 +172,12 @@ export default defineComponent({
         .then((value) => {
           console.log("save value", value);
           this.doSaveFilter(value);
+          console.log("After save value", value);
         })
         .catch((e) => {
           console.log(e);
           //this.$notify("Save canceled.");
+          
         });
     },
   },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/savedFilters.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/savedFilters.vue
@@ -17,6 +17,7 @@
       <span
         class="dropdown-toggle btn btn-secondary btn-sm"
         :class="query && query.filterName ? 'text-info' : 'text-secondary'"
+        data-test-id="dropdown-toggle"
       >
         {{ $t("Filters") }}
         <span class="caret"></span>
@@ -48,8 +49,9 @@
         >
           <a role="button" @click="selectFilter(filter)">
             {{ filter.filterName }}
-            <span v-if="query && filter.filterName === query.filterName"
-            data-testid="checkmark-span"
+            <span
+              v-if="query && filter.filterName === query.filterName"
+              data-test-id="checkmark-span"
               >√</span
             >
           </a>
@@ -93,8 +95,6 @@ export default defineComponent({
     };
   },
   mounted() {
-    console.log(this.filters);
-    console.log(this.$el.querySelectorAll('[data-test-id="filter-item"]'));
     this.projectName = getRundeckContext().projectName;
     this.loadFilters();
 
@@ -114,7 +114,6 @@ export default defineComponent({
       });
     },
     async loadFilters() {
-      console.log("loadFilters is called");
       this.filters =
         this.filterStore.loadForProject(this.projectName).filters || [];
     },
@@ -122,8 +121,6 @@ export default defineComponent({
       this.$emit("select_filter", filter);
     },
     deleteFilter() {
-      console.log("Before deletion:", this.filters);
-      console.log("deleteFilter was called");
       if (!this.query || !this.query.filterName) {
         return;
       }
@@ -135,7 +132,7 @@ export default defineComponent({
 
         .then(() => {
           this.doDeleteFilter(this.query.filterName);
-          console.log("After deletion:", this.filters);
+          this.$emit("delete-filter", this.query.filterName);
         })
 
         .catch(() => {
@@ -144,7 +141,7 @@ export default defineComponent({
     },
     async doDeleteFilter(name) {
       this.filterStore.removeFilter(this.projectName, name);
-      console.log("Immediately after deletion:", this.filters);
+
       await this.loadFilters();
     },
     async doSaveFilter(name) {
@@ -159,8 +156,6 @@ export default defineComponent({
       }
     },
     saveFilterPrompt() {
-      console.log("saveFilterPrompt is called");
-      console.log("About to call MessageBox.prompt");
       MessageBox.prompt({
         title: this.promptTitle,
 
@@ -170,14 +165,11 @@ export default defineComponent({
         },
       })
         .then((value) => {
-          console.log("save value", value);
           this.doSaveFilter(value);
-          console.log("After save value", value);
         })
         .catch((e) => {
           console.log(e);
           //this.$notify("Save canceled.");
-          
         });
     },
   },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/savedFilters.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/savedFilters.spec.ts
@@ -1,262 +1,3 @@
-// import { mount } from "@vue/test-utils";
-// import SavedFilters from "../savedFilters.vue";
-// import { Notification, MessageBox } from "uiv";
-// // Global mocking of dependent services
-// jest.mock("@/library/rundeckService", () => ({
-//   getRundeckContext: jest.fn().mockReturnValue({ projectName: "test" }),
-// }));
-// jest.mock("../../../../library/stores/ActivityFilterStore", () => ({
-//   ActivityFilterStore: jest.fn().mockImplementation(() => ({
-//     loadForProject: jest.fn().mockReturnValue({
-//       filters: [
-//         { filterName: "Filter 1" },
-//         { filterName: "Filter 2" },
-//         { filterName: "Filter 3" },
-//       ],
-//     }),
-//     saveFilter: jest.fn().mockResolvedValue({ success: true }),
-//     removeFilter: jest.fn().mockResolvedValue(undefined),
-//   })),
-// }));
-// jest.mock("uiv", () => ({
-//   MessageBox: {
-//     confirm: jest.fn().mockResolvedValue(true),
-//     prompt: jest.fn().mockResolvedValue("new filter name"),
-//   },
-//   Notification: {
-//     notify: jest.fn(),
-//   },
-// }));
-// const mockDropdown = {
-//   template: `
-//     <div data-test-id="dropdown">
-//       <button @click="toggleDropdown" data-test-id="toggle-button">Toggle</button>
-//       <div v-if="isOpen">
-//         <slot></slot>
-//         <span data-test-id="checkmark-span">√</span>
-//         <button data-test-id="delete-filter-btn" @click="emitDeleteFilter">Delete Filter</button>
-//       </div>
-//     </div>
-//   `,
-//   data() {
-//     return {
-//       isOpen: false,
-//     };
-//   },
-//   methods: {
-//     toggleDropdown() {
-//       this.isOpen = !this.isOpen;
-//     },
-//     emitDeleteFilter() {
-//       this.$emit("delete-filter");
-//     },
-//   },
-// };
-// describe("SavedFilters", () => {
-//   let wrapper;
-//   const eventBus = {
-//     on: jest.fn(),
-//     emit: jest.fn(),
-//     off: jest.fn(),
-//   };
-//   beforeEach(() => {
-//     wrapper = mount(SavedFilters, {
-//       props: {
-//         hasQuery: true,
-//         query: { filterName: "test4" },
-//         eventBus,
-//       },
-//       attachTo: document.body,
-//       global: {
-//         mocks: {
-//           $t: (msg) => msg,
-//         },
-//         stubs: {
-//           btn: true,
-//           dropdown: mockDropdown,
-//         },
-//       },
-//     });
-//   });
-//   afterEach(() => {
-//     jest.clearAllMocks();
-//   });
-//   describe("Component Initialization", () => {
-//     it("should register and unregister event listeners", async () => {
-//       expect(eventBus.on).toHaveBeenCalledWith(
-//         "invoke-save-filter",
-//         expect.any(Function)
-//       );
-//       wrapper.unmount();
-//       expect(eventBus.off).toHaveBeenCalledWith("invoke-save-filter");
-//     });
-//   });
-//   describe("Interaction with Filters", () => {
-//     it("renders save button conditionally based on query props", () => {
-//       expect(wrapper.find('[data-test-id="save-filter-button"]').exists()).toBe(
-//         wrapper.props().hasQuery && !wrapper.props().query.filterName
-//       );
-//     });
-//     it("emits 'select_filter' when a filter is selected", async () => {
-//       await wrapper.vm.selectFilter({ filterName: "Test Filter" });
-//       expect(wrapper.emitted("select_filter")[0]).toEqual([
-//         { filterName: "Test Filter" },
-//       ]);
-//     });
-//     it("handles delete filter action", async () => {
-//       const dropdownToggle = wrapper.find('[data-test-id="toggle-button"]');
-//       await dropdownToggle.trigger("click");
-//       await wrapper.vm.$nextTick();
-//       const deleteButton = wrapper.find('[data-test-id="delete-filter-btn"]');
-//       expect(deleteButton.exists()).toBe(true);
-//     });
-//     it("calls deleteFilter when the delete filter button is clicked", async () => {
-//       await wrapper.vm.$nextTick();
-//       const dropdownToggle = wrapper.find('[data-test-id="toggle-button"]');
-//       await dropdownToggle.trigger("click");
-//       await wrapper.vm.$nextTick();
-//       // Simulate user clicking the delete button
-//       const deleteButton = wrapper.find('[data-test-id="delete-filter-btn"]');
-//       if (deleteButton.exists()) {
-//         await deleteButton.trigger("click");
-//         // Wait for the delete action to be processed
-//         await wrapper.vm.$nextTick();
-//       } else {
-//         throw new Error("Delete button not found in the DOM");
-//       }
-//     });
-//     it("should handle dropdown interactions and delete filter", async () => {
-//       const deleteFilterSpy = jest.spyOn(wrapper.vm, "deleteFilter");
-//       const deleteButton = wrapper.find('[data-test-id="delete-filter-btn"]');
-//       if (deleteButton.exists()) {
-//         await deleteButton.trigger("click");
-//         // Check if the delete-filter event was emitted by the mockDropdown component
-//         const dropdownComponent = wrapper.findComponent(mockDropdown);
-//         expect(
-//           dropdownComponent.emitted().hasOwnProperty("delete-filter")
-//         ).toBe(true);
-//         expect(deleteFilterSpy).toHaveBeenCalled(); // Check if deleteFilter method was called
-//       }
-//       deleteFilterSpy.mockRestore();
-//     });
-//   });
-//   describe("Rendering of UI Components", () => {
-//     it("checks for the presence of dropdown when filters exist", async () => {
-//       await wrapper.setData({ filters: [{ filterName: "Test Filter" }] });
-//       await wrapper.vm.$nextTick();
-//       expect(wrapper.find('[data-test-id="dropdown"]').exists()).toBe(true);
-//     });
-//     it("displays no filters message when no filters are available", async () => {
-//       wrapper.setData({ filters: [] });
-//       await wrapper.vm.$nextTick();
-//       expect(
-//         wrapper.find('[data-test-id="no-filters-message"]').text()
-//       ).toContain("No filters available");
-//     });
-//     it("renders checkmark span when query and filterName matches a filter", async () => {
-//       // Set the filters prop using the setProps method
-//       await wrapper.setData({ filters: [{ filterName: "Filter 1" }] });
-//       // Wait for the next tick to ensure the component is fully rendered
-//       await wrapper.vm.$nextTick();
-//       // Find the toggle button and trigger a click event
-//       const toggleButton = wrapper.find('[data-test-id="toggle-button"]');
-//       if (toggleButton.exists()) {
-//         await toggleButton.trigger("click");
-//         await wrapper.vm.$nextTick();
-//       }
-//       const checkmarkSpan = wrapper.find('[data-test-id="checkmark-span"]');
-//       expect(checkmarkSpan.exists()).toBe(true);
-//       expect(checkmarkSpan.text()).toContain("√");
-//     });
-//   });
-//   describe("Success and Error Handling", () => {
-//     it("displays notification upon successful filter save", async () => {
-//       const saveFilterMock = jest.fn().mockImplementation(() => {
-//         Notification.notify({ type: "success" });
-//       });
-//       wrapper.vm.saveFilter = saveFilterMock;
-//       const notifySpy = jest.spyOn(Notification, "notify");
-//       await wrapper.vm.saveFilter("New Filter");
-//       expect(notifySpy).toHaveBeenCalledWith(
-//         expect.objectContaining({ type: "success" })
-//       );
-//       notifySpy.mockRestore();
-//     });
-//     it("displays error when filter saving fails", async () => {
-//       wrapper.vm.saveFilter = async function (filterName) {
-//         try {
-//           // original saveFilter logic...
-//           throw new Error("Save failed"); // This line simulates a failure
-//         } catch (error) {
-//           Notification.notify({
-//             type: "danger",
-//             message: error.message,
-//             placement: "top-right",
-//           });
-//           throw error;
-//         }
-//       };
-//       const notifySpy = jest.spyOn(Notification, "notify");
-//       try {
-//         await wrapper.vm.saveFilter("New Filter");
-//       } catch (error) {
-//         expect(notifySpy).toHaveBeenCalledWith(
-//           expect.objectContaining({
-//             type: "danger",
-//             message: "Save failed",
-//             placement: "top-right",
-//           })
-//         );
-//       } finally {
-//         notifySpy.mockRestore();
-//       }
-//     });
-//   });
-//   describe("loadFilters Method", () => {
-//     it("correctly sets filters when loadFilters is called", async () => {
-//       wrapper.vm.filters = [];
-//       await wrapper.vm.loadFilters();
-//       expect(wrapper.vm.filters).toEqual([
-//         { filterName: "Filter 1" },
-//         { filterName: "Filter 2" },
-//         { filterName: "Filter 3" },
-//       ]);
-//     });
-//   });
-//   describe("saveFilterPrompt Method", () => {
-//     it("triggers MessageBox.prompt and calls doSaveFilter on confirm", async () => {
-//       const doSaveFilterSpy = jest.spyOn(wrapper.vm, "doSaveFilter");
-//       await wrapper.vm.saveFilterPrompt();
-//       expect(MessageBox.prompt).toHaveBeenCalled();
-//       await wrapper.vm.$nextTick();
-//       expect(doSaveFilterSpy).toHaveBeenCalledWith("new filter name");
-//       doSaveFilterSpy.mockRestore();
-//     });
-//   });
-//   describe("notifyError Method", () => {
-//     it("displays a notification with the correct message", () => {
-//       const notifySpy = jest.spyOn(Notification, "notify");
-//       wrapper.vm.notifyError("Test error message");
-//       expect(notifySpy).toHaveBeenCalledWith({
-//         type: "danger",
-//         title: "An Error Occurred",
-//         content: "Test error message",
-//         duration: 0,
-//       });
-//       notifySpy.mockRestore();
-//     });
-//   });
-//   describe("Different States", () => {
-//     it("shows 'no filters available' message when no filters are loaded", async () => {
-//       wrapper.setData({ filters: [] });
-//       await wrapper.vm.$nextTick();
-//       expect(
-//         wrapper.find('[data-test-id="no-filters-message"]').text()
-//       ).toContain("No filters available");
-//     });
-//   });
-// });
-
 import { mount } from "@vue/test-utils";
 import { ComponentPublicInstance } from "vue";
 import SavedFilters from "../savedFilters.vue";
@@ -358,7 +99,7 @@ describe("SavedFilters", () => {
       const wrapper = await mountSavedFilters();
       expect(eventBus.on).toHaveBeenCalledWith(
         "invoke-save-filter",
-        expect.any(Function)
+        expect.any(Function),
       );
       wrapper.unmount();
       expect(eventBus.off).toHaveBeenCalledWith("invoke-save-filter");
@@ -368,7 +109,7 @@ describe("SavedFilters", () => {
     it("renders save button conditionally based on query props", async () => {
       const wrapper = await mountSavedFilters();
       expect(wrapper.find('[data-test-id="save-filter-button"]').exists()).toBe(
-        wrapper.props().hasQuery && !wrapper.props().query.filterName
+        wrapper.props().hasQuery && !wrapper.props().query.filterName,
       );
     });
     it("emits 'select_filter' when a filter is selected", async () => {
@@ -406,7 +147,7 @@ describe("SavedFilters", () => {
 
         const dropdownComponent = wrapper.findComponent(mockDropdown);
         expect(
-          dropdownComponent.emitted().hasOwnProperty("delete-filter")
+          dropdownComponent.emitted().hasOwnProperty("delete-filter"),
         ).toBe(true);
         expect(deleteFilterSpy).toHaveBeenCalled(); // Check if deleteFilter method was called
       }
@@ -425,7 +166,7 @@ describe("SavedFilters", () => {
       wrapper.setData({ filters: [] });
       await wrapper.vm.$nextTick();
       expect(
-        wrapper.find('[data-test-id="no-filters-message"]').text()
+        wrapper.find('[data-test-id="no-filters-message"]').text(),
       ).toContain("No filters available");
     });
     it("renders checkmark span when query and filterName matches a filter", async () => {
@@ -452,7 +193,7 @@ describe("SavedFilters", () => {
       const notifySpy = jest.spyOn(Notification, "notify");
       await wrapper.vm.saveFilter("New Filter");
       expect(notifySpy).toHaveBeenCalledWith(
-        expect.objectContaining({ type: "success" })
+        expect.objectContaining({ type: "success" }),
       );
       notifySpy.mockRestore();
     });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/savedFilters.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/savedFilters.spec.ts
@@ -1,32 +1,277 @@
+// import { mount } from "@vue/test-utils";
+// import SavedFilters from "../savedFilters.vue";
+// import { Notification, MessageBox } from "uiv";
+// // Global mocking of dependent services
+// jest.mock("@/library/rundeckService", () => ({
+//   getRundeckContext: jest.fn().mockReturnValue({ projectName: "test" }),
+// }));
+// jest.mock("../../../../library/stores/ActivityFilterStore", () => ({
+//   ActivityFilterStore: jest.fn().mockImplementation(() => ({
+//     loadForProject: jest.fn().mockReturnValue({
+//       filters: [
+//         { filterName: "Filter 1" },
+//         { filterName: "Filter 2" },
+//         { filterName: "Filter 3" },
+//       ],
+//     }),
+//     saveFilter: jest.fn().mockResolvedValue({ success: true }),
+//     removeFilter: jest.fn().mockResolvedValue(undefined),
+//   })),
+// }));
+// jest.mock("uiv", () => ({
+//   MessageBox: {
+//     confirm: jest.fn().mockResolvedValue(true),
+//     prompt: jest.fn().mockResolvedValue("new filter name"),
+//   },
+//   Notification: {
+//     notify: jest.fn(),
+//   },
+// }));
+// const mockDropdown = {
+//   template: `
+//     <div data-test-id="dropdown">
+//       <button @click="toggleDropdown" data-test-id="toggle-button">Toggle</button>
+//       <div v-if="isOpen">
+//         <slot></slot>
+//         <span data-test-id="checkmark-span">√</span>
+//         <button data-test-id="delete-filter-btn" @click="emitDeleteFilter">Delete Filter</button>
+//       </div>
+//     </div>
+//   `,
+//   data() {
+//     return {
+//       isOpen: false,
+//     };
+//   },
+//   methods: {
+//     toggleDropdown() {
+//       this.isOpen = !this.isOpen;
+//     },
+//     emitDeleteFilter() {
+//       this.$emit("delete-filter");
+//     },
+//   },
+// };
+// describe("SavedFilters", () => {
+//   let wrapper;
+//   const eventBus = {
+//     on: jest.fn(),
+//     emit: jest.fn(),
+//     off: jest.fn(),
+//   };
+//   beforeEach(() => {
+//     wrapper = mount(SavedFilters, {
+//       props: {
+//         hasQuery: true,
+//         query: { filterName: "test4" },
+//         eventBus,
+//       },
+//       attachTo: document.body,
+//       global: {
+//         mocks: {
+//           $t: (msg) => msg,
+//         },
+//         stubs: {
+//           btn: true,
+//           dropdown: mockDropdown,
+//         },
+//       },
+//     });
+//   });
+//   afterEach(() => {
+//     jest.clearAllMocks();
+//   });
+//   describe("Component Initialization", () => {
+//     it("should register and unregister event listeners", async () => {
+//       expect(eventBus.on).toHaveBeenCalledWith(
+//         "invoke-save-filter",
+//         expect.any(Function)
+//       );
+//       wrapper.unmount();
+//       expect(eventBus.off).toHaveBeenCalledWith("invoke-save-filter");
+//     });
+//   });
+//   describe("Interaction with Filters", () => {
+//     it("renders save button conditionally based on query props", () => {
+//       expect(wrapper.find('[data-test-id="save-filter-button"]').exists()).toBe(
+//         wrapper.props().hasQuery && !wrapper.props().query.filterName
+//       );
+//     });
+//     it("emits 'select_filter' when a filter is selected", async () => {
+//       await wrapper.vm.selectFilter({ filterName: "Test Filter" });
+//       expect(wrapper.emitted("select_filter")[0]).toEqual([
+//         { filterName: "Test Filter" },
+//       ]);
+//     });
+//     it("handles delete filter action", async () => {
+//       const dropdownToggle = wrapper.find('[data-test-id="toggle-button"]');
+//       await dropdownToggle.trigger("click");
+//       await wrapper.vm.$nextTick();
+//       const deleteButton = wrapper.find('[data-test-id="delete-filter-btn"]');
+//       expect(deleteButton.exists()).toBe(true);
+//     });
+//     it("calls deleteFilter when the delete filter button is clicked", async () => {
+//       await wrapper.vm.$nextTick();
+//       const dropdownToggle = wrapper.find('[data-test-id="toggle-button"]');
+//       await dropdownToggle.trigger("click");
+//       await wrapper.vm.$nextTick();
+//       // Simulate user clicking the delete button
+//       const deleteButton = wrapper.find('[data-test-id="delete-filter-btn"]');
+//       if (deleteButton.exists()) {
+//         await deleteButton.trigger("click");
+//         // Wait for the delete action to be processed
+//         await wrapper.vm.$nextTick();
+//       } else {
+//         throw new Error("Delete button not found in the DOM");
+//       }
+//     });
+//     it("should handle dropdown interactions and delete filter", async () => {
+//       const deleteFilterSpy = jest.spyOn(wrapper.vm, "deleteFilter");
+//       const deleteButton = wrapper.find('[data-test-id="delete-filter-btn"]');
+//       if (deleteButton.exists()) {
+//         await deleteButton.trigger("click");
+//         // Check if the delete-filter event was emitted by the mockDropdown component
+//         const dropdownComponent = wrapper.findComponent(mockDropdown);
+//         expect(
+//           dropdownComponent.emitted().hasOwnProperty("delete-filter")
+//         ).toBe(true);
+//         expect(deleteFilterSpy).toHaveBeenCalled(); // Check if deleteFilter method was called
+//       }
+//       deleteFilterSpy.mockRestore();
+//     });
+//   });
+//   describe("Rendering of UI Components", () => {
+//     it("checks for the presence of dropdown when filters exist", async () => {
+//       await wrapper.setData({ filters: [{ filterName: "Test Filter" }] });
+//       await wrapper.vm.$nextTick();
+//       expect(wrapper.find('[data-test-id="dropdown"]').exists()).toBe(true);
+//     });
+//     it("displays no filters message when no filters are available", async () => {
+//       wrapper.setData({ filters: [] });
+//       await wrapper.vm.$nextTick();
+//       expect(
+//         wrapper.find('[data-test-id="no-filters-message"]').text()
+//       ).toContain("No filters available");
+//     });
+//     it("renders checkmark span when query and filterName matches a filter", async () => {
+//       // Set the filters prop using the setProps method
+//       await wrapper.setData({ filters: [{ filterName: "Filter 1" }] });
+//       // Wait for the next tick to ensure the component is fully rendered
+//       await wrapper.vm.$nextTick();
+//       // Find the toggle button and trigger a click event
+//       const toggleButton = wrapper.find('[data-test-id="toggle-button"]');
+//       if (toggleButton.exists()) {
+//         await toggleButton.trigger("click");
+//         await wrapper.vm.$nextTick();
+//       }
+//       const checkmarkSpan = wrapper.find('[data-test-id="checkmark-span"]');
+//       expect(checkmarkSpan.exists()).toBe(true);
+//       expect(checkmarkSpan.text()).toContain("√");
+//     });
+//   });
+//   describe("Success and Error Handling", () => {
+//     it("displays notification upon successful filter save", async () => {
+//       const saveFilterMock = jest.fn().mockImplementation(() => {
+//         Notification.notify({ type: "success" });
+//       });
+//       wrapper.vm.saveFilter = saveFilterMock;
+//       const notifySpy = jest.spyOn(Notification, "notify");
+//       await wrapper.vm.saveFilter("New Filter");
+//       expect(notifySpy).toHaveBeenCalledWith(
+//         expect.objectContaining({ type: "success" })
+//       );
+//       notifySpy.mockRestore();
+//     });
+//     it("displays error when filter saving fails", async () => {
+//       wrapper.vm.saveFilter = async function (filterName) {
+//         try {
+//           // original saveFilter logic...
+//           throw new Error("Save failed"); // This line simulates a failure
+//         } catch (error) {
+//           Notification.notify({
+//             type: "danger",
+//             message: error.message,
+//             placement: "top-right",
+//           });
+//           throw error;
+//         }
+//       };
+//       const notifySpy = jest.spyOn(Notification, "notify");
+//       try {
+//         await wrapper.vm.saveFilter("New Filter");
+//       } catch (error) {
+//         expect(notifySpy).toHaveBeenCalledWith(
+//           expect.objectContaining({
+//             type: "danger",
+//             message: "Save failed",
+//             placement: "top-right",
+//           })
+//         );
+//       } finally {
+//         notifySpy.mockRestore();
+//       }
+//     });
+//   });
+//   describe("loadFilters Method", () => {
+//     it("correctly sets filters when loadFilters is called", async () => {
+//       wrapper.vm.filters = [];
+//       await wrapper.vm.loadFilters();
+//       expect(wrapper.vm.filters).toEqual([
+//         { filterName: "Filter 1" },
+//         { filterName: "Filter 2" },
+//         { filterName: "Filter 3" },
+//       ]);
+//     });
+//   });
+//   describe("saveFilterPrompt Method", () => {
+//     it("triggers MessageBox.prompt and calls doSaveFilter on confirm", async () => {
+//       const doSaveFilterSpy = jest.spyOn(wrapper.vm, "doSaveFilter");
+//       await wrapper.vm.saveFilterPrompt();
+//       expect(MessageBox.prompt).toHaveBeenCalled();
+//       await wrapper.vm.$nextTick();
+//       expect(doSaveFilterSpy).toHaveBeenCalledWith("new filter name");
+//       doSaveFilterSpy.mockRestore();
+//     });
+//   });
+//   describe("notifyError Method", () => {
+//     it("displays a notification with the correct message", () => {
+//       const notifySpy = jest.spyOn(Notification, "notify");
+//       wrapper.vm.notifyError("Test error message");
+//       expect(notifySpy).toHaveBeenCalledWith({
+//         type: "danger",
+//         title: "An Error Occurred",
+//         content: "Test error message",
+//         duration: 0,
+//       });
+//       notifySpy.mockRestore();
+//     });
+//   });
+//   describe("Different States", () => {
+//     it("shows 'no filters available' message when no filters are loaded", async () => {
+//       wrapper.setData({ filters: [] });
+//       await wrapper.vm.$nextTick();
+//       expect(
+//         wrapper.find('[data-test-id="no-filters-message"]').text()
+//       ).toContain("No filters available");
+//     });
+//   });
+// });
+
 import { mount } from "@vue/test-utils";
+import { ComponentPublicInstance } from "vue";
 import SavedFilters from "../savedFilters.vue";
 import { Notification, MessageBox } from "uiv";
-// Global mocking of dependent services
-jest.mock("@/library/rundeckService", () => ({
-  getRundeckContext: jest.fn().mockReturnValue({ projectName: "test" }),
-}));
-jest.mock("../../../../library/stores/ActivityFilterStore", () => ({
-  ActivityFilterStore: jest.fn().mockImplementation(() => ({
-    loadForProject: jest.fn().mockReturnValue({
-      filters: [
-        { filterName: "Filter 1" },
-        { filterName: "Filter 2" },
-        { filterName: "Filter 3" },
-      ],
-    }),
-    saveFilter: jest.fn().mockResolvedValue({ success: true }),
-    removeFilter: jest.fn().mockResolvedValue(undefined),
-  })),
-}));
-jest.mock("uiv", () => ({
-  MessageBox: {
-    confirm: jest.fn().mockResolvedValue(true),
-    prompt: jest.fn().mockResolvedValue("new filter name"),
-  },
-  Notification: {
-    notify: jest.fn(),
-  },
-}));
+// Custom type for the component instance
+type SavedFiltersInstance = ComponentPublicInstance<{
+  filters: { filterName: string }[];
+  selectFilter: (filter: { filterName: string }) => void;
+  deleteFilter: () => void;
+  saveFilter: (filterName: string) => void;
+  loadFilters: () => void;
+  saveFilterPrompt: () => void;
+  notifyError: (message: string) => void;
+  doSaveFilter: (filterName: string) => void;
+}>;
 const mockDropdown = {
   template: `
     <div data-test-id="dropdown">
@@ -52,37 +297,65 @@ const mockDropdown = {
     },
   },
 };
-describe("SavedFilters", () => {
-  let wrapper;
-  const eventBus = {
-    on: jest.fn(),
-    emit: jest.fn(),
-    off: jest.fn(),
-  };
-  beforeEach(() => {
-    wrapper = mount(SavedFilters, {
-      props: {
-        hasQuery: true,
-        query: { filterName: "test4" },
-        eventBus,
+const eventBus = {
+  on: jest.fn(),
+  emit: jest.fn(),
+  off: jest.fn(),
+};
+const mountSavedFilters = async (props = {}) => {
+  const wrapper = mount<SavedFiltersInstance>(SavedFilters, {
+    props: {
+      hasQuery: true,
+      query: { filterName: "test4" },
+      eventBus,
+      ...props,
+    },
+    attachTo: document.body,
+    global: {
+      mocks: {
+        $t: (msg: string) => msg,
       },
-      attachTo: document.body,
-      global: {
-        mocks: {
-          $t: (msg) => msg,
-        },
-        stubs: {
-          btn: true,
-          dropdown: mockDropdown,
-        },
+      stubs: {
+        btn: true,
+        dropdown: mockDropdown,
       },
-    });
+    },
   });
+  await wrapper.vm.$nextTick();
+  return wrapper;
+};
+jest.mock("@/library/rundeckService", () => ({
+  getRundeckContext: jest.fn().mockReturnValue({ projectName: "test" }),
+}));
+jest.mock("../../../../library/stores/ActivityFilterStore", () => ({
+  ActivityFilterStore: jest.fn().mockImplementation(() => ({
+    loadForProject: jest.fn().mockReturnValue({
+      filters: [
+        { filterName: "Filter 1" },
+        { filterName: "Filter 2" },
+        { filterName: "Filter 3" },
+      ],
+    }),
+    saveFilter: jest.fn().mockResolvedValue({ success: true }),
+    removeFilter: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+jest.mock("uiv", () => ({
+  MessageBox: {
+    confirm: jest.fn().mockResolvedValue(true),
+    prompt: jest.fn().mockResolvedValue("new filter name"),
+  },
+  Notification: {
+    notify: jest.fn(),
+  },
+}));
+describe("SavedFilters", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
   describe("Component Initialization", () => {
     it("should register and unregister event listeners", async () => {
+      const wrapper = await mountSavedFilters();
       expect(eventBus.on).toHaveBeenCalledWith(
         "invoke-save-filter",
         expect.any(Function)
@@ -92,18 +365,21 @@ describe("SavedFilters", () => {
     });
   });
   describe("Interaction with Filters", () => {
-    it("renders save button conditionally based on query props", () => {
+    it("renders save button conditionally based on query props", async () => {
+      const wrapper = await mountSavedFilters();
       expect(wrapper.find('[data-test-id="save-filter-button"]').exists()).toBe(
         wrapper.props().hasQuery && !wrapper.props().query.filterName
       );
     });
     it("emits 'select_filter' when a filter is selected", async () => {
+      const wrapper = await mountSavedFilters();
       await wrapper.vm.selectFilter({ filterName: "Test Filter" });
-      expect(wrapper.emitted("select_filter")[0]).toEqual([
+      expect(wrapper.emitted("select_filter")![0]).toEqual([
         { filterName: "Test Filter" },
       ]);
     });
-    it("handles delete filter action", async () => {
+    it("triggers delete filter action when delete button is clicked", async () => {
+      const wrapper = await mountSavedFilters();
       const dropdownToggle = wrapper.find('[data-test-id="toggle-button"]');
       await dropdownToggle.trigger("click");
       await wrapper.vm.$nextTick();
@@ -111,26 +387,23 @@ describe("SavedFilters", () => {
       expect(deleteButton.exists()).toBe(true);
     });
     it("calls deleteFilter when the delete filter button is clicked", async () => {
+      const wrapper = await mountSavedFilters();
       await wrapper.vm.$nextTick();
       const dropdownToggle = wrapper.find('[data-test-id="toggle-button"]');
       await dropdownToggle.trigger("click");
       await wrapper.vm.$nextTick();
-      // Simulate user clicking the delete button
       const deleteButton = wrapper.find('[data-test-id="delete-filter-btn"]');
-      if (deleteButton.exists()) {
-        await deleteButton.trigger("click");
-        // Wait for the delete action to be processed
-        await wrapper.vm.$nextTick();
-      } else {
-        throw new Error("Delete button not found in the DOM");
-      }
+
+      await deleteButton.trigger("click");
+      await wrapper.vm.$nextTick();
     });
     it("should handle dropdown interactions and delete filter", async () => {
+      const wrapper = await mountSavedFilters();
       const deleteFilterSpy = jest.spyOn(wrapper.vm, "deleteFilter");
       const deleteButton = wrapper.find('[data-test-id="delete-filter-btn"]');
       if (deleteButton.exists()) {
         await deleteButton.trigger("click");
-        // Check if the delete-filter event was emitted by the mockDropdown component
+
         const dropdownComponent = wrapper.findComponent(mockDropdown);
         expect(
           dropdownComponent.emitted().hasOwnProperty("delete-filter")
@@ -142,11 +415,13 @@ describe("SavedFilters", () => {
   });
   describe("Rendering of UI Components", () => {
     it("checks for the presence of dropdown when filters exist", async () => {
+      const wrapper = await mountSavedFilters();
       await wrapper.setData({ filters: [{ filterName: "Test Filter" }] });
       await wrapper.vm.$nextTick();
       expect(wrapper.find('[data-test-id="dropdown"]').exists()).toBe(true);
     });
     it("displays no filters message when no filters are available", async () => {
+      const wrapper = await mountSavedFilters();
       wrapper.setData({ filters: [] });
       await wrapper.vm.$nextTick();
       expect(
@@ -154,16 +429,14 @@ describe("SavedFilters", () => {
       ).toContain("No filters available");
     });
     it("renders checkmark span when query and filterName matches a filter", async () => {
-      // Set the filters prop using the setProps method
+      const wrapper = await mountSavedFilters();
       await wrapper.setData({ filters: [{ filterName: "Filter 1" }] });
-      // Wait for the next tick to ensure the component is fully rendered
       await wrapper.vm.$nextTick();
-      // Find the toggle button and trigger a click event
       const toggleButton = wrapper.find('[data-test-id="toggle-button"]');
-      if (toggleButton.exists()) {
-        await toggleButton.trigger("click");
-        await wrapper.vm.$nextTick();
-      }
+
+      await toggleButton.trigger("click");
+      await wrapper.vm.$nextTick();
+
       const checkmarkSpan = wrapper.find('[data-test-id="checkmark-span"]');
       expect(checkmarkSpan.exists()).toBe(true);
       expect(checkmarkSpan.text()).toContain("√");
@@ -171,6 +444,7 @@ describe("SavedFilters", () => {
   });
   describe("Success and Error Handling", () => {
     it("displays notification upon successful filter save", async () => {
+      const wrapper = await mountSavedFilters();
       const saveFilterMock = jest.fn().mockImplementation(() => {
         Notification.notify({ type: "success" });
       });
@@ -183,30 +457,16 @@ describe("SavedFilters", () => {
       notifySpy.mockRestore();
     });
     it("displays error when filter saving fails", async () => {
-      wrapper.vm.saveFilter = async function (filterName) {
-        try {
-          // original saveFilter logic...
-          throw new Error("Save failed"); // This line simulates a failure
-        } catch (error) {
-          Notification.notify({
-            type: "danger",
-            message: error.message,
-            placement: "top-right",
-          });
-          throw error;
-        }
+      const wrapper = await mountSavedFilters();
+      wrapper.vm.doSaveFilter = async function () {
+        throw new Error("Save failed"); // This line simulates a failure
       };
-      const notifySpy = jest.spyOn(Notification, "notify");
+      const notifySpy = jest.spyOn(wrapper.vm, "notifyError");
       try {
-        await wrapper.vm.saveFilter("New Filter");
+        await wrapper.vm.doSaveFilter("New Filter");
       } catch (error) {
-        expect(notifySpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            type: "danger",
-            message: "Save failed",
-            placement: "top-right",
-          })
-        );
+        wrapper.vm.notifyError(error.message);
+        expect(notifySpy).toHaveBeenCalledWith("Save failed");
       } finally {
         notifySpy.mockRestore();
       }
@@ -214,6 +474,7 @@ describe("SavedFilters", () => {
   });
   describe("loadFilters Method", () => {
     it("correctly sets filters when loadFilters is called", async () => {
+      const wrapper = await mountSavedFilters();
       wrapper.vm.filters = [];
       await wrapper.vm.loadFilters();
       expect(wrapper.vm.filters).toEqual([
@@ -225,6 +486,7 @@ describe("SavedFilters", () => {
   });
   describe("saveFilterPrompt Method", () => {
     it("triggers MessageBox.prompt and calls doSaveFilter on confirm", async () => {
+      const wrapper = await mountSavedFilters();
       const doSaveFilterSpy = jest.spyOn(wrapper.vm, "doSaveFilter");
       await wrapper.vm.saveFilterPrompt();
       expect(MessageBox.prompt).toHaveBeenCalled();
@@ -234,7 +496,8 @@ describe("SavedFilters", () => {
     });
   });
   describe("notifyError Method", () => {
-    it("displays a notification with the correct message", () => {
+    it("displays a notification with the correct message", async () => {
+      const wrapper = await mountSavedFilters();
       const notifySpy = jest.spyOn(Notification, "notify");
       wrapper.vm.notifyError("Test error message");
       expect(notifySpy).toHaveBeenCalledWith({
@@ -244,15 +507,6 @@ describe("SavedFilters", () => {
         duration: 0,
       });
       notifySpy.mockRestore();
-    });
-  });
-  describe("Different States", () => {
-    it("shows 'no filters available' message when no filters are loaded", async () => {
-      wrapper.setData({ filters: [] });
-      await wrapper.vm.$nextTick();
-      expect(
-        wrapper.find('[data-test-id="no-filters-message"]').text()
-      ).toContain("No filters available");
     });
   });
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/savedFilters.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/savedFilters.spec.ts
@@ -1,0 +1,162 @@
+import { mount } from "@vue/test-utils";
+import SavedFilters from "../savedFilters.vue";
+import { Notification, MessageBox } from "uiv";
+
+jest.mock("@/library/rundeckService", () => ({
+  getRundeckContext: jest.fn().mockReturnValue({ projectName: "test" }),
+}));
+jest.mock("../../../../library/stores/ActivityFilterStore", () => ({
+  ActivityFilterStore: jest.fn().mockImplementation(() => ({
+    loadForProject: jest.fn().mockReturnValue({
+      filters: [
+        { filterName: "Filter 1" },
+        { filterName: "Filter 2" },
+        { filterName: "Filter 3" },
+      ],
+    }),
+    saveFilter: jest.fn().mockResolvedValue({ success: true }),
+    removeFilter: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+jest.mock("uiv", () => ({
+  MessageBox: {
+    confirm: jest.fn(),
+    prompt: jest.fn().mockResolvedValue({ value: "test" }),
+  },
+  Notification: {
+    notify: jest.fn(),
+  },
+}));
+describe("SavedFilters", () => {
+  let wrapper;
+  const eventBus = {
+    on: jest.fn(),
+    emit: jest.fn(),
+    off: jest.fn(),
+  };
+  beforeEach(async () => {
+    wrapper = mount(SavedFilters, {
+      props: {
+        hasQuery: true,
+        query: {},
+        eventBus,
+      },
+      global: {
+        mocks: {
+          $t: (msg) => msg,
+        },
+        stubs: {
+          btn: true,
+        },
+      },
+    });
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  describe("Component Mounting", () => {
+    it("mounts properly with all props", () => {
+      expect(wrapper.exists()).toBe(true);
+    });
+    it("registers event listeners on mount", () => {
+      expect(eventBus.on).toHaveBeenCalledWith(
+        "invoke-save-filter",
+        expect.any(Function),
+      );
+    });
+    it("unregisters event listeners on unmount", () => {
+      // Create a mock event bus
+      const mockEventBus = {
+        on: jest.fn(),
+        off: jest.fn(),
+      };
+
+      // Mount the component
+      const wrapper = mount(SavedFilters, {
+        props: {
+          hasQuery: true,
+          query: {},
+          eventBus: mockEventBus,
+        },
+        global: {
+          mocks: {
+            $t: (msg) => msg,
+          },
+          stubs: {
+            btn: true,
+          },
+        },
+      });
+
+      const spy = jest.spyOn(mockEventBus, "off");
+
+      wrapper.unmount();
+
+      expect(spy).toHaveBeenCalledWith("invoke-save-filter");
+    });
+  });
+  describe("User Interactions", () => {
+    it("renders save button when hasQuery is true and query is empty", () => {
+      expect(wrapper.find('[data-test-id="save-filter-button"]').exists()).toBe(
+        true,
+      );
+    });
+    it("does not render delete filter button when query has no filterName", () => {
+      expect(wrapper.find('[data-test-id="delete-filter-btn"]').exists()).toBe(
+        false,
+      );
+    });
+    it("emits 'select_filter' when a filter is selected", async () => {
+      await wrapper.vm.selectFilter({ filterName: "Test Filter" });
+      expect(wrapper.emitted("select_filter")[0]).toEqual([
+        { filterName: "Test Filter" },
+      ]);
+    });
+    it("calls MessageBox.prompt when saveFilterPrompt is triggered", async () => {
+      await wrapper.vm.saveFilterPrompt();
+      expect(MessageBox.prompt).toHaveBeenCalled();
+    });
+  });
+  describe("Filter Management", () => {
+    it("updates filters after successful deletion", async () => {
+      await wrapper.vm.loadFilters();
+      await wrapper.vm.$nextTick();
+      const initialCount = wrapper.vm.filters.length;
+      if (initialCount > 0) {
+        console.log("Before delete:", wrapper.vm.filters);
+        // Mock the deleteFilter method
+        wrapper.vm.deleteFilter = (filterName) => {
+          const index = wrapper.vm.filters.findIndex(
+            (filter) => filter.filterName === filterName,
+          );
+          if (index !== -1) {
+            wrapper.vm.filters.splice(index, 1);
+          }
+        };
+        await wrapper.vm.deleteFilter(wrapper.vm.filters[0].filterName);
+        await wrapper.vm.$nextTick();
+        console.log("After delete:", wrapper.vm.filters);
+
+        expect(wrapper.vm.filters.length).toBeLessThan(initialCount);
+      } else {
+        throw new Error("No filters available to delete");
+      }
+    });
+
+    it("shows 'No filters available' when filters array is empty", async () => {
+      wrapper.vm.filters = [];
+      await wrapper.vm.$nextTick();
+
+      const noFiltersMessage = wrapper
+        .find('[data-test-id="no-filters-message"]')
+        .text();
+      expect(noFiltersMessage).toContain("No filters available");
+    });
+    it("updates visible elements when 'query.filterName' changes", async () => {
+      await wrapper.setProps({ query: { filterName: "Updated Filter" } });
+      expect(wrapper.find('[data-test-id="filter-name"]').text()).toBe(
+        "Updated Filter",
+      );
+    });
+  });
+});


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
This is an enhancement. The tests are added to improve the test coverage for the SavedFilters component, ensuring that various scenarios and functionalities are correctly handled

**Describe the solution you've implemented**
 I have implemented a comprehensive suite of unit tests for the SavedFilters component using Jest and Vue Test Utils. These tests cover various aspects of the component, including its initialization, interaction with filters, UI rendering, success and error handling, and behavior in different states. Mocks are used to isolate the component and simulate dependencies, user interactions, and different scenarios.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
