### PR TITLE
[RUN-2636] Red Hat image for RPM packaging test

### DIFF
--- a/packaging/test/docker/installcommon/redhatubi8.Dockerfile
+++ b/packaging/test/docker/installcommon/redhatubi8.Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:8
+FROM redhat/ubi8
 
 RUN yum -y update
 RUN yum -y install java-11-openjdk java-11-openjdk-devel initscripts openssh openssl

--- a/packaging/test/docker/installcommon/rockylinux8.Dockerfile
+++ b/packaging/test/docker/installcommon/rockylinux8.Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM rockylinux:8
 
 RUN yum -y update
 RUN yum -y install java-11-openjdk java-11-openjdk-devel initscripts openssh openssl

--- a/packaging/test/docker/rpminstall/Dockerfile
+++ b/packaging/test/docker/rpminstall/Dockerfile
@@ -1,5 +1,5 @@
 # original https://hub.docker.com/r/bwits/rundeck-build/
-FROM rdpro-centos7-util:latest
+FROM rdpro-rockylinux8-util:latest
 
 RUN useradd rundeck
 #USER rundeck

--- a/packaging/test/docker/rpminstall/Dockerfile
+++ b/packaging/test/docker/rpminstall/Dockerfile
@@ -1,5 +1,5 @@
 # original https://hub.docker.com/r/bwits/rundeck-build/
-FROM rdpro-rockylinux8-util:latest
+FROM rdpro-redhatubi8-util:latest
 
 RUN useradd rundeck
 #USER rundeck

--- a/packaging/test/test-docker-install-rpm.sh
+++ b/packaging/test/test-docker-install-rpm.sh
@@ -2,7 +2,7 @@
 
 LDIR=$( cd $(dirname $0) ; echo $PWD )
 export DIR="${PACKAGING_DIR}/test/docker/rpminstall"
-export COMMON="rockylinux8"
+export COMMON="redhatubi8"
 export PACKAGE_TYPE="rpm"
 
 

--- a/packaging/test/test-docker-install-rpm.sh
+++ b/packaging/test/test-docker-install-rpm.sh
@@ -2,7 +2,7 @@
 
 LDIR=$( cd $(dirname $0) ; echo $PWD )
 export DIR="${PACKAGING_DIR}/test/docker/rpminstall"
-export COMMON="centos7"
+export COMMON="rockylinux8"
 export PACKAGE_TYPE="rpm"
 
 


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Resolves an issue with the packaging tests in the CI pipeline.

**Describe the solution you've implemented**
This PR switches the image used to test the Rundeck RPM distribution from [the now deprecated] CentOS to [Red Hat's Universal Base Images](https://developers.redhat.com/articles/ubi-faq).

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
