### PR TITLE
RUN-2354: fix: npe during cleanup incomplete executions

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/logstorage/GormLogFileStorageRequestProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/logstorage/GormLogFileStorageRequestProvider.groovy
@@ -84,10 +84,13 @@ class GormLogFileStorageRequestProvider implements LogFileStorageRequestProvider
     @Override
     void delete(String executionUuid) {
         def execution = findExecutionByUuid(executionUuid)
+        if(!execution){
+            return
+        }
         def request = findByExecution(execution)
         execution.setLogFileStorageRequest(null)
         execution.save(flush:true)
-        request.delete(flush:true)
+        request?.delete(flush:true)
     }
 
     @Override

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/logstorage/GormLogFileStorageRequestProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/logstorage/GormLogFileStorageRequestProviderSpec.groovy
@@ -1,0 +1,87 @@
+package org.rundeck.app.data.providers.logstorage
+
+import grails.testing.gorm.DataTest
+import org.rundeck.app.data.model.v1.logstorage.LogFileStorageRequestData
+import org.rundeck.app.data.providers.GormExecReportDataProvider
+import rundeck.CommandExec
+import rundeck.ExecReport
+import rundeck.Execution
+import rundeck.JobExec
+import rundeck.LogFileStorageRequest
+import rundeck.PluginStep
+import rundeck.Workflow
+import spock.lang.Specification
+
+class GormLogFileStorageRequestProviderSpec extends Specification implements DataTest {
+    def provider = new GormLogFileStorageRequestProvider()
+
+    def setupSpec() {
+        mockDomains(Execution, LogFileStorageRequest, Workflow, CommandExec, PluginStep, JobExec)
+    }
+
+    def "Delete by execid no execution"() {
+        given:
+
+            def execUuid = UUID.randomUUID().toString()
+        when:
+            provider.delete(execUuid)
+        then:
+            noExceptionThrown()
+    }
+
+    def "Delete by execid no request"() {
+        given:
+            def execUuid = UUID.randomUUID().toString()
+            def exec = new Execution(
+                dateStarted: new Date(),
+                dateCompleted: null,
+                user: 'user1',
+                project: 'test',
+                serverNodeUUID: null,
+                outputfilepath: '/tmp/test/logs/blah/1.rdlog',
+                uuid: execUuid
+            ).save()
+
+
+        when:
+            provider.delete(execUuid)
+        then:
+            noExceptionThrown()
+    }
+
+    def "Delete by execid valid"() {
+        given:
+            def execUuid = UUID.randomUUID().toString()
+            def exec = new Execution(
+                dateStarted: new Date(),
+                dateCompleted: null,
+                user: 'user1',
+                project: 'test',
+                serverNodeUUID: null,
+                outputfilepath: '/tmp/test/logs/blah/1.rdlog',
+                uuid: execUuid
+            ).save()
+
+
+            def request = provider.create(
+                Mock(LogFileStorageRequestData) {
+                    getExecutionUuid() >> execUuid
+                    getExecutionId() >> exec.id
+                    getPluginName() >> 'test'
+                    getFiletype() >> 'test'
+                    getCompleted() >> false
+
+                }
+            )
+        when:
+            def found = Execution.get(exec.id).logFileStorageRequest
+        then:
+            found != null
+        when:
+            provider.delete(execUuid)
+        then:
+            Execution.get(exec.id).logFileStorageRequest == null
+            LogFileStorageRequest.get(request.id) == null
+            noExceptionThrown()
+    }
+}


### PR DESCRIPTION
the log file storage request may already be deleted, causing NPE when deleting by execution UUID

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
