### PR TITLE
RCLOUD-1371: Add JMX metrics for to track user login and logout

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -592,6 +592,7 @@ beans={
 
     auditEventsService(AuditEventsService) {
         frameworkService = ref('frameworkService')
+        metricService = ref('metricService')
     }
 
     scmJobImporter(ScmJobImporter)

--- a/rundeckapp/src/test/groovy/rundeck/services/audit/AuditEventsServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/audit/AuditEventsServiceSpec.groovy
@@ -50,6 +50,9 @@ class AuditEventsServiceSpec extends Specification implements ServiceUnitTest<Au
 
     def "Test event builder data cloning"() {
         given:
+        defineBeans {
+            metricService(InstanceFactoryBean, Mock(MetricService))
+        }
         def user = "MockUsername"
         def roleList = ["admin", "user", "test"]
         def uuid = "11111111-1111-0000-0000-111111111111"
@@ -87,6 +90,9 @@ class AuditEventsServiceSpec extends Specification implements ServiceUnitTest<Au
         def invocations = 0
 
         given:
+        defineBeans {
+            metricService(InstanceFactoryBean, Mock(MetricService))
+        }
         def user = "MockUsername"
         def roleList = ["admin", "user", "test"]
         def uuid = "11111111-1111-0000-0000-111111111111"


### PR DESCRIPTION
Add JMX metrics to track user logins both successful and failed and user logouts.

New metrics:
userLogin.success
userLogin.failure
userLogout.success