### PR TITLE
RUN-2554: Restores Tomcat JDBC pool.

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -254,6 +254,7 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql:42.7.2'
     runtimeOnly 'org.rundeck.hibernate:rundeck-oracle-dialect:1.0.0'
 
+    runtimeOnly "org.apache.tomcat:tomcat-jdbc:9.0.89"
     runtimeOnly "org.springframework:spring-jcl:${springVersion}"
     runtimeOnly "org.codehaus.groovy:groovy-dateutil:${groovyVersion}"
     api ("com.bertramlabs.plugins:asset-pipeline-grails:$assetPluginVersion")


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
During the upgrade to Grails 6.1.2 (PR https://github.com/rundeck/rundeck/pull/9068) the `org.apache.tomcat:tomcat-jdbc` runtime dependency was removed by a developer thinking it was unused.

It turns out that the `tomcat-jdbc` pool was detected and configured by Spring's auto-configuration. The removal of this dependency changed the primary DataSource used by the job scheduler from `tomcat-jdbc` to `HikariCP` (which has a different default configuration).

This PR restores the `tomcat-jdbc` pool and upgrades the minor version.

**Describe the solution you've implemented**
Restores the `tomcat-jdbc` pool as the primary `DataSource` used by the application.

**Describe alternatives you've considered**
We considered rolling forward with the `HikariCP` connection pool (a change that might be nice in the future) but we would prefer to do that in a controlled way in the future.

**Additional context**
I have verified that this change restores the `org.apache.tomcat.jdbc.pool.DataSource` and fixes some issues we were observing with the primary connection pool.
