### PR TITLE
Add stability for tests

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/JobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/JobsSpec.groovy
@@ -2,6 +2,7 @@ package org.rundeck.tests.functional.selenium.jobs
 
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
+import org.openqa.selenium.By
 import org.openqa.selenium.Keys
 import org.openqa.selenium.support.ui.ExpectedConditions
 import org.rundeck.util.api.responses.jobs.CreateJobResponse
@@ -640,6 +641,7 @@ class JobsSpec extends SeleniumBase {
 
         jobShowPage.selectOptionFromOptionListByName(optionListOfNames, selection)
         jobShowPage.waitForElementToBeClickable(jobShowPage.getOptionSelectByName(optionListOfValues))
+        jobShowPage.waitForNumberOfElementsToBe(By.name("extra.option.search"), Integer.valueOf(selection))
         def flag = true
         (0..(selection-1)).each{
             if(!jobShowPage.getOptionSelectChildren(optionListOfValues)[it].isSelected()) flag = false

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/ScheduledJobSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/ScheduledJobSpec.groovy
@@ -30,7 +30,7 @@ class ScheduledJobSpec extends SeleniumBase{
         loginPage.login(TEST_USER, TEST_PASS)
         jobListPage.go()
         jobListPage.validatePage()
-        hold(10)
+        hold(15)
         activityPage.loadActivityPageForProject(projectName)
         activityPage.go()
 


### PR DESCRIPTION
scheduled job: sometimes fails on PRO due to not waiting enough for the executions to run
Select all json list options by default: it was not waiting for the options to be shown

- It increases the waiting time for scheduled execution to run
- It waits for the final options to be shown