### PR TITLE
RUN-2369 Login as local user doesn't evaluate case sensitive feature

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
@@ -329,7 +329,9 @@ class GormUserDataProvider implements UserDataProvider, SystemConfigurable{
      * @return The User object corresponding to the provided login name.
      */
     User findUserByLoginCaseSensitivity(String login) {
-        return isLoginNameCaseInsensitiveEnabled() ? User.findByLoginIlike(login) : User.findByLogin(login)
+        return isLoginNameCaseInsensitiveEnabled() ?
+                User.findAllByLoginIlike(login).find(){ user -> user.login.equalsIgnoreCase(login)} :
+                User.findByLogin(login)
     }
 
     @Override


### PR DESCRIPTION
Related to https://github.com/rundeckpro/rundeckpro/pull/3681
 
improve method findUserByLoginCaseSensitivity to avoid undesired logins 