### PR TITLE
RUN-2267: new local node executor feature flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -704,3 +704,8 @@ workflows:
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/integration/**/*{.groovy,.java}"
           <<: *require-build
           <<: *slack-defaults
+      - test-gradle-functional:
+          name: Test Feature NewLocalExec
+          gradle-task: apiTestNewLocal
+          <<: *require-build
+          <<: *slack-defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -707,5 +707,6 @@ workflows:
       - test-gradle-functional:
           name: Test Feature NewLocalExec
           gradle-task: apiTestNewLocal
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionOutputSpec.groovy"
           <<: *require-build
           <<: *slack-defaults

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/BaseFrameworkExecutionServices.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/BaseFrameworkExecutionServices.java
@@ -11,6 +11,7 @@ import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepExecutionS
 import com.dtolabs.rundeck.core.resources.ResourceModelSourceService;
 import com.dtolabs.rundeck.core.resources.format.ResourceFormatGeneratorService;
 import com.dtolabs.rundeck.core.resources.format.ResourceFormatParserService;
+import com.dtolabs.rundeck.plugins.ServiceNameConstants;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -37,6 +38,9 @@ public class BaseFrameworkExecutionServices
      */
     @Override
     public FrameworkSupportService getService(String name) {
+        if(ServiceNameConstants.NodeExecutor.equals(name)){
+            return getNodeExecutorService();
+        }
         return services.get(name);
     }
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/BaseFrameworkExecutionServices.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/BaseFrameworkExecutionServices.java
@@ -23,6 +23,8 @@ public class BaseFrameworkExecutionServices
 
     @Getter @Setter private Framework framework;
 
+    @Getter @Setter private NodeExecutorService nodeExecutorService;
+
     public static BaseFrameworkExecutionServices create(final Framework framework) {
         BaseFrameworkExecutionServices impl = new BaseFrameworkExecutionServices();
         impl.setFramework(framework);
@@ -85,11 +87,6 @@ public class BaseFrameworkExecutionServices
     @Override
     public FileCopierService getFileCopierService() {
         return FileCopierService.getInstanceForFramework(getFramework(), this);
-    }
-
-    @Override
-    public NodeExecutorService getNodeExecutorService() {
-        return NodeExecutorService.getInstanceForFramework(getFramework(), this);
     }
 
     @Override

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkBase.java
@@ -218,11 +218,21 @@ public class FrameworkBase implements IFramework{
     public static PropertyRetriever createPropertyRetriever(File basedir) {
         return FilesystemFramework.createPropertyRetriever(basedir);
     }
+
+    /**
+     *
+     * @param basedir
+     * @param projectsdir
+     * @return
+     * @Deprecated used in tests
+     */
+    @Deprecated
     public static Framework getInstance(String basedir, String projectsdir) {
         ServiceSupport serviceSupport = new ServiceSupport();
         BaseFrameworkExecutionServices executionServices = new BaseFrameworkExecutionServices();
         serviceSupport.setExecutionServices(executionServices);
         Framework framework = FrameworkFactory.createForFilesystem(basedir, serviceSupport);
+        executionServices.setNodeExecutorService(new NodeExecutorService(framework));
         executionServices.setFramework(framework);
         return framework;
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
@@ -41,8 +41,9 @@ public enum Features implements FeaturesDefinition{
     LEGACY_UI("legacyUi"),
     LEGACY_XML("legacyXml"),
     CASE_INSENSITIVE_USERNAME("caseInsensitiveUsername"),
-
-    API_PROJECT_CONFIG_VALIDATION("apiProjectConfigValidation");
+    API_PROJECT_CONFIG_VALIDATION("apiProjectConfigValidation"),
+    NEW_LOCAL_NODE_EXECUTOR("newLocalNodeExecutor"),
+    ;
 
     private final String propertyName;
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -443,6 +443,7 @@ public class RundeckConfigBase {
         Enabled legacyXml = new Enabled();
         Enabled apiProjectConfigValidation = new Enabled();
         Enabled caseInsensitiveUsername = new Enabled();
+        Enabled newLocalNodeExecutor = new Enabled();
 
 
         @Data

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/LocalNodeExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/LocalNodeExecutor.java
@@ -70,7 +70,7 @@ public class LocalNodeExecutor implements NodeExecutor {
         this.disableLocalExecutor = getDisableLocalExecutorEnv();
     }
 
-    static Boolean getDisableLocalExecutorEnv(){
+    public static Boolean getDisableLocalExecutorEnv(){
         String disableLocalExecutor = System.getenv(DISABLE_LOCAL_EXECUTOR_ENV);
 
         if(disableLocalExecutor!=null && disableLocalExecutor.equals("true")){

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/NewLocalNodeExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/impl/local/NewLocalNodeExecutor.java
@@ -19,48 +19,93 @@ package com.dtolabs.rundeck.core.execution.impl.local;
 import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.dispatcher.DataContextUtils;
 import com.dtolabs.rundeck.core.execution.ExecutionContext;
+import com.dtolabs.rundeck.core.execution.ExecutionException;
+import com.dtolabs.rundeck.core.execution.script.ExecTaskParameterGenerator;
+import com.dtolabs.rundeck.core.execution.script.ExecTaskParameterGeneratorImpl;
+import com.dtolabs.rundeck.core.execution.script.ExecTaskParameters;
 import com.dtolabs.rundeck.core.execution.service.NodeExecutor;
 import com.dtolabs.rundeck.core.execution.service.NodeExecutorResult;
 import com.dtolabs.rundeck.core.execution.service.NodeExecutorResultImpl;
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepFailureReason;
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepFailureReason;
+import com.dtolabs.rundeck.core.plugins.Plugin;
 import com.dtolabs.rundeck.core.utils.ScriptExecUtil;
+import com.dtolabs.rundeck.plugins.ServiceNameConstants;
+import com.dtolabs.rundeck.plugins.descriptions.PluginDescription;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+
+import static com.dtolabs.rundeck.core.execution.impl.local.LocalNodeExecutor.getDisableLocalExecutorEnv;
 
 /**
  * @author greg
  * @since 6/12/17
  */
-public class NewLocalNodeExecutor implements NodeExecutor {
+@Plugin(name = NewLocalNodeExecutor.SERVICE_PROVIDER_TYPE, service = ServiceNameConstants.NodeExecutor)
+@PluginDescription(title = "Local (New)", description = "Beta - Executes commands locally on the Rundeck server")
+public class NewLocalNodeExecutor
+        implements NodeExecutor
+{
     public static final String SERVICE_PROVIDER_TYPE = "newlocal";
+    private ExecTaskParameterGenerator parameterGenerator = new ExecTaskParameterGeneratorImpl();
+    private boolean disableLocalExecutor = false;
+
+    public NewLocalNodeExecutor() {
+        this.disableLocalExecutor = getDisableLocalExecutorEnv();
+    }
 
     @Override
     public NodeExecutorResult executeCommand(
             final ExecutionContext context, final String[] command, final INodeEntry node
     )
     {
+        if (disableLocalExecutor) {
+            return NodeExecutorResultImpl.createFailure(
+                    StepFailureReason.ConfigurationFailure,
+                    "Local Executor is disabled",
+                    node
+            );
+        }
+
+        List<String> commandList = new ArrayList<>();
+        try {
+            ExecTaskParameters
+                    taskParameters =
+                    parameterGenerator.generate(node, true, null, command);
+            commandList.add(taskParameters.getCommandexecutable());
+            commandList.addAll(Arrays.asList(taskParameters.getCommandArgs()));
+        } catch (ExecutionException e) {
+            return NodeExecutorResultImpl.createFailure(
+                    StepFailureReason.ConfigurationFailure,
+                    e.getMessage(),
+                    node
+            );
+        }
 
         StringBuilder preview = new StringBuilder();
-
-        for (final String aCommand : command) {
+        for (final String aCommand : commandList) {
             preview.append("'").append(aCommand).append("'");
         }
         context.getExecutionLogger().log(
                 5,
-                "NewLocalNodeExecutor, running command (" + command.length + "): " + preview.toString()
+                "NewLocalNodeExecutor, running command (" + commandList.size() + "): " + preview
         );
         Map<String, String> env = DataContextUtils.generateEnvVarsFromContext(context.getDataContext());
 
         final int result;
         try {
-            result = ScriptExecUtil.runLocalCommand(command, env, null, System.out, System.err);
-            if (result != 0) {
-                return NodeExecutorResultImpl.createFailure(NodeStepFailureReason.NonZeroResultCode,
-                                                            "Result code was " + result, node, result
-                );
-            }
+            result =
+                    ScriptExecUtil.runLocalCommand(
+                            commandList.toArray(new String[]{}),
+                            env,
+                            null,
+                            System.out,
+                            System.err
+                    );
         } catch (IOException e) {
             return NodeExecutorResultImpl.createFailure(
                     StepFailureReason.IOFailure,
@@ -76,9 +121,14 @@ public class NewLocalNodeExecutor implements NodeExecutor {
                     node
             );
         }
-
         if (null != context.getOutputContext()) {
             context.getOutputContext().addOutput("exec", "exitCode", String.valueOf(result));
+        }
+        if (result != 0) {
+            return NodeExecutorResultImpl.createFailure(
+                    NodeStepFailureReason.NonZeroResultCode,
+                    "Result code was " + result, node, result
+            );
         }
         return NodeExecutorResultImpl.createSuccess(node);
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeExecutorService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeExecutorService.java
@@ -71,18 +71,6 @@ public class NodeExecutorService
         PRESET_PROVIDERS = Collections.unmodifiableMap(map);
     }
 
-    @Getter
-    static class Factory {
-        @Setter Framework rundeckFramework;
-        @Setter FeatureService featureService;
-
-        public NodeExecutorService create() {
-            final NodeExecutorService nodeExecutorService = new NodeExecutorService(rundeckFramework);
-            nodeExecutorService.setFeatureService(featureService);
-            return nodeExecutorService;
-        }
-    }
-
     public String getName() {
         return SERVICE_NAME;
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeExecutorService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeExecutorService.java
@@ -158,7 +158,7 @@ public class NodeExecutorService
     }
 
     public List<Description> listDescriptions() {
-        return DescribableServiceUtil.listDescriptions(this, false);
+        return DescribableServiceUtil.listDescriptions(this, true);
     }
 
     public List<ProviderIdent> listDescribableProviders() {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeExecutorService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeExecutorService.java
@@ -100,15 +100,6 @@ public class NodeExecutorService
         );
     }
 
-    public static NodeExecutorService getInstanceForFramework(final Framework framework,
-                                                              final IServicesRegistration registration) {
-        if (null == registration.getService(SERVICE_NAME)) {
-            final NodeExecutorService service = new NodeExecutorService(framework);
-            registration.setService(SERVICE_NAME, service);
-            return service;
-        }
-        return (NodeExecutorService) registration.getService(SERVICE_NAME);
-    }
 
     @Override
     public String getServiceProviderNodeAttributeForNode(INodeEntry node) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeExecutorServiceProfile.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeExecutorServiceProfile.java
@@ -1,0 +1,23 @@
+package com.dtolabs.rundeck.core.execution.service;
+
+import java.util.Map;
+
+/**
+ * Define default providers for NodeExecutorService
+ */
+public interface NodeExecutorServiceProfile {
+    /**
+     * @return default local provider name
+     */
+    String getDefaultLocalProvider();
+
+    /**
+     * @return default remote provider name
+     */
+    String getDefaultRemoteProvider();
+
+    /**
+     * @return local provider registry
+     */
+    Map<String, Class<? extends NodeExecutor>> getLocalRegistry();
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeSpecifiedPlugins.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/service/NodeSpecifiedPlugins.java
@@ -9,11 +9,13 @@ import lombok.Setter;
 /**
  * Provides provider info for {@link FileCopier} and {@link NodeExecutor} given a node and project
  */
+@Getter
 public class NodeSpecifiedPlugins
         implements NodeProviderName
 {
-    @Getter @Setter private ProjectManager projectManager;
-    @Getter @Setter private IFrameworkNodes frameworkNodes;
+    @Setter private ProjectManager projectManager;
+    @Setter private IFrameworkNodes frameworkNodes;
+    @Setter private NodeExecutorService nodeExecutorService;
 
     public <T> String getProviderNameForNodeAndProject(final INodeEntry node, final String project, Class<T> type) {
         if (type.equals(FileCopier.class)) {
@@ -32,7 +34,7 @@ public class NodeSpecifiedPlugins
         } else if (type.equals(NodeExecutor.class)) {
             String
                     copiername =
-                    NodeExecutorService.getProviderNameForNode(
+                    nodeExecutorService.getProviderNameForNode(
                             getFrameworkNodes().isLocalNode(node),
                             getProjectManager().loadProjectConfig(project)
                     );

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/utils/ResolverUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/utils/ResolverUtil.java
@@ -16,12 +16,14 @@
 
 package com.dtolabs.rundeck.core.execution.utils;
 
+import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.common.IFramework;
 import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.common.IRundeckProject;
 
 /**
  * Created by greg on 3/19/15.
+ * TODO: refactor to not use static methods
  */
 public class ResolverUtil {
     /**
@@ -31,6 +33,32 @@ public class ResolverUtil {
      */
     public static final String PROJ_PROP_PREFIX = "project.";
     public static final String FWK_PROP_PREFIX = "framework.";
+
+    /**
+     * @param nodeAttribute
+     * @param defaultValue
+     * @param node
+     * @param frameworkProject
+     * @param framework
+     * @deprecated use {@link #resolveProperty(String, String, INodeEntry, IRundeckProject, IFramework)}
+     */
+    @Deprecated
+    public static String resolveProperty(
+            final String nodeAttribute,
+            final String defaultValue,
+            final INodeEntry node,
+            final IRundeckProject frameworkProject,
+            final Framework framework
+    )
+    {
+        return resolveProperty(
+                nodeAttribute,
+                defaultValue,
+                node,
+                frameworkProject,
+                (IFramework) framework
+        );
+    }
 
     public static String resolveProperty(
             final String nodeAttribute,
@@ -50,6 +78,28 @@ public class ResolverUtil {
         } else {
             return defaultValue;
         }
+    }
+
+    /**
+     * Resolve a property as an integer, or return the default value
+     *
+     * @param attribute
+     * @param defaultValue
+     * @param iNodeEntry
+     * @param frameworkProject
+     * @param framework
+     * @deprecated use {@link #resolveIntProperty(String, int, INodeEntry, IRundeckProject, IFramework)}
+     */
+    @Deprecated
+    public static int resolveIntProperty(
+            final String attribute,
+            final int defaultValue,
+            final INodeEntry iNodeEntry,
+            final IRundeckProject frameworkProject,
+            final Framework framework
+    )
+    {
+        return resolveIntProperty(attribute, defaultValue, iNodeEntry, frameworkProject, (IFramework) framework);
     }
 
     public static int resolveIntProperty(
@@ -72,6 +122,34 @@ public class ResolverUtil {
         return value;
     }
 
+    /**
+     *
+     * @param attribute
+     * @param defaultValue
+     * @param iNodeEntry
+     * @param frameworkProject
+     * @param framework
+     * @return
+     * @deprecated use {@link #resolveLongProperty(String, long, INodeEntry, IRundeckProject, IFramework)}
+     */
+    @Deprecated
+    public static long resolveLongProperty(
+            final String attribute,
+            final long defaultValue,
+            final INodeEntry iNodeEntry,
+            final IRundeckProject frameworkProject,
+            final Framework framework
+    )
+    {
+        return resolveLongProperty(
+                attribute,
+                defaultValue,
+                iNodeEntry,
+                frameworkProject,
+                (IFramework) framework
+        );
+    }
+
     public static long resolveLongProperty(
             final String attribute,
             final long defaultValue,
@@ -90,6 +168,34 @@ public class ResolverUtil {
             }
         }
         return value;
+    }
+
+    /**
+     *
+     * @param attribute
+     * @param defaultValue
+     * @param iNodeEntry
+     * @param frameworkProject
+     * @param framework
+     * @return
+     * @deprecated use {@link #resolveBooleanProperty(String, boolean, INodeEntry, IRundeckProject, IFramework)}
+     */
+    @Deprecated
+    public static boolean resolveBooleanProperty(
+            final String attribute,
+            final boolean defaultValue,
+            final INodeEntry iNodeEntry,
+            final IRundeckProject frameworkProject,
+            final Framework framework
+    )
+    {
+        return resolveBooleanProperty(
+                attribute,
+                defaultValue,
+                iNodeEntry,
+                frameworkProject,
+                (IFramework) framework
+        );
     }
 
     public static boolean resolveBooleanProperty(

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/utils/ResolverUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/utils/ResolverUtil.java
@@ -16,7 +16,7 @@
 
 package com.dtolabs.rundeck.core.execution.utils;
 
-import com.dtolabs.rundeck.core.common.Framework;
+import com.dtolabs.rundeck.core.common.IFramework;
 import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.common.IRundeckProject;
 
@@ -37,7 +37,7 @@ public class ResolverUtil {
             final String defaultValue,
             final INodeEntry node,
             final IRundeckProject frameworkProject,
-            final Framework framework
+            final IFramework framework
     )
     {
         if (null != node.getAttributes().get(nodeAttribute)) {
@@ -45,8 +45,8 @@ public class ResolverUtil {
         } else if (frameworkProject.hasProperty(PROJ_PROP_PREFIX + nodeAttribute)
                    && !"".equals(frameworkProject.getProperty(PROJ_PROP_PREFIX + nodeAttribute))) {
             return frameworkProject.getProperty(PROJ_PROP_PREFIX + nodeAttribute);
-        } else if (framework.hasProperty(FWK_PROP_PREFIX + nodeAttribute)) {
-            return framework.getProperty(FWK_PROP_PREFIX + nodeAttribute);
+        } else if (framework.getPropertyLookup().hasProperty(FWK_PROP_PREFIX + nodeAttribute)) {
+            return framework.getPropertyLookup().getProperty(FWK_PROP_PREFIX + nodeAttribute);
         } else {
             return defaultValue;
         }
@@ -57,7 +57,7 @@ public class ResolverUtil {
             final int defaultValue,
             final INodeEntry iNodeEntry,
             final IRundeckProject frameworkProject,
-            final Framework framework
+            final IFramework framework
     )
     {
 
@@ -77,7 +77,7 @@ public class ResolverUtil {
             final long defaultValue,
             final INodeEntry iNodeEntry,
             final IRundeckProject frameworkProject,
-            final Framework framework
+            final IFramework framework
     )
     {
 
@@ -97,7 +97,7 @@ public class ResolverUtil {
             final boolean defaultValue,
             final INodeEntry iNodeEntry,
             final IRundeckProject frameworkProject,
-            final Framework framework
+            final IFramework framework
     )
     {
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/WorkflowStrategyService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/WorkflowStrategyService.java
@@ -193,10 +193,12 @@ public class WorkflowStrategyService extends ChainedProviderService<WorkflowStra
         return DescribableServiceUtil.listDescribableProviders(this);
     }
 
+    @Deprecated
     public void registerClass(String name, Class<? extends WorkflowStrategy> clazz) {
         builtinService.registerClass(name, clazz);
     }
 
+    @Deprecated
     public void registerInstance(String name, WorkflowStrategy object) {
         builtinService.registerInstance(name, object);
     }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepExecutionService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/NodeStepExecutionService.java
@@ -209,15 +209,6 @@ public class NodeStepExecutionService
         return serviceList;
     }
 
-    public void registerInstance(final String name, final NodeStepExecutor object) {
-        primaryService.registerInstance(name, object);
-    }
-
-    public void registerClass(final String name, final Class<? extends NodeStepExecutor> clazz) {
-        primaryService.registerClass(name, clazz);
-    }
-
-
     public NodeStepExecutor getExecutorForExecutionItem(final NodeStepExecutionItem item) throws
                                                                                           ExecutionServiceException {
         return providerOfType(item.getNodeStepType());

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractProviderRegistryService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractProviderRegistryService.java
@@ -105,20 +105,28 @@ public abstract class AbstractProviderRegistryService<T>
 
 
     private T createProviderInstanceOfType(final String providerName) throws ExecutionServiceException {
-        if (null == registry.get(providerName)) {
+        if (null == getRegistryMap().get(providerName)) {
             throw new MissingProviderException("Not found", getName(),
                                                providerName
             );
         }
-        final Class<? extends T> execClass = registry.get(providerName);
+        final Class<? extends T> execClass = getRegistryMap().get(providerName);
         return createProviderInstanceFromType(execClass, providerName);
+    }
+
+    /**
+     * Return the map of registered classes
+     * @return the internal map
+     */
+    protected Map<String, Class<? extends T>> getRegistryMap() {
+        return registry;
     }
 
     public List<ProviderIdent> listProviders() {
 
         final HashSet<ProviderIdent> providers = new HashSet<>();
 
-        for (final String s : registry.keySet()) {
+        for (final String s : getRegistryMap().keySet()) {
             providers.add(new ProviderIdent(getName(), s));
         }
         for (final String s : instanceregistry.keySet()) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/IFrameworkProviderRegistryService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/IFrameworkProviderRegistryService.java
@@ -36,7 +36,7 @@ public abstract class IFrameworkProviderRegistryService<T>
         implements ProviderService<T>, ProviderRegistryService<T>
 {
     protected final IFramework framework;
-
+    @Deprecated
     public IFrameworkProviderRegistryService() {
         this((IFramework) null);
     }
@@ -45,7 +45,7 @@ public abstract class IFrameworkProviderRegistryService<T>
         super();
         this.framework = framework;
     }
-
+    @Deprecated
     public IFrameworkProviderRegistryService(final IFramework framework, final boolean cacheInstances) {
         super(cacheInstances);
         this.framework = framework;
@@ -56,6 +56,7 @@ public abstract class IFrameworkProviderRegistryService<T>
         this.framework = framework;
     }
 
+    @Deprecated
     public IFrameworkProviderRegistryService(
             final Map<String, Class<? extends T>> registry,
             final IFramework framework,

--- a/core/src/main/java/com/dtolabs/rundeck/core/utils/ScriptExecUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/utils/ScriptExecUtil.java
@@ -300,7 +300,7 @@ public class ScriptExecUtil {
     }
 
     public static void killProcessHandleDescend(ProcessHandle handle) {
-        handle.descendants().forEach(ScriptExecUtil::killProcessHandleDescend);
+        handle.descendants().forEach(ScriptExecUtil::killProcessHandle);
         handle.destroy();
     }
     public static void killProcessHandle(ProcessHandle handle) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/utils/ScriptExecUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/utils/ScriptExecUtil.java
@@ -292,11 +292,11 @@ public class ScriptExecUtil {
         }
     }
 
-    protected static void killProcessHandleDescend(ProcessHandle handle) {
+    public static void killProcessHandleDescend(ProcessHandle handle) {
         handle.descendants().forEach(ScriptExecUtil::killProcessHandleDescend);
         handle.destroy();
     }
-    protected static void killProcessHandle(ProcessHandle handle) {
+    public static void killProcessHandle(ProcessHandle handle) {
         handle.destroy();
     }
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/utils/ScriptExecUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/utils/ScriptExecUtil.java
@@ -230,6 +230,7 @@ public class ScriptExecUtil {
                 workingdir,
                 outputStream,
                 errorStream,
+                false,
                 ScriptExecUtil::killProcessHandleDescend
         );
     }
@@ -254,11 +255,17 @@ public class ScriptExecUtil {
             final File workingdir,
             final OutputStream outputStream,
             final OutputStream errorStream,
+            boolean clearEnv,
             Consumer<ProcessHandle> killHandler
     )
             throws IOException, InterruptedException {
         final ProcessBuilder processBuilder = new ProcessBuilder().command(command);
-        processBuilder.environment().putAll(envMap);
+
+        final Map<String, String> environment = processBuilder.environment();
+        if(clearEnv) {
+            environment.clear();
+        }
+        environment.putAll(envMap);
 
         final Process exec = processBuilder.start();
         exec.getOutputStream().close();

--- a/core/src/main/java/com/dtolabs/rundeck/core/utils/ScriptExecUtil.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/utils/ScriptExecUtil.java
@@ -257,10 +257,10 @@ public class ScriptExecUtil {
             Consumer<ProcessHandle> killHandler
     )
             throws IOException, InterruptedException {
-        final String[] envarr = createEnvironmentArray(envMap);
+        final ProcessBuilder processBuilder = new ProcessBuilder().command(command);
+        processBuilder.environment().putAll(envMap);
 
-        final Runtime runtime = Runtime.getRuntime();
-        final Process exec = runtime.exec(command, envarr, workingdir);
+        final Process exec = processBuilder.start();
         exec.getOutputStream().close();
         final Streams.StreamCopyThread errthread = Streams.copyStreamThread(exec.getErrorStream(), errorStream);
         final Streams.StreamCopyThread outthread = Streams.copyStreamThread(exec.getInputStream(), outputStream);

--- a/functional-test/build.gradle
+++ b/functional-test/build.gradle
@@ -111,6 +111,16 @@ task pluginBlocklistTest(type: Test){
     description = "Run Plugin Blocklist tests"
 }
 
+task apiTestNewLocal(type: Test){
+    useJUnitPlatform()
+    def featureName='newLocalNodeExecutor'
+    systemProperty("TEST_FEATURE_ENABLED_NAME", featureName)
+    systemProperty('TEST_IMAGE', "rundeck/rundeck:SNAPSHOT")
+    systemProperty("COMPOSE_PATH", "docker/compose/oss/docker-compose.yml")
+    systemProperty('spock.configuration','spock-configs/IncludeAPIExecOutputTestsConfig.groovy')
+    description = "Run Execution Output Tests (test ${featureName} feature)"
+}
+
 task seleniumCoreTest(type: Test){
     useJUnitPlatform()
     systemProperty('TEST_IMAGE', "rundeck/rundeck:SNAPSHOT")

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionOutputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionOutputSpec.groovy
@@ -15,7 +15,7 @@ class ExecutionOutputSpec extends BaseContainer {
     }
 
     def "execution output using lastmod param"() {
-        def params = "exec=echo+testing+execution+output+api1+line+1;sleep+2;echo+line+2;sleep+2;echo+line+3;sleep+2;" +
+        def params = "exec=echo+testing+execution+output+api1+line+1;sleep+1;echo+line+2;sleep+1;echo+line+3;sleep+1;" +
                 "echo+line+4+final"
         when:
         def adhoc = post("/project/${PROJECT_NAME}/run/command?${params}", Map)
@@ -68,7 +68,7 @@ echo line 4 final
     }
 
     def "execution output using maxlines param"() {
-        def params = "exec=echo+testing+execution+output+api1+line+1;sleep+2;echo+line+2;sleep+2;echo+line+3;sleep+2;" +
+        def params = "exec=echo+testing+execution+output+api1+line+1;sleep+1;echo+line+2;sleep+1;echo+line+3;sleep+1;" +
                 "echo+line+4+final"
         when:
         def adhoc = post("/project/${PROJECT_NAME}/run/command?${params}", Map)
@@ -90,7 +90,7 @@ echo line 4 final
     }
 
     def "execution output greedy"() {
-        def params = "exec=echo+testing+execution+output+api1+line+1;sleep+2;echo+line+2;sleep+2;echo+line+3;sleep+2;" +
+        def params = "exec=echo+testing+execution+output+api1+line+1;sleep+1;echo+line+2;sleep+1;echo+line+3;sleep+1;" +
                 "echo+line+4+final"
         when:
         def adhoc = post("/project/${PROJECT_NAME}/run/command?${params}", Map)
@@ -112,7 +112,7 @@ echo line 4 final
     }
 
     def "execution output plain text"() {
-        def params = "exec=echo+testing+execution+output+api1+line+1;sleep+2;echo+line+2;sleep+2;echo+line+3;sleep+2;" +
+        def params = "exec=echo+testing+execution+output+api1+line+1;sleep+1;echo+line+2;sleep+1;echo+line+3;sleep+1;" +
                 "echo+line+4+final"
         when:
         def adhoc = post("/project/${PROJECT_NAME}/run/command?${params}", Map)
@@ -135,7 +135,7 @@ echo line 4 final
 
     @ExcludePro
     def "execution output plain text unicode"() {
-        def params="exec=echo+%22%27testing+execution+%3Coutput%3E+api-unicode+line+1%27%22+;sleep+2;echo+line+%F0%9F%98%84;sleep+2;echo+%E4%BD%A0%E5%A5%BD;sleep+2;echo+line+4+final"
+        def params="exec=echo+%22%27testing+execution+%3Coutput%3E+api-unicode+line+1%27%22+;sleep+1;echo+line+%F0%9F%98%84;sleep+1;echo+%E4%BD%A0%E5%A5%BD;sleep+1;echo+line+4+final"
         when:
         def adhoc = post("/project/${PROJECT_NAME}/run/command?${params}", Map)
         then:
@@ -154,7 +154,7 @@ line 4 final'''
     }
 
     def "execution output plain text using lastlines"() {
-        def params = "exec=echo+testing+execution+output+api1+line+1;sleep+2;echo+line+2;sleep+2;echo+line+3;sleep+2;" +
+        def params = "exec=echo+testing+execution+output+api1+line+1;sleep+1;echo+line+2;sleep+1;echo+line+3;sleep+1;" +
                 "echo+line+4+final"
         when:
         def adhoc = post("/project/${PROJECT_NAME}/run/command?${params}", Map)

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionOutputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionOutputSpec.groovy
@@ -36,6 +36,37 @@ class ExecutionOutputSpec extends BaseContainer {
         ]
     }
 
+    def "execution script output using lastmod param"() {
+        def body=[
+            script:'''#!/bin/bash
+echo testing execution output api1 line 1
+sleep 1
+echo line 2
+echo line 3
+sleep 1
+echo line 4 final
+''',
+            project: PROJECT_NAME
+        ]
+        when:
+        def adhoc = post("/project/${PROJECT_NAME}/run/script?", body, Map)
+        then:
+        adhoc.execution != null
+        adhoc.execution.id != null
+        when:
+        def execid = adhoc.execution.id
+        def logs = getAllLogs(execid) {
+            "offset=${it.offset}&lastmod=${it.lastmod}"
+        }
+        then:
+        logs == [
+                "testing execution output api1 line 1",
+                "line 2",
+                "line 3",
+                "line 4 final"
+        ]
+    }
+
     def "execution output using maxlines param"() {
         def params = "exec=echo+testing+execution+output+api1+line+1;sleep+2;echo+line+2;sleep+2;echo+line+3;sleep+2;" +
                 "echo+line+4+final"

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionOutputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionOutputSpec.groovy
@@ -1,5 +1,6 @@
 package org.rundeck.tests.functional.api.execution
 
+import org.rundeck.util.annotations.APIExecOutputTest
 import org.rundeck.util.annotations.APITest
 import org.rundeck.util.annotations.ExcludePro
 import org.rundeck.util.container.BaseContainer
@@ -7,6 +8,7 @@ import org.rundeck.util.container.BaseContainer
 import java.util.function.Function
 
 @APITest
+@APIExecOutputTest
 class ExecutionOutputSpec extends BaseContainer {
 
     def setupSpec() {

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/integration/BlocklistSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/integration/BlocklistSpec.groovy
@@ -7,7 +7,7 @@ import org.rundeck.util.container.BaseContainer
 class BlocklistSpec extends BaseContainer {
 
 
-    public static final int EXPECTED_PLUGIN_LIST_SIZE = 64
+    public static final int EXPECTED_PLUGIN_LIST_SIZE = 65
     static List<String> BLOCKED_NAMES = [
         'cyberark',
         'openssh',

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/ExecutorSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/ExecutorSpec.groovy
@@ -13,8 +13,8 @@ import java.util.stream.Collectors
 @SeleniumCoreTest
 class ExecutorSpec extends SeleniumBase {
 
-    private static final List<String> availableExecutors = Arrays.asList(new String[] { "SSH", "Local", "SSHJ-SSH", "Script Execution", "Stub", "Ansible Ad-Hoc Node Executor", "WinRM Node Executor Python", "openssh / executor" });
-
+    private static final List<String> availableExecutors = Arrays.asList(new String[] { "SSH", "Local", "Local (New)", "SSHJ-SSH", "Script Execution", "Stub", "Ansible Ad-Hoc Node Executor", "WinRM Node Executor Python", "openssh / executor" });
+    private static final int EXPECTED_EXECUTORS_SIZE = availableExecutors.size()
     /**
      * Checks if the node executor list renders.
      *
@@ -43,7 +43,7 @@ class ExecutorSpec extends SeleniumBase {
         }.collect(Collectors.toList())
 
         then: "We check if the size isn't zero and if the list contains all available node executors"
-        availableExecutors.size() == executorsInProject.size()
+        executorsInProject.size() == EXPECTED_EXECUTORS_SIZE
         availableExecutors.containsAll(executorsToList)
 
         cleanup:

--- a/functional-test/src/test/groovy/org/rundeck/util/annotations/APIExecOutputTest.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/annotations/APIExecOutputTest.groovy
@@ -1,0 +1,11 @@
+package org.rundeck.util.annotations
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Target([ElementType.TYPE, ElementType.METHOD])
+@Retention(RetentionPolicy.RUNTIME)
+@interface APIExecOutputTest {
+}

--- a/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
@@ -59,11 +59,16 @@ abstract class BaseContainer extends Specification implements ClientProvider {
                         "readTimeout", 60,
                 )
 
+                String featureName = System.getProperty("TEST_FEATURE_ENABLED_NAME")
                 log.info("Starting testcontainer: ${getClass().getClassLoader().getResource(System.getProperty("COMPOSE_PATH")).toURI()}")
                 log.info("Starting testcontainer: RUNDECK_IMAGE: ${RdContainer.RUNDECK_IMAGE}")
                 log.info("Starting testcontainer: LICENSE_LOCATION: ${RdContainer.LICENSE_LOCATION}")
                 log.info("Starting testcontainer: TEST_RUNDECK_GRAILS_URL: ${RdContainer.TEST_RUNDECK_GRAILS_URL}")
-                RUNDECK = new RdContainer(getClass().getClassLoader().getResource(System.getProperty("COMPOSE_PATH")).toURI(), clientConfig)
+                RUNDECK = new RdContainer(
+                    getClass().getClassLoader().getResource(System.getProperty("COMPOSE_PATH")).toURI(),
+                    featureName,
+                    clientConfig
+                )
                 RUNDECK.start()
                 CLIENT_PROVIDER = RUNDECK
             }

--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdContainer.groovy
@@ -23,7 +23,12 @@ class RdContainer extends DockerComposeContainer<RdContainer> implements ClientP
 
     private final Map<String, Integer> clientConfig
 
-    RdContainer(URI composeFilePath, Map<String, Integer> clientConfig = Collections.emptyMap()) {
+    /**
+     *
+     * @param composeFilePath
+     * @param featureName an optional feature name to enable
+     */
+    RdContainer(URI composeFilePath, String featureName, Map<String, Integer> clientConfig = Collections.emptyMap()) {
         super(new File(composeFilePath))
         this.clientConfig = clientConfig
         if (CONTEXT_PATH && !CONTEXT_PATH.startsWith('/')) {
@@ -33,6 +38,7 @@ class RdContainer extends DockerComposeContainer<RdContainer> implements ClientP
         withEnv("TEST_IMAGE", RUNDECK_IMAGE)
         withEnv("LICENSE_LOCATION", LICENSE_LOCATION)
         withEnv("TEST_RUNDECK_GRAILS_URL", TEST_RUNDECK_GRAILS_URL)
+        withEnv("TEST_RUNDECK_FEATURE_NAME", featureName ?: 'placeholderFeatureName')
         withLogConsumer(DEFAULT_SERVICE_TO_EXPOSE, new Slf4jLogConsumer(log))
         waitingFor(DEFAULT_SERVICE_TO_EXPOSE,
                 Wait.forHttp("${CONTEXT_PATH}/api/14/system/info")

--- a/functional-test/src/test/resources/docker/compose/oss/docker-compose.yml
+++ b/functional-test/src/test/resources/docker/compose/oss/docker-compose.yml
@@ -11,8 +11,8 @@ services:
       RUNDECK_TOKENS_FILE: /home/rundeck/server/config/tokens.properties
       RUNDECK_MULTIURL_ENABLED: "true"
       RUNDECK_METRICS_ENABLED: "true"
-      RUNDECK_FEATURE_XYZ_ENABLED: "true"
-      RUNDECK_FEATURE_XYZ_NAME: ${TEST_RUNDECK_FEATURE_NAME}
+      RUNDECK_FEATURE_FEATURETOTEST_ENABLED: "true"
+      RUNDECK_FEATURE_FEATURETOTEST_NAME: ${TEST_RUNDECK_FEATURE_NAME}
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
       - "/etc/timezone:/etc/timezone:ro"

--- a/functional-test/src/test/resources/docker/compose/oss/docker-compose.yml
+++ b/functional-test/src/test/resources/docker/compose/oss/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       RUNDECK_TOKENS_FILE: /home/rundeck/server/config/tokens.properties
       RUNDECK_MULTIURL_ENABLED: "true"
       RUNDECK_METRICS_ENABLED: "true"
+      RUNDECK_FEATURE_XYZ_ENABLED: "true"
+      RUNDECK_FEATURE_XYZ_NAME: ${TEST_RUNDECK_FEATURE_NAME}
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
       - "/etc/timezone:/etc/timezone:ro"

--- a/functional-test/src/test/resources/spock-configs/IncludeAPIExecOutputTestsConfig.groovy
+++ b/functional-test/src/test/resources/spock-configs/IncludeAPIExecOutputTestsConfig.groovy
@@ -1,0 +1,5 @@
+import org.rundeck.util.annotations.APIExecOutputTest
+
+runner {
+    include APIExecOutputTest
+}

--- a/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/JschNodeExecutor.java
+++ b/plugins/jsch-plugin/src/main/java/org/rundeck/plugins/jsch/JschNodeExecutor.java
@@ -337,12 +337,12 @@ public class JschNodeExecutor implements NodeExecutor, Describable, ProxyRunnerP
             );
         }
         boolean forceNewPty = ResolverUtil.resolveBooleanProperty(CONFIG_SET_PTY,false,
-                node,context.getFramework().getFrameworkProjectMgr().getFrameworkProject(context.getFrameworkProject()),
-                context.getFramework());
+                node,context.getIFramework().getFrameworkProjectMgr().getFrameworkProject(context.getFrameworkProject()),
+                context.getIFramework());
 
         boolean passEnvVar = ResolverUtil.resolveBooleanProperty(CONFIG_PASS_ENV,false,
-                node,context.getFramework().getFrameworkProjectMgr().getFrameworkProject(context.getFrameworkProject()),
-                context.getFramework());
+                node,context.getIFramework().getFrameworkProjectMgr().getFrameworkProject(context.getFrameworkProject()),
+                context.getIFramework());
 
         final ExecutionListener listener = context.getExecutionListener();
         final Project project = new Project();

--- a/plugins/jsch-plugin/src/test/groovy/org/rundeck/plugins/jsch/JschNodeExecutorSpec.groovy
+++ b/plugins/jsch-plugin/src/test/groovy/org/rundeck/plugins/jsch/JschNodeExecutorSpec.groovy
@@ -22,6 +22,7 @@ import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import com.dtolabs.rundeck.core.common.ProjectManager
 import com.dtolabs.rundeck.core.execution.ExecutionContext
 import com.dtolabs.rundeck.core.execution.ExecutionListener
+import com.dtolabs.rundeck.core.utils.IPropertyLookup
 import org.rundeck.plugins.jsch.util.JschTestUtil
 import spock.lang.Specification
 
@@ -76,10 +77,11 @@ class JschNodeExecutorSpec extends Specification {
         def frameworkProject = Mock(IRundeckProject)
         def context = Mock(ExecutionContext) {
             getFrameworkProject() >> PROJECT_NAME
-            getFramework() >> Mock(Framework){
+            getIFramework() >> Mock(Framework){
                 getFrameworkProjectMgr()>> Mock(ProjectManager){
                     getFrameworkProject(PROJECT_NAME) >> frameworkProject
                 }
+                getPropertyLookup()>>Mock(IPropertyLookup)
             }
             getExecutionListener() >> Mock(ExecutionListener)
         }
@@ -101,15 +103,16 @@ class JschNodeExecutorSpec extends Specification {
         given:
         def exec = new JschNodeExecutor(framework)
         def frameworkProject = Mock(IRundeckProject)
+        def lookup = Mock(IPropertyLookup)
         def framework = Mock(Framework){
             getFrameworkProjectMgr()>> Mock(ProjectManager){
                 getFrameworkProject(PROJECT_NAME) >> frameworkProject
             }
-
+            getPropertyLookup()>>lookup
         }
         def context = Mock(ExecutionContext) {
             getFrameworkProject() >> PROJECT_NAME
-            getFramework() >> framework
+            getIFramework() >> framework
             getExecutionListener() >> Mock(ExecutionListener)
         }
         def command = ['echo', 'hi'].toArray(new String[2])
@@ -122,8 +125,8 @@ class JschNodeExecutorSpec extends Specification {
 
         then:
         1 * frameworkProject.hasProperty(JschNodeExecutor.PROJ_PROP_PREFIX + JschNodeExecutor.CONFIG_PASS_ENV) >> false
-        1 * framework.hasProperty(JschNodeExecutor.FWK_PROP_PREFIX + JschNodeExecutor.CONFIG_PASS_ENV) >> true
-        1 * framework.getProperty(JschNodeExecutor.FWK_PROP_PREFIX + JschNodeExecutor.CONFIG_PASS_ENV) >> 'true'
+        1 * lookup.hasProperty(JschNodeExecutor.FWK_PROP_PREFIX + JschNodeExecutor.CONFIG_PASS_ENV) >> true
+        1 * lookup.getProperty(JschNodeExecutor.FWK_PROP_PREFIX + JschNodeExecutor.CONFIG_PASS_ENV) >> 'true'
 
     }
 }

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -25,7 +25,9 @@ import com.dtolabs.rundeck.app.internal.framework.ConfigFrameworkPropertyLookupF
 import com.dtolabs.rundeck.app.config.RundeckConfig
 import com.dtolabs.rundeck.app.internal.framework.FrameworkPropertyLookupFactory
 import com.dtolabs.rundeck.app.internal.framework.NodeExecutorServiceFactory
+import com.dtolabs.rundeck.app.internal.framework.FeatureToggleNodeExecutorProfile
 import com.dtolabs.rundeck.app.internal.framework.RundeckFrameworkFactory
+import com.dtolabs.rundeck.app.internal.framework.RundeckNodeExecutorProfile
 import com.dtolabs.rundeck.app.tree.DelegateStorageTree
 import com.dtolabs.rundeck.app.tree.RundeckBootstrapStorageTreeUpdater
 import com.dtolabs.rundeck.app.tree.JasyptEncryptionEnforcerUpdaterConfig
@@ -42,6 +44,9 @@ import com.dtolabs.rundeck.core.common.FrameworkExecutionProviderServices
 import com.dtolabs.rundeck.core.common.FrameworkFactory
 import com.dtolabs.rundeck.core.common.NodeSupport
 import com.dtolabs.rundeck.core.common.ServiceSupport
+import com.dtolabs.rundeck.core.config.Features
+import com.dtolabs.rundeck.core.execution.impl.local.LocalNodeExecutor
+import com.dtolabs.rundeck.core.execution.impl.local.NewLocalNodeExecutor
 import com.dtolabs.rundeck.core.execution.logstorage.ExecutionFileManagerService
 import com.dtolabs.rundeck.core.execution.ExecutionServiceImpl
 import com.dtolabs.rundeck.core.execution.service.NodeSpecifiedPlugins
@@ -304,6 +309,28 @@ beans={
         projectManager = ref('projectManagerService')
         frameworkNodes = ref('rundeckNodeSupport')
         nodeExecutorService = ref('rundeckNodeExecutorService')
+    }
+    rundeckBaseNodeExecutorProfile(RundeckNodeExecutorProfile){
+        defaultLocalProvider = LocalNodeExecutor.SERVICE_PROVIDER_TYPE
+        defaultRemoteProvider = "sshj-ssh"
+        localRegistry = [
+                (LocalNodeExecutor.SERVICE_PROVIDER_TYPE): LocalNodeExecutor,
+                (NewLocalNodeExecutor.SERVICE_PROVIDER_TYPE): NewLocalNodeExecutor,
+        ]
+    }
+    rundeckNewLocalNodeExecutorProfile(RundeckNodeExecutorProfile){
+        defaultLocalProvider = NewLocalNodeExecutor.SERVICE_PROVIDER_TYPE
+        defaultRemoteProvider = "sshj-ssh"
+        localRegistry = [
+            (LocalNodeExecutor.SERVICE_PROVIDER_TYPE): LocalNodeExecutor,
+            (NewLocalNodeExecutor.SERVICE_PROVIDER_TYPE): NewLocalNodeExecutor,
+        ]
+    }
+    rundeckNodeExecutorProfile(FeatureToggleNodeExecutorProfile){
+        baseProfile = ref('rundeckBaseNodeExecutorProfile')
+        toggleProfile = ref('rundeckNewLocalNodeExecutorProfile')
+        featureService = ref('featureService')
+        feature = Features.NEW_LOCAL_NODE_EXECUTOR
     }
     rundeckNodeExecutorService(NodeExecutorServiceFactory)
     rundeckBaseFrameworkExecutionServices(BaseFrameworkExecutionServices){

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -24,6 +24,7 @@ import com.dtolabs.rundeck.app.gui.UserSummaryMenuItem
 import com.dtolabs.rundeck.app.internal.framework.ConfigFrameworkPropertyLookupFactory
 import com.dtolabs.rundeck.app.config.RundeckConfig
 import com.dtolabs.rundeck.app.internal.framework.FrameworkPropertyLookupFactory
+import com.dtolabs.rundeck.app.internal.framework.NodeExecutorServiceFactory
 import com.dtolabs.rundeck.app.internal.framework.RundeckFrameworkFactory
 import com.dtolabs.rundeck.app.tree.DelegateStorageTree
 import com.dtolabs.rundeck.app.tree.RundeckBootstrapStorageTreeUpdater
@@ -302,9 +303,12 @@ beans={
     rundeckNodeSpecifiedProviderNames(NodeSpecifiedPlugins){
         projectManager = ref('projectManagerService')
         frameworkNodes = ref('rundeckNodeSupport')
+        nodeExecutorService = ref('rundeckNodeExecutorService')
     }
+    rundeckNodeExecutorService(NodeExecutorServiceFactory)
     rundeckBaseFrameworkExecutionServices(BaseFrameworkExecutionServices){
         framework = ref('rundeckFramework')
+        nodeExecutorService = ref('rundeckNodeExecutorService')
     }
     rundeckBaseFrameworkExecutionProviders(BaseFrameworkExecutionProviders){
         executionServices = ref('rundeckBaseFrameworkExecutionServices')

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/framework/FeatureToggleNodeExecutorProfile.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/framework/FeatureToggleNodeExecutorProfile.groovy
@@ -1,0 +1,38 @@
+package com.dtolabs.rundeck.app.internal.framework
+
+import com.dtolabs.rundeck.core.config.FeatureService
+import com.dtolabs.rundeck.core.config.FeaturesDefinition
+import com.dtolabs.rundeck.core.execution.service.NodeExecutorServiceProfile
+import groovy.transform.CompileStatic
+import org.springframework.beans.factory.annotation.Autowired
+
+/**
+ * Switches between two profiles based on the presence of a feature
+ */
+@CompileStatic
+class FeatureToggleNodeExecutorProfile implements NodeExecutorServiceProfile {
+    /**
+     * Base profile
+     */
+    NodeExecutorServiceProfile baseProfile
+    /**
+     * Profile to use when feature is present
+     */
+    NodeExecutorServiceProfile toggleProfile
+    /**
+     * Feature to check for
+     */
+    FeaturesDefinition feature
+
+    @Autowired
+    FeatureService featureService
+
+    @Delegate
+    NodeExecutorServiceProfile getDelegate() {
+        if (featureService.featurePresent(feature)) {
+            return toggleProfile
+        } else {
+            return baseProfile
+        }
+    }
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/framework/NodeExecutorServiceFactory.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/framework/NodeExecutorServiceFactory.groovy
@@ -1,13 +1,12 @@
 package com.dtolabs.rundeck.app.internal.framework
 
 import com.dtolabs.rundeck.core.common.Framework
-import com.dtolabs.rundeck.core.config.FeatureService
 import com.dtolabs.rundeck.core.execution.service.NodeExecutorService
+import com.dtolabs.rundeck.core.execution.service.NodeExecutorServiceProfile
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.FactoryBean
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Lazy
-
 /**
  * Factory to create NodeExecutorService, required to lazily load injection dependencies
  */
@@ -15,12 +14,12 @@ import org.springframework.context.annotation.Lazy
 class NodeExecutorServiceFactory implements FactoryBean<NodeExecutorService> {
     @Autowired @Lazy
     Framework rundeckFramework
-    @Autowired @Lazy
-    FeatureService featureService
+    @Autowired
+    NodeExecutorServiceProfile rundeckNodeExecutorProfile
 
     @Override
     NodeExecutorService getObject() throws Exception {
-        return new NodeExecutorService(rundeckFramework, featureService)
+        return new NodeExecutorService(rundeckFramework, rundeckNodeExecutorProfile)
     }
     Class<?> objectType = NodeExecutorService
 }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/framework/NodeExecutorServiceFactory.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/framework/NodeExecutorServiceFactory.groovy
@@ -1,0 +1,26 @@
+package com.dtolabs.rundeck.app.internal.framework
+
+import com.dtolabs.rundeck.core.common.Framework
+import com.dtolabs.rundeck.core.config.FeatureService
+import com.dtolabs.rundeck.core.execution.service.NodeExecutorService
+import groovy.transform.CompileStatic
+import org.springframework.beans.factory.FactoryBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Lazy
+
+/**
+ * Factory to create NodeExecutorService, required to lazily load injection dependencies
+ */
+@CompileStatic
+class NodeExecutorServiceFactory implements FactoryBean<NodeExecutorService> {
+    @Autowired @Lazy
+    Framework rundeckFramework
+    @Autowired @Lazy
+    FeatureService featureService
+
+    @Override
+    NodeExecutorService getObject() throws Exception {
+        return new NodeExecutorService(rundeckFramework, featureService)
+    }
+    Class<?> objectType = NodeExecutorService
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/framework/RundeckNodeExecutorProfile.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/framework/RundeckNodeExecutorProfile.groovy
@@ -1,0 +1,15 @@
+package com.dtolabs.rundeck.app.internal.framework
+
+import com.dtolabs.rundeck.core.execution.service.NodeExecutor
+import com.dtolabs.rundeck.core.execution.service.NodeExecutorServiceProfile
+import groovy.transform.CompileStatic
+
+/**
+ * Bean class for NodeExecutorServiceProfile
+ */
+@CompileStatic
+class RundeckNodeExecutorProfile implements NodeExecutorServiceProfile {
+    String defaultLocalProvider
+    String defaultRemoteProvider
+    Map<String, Class<? extends NodeExecutor>> localRegistry
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/AppExecutionPluginLoader.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/AppExecutionPluginLoader.groovy
@@ -122,9 +122,6 @@ class AppExecutionPluginLoader implements IExecutionProviders, ApplicationContex
         throws ExecutionServiceException {
         String provider = nodeProviderName.getProviderNameForNodeAndProject(node, context.getFrameworkProject(), NodeExecutor)
 
-        if (NodeExecutorService.isRegistered(provider)) {
-            return frameworkProviders.getNodeExecutorForNodeAndProject(node,context);
-        }
 
         def configured = pluginService.configurePlugin(provider, [:], context.getFrameworkProject(), framework, NodeExecutor)
         if (null == configured) {


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Updates the “newlocal” node executor, to work as a drop in replacement for the old “local” node executor

- Execution context (env vars) and all log output should match the previous implementation
- It has the benefit of being able to kill child processes when the local process finishes
- It introduces an experimental flag to disable env var inheritance from the server process


**Describe the solution you've implemented**


Make some behind the scenes changes to enable a feature flag that can make the “newlocal” the default local executor

`rundeck.feature.newLocalNodeExecutor.enabled=true` will set it as the default local executor

Add a new functional test step in the CircleCI workflow was added “Test Feature NewLocalExec”

This runs the same “ExecutionOutputSpec” but with the newLocalNodeExecutor feature flag enabled, to validate the output is the same

.. if there are some other functional tests that use local node executor in specific ways, we can enable those tests with this feature flag as well

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
