### PR TITLE
RUN-2499: Fix typescript issues to use NodeTable and NodeFilterInput components in another enterprise component

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeFilterInput.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeFilterInput.vue
@@ -234,7 +234,7 @@
   </modal>
 </template>
 <script lang="ts">
-import { getRundeckContext } from "@/library";
+import { getRundeckContext } from "../../../../library";
 import {
   NodeFilterStore,
   ProjectFilters,
@@ -387,7 +387,9 @@ export default defineComponent({
   },
   watch: {
     modelValue() {
-      this.outputValue = this.modelValue;
+      if (this.modelValue) {
+        this.outputValue = this.modelValue;
+      }
       if (
         this.selectedFilterName &&
         this.selectedFilterName !== this.matchedFilter
@@ -481,7 +483,9 @@ export default defineComponent({
       this.setDefaultFilterValue(".*");
     },
     async onMount() {
-      this.outputValue = this.modelValue;
+      if (this.modelValue) {
+        this.outputValue = this.modelValue;
+      }
       if (
         this.selectedFilterName &&
         this.selectedFilterName !== this.matchedFilter

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeTable.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeTable.vue
@@ -355,10 +355,10 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
-import { _genUrl } from "@/app/utilities/genUrl";
-import { getAppLinks } from "@/library";
-import NodeDetailsSimple from "@/app/components/job/resources/NodeDetailsSimple.vue";
-import NodeRemoteEdit from "@/app/components/job/resources/NodeRemoteEdit.vue";
+import { _genUrl } from "../../../utilities/genUrl";
+import { getAppLinks } from "../../../../library";
+import NodeDetailsSimple from "./NodeDetailsSimple.vue";
+import NodeRemoteEdit from "./NodeRemoteEdit.vue";
 import {
   cssForIcon,
   expandNodeAttributes,
@@ -370,8 +370,9 @@ import {
   statusIconStyle,
   styleForIcon,
   styleForNode,
-} from "@/app/utilities/nodeUi";
-import NodeFilterLink from "@/app/components/job/resources/NodeFilterLink.vue";
+} from "../../../utilities/nodeUi";
+import NodeFilterLink from "./NodeFilterLink.vue";
+import { Node } from "./types/nodeTypes";
 
 export default defineComponent({
   name: "NodeTable",
@@ -418,8 +419,8 @@ export default defineComponent({
   data() {
     return {
       shouldRefresh: false,
-      remoteUrl: null,
-      remoteEditNodename: null,
+      remoteUrl: null as null | string,
+      remoteEditNodename: null as null | string,
     };
   },
   computed: {
@@ -434,24 +435,27 @@ export default defineComponent({
       return this.useDefaultColumns ? 5 : filterColumnsLength + 2;
     },
     remoteEditStarted(): boolean {
-      return this.remoteUrl && this.remoteEditNodename;
+      return !!(this.remoteUrl && this.remoteEditNodename) || false;
     },
     pageNumbersSkipped(): string[] {
       const arr = [];
       const cur = this.page;
       const maxPages = this.maxPages;
       const buffer = 3;
-      for (let i = 0; i < maxPages; i++) {
-        if (
-          (i >= cur - buffer && i <= cur + buffer) ||
-          i < buffer ||
-          i >= maxPages - buffer
-        ) {
-          arr.push(i);
-        } else if (i == cur - buffer - 1 || i == cur + buffer + 1) {
-          arr.push("..");
+      if (maxPages) {
+        for (let i = 0; i < maxPages; i++) {
+          if (
+            (i >= cur - buffer && i <= cur + buffer) ||
+            i < buffer ||
+            i >= maxPages - buffer
+          ) {
+            arr.push(`${i}`);
+          } else if (i == cur - buffer - 1 || i == cur + buffer + 1) {
+            arr.push("..");
+          }
         }
       }
+
       return arr;
     },
     browseNodesPageNextUrl(): string {
@@ -470,7 +474,7 @@ export default defineComponent({
     statusIconCss,
     styleForNode,
     expandNodeAttributes,
-    nodeCss(attrs) {
+    nodeCss(attrs: { [key: string]: string }) {
       const classnames = [];
       const uiColor = nodeFgCss(attrs);
       if (uiColor) {
@@ -480,9 +484,8 @@ export default defineComponent({
       if (uiBgcolor) {
         classnames.push(uiBgcolor);
       }
-      const cnames = classnames.join(" ");
 
-      return cnames;
+      return classnames.join(" ");
     },
     filterClick(filter: any) {
       this.$emit("filter", filter);
@@ -491,7 +494,7 @@ export default defineComponent({
       this.$emit("changePagingMax", Number(event.target.value));
     },
     browseNodesPageNext() {
-      if (this.page + 1 < this.maxPages) {
+      if (this.maxPages && this.page + 1 < this.maxPages) {
         this.browseNodesPage(this.page + 1);
       }
     },
@@ -500,7 +503,7 @@ export default defineComponent({
         this.browseNodesPage(this.page - 1);
       }
     },
-    browseNodesPage(newPage) {
+    browseNodesPage(newPage: number | string) {
       if (this.page === newPage) {
         return;
       } else {
@@ -515,7 +518,7 @@ export default defineComponent({
         max: this.pagingMax,
       };
       const castPage = parseInt(page as string);
-      if (castPage >= 0 && castPage < this.maxPages) {
+      if (castPage >= 0 && this.maxPages && castPage < this.maxPages) {
         pageParams.page = castPage;
       } else {
         pageParams.page = 0;
@@ -523,7 +526,7 @@ export default defineComponent({
       return _genUrl(getAppLinks().frameworkNodes, pageParams);
     },
 
-    triggerNodeRemoteEdit(node) {
+    triggerNodeRemoteEdit(node: Node) {
       if (node.attributes["remoteUrl"]) {
         this.remoteUrl = node.attributes["remoteUrl"];
         this.remoteEditNodename = node.nodename;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/types/nodeTypes.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/types/nodeTypes.ts
@@ -10,4 +10,12 @@ interface NodeSummary extends ProjectFilters {
   totalCount?: number;
 }
 
-export { NodeSummary, Tag };
+interface Node {
+  attributes: { [key: string]: string };
+  isLocal?: boolean;
+  authrun?: boolean;
+  nodename: string;
+  tags: Tag[];
+}
+
+export { Node, NodeSummary, Tag };

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/NodeFilterLocalstore.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/NodeFilterLocalstore.ts
@@ -1,12 +1,12 @@
 export interface StoredFilter {
   filterName: string;
   isJobEdit: boolean;
-  filter: string;
+  filter: string | null;
 }
 
 export interface ProjectFilters {
   filters?: StoredFilter[];
-  defaultFilter?: string;
+  defaultFilter?: null | string;
 }
 
 export interface StoredNodeFilters {
@@ -55,7 +55,7 @@ export class NodeFilterStore {
     return storedNodeFilters[project] || {};
   }
 
-  getStoredDefaultFilter(project: string): string | undefined {
+  getStoredDefaultFilter(project: string): string | null | undefined {
     return this.loadStoredProjectNodeFilters(project).defaultFilter;
   }
 


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
This PR fixes some typescript checks issue when including NodeTable and NodeFilterInput components in a enterprise componente vue

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
