### PR TITLE
RCLOUD-1389: add metric

### DIFF
--- a/rundeckapp/src/test/groovy/rundeck/interceptors/AuthorizationInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/AuthorizationInterceptorSpec.groovy
@@ -1,12 +1,22 @@
 package rundeck.interceptors
 
+import com.codahale.metrics.Counter
 import grails.testing.web.interceptor.InterceptorUnitTest
+import org.grails.plugins.metricsweb.MetricService
+import org.grails.spring.beans.factory.InstanceFactoryBean
 import org.rundeck.app.access.InterceptorHelper
 import spock.lang.Specification
 
 class AuthorizationInterceptorSpec extends Specification implements InterceptorUnitTest<AuthorizationInterceptor> {
 
+    AuthorizationInterceptor interceptor
     def setup() {
+        interceptor = new AuthorizationInterceptor()
+        interceptor.apiAuthorizationSuccess = Mock(Counter)
+        interceptor.apiAuthorizationFailure = Mock(Counter)
+        defineBeans {
+            metricService(InstanceFactoryBean, Mock(MetricService))
+        }
     }
 
     def cleanup() {
@@ -26,6 +36,7 @@ class AuthorizationInterceptorSpec extends Specification implements InterceptorU
             request.apiVersionStatusNotReady = true
             request.invalidApiAuthentication = invalidApiAuthentication
             interceptor.interceptorHelper = Mock(InterceptorHelper)
+
         when:
             def result = interceptor.before()
         then:
@@ -60,4 +71,31 @@ class AuthorizationInterceptorSpec extends Specification implements InterceptorU
             'json' | false   | true
             null   | false   | true
     }
+
+    def "should increment success counter when request is authorized"() {
+        given:
+        request.invalidApiAuthentication = false
+        interceptor.interceptorHelper = Mock(InterceptorHelper)
+
+        when:
+        interceptor.before()
+
+        then:
+        1 * interceptor.apiAuthorizationSuccess.inc()
+
+    }
+
+    def "should increment failure counter when request is not authorized"() {
+        given:
+        request.invalidApiAuthentication = true
+        interceptor.interceptorHelper = Mock(InterceptorHelper)
+
+        when:
+        interceptor.before()
+
+        then:
+        1 * interceptor.apiAuthorizationFailure.inc()
+
+    }
+
 }


### PR DESCRIPTION
Add JMX metrics to track api authorizations

New metrics:
apiAuthorization.success
apiAuthorization.failure