### PR TITLE
[RCLOUD-1380] Initial request id support

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -137,6 +137,7 @@ import org.rundeck.app.services.EnhancedNodeService
 import org.rundeck.app.spi.RundeckSpiBaseServicesProvider
 import org.rundeck.core.auth.app.RundeckAccess
 import org.rundeck.security.*
+import org.rundeck.web.DefaultRequestIdProvider
 import org.rundeck.web.ExceptionHandler
 import org.rundeck.web.WebUtil
 import org.rundeck.web.infosec.ContainerPrincipalRoleSource
@@ -936,6 +937,8 @@ beans={
         workflowService = ref('workflowService')
     }
     quartzJobSpecifier(ExecutionJobQuartzJobSpecifier)
+
+    requestIdProvider(DefaultRequestIdProvider)
 
     //provider implementations
     tokenDataProvider(GormTokenDataProvider)

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/AA_TimerInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/AA_TimerInterceptor.groovy
@@ -2,6 +2,7 @@ package rundeck.interceptors
 
 import com.codahale.metrics.MetricRegistry
 import org.grails.web.util.WebUtils
+import org.rundeck.web.RequestIdProvider
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
@@ -88,6 +89,7 @@ class AA_TimerInterceptor {
                        duration: data.duration,
                        remoteUser: request.remoteUser ?: request.authenticatedUser,
                        remoteHost: request.remoteHost,
+                       requestId: request.getAttribute(RequestIdProvider.HTTP_ATTRIBUTE_NAME),
                        userAgent: request.getHeader('User-Agent') ?: '-',
                        authToken: (request.authenticatedToken ? 'token' : 'form'),
                        method: request.method,

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/ApiVersionInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/ApiVersionInterceptor.groovy
@@ -6,7 +6,6 @@ import grails.converters.XML
 import org.grails.web.converters.exceptions.ConverterException
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 import org.grails.web.util.WebUtils
-
 import org.rundeck.web.RequestIdProvider
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/ApiVersionInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/ApiVersionInterceptor.groovy
@@ -6,6 +6,8 @@ import grails.converters.XML
 import org.grails.web.converters.exceptions.ConverterException
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 import org.grails.web.util.WebUtils
+
+import org.rundeck.web.RequestIdProvider
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
@@ -43,6 +45,7 @@ class ApiVersionInterceptor {
 
         Map context = [
                 remoteHost: request.remoteHost,
+                requestId: request.getAttribute(RequestIdProvider.HTTP_ATTRIBUTE_NAME),
                 version: request.api_version ?: '?',
                 remoteUser: request.remoteUser ?: request.authenticatedUser,
                 valid: !(request.invalidApiAuthentication),

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/FormTokenInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/FormTokenInterceptor.groovy
@@ -28,7 +28,7 @@ class FormTokenInterceptor {
     public static final String TOKEN_KEY_HEADER = 'X-RUNDECK-TOKEN-KEY'
     public static final String TOKEN_URI_HEADER = 'X-RUNDECK-TOKEN-URI'
 
-    int order = HIGHEST_PRECEDENCE + 1
+    int order = HIGHEST_PRECEDENCE + 2
 
     InterceptorHelper interceptorHelper
 

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/RequestIdInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/RequestIdInterceptor.groovy
@@ -1,0 +1,28 @@
+package rundeck.interceptors
+
+import groovy.transform.CompileStatic
+
+import org.rundeck.web.RequestIdProvider
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Autowired
+
+@CompileStatic
+class RequestIdInterceptor {
+    int order = HIGHEST_PRECEDENCE + 1
+
+    @Autowired
+    RequestIdProvider requestIdProvider
+
+    RequestIdInterceptor() {
+        matchAll()
+    }
+
+    boolean before() {
+        def requestId = requestIdProvider.getRequestId(request)
+
+        request.setAttribute(RequestIdProvider.HTTP_ATTRIBUTE_NAME, requestId)
+        MDC.put("requestId", requestId)
+
+        true
+    }
+}

--- a/rundeckapp/src/main/groovy/org/rundeck/web/DefaultRequestIdProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/web/DefaultRequestIdProvider.groovy
@@ -1,6 +1,5 @@
 package org.rundeck.web
 
-
 import javax.servlet.http.HttpServletRequest
 
 /**

--- a/rundeckapp/src/main/groovy/org/rundeck/web/DefaultRequestIdProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/web/DefaultRequestIdProvider.groovy
@@ -1,0 +1,14 @@
+package org.rundeck.web
+
+
+import javax.servlet.http.HttpServletRequest
+
+/**
+ * Provides a default RequestId when no other provider has been wired up to do so.
+ */
+class DefaultRequestIdProvider implements RequestIdProvider {
+    @Override
+    String getRequestId(HttpServletRequest request) {
+        return UUID.randomUUID().toString()
+    }
+}

--- a/rundeckapp/src/main/groovy/org/rundeck/web/RequestIdProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/web/RequestIdProvider.groovy
@@ -1,0 +1,9 @@
+package org.rundeck.web
+
+import javax.servlet.http.HttpServletRequest
+
+interface RequestIdProvider {
+    String HTTP_ATTRIBUTE_NAME = "requestId"
+
+    String getRequestId(HttpServletRequest request)
+}


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is the first in a series of small changes aimed to improve the ability to operate Rundeck. It adds a randomly generated "request id" to each HTTP request and sets this value in the logger's context.

**Describe the solution you've implemented**
This change adds a `requestId` value to the logger's MDC. The `requestId` used can be customized by implementing your own `RequestIdProvider` and replacing the `requestIdProvider` bean.

**Describe alternatives you've considered**
Not exactly an alternative but this PR stops short of updating the default log4j2 configuration for the next release. This will happen in a subsequent release after we have exercised this change for some time.

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

Here are a few sample log statements assuming the following `log4j2` configuration:
```
property.prefix = %style{[%style{%d{ISO8601}}{dim, noConsoleNoAnsi=${noConsoleNoAnsi}}] %highlight{%-5p}{noConsoleNoAnsi=${noConsoleNoAnsi}} %style{%c{${classLength}}}{cyan, noConsoleNoAnsi=${noConsoleNoAnsi}}}{disableAnsi=true} [%X{requestId}]
```

Request Id `44f1acfa-fb8c-4639-b6c3-17111f7a32cc`:
```
[2024-07-15T10:42:34,031] WARN  o.hi.engine.jdbc.spi.SqlExceptionHelper [44f1acfa-fb8c-4639-b6c3-17111f7a32cc] [qtp952483937-42] - SQL Error: 1205, SQLState: HY000
[2024-07-15T10:42:34,031] ERROR o.hi.engine.jdbc.spi.SqlExceptionHelper [44f1acfa-fb8c-4639-b6c3-17111f7a32cc] [qtp952483937-42] - (conn=80) Lock wait timeout exceeded; try restarting transaction
[2024-07-15T10:42:34,032] ERROR r.se.ExecutionService [44f1acfa-fb8c-4639-b6c3-17111f7a32cc] [qtp952483937-42] - Could not abort 471, the execution was modified

[2024-07-15T10:42:34,252] INFO mo.ru.web.requests [44f1acfa-fb8c-4639-b6c3-17111f7a32cc] "POST /execution/cancelExecution" 127.0.0.1 http admin form 50404 ? [] (Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36)
```
