### PR TITLE
Prevents chrome windows to open unnecessarily

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/container/SeleniumBase.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/SeleniumBase.groovy
@@ -53,21 +53,23 @@ class SeleniumBase extends BaseContainer implements WebDriver, SeleniumContext {
 
 
     def cleanup() {
-        specificationContext.currentSpec.listeners
-                .findAll { it instanceof TestResultExtension.ErrorListener }
-                .each {
-                    def errorInfo = (it as TestResultExtension.ErrorListener).errorInfo
-                    if(errorInfo){
-                        File screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE)
-                        File testResourcesDir = new File("build/test-results/images")
-                        if (!testResourcesDir.exists()) {
-                            testResourcesDir.mkdirs()
+        if(_driver){
+            specificationContext.currentSpec.listeners
+                    .findAll { it instanceof TestResultExtension.ErrorListener }
+                    .each {
+                        def errorInfo = (it as TestResultExtension.ErrorListener).errorInfo
+                        if(errorInfo){
+                            File screenshot = ((TakesScreenshot) _driver).getScreenshotAs(OutputType.FILE)
+                            File testResourcesDir = new File("build/test-results/images")
+                            if (!testResourcesDir.exists()) {
+                                testResourcesDir.mkdirs()
+                            }
+                            File destination = new File(testResourcesDir, "${specificationContext.currentSpec.filename}-${specificationContext.currentIteration.name}" + ".png")
+                            screenshot.renameTo(destination)
                         }
-                        File destination = new File(testResourcesDir, "${specificationContext.currentSpec.filename}-${specificationContext.currentIteration.name}" + ".png")
-                        screenshot.renameTo(destination)
                     }
-                }
-        driver?.quit()
+            _driver?.quit()
+        }
     }
 
     /**


### PR DESCRIPTION
When doing the test cleanup, it was always triggering a new chrome windows, with this it will use the current chrome instance (if there is one) to take the screenshot if the test has failed. If there is no chrome instance running then there is no point in taking the screenshot since it would be either that it's not a selenium test or for some reason the selenium test couldn't create a new chrome instance, hence it doesn't make any sense to capture a screenshot of a blank page