### PR TITLE
Testdeck improvement scm

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/scm/ConfigureScmPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/scm/ConfigureScmPage.groovy
@@ -59,16 +59,10 @@ class ConfigureScmPage extends BasePage{
                             ExpectedConditions.elementToBeClickable(oppositeDataTargetValueBy)
                     ))
 
-        WebElement toggleButton = null
-        try{
-            toggleButton = driver.findElement(dataTargetValueBy)
-        } catch (NoSuchElementException ignored){}
-
-
-        if(toggleButton){
-            toggleButton.click()
-            waitForModal(1)
-            byAndWait(modalField).findElement(By.xpath(".//input[@type='submit'][@value='Yes']")).click()
-        }
+        waitForNumberOfElementsToBe(dataTargetValueBy, 1)
+        WebElement toggleButton = driver.findElement(dataTargetValueBy)
+        toggleButton.click()
+        waitForModal(1)
+        byAndWait(modalField).findElement(By.xpath(".//input[@type='submit'][@value='Yes']")).click()
     }
 }


### PR DESCRIPTION
**Issue:** Whenever changing from enable/disable, if the "toggleButton" was not found it was just ignoring it and just letting the process to continue, this way if the button is not found the test would fail after leaving no clue on what really happen

**Fix:** Now it waits for the toggleButton to exist and then clicking it. This way if the button for some reason does not show, it will be easier to identify the failure