### PR TITLE
RCLOUD-1344: Fix API calls returning 500 where 400 is more appropriate

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
@@ -262,7 +262,7 @@ class JobExecutionSpec extends BaseContainer {
         assert disabledJobsResponse.successful
 
         def jobExecResponseFor1AfterDisable = JobUtils.executeJob(job1Id, client)
-        assert jobExecResponseFor1AfterDisable.code() == 500 // bc execs are disabled
+        assert jobExecResponseFor1AfterDisable.code() == 400 // bc execs are disabled
 
         def executionsForJob1AfterDisable = doGet("/job/${job1Id}/executions")
         JobExecutionsResponse parsedExecutionsResponseForExecution1AfterDisable = mapper.readValue(executionsForJob1AfterDisable.body().string(), JobExecutionsResponse.class)
@@ -364,10 +364,10 @@ class JobExecutionSpec extends BaseContainer {
         assert disabledJobsResponse.successful
 
         def jobExecResponseFor1AfterDisable = JobUtils.executeJob(job1Id, client)
-        assert jobExecResponseFor1AfterDisable.code() == 500 // bc execs are disabled
+        assert jobExecResponseFor1AfterDisable.code() == 400 // bc execs are disabled
 
         def jobExecResponseFor2AfterDisable = JobUtils.executeJob(job2Id, client)
-        assert jobExecResponseFor2AfterDisable.code() == 500  // bc execs are disabled
+        assert jobExecResponseFor2AfterDisable.code() == 400  // bc execs are disabled
 
         def executionsForJob1AfterDisable = doGet("/job/${job1Id}/executions")
         JobExecutionsResponse parsedExecutionsResponseForExecution1AfterDisable = mapper.readValue(executionsForJob1AfterDisable.body().string(), JobExecutionsResponse.class)

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -4175,16 +4175,22 @@ This is a ISO-8601 date and time stamp with timezone, with optional milliseconds
             if (result.error == 'unauthorized') {
                 return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_FORBIDDEN,
                         code: 'api.error.item.unauthorized', args: ['Execute', 'Job ID', jobid]])
+            } else if (result.error=='disabled') {
+                return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_BAD_REQUEST,
+                                                               code: 'api.error.job.disabled', message: result.message])
             } else if (result.error=='invalid') {
                 return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_BAD_REQUEST,
                         code: 'api.error.job.options-invalid', args: [result.message]])
+            } else if (result.error=='failed') {
+                return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_BAD_REQUEST,
+                                                               code: 'api.error.execution.failed', args: [result.message]])
             } else if (result.error=='conflict') {
                 return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_CONFLICT,
                         code: 'api.error.execution.conflict', args: [result.message]])
             } else {
                 //failed
                 return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                        code: 'api.error.execution.failed', args: [result.message]])
+                        code: 'api.error.execution.error', args: [result.message]])
             }
         }
         def e = result.execution
@@ -5312,13 +5318,19 @@ For Content-Type: `multipart/form-data`
             if (results.error == 'unauthorized') {
                 return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_FORBIDDEN,
                         code: 'api.error.item.unauthorized', args: ['Execute', 'Adhoc', 'Command']])
+            } else if (results.error=='disabled') {
+                return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_BAD_REQUEST,
+                                                               code: 'api.error.job.disabled', args: [results.message]])
             } else if (results.error == 'invalid') {
                 return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_BAD_REQUEST,
                         code: 'api.error.execution.invalid', args: [errors.join(", ")]])
+            } else if (results.error=='failed') {
+                return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_BAD_REQUEST,
+                                                               code: 'api.error.execution.failed', args: [results.message]])
             } else {
                 //failed
                 return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                        code: 'api.error.execution.failed', args: [errors.join(", ")]])
+                        code: 'api.error.execution.error', args: [errors.join(", ")]])
             }
         } else {
             def controller = this

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -445,7 +445,7 @@ Since: v21''',
             if(!updateResponse.isSaved){
                 def errorMsg= updateResponse.errors.allErrors.collect { g.message(error:it) }.join(";")
                 return apiService.renderErrorFormat(response,[
-                        status: HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                        status: HttpServletResponse.SC_BAD_REQUEST,
                         message:errorMsg,
                         format:respFormat
                 ])


### PR DESCRIPTION
Fix component errors return 500 on API job run action
Fix disabled job and project return 500 on API job run 
Fix failed user profile update returns 500 on API update

All of these API calls now return a 400 with a descriptive message.