### PR TITLE
RUN-2689: fix: exitCode from script steps is not correct in context variable data

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtils.java
@@ -18,6 +18,8 @@ package com.dtolabs.rundeck.core.execution.workflow.steps.node.impl;
 
 import com.dtolabs.rundeck.core.common.IFramework;
 import com.dtolabs.rundeck.core.common.INodeEntry;
+import com.dtolabs.rundeck.core.data.SharedDataContextUtils;
+import com.dtolabs.rundeck.core.dispatcher.ContextView;
 import com.dtolabs.rundeck.core.execution.*;
 import com.dtolabs.rundeck.core.execution.impl.common.DefaultFileCopierUtil;
 import com.dtolabs.rundeck.core.execution.impl.common.FileCopierUtil;
@@ -535,9 +537,18 @@ public class DefaultScriptFileNodeStepUtils implements ScriptFileNodeStepUtils {
                 executeCommand(framework, context, scriptArgList, node, input, retryExecuteCommand, 500);
 
         if (removeFile) {
+            //replace output context so that below executeCommand does not modify output data from previous script execution
+            final ExecutionContextImpl ctx1 = ExecutionContextImpl
+                    .builder(context)
+                    .outputContext(SharedDataContextUtils.outputContext(ContextView.global()))
+                    .build();
+
             //remove file
             final NodeExecutorResult nodeExecutorResult2 = framework.getExecutionService().executeCommand(
-                    context, removeArgsForOsFamily(filepath, node.getOsFamily()), node);
+                    ctx1,
+                    removeArgsForOsFamily(filepath, node.getOsFamily()),
+                    node
+            );
             if (!nodeExecutorResult2.isSuccess()) {
                 if (null != context.getExecutionListener()) {
                     context.getExecutionListener().log(1, "Failed to remove remote file: " + filepath);

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/workflowSteps/StepExecutionContextSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/workflowSteps/StepExecutionContextSpec.groovy
@@ -1,0 +1,100 @@
+package org.rundeck.tests.functional.api.workflowSteps
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.rundeck.util.annotations.APITest
+import org.rundeck.util.common.WaitingTime
+import org.rundeck.util.common.execution.ExecutionStatus
+import org.rundeck.util.common.jobs.JobUtils
+import org.rundeck.util.container.BaseContainer
+
+/**
+ * Test script and command steps should produce the correct exitCode into the output context
+ */
+@APITest
+class StepExecutionContextSpec extends BaseContainer {
+    public static final String TEST_PROJECT = "test-step-execution-context"
+    public static final String TEST_ARCHIVE_DIR = "/projects-import/step-execution-context"
+
+    def setupSpec() {
+        startEnvironment()
+        setupProjectArchiveDirectory(
+            TEST_PROJECT,
+            new File(getClass().getResource(TEST_ARCHIVE_DIR).getPath()),
+            [
+                "importJobs"   : "true",
+                "jobUuidOption": "preserve"
+            ]
+        )
+    }
+
+    def "test Job with script step should define correct exitCode"() {
+        given:
+            def jobId = "1266c6ed-5cb7-4736-9e64-7f902f1090fa"
+            def jobConfig = [
+                "loglevel": "DEBUG"
+            ]
+
+        when:
+            def json = post("/job/${jobId}/executions", jobConfig, Map)
+        then:
+            json.id != null
+        when:
+            def exec = JobUtils.waitForExecutionToBe(
+                ExecutionStatus.FAILED.state,
+                json.id as String,
+                new ObjectMapper(),
+                client,
+                WaitingTime.MODERATE.milliSeconds,
+                WaitingTime.EXCESSIVE.milliSeconds / 1000 as int
+            )
+        then:
+            exec.status == 'failed'
+        when:
+            String execId = json.id
+            def entries = getExecutionOutput(execId)
+        then:
+            entries.containsAll(
+                "STEP 1: will succeed",
+                "STEP 2: will fail with code 99",
+                "Result: 99",
+                "Failed: NonZeroResultCode: Result code was 99",
+                "STEP 3: ExitCode from Step1: 0",
+                "STEP 4: ExitCode from Step2: 99"
+            )
+    }
+    def "test Job with command step should define correct exitCode"() {
+        given:
+            def jobId = "aeb9ce8c-c78b-4414-9948-26bfd134303c"
+            def jobConfig = [
+                "loglevel": "DEBUG"
+            ]
+
+        when:
+            def json = post("/job/${jobId}/executions", jobConfig, Map)
+        then:
+            json.id != null
+        when:
+            def exec = JobUtils.waitForExecutionToBe(
+                ExecutionStatus.FAILED.state,
+                json.id as String,
+                new ObjectMapper(),
+                client,
+                WaitingTime.MODERATE.milliSeconds,
+                WaitingTime.EXCESSIVE.milliSeconds / 1000 as int
+            )
+        then:
+            exec.status == 'failed'
+        when:
+            String execId = json.id
+            def entries = getExecutionOutput(execId)
+        then:
+            entries.containsAll(
+                "STEP 1: will succeed",
+                "STEP 2: will fail with code 77",
+                "Result: 77",
+                "Failed: NonZeroResultCode: Result code was 77",
+                "STEP 3: ExitCode from Step1: 0",
+                "STEP 4: ExitCode from Step2: 77"
+            )
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/workflowSteps/StepExecutionContextSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/workflowSteps/StepExecutionContextSpec.groovy
@@ -44,8 +44,8 @@ class StepExecutionContextSpec extends BaseContainer {
                 json.id as String,
                 new ObjectMapper(),
                 client,
-                WaitingTime.MODERATE.milliSeconds,
-                WaitingTime.EXCESSIVE.milliSeconds / 1000 as int
+                WaitingTime.MODERATE,
+                WaitingTime.EXCESSIVE
             )
         then:
             exec.status == 'failed'
@@ -79,8 +79,8 @@ class StepExecutionContextSpec extends BaseContainer {
                 json.id as String,
                 new ObjectMapper(),
                 client,
-                WaitingTime.MODERATE.milliSeconds,
-                WaitingTime.EXCESSIVE.milliSeconds / 1000 as int
+                WaitingTime.MODERATE,
+                WaitingTime.EXCESSIVE
             )
         then:
             exec.status == 'failed'

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/workflowSteps/StepExecutionContextSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/workflowSteps/StepExecutionContextSpec.groovy
@@ -39,19 +39,12 @@ class StepExecutionContextSpec extends BaseContainer {
         then:
             json.id != null
         when:
-            def exec = JobUtils.waitForExecutionToBe(
-                ExecutionStatus.FAILED.state,
-                json.id as String,
-                new ObjectMapper(),
-                client,
-                WaitingTime.MODERATE,
-                WaitingTime.EXCESSIVE
-            )
+            def exec = waitForExecutionFinish(json.id as String)
         then:
             exec.status == 'failed'
         when:
             String execId = json.id
-            def entries = getExecutionOutput(execId)
+            def entries = getExecutionOutputLines(execId)
         then:
             entries.containsAll(
                 "STEP 1: will succeed",
@@ -74,19 +67,12 @@ class StepExecutionContextSpec extends BaseContainer {
         then:
             json.id != null
         when:
-            def exec = JobUtils.waitForExecutionToBe(
-                ExecutionStatus.FAILED.state,
-                json.id as String,
-                new ObjectMapper(),
-                client,
-                WaitingTime.MODERATE,
-                WaitingTime.EXCESSIVE
-            )
+            def exec = waitForExecutionFinish(json.id as String)
         then:
             exec.status == 'failed'
         when:
             String execId = json.id
-            def entries = getExecutionOutput(execId)
+            def entries = getExecutionOutputLines(execId)
         then:
             entries.containsAll(
                 "STEP 1: will succeed",

--- a/functional-test/src/test/resources/projects-import/step-execution-context/rundeck-TestStepExecContext/jobs/job-1266c6ed-5cb7-4736-9e64-7f902f1090fa.xml
+++ b/functional-test/src/test/resources/projects-import/step-execution-context/rundeck-TestStepExecContext/jobs/job-1266c6ed-5cb7-4736-9e64-7f902f1090fa.xml
@@ -1,0 +1,31 @@
+<joblist>
+  <job>
+    <defaultTab>summary</defaultTab>
+    <description>Test script failure correctly sets exit code context variable</description>
+    <executionEnabled>true</executionEnabled>
+    <id>1266c6ed-5cb7-4736-9e64-7f902f1090fa</id>
+    <loglevel>INFO</loglevel>
+    <name>Script Fails with exitCode</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <scheduleEnabled>true</scheduleEnabled>
+    <sequence keepgoing='true' strategy='node-first'>
+      <command>
+        <script><![CDATA[echo "STEP 1: will succeed"
+]]></script>
+      </command>
+      <command>
+        <script><![CDATA[ echo "STEP 2: will fail with code 99"
+
+        exit 99]]></script>
+        <scriptargs />
+      </command>
+      <command>
+        <exec><![CDATA[echo "STEP 3: ExitCode from Step1: ${1:exec.exitCode*}"]]></exec>
+      </command>
+      <command>
+        <exec><![CDATA[echo "STEP 4: ExitCode from Step2: ${2:exec.exitCode*}"]]></exec>
+      </command>
+    </sequence>
+    <uuid>1266c6ed-5cb7-4736-9e64-7f902f1090fa</uuid>
+  </job>
+</joblist>

--- a/functional-test/src/test/resources/projects-import/step-execution-context/rundeck-TestStepExecContext/jobs/job-aeb9ce8c-c78b-4414-9948-26bfd134303c.xml
+++ b/functional-test/src/test/resources/projects-import/step-execution-context/rundeck-TestStepExecContext/jobs/job-aeb9ce8c-c78b-4414-9948-26bfd134303c.xml
@@ -1,0 +1,27 @@
+<joblist>
+  <job>
+    <defaultTab>summary</defaultTab>
+    <description>Test command failure correctly sets exit code context variable</description>
+    <executionEnabled>true</executionEnabled>
+    <id>aeb9ce8c-c78b-4414-9948-26bfd134303c</id>
+    <loglevel>INFO</loglevel>
+    <name>Command Fails with exitCode</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <scheduleEnabled>true</scheduleEnabled>
+    <sequence keepgoing='true' strategy='node-first'>
+      <command>
+        <exec><![CDATA[ echo "STEP 1: will succeed"]]></exec>
+      </command>
+      <command>
+        <exec><![CDATA[ echo "STEP 2: will fail with code 77"; exit 77]]></exec>
+      </command>
+      <command>
+        <exec><![CDATA[echo "STEP 3: ExitCode from Step1: ${1:exec.exitCode*}"]]></exec>
+      </command>
+      <command>
+        <exec><![CDATA[echo "STEP 4: ExitCode from Step2: ${2:exec.exitCode*}"]]></exec>
+      </command>
+    </sequence>
+    <uuid>aeb9ce8c-c78b-4414-9948-26bfd134303c</uuid>
+  </job>
+</joblist>


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Fix: script steps that fail do not correctly export the "exec.exitCode" context variable

**Describe the solution you've implemented**
Fix the error where the script cleanup step exitCode was overriding the script's exit code.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
