### PR TITLE
RUN-2606: Liquibase migration for generating execution uuids.

### DIFF
--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -117,4 +117,6 @@ databaseChangeLog = {
         include file: 'core/DBChangelogPrimaryKey.groovy'
         include file: 'core/BaseReportSpi.groovy'
         include file: 'core/RemoveFilters-5.0.groovy'
+        include file: 'core/ExecutionUUIDGeneration.groovy'
+
 }

--- a/rundeckapp/grails-app/migrations/core/ExecutionUUIDGeneration.groovy
+++ b/rundeckapp/grails-app/migrations/core/ExecutionUUIDGeneration.groovy
@@ -1,0 +1,41 @@
+package core
+
+databaseChangeLog = {
+
+    property name: "uuid_function", value: "gen_random_uuid()", dbms: "postgresql"
+    property name: "uuid_function", value: "uuid()", dbms: "mysql,mariadb"
+    property name: "uuid_function", value: "newid()", dbms: "mssql"
+    property name: "uuid_function", value: "RANDOM_UUID()", dbms: "h2"
+    property name: "uuid_function", value: "sys_guid()", dbms: "oracle"
+
+    changeSet(author: "ahormazabal (generated)", id: "gen-exec-uuids-20240801-00") {
+        comment { 'Populate UUID into execution table' }
+        preConditions(onFail: 'MARK_RAN') {
+            and {
+                columnExists(tableName: "execution", columnName: 'uuid')
+                columnExists(tableName: "execution", columnName: 'job_uuid')
+            }
+        }
+
+        update(tableName: "execution") {
+            column(name: "uuid", valueComputed: '${uuid_function}')
+            column(name: "job_uuid", valueComputed: "SELECT s.uuid FROM scheduled_execution s WHERE s.id = scheduled_execution_id")
+            where("uuid IS NULL")
+        }
+    }
+
+
+    changeSet(author: "ahormazabal (generated)", id: "gen-exec-uuids-basereport-20240801-01") {
+        comment { 'Populate UUID into base_report table' }
+        preConditions(onFail: 'MARK_RAN') {
+            columnExists(tableName: "base_report", columnName: 'execution_uuid')
+        }
+
+        update(tableName: "base_report") {
+            column(name: "execution_uuid", valueComputed: 'SELECT e.uuid FROM execution e WHERE execution_id = e.id')
+            where("execution_uuid IS NULL")
+        }
+    }
+
+
+}

--- a/rundeckapp/grails-app/migrations/core/ExecutionUUIDGeneration.groovy
+++ b/rundeckapp/grails-app/migrations/core/ExecutionUUIDGeneration.groovy
@@ -19,7 +19,7 @@ databaseChangeLog = {
 
         update(tableName: "execution") {
             column(name: "uuid", valueComputed: '${uuid_function}')
-            column(name: "job_uuid", valueComputed: "SELECT s.uuid FROM scheduled_execution s WHERE s.id = scheduled_execution_id")
+            column(name: "job_uuid", valueComputed: "(SELECT s.uuid FROM scheduled_execution s WHERE s.id = scheduled_execution_id)")
             where("uuid IS NULL")
         }
     }
@@ -32,7 +32,7 @@ databaseChangeLog = {
         }
 
         update(tableName: "base_report") {
-            column(name: "execution_uuid", valueComputed: 'SELECT e.uuid FROM execution e WHERE execution_id = e.id')
+            column(name: "execution_uuid", valueComputed: '(SELECT e.uuid FROM execution e WHERE execution_id = e.id)')
             where("execution_uuid IS NULL")
         }
     }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Bug-Fix:
Adds a migration script that would generate missing `uuid` values in the `execution` table, and fix the relation with the `base_report` table.

**Describe the solution you've implemented**
A liquibase script that would update the execution table with a random uuid and the job uuid relation, plus afterwards. performing an update to the base_report table assigning the corresponding execution_uuid

**To Test**

- Create an installation of Rundeck `4.16` or earlier, and run as much executions as you want.
- Upgrade to `5.4.0` and notice you don't see any old execution and new executions will show correctly.
- Upgrade to this version and you should see the executions back.

**NOTE**: This process can take very long if your execution table size is in the tens of millions scale. In this case is recommended to run the migration in a separate process:

`java -jar rundeck.war -m`



