### PR TITLE
RCLOUD-1270: Hide version from footer for rba

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
@@ -42,7 +42,8 @@ public enum Features implements FeaturesDefinition{
     LEGACY_XML("legacyXml"),
     CASE_INSENSITIVE_USERNAME("caseInsensitiveUsername"),
 
-    API_PROJECT_CONFIG_VALIDATION("apiProjectConfigValidation");
+    API_PROJECT_CONFIG_VALIDATION("apiProjectConfigValidation"),
+    HIDE_VERSION("hideVersion");
 
     private final String propertyName;
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -443,6 +443,7 @@ public class RundeckConfigBase {
         Enabled legacyXml = new Enabled();
         Enabled apiProjectConfigValidation = new Enabled();
         Enabled caseInsensitiveUsername = new Enabled();
+        Enabled hideVersion = new Enabled();
 
 
         @Data

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/rundeck-info/RundeckInfo.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/rundeck-info/RundeckInfo.spec.ts
@@ -31,6 +31,7 @@ const mountRundeckInfo = async (props = {}) => {
         icon: "knight",
         edition: "Community",
       },
+      hideVersion: false,
       ...props,
     },
   });
@@ -107,5 +108,12 @@ describe("RundeckInfo", () => {
     expect(latestReleaseComponent.find("span").text()).toBe("v5.2.0-20240410");
     expect(latestReleaseComponent.props().number).toBe("v5.2.0-20240410");
     expect(latestReleaseComponent.props().tag).toBe("GA");
+  });
+  it("does not render release information when hideVersion is true", async () => {
+    const wrapper = await mountRundeckInfo({ hideVersion: true });
+    const rundeckVersionComponent = wrapper.find('div.rundeck-version-display');
+    const versionDisplayComponent = wrapper.find('span.rundeck-version-icon');
+    expect(rundeckVersionComponent.exists()).toBe(false);
+    expect(versionDisplayComponent.exists()).toBe(false);
   });
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/rundeck-info/RundeckInfo.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/rundeck-info/RundeckInfo.vue
@@ -7,22 +7,24 @@
           <PagerdutyLogo v-else />
         </a>
       </div>
-      <div v-if="version && appInfo" class="rundeck-info-widget__header">
-        <RundeckVersion
-          :logo="false"
-          :title="appInfo.title"
-          :logocss="appInfo.logocss"
-          :number="version.number"
-          :tag="version.tag"
-        />
-      </div>
-      <div v-if="version && version.icon && version.color">
-        <VersionDisplay
-          :text="`${version.name} ${version.color} ${version.icon}`"
-          :icon="version.icon"
-          :color="version.color"
-        />
-      </div>
+      <template v-if="!hideVersion">
+        <div v-if="version && appInfo" class="rundeck-info-widget__header">
+          <RundeckVersion
+            :logo="false"
+            :title="appInfo.title"
+            :logocss="appInfo.logocss"
+            :number="version.number"
+            :tag="version.tag"
+          />
+        </div>
+        <div v-if="version && version.icon && version.color">
+          <VersionDisplay
+            :text="`${version.name} ${version.color} ${version.icon}`"
+            :icon="version.icon"
+            :color="version.color"
+          />
+        </div>
+      </template>
       <div v-if="server">
         <span class="server-display">
           <ServerDisplay
@@ -34,7 +36,7 @@
       </div>
     </div>
     <div
-      v-if="latest"
+      v-if="!hideVersion && latest"
       class="rundeck-info-widget__group"
       style="border-top: solid 1px grey"
     >
@@ -89,6 +91,10 @@ export default defineComponent({
     },
     appInfo: {
       type: Object as PropType<AppInfo>,
+    },
+    hideVersion: {
+      type: Boolean,
+      default: false,
     },
   },
   methods: {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/rundeck-info/RundeckInfoWidget.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/rundeck-info/RundeckInfoWidget.vue
@@ -4,6 +4,7 @@
     :latest="releases.releases[0]"
     :server="system.serverInfo"
     :app-info="system.appInfo"
+    :hide-version="hideVersion"
   />
 </template>
 
@@ -11,11 +12,18 @@
 import { RootStore } from "../../../stores/RootStore";
 import { defineComponent, inject } from "vue";
 import InfoDisplay from "./RundeckInfo.vue";
+import { getFeatureEnabled } from "../../../services/featureConfig"
 
+const HIDE_VERSION_CONFIG_KEY = "hideVersion";
 export default defineComponent({
   name: "RundeckInfoWidget",
   components: {
     InfoDisplay,
+  },
+  data() {
+      return {
+          hideVersion: true
+      }
   },
   setup() {
     const { system, releases } = inject("rootStore") as RootStore;
@@ -23,8 +31,18 @@ export default defineComponent({
   },
   async mounted() {
     try {
-      await Promise.all([this.releases.load(), this.system.load()]);
+      await Promise.all([
+        this.releases.load(),
+        this.system.load(),
+        this.loadConfigs(),
+      ]);
     } catch (e) {}
+  },
+  methods: {
+    async loadConfigs() {
+      const val = await getFeatureEnabled(HIDE_VERSION_CONFIG_KEY);
+      this.hideVersion = (val !== null) ? val : false;
+    },
   },
 });
 </script>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/services/featureConfig.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/services/featureConfig.ts
@@ -1,0 +1,6 @@
+import { api } from "./api";
+
+export async function getFeatureEnabled(featureName: string) {
+    const resp =  await api.get(`/feature/${featureName}`);
+    return !!resp?.data.enabled;
+}


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Change of behavior for rba

**Describe the solution you've implemented**
Adding the option to hide the version number from the footer

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
https://pagerduty.atlassian.net/browse/RCLOUD-1270
