### PR TITLE
RUN-2703 : improve functional test harness

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdClient.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdClient.groovy
@@ -34,14 +34,14 @@ class RdClient {
         this.httpClient = httpClient
     }
 
-    static RdClient create(final String baseUrl, final String apiToken) {
+    static RdClient create(final String baseUrl, final String apiToken, Map<String, Integer> config = Collections.emptyMap() ) {
         new RdClient(
                 baseUrl,
                 new OkHttpClient.Builder().
                         addInterceptor(new HeaderInterceptor("X-Rundeck-Auth-token", apiToken)).
-                        connectTimeout(25, TimeUnit.SECONDS).
-                        readTimeout(25, TimeUnit.SECONDS).
-                        writeTimeout(25, TimeUnit.SECONDS).
+                        connectTimeout(config.getOrDefault("connectTimeout", 25), TimeUnit.SECONDS).
+                        readTimeout(config.getOrDefault("readTimeout", 25), TimeUnit.SECONDS).
+                        writeTimeout(config.getOrDefault("writeTimeout", 25), TimeUnit.SECONDS).
                         connectionPool(new ConnectionPool(2, 25, TimeUnit.SECONDS)).
                         build()
         )

--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdContainer.groovy
@@ -3,10 +3,8 @@ package org.rundeck.util.container
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.testcontainers.containers.DockerComposeContainer
-import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.utility.MountableFile
 
 import java.time.Duration
 
@@ -23,10 +21,11 @@ class RdContainer extends DockerComposeContainer<RdContainer> implements ClientP
     public static final String LICENSE_LOCATION = System.getenv("LICENSE_LOCATION")
     public static final String TEST_RUNDECK_GRAILS_URL = System.getenv("TEST_RUNDECK_GRAILS_URL") ?: "http://localhost:4440"
 
+    private final Map<String, Integer> clientConfig
 
-    RdContainer(URI composeFilePath) {
-
+    RdContainer(URI composeFilePath, Map<String, Integer> clientConfig = Collections.emptyMap()) {
         super(new File(composeFilePath))
+        this.clientConfig = clientConfig
         if (CONTEXT_PATH && !CONTEXT_PATH.startsWith('/')) {
             throw new IllegalArgumentException("Context path must start with /")
         }
@@ -49,7 +48,7 @@ class RdContainer extends DockerComposeContainer<RdContainer> implements ClientP
     }
 
     RdClient clientWithToken(String token) {
-        RdClient.create("http://${getServiceHost(DEFAULT_SERVICE_TO_EXPOSE,DEFAULT_PORT)}:${getServicePort(DEFAULT_SERVICE_TO_EXPOSE,DEFAULT_PORT)}${CONTEXT_PATH}", token)
+        RdClient.create("http://${getServiceHost(DEFAULT_SERVICE_TO_EXPOSE,DEFAULT_PORT)}:${getServicePort(DEFAULT_SERVICE_TO_EXPOSE,DEFAULT_PORT)}${CONTEXT_PATH}", token, clientConfig)
     }
 
     @Override


### PR DESCRIPTION
Improvement to the functional tests harness:
- Made Rundeck HTTP client timeouts in the RdContainer configurable
- Added handling for the unsuccessfully created job executions in the RdContainer that resulted in an infinite loop

Jira ticket: https://pagerduty.atlassian.net/browse/RUN-2703?atlOrigin=eyJpIjoiOGE5ZjhiYTM3MjllNGRlZDg1M2NjZGE4M2U1ZGViZmMiLCJwIjoiaiJ9

