### PR TITLE
RUN-2353-Refactor editProject test to improve readability and maintainability

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/EditProjectFile.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/EditProjectFile.spec.ts
@@ -2,7 +2,17 @@ import { mount } from "@vue/test-utils";
 import EditProjectFile from "./EditProjectFile.vue";
 import * as editProjectFileService from "./editProjectFileService";
 
-jest.mock("@/app/components/readme-motd/editProjectFileService", () => ({
+jest.mock("@/library/rundeckService", () => ({
+  getRundeckContext: () => ({
+    rundeckClient: {},
+  }),
+  url: jest.fn().mockImplementation((path) => {
+    return {
+      href: `http://localhost:4440/${path}`,
+    };
+  }),
+}));
+jest.mock("./editProjectFileService", () => ({
   getFileText: jest.fn().mockResolvedValue({
     success: true,
     contents: "sample file content",
@@ -13,143 +23,100 @@ jest.mock("@/app/components/readme-motd/editProjectFileService", () => ({
   }),
 }));
 
-jest.mock("@/library/rundeckService", () => ({
-  getRundeckContext: jest.fn().mockReturnValue({
-    rundeckClient: {
-      getFileText: jest.fn().mockResolvedValue({
-        filename: "readme.md",
-        success: true,
-        contents: "Some content",
-        rdBase: "http://localhost:4440",
-      }),
-      saveProjectFile: jest.fn().mockResolvedValue({
-        success: true,
-        message: "File saved successfully.",
-      }),
-    },
-    rdBase: "http://localhost:4440",
-  }),
-  url: jest.fn().mockReturnValue({
-    href: "http://localhost:4440/project/default/home",
-  }),
-}));
-
 jest.mock("../../../library/components/utils/AceEditor.vue", () => ({
   name: "AceEditor",
   functional: true,
-  template: '<span class="ace_text ace_xml"></span>',
+  template: '<span class="ace_text ace_xml">sample file content</span>',
   methods: {
     getValue: jest.fn().mockReturnValue("sample file content"),
   },
 }));
 
-describe("EditProjectFile", () => {
-  let wrapper;
-  let originalLocation;
-
-  const mountEditProjectFile = async (props = {}) => {
-    wrapper = mount(EditProjectFile, {
-      props: {
-        filename: "readme.md",
-        project: "default",
-        authAdmin: true,
-        displayConfig: ["none"],
-        ...props,
+const mountEditProjectFile = async (props = {}) => {
+  return mount(EditProjectFile, {
+    props: {
+      filename: "readme.md",
+      project: "default",
+      authAdmin: true,
+      displayConfig: ["none"],
+      ...props,
+    },
+    global: {
+      mocks: {
+        $t: (msg) => msg,
       },
-      global: {
-        mocks: {
-          $t: (msg) => msg,
-        },
-      },
-    });
-    await wrapper.vm.$nextTick();
-  };
-
-  beforeEach(async () => {
-    originalLocation = window.location;
-    delete (window as any).location;
-    window.location = {
-      ...originalLocation,
-      assign: jest.fn(),
-      href: jest.fn(),
-      replace: jest.fn(),
-      toString: () => (window.location as any)._href || "http://localhost:4440",
-    };
-
-    await mountEditProjectFile();
+    },
   });
-
+};
+describe("EditProjectFile", () => {
   afterEach(() => {
     jest.clearAllMocks();
-    window.location = originalLocation;
   });
-
   it.each([
     ["readme.md", "edit.readme.label"],
     ["motd.md", "edit.motd.label"],
   ])("renders the correct title for %s", async (filename, expectedTitle) => {
-    await mountEditProjectFile({ filename });
+    const wrapper = await mountEditProjectFile({ filename });
     expect(wrapper.find('[data-test-id="title"]').text()).toContain(
-      expectedTitle
+      expectedTitle,
     );
   });
   it("renders file content inside AceEditor's span element when getFileText method returns successfully", async () => {
-    wrapper.vm.getFileText = jest.fn().mockResolvedValue("sample file content");
-    await wrapper.vm.getFileText();
-    await wrapper.vm.$nextTick();
+    const wrapper = await mountEditProjectFile();
     const aceEditor = wrapper.findComponent({ name: "AceEditor" });
     expect(aceEditor.exists()).toBe(true);
     const span = aceEditor.find("span.ace_text.ace_xml");
     expect(span.exists()).toBe(true);
-    const spanHtml = span.html();
+    const spanHtml = span.text();
     expect(spanHtml).toContain("sample file content");
   });
   it("handles failure when getFileText method fails", async () => {
+    const wrapper = await mountEditProjectFile();
     const notifyErrorSpy = jest.spyOn(wrapper.vm, "notifyError");
     (editProjectFileService.getFileText as jest.Mock).mockImplementationOnce(
-      () => Promise.reject(new Error("Failed to fetch file"))
+      () => Promise.reject(new Error("Failed to fetch file")),
     );
     await wrapper.vm.getFileText();
     expect(notifyErrorSpy).toHaveBeenCalledWith("Failed to fetch file");
   });
-
   it("handles failure when user edits the file and fails to save it", async () => {
+    const wrapper = await mountEditProjectFile();
+    const notifyErrorSpy = jest.spyOn(wrapper.vm, "notifyError");
     (
       editProjectFileService.saveProjectFile as jest.Mock
     ).mockImplementationOnce(() =>
-      Promise.reject(new Error("Failed to save file"))
+      Promise.reject(new Error("Failed to save file")),
     );
-    const notifyErrorSpy = jest.spyOn(wrapper.vm, "notifyError");
     wrapper.vm.fileText = "new content";
     await wrapper.find('[data-test-id="save"]').trigger("click");
     expect(notifyErrorSpy).toHaveBeenCalledWith("Failed to save file");
   });
   it("handles success when user edits the file and saves it", async () => {
+    const wrapper = await mountEditProjectFile();
     wrapper.vm.fileText = "new content";
     await wrapper.find('[data-test-id="save"]').trigger("click");
-    expect(
-      editProjectFileService.saveProjectFile as jest.Mock
-    ).toHaveBeenCalledWith("default", "readme.md", "new content");
+    expect(editProjectFileService.saveProjectFile).toHaveBeenCalledWith(
+      "default",
+      "readme.md",
+      "new content",
+    );
   });
-
-  it("displays warning message and configuration link when user is an admin and displayConfig value is 'none", async () => {
+  it("displays warning message and configuration link when user is an admin and displayConfig is 'none'", async () => {
+    const wrapper = await mountEditProjectFile();
     const footerText = wrapper.find(".card-footer").text();
     expect(footerText).toContain("file.warning.not.displayed.admin.message");
     expect(wrapper.find(".card-footer a").text()).toBe(
-      "project.configuration.label"
+      "project.configuration.label",
     );
   });
-
-  it("displays warning message and configuration link when user isn't an admin and displayConfig value is 'none", async () => {
-    await mountEditProjectFile({
-      authAdmin: false,
-    });
+  it("displays warning message and configuration link when user isn't an admin and displayConfig is 'none'", async () => {
+    const wrapper = await mountEditProjectFile({ authAdmin: false });
     expect(
-      wrapper.find('[data-test-id="nonadmin-warning-message"]').text()
+      wrapper.find('[data-test-id="nonadmin-warning-message"]').text(),
     ).toContain("file.warning.not.displayed.nonadmin.message");
   });
   it("navigates to the home page when the cancel button is clicked", async () => {
-    await mountEditProjectFile();
+    const wrapper = await mountEditProjectFile();
     const button = wrapper.find('[data-test-id="cancel"]');
 
     await button.trigger("click");

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/EditProjectFile.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/EditProjectFile.spec.ts
@@ -25,11 +25,8 @@ jest.mock("./editProjectFileService", () => ({
 
 jest.mock("../../../library/components/utils/AceEditor.vue", () => ({
   name: "AceEditor",
-  props: ["value"],
-  template: '<span class="ace_text ace_xml">{{ getValue() }}</span>',
-  methods: {
-    getValue: jest.fn().mockReturnValue("sample file content"),
-  },
+  props: ["modelValue"],
+  template: '<span class="ace_text ace_xml">{{modelValue }}</span>',
 }));
 const mountEditProjectFile = async (props = {}) => {
   return mount(EditProjectFile, {
@@ -65,7 +62,6 @@ describe("EditProjectFile", () => {
   it("renders file content inside AceEditor's span element when getFileText method returns successfully", async () => {
     const wrapper = await mountEditProjectFile();
     const aceEditor = wrapper.findComponent({ name: "AceEditor" });
-    aceEditor.vm.getValue();
     await wrapper.vm.$nextTick();
     const span = aceEditor.find("span.ace_text.ace_xml");
     expect(span.text()).toContain("sample file content");
@@ -74,7 +70,7 @@ describe("EditProjectFile", () => {
     const wrapper = await mountEditProjectFile();
     const notifyErrorSpy = jest.spyOn(wrapper.vm, "notifyError");
     (editProjectFileService.getFileText as jest.Mock).mockImplementationOnce(
-      () => Promise.reject(new Error("Failed to fetch file")),
+      () => Promise.reject(new Error("Failed to fetch file"))
     );
     await wrapper.vm.getFileText();
     expect(notifyErrorSpy).toHaveBeenCalledWith("Failed to fetch file");

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/EditProjectFile.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/EditProjectFile.vue
@@ -153,7 +153,7 @@ export default defineComponent({
         const resp = await saveProjectFile(
           this.project,
           this.filename,
-          this.fileText
+          this.fileText,
         );
         if (resp.success) {
           this.notifySuccess("Success", "Saved Project File " + this.filename);
@@ -204,7 +204,7 @@ export default defineComponent({
               this.filename +
               " does not exist in project " +
               this.project +
-              " yet. Please save to create it."
+              " yet. Please save to create it.",
           );
         } else {
           this.notifyError(e.message);


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
This is an enhancement of the testing suite for the `EditProjectFile.vue` component.

**Describe the solution you've implemented**
I've refactored the tests for `EditProjectFile.vue` to improve readability and maintainability. The changes include better organization of test cases, clearer descriptions, and removal of unnecessary global mocks.

**Describe alternatives you've considered**
An alternative would have been to leave the tests as they were, but this would have made the test suite harder to maintain and understand in the long run.

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
