### PR TITLE
RCLOUD-1221: Remove Execution usages of GormExecReportDataProvider

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api project(":rundeck-authz:rundeck-authz-api")
     api project(":rundeck-authz:rundeck-authz-core")
     api project(":rundeck-authz:rundeck-authz-yaml")
-    api "org.rundeck:rundeck-data-models:1.0.5"
+    api "org.rundeck:rundeck-data-models:1.0.6"
 
     api ('com.google.guava:guava:32.0.1-jre') {
         exclude group:'org.codehaus.mojo', module: 'animal-sniffer-annotations'

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/execution/RdExecution.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/execution/RdExecution.groovy
@@ -77,4 +77,5 @@ class RdExecution implements ExecutionData, Validateable {
     boolean statusSucceeded(){
         return getExecutionState()== ExecutionConstants.EXECUTION_SUCCEEDED
     }
+
 }

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/report/SaveReportRequestImpl.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/report/SaveReportRequestImpl.groovy
@@ -7,28 +7,30 @@ import java.lang.reflect.Field;
 
 @Slf4j
 class SaveReportRequestImpl implements SaveReportRequest {
-    Long executionId;
-    Date dateStarted;
-    String jobId;
-    String reportId;
-    Boolean adhocExecution;
-    String succeededNodeList;
-    String failedNodeList;
-    String filterApplied;
-    String project;
-    String abortedByUser;
-    String author;
-    String title;
-    String status;
-    String node;
-    String message;
-    Date dateCompleted;
-    String adhocScript;
-    String tags;
+    Long executionId
+    Date dateStarted
+    String jobId
+    String reportId
+    Boolean adhocExecution
+    String succeededNodeList
+    String failedNodeList
+    String filterApplied
+    String project
+    String abortedByUser
+    String author
+    String title
+    String status
+    String node
+    String message
+    Date dateCompleted
+    String adhocScript
+    String tags
+    String jobUuid
+    String executionUuid
 
     static void buildFromMap(SaveReportRequestImpl obj, Map<String, Object> data) {
         for (String key : data.keySet()) {
-            Field field;
+            Field field
             try {
                 if(key == "ctxProject") {
                     obj.project = (String)data.get("ctxProject");
@@ -41,17 +43,17 @@ class SaveReportRequestImpl implements SaveReportRequest {
                     if(field != null){
                         if(key == "dateStarted" | key == "dateCompleted"){
                             if (!(data.get("dateCompleted") instanceof Date)) {
-                                obj.dateCompleted = new Date();
+                                obj.dateCompleted = new Date()
                             } else {
-                                obj.dateCompleted = (Date)data.get("dateCompleted");
+                                obj.dateCompleted = (Date)data.get("dateCompleted")
                             }
                             if (data.get("dateStarted") instanceof Date) {
-                                obj.dateStarted = (Date)data.get("dateStarted");
+                                obj.dateStarted = (Date)data.get("dateStarted")
                             }
                         }else if(key == "executionId"){
-                            obj.executionId = new Long((Integer)data.get(key));
+                            obj.executionId = new Long((Integer)data.get(key))
                         }else if(key == "adhocExecution"){
-                            obj.adhocExecution = Boolean.parseBoolean(String.valueOf(data.get(key)));
+                            obj.adhocExecution = Boolean.parseBoolean(String.valueOf(data.get(key)))
                         }else{
                             obj[key] = data.get(key)
                         }
@@ -60,18 +62,19 @@ class SaveReportRequestImpl implements SaveReportRequest {
 
             } catch (NoSuchFieldException nsfe) {
                 if(!DEPRECATED_FIELD_NAMES.contains(key)) {
-                    log.info("Report builder found unknown field: " + key);
+                    log.info("Report builder found unknown field: " + key)
                 }
             } catch (IllegalAccessException iex) {
-                log.warn("Unable to set field: "+key+" illegal access");
+                log.warn("Unable to set field: "+key+" illegal access")
             }
         }
     }
     static SaveReportRequestImpl fromMap(Map data) {
-        SaveReportRequestImpl SaveReportRequest = new SaveReportRequestImpl();
-        buildFromMap(SaveReportRequest, data);
-        return SaveReportRequest;
+        SaveReportRequestImpl SaveReportRequest = new SaveReportRequestImpl()
+        buildFromMap(SaveReportRequest, data)
+        return SaveReportRequest
     }
 
-    public static final List<String> DEPRECATED_FIELD_NAMES = Arrays.asList("ctxProject","jcJobId","jcExecId","actionType","ctxType","ctxName","ctxCommand","ctxController","maprefUri");
+    public static final List<String> DEPRECATED_FIELD_NAMES = Arrays.asList("ctxProject","jcJobId","jcExecId","actionType","ctxType","ctxName","ctxCommand","ctxController","maprefUri")
+
 }

--- a/rundeckapp/grails-app/domain/rundeck/ExecReport.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ExecReport.groovy
@@ -35,6 +35,7 @@ class ExecReport extends BaseReport implements RdExecReport{
     String failedNodeList
     String filterApplied
     String jobUuid
+    String executionUuid
 
     static mapping = {
         adhocScript type: 'text'
@@ -61,6 +62,7 @@ class ExecReport extends BaseReport implements RdExecReport{
         failedNodeList(nullable:true,blank:true)
         filterApplied(nullable:true,blank:true)
         jobUuid(nullable:true)
+        executionUuid(nullable:true)
 
     }
 
@@ -73,7 +75,8 @@ class ExecReport extends BaseReport implements RdExecReport{
             'succeededNodeList',
             'failedNodeList',
             'filterApplied',
-            'jobUuid'
+            'jobUuid',
+            'executionUuid'
     ]
     def Map toMap(){
         def map = this.properties.subMap(exportProps)
@@ -135,7 +138,8 @@ class ExecReport extends BaseReport implements RdExecReport{
                 failedNodeList: failedList,
                 succeededNodeList: succeededList,
                 filterApplied: exec.filter,
-                jobUuid: exec.scheduledExecution?.uuid
+                jobUuid: exec.scheduledExecution?.uuid,
+                executionUuid: exec.uuid
         ])
     }
     static ExecReport fromMap(Map map) {

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -27,8 +27,10 @@ import com.fasterxml.jackson.core.JsonParseException
 import grails.gorm.DetachedCriteria
 import org.rundeck.app.data.model.v1.execution.ExecutionData
 import org.rundeck.app.data.model.v1.execution.ExecutionDataSummary
+import org.rundeck.app.data.model.v1.report.dto.SaveReportRequest
 import rundeck.data.execution.RdExecutionDataSummary
 import rundeck.data.job.RdNodeConfig
+import rundeck.data.report.SaveReportRequestImpl
 import rundeck.data.validation.shared.SharedExecutionConstraints
 import rundeck.data.validation.shared.SharedNodeConfigConstraints
 import rundeck.data.validation.shared.SharedProjectNameConstraints
@@ -565,5 +567,51 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
                 serverNodeUUID: this.serverNodeUUID
         )
     }
+
+    SaveReportRequest toSaveReportRequest() {
+        def failedCount = failedNodeList ? failedNodeList.split(',').size() : 0
+        def successCount = succeededNodeList ? succeededNodeList.split(',').size() : 0;
+        def failedList = failedNodeList ? failedNodeList : ''
+        def succeededList = succeededNodeList ? succeededNodeList : '';
+        def totalCount = failedCount + successCount;
+        def adhocScript = null
+        if (
+                null == scheduledExecution
+                        && workflow.commands
+                        && workflow.commands.size() == 1
+                        && workflow.commands[0] instanceof CommandExec
+        ) {
+            adhocScript = workflow.commands[0].adhocRemoteString
+        }
+        def summary = "[${workflow.commands ? workflow.commands.size() : 0} steps]"
+        def issuccess = statusSucceeded()
+        def iscancelled = cancelled
+        def istimedout = timedOut
+        def ismissed = status == "missed"
+        def status = issuccess ? "succeed" : iscancelled ? "cancel" : willRetry ? "retry" : istimedout ?
+                "timedout" : ismissed ? "missed" : "fail"
+        return new SaveReportRequestImpl(
+                executionId: id,
+                jobId: scheduledExecution?.id,
+                adhocExecution: null == scheduledExecution,
+                adhocScript: adhocScript,
+                abortedByUser: iscancelled ? abortedby ?: user : null,
+                node: "${successCount}/${failedCount}/${totalCount}",
+                title: adhocScript ? adhocScript : summary,
+                status: status,
+                project: project,
+                reportId: scheduledExecution ? (scheduledExecution.groupPath ? scheduledExecution.generateFullName() : scheduledExecution.jobName) : 'adhoc',
+                author: user,
+                message: (issuccess ? 'Job completed successfully' : iscancelled ? ('Job killed by: ' + (abortedby ?: user)) : ismissed ? "Job missed execution at: ${dateStarted}" : 'Job failed'),
+                dateStarted: dateStarted,
+                dateCompleted: dateCompleted,
+                failedNodeList: failedList,
+                succeededNodeList: succeededList,
+                filterApplied: filter,
+                jobUuid: scheduledExecution?.uuid,
+                executionUuid: uuid)
+    }
+
+
 }
 

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
@@ -91,7 +91,7 @@ class ExecutionsCleanUp implements InterruptableJob {
             referencedExecutionDataProvider.deleteByExecutionId(e.id)
 
             //delete all reports
-            reportService.deleteByExecutionId(e.id)
+            reportService.deleteByExecutionUuid(e.uuid)
             def executionFiles = logFileStorageService.getExecutionFiles(e, [], false)
 
             List<File> files = []

--- a/rundeckapp/grails-app/migrations/core/BaseReportSpi.groovy
+++ b/rundeckapp/grails-app/migrations/core/BaseReportSpi.groovy
@@ -25,4 +25,32 @@ databaseChangeLog = {
                 "                  inner join execution ON execution.scheduled_execution_id = scheduled_execution.id\n" +
                 "         WHERE base_report.execution_id = execution.id)")
     }
+
+    changeSet(author: "rundeckdev", id: "add-execution-uuid-to-base-report") {
+        preConditions(onFail: "MARK_RAN") {
+            not {
+                columnExists(tableName: "base_report", columnName: 'execution_uuid')
+            }
+        }
+        addColumn(tableName: "base_report") {
+            column(name: 'execution_uuid', type: '${varchar255.type}')
+        }
+        createIndex(indexName: "base_report_execution_uuid_idx", tableName: "base_report") {
+            column(name: "execution_uuid")
+        }
+
+    }
+
+    changeSet(author: "rundeckdev", id: "populate-base-report-execution-uuid") {
+        preConditions(onFail: "MARK_RAN") {
+            tableExists(tableName: "base_report")
+            tableExists(tableName: "execution")
+        }
+        sql("update base_report\n" +
+                "set execution_uuid =\n" +
+                "        (select execution.uuid\n" +
+                "         from execution\n" +
+                "         WHERE base_report.execution_id = execution.id)")
+    }
+
 }

--- a/rundeckapp/src/integration-test/groovy/ReportServiceTests.groovy
+++ b/rundeckapp/src/integration-test/groovy/ReportServiceTests.groovy
@@ -47,15 +47,15 @@ class ReportServiceTests extends GroovyTestCase {
     void testGetExecReportsReportIdFilter(){
         def r1, r2, r3
 
-        r1 = proto(reportId: 'blah', executionId: '123')
+        r1 = proto(reportId: 'blah', executionId: '123', executionUuid: 'uuid1')
         assert r1.validate()
         assert null != r1.save(flush: true)
         assert 'blah' == r1.reportId
         assertNotNull(r1.id)
-        r2 = proto(reportId: 'blah2', executionId: '124')
+        r2 = proto(reportId: 'blah2', executionId: '124', executionUuid: 'uuid2')
         assert r2.validate()
         assert null != r2.save(flush: true)
-        r3 = proto(reportId: 'blah3', executionId: '125')
+        r3 = proto(reportId: 'blah3', executionId: '125', executionUuid: 'uuid3')
         assert r3.validate()
         println r3.save(flush: true)
 
@@ -79,18 +79,18 @@ class ReportServiceTests extends GroovyTestCase {
     void testGetExecNodeFilterReportIdFilter(){
         def r1,r2,r3, r4
 
-            r1=proto(reportId:'blah', executionId: '123', succeededNodeList:'test')
+            r1=proto(reportId:'blah', executionId: '123', succeededNodeList:'test', executionUuid: 'uuid1')
             assert r1.validate()
             assert null!=r1.save(flush: true)
             assert 'blah'==r1.reportId
             assertNotNull(r1.id)
-            r2 = proto(reportId: 'blah2', executionId: '124', failedNodeList:'test')
+            r2 = proto(reportId: 'blah2', executionId: '124', failedNodeList:'test', executionUuid: 'uuid2')
             assert r2.validate()
             assert null != r2.save(flush: true)
-            r3 = proto(reportId: 'blah3', executionId: '125', filterApplied:'tags: monkey')
+            r3 = proto(reportId: 'blah3', executionId: '125', filterApplied:'tags: monkey', executionUuid: 'uuid3')
             assert r3.validate()
             println r3.save(flush: true)
-            r4 = proto(reportId: 'blah4', executionId: '126', filterApplied:'.*',succeededNodeList:'test')
+            r4 = proto(reportId: 'blah4', executionId: '126', filterApplied:'.*',succeededNodeList:'test', executionUuid: 'uuid4')
             assert r4.validate()
             println r4.save(flush: true)
 
@@ -121,15 +121,15 @@ class ReportServiceTests extends GroovyTestCase {
     void testGetExecReportsProjFilterIsExact(){
         def r1,r2,r3
 
-        r1=proto(reportId:'blah', executionId: '123', project:'abc')
+        r1=proto(reportId:'blah', executionId: '123', project:'abc', executionUuid: 'uuid1')
         assert r1.validate()
         assert null!=r1.save(flush: true)
         assert 'blah'==r1.reportId
         assertNotNull(r1.id)
-        r2 = proto(reportId: 'blah2', executionId: '124', project: 'abc')
+        r2 = proto(reportId: 'blah2', executionId: '124', project: 'abc', executionUuid: 'uuid2')
         assert r2.validate()
         assert null != r2.save(flush: true)
-        r3 = proto(reportId: 'blah3', executionId: '125', project: 'abcdef')
+        r3 = proto(reportId: 'blah3', executionId: '125', project: 'abcdef', executionUuid: 'uuid3')
         assert r3.validate()
         println r3.save(flush: true)
 
@@ -152,13 +152,13 @@ class ReportServiceTests extends GroovyTestCase {
     }
     @Test
     void testGetExecReportsJobListFilter(){
-        def r1 = proto(reportId: 'group/name', executionId: '1')
+        def r1 = proto(reportId: 'group/name', executionId: '1', executionUuid: 'uuid1')
         assert null != r1.save(flush: true)
-        def r2 = proto(reportId: 'group/name2', executionId: '2')
+        def r2 = proto(reportId: 'group/name2', executionId: '2', executionUuid: 'uuid2')
         assert null != r2.save(flush: true)
-        def r3 = proto(reportId: 'group/name3', executionId: '3')
+        def r3 = proto(reportId: 'group/name3', executionId: '3', executionUuid: 'uuid3')
         assert null != r3.save(flush: true)
-        def r4 = proto(reportId: 'group/monkey', executionId: '4')
+        def r4 = proto(reportId: 'group/monkey', executionId: '4', executionUuid: 'uuid4')
         assert null != r4.save(flush: true)
 
         assertQueryResult([jobListFilter: ['group/name']], [r1])
@@ -169,14 +169,14 @@ class ReportServiceTests extends GroovyTestCase {
     }
     @Test
     void testGetExecReportsStatusStringVariations(){
-        def r1 = proto(reportId: 'group/name', executionId: '1', status: 'failed', actionType: 'failed')
+        def r1 = proto(reportId: 'group/name', executionId: '1', status: 'failed', actionType: 'failed', executionUuid: 'uuid1')
         assert null != r1.save(flush: true)
-        def r2 = proto(reportId: 'group/name2', executionId: '2', status: 'fail', actionType: 'fail')
+        def r2 = proto(reportId: 'group/name2', executionId: '2', status: 'fail', actionType: 'fail', executionUuid: 'uuid2')
         assert null != r2.save(flush: true)
 
-        def r3 = proto(reportId: 'group/name2', executionId: '3', status: 'succeed', actionType: 'succeed')
+        def r3 = proto(reportId: 'group/name2', executionId: '3', status: 'succeed', actionType: 'succeed', executionUuid: 'uuid3')
         assert null != r3.save(flush: true)
-        def r4 = proto(reportId: 'group/name2', executionId: '4', status: 'succeeded', actionType: 'succeeded')
+        def r4 = proto(reportId: 'group/name2', executionId: '4', status: 'succeeded', actionType: 'succeeded', executionUuid: 'uuid4')
         assert null != r4.save(flush: true)
 
         assertQueryResult([statFilter: 'fail'], [r1, r2])
@@ -185,11 +185,11 @@ class ReportServiceTests extends GroovyTestCase {
     }
     @Test
     void testGetCombinedReportsExcludeJobListFilter(){
-        def r1 = proto(reportId: 'group/name', executionId: '1')
+        def r1 = proto(reportId: 'group/name', executionId: '1', executionUuid: 'uuid1')
         assert null != r1.save(flush: true)
-        def r2 = proto(reportId: 'group/name2', executionId: '2')
+        def r2 = proto(reportId: 'group/name2', executionId: '2', executionUuid: 'uuid2')
         assert null != r2.save(flush: true)
-        def r3 = proto(reportId: 'group/name3', executionId: '3')
+        def r3 = proto(reportId: 'group/name3', executionId: '3', executionUuid: 'uuid3')
         assert null != r3.save(flush: true)
 
         assertQueryResult([excludeJobListFilter: ['group/name']], [r2, r3])
@@ -209,9 +209,9 @@ class ReportServiceTests extends GroovyTestCase {
         assert null != se.save(flush: true)
         assert null != se2.save(flush: true)
 
-        def r1 = proto(reportId: 'group/name', jobId: se.id,project: 'one')
+        def r1 = proto(reportId: 'group/name', jobId: se.id,project: 'one', executionUuid: 'uuid1')
         assert null != r1.save(flush: true)
-        def r2 = proto(reportId: 'group/name2', jobId: se2.id,project: 'one')
+        def r2 = proto(reportId: 'group/name2', jobId: se2.id,project: 'one', executionUuid: 'uuid2')
         assert null != r2.save(flush: true)
         sessionFactory.currentSession.flush()
 
@@ -238,15 +238,15 @@ class ReportServiceTests extends GroovyTestCase {
     void testGetExecReportsFailedStat(){
         def r1,r2,r3
 
-        r1 = proto(reportId: 'blah', executionId: '123', status: 'fail')
+        r1 = proto(reportId: 'blah', executionId: '123', status: 'fail', executionUuid: 'uuid1')
         assert r1.validate()
         assert null != r1.save(flush: true)
         assert 'blah' == r1.reportId
         assertNotNull(r1.id)
-        r2 = proto(reportId: 'blah2', executionId: '124', status: 'fail')
+        r2 = proto(reportId: 'blah2', executionId: '124', status: 'fail', executionUuid: 'uuid2')
         assert r2.validate()
         assert null != r2.save(flush: true)
-        r3 = proto(reportId: 'blah3', executionId: '125', status: 'succes')
+        r3 = proto(reportId: 'blah3', executionId: '125', status: 'succes', executionUuid: 'uuid3')
         assert r3.validate()
         println r3.save(flush: true)
 
@@ -271,15 +271,15 @@ class ReportServiceTests extends GroovyTestCase {
     void testGetExecReportsKilledStat(){
         def r1,r2,r3
 
-        r1=proto(reportId:'blah', executionId: '123', status: 'fail', abortedByUser: 'admin')
+        r1=proto(reportId:'blah', executionId: '123', status: 'fail', abortedByUser: 'admin', executionUuid: 'uuid1')
         assert r1.validate()
         assert null!=r1.save(flush: true)
         assert 'blah'==r1.reportId
         assertNotNull(r1.id)
-        r2 = proto(reportId: 'blah2', executionId: '124',status: 'fail')
+        r2 = proto(reportId: 'blah2', executionId: '124',status: 'fail', executionUuid: 'uuid2')
         assert r2.validate()
         assert null != r2.save(flush: true)
-        r3 = proto(reportId: 'blah3', executionId: '125',status: 'succes')
+        r3 = proto(reportId: 'blah3', executionId: '125',status: 'succes', executionUuid: 'uuid3')
         assert r3.validate()
         println r3.save(flush: true)
 

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormExecReportDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormExecReportDataProvider.groovy
@@ -8,21 +8,18 @@ import org.rundeck.app.data.model.v1.query.RdExecQuery
 import org.rundeck.app.data.model.v1.report.RdExecReport
 import org.rundeck.app.data.model.v1.report.dto.SaveReportRequest
 import org.rundeck.app.data.model.v1.report.dto.SaveReportResponse
-import rundeck.data.report.SaveReportResponseImpl;
+import rundeck.data.report.SaveReportResponseImpl
 import org.rundeck.app.data.providers.v1.report.ExecReportDataProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.MessageSource
 import org.springframework.transaction.TransactionStatus
-import rundeck.BaseReport;
+import rundeck.BaseReport
 import rundeck.ExecReport
-import rundeck.Execution
 import rundeck.ReferencedExecution
 import rundeck.ScheduledExecution
 import rundeck.services.ConfigurationService
-
-import javax.persistence.EntityNotFoundException
-import javax.sql.DataSource;
+import javax.sql.DataSource
 
 @CompileStatic(TypeCheckingMode.SKIP)
 class GormExecReportDataProvider implements ExecReportDataProvider {
@@ -39,30 +36,8 @@ class GormExecReportDataProvider implements ExecReportDataProvider {
     }
 
     @Override
-    SaveReportResponse createReportFromExecution(Long id) {
-        Execution execution = Execution.get(id)
-        if(!execution) throw new EntityNotFoundException("Execution not found with id: ${id}")
-        createReportFromExecution(execution)
-    }
-
-    @Override
-    SaveReportResponse createReportFromExecution(String uuid) {
-        Execution execution = Execution.findByUuid(uuid)
-        if(!execution) throw new EntityNotFoundException("Execution not found with uuid: ${uuid}")
-        createReportFromExecution(execution)
-    }
-
-    SaveReportResponse createReportFromExecution(Execution execution) {
-        ExecReport execReport = ExecReport.fromExec(execution)
-        boolean isUpdated = execReport.save(flush: true)
-        String errors = execReport.errors.hasErrors() ? execReport.errors.allErrors.collect { messageSource.getMessage(it,null) }.join(",")  : null
-        return new SaveReportResponseImpl(report: execReport, isSaved: isUpdated, errors: errors)
-    }
-
-    @Override
     SaveReportResponse saveReport(SaveReportRequest saveReportRequest) {
         ExecReport execReport = new ExecReport()
-        Execution execution = Execution.get(saveReportRequest.executionId)
         execReport.executionId = saveReportRequest.executionId
         execReport.jobId = saveReportRequest.jobId
         execReport.adhocExecution = saveReportRequest.adhocExecution
@@ -82,15 +57,17 @@ class GormExecReportDataProvider implements ExecReportDataProvider {
         execReport.message = saveReportRequest.message
         execReport.dateStarted = saveReportRequest.dateStarted
         execReport.dateCompleted = saveReportRequest.dateCompleted
-        execReport.jobUuid = execution.scheduledExecution?.uuid
+        execReport.jobUuid = saveReportRequest.jobUuid
+        execReport.executionUuid = saveReportRequest.executionUuid
         boolean isUpdated = execReport.save(flush: true)
-        String errors = execReport.errors.hasErrors() ? execReport.errors.allErrors.collect { messageSource.getMessage(it,null) }.join(",") : null
+        String errors = execReport.errors.hasErrors() ? execReport.errors.allErrors.collect {
+            messageSource.getMessage(it,null) }.join(",") : null
         return new SaveReportResponseImpl(report: execReport, isSaved: isUpdated, errors: errors)
     }
 
     @Override
     List<RdExecReport> findAllByProject(String projectName) {
-        return BaseReport.findAllByProject(projectName)
+        return ExecReport.findAllByProject(projectName)
     }
 
     @Override
@@ -98,12 +75,8 @@ class GormExecReportDataProvider implements ExecReportDataProvider {
         return ExecReport.findAllByStatus(status)
     }
     @Override
-    List<RdExecReport> findAllByExecutionId(Long id) {
-        return ExecReport.findAllByExecutionId(id)
-    }
-    @Override
-    List<RdExecReport> findAllByProjectAndExecutionIdInList(String projectName, List<Long> execIds) {
-        return ExecReport.findAllByProjectAndExecutionIdInList(projectName, execIds)
+    List<RdExecReport> findAllByProjectAndExecutionUuidInList(String projectName, List<String> execUuids) {
+        return ExecReport.findAllByProjectAndExecutionUuidInList(projectName, execUuids)
     }
 
     @Override
@@ -119,10 +92,10 @@ class GormExecReportDataProvider implements ExecReportDataProvider {
     }
 
     @Override
-    int countExecutionReportsWithTransaction(RdExecQuery query, boolean isJobs, Long jobId) {
+    int countExecutionReportsWithTransaction(RdExecQuery query, boolean isJobs, String jobId) {
         return ExecReport.withTransaction {
             ExecReport.createCriteria().count {
-                applyExecutionCriteria(query, delegate, isJobs, jobId)
+                applyExecutionCriteria(query, delegate, isJobs, jobId, [])
             }
         }
     }
@@ -147,7 +120,7 @@ class GormExecReportDataProvider implements ExecReportDataProvider {
     }
 
     @Override
-    List<RdExecReport> getExecutionReports(RdExecQuery query, boolean isJobs, Long jobId) {
+    List<RdExecReport> getExecutionReports(RdExecQuery query, boolean isJobs, String jobId, List<String> execUuids) {
         def eqfilters = [
                 stat: 'status',
                 reportId: 'reportId',
@@ -166,7 +139,7 @@ class GormExecReportDataProvider implements ExecReportDataProvider {
         filters.putAll(txtfilters)
         filters.putAll(eqfilters)
 
-         return ExecReport.createCriteria().list {
+        return ExecReport.createCriteria().list {
 
             if (query?.max) {
                 maxResults(query?.max.toInteger())
@@ -176,7 +149,7 @@ class GormExecReportDataProvider implements ExecReportDataProvider {
             if (query?.offset) {
                 firstResult(query.offset.toInteger())
             }
-            applyExecutionCriteria(query, delegate,isJobs, jobId)
+            applyExecutionCriteria(query, delegate,isJobs, jobId, execUuids)
 
             if (query && query.sortBy && filters[query.sortBy]) {
                 order(filters[query.sortBy], query.sortOrder == 'ascending' ? 'asc' : 'desc')
@@ -205,13 +178,13 @@ class GormExecReportDataProvider implements ExecReportDataProvider {
     }
 
     @Override
-    void deleteAllByExecutionId(Long executionId) {
-        ExecReport.findAllByExecutionId(executionId).each { rpt ->
+    void deleteAllByExecutionUuid(String executionUuid) {
+        ExecReport.findAllByExecutionUuid(executionUuid).each { rpt ->
             rpt.delete()
         }
     }
 
-    def applyExecutionCriteria(RdExecQuery query, delegate, boolean isJobs=true, Long seId=null){
+    def applyExecutionCriteria(RdExecQuery query, delegate, boolean isJobs=true, String seId=null, List<String> execUuids=[]){
         def eqfilters = [
                 stat: 'status',
                 reportId: 'reportId',
@@ -277,20 +250,21 @@ class GormExecReportDataProvider implements ExecReportDataProvider {
                 }
 
                 if (query.execProjects && seId) {
-                    String jobUuid = ScheduledExecution.get(seId).uuid
                     or {
-                        exists(new DetachedCriteria(ReferencedExecution, "re").build {
-                            projections { property 're.execution.id' }
-                            eq('re.jobUuid', jobUuid)
-                            eqProperty('re.execution.id', 'this.executionId')
-                            List execProjectsPartitioned = Lists.partition(query.execProjects, 1000)
-                            or{
-                                for(def partition : execProjectsPartitioned){
-                                    'in'('this.project', partition)
+                        if(execUuids && execUuids.size() > 0){
+                            and{
+                                'in'('executionUuid', execUuids)
+                                List execProjectsPartitioned = Lists.partition(query.execProjects, 1000)
+                                or{
+                                    for(def partition : execProjectsPartitioned){
+                                        'in'('project', partition)
+                                    }
                                 }
                             }
-                        })
-                        eq('jobId', String.valueOf(seId))
+                        }
+
+
+                        eq('jobUuid', seId)
                         and{
                             jobfilters.each { key, val ->
                                 if (query["${key}Filter"] == 'null') {

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormReferencedExecutionDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormReferencedExecutionDataProvider.groovy
@@ -40,6 +40,11 @@ class GormReferencedExecutionDataProvider implements ReferencedExecutionDataProv
     }
 
     @Override
+    List<String> getExecutionUuidsByJobUuid(String jobUuid) {
+        return ReferencedExecution.findAllByJobUuid(jobUuid).collect{ it.execution.scheduledExecution.uuid }
+    }
+
+    @Override
     void deleteByExecutionId(Long id) {
         def execution = Execution.findById(id)
         ReferencedExecution.findAllByExecution(execution).each{ re ->

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecReportDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecReportDataProviderSpec.groovy
@@ -1,12 +1,14 @@
 package org.rundeck.app.data.providers
 
 import grails.testing.gorm.DataTest
+import org.springframework.context.MessageSource
 import rundeck.CommandExec
 import rundeck.ExecReport
 import rundeck.Execution
 import rundeck.JobExec
 import rundeck.PluginStep
 import rundeck.Workflow
+import rundeck.data.report.SaveReportRequestImpl
 import spock.lang.Specification
 import testhelper.TestDomainFactory
 
@@ -17,15 +19,16 @@ class GormExecReportDataProviderSpec extends Specification implements DataTest {
 
     def setupSpec() {
         mockDomains(Execution, ExecReport, Workflow, CommandExec, PluginStep, JobExec)
+
     }
 
-    def "CreateReportFromExecutionId"() {
+    def "CreateReportFromExecution"() {
         given:
         String uuid = UUID.randomUUID().toString()
         Execution e = TestDomainFactory.createExecution(uuid: uuid, status: 'succeeded', dateCompleted: new Date())
 
         when:
-        def actual = provider.createReportFromExecution(e.id)
+        def actual = provider.saveReport(e.toSaveReportRequest())
         def created = provider.get(actual.report.id)
 
         then:
@@ -34,31 +37,35 @@ class GormExecReportDataProviderSpec extends Specification implements DataTest {
         created
     }
 
-    def "CreateReportFromExecutionUuid"() {
+    def "CreateReportFromWithEmptyRequestShouldReturnError"() {
+        when:
+
+        provider.messageSource = Mock(MessageSource) {
+            getMessage(_,_) >> "Error saving report"
+        }
+
+        def response = provider.saveReport(new SaveReportRequestImpl())
+
+        then:
+        !response.isSaved
+        response.errors != null
+
+    }
+
+    def "ShouldDeleteExecReportsByExecutionUuid"() {
         given:
         String uuid = UUID.randomUUID().toString()
         Execution e = TestDomainFactory.createExecution(uuid: uuid, status: 'succeeded', dateCompleted: new Date())
+        def report = provider.saveReport(e.toSaveReportRequest())
 
         when:
-        def actual = provider.createReportFromExecution(e.uuid)
-        def created = provider.get(actual.report.id)
+        def created = provider.get(report.report.id)
+        provider.deleteAllByExecutionUuid(report.report.executionUuid)
+        def deleted = provider.get(report.report.id)
 
         then:
-        actual.isSaved
-        !actual.errors
         created
-    }
+        deleted == null
 
-    def "CreateReportFromExecutionShouldThrowErrorIfExceptionDoesNotExist"() {
-        when:
-        provider.createReportFromExecution(execId)
-
-        then:
-        thrown(EntityNotFoundException)
-
-        where:
-        execId | _
-        -1011L | 'Execution with id -1011 does not exist'
-        "some-uuid" | 'Execution with uuid some-uuid does not exist'
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
@@ -1333,7 +1333,6 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
                 status: 'true',
                 workflow: new Workflow(commands: [new CommandExec(adhocRemoteString: 'exec command')]),
                 scheduledExecution: se
-
             )
             assertNotNull exec.save()
             ExecReport er = ExecReport.fromExec(exec).save()
@@ -2589,6 +2588,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
   <failedNodeList />
   <filterApplied />
   <jobUuid>test-job-uuid</jobUuid>
+  <executionUuid>uuid</executionUuid>
 </report>'''
     /**
      * uses deprecated jcExecId
@@ -2607,6 +2607,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
   <dateCompleted>1970-01-01T01:00:00Z</dateCompleted>
   <jcExecId>123</jcExecId>
   <jcJobId>test-job-uuid</jcJobId>
+  <executionUuid>uuid</executionUuid>
   <adhocExecution />
   <adhocScript />
   <abortedByUser />
@@ -2650,6 +2651,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
             dateCompleted: new Date(3600000),
             message: 'Report message',
             jobUuid: se.uuid,
+            executionUuid: 'uuid'
             )
         assertNotNull exec.save()
 
@@ -2745,6 +2747,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
             dateStarted: new Date(0),
             dateCompleted: new Date(3600000),
             message: 'Report message',
+            executionUuid: 'uuid'
             )
         assertNotNull exec.save()
 


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Refactor of GormExecReportDataProvider

**Describe the solution you've implemented**
Update the GormExecReportDataProvider to remove usage of Execution and ReferencedExecution Domains


**Additional context**
There are non-destructive migrations in this PR, but deploying them could take a long time depending on the size of the tables, as we recently experienced.
