### PR TITLE
RUN-2453: Feature rundeck.feature.caseInsensitiveUsername.enabled doesn't show on System configuration page

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
@@ -336,7 +336,7 @@ class GormUserDataProvider implements UserDataProvider, SystemConfigurable{
     List<SysConfigProp> getSystemConfigProps() {
         return [
                 SystemConfig.builder().with {
-                    key("rundeck."+Features.CASE_INSENSITIVE_USERNAME)
+                     key("rundeck.feature.caseInsensitiveUsername.enabled")
                     .datatype("Boolean")
                     .label("Enable case insensitive on login name")
                     .defaultValue("false")

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
@@ -338,7 +338,7 @@ class GormUserDataProvider implements UserDataProvider, SystemConfigurable{
                 SystemConfig.builder().with {
                      key("rundeck.feature.caseInsensitiveUsername.enabled")
                     .datatype("Boolean")
-                    .label("Enable case insensitive on login name")
+                    .label("Enable case insensitive login name")
                     .defaultValue("false")
                     .category("Custom")
                     .visibility("Advanced")


### PR DESCRIPTION
On bug bash found that rundeck.feature.caseInsensitiveUsername.enabled can be enabled/disabled on the rundeck-config.properties but not from the GUI on System configuration page.