### PR TITLE
RUN-2603 Jobs scheduled at Project level continue to run when disabled by a Not Owner cluster member

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1664,7 +1664,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         data.put("scheduledExecutionId", se.uuid)
         data.put("rdeck.base", frameworkService.getRundeckBase())
 
-        if(se.scheduled){
+        if(se.scheduled ||jobSchedulesService.shouldScheduleExecution(se.uuid)){
             data.put("userRoles", se.userRoleList)
             if(frameworkService.isClusterModeEnabled()){
                 data.put("serverUUID", frameworkService.getServerUUID())

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -3283,6 +3283,9 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         service.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor)
         service.fileUploadService = Mock(FileUploadService)
         service.jobSchedulerService = Mock(JobSchedulerService)
+        service.jobSchedulesService = Mock(JobSchedulesService){
+            shouldScheduleExecution(_) >> true
+        }
 
         when:
         def result = service.rescheduleOnetimeExecutions(Arrays.asList(exec1))

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -3284,7 +3284,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         service.fileUploadService = Mock(FileUploadService)
         service.jobSchedulerService = Mock(JobSchedulerService)
         service.jobSchedulesService = Mock(JobSchedulesService){
-            shouldScheduleExecution(_) >> true
+          1 * shouldScheduleExecution(_) >> true
         }
 
         when:


### PR DESCRIPTION
Problem:
Jobs scheduled at Project level continue to run when disabled by a Not Owner cluster member

Solution:
Add a condition to validate if scheduled executions are scheduled at project level.

STR:
1. Steps to reproduce the behavior:
2. Create a simple job (no schedule at job level)
3. Add as Project Schedule to this job (example, run every minute).
4. Disable the job schedule from the Jobs tab (Actions > Disable Schedule)
5. Wait to check that the job does not run and it has the NEVER next to it (expected)
6. Enable back the job schedule from the Jobs tab (Actions > Enable Schedule)
7. Log in to the other cluster member (not owner)
8. Disable the job schedule from the Jobs tab (Actions > Disable Schedule
9. Wait to check that the job still runs even if it has the NEVER next to it (NOT expected)
