### PR TITLE
[RUN-2508] Enables building arm64 Docker images locally

### DIFF
--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -14,6 +14,8 @@ RUN go install github.com/HeavyHorst/remco/cmd/remco@$REMCO_VERSION
 ######################
 FROM ubuntu:22.04
 
+ARG TARGETARCH
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
@@ -47,8 +49,8 @@ RUN adduser --gid 0 --shell /bin/bash --home /home/rundeck --gecos "" --disabled
 
 # Install Tini
 ENV TINI_VERSION=0.19.0
-RUN curl -sSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini -o /tini && \
-    curl -sSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini.asc -o /tini.asc && \
+RUN curl -sSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH} -o /tini && \
+    curl -sSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-${TARGETARCH}.asc -o /tini.asc && \
     gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
     gpg --batch --verify /tini.asc /tini && \
     chmod +x /tini


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is a small enhancement to enable building `rundeck` Docker images for an `arm64` architecture.

This change enables building `arm64` images locally as described in [README.md](https://github.com/rundeck/rundeck/blob/main/README.md). It is a prerequisite for official CI builds of arm64 images (as requested in https://github.com/rundeck/rundeck/issues/6433).

**Describe the solution you've implemented**
Adds the appropriate build of https://github.com/krallin/tini into the `ubuntu-base` image based on the Docker build's target architecture.

**Describe alternatives you've considered**
This seems like a practical first step?

**Additional context**
Before this enhancement, attempting to build and run the project from an Apple Silicon machine results in the following error when starting the container:

```
rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2

      "Entrypoint": [
        "/tini",
        "--",
        "docker-lib/entry.sh"
      ],
```
