### PR TITLE
RUN-2450: fix config for detectFirstrun

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -64,6 +64,11 @@ public class RundeckConfigBase {
     RundeckHealthIndicatorConfig health;
     RundeckJobsConfig jobs;
     JobsImport jobsImport;
+    Startup startup;
+
+    @Data public static class Startup {
+        Boolean detectFirstRun;
+    }
 
     @Data public static class JobsImport{
         XmlValueListDelimiter xmlValueListDelimiter;

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -97,3 +97,7 @@ rundeck.scm.startup.initDeferred={{ getv("/rundeck/scm/startup/initdeferred") }}
 {% if exists("/rundeck/plugins/providerblocklistfile") %}
 rundeck.plugins.providerBlockListFile={{ getv("/rundeck/plugins/providerblocklistfile") }}
 {% endif %}
+
+{% if exists("/rundeck/startup/detectfirstrun") %}
+rundeck.startup.detectFirstRun={{ getv("/rundeck/startup/detectfirstrun") }}
+{% endif %}

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -1875,25 +1875,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
 
     def home() {
         //first-run html info
-        def isFirstRun=false
-
-        if (configurationService.getBoolean('startup.alwaysFirstRun', false)) {
-            isFirstRun=true
-        }else{
-            if(configurationService.getBoolean("startup.detectFirstRun",true) &&
-                    frameworkService.rundeckFramework.hasProperty('framework.var.dir')) {
-                def vardir = frameworkService.rundeckFramework.getProperty('framework.var.dir')
-                String buildIdent = grailsApplication.metadata.getProperty('build.ident', String).get()
-                def vers = buildIdent.replaceAll('\\s+\\(.+\\)$','')
-                def file = new File(vardir, ".first-run-${vers}")
-                if(!file.exists()){
-                    isFirstRun=true
-                    file.withWriter("UTF-8"){out->
-                        out.write('#'+(new Date().toString()))
-                    }
-                }
-            }
-        }
+        def isFirstRun = menuService.shouldShowFirstRunInfo()
 
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubject(session.subject)
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -136,7 +136,7 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
             model.projectNames==null
             model.isFirstRun==false
     }
-    def "home without first run"(){
+    def "home with first run true"(){
         given:
             controller.configurationService=Mock(ConfigurationService)
             controller.frameworkService=Mock(FrameworkService){

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -113,6 +113,7 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         controller.featureService = Mock(com.dtolabs.rundeck.core.config.FeatureService){
             _ * featurePresent(Features.LEGACY_UI) >> true
         }
+        controller.menuService = Mock(MenuService)
 
         defineBeans {
             configurationService(ConfigurationService) {
@@ -133,6 +134,25 @@ class MenuControllerSpec extends RundeckHibernateSpec implements ControllerUnitT
         then:
             model!=null
             model.projectNames==null
+            model.isFirstRun==false
+    }
+    def "home without first run"(){
+        given:
+            controller.configurationService=Mock(ConfigurationService)
+            controller.frameworkService=Mock(FrameworkService){
+                getRundeckFramework()>>Mock(IFramework)
+            }
+            controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)
+            controller.featureService=Mock(FeatureService)
+            controller.menuService=Mock(MenuService){
+                1 * shouldShowFirstRunInfo()>>true
+            }
+        when:
+            def result = controller.home()
+        then:
+            model!=null
+            model.projectNames==null
+            model.isFirstRun==true
     }
     def "api job detail json"() {
         given:

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuServiceSpec.groovy
@@ -1,0 +1,84 @@
+package rundeck.controllers
+
+import com.dtolabs.rundeck.core.VersionConstants
+import com.dtolabs.rundeck.core.common.IFramework
+import com.dtolabs.rundeck.core.utils.IPropertyLookup
+import grails.testing.services.ServiceUnitTest
+import org.rundeck.app.config.ConfigService
+import rundeck.services.FrameworkService
+import spock.lang.Specification
+
+import java.nio.file.Files
+
+class MenuServiceSpec extends Specification implements ServiceUnitTest<MenuService> {
+    def setup() {
+        service.configurationService = Mock(ConfigService)
+        service.frameworkService = Mock(FrameworkService)
+    }
+
+    def "should show first run disabled"() {
+        when:
+            def result = service.shouldShowFirstRunInfo()
+
+        then:
+            !result
+            1 * service.configurationService.getBoolean(MenuService.SYS_CONFIG_DETECT_FIRST_RUN, true) >> false
+            0 * service.frameworkService.getRundeckFramework()
+    }
+
+    def "should show first run enabled, does not exist"() {
+        given:
+            def tmpdir = Files.createTempDirectory("MenuServiceSpec")
+            def fwk = Mock(IFramework) {
+                _ * getPropertyLookup() >> Mock(IPropertyLookup) {
+                    _ * getProperty('framework.var.dir') >> tmpdir.toFile().absolutePath
+                    _ * hasProperty('framework.var.dir') >> true
+                }
+            }
+            service.frameworkService = Mock(FrameworkService) {
+                _ * getRundeckFramework() >> fwk
+            }
+            def File firstrun = new File(tmpdir.toFile(),".first-run-${VersionConstants.VERSION}")
+
+            assert !firstrun.exists()
+        when:
+            def result = service.shouldShowFirstRunInfo()
+
+        then:
+            result
+            1 * service.configurationService.getBoolean(MenuService.SYS_CONFIG_DETECT_FIRST_RUN, true) >> true
+            firstrun.exists()
+        cleanup:
+            //remove files
+            firstrun.delete()
+            Files.delete(tmpdir)
+
+    }
+    def "should show first run enabled, does exist"() {
+        given:
+            def tmpdir = Files.createTempDirectory("MenuServiceSpec")
+            def fwk = Mock(IFramework) {
+                _ * getPropertyLookup() >> Mock(IPropertyLookup) {
+                    _ * getProperty('framework.var.dir') >> tmpdir.toFile().absolutePath
+                    _ * hasProperty('framework.var.dir') >> true
+                }
+            }
+            service.frameworkService = Mock(FrameworkService) {
+                _ * getRundeckFramework() >> fwk
+            }
+            def File firstrun = new File(tmpdir.toFile(),".first-run-${VersionConstants.VERSION}")
+
+            assert firstrun.createNewFile()
+        when:
+            def result = service.shouldShowFirstRunInfo()
+
+        then:
+            !result
+            1 * service.configurationService.getBoolean(MenuService.SYS_CONFIG_DETECT_FIRST_RUN, true) >> true
+            firstrun.exists()
+        cleanup:
+            firstrun.delete()
+            Files.delete(tmpdir)
+
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

Fixes the `rundeck.startup.detectFirstRun` config flag to work, enables setting it via remco.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
