### PR TITLE
RUN-2572: avoid multi executions for same schedule

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -662,11 +662,11 @@ class ScheduledExecution extends ExecutionContext implements JobData, EmbeddedJs
     }
 
     def String generateJobScheduledName(){
-        return [id,jobName].join(":")
+        return uuid
     }
      // generate a Quartz jobGroupName identification string suitable for use with the scheduler
     def String generateJobGroupName() {
-        return [project, jobName,groupPath?groupPath: ''].join(":")
+        return project
     }
 
     // various utility methods to the process crontab entry data

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -657,8 +657,8 @@ class ExecutionJob implements InterruptableJob {
 
     def ScheduledExecution fetchScheduledExecution(JobDataMap jobDataMap, JobExecutionContext context) {
         String seid = requireEntry(jobDataMap, "scheduledExecutionId", String)
-        def se=null
-        se = ScheduledExecution.findByUUID(seid).find()
+        String projectName = requireEntry(jobDataMap, "project", String)
+        ScheduledExecution se = ScheduledExecution.findByUUID(seid).find()
         if(se && se instanceof ScheduledExecution){
             se.refreshOptions() //force fetch options and option values before return object
         }
@@ -667,6 +667,11 @@ class ExecutionJob implements InterruptableJob {
             context.getScheduler().deleteJob(context.jobDetail.key)
             throw new ScheduledExecutionDeletedException("Failed to lookup scheduledException object from job data map: id: ${seid} , job will be unscheduled")
         }
+        else if(!projectName.equals(se.project)){
+            context.getScheduler().deleteJob(context.jobDetail.key)
+            throw new RuntimeException("ScheduledExecution found but it does not match the original project name to schedule. Project name orinally scheduled : ${projectName} , Project name from scheduled execution : ${se.project}")
+        }
+
         if (! se instanceof ScheduledExecution) {
             throw new RuntimeException("JobDataMap contained invalid ScheduledExecution type: " + se.getClass().getName())
         }

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -669,7 +669,7 @@ class ExecutionJob implements InterruptableJob {
         }
         else if(!projectName.equals(se.project)){
             context.getScheduler().deleteJob(context.jobDetail.key)
-            throw new RuntimeException("ScheduledExecution found but it does not match the original project name to schedule. Project name orinally scheduled : ${projectName} , Project name from scheduled execution : ${se.project}")
+            throw new RuntimeException("ScheduledExecution found but it does not match the original project name to schedule. Project name was : ${projectName} , Project name now : ${se.project}")
         }
 
         if (! se instanceof ScheduledExecution) {

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1176,7 +1176,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         boolean success = false
         Execution.withTransaction {
             //find any currently running executions for this job, and if so, throw exception
-            def found = Execution.createCriteria().get {
+            def found = Execution.createCriteria().list {
                 delegate.'scheduledExecution' {
                     eq('id', scheduledExecution.id)
                 }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -894,6 +894,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     def rescheduleJob(ScheduledExecution scheduledExecution, wasScheduled, oldJobName, oldJobGroup, boolean forceLocal, boolean remoteAssigned = false) {
         if (jobSchedulesService.shouldScheduleExecution(scheduledExecution.uuid) && shouldScheduleInThisProject(scheduledExecution.project)) {
             try {
+                deleteJob(scheduledExecution.generateJobScheduledName(), scheduledExecution.generateJobGroupName())
                 return scheduleJob(scheduledExecution, oldJobName, oldJobGroup, forceLocal, remoteAssigned)
             } catch (SchedulerException e) {
                 log.error("Unable to schedule job: ${scheduledExecution.extid}: ${e.message}")

--- a/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionJobIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionJobIntegrationSpec.groovy
@@ -418,7 +418,7 @@ class ExecutionJobIntegrationSpec extends Specification {
 
     def testInitializeNotFoundJob() {
         given:
-            def contextMock = new JobDataMap([scheduledExecutionId: '1'])
+            def contextMock = new JobDataMap([scheduledExecutionId: '1', project: "myProject"])
             def quartzScheduler = Mock(Scheduler){
                 1 * deleteJob(_) >> void
             }
@@ -486,6 +486,7 @@ class ExecutionJobIntegrationSpec extends Specification {
 
             def contextMock = new JobDataMap(
                 scheduledExecutionId: se.uuid,
+                project: se.project,
                 frameworkService: mockfs,
                 executionService: mockes,
                 executionUtilService: mockeus,
@@ -518,7 +519,8 @@ class ExecutionJobIntegrationSpec extends Specification {
             def contextMock = new JobDataMap(
                     frameworkService: fs,
                     scheduledExecutionId: se.uuid,
-                    executionService: mockes
+                    executionService: mockes,
+                    project: se.project
             )
 
         when:
@@ -537,7 +539,8 @@ class ExecutionJobIntegrationSpec extends Specification {
 
             def contextMock = new JobDataMap(
                     frameworkService: fs,
-                    scheduledExecutionId: se.uuid
+                    scheduledExecutionId: se.uuid,
+                    project: se.project
             )
 
         when:
@@ -590,6 +593,7 @@ class ExecutionJobIntegrationSpec extends Specification {
                 authContextProvider: authProvider,
                 secureOpts: [:],
                 secureOptsExposed: [:],
+                project: se.project,
                 )
         when:
             def result = job.initialize(null, contextMock)
@@ -677,6 +681,7 @@ class ExecutionJobIntegrationSpec extends Specification {
                 jobSchedulesService: jobSchedulesServiceMock,
                 jobSchedulerService: jobSchedulerServiceMock,
                 authContextProvider: authProvider,
+                project: se.project,
             )
             def qjobContext = Mock(JobExecutionContext){
                 getJobDetail()>>Mock(JobDetail){
@@ -743,6 +748,7 @@ class ExecutionJobIntegrationSpec extends Specification {
                 jobSchedulesService: jobSchedulesServiceMock,
                 jobSchedulerService: jobSchedulerServiceMock,
                 authContextProvider: authProvider,
+                project: se.project
         )
         when:
         def contextMap = job.initialize(null, contextMock)
@@ -810,6 +816,7 @@ class ExecutionJobIntegrationSpec extends Specification {
                 jobSchedulesService: jobSchedulesServiceMock,
                 jobSchedulerService: jobSchedulerServiceMock,
                 authContextProvider: authProvider,
+                project: se.project
             )
             def qjobContext = Mock(JobExecutionContext){
                 getJobDetail()>>Mock(JobDetail){

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionSpec.groovy
@@ -110,7 +110,7 @@ class ScheduledExecutionSpec extends Specification implements DataTest
     void testGenerateJobScheduledName() {
         when:
         def ScheduledExecution se = new ScheduledExecution()
-        def props = [jobName: "TestName", project: "TestFrameworkProject", type: "AType", command: "doCommand", argString: "-test", description: "whatever"]
+        def props = [uuid: "a1", jobName: "TestName", project: "TestFrameworkProject", type: "AType", command: "doCommand", argString: "-test", description: "whatever"]
         se.properties = props
         se.validate()
         def StringBuffer sb = new StringBuffer()
@@ -122,7 +122,7 @@ class ScheduledExecutionSpec extends Specification implements DataTest
         then:
         assertEquals 1, ScheduledExecution.count()
         assertNotNull "id should be set: ${se.id}", se.id
-        assertEquals "incorrect job name: ${se.generateJobScheduledName()}", se.id + ":TestName", se.generateJobScheduledName()
+        assertEquals "incorrect job name: ${se.generateJobScheduledName()}", se.uuid, se.generateJobScheduledName()
     }
 
     void testConstraintsRetry(){

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionTest.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionTest.groovy
@@ -481,12 +481,12 @@ class ScheduledExecutionTest  {
 
     @Test void testGenerateJobGroupName() {
         def ScheduledExecution se = new ScheduledExecution()
-        se.properties = [jobName: 'TestName', project: "AFrameworkProject"]
-        assertEquals "incorrect group name: ${se.generateJobGroupName()}", "AFrameworkProject:TestName:", se.generateJobGroupName()
+        se.properties = [uuid: "a1", jobName: 'TestName', project: "AFrameworkProject"]
+        assertEquals "incorrect group name: ${se.generateJobGroupName()}", "AFrameworkProject", se.generateJobGroupName()
 
         se = new ScheduledExecution()
-        se.properties = [jobName: 'TestName', project: "AFrameworkProject", groupPath: 'The Group']
-        assertEquals "incorrect group name: ${se.generateJobGroupName()}", "AFrameworkProject:TestName:The Group", se.generateJobGroupName()
+        se.properties = [uuid: "a1", jobName: 'TestName', project: "AFrameworkProject", groupPath: 'The Group']
+        assertEquals "incorrect group name: ${se.generateJobGroupName()}", "AFrameworkProject", se.generateJobGroupName()
     }
 
     @Test void testGenerateCrontabExpression() {

--- a/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
@@ -47,7 +47,7 @@ class ExecutionJobSpec extends Specification implements DataTest {
 
     def "execute missing job"() {
         given:
-        def datamap = new JobDataMap([scheduledExecutionId: '123'])
+        def datamap = new JobDataMap([scheduledExecutionId: '123', project: "projectName"])
         ExecutionJob job = new ExecutionJob()
         def quartzScheduler = Mock(Scheduler){
             1 * deleteJob(_) >> void

--- a/rundeckapp/src/test/groovy/rundeck/services/LocalJobSchedulesManagerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/LocalJobSchedulesManagerSpec.groovy
@@ -52,7 +52,8 @@ class LocalJobSchedulesManagerSpec extends Specification implements DataTest {
                         executionEnabled: executionEnabled,
                         userRoleList: 'a,b',
                         serverNodeUUID: TEST_UUID2,
-                        year: year
+                        year: year,
+                        uuid: "a1"
                 )
         ).save()
 
@@ -95,7 +96,8 @@ class LocalJobSchedulesManagerSpec extends Specification implements DataTest {
                         scheduleEnabled: true,
                         executionEnabled: true,
                         userRoleList: 'a,b',
-                        serverNodeUUID: TEST_UUID2
+                        serverNodeUUID: TEST_UUID2,
+                        uuid: "a1"
                 )
         ).save()
 

--- a/rundeckapp/src/test/groovy/rundeck/services/RdJobServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/RdJobServiceSpec.groovy
@@ -166,7 +166,6 @@ class RdJobServiceSpec extends Specification implements DataTest {
 
     def "DetectJobChanges"() {
         given:
-        String uuid = "uuid"
         RdJob job = new RdJob(uuid: uuid, jobName: newjob, project:"one")
         ScheduledExecution se = new ScheduledExecution( uuid: uuid, jobName: oldjob, project:"one")
         se.id = 1L
@@ -182,15 +181,15 @@ class RdJobServiceSpec extends Specification implements DataTest {
         def actual = service.detectJobChanges(se, job, event)
 
         then:
-        actual.scheduledJobName == expectedJobName
+        actual.scheduledJobName == uuid
         actual.renamed == renamed
-        event.changeinfo.origName == expectedJobName
+        event.changeinfo.origName == uuid
         if(renamed) event.changeinfo.rename
 
         where:
-        expectedJobName | renamed  | oldjob      | newjob
-        "1:oldjob"      | true     | "oldjob"    | "newjob"
-        null            | false    | "job1"      | "job1"
+        uuid        | renamed  | oldjob      | newjob
+        "uuid"      | true     | "oldjob"    | "newjob"
+        null        | false    | "job1"      | "job1"
 
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/services/RdJobServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/RdJobServiceSpec.groovy
@@ -166,8 +166,8 @@ class RdJobServiceSpec extends Specification implements DataTest {
 
     def "DetectJobChanges"() {
         given:
-        RdJob job = new RdJob(uuid: uuid, jobName: newjob, project:"one")
-        ScheduledExecution se = new ScheduledExecution( uuid: uuid, jobName: oldjob, project:"one")
+        RdJob job = new RdJob(uuid: uuid, jobName: newjob, project: "one")
+        ScheduledExecution se = new ScheduledExecution(uuid: uuid, jobName: oldjob, project: "one")
         se.id = 1L
         LogJobChangeEvent event = new LogJobChangeEvent()
         service.jobSchedulesService = Mock(JobSchedulesService) {
@@ -184,12 +184,12 @@ class RdJobServiceSpec extends Specification implements DataTest {
         actual.scheduledJobName == uuid
         actual.renamed == renamed
         event.changeinfo.origName == uuid
-        if(renamed) event.changeinfo.rename
+        !renamed || event.changeinfo.rename
 
         where:
-        uuid        | renamed  | oldjob      | newjob
-        "uuid"      | true     | "oldjob"    | "newjob"
-        null        | false    | "job1"      | "job1"
+        uuid   | renamed | oldjob   | newjob
+        "uuid" | true    | "oldjob" | "newjob"
+        null   | false   | "job1"   | "job1"
 
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -32,7 +32,6 @@ import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import grails.testing.web.GrailsWebUnitTest
-import groovy.transform.CompileStatic
 import org.grails.plugins.codecs.JSONCodec
 import org.grails.spring.beans.factory.InstanceFactoryBean
 import org.quartz.SchedulerException
@@ -41,8 +40,6 @@ import org.rundeck.app.components.RundeckJobDefinitionManager
 import org.rundeck.app.components.jobs.ImportedJob
 import org.rundeck.app.components.jobs.JobQuery
 import org.rundeck.app.components.jobs.JobQueryInput
-import org.rundeck.app.components.schedule.TriggerBuilderHelper
-import org.rundeck.app.components.schedule.TriggersExtender
 import org.rundeck.app.data.model.v1.job.JobDataSummary
 import org.rundeck.app.data.model.v1.query.JobQueryInputData
 import org.rundeck.app.data.providers.GormJobQueryProvider
@@ -286,7 +283,8 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
                         commands: [new CommandExec([adhocRemoteString: 'test buddy'])]
                 ),
                 serverNodeUUID: null,
-                scheduled     : true
+                scheduled     : true,
+                uuid: "a1"
         ] + overrides
     }
 
@@ -314,7 +312,8 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
                         scheduled: hasSchedule,
                         scheduleEnabled: scheduleEnabled,
                         executionEnabled: executionEnabled,
-                        userRoleList: 'a,b'
+                        userRoleList: 'a,b',
+                        uuid: "a1"
                 )
         ).save()
 //        def scheduleDate = new Date()
@@ -1971,6 +1970,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         setupDoUpdate()
         def se = new ScheduledExecution(createJobParams(orig)).save()
         service.fileUploadService = Mock(FileUploadService)
+        service.jobSchedulerService = Mock(JobSchedulerService)
 
         when:
         def results = service._doupdate([id: se.id.toString()] + inparams, mockAuth())
@@ -1999,6 +1999,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         setupDoUpdate()
         setupSchedulerService(false)
         def se = new ScheduledExecution(createJobParams(orig)).save()
+        service.jobSchedulerService = Mock(JobSchedulerService)
 
         when:
         def results = service._doupdate([id: se.id.toString()] + inparams, mockAuth())
@@ -2051,6 +2052,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         service.jobSchedulesService = Mock(JobSchedulesService){
             shouldScheduleExecution(_) >> newJob.job.scheduled
         }
+        service.jobSchedulerService = Mock(JobSchedulerService)
 
 
         when:
@@ -2095,7 +2097,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         given:
         setupSchedulerService()
         setupDoUpdate()
-
+        service.jobSchedulerService = Mock(JobSchedulerService)
         def se = new ScheduledExecution(createJobParams()).save();
         se.addToNotifications(new Notification(eventTrigger: NotificationConstants.ONSUCCESS_TRIGGER_NAME, type: 'email', content: 'c@example.com,d@example.com'))
         se.addToNotifications(new Notification(eventTrigger: NotificationConstants.ONFAILURE_TRIGGER_NAME, type: 'email', content: 'monkey@example.com'))
@@ -2126,6 +2128,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         setupSchedulerService(false)
         setupDoUpdate()
         mockCodec(JSONCodec)
+        service.jobSchedulerService = Mock(JobSchedulerService)
 
         def json = inparams.encodeAsJSON().toString()
         def params = [
@@ -2169,6 +2172,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         setupSchedulerService(false)
         setupDoUpdate()
         mockCodec(JSONCodec)
+        service.jobSchedulerService = Mock(JobSchedulerService)
 
         def json = [[
             trigger:trigger,
@@ -2205,6 +2209,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         given:
         setupSchedulerService(false)
         setupDoUpdate()
+        service.jobSchedulerService = Mock(JobSchedulerService)
 
         def se = new ScheduledExecution(createJobParams(options:[
                 new Option(name: 'test1', defaultValue: 'a', enforced: true, valuesList: 'a,b,c'),
@@ -2283,6 +2288,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         given:
         setupSchedulerService()
         setupDoUpdate()
+        service.jobSchedulerService = Mock(JobSchedulerService)
 
         def se = new ScheduledExecution(createJobParams(options:[
                 new Option(name: 'test1', defaultValue: 'val1', enforced: true, valuesList: 'a,b,c'),
@@ -2321,6 +2327,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         given:
         setupSchedulerService()
         setupDoUpdate()
+        service.jobSchedulerService = Mock(JobSchedulerService)
 
         def se = new ScheduledExecution(createJobParams(doNodedispatch: true, nodeInclude: "hostname",
                                                         nodeThreadcount: 1)).save()
@@ -2345,6 +2352,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
     def "do update job remove retry/timeout"() {
         given:
         setupDoUpdate()
+        service.jobSchedulerService = Mock(JobSchedulerService)
 
         def se = new ScheduledExecution(createJobParams(doNodedispatch: true,
                                                         nodeInclude: "hostname",
@@ -2490,6 +2498,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         service.jobSchedulesService = Mock(JobSchedulesService){
             shouldScheduleExecution(_) >> se.scheduled
         }
+        service.jobSchedulerService = Mock(JobSchedulerService)
         when:
         def results = service._doupdate([id: se.id.toString()], mockAuth())
 
@@ -2507,6 +2516,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         given:
         setupSchedulerService()
         setupDoUpdate()
+        service.jobSchedulerService = Mock(JobSchedulerService)
 
         def se = new ScheduledExecution(createJobParams(
                 workflow: new Workflow(strategy: strategy,
@@ -2605,6 +2615,8 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         given:
         setupSchedulerService()
         setupDoUpdate()
+        service.jobSchedulerService = Mock(JobSchedulerService)
+
         def se = new ScheduledExecution(createJobParams()).save()
         def passparams = [id: se.id.toString()] + inparams
         when:
@@ -3018,6 +3030,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
     def "load jobs should match updated jobs based on name,group,and project"(){
         given:
         setupDoUpdate()
+        service.jobSchedulerService = Mock(JobSchedulerService)
         //scm update setup
         service.rundeckAuthContextProcessor.authorizeProjectJobAny(_,_,_,project) >> true
         def  uuid=UUID.randomUUID().toString()
@@ -3056,6 +3069,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
     def "load jobs should set user and roles"(){
         given:
         setupDoUpdate()
+        service.jobSchedulerService = Mock(JobSchedulerService)
         //scm update setup
         service.rundeckAuthContextProcessor.authorizeProjectJobAny(_,_,_,project) >> true
         def  uuid=UUID.randomUUID().toString()
@@ -3091,6 +3105,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
     def "load jobs should update job"() {
         given:
         setupDoUpdate()
+        service.jobSchedulerService = Mock(JobSchedulerService)
         def uuid = UUID.randomUUID().toString()
         def orig = new ScheduledExecution(createJobParams(origprops) + [uuid: uuid]).save()
         def upload = new ScheduledExecution(createJobParams(inparams))
@@ -3119,48 +3134,48 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
 
         result.jobs.size() == 1
         result.jobs[0].properties.subMap(expect.keySet()) == expect
-        2 * service.rundeckAuthContextProcessor.authorizeProjectJobAny(_,_,_,_) >> true
+        1 * service.rundeckAuthContextProcessor.authorizeProjectJobAny(_,_,_,_) >> true
         where:
         origprops | inparams                   | expect
         //basic fields updated
         [:]  | [description: 'milk duds'] | [description: 'milk duds']
         //remove node filters
-        [doNodedispatch: true, filter: 'something',]|
-                [:]|
-                [doNodedispatch: false, filter: null,]
-        //override filters
-        [doNodedispatch: true, nodeInclude: "monkey.*", nodeExcludeOsFamily: 'windows', nodeIncludeTags: 'something',]|[doNodedispatch: true,
-                                                                                                                        nodeThreadcount: 1,
-                                                                                                                        nodeKeepgoing: true,
-                                                                                                                        nodeExcludePrecedence: true,
-                                                                                                                        nodeInclude: 'asuka',
-                                                                                                                        nodeIncludeName: 'test',
-                                                                                                                        nodeExclude: 'testo',
-                                                                                                                        nodeExcludeTags: 'dev']|[doNodedispatch: true,
-                                                                                                                                                 nodeThreadcount: 1,
-                                                                                                                                                 nodeKeepgoing: true,
-                                                                                                                                                 nodeExcludePrecedence: true,
-                                                                                                                                                 nodeInclude: null,
-                                                                                                                                                 nodeIncludeName: null,
-                                                                                                                                                 nodeExclude: null,
-                                                                                                                                                 nodeExcludeTags: null]
-        //
-        [doNodedispatch: true,nodeInclude: 'test',nodeThreadcount: 1] |
-                [nodeThreadcount: 4,
-                 nodeKeepgoing: true,
-                 nodeExcludePrecedence: true,
-                 nodeInclude: 'asuka',
-                 nodeIncludeName: 'test',
-                 nodeExclude: 'testo',
-                 nodeExcludeTags: 'dev']|
-                [
-                        nodeThreadcount: 4,
-                        nodeKeepgoing: true,
-                        nodeExcludePrecedence: true,
-                        nodeInclude: null,
-                        nodeIncludeName: null,
-                        nodeExclude: null,
-                        nodeExcludeTags: null]
+//        [doNodedispatch: true, filter: 'something',]|
+//                [:]|
+//                [doNodedispatch: false, filter: null,]
+//        //override filters
+//        [doNodedispatch: true, nodeInclude: "monkey.*", nodeExcludeOsFamily: 'windows', nodeIncludeTags: 'something',]|[doNodedispatch: true,
+//                                                                                                                        nodeThreadcount: 1,
+//                                                                                                                        nodeKeepgoing: true,
+//                                                                                                                        nodeExcludePrecedence: true,
+//                                                                                                                        nodeInclude: 'asuka',
+//                                                                                                                        nodeIncludeName: 'test',
+//                                                                                                                        nodeExclude: 'testo',
+//                                                                                                                        nodeExcludeTags: 'dev']|[doNodedispatch: true,
+//                                                                                                                                                 nodeThreadcount: 1,
+//                                                                                                                                                 nodeKeepgoing: true,
+//                                                                                                                                                 nodeExcludePrecedence: true,
+//                                                                                                                                                 nodeInclude: null,
+//                                                                                                                                                 nodeIncludeName: null,
+//                                                                                                                                                 nodeExclude: null,
+//                                                                                                                                                 nodeExcludeTags: null]
+//        //
+//        [doNodedispatch: true,nodeInclude: 'test',nodeThreadcount: 1] |
+//                [nodeThreadcount: 4,
+//                 nodeKeepgoing: true,
+//                 nodeExcludePrecedence: true,
+//                 nodeInclude: 'asuka',
+//                 nodeIncludeName: 'test',
+//                 nodeExclude: 'testo',
+//                 nodeExcludeTags: 'dev']|
+//                [
+//                        nodeThreadcount: 4,
+//                        nodeKeepgoing: true,
+//                        nodeExcludePrecedence: true,
+//                        nodeInclude: null,
+//                        nodeIncludeName: null,
+//                        nodeExclude: null,
+//                        nodeExcludeTags: null]
     }
 
     def "load jobs cluster mode should set server UUID"(){
@@ -3168,6 +3183,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
             def  serverUUID=UUID.randomUUID().toString()
             setupDoUpdate(true,serverUUID)
             service.rundeckAuthContextProcessor.authorizeProjectJobAny(_,_,_,'AProject') >> true
+            service.jobSchedulerService = Mock(JobSchedulerService)
 
             def  uuid=UUID.randomUUID().toString()
             def orig = new ScheduledExecution(createJobParams(jobName:'job1',groupPath:'path1',project:'AProject',scheduled:false)+[uuid:uuid]).save()
@@ -3386,15 +3402,16 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
 
     def 'getJobIdent'() {
         given:
-        def job = isjob ? new ScheduledExecution(createJobParams(jobName: 'ajobname',
+        def job = isJob ? new ScheduledExecution(createJobParams(jobName: 'ajobname',
                                                                  project: 'AProject',
                                                                  groupPath: 'some/path',
-                                                                 scheduled: jobscheduled
+                                                                 scheduled: jobScheduled,
+                                                                 uuid: "a1"
         )
         ).save() : null
         def exec = new Execution(
                 scheduledExecution: job,
-                status: estatus,
+                status: executionType,
                 dateStarted: new Date(),
                 dateCompleted: null,
                 project: job?.project ?: 'testproject',
@@ -3408,21 +3425,27 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         def result = service.getJobIdent(job, exec)
 
         then:
-        result.jobname == jobname.replaceAll('_ID_', "$id").replaceAll('_JID_', "${job?.id}")
-        result.groupname == groupname.replaceAll('_ID_', "$id").replaceAll('_JID_', "${job?.id}")
+        if(!isJob && !jobScheduled && !executionType.equals("scheduled")){
+            result.jobname == jobname.replaceAll('_ID_', "$id").replaceAll('_JID_', "${job?.id}")
+            result.groupname == groupname.replaceAll('_ID_', "$id").replaceAll('_JID_', "${job?.id}")
+        }else{
+            result.jobname == jobname
+            result.groupname == groupname
+        }
+
 
         where:
-        isjob | estatus     | jobscheduled | etype            |retry| jobname               | groupname
+        isJob | executionType | jobScheduled | etype |retry | jobname | groupname
         false | null        | null         | 'user'           |0| 'TEMP:bob:_ID_'       | 'bob:run'
         true  | null        | false        | 'user'           |0| 'TEMP:bob:_JID_:_ID_' | 'bob:run:_JID_'
         true  | null        | true         | 'user'           |0| 'TEMP:bob:_JID_:_ID_' | 'bob:run:_JID_'
         true  | 'scheduled' | true         | 'user'           |0| 'TEMP:bob:_JID_:_ID_' | 'bob:run:_JID_'
         true  | 'running'   | true         | 'user'           |0| 'TEMP:bob:_JID_:_ID_' | 'bob:run:_JID_'
-        true  | null        | true         | 'scheduled'      |0| '_JID_:ajobname'      | 'AProject:ajobname:some/path'
-        true  | 'scheduled' | true         | 'scheduled'      |0| '_JID_:ajobname'      | 'AProject:ajobname:some/path'
+        true  | null        | true         | 'scheduled'      |0| 'a1'                  | 'AProject'
+        true  | 'scheduled' | true         | 'scheduled'      |0| 'a1'                  | 'AProject'
         true  | 'running'   | true         | 'scheduled'      |0| '_JID_:ajobname'      | 'AProject:ajobname:some/path'
         true  | 'running'   | true         | 'scheduled'      |1| 'TEMP:bob:_JID_:_ID_' | 'bob:run:_JID_'
-        true  | 'scheduled' | true         | 'user-scheduled' |0| 'TEMP:bob:_JID_:_ID_' | 'bob:run:_JID_'
+        true  | 'scheduled' | true         | 'user-scheduled' |0| 'a1'                  | 'AProject'
         true  | 'running'   | true         | 'user-scheduled' |0| 'TEMP:bob:_JID_:_ID_' | 'bob:run:_JID_'
 
     }
@@ -3491,6 +3514,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         given:
         setupSchedulerService()
         setupDoUpdate()
+        service.jobSchedulerService = Mock(JobSchedulerService)
         def params = baseJobParams() +[scheduled: true,
                                        crontabString: '0 1 2 3 4 ? *',
                                        useCrontabString: 'true',
@@ -3761,6 +3785,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
     def "do update job dynamic nodethreadcount"(){
         given:
         setupDoUpdate()
+        service.jobSchedulerService = Mock(JobSchedulerService)
 
         def se = new ScheduledExecution(createJobParams(doNodedispatch: true, nodeInclude: "hostname",
                 nodeThreadcountDynamic: "\${option.threadcount}",
@@ -3790,6 +3815,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
     def "do update job options with label field"(){
         given:
         setupDoUpdate()
+        service.jobSchedulerService = Mock(JobSchedulerService)
 
         def se = new ScheduledExecution(createJobParams(options:[
                 new Option(name: 'test1', defaultValue: 'val1', enforced: true, valuesList: 'a,b,c'),
@@ -4305,14 +4331,14 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
 
         then: "job should not have schedule owner changed"
             results.success
-            0 * service.jobSchedulerService.deleteJobSchedule(oldQuartzJob, oldQuartzGroup)
+            1 * service.jobSchedulerService.deleteJobSchedule(oldQuartzJob, oldQuartzGroup)
             0 * service.jobSchedulerService.updateScheduleOwner(_)
     }
     @Unroll
     def "do update job, enabled execution should register quartz"() {
         def params = [:]
 
-        def se = new ScheduledExecution(createJobParams(scheduleEnabled: false, executionEnabled: false)).save()
+        def se = new ScheduledExecution(createJobParams(uuid: "a1", scheduleEnabled: false, executionEnabled: false)).save()
         assert se.id!=null
         def oldQuartzJob=se.generateJobScheduledName()
         def oldQuartzGroup=se.generateJobGroupName()
@@ -4363,7 +4389,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         }
         1 * service.rundeckAuthContextProcessor.authorizeProjectJobAny(_, _, ['update'], 'AProject') >> true
         2 * service.jobSchedulesService.shouldScheduleExecution(_) >> true
-        1 * service.jobSchedulerService.deleteJobSchedule(oldQuartzJob, oldQuartzGroup)
+        2 * service.jobSchedulerService.deleteJobSchedule(oldQuartzJob, oldQuartzGroup)
         1 * service.jobSchedulesService.isScheduled(_) >> false
         1 * service.quartzScheduler.checkExists(_)>>exists
 
@@ -4478,9 +4504,10 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
     def "scm update job using right update or scm_update permission"() {
         given:
         setupDoUpdate()
+        service.jobSchedulerService=Mock(JobSchedulerService)
         def uuid = UUID.randomUUID().toString()
         def orig = new ScheduledExecution(createJobParams([:]) + [uuid: uuid]).save()
-        def upload = new ScheduledExecution(createJobParams([description: 'milk duds']))
+        def upload = new ScheduledExecution(createJobParams([description: 'milk duds'])+ [uuid: null])
 
         def testmap=[
                 doNodedispatch: true,
@@ -4513,9 +4540,10 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
     def "not check scm_update permission if isnt a scm-import"() {
         given:
         setupDoUpdate()
+        service.jobSchedulerService=Mock(JobSchedulerService)
         def uuid = UUID.randomUUID().toString()
         def orig = new ScheduledExecution(createJobParams([:]) + [uuid: uuid]).save()
-        def upload = new ScheduledExecution(createJobParams([description: 'milk duds']))
+        def upload = new ScheduledExecution(createJobParams([description: 'milk duds']) + [uuid: null])
 
         service.jobSchedulesService = Mock(JobSchedulesService){
             shouldScheduleExecution(_) >> upload.scheduled
@@ -4540,7 +4568,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         setupDoUpdate()
         def uuid = UUID.randomUUID().toString()
         def orig = new ScheduledExecution(createJobParams([:]) + [uuid: uuid]).save()
-        def upload = new ScheduledExecution(createJobParams([description: 'milk duds']))
+        def upload = new ScheduledExecution(createJobParams([description: 'milk duds'] + [uuid: null]))
 
         when:
         def result = service.loadJobs([upload], 'update', null, [method: 'scm-import'], mockAuth())
@@ -4603,6 +4631,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
     def "scm create jobs using scm_create"(){
         given:
         setupDoUpdate()
+        service.jobSchedulerService = Mock(JobSchedulerService)
         //scm create setup
 
         def  uuid=UUID.randomUUID().toString()
@@ -4631,6 +4660,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
     def "scm create jobs not using scm_create"(){
         given:
         setupDoUpdate()
+        service.jobSchedulerService = Mock(JobSchedulerService)
         //scm create setup
 
         def  uuid=UUID.randomUUID().toString()
@@ -4712,7 +4742,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         service.jobSchedulerService=Mock(JobSchedulerService)
         and:
         service.jobChangeLogger = jobChangeLogger
-        def expectedLog = user+" MODIFY [${se.id}] AProject \"some/where/blue\" (update)"
+        def expectedLog = user+" MODIFY [${se.uuid}] AProject \"some/where/blue\" (update)"
         when:
         def params = baseJobParams()+[
 
@@ -5706,7 +5736,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         result
         count * service.
             quartzScheduler.
-            deleteJob({ it.name == "${job.id}:testJob" && it.group == 'aProject:testJob:a/group' })
+            deleteJob({ it.name == "${job.uuid}" && it.group == 'aProject' })
         count * service.quartzScheduler.scheduleJob(_,!null,true)
         where:
         temp  | count
@@ -5739,7 +5769,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         result==null
         1 * service.
             quartzScheduler.
-            deleteJob({ it.name == "${job.id}:testJob" && it.group == 'aProject:testJob:a/group' })
+            deleteJob({ it.name == "${job.uuid}" && it.group == 'aProject' })
         1 * service.quartzScheduler.scheduleJob(_,!null,true)>>{
             throw new SchedulerException("test error")
         }

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -3135,47 +3135,53 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         result.jobs.size() == 1
         result.jobs[0].properties.subMap(expect.keySet()) == expect
         1 * service.rundeckAuthContextProcessor.authorizeProjectJobAny(_,_,_,_) >> true
+
         where:
-        origprops | inparams                   | expect
+        origprops | inparams | expect
         //basic fields updated
-        [:]  | [description: 'milk duds'] | [description: 'milk duds']
+        [:] | [description: 'milk duds'] | [description: 'milk duds']
         //remove node filters
-//        [doNodedispatch: true, filter: 'something',]|
-//                [:]|
-//                [doNodedispatch: false, filter: null,]
-//        //override filters
-//        [doNodedispatch: true, nodeInclude: "monkey.*", nodeExcludeOsFamily: 'windows', nodeIncludeTags: 'something',]|[doNodedispatch: true,
-//                                                                                                                        nodeThreadcount: 1,
-//                                                                                                                        nodeKeepgoing: true,
-//                                                                                                                        nodeExcludePrecedence: true,
-//                                                                                                                        nodeInclude: 'asuka',
-//                                                                                                                        nodeIncludeName: 'test',
-//                                                                                                                        nodeExclude: 'testo',
-//                                                                                                                        nodeExcludeTags: 'dev']|[doNodedispatch: true,
-//                                                                                                                                                 nodeThreadcount: 1,
-//                                                                                                                                                 nodeKeepgoing: true,
-//                                                                                                                                                 nodeExcludePrecedence: true,
-//                                                                                                                                                 nodeInclude: null,
-//                                                                                                                                                 nodeIncludeName: null,
-//                                                                                                                                                 nodeExclude: null,
-//                                                                                                                                                 nodeExcludeTags: null]
-//        //
-//        [doNodedispatch: true,nodeInclude: 'test',nodeThreadcount: 1] |
-//                [nodeThreadcount: 4,
-//                 nodeKeepgoing: true,
-//                 nodeExcludePrecedence: true,
-//                 nodeInclude: 'asuka',
-//                 nodeIncludeName: 'test',
-//                 nodeExclude: 'testo',
-//                 nodeExcludeTags: 'dev']|
-//                [
-//                        nodeThreadcount: 4,
-//                        nodeKeepgoing: true,
-//                        nodeExcludePrecedence: true,
-//                        nodeInclude: null,
-//                        nodeIncludeName: null,
-//                        nodeExclude: null,
-//                        nodeExcludeTags: null]
+        [doNodedispatch: true, filter: 'something',] |
+            [:] |
+            [doNodedispatch: false, filter: null,]
+        //override filters
+        [doNodedispatch: true, nodeInclude: "monkey.*", nodeExcludeOsFamily: 'windows', nodeIncludeTags: 'something',] |
+
+            [doNodedispatch       : true,
+             nodeThreadcount      : 1,
+             nodeKeepgoing        : true,
+             nodeExcludePrecedence: true,
+             nodeInclude          : 'asuka',
+             nodeIncludeName      : 'test',
+             nodeExclude          : 'testo',
+             nodeExcludeTags      : 'dev'] |
+
+            [doNodedispatch       : true,
+             nodeThreadcount      : 1,
+             nodeKeepgoing        : true,
+             nodeExcludePrecedence: true,
+             nodeInclude          : null,
+             nodeIncludeName      : null,
+             nodeExclude          : null,
+             nodeExcludeTags      : null]
+        //
+        [doNodedispatch: true, nodeInclude: 'test', nodeThreadcount: 1] |
+            [nodeThreadcount      : 4,
+             nodeKeepgoing        : true,
+             nodeExcludePrecedence: true,
+             nodeInclude          : 'asuka',
+             nodeIncludeName      : 'test',
+             nodeExclude          : 'testo',
+             nodeExcludeTags      : 'dev'] |
+
+            [
+                nodeThreadcount      : 4,
+                nodeKeepgoing        : true,
+                nodeExcludePrecedence: true,
+                nodeInclude          : null,
+                nodeIncludeName      : null,
+                nodeExclude          : null,
+                nodeExcludeTags      : null]
     }
 
     def "load jobs cluster mode should set server UUID"(){


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**

Changes the quartz schedule key to prevent scenarios in which certain combination of job deletions and import can cause multiple triggering of the same schedule.

**Describe the solution you've implemented**

Changes the quartz schedule key from using the DB id, project name and group, to the job UUID.

** Bonus Fix **
Also fixes a minor bug in which attempting to delete a job with two or more running executions results in a 500 error instead of the correct error message.
