### PR TITLE
fixed and added test for glyphiconBadges

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/nodeUi.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/nodeUi.spec.ts
@@ -1,0 +1,35 @@
+import { glyphiconBadges } from "./nodeUi";
+
+describe("glyphiconBadges", () => {
+  test("parses well-formed input string correctly", () => {
+    const input = "glyphicon-user1, fa-badge2, fab-badge1, glyphicon-lock-1";
+    expect(glyphiconBadges({ "ui:badges": input })).toEqual([
+      "glyphicon-user1",
+      "fa-badge2",
+      "fab-badge1",
+      "glyphicon-lock-1",
+    ]);
+  });
+
+  test("filters out invalid badge names", () => {
+    const input = "glyphicon-user, invalid-badge, fa2-car, fab_badge";
+    expect(glyphiconBadges({ "ui:badges": input })).toEqual([
+      "glyphicon-user", // Assuming 'fa2-car' and 'fab_badge' are invalid
+    ]);
+  });
+
+  test("returns an empty array for an empty string", () => {
+    const input = "";
+    expect(glyphiconBadges({ "ui:badges": input })).toEqual([]);
+  });
+
+  test("returns an empty array when no valid badges are provided", () => {
+    const input = "invalid-badge, another-invalid";
+    expect(glyphiconBadges({ "ui:badges": input })).toEqual([]);
+  });
+
+  test("handles null or undefined input gracefully", () => {
+    expect(glyphiconBadges({ "ui:badges": null })).toEqual([]);
+    expect(glyphiconBadges({ "ui:badges": undefined })).toEqual([]);
+  });
+});

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/nodeUi.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/nodeUi.ts
@@ -181,13 +181,13 @@ export function glyphiconForName(name: string) {
 export function glyphiconBadges(attributes: any): Array<string> {
   const badges = [];
   if (attributes["ui:badges"]) {
-    const found = attributes["ui:badges"]().split(/,\s*/g);
+    const found = attributes["ui:badges"].split(/,\s*/g);
     for (let i = 0; i < found.length; i++) {
-      if (found[i].match(/^glyphicon-[a-z-]+$/)) {
+      if (found[i].match(/^glyphicon-[a-z0-9-]+$/)) {
         badges.push(found[i]);
-      } else if (found[i].match(/^fa-[a-z-]+$/)) {
+      } else if (found[i].match(/^fa-[a-z0-9-]+$/)) {
         badges.push(found[i]);
-      } else if (found[i].match(/^fab-[a-z-]+$/)) {
+      } else if (found[i].match(/^fab-[a-z0-9-]+$/)) {
         badges.push(found[i]);
       }
     }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/tests/nodeUi.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/tests/nodeUi.spec.ts
@@ -1,7 +1,7 @@
 import { glyphiconBadges } from "../nodeUi";
 
 describe("glyphiconBadges", () => {
-  test("parses well-formed input string correctly", () => {
+  it("parses well-formed input string correctly", () => {
     const input = "glyphicon-user1, fa-badge2, fab-badge1, glyphicon-lock-1";
     expect(glyphiconBadges({ "ui:badges": input })).toEqual([
       "glyphicon-user1",
@@ -11,24 +11,24 @@ describe("glyphiconBadges", () => {
     ]);
   });
 
-  test("filters out invalid badge names", () => {
+  it("filters out invalid badge names", () => {
     const input = "glyphicon-user, invalid-badge, fa2-car, fab_badge";
     expect(glyphiconBadges({ "ui:badges": input })).toEqual([
       "glyphicon-user", // Assuming 'fa2-car' and 'fab_badge' are invalid
     ]);
   });
 
-  test("returns an empty array for an empty string", () => {
+  it("returns an empty array for an empty string", () => {
     const input = "";
     expect(glyphiconBadges({ "ui:badges": input })).toEqual([]);
   });
 
-  test("returns an empty array when no valid badges are provided", () => {
+  it("returns an empty array when no valid badges are provided", () => {
     const input = "invalid-badge, another-invalid";
     expect(glyphiconBadges({ "ui:badges": input })).toEqual([]);
   });
 
-  test("handles null or undefined input gracefully", () => {
+  it("handles null or undefined input gracefully", () => {
     expect(glyphiconBadges({ "ui:badges": null })).toEqual([]);
     expect(glyphiconBadges({ "ui:badges": undefined })).toEqual([]);
   });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/tests/nodeUi.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/tests/nodeUi.spec.ts
@@ -1,4 +1,4 @@
-import { glyphiconBadges } from "./nodeUi";
+import { glyphiconBadges } from "../nodeUi";
 
 describe("glyphiconBadges", () => {
   test("parses well-formed input string correctly", () => {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/tests/nodeUi.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/tests/nodeUi.spec.ts
@@ -10,6 +10,13 @@ describe("glyphiconBadges", () => {
       "glyphicon-lock-1",
     ]);
   });
+  it("parses input string with badges that do not end with a number", () => {
+    const input = "fa-house-user, glyphicon-download-alt";
+    expect(glyphiconBadges({ "ui:badges": input })).toEqual([
+      "fa-house-user",
+      "glyphicon-download-alt",
+    ]);
+  });
 
   it("filters out invalid badge names", () => {
     const input = "glyphicon-user, invalid-badge, fa2-car, fab_badge";


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
This update serves as both a bugfix and an enhancement. This is a bugfix related to the incorrect handling of `ui.attributes` while the enhancement includes the addition of tests to ensure the component behaves as expected.

**Describe the solution you've implemented**
I have modified the `glyphiconBadges` function to correctly parse and validate the badge names provided in the `attributes["ui:badges"]` string.
Additionally, I have added comprehensive tests to verify the function's behavior:
- Parsing well-formed input strings.
- Parsing input strings that do not end with numbers
- Filtering out invalid badge names.
- Handling empty input strings.
- Returning an empty array when no valid badges are provided.
- Handling null or undefined input gracefully.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
