### PR TITLE
RUN-2478: bring in uiv translations

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -9,12 +9,6 @@ const messages = {
     "Dispatch to Nodes": "Dispatch to Nodes",
     Nodes: "Nodes",
   },
-  uiv: {
-    modal: {
-      cancel: "Cancel",
-      ok: "OK",
-    },
-  },
   cron: {
     section: {
       0: "Seconds",
@@ -829,6 +823,45 @@ const messages = {
   "option.view.action.moveUp.title": "Move Up",
   "option.view.action.moveDown.title": "Move Down",
   "option.view.action.drag.title": "Drag to reorder",
+  uiv: {
+    datePicker: {
+      clear: "Clear",
+      today: "Today",
+      month: "Month",
+      month1: "January",
+      month2: "February",
+      month3: "March",
+      month4: "April",
+      month5: "May",
+      month6: "June",
+      month7: "July",
+      month8: "August",
+      month9: "September",
+      month10: "October",
+      month11: "November",
+      month12: "December",
+      year: "Year",
+      week1: "Mon",
+      week2: "Tue",
+      week3: "Wed",
+      week4: "Thu",
+      week5: "Fri",
+      week6: "Sat",
+      week7: "Sun",
+    },
+    timePicker: {
+      am: "AM",
+      pm: "PM",
+    },
+    modal: {
+      cancel: "Cancel",
+      ok: "OK",
+    },
+    multiSelect: {
+      placeholder: "Select...",
+      filterPlaceholder: "Search...",
+    },
+  },
 };
 
 export default messages;


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

bugfix: when updating webpack to version 5, had to remove the locale strings imports from uiv, as due to the way they were exported from the package, it wasn't possible to import them anymore. 

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Manually added these strings to project's locale file.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
To reproduce:

1. Project > Activity > Search… modal
2. Time dropdown choose Other…
3. check Start After or any other filter
4. Click the calendar icon to show the date/time picker
5. See the AM/PM button label text is uiv.timePicker.pm

After:
![Screenshot 2024-07-10 at 2 40 55 PM](https://github.com/rundeck/rundeck/assets/139791797/345aac88-28ee-4d5f-9e92-29067e7c8be3)


