### PR TITLE
RUN-2333: qaf migration

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/api/scm/GitScmApiClient.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/api/scm/GitScmApiClient.groovy
@@ -26,6 +26,10 @@ class GitScmApiClient {
         this.client = clientProvider.client
     }
 
+    GitScmApiClient(RdClient client){
+        this.client = client
+    }
+
     GitScmApiClient forIntegration(ScmIntegration integration){
         this.integration = integration.name
         this.pluginName = "git-${integration.name}"

--- a/functional-test/src/test/groovy/org/rundeck/util/api/scm/httpbody/GitExportSetupRequest.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/api/scm/httpbody/GitExportSetupRequest.groovy
@@ -35,6 +35,12 @@ class GitExportSetupRequest {
         @JsonProperty
         String gitPasswordPath
 
+        @JsonProperty
+        String apiToken
+
+        @JsonProperty
+        String project
+
         Map toMap(){
             return [
                     dir: dir,

--- a/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
@@ -25,19 +25,20 @@ abstract class BaseContainer extends Specification implements ClientProvider {
     private static final Object LOCK = new Object()
     private static ClientProvider CLIENT_PROVIDER
     private static final String DEFAULT_DOCKERFILE_LOCATION = System.getenv("DEFAULT_DOCKERFILE_LOCATION") ?: System.getProperty("DEFAULT_DOCKERFILE_LOCATION")
+    private static final String TEST_RUNDECK_URL = System.getenv("TEST_RUNDECK_URL")?: System.getProperty("TEST_RUNDECK_URL")
 
     ClientProvider getClientProvider() {
-        if (System.getenv("TEST_RUNDECK_URL") != null) {
+        if (TEST_RUNDECK_URL != null) {
             if (CLIENT_PROVIDER == null) {
                 CLIENT_PROVIDER = new ClientProvider() {
                     @Override
                     RdClient getClient() {
-                        return RdClient.create(System.getenv("TEST_RUNDECK_URL"), System.getenv("TEST_RUNDECK_TOKEN"))
+                        return RdClient.create(TEST_RUNDECK_URL, System.getenv("TEST_RUNDECK_TOKEN"))
                     }
 
                     @Override
                     RdClient clientWithToken(String token) {
-                        return RdClient.create(System.getenv("TEST_RUNDECK_URL"), token)
+                        return RdClient.create(TEST_RUNDECK_URL, token)
                     }
                 }
             }

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/BasePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/BasePage.groovy
@@ -222,4 +222,8 @@ abstract class BasePage {
             ExpectedConditions.invisibilityOf(element)
         }
     }
+
+    List<WebElement> findElementsByXpath(String xpath){
+        return driver.findElements(By.xpath(xpath))
+    }
 }


### PR DESCRIPTION
This changes allow the scm replication plugin (PRO), to perform scm operations via API