### PR TITLE
RSE-961 Login counting multiple times in user classes

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
@@ -220,7 +220,7 @@ class GormUserDataProvider implements UserDataProvider, SystemConfigurable{
 
     @Override
     boolean validateUserExists(String username) {
-        return User.countByLogin(username) > 0
+        return isLoginNameCaseInsensitiveEnabled() ? User.countByLoginIlike(username) > 0 : User.countByLogin(username) > 0
     }
 
     @Override

--- a/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
@@ -289,16 +289,19 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
     @Unroll
     def "Should validate user exists"() {
         given:
-        User savedUser = new User(login: "saved")
+        User savedUser = new User(login: login)
         savedUser.save()
+        provider.featureService = Mock(FeatureService){
+            1 * featurePresent(Features.CASE_INSENSITIVE_USERNAME) >> caseSensitive
+        }
         when:
-        Boolean userExists = provider.validateUserExists(login)
+        Boolean userExists = provider.validateUserExists(login.toUpperCase())
         then:
         userExists == expect
         where:
-        login   | expect
-        "login" | false
-        "saved" | true
+        login   | expect   | caseSensitive
+        "user1" | false    | false
+        "user2" | true     | true
     }
 
     def "Should list all by order by login"() {

--- a/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
@@ -294,14 +294,14 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
             savedUser.save()
         }
         provider.featureService = Mock(FeatureService){
-            1 * featurePresent(Features.CASE_INSENSITIVE_USERNAME) >> caseSensitive
+            1 * featurePresent(Features.CASE_INSENSITIVE_USERNAME) >> caseInsensitive
         }
         when:
         Boolean userExists = provider.validateUserExists(login.toUpperCase())
         then:
         userExists == expect
         where:
-        login   | expect   | caseSensitive | persitUser
+        login   | expect   | caseInsensitive | persitUser
         "user1" | false    | false         |    true
         "user2" | true     | true          |    true
         "user3" | false    | true          |    false

--- a/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
@@ -290,7 +290,9 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
     def "Should validate user exists"() {
         given:
         User savedUser = new User(login: login)
-        savedUser.save()
+        if(persitUser){
+            savedUser.save()
+        }
         provider.featureService = Mock(FeatureService){
             1 * featurePresent(Features.CASE_INSENSITIVE_USERNAME) >> caseSensitive
         }
@@ -299,9 +301,12 @@ class GormUserDataProviderSpec extends RundeckHibernateSpec implements DataTest 
         then:
         userExists == expect
         where:
-        login   | expect   | caseSensitive
-        "user1" | false    | false
-        "user2" | true     | true
+        login   | expect   | caseSensitive | persitUser
+        "user1" | false    | false         |    true
+        "user2" | true     | true          |    true
+        "user3" | false    | true          |    false
+        "user4" | false    | false         |    false
+
     }
 
     def "Should list all by order by login"() {


### PR DESCRIPTION
Related to:
https://pagerduty.atlassian.net/browse/RSE-864

Problem:
After solving the issue where users were duplicated when authenticating with LDAP, an error was thrown on user/profile page when authenticating with AD.

Solution:
Evaluate case sensitiveness on the validateUserExists method, this change avoid an error 500 that was generated on the user/profile page. It was only generated when authenticating from AD 

Extra info on :
https://pagerduty.atlassian.net/browse/RSE-961
