### PR TITLE
RSE-1052: fix IP disclosure when request doesnt have Host header

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -887,6 +887,8 @@ beans={
             [it.key.toString(), it.value.toString()]
         }
         useForwardHeaders = useForwardHeadersConfig ?: Boolean.getBoolean('rundeck.jetty.connector.forwarded')
+        serverUrl = grailsApplication.config.getProperty('server.address', String.class)
+        serverPort = grailsApplication.config.getProperty('server.port', String.class)
     }
 
     def stsMaxAgeSeconds = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsMaxAgeSeconds",Integer.class,-1)

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -880,6 +880,7 @@ beans={
     }
 
     jettyServletCustomizer(JettyServletContainerCustomizer) {
+        featureService = ref('featureService')
         def configParams = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.initParams", String.class)
         def useForwardHeadersConfig = grailsApplication.config.getProperty("server.useForwardHeaders",Boolean.class)
 

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -888,8 +888,7 @@ beans={
             [it.key.toString(), it.value.toString()]
         }
         useForwardHeaders = useForwardHeadersConfig ?: Boolean.getBoolean('rundeck.jetty.connector.forwarded')
-        serverUrl = grailsApplication.config.getProperty('server.address', String.class)
-        serverPort = grailsApplication.config.getProperty('server.port', String.class)
+        serverUrl = grailsApplication.config.getProperty('grails.serverURL', String.class)
     }
 
     def stsMaxAgeSeconds = grailsApplication.config.getProperty("rundeck.web.jetty.servlet.stsMaxAgeSeconds",Integer.class,-1)

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/BanHttpMethodCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/BanHttpMethodCustomizer.groovy
@@ -3,7 +3,6 @@ package rundeckapp.init.servlet
 import org.eclipse.jetty.http.HttpMethod
 import org.eclipse.jetty.http.HttpStatus
 import org.eclipse.jetty.server.Connector
-import org.eclipse.jetty.server.HostHeaderCustomizer
 import org.eclipse.jetty.server.HttpConfiguration
 import org.eclipse.jetty.server.HttpConnectionFactory
 import org.eclipse.jetty.server.Request

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/BanHttpMethodCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/BanHttpMethodCustomizer.groovy
@@ -25,28 +25,6 @@ class BanHttpMethodCustomizer implements JettyServerCustomizer {
     }
 }
 
-class RundeckHostHeaderCustomizer implements JettyServerCustomizer {
-    String serverUrl
-    int serverPort
-
-    RundeckHostHeaderCustomizer(String serverUrl) {
-        this.serverUrl = serverUrl
-    }
-
-    RundeckHostHeaderCustomizer(String serverUrl, int serverPort) {
-        this.serverUrl = serverUrl
-        this.serverPort = serverPort
-    }
-
-    @Override
-    void customize(Server server) {
-        server.connectors.each {connector ->
-            HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).httpConfiguration
-            config.addCustomizer(new HostHeaderCustomizer(serverUrl, serverPort))
-        }
-    }
-}
-
 /**
  * Includes and validates paths and http methods banned for security reasons
  */

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/BanHttpMethodCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/BanHttpMethodCustomizer.groovy
@@ -3,6 +3,7 @@ package rundeckapp.init.servlet
 import org.eclipse.jetty.http.HttpMethod
 import org.eclipse.jetty.http.HttpStatus
 import org.eclipse.jetty.server.Connector
+import org.eclipse.jetty.server.HostHeaderCustomizer
 import org.eclipse.jetty.server.HttpConfiguration
 import org.eclipse.jetty.server.HttpConnectionFactory
 import org.eclipse.jetty.server.Request
@@ -20,6 +21,28 @@ class BanHttpMethodCustomizer implements JettyServerCustomizer {
         server.connectors.each {connector ->
             HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).httpConfiguration
             config.addCustomizer(new BanHttpCustomizer([HttpMethod.TRACE]))
+        }
+    }
+}
+
+class RundeckHostHeaderCustomizer implements JettyServerCustomizer {
+    String serverUrl
+    int serverPort
+
+    RundeckHostHeaderCustomizer(String serverUrl) {
+        this.serverUrl = serverUrl
+    }
+
+    RundeckHostHeaderCustomizer(String serverUrl, int serverPort) {
+        this.serverUrl = serverUrl
+        this.serverPort = serverPort
+    }
+
+    @Override
+    void customize(Server server) {
+        server.connectors.each {connector ->
+            HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).httpConfiguration
+            config.addCustomizer(new HostHeaderCustomizer(serverUrl, serverPort))
         }
     }
 }

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -54,7 +54,7 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
             }
         })
         factory.addServerCustomizers(new BanHttpMethodCustomizer())
-        if(featureService.featurePresent("setServerUrlOnNoHostHeader", false) && serverUrl) {
+        if(serverUrl && featureService.featurePresent("setServerUrlOnNoHostHeader", false)) {
             factory.addServerCustomizers(new RundeckHostHeaderCustomizer(serverUrl: serverUrl))
         }
         factory.addConfigurations(new JettyConfigPropsInitParameterConfiguration(initParams))

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -17,6 +17,7 @@ package rundeckapp.init.servlet
 
 import com.dtolabs.rundeck.core.init.CustomWebAppInitializer
 import org.eclipse.jetty.server.Handler
+import org.eclipse.jetty.server.HostHeaderCustomizer
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ContextHandler
 import org.eclipse.jetty.webapp.AbstractConfiguration
@@ -36,6 +37,8 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
      */
     Map<String, String> initParams = [:]
     Boolean useForwardHeaders
+    String serverUrl
+    String serverPort
 
     @Override
     void customize(final JettyServletWebServerFactory factory) {
@@ -50,6 +53,7 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
             }
         })
         factory.addServerCustomizers(new BanHttpMethodCustomizer())
+        factory.addServerCustomizers(new RundeckHostHeaderCustomizer(serverUrl, Integer.parseInt(serverPort ?: "4440")))
         factory.addConfigurations(new JettyConfigPropsInitParameterConfiguration(initParams))
         factory.useForwardHeaders=useForwardHeaders
     }

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.web.embedded.jetty.JettyServerCustomizer
 import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory
 import org.springframework.boot.web.server.WebServerFactoryCustomizer
+import rundeck.services.feature.FeatureService
 
 /**
  * Customize embedded jetty
@@ -39,6 +40,7 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
     Boolean useForwardHeaders
     String serverUrl
     String serverPort
+    FeatureService featureService
 
     @Override
     void customize(final JettyServletWebServerFactory factory) {
@@ -53,7 +55,9 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
             }
         })
         factory.addServerCustomizers(new BanHttpMethodCustomizer())
-        factory.addServerCustomizers(new RundeckHostHeaderCustomizer(serverUrl, Integer.parseInt(serverPort ?: "4440")))
+        if(featureService.featurePresent("setServerUrlOnNohostHeader", false)) {
+            factory.addServerCustomizers(new RundeckHostHeaderCustomizer(serverUrl, Integer.parseInt(serverPort ?: "4440")))
+        }
         factory.addConfigurations(new JettyConfigPropsInitParameterConfiguration(initParams))
         factory.useForwardHeaders=useForwardHeaders
     }

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/JettyServletContainerCustomizer.groovy
@@ -39,7 +39,6 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
     Map<String, String> initParams = [:]
     Boolean useForwardHeaders
     String serverUrl
-    String serverPort
     FeatureService featureService
 
     @Override
@@ -55,8 +54,8 @@ class JettyServletContainerCustomizer implements WebServerFactoryCustomizer<Jett
             }
         })
         factory.addServerCustomizers(new BanHttpMethodCustomizer())
-        if(featureService.featurePresent("setServerUrlOnNohostHeader", false)) {
-            factory.addServerCustomizers(new RundeckHostHeaderCustomizer(serverUrl, Integer.parseInt(serverPort ?: "4440")))
+        if(featureService.featurePresent("setServerUrlOnNoHostHeader", false) && serverUrl) {
+            factory.addServerCustomizers(new RundeckHostHeaderCustomizer(serverUrl: serverUrl))
         }
         factory.addConfigurations(new JettyConfigPropsInitParameterConfiguration(initParams))
         factory.useForwardHeaders=useForwardHeaders

--- a/rundeckapp/grails-app/init/rundeckapp/init/servlet/RundeckHostHeaderCustomizer.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/init/servlet/RundeckHostHeaderCustomizer.groovy
@@ -1,0 +1,19 @@
+package rundeckapp.init.servlet
+
+import org.eclipse.jetty.server.HostHeaderCustomizer
+import org.eclipse.jetty.server.HttpConfiguration
+import org.eclipse.jetty.server.HttpConnectionFactory
+import org.eclipse.jetty.server.Server
+import org.springframework.boot.web.embedded.jetty.JettyServerCustomizer
+
+class RundeckHostHeaderCustomizer implements JettyServerCustomizer {
+    String serverUrl
+
+    @Override
+    void customize(Server server) {
+        server.connectors.each {connector ->
+            HttpConfiguration config = connector.getConnectionFactory(HttpConnectionFactory.class).httpConfiguration
+            config.addCustomizer(new HostHeaderCustomizer(serverUrl))
+        }
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
When performing a request to Rundeck with no Host header, the internal IP is revealed on the response

**Describe the solution you've implemented**
This PR add a customizer that is enabled by the config `rundeck.feature.setServerUrlOnNoHostHeader.enabled` that will force the serverUrl and serverPort in the response if there is no Host header on request

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
