### PR TITLE
RUN-2308: Use release/5.3.x branch of packaging repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "packaging/packaging"]
 	path = packaging/packaging
 	url = git@github.com:rundeck/packaging.git
-	branch = main
+	branch = release/5.3.x
 


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Update release/5.3.x branch to point at correct branch in packaging repo

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
