### PR TITLE
RUN-2672: Fix flaky unit test for `emits update:modelValue when time changes`

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/dateTimePicker.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/dateTimePicker.spec.ts
@@ -14,16 +14,13 @@ interface DateTimePickerInstance extends ComponentPublicInstance {
   setFromValue: () => void;
   recalcDate: () => void;
 }
+const newTime = new Date("2024-07-01");
 const mountDateTimePicker = async (
-  props: Partial<DateTimePickerProps> = {}
+  props: Partial<DateTimePickerProps> = {},
 ) => {
-  const modelValue =
-    typeof props.modelValue === "string"
-      ? moment(props.modelValue).format()
-      : props.modelValue || moment().format();
   return mount(DateTimePicker, {
     props: {
-      modelValue,
+      modelValue: newTime,
       dateClass: "date-class",
       timeClass: "time-class",
       ...props,
@@ -42,7 +39,7 @@ describe("DateTimePicker.vue", () => {
   });
   it("emits update:modelValue when time changes", async () => {
     const wrapper = await mountDateTimePicker();
-    const newTime = new Date();
+
     const newTimeFormatted = moment(newTime).format();
     const timePicker = wrapper.findComponent({ name: "time-picker" });
     timePicker.vm.$emit("update:modelValue", newTime);
@@ -54,7 +51,7 @@ describe("DateTimePicker.vue", () => {
     const newModelValue = moment().add(1, "days").format();
     await wrapper.setProps({ modelValue: newModelValue });
     expect(wrapper.vm.dateString).toBe(
-      moment(newModelValue).format("YYYY-MM-DD")
+      moment(newModelValue).format("YYYY-MM-DD"),
     );
     expect(wrapper.vm.time).toEqual(moment(newModelValue).toDate());
   });
@@ -72,7 +69,7 @@ describe("DateTimePicker.vue", () => {
     expect(datePicker.attributes("class")).toContain("date-class");
     expect(datePicker.attributes("clear-btn")).toBe("false");
     const receivedTime = new Date(
-      timePicker.attributes("modelvalue")
+      timePicker.attributes("modelvalue"),
     ).toISOString();
     const expectedTime = new Date(wrapper.vm.time).toISOString();
     expect(receivedTime).toBe(expectedTime);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/dateTimePicker.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/dateTimePicker.spec.ts
@@ -14,13 +14,14 @@ interface DateTimePickerInstance extends ComponentPublicInstance {
   setFromValue: () => void;
   recalcDate: () => void;
 }
-const newTime = new Date("2024-07-01");
+const initialTime = new Date("2024-06-30T13:00:00");
+const newTime = new Date("2024-07-01T07:00:00");
 const mountDateTimePicker = async (
   props: Partial<DateTimePickerProps> = {},
 ) => {
   return mount(DateTimePicker, {
     props: {
-      modelValue: newTime,
+      modelValue: initialTime,
       dateClass: "date-class",
       timeClass: "time-class",
       ...props,
@@ -43,34 +44,44 @@ describe("DateTimePicker.vue", () => {
     const newTimeFormatted = moment(newTime).format();
     const timePicker = wrapper.findComponent({ name: "time-picker" });
     timePicker.vm.$emit("update:modelValue", newTime);
+    await wrapper.vm.$nextTick();
+
     const emitted = wrapper.emitted("update:modelValue");
-    expect(emitted[0]).toEqual([newTimeFormatted]);
+    expect(emitted.pop()).toEqual([newTimeFormatted]);
   });
   it("updates time and dateString when modelValue changes", async () => {
     const wrapper = await mountDateTimePicker();
-    const newModelValue = moment().add(1, "days").format();
+    const newModelValue = moment(newTime).add(1, "days").format();
     await wrapper.setProps({ modelValue: newModelValue });
-    expect(wrapper.vm.dateString).toBe(
-      moment(newModelValue).format("YYYY-MM-DD"),
-    );
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.dateString).toBe("2024-07-02");
     expect(wrapper.vm.time).toEqual(moment(newModelValue).toDate());
   });
   it("recalculates date when dateString changes", async () => {
     const wrapper = await mountDateTimePicker();
-    const newDateString = moment().add(1, "days").format("YYYY-MM-DD");
-    await wrapper.setData({ dateString: newDateString });
+    const newDateString = moment(newTime).add(1, "days").format("YYYY-MM-DD");
+    const datePicker = wrapper.findComponent({ name: "date-picker" });
+    datePicker.vm.$emit("update:modelValue", newDateString);
+    await wrapper.vm.$nextTick();
+
     expect(moment(wrapper.vm.time).format("YYYY-MM-DD")).toBe(newDateString);
   });
   it("binds v-model, class correctly and sets correct attributes on date-picker and time-picker", async () => {
     const wrapper = await mountDateTimePicker();
     const datePicker = wrapper.findComponent({ name: "date-picker" });
     const timePicker = wrapper.findComponent({ name: "time-picker" });
+
     expect(datePicker.attributes("modelvalue")).toBe(wrapper.vm.dateString);
     expect(datePicker.attributes("class")).toContain("date-class");
     expect(datePicker.attributes("clear-btn")).toBe("false");
+    expect(datePicker.attributes("role")).toBe("combobox");
+    expect(timePicker.attributes("role")).toBe("combobox");
+
     const receivedTime = new Date(
       timePicker.attributes("modelvalue"),
     ).toISOString();
+
     const expectedTime = new Date(wrapper.vm.time).toISOString();
     expect(receivedTime).toBe(expectedTime);
     expect(timePicker.attributes("class")).toContain("time-class");
@@ -84,12 +95,5 @@ describe("DateTimePicker.vue", () => {
     const wrapper = await mountDateTimePicker({ modelValue: leapYear });
     expect(wrapper.vm.dateString).toBe(leapYear);
     expect(wrapper.vm.time).toBeInstanceOf(Date);
-  });
-  it("is accessible", async () => {
-    const wrapper = await mountDateTimePicker();
-    const datePicker = wrapper.findComponent({ name: "date-picker" });
-    const timePicker = wrapper.findComponent({ name: "time-picker" });
-    expect(datePicker.attributes("role")).toBe("combobox");
-    expect(timePicker.attributes("role")).toBe("combobox");
   });
 });


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

In accordance to circle ci, the test `emits update:modelValue when time changes` is flaky because of dates

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
froze the dates to fix this and make all these tests sturdier + concatenated 2 tests that were asserting similar things.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
To mock the global Date object.

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
