### PR TITLE
RUN-2661, RUN-2663: CSS fixes and switch component started

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/InputSwitch/Docs.mdx
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/InputSwitch/Docs.mdx
@@ -1,4 +1,4 @@
-import { Meta, Subtitle, Title, Canvas, Controls, Description, Stories } from "@storybook/blocks";
+import { Meta, Subtitle, Title, Canvas, Controls, Description, Stories, Markdown } from "@storybook/blocks";
 import * as InputSwitchStories from './InputSwitch.stories'
 
 <Meta of={InputSwitchStories} />
@@ -33,4 +33,20 @@ import InputSwitch from "primevue/inputswitch";
 
 ## Accessibility
 
-{/* Bring in accessibility notes from primeVue here and\/or add aspects important for accessibility */}
+### Screen Reader
+InputSwitch component uses a hidden native checkbox element with `switch` role internally that is only visible to screen readers. Value to describe the component can either be provided via `label` tag combined with `id` prop or using `aria-labelledby`, `aria-label` props.
+
+### Keyboard Support
+
+Key	Function
+tab	Moves focus to the switch.
+space	Toggles the checked state.
+
+<Markdown>
+    {`
+| Key         | Function                   |
+| ----------- | -------------------------- |
+| tab         | Moves focus to the switch. |
+| space       | Toggles the checked state. |
+`}
+</Markdown>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/InputSwitch/Docs.mdx
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/InputSwitch/Docs.mdx
@@ -1,0 +1,36 @@
+import { Meta, Subtitle, Title, Canvas, Controls, Description, Stories } from "@storybook/blocks";
+import * as InputSwitchStories from './InputSwitch.stories'
+
+<Meta of={InputSwitchStories} />
+
+<Title />
+
+<Subtitle />
+[Component reference on primevue](https://primevue.org/inputswitch/)
+
+## Import
+
+```ts
+import InputSwitch from "primevue/inputswitch";
+```
+
+## Playground
+
+{/* Make sure your stories file has an export for playground, otherwise storybook will break */}
+
+<Canvas of={InputSwitchStories.Playground} sourceState="shown" />
+<Controls of={InputSwitchStories.Playground} />
+
+## How to use
+
+{/* Add a note here about the relevant props to change appearance of component */}
+
+
+<Description of={InputSwitchStories} />
+
+<Stories title='' includePrimary={false} />
+
+
+## Accessibility
+
+{/* Bring in accessibility notes from primeVue here and\/or add aspects important for accessibility */}

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/InputSwitch/InputSwitch.stories.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/InputSwitch/InputSwitch.stories.ts
@@ -47,15 +47,26 @@ export const Playground: Story = {
 };
 
 const generateTemplate = (args: Record<string, any>) => {
-  return `<div>
-    <InputSwitch v-bind="args" />
-  </div>`;
+  return '<div><InputSwitch :disabled="args.disabled" v-model="args.modelValue" /></div>';
 };
 
-export const Default: Story = {
+export const Active: Story = {
   render: (args) => ({
     components: { InputSwitch },
     setup: () => ({ args }),
     template: generateTemplate(args),
   }),
+};
+
+export const Disabled: Story = {
+  render: (args) => ({
+    components: { InputSwitch },
+    setup: () => ({ args }),
+    template:
+      '<div style="gap: 10px; display: flex;"><InputSwitch :disabled="args.disabled" v-model="args.modelValue" /><InputSwitch :disabled="args.disabled" /></div>',
+  }),
+  args: {
+    disabled: true,
+    modelValue: true,
+  },
 };

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/InputSwitch/InputSwitch.stories.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/InputSwitch/InputSwitch.stories.ts
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/vue3";
+import "./inputswitch.scss";
+import InputSwitch from "primevue/inputswitch";
+
+const meta: Meta<typeof InputSwitch> = {
+  title: "InputSwitch",
+  parameters: {
+    docs: {
+      componentSubtitle: "InputSwitch is used to select a boolean value.",
+    },
+    actions: {
+      disable: true,
+    },
+    controls: {
+      disable: true,
+    },
+  },
+  argTypes: {
+    disabled: {
+      type: "boolean",
+      description:
+        "When present, it specifies that the component should be disabled.",
+    },
+    modelValue: {
+      type: "string | boolean",
+      description: "Specifies whether a inputswitch should be checked or not.",
+    },
+  },
+  args: {
+    disabled: false,
+    modelValue: true,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof InputSwitch>;
+
+// TODO: manually wire the props to the component name, so that the source will update correctly in the story
+export const Playground: Story = {
+  name: "Playground",
+  render: (args) => ({
+    components: { InputSwitch },
+    setup: () => ({ args }),
+    template: `<InputSwitch :disabled="args.disabled" v-model="args.checked" />`,
+  }),
+};
+
+const generateTemplate = (args: Record<string, any>) => {
+  return `<div>
+    <InputSwitch v-bind="args" />
+  </div>`;
+};
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { InputSwitch },
+    setup: () => ({ args }),
+    template: generateTemplate(args),
+  }),
+};

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/InputSwitch/inputswitch.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/InputSwitch/inputswitch.scss
@@ -1,0 +1,12 @@
+.p-inputswitch {
+    .p-inputswitch-slider {
+        background: var(--colors-gray-300);
+    }
+    &.p-highlight .p-inputswitch-slider {
+        background: var(--colors-blue-500);
+    }
+
+    &.p-disabled .p-inputswitch-slider {
+        background: var(--colors-blue-200);
+    }
+}

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/InputSwitch/inputswitch.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/InputSwitch/inputswitch.scss
@@ -2,11 +2,18 @@
     .p-inputswitch-slider {
         background: var(--colors-gray-300);
     }
-    &.p-highlight .p-inputswitch-slider {
-        background: var(--colors-blue-500);
+    &.p-disabled .p-inputswitch-slider {
+        background: var(--colors-gray-200);
     }
 
-    &.p-disabled .p-inputswitch-slider {
-        background: var(--colors-blue-200);
+    &.p-highlight {
+        &.p-disabled .p-inputswitch-slider {
+            background: var(--colors-blue-200);
+        }
+
+        .p-inputswitch-slider {
+            background: var(--colors-blue-500);
+        }
     }
+
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/Message/message.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/Message/message.scss
@@ -35,7 +35,7 @@
         }
     }
 
-    &--warning {
+    &-warn {
         background: var(--colors-orange-100);
         border-color: var(--colors-orange-600);
 
@@ -44,7 +44,7 @@
         }
     }
 
-    &--danger {
+    &-error {
         background: var(--colors-red-100);
         border-color: var(--colors-red-600);
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/TabView/tabview.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/TabView/tabview.scss
@@ -1,8 +1,10 @@
 .p-tabview {
     .p-tabview-nav {
+        border-color: var(--colors-gray-300);
         li {
             .p-tabview-nav-link:not(.p-disabled) {
                 color: var(--colors-gray-500);
+                border-color: var(--colors-gray-300);
 
                 &:focus-visible {
                     box-shadow: inset 0 0 0 0.1rem var(--colors-gray-800);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/Tag/Tag.stories.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/Tag/Tag.stories.ts
@@ -72,7 +72,7 @@ export const Playground: Story = {
 
 const generateTemplate = (severity, args) => {
   return `
-      <Tag value="${args.value}" severity="${severity}" ico="${args.icon}" />
+      <Tag value="${args.value}" severity="${severity}" icon="${args.icon}" />
 `;
 };
 


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

Small CSS fixes for message and tabs components (RUN-2661 and RUN-2663); and style the switch component.

To see run locally `npm run storybook`

PS: these changes will be validated by designers afterwards.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

List of fixes:
- message component colors were wrong for variants info and warning;
- tabs's grey board wasn't gray-300 color;

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
