### PR TITLE
RUN-2540: Webpack fix for assets urls inside css files

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -474,6 +474,10 @@ task copySpa(type: Copy) {
         include('provided/**')
     }
     into "$projectDir/grails-app/assets"
+    from(configurations.spa){
+        include('fonts/**', 'img/**')
+        into('provided/static')
+    }
     outputs.dir "$projectDir/grails-app/assets/provided"
 }
 assetPluginPackage.dependsOn copySpa

--- a/rundeckapp/grails-spa/packages/ui-trellis/vue.config.app.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/vue.config.app.js
@@ -58,12 +58,16 @@ module.exports = {
     "pages/nodes": { entry: "./src/app/pages/nodes/main.ts" },
     "pages/job/browse": { entry: "./src/app/pages/job/browse/main.ts" },
     "pages/home": { entry: "./src/app/pages/home/main.ts" },
-    "pages/job/head/scm-action-buttons": { entry: './src/app/pages/job/head/scm/scm-action-buttons.ts'},
-    "pages/job/head/scm-status-badge": { entry: './src/app/pages/job/head/scm/scm-status-badge.ts'}
+    "pages/job/head/scm-action-buttons": {
+      entry: "./src/app/pages/job/head/scm/scm-action-buttons.ts",
+    },
+    "pages/job/head/scm-status-badge": {
+      entry: "./src/app/pages/job/head/scm/scm-status-badge.ts",
+    },
   },
 
   outputDir: process.env.VUE_APP_OUTPUT_DIR,
-  publicPath: "/assets/static/",
+  publicPath: "./assets/static/",
   filenameHashing: false,
   parallel: true,
   css: {

--- a/rundeckapp/grails-spa/packages/ui-trellis/vue.config.app.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/vue.config.app.js
@@ -58,8 +58,12 @@ module.exports = {
     "pages/nodes": { entry: "./src/app/pages/nodes/main.ts" },
     "pages/job/browse": { entry: "./src/app/pages/job/browse/main.ts" },
     "pages/home": { entry: "./src/app/pages/home/main.ts" },
-    "pages/job/head/scm-action-buttons": { entry: './src/app/pages/job/head/scm/scm-action-buttons.ts'},
-    "pages/job/head/scm-status-badge": { entry: './src/app/pages/job/head/scm/scm-status-badge.ts'}
+    "pages/job/head/scm-action-buttons": {
+      entry: "./src/app/pages/job/head/scm/scm-action-buttons.ts",
+    },
+    "pages/job/head/scm-status-badge": {
+      entry: "./src/app/pages/job/head/scm/scm-status-badge.ts",
+    },
   },
 
   outputDir: process.env.VUE_APP_OUTPUT_DIR,
@@ -78,6 +82,11 @@ module.exports = {
             chunkFilename: "./css/[name].css",
           }
         : false,
+    loaderOptions: {
+      css: {
+        url: false,
+      },
+    },
   },
   chainWebpack: (config) => {
     /** Do not create index pages for entry points */

--- a/rundeckapp/grails-spa/packages/ui-trellis/vue.config.app.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/vue.config.app.js
@@ -67,7 +67,8 @@ module.exports = {
   },
 
   outputDir: process.env.VUE_APP_OUTPUT_DIR,
-  publicPath: "./assets/static/",
+  publicPath: "auto",
+  assetsDir: "../../",
   filenameHashing: false,
   parallel: true,
   css: {

--- a/rundeckapp/grails-spa/packages/ui-trellis/vue.config.app.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/vue.config.app.js
@@ -58,12 +58,8 @@ module.exports = {
     "pages/nodes": { entry: "./src/app/pages/nodes/main.ts" },
     "pages/job/browse": { entry: "./src/app/pages/job/browse/main.ts" },
     "pages/home": { entry: "./src/app/pages/home/main.ts" },
-    "pages/job/head/scm-action-buttons": {
-      entry: "./src/app/pages/job/head/scm/scm-action-buttons.ts",
-    },
-    "pages/job/head/scm-status-badge": {
-      entry: "./src/app/pages/job/head/scm/scm-status-badge.ts",
-    },
+    "pages/job/head/scm-action-buttons": { entry: './src/app/pages/job/head/scm/scm-action-buttons.ts'},
+    "pages/job/head/scm-status-badge": { entry: './src/app/pages/job/head/scm/scm-status-badge.ts'}
   },
 
   outputDir: process.env.VUE_APP_OUTPUT_DIR,
@@ -82,11 +78,6 @@ module.exports = {
             chunkFilename: "./css/[name].css",
           }
         : false,
-    loaderOptions: {
-      css: {
-        url: false,
-      },
-    },
   },
   chainWebpack: (config) => {
     /** Do not create index pages for entry points */

--- a/rundeckapp/grails-spa/packages/ui-trellis/vue.config.library.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/vue.config.library.js
@@ -45,11 +45,6 @@ module.exports = {
   parallel: true,
   css: {
     extract: false,
-    loaderOptions: {
-      css: {
-        url: false,
-      },
-    },
   },
   /** Don't emit index html files */
   chainWebpack: (config) => {

--- a/rundeckapp/grails-spa/packages/ui-trellis/vue.config.library.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/vue.config.library.js
@@ -45,6 +45,11 @@ module.exports = {
   parallel: true,
   css: {
     extract: false,
+    loaderOptions: {
+      css: {
+        url: false,
+      },
+    },
   },
   /** Don't emit index html files */
   chainWebpack: (config) => {


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

Bugfix - fixes assets' URLs in CSS files.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

TLDR; webpack 5 changed how it bundles things and resolve URLs, preferring to use asset modules/asset management in prol of loaders, while vue-cli still leverages them, which makes it hard to adjust things.
Therefore the best solution was to follow the advice of one of the maintainers of leaving the publicPath as auto and change other things instead (github.com/webpack/webpack/discussions/17290)

Some other relevant links:
https://github.com/webpack/webpack/issues/15499
https://github.com/webpack-contrib/css-loader/issues/256

How to test:
run project with:
docker run -d -P -p 4441:4440 -e RUNDECK_SERVER_ADDRESS=0.0.0.0 -e RUNDECK_GRAILS_URL=http://localhost:4441/rundeckpro -e RUNDECK_SERVER_CONTEXTPATH=/rundeckpro rundeckpro/ci:webpack-css-fix

and check if there are any 404 for images and/or fonts.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
Considered to completely remove loaders;
Considered to adjust gradle scripts to move files around to replicate the new paths;
Also tried to adjust the public path in all possible ways I could think of (absolute path, relative path)

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

Somehow hashing isn't being added correctly by gradle. But didn't want to enable it on the webpack side. Besides the hashing, matches 5.3 imports:

![image](https://github.com/rundeck/rundeck/assets/139791797/0656ed55-b37e-4477-a676-0b76930f2aca)
