### PR TITLE
[RCLOUD-1380] Moves requestId interface to core module.

### DIFF
--- a/core/src/main/java/org/rundeck/app/web/RequestIdProvider.java
+++ b/core/src/main/java/org/rundeck/app/web/RequestIdProvider.java
@@ -1,0 +1,9 @@
+package org.rundeck.app.web;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface RequestIdProvider {
+    String HTTP_ATTRIBUTE_NAME = "requestId";
+    
+    String getRequestId(HttpServletRequest request);
+}

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/AA_TimerInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/AA_TimerInterceptor.groovy
@@ -2,7 +2,8 @@ package rundeck.interceptors
 
 import com.codahale.metrics.MetricRegistry
 import org.grails.web.util.WebUtils
-import org.rundeck.web.RequestIdProvider
+import org.rundeck.app.web.RequestIdProvider
+
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/ApiVersionInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/ApiVersionInterceptor.groovy
@@ -6,7 +6,7 @@ import grails.converters.XML
 import org.grails.web.converters.exceptions.ConverterException
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 import org.grails.web.util.WebUtils
-import org.rundeck.web.RequestIdProvider
+import org.rundeck.app.web.RequestIdProvider
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/RequestIdInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/RequestIdInterceptor.groovy
@@ -1,8 +1,7 @@
 package rundeck.interceptors
 
 import groovy.transform.CompileStatic
-
-import org.rundeck.web.RequestIdProvider
+import org.rundeck.app.web.RequestIdProvider
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
 

--- a/rundeckapp/src/main/groovy/org/rundeck/web/DefaultRequestIdProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/web/DefaultRequestIdProvider.groovy
@@ -1,10 +1,14 @@
 package org.rundeck.web
 
+import groovy.transform.CompileStatic
+import org.rundeck.app.web.RequestIdProvider
+
 import javax.servlet.http.HttpServletRequest
 
 /**
  * Provides a default RequestId when no other provider has been wired up to do so.
  */
+@CompileStatic
 class DefaultRequestIdProvider implements RequestIdProvider {
     @Override
     String getRequestId(HttpServletRequest request) {

--- a/rundeckapp/src/main/groovy/org/rundeck/web/RequestIdProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/web/RequestIdProvider.groovy
@@ -1,9 +1,0 @@
-package org.rundeck.web
-
-import javax.servlet.http.HttpServletRequest
-
-interface RequestIdProvider {
-    String HTTP_ATTRIBUTE_NAME = "requestId"
-
-    String getRequestId(HttpServletRequest request)
-}


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Resolves an issue where https://github.com/rundeck/rundeck/pull/9210 was not actually very extendable because the `RequestIdProvider` interface was not in an appropriate module.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
