### PR TITLE
RUN-2159: new methods for projectComponent interface

### DIFF
--- a/core/src/main/java/org/rundeck/app/components/project/ProjectComponent.java
+++ b/core/src/main/java/org/rundeck/app/components/project/ProjectComponent.java
@@ -37,4 +37,12 @@ public interface ProjectComponent
     default void projectDeleted(String name) throws Exception{
 
     }
+
+    default boolean isComponentEnabled(){
+        return true;
+    }
+
+    default void afterProjectCreate(String name) throws Exception{
+
+    }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -102,6 +102,7 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService, F
     RemoteJsonOptionRetriever remoteJsonOptionRetriever
     WorkflowExecutionItemFactory workflowExecutionItemFactory
     ReferencedExecutionDataProvider referencedExecutionDataProvider
+    ProjectService projectService
 
     String getRundeckBase(){
         return rundeckFramework.baseDir.absolutePath
@@ -485,7 +486,7 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService, F
     /**
      * Create a new project
      * @param project name
-     * @param properties config properties
+     * @param properties config propertiescreateFrameworkProject
      * @return [project, [error list]]
      */
     def createFrameworkProject(String project, Properties properties){
@@ -500,6 +501,15 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService, F
             log.error(e.message,e)
             errors << e.getMessage()
         }
+
+        //initialize project components after  project creation
+        try{
+            projectService?.afterCreationProjectComponents(project)
+        }catch (Exception e){
+            log.error("Error initializing project components: ${e.message}",e)
+            errors << "Error initializing project components: ${e.message}"
+        }
+
         [proj,errors]
     }
     /**

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -486,7 +486,7 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService, F
     /**
      * Create a new project
      * @param project name
-     * @param properties config propertiescreateFrameworkProject
+     * @param properties config properties
      * @return [project, [error list]]
      */
     def createFrameworkProject(String project, Properties properties){

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectService.groovy
@@ -1462,9 +1462,23 @@ class ProjectService implements InitializingBean, ExecutionFileProducer, EventPu
         def types = componentBeanProvider.getBeans()
         Map<String, ProjectComponent> values = [:]
         types.each { k, v ->
-            values[v.name] = v
+            if(v.componentEnabled){
+                values[v.name] = v
+            }
         }
         values
+    }
+
+    //Call project component after the project was created
+    @CompileStatic
+    void afterCreationProjectComponents(String project){
+        getProjectComponents().each {key, component->
+            try{
+                component.afterProjectCreate(project)
+            }catch (Exception e){
+                log.error("error afterProjectCreate component ${key}: ${e.message}")
+            }
+        }
     }
 
     @CompileStatic

--- a/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
@@ -1023,6 +1023,27 @@ class FrameworkServiceSpec extends Specification implements ServiceUnitTest<Fram
             ['z', 'y', 'x'] | ['z',]          | ['z']           | ['z Label']
     }
 
+    def "test after project creation projectComponent "(){
+        given:
+        def manager = Mock(ProjectManager)
+
+
+        def project="testProject"
+        Properties properties = new Properties()
+        service.projectService = Mock(ProjectService)
+
+        when:
+        service.rundeckFramework = Mock(Framework) {
+            getFrameworkProjectMgr() >> manager
+        }
+
+        service.createFrameworkProject(project,properties)
+
+        then:
+        1* manager.createFrameworkProjectStrict(_,_)
+        1* service.projectService.afterCreationProjectComponents(project)
+    }
+
     class MockScheduledExecutionService{
         def workflows = []
         def rescheduleJobs(String uuuid, String project){

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectServiceSpec.groovy
@@ -468,9 +468,11 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
         given:
         ProjectComponent component1 = Mock(ProjectComponent){
             getName()>>'comp1'
+            isComponentEnabled() >> true
         }
         ProjectComponent component2 = Mock(ProjectComponent){
             getName()>>'comp2'
+            isComponentEnabled() >> true
         }
         service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
             Map<String, ProjectComponent> beans = [comp1: component1,comp2:component2]
@@ -819,6 +821,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
         ProjectComponent component = Mock(ProjectComponent){
             getName()>>'webhooks'
             getImportFilePatterns()>>['webhooks.yaml']
+            isComponentEnabled() >> true
         }
             service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
                 Map<String, ProjectComponent> beans = [webhooks: component]
@@ -885,6 +888,7 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
             ProjectComponent component = Mock(ProjectComponent) {
                 getName() >> 'webhooks'
                 getImportFilePatterns() >> ['webhooks.yaml']
+                isComponentEnabled() >> true
             }
             service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
                 Map<String, ProjectComponent> beans = [webhooks: component]
@@ -948,7 +952,9 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
 
     def "import project archive with component with matching pattern"() {
         setup:
-            ProjectComponent component = Mock(ProjectComponent)
+            ProjectComponent component = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
             service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
                 Map<String, ProjectComponent> beans = [test1: component]
             }
@@ -1006,8 +1012,12 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
     @Unroll
     def "import project archive with component ordering"() {
 
-            ProjectComponent component = Mock(ProjectComponent)
-            ProjectComponent component2 = Mock(ProjectComponent)
+            ProjectComponent component = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
+            ProjectComponent component2 = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
             service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
                 Map<String, ProjectComponent> beans = [bean1: component, bean2: component2]
             }
@@ -1098,7 +1108,9 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
     }
     def "import project archive with importComponent option false"() {
         setup:
-            ProjectComponent component = Mock(ProjectComponent)
+            ProjectComponent component = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
             service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
                 Map<String, ProjectComponent> beans = [test1: component]
             }
@@ -1154,7 +1166,9 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
     }
     def "import project archive with component unauthorized"() {
         setup:
-            ProjectComponent component = Mock(ProjectComponent)
+            ProjectComponent component = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
             service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
                 Map<String, ProjectComponent> beans = [test1: component]
             }
@@ -1213,7 +1227,9 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
     @Unroll
     def "import project archive with component with matching pattern #pattern"() {
         setup:
-            ProjectComponent component = Mock(ProjectComponent)
+            ProjectComponent component = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
             service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
                 Map<String, ProjectComponent> beans = [test1: component]
             }
@@ -1391,7 +1407,9 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
     }
     def "component export project to stream"() {
         given:
-            ProjectComponent component = Mock(ProjectComponent)
+            ProjectComponent component = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
             component.getName() >> 'test1'
             service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
                 Map<String, ProjectComponent> beans = [test1: component]
@@ -1425,8 +1443,12 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
     @Unroll
     def "export project with components ordered"() {
         given:
-            ProjectComponent component = Mock(ProjectComponent)
-            ProjectComponent component2 = Mock(ProjectComponent)
+            ProjectComponent component = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
+            ProjectComponent component2 = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
 
             service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
                 Map<String, ProjectComponent> beans = [test1: component,test2:component2]
@@ -1485,9 +1507,15 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
     @Unroll
     def "export project with components ordered cyclic"() {
         given:
-            ProjectComponent component = Mock(ProjectComponent)
-            ProjectComponent component2 = Mock(ProjectComponent)
-            ProjectComponent component3 = Mock(ProjectComponent)
+            ProjectComponent component = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
+            ProjectComponent component2 = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
+            ProjectComponent component3 = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
 
             service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
                 Map<String, ProjectComponent> beans = [test1: component, test2: component2, test3: component3]
@@ -1544,7 +1572,9 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
 
     def "export project to stream optional component no components specified"() {
         given:
-            ProjectComponent component = Mock(ProjectComponent)
+            ProjectComponent component = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
             component.getName() >> 'test1'
             component.isExportOptional() >> true
             service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
@@ -1577,7 +1607,9 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
     @Unroll
     def "component export project to stream when authorized #authorized"() {
         given:
-            ProjectComponent component = Mock(ProjectComponent)
+            ProjectComponent component = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
             component.getName() >> 'test1'
             component.getExportAuthRequiredActions() >> ['a', 'b']
             service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
@@ -1657,7 +1689,9 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
     @Unroll
     def "component export project to stream optional"() {
         given:
-            ProjectComponent component = Mock(ProjectComponent)
+            ProjectComponent component = Mock(ProjectComponent){
+                isComponentEnabled() >> true
+            }
             component.getName() >> 'test1'
             component.isExportOptional() >> exportOptional
             service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
@@ -3267,6 +3301,78 @@ class ProjectServiceSpec extends Specification implements ServiceUnitTest<Projec
         then:
         created
 
+    }
+
+    def "call afterProjectCreate of projectComponents"() {
+        given:
+        ProjectComponent component1 = Mock(ProjectComponent){
+            getName()>>'comp1'
+            isComponentEnabled() >> true
+        }
+        ProjectComponent component2 = Mock(ProjectComponent){
+            getName()>>'comp2'
+            isComponentEnabled() >> true
+        }
+        service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
+            Map<String, ProjectComponent> beans = [comp1: component1,comp2:component2]
+        }
+
+        def project = Mock(IRundeckProject) {
+            getName() >> 'myproject'
+        }
+        service.scmService = Mock(ScmService)
+        service.executionService = Mock(ExecutionService)
+        service.fileUploadService = Mock(FileUploadService)
+        service.targetEventBus = Mock(EventBus)
+
+        def prjMgr = Mock(ProjectManager) {
+            removeFrameworkProject(_) >> {}
+        }
+        def fwk = Mock(Framework) {
+            getFrameworkProjectMgr() >> { prjMgr }
+        }
+
+        when:
+        service.afterCreationProjectComponents("myproject")
+
+        then:
+        1 * component1.afterProjectCreate('myproject')
+        1 * component2.afterProjectCreate('myproject')
+    }
+
+
+    def "don't load project componets marked as disabled"() {
+        given:
+        ProjectComponent component1 = Mock(ProjectComponent){
+            getName()>>'comp1'
+            isComponentEnabled() >> true
+        }
+        ProjectComponent component2 = Mock(ProjectComponent){
+            getName()>>'comp2'
+            isComponentEnabled() >> false
+        }
+        service.componentBeanProvider=new ProjectService.BeanProvider<ProjectComponent>() {
+            Map<String, ProjectComponent> beans = [comp1: component1,comp2:component2]
+        }
+
+        service.scmService = Mock(ScmService)
+        service.executionService = Mock(ExecutionService)
+        service.fileUploadService = Mock(FileUploadService)
+        service.targetEventBus = Mock(EventBus)
+
+        def prjMgr = Mock(ProjectManager) {
+            removeFrameworkProject(_) >> {}
+        }
+        def fwk = Mock(Framework) {
+            getFrameworkProjectMgr() >> { prjMgr }
+        }
+
+        when:
+        service.afterCreationProjectComponents("myproject")
+
+        then:
+        1 * component1.afterProjectCreate('myproject')
+        0 * component2.afterProjectCreate('myproject')
     }
 }
 


### PR DESCRIPTION

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Enhancement
- Add a mechanism to disable project component 
- Add a mechanism to call a method in project components after the project is created (using API or GUI)


**Describe the solution you've implemented**

- new methods for `projectComponent` interface to check if the component is enabled and after-project-creation mechanisms
- call after-project-creation method of `projectComponent` after the project is created (using API or the GUI)

**Describe alternatives you've considered**

**Additional context**
