### PR TITLE
RUN-2544 Fix: Main docs link goes to 404

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/login/BasicLoginSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/login/BasicLoginSpec.groovy
@@ -1,5 +1,6 @@
 package org.rundeck.tests.functional.selenium.login
 
+import org.openqa.selenium.support.ui.WebDriverWait
 import org.rundeck.util.gui.pages.TopMenuPage
 import org.rundeck.util.gui.pages.login.LoginPage
 
@@ -92,4 +93,13 @@ class BasicLoginSpec extends SeleniumBase {
         topMenuPage.logOut()
     }
 
+    def "visits help link"(){
+        when:
+        def loginPage = go LoginPage
+        loginPage.getHelpLink().click()
+        loginPage.waitForUrlToContain("/about/getting-help.html")
+
+        then:
+        loginPage.waitForElementVisible(By.id("getting-help"))
+    }
 }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/login/BasicLoginSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/login/BasicLoginSpec.groovy
@@ -1,5 +1,6 @@
 package org.rundeck.tests.functional.selenium.login
 
+import org.openqa.selenium.By
 import org.openqa.selenium.support.ui.WebDriverWait
 import org.rundeck.util.gui.pages.TopMenuPage
 import org.rundeck.util.gui.pages.login.LoginPage
@@ -93,13 +94,14 @@ class BasicLoginSpec extends SeleniumBase {
         topMenuPage.logOut()
     }
 
-    def "visits help link"(){
+    def "visits help link from login page"(){
         when:
         def loginPage = go LoginPage
+        loginPage.executeScript("arguments[0].setAttribute('target', '_self');", loginPage.getHelpLink())
         loginPage.getHelpLink().click()
-        loginPage.waitForUrlToContain("/about/getting-help.html")
 
         then:
-        loginPage.waitForElementVisible(By.id("getting-help"))
+        loginPage.waitForUrlToContain("/about/getting-help.html")
+        loginPage.waitForElementVisible(By.xpath("//h1[text()='Getting Help']"))
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/login/LoginPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/login/LoginPage.groovy
@@ -16,17 +16,21 @@ class LoginPage extends BasePage {
     By passwordFieldBy = By.id("password")
     By loginBtnBy = By.id("btn-login")
     By errorBy = By.cssSelector(".alert.alert-danger > span")
+    By helpLinkBy = By.linkText("Help")
 
     String loadPath = "/user/login"
 
     LoginPage(final SeleniumContext context) {
         super(context)
     }
-
     void validatePage() {
         if (!driver.currentUrl.contains(loadPath)) {
             throw new IllegalStateException("Not on login page: " + driver.currentUrl)
         }
+    }
+
+    WebElement getHelpLink() {
+        el helpLinkBy
     }
 
     WebElement getLoginField() {

--- a/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
@@ -870,7 +870,7 @@ class UtilityTagLib{
             if (path)
                 helpBase="https://docs.rundeck.com/${docVersion}"
             else
-                helpBase="https://docs.rundeck.com/${docVersion}/manual/02-getting-help.html"
+                helpBase="https://docs.rundeck.com/${docVersion}/about/getting-help.html"
 
             def helpParams = helpLinkParams(attrs,body)
             helpUrl= helpBase + path + '?' + helpParams + fragment


### PR DESCRIPTION
**Problem:** 
The “Docs” link on the front page when starting OSS gives a 404 error. It directs to:
“https://docs.rundeck.com/5.3.0/manual/02-getting-help.html?utm_source=rundeckapp&utm_medium=5.3.0-20240520 Linux java 11.0.22&utm_campaign=helplink&utm_content=menu%2Fwelcome”

instead of:
"https://docs.rundeck.com/docs/5.3.0/introduction/getting-help.html”

Solution:
Modify the link in the UtilityTagLib to redirect to the correct URL. Additionally, a functional test was added to validate that the URL is always correct.
