### PR TITLE
RUN-537: Fix for group selection on old UI

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/BasicJobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/BasicJobsSpec.groovy
@@ -105,10 +105,10 @@ class BasicJobsSpec extends SeleniumBase {
             jobCreatePage.nextUi=nextUi
             jobCreatePage.go()
             def jobShowPage = page JobShowPage
+            jobShowPage.nextUi=nextUi
         then:
             jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de"
             jobCreatePage.go()
-            jobCreatePage.descriptionTextarea.clear()
             jobCreatePage.descriptionTextarea.sendKeys 'a new job description'
             jobCreatePage.updateJobButton.click()
         expect:
@@ -142,8 +142,10 @@ class BasicJobsSpec extends SeleniumBase {
             jobCreatePage.groupChooseButton.click()
             jobCreatePage.waitForElementToBeClickable jobCreatePage.groupNameOption
             jobCreatePage.groupNameOption.click()
+        expect:
+            'test' == jobCreatePage.jobGroupField.getAttribute("value")
         where:
-        nextUi<<[false,true]
+            nextUi<<[false, true]
     }
 
     def "edit job and set schedules tab"() {

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/BasicJobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/BasicJobsSpec.groovy
@@ -102,6 +102,8 @@ class BasicJobsSpec extends SeleniumBase {
     def "edit job set description"() {
         when:
             def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
+            jobCreatePage.nextUi=nextUi
+            jobCreatePage.go()
             def jobShowPage = page JobShowPage
         then:
             jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de"
@@ -111,16 +113,36 @@ class BasicJobsSpec extends SeleniumBase {
             jobCreatePage.updateJobButton.click()
         expect:
             'a new job description' == jobShowPage.descriptionTextLabel.getText()
+        where:
+            nextUi<<[false,true]
     }
 
     def "edit job set groups"() {
         when:
             def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
+            jobCreatePage.nextUi=nextUi
+            jobCreatePage.go()
         then:
             jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de"
             jobCreatePage.go()
             jobCreatePage.jobGroupField.clear()
             jobCreatePage.jobGroupField.sendKeys 'testGroup'
+        where:
+            nextUi<<[false,true]
+    }
+
+    def "edit job set group via modal"() {
+        when:
+            def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
+            jobCreatePage.nextUi=nextUi
+            jobCreatePage.go()
+        then:
+            jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de"
+            jobCreatePage.go()
+            jobCreatePage.groupChooseButton.click()
+            jobCreatePage.groupNameOption.click()
+        where:
+        nextUi<<[false,true]
     }
 
     def "edit job and set schedules tab"() {

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/BasicJobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/BasicJobsSpec.groovy
@@ -140,6 +140,7 @@ class BasicJobsSpec extends SeleniumBase {
             jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de"
             jobCreatePage.go()
             jobCreatePage.groupChooseButton.click()
+            jobCreatePage.waitForElementToBeClickable jobCreatePage.groupNameOption
             jobCreatePage.groupNameOption.click()
         where:
         nextUi<<[false,true]

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobCreatePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobCreatePage.groovy
@@ -30,6 +30,8 @@ class JobCreatePage extends BasePage {
     By updateJob = By.id("jobUpdateSaveButton")
     By jobNameInputBy = By.cssSelector("form input[name=\"jobName\"]")
     By groupPathInputBy = By.cssSelector("form input[name=\"groupPath\"]")
+    By groupChooseButton = By.id("groupChooseModalBtn")
+    By groupNameOption = By.cssSelector("span.groupname.jobgroupexpand")
     By descriptionTextareaBy = By.cssSelector("form textarea[name='description']")
     By jobGroupBy = By.cssSelector("input#schedJobGroup")
     By scheduleRunYesBy = By.cssSelector('input#scheduledTrue')

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobCreatePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobCreatePage.groovy
@@ -31,6 +31,7 @@ class JobCreatePage extends BasePage {
     By jobNameInputBy = By.cssSelector("form input[name=\"jobName\"]")
     By groupPathInputBy = By.cssSelector("form input[name=\"groupPath\"]")
     By groupChooseButton = By.id("groupChooseModalBtn")
+    By groupChooseModal = By.cssSelector('#groupChooseModal')
     By groupNameOption = By.cssSelector("span.groupname.jobgroupexpand")
     By descriptionTextareaBy = By.cssSelector("form textarea[name='description']")
     By jobGroupBy = By.cssSelector("input#schedJobGroup")
@@ -55,6 +56,7 @@ class JobCreatePage extends BasePage {
     static class NextUi {
         static By jobNameInputBy = By.cssSelector("form input[id=\"schedJobName\"]")
         static By groupPathInputBy = By.cssSelector("form input[id=\"schedJobGroup\"]")
+        static By descriptionTextareaBy = By.cssSelector("form textarea.ace_text-input")
         static By optionBy = By.cssSelector("#optnewbutton > button")
         static By separatorOptionBy = By.cssSelector("#option_preview")
         static By optionCloseKeyStorageBy = By.cssSelector("#storage-file.modal .modal-footer > button.btn-default")
@@ -302,6 +304,10 @@ class JobCreatePage extends BasePage {
         waitForNumberOfElementsToBe notificationModalBy, totalNotificationModals
     }
 
+    void waitGroupModal(Integer totalGroupModals) {
+        waitForNumberOfElementsToBe groupChooseModal, totalGroupModals
+    }
+
     WebElement getJobNameInput() {
         el nextUi ? NextUi.jobNameInputBy : jobNameInputBy
     }
@@ -310,12 +316,24 @@ class JobCreatePage extends BasePage {
         el nextUi ? NextUi.groupPathInputBy :groupPathInputBy
     }
 
+    WebElement getGroupChooseButton() {
+        el groupChooseButton
+    }
+
+    WebElement getGroupNameOption() {
+        el groupNameOption
+    }
+
     WebElement getDescriptionTextarea() {
-        def element = el descriptionTextareaBy
-        String js = 'jQuery(\'form textarea[name="description"]\').show()'
-        ((JavascriptExecutor) driver).executeScript(js, element)
-        waitForElementVisible element
-        element
+        if(nextUi) {
+            el NextUi.descriptionTextareaBy
+        } else {
+            def element = el descriptionTextareaBy
+            String js = 'jQuery(\'form textarea[name="description"]\').show()'
+            ((JavascriptExecutor) driver).executeScript(js, element)
+            waitForElementVisible element
+            element
+        }
     }
 
     WebElement getRefreshNodesButton(){

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobShowPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobShowPage.groovy
@@ -66,9 +66,15 @@ class JobShowPage extends BasePage{
     By jobOptionValuesBy = By.cssSelector(".optionvalues")
     By jobOptionValueInputBy = By.cssSelector(".optionvalues > option:nth-child(6)")
 
+    static class NextUi {
+        static By descriptionText = By
+                .xpath("//*[@class=\"markdown-body\"]")
+    }
+
     static final String PAGE_PATH = "/job/show"
     String loadPath = "/job/show"
     private String project
+    boolean nextUi = false
 
     JobShowPage(final SeleniumContext context) {
         super(context)
@@ -129,7 +135,7 @@ class JobShowPage extends BasePage{
     }
 
     WebElement getDescriptionTextLabel() {
-        el descriptionText
+        el nextUi ? NextUi.descriptionText : descriptionText
     }
 
     List<WebElement> getCronLabel() {

--- a/rundeckapp/grails-app/assets/javascripts/jobedit.js
+++ b/rundeckapp/grails-app/assets/javascripts/jobedit.js
@@ -1644,7 +1644,7 @@ function loadJobChooserModal(elem, uuid, nameid, groupid, projectid, modalid, mo
 function groupChosen(path) {
   jobWasEdited();
   let isNextUi = jQuery('.ui-type-next');
-  if(isNextUi) {
+  if(isNextUi.length > 0) {
     window._rundeck.eventBus.emit("group-selected", path);
   } else {
     jobeditor.groupPath(path)

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -118,7 +118,9 @@
                       <span class="btn btn-default"
                             data-toggle="modal"
                             data-target="#groupChooseModal"
-                            title="${message(code:"job.edit.groupPath.choose.text")}">
+                            title="${message(code:"job.edit.groupPath.choose.text")}"
+                            id="groupChooseModalBtn"
+                      >
                           <g:message code="choose.action.label" />
                       </span>
                   </span>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/details/DetailsEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/details/DetailsEditor.vue
@@ -31,6 +31,7 @@
             />
             <span class="input-group-btn">
               <span
+                id="groupChooseModalBtn"
                 class="btn btn-default"
                 data-toggle="modal"
                 data-target="#groupChooseModal"


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

With the vue conversion of the job creation/edit details tab, the mechanism to update the UI upon selecting a group was changed and it broke the old UI. 

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

Tweaked a bit the check for the new UI to ensure it will use the correct mechanism (new UI, emit an event, old UI, manipulate the DOM).


**How to test**
<!-- Add any other context or screenshots about the change here. -->
Without the nextUi enabled:
Edit or create a new job - on the details tab, click to select a group and select one. Input should update the data.

