### PR TITLE
RUN-2606: fix report delete by execution ID

### DIFF
--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
@@ -91,7 +91,7 @@ class ExecutionsCleanUp implements InterruptableJob {
             referencedExecutionDataProvider.deleteByExecutionId(e.id)
 
             //delete all reports
-            reportService.deleteByExecutionUuid(e.uuid)
+            reportService.deleteByExecution(e)
             def executionFiles = logFileStorageService.getExecutionFiles(e, [], false)
 
             List<File> files = []

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2038,8 +2038,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 return [error: 'running', message: "Failed to delete execution {{Execution ${e.id}}}: The execution is currently running", success: false]
             }
             referencedExecutionDataProvider.deleteByExecutionId(e.id)
-                //delete all reports
-            execReportDataProvider.deleteAllByExecutionUuid(e.uuid)
+            //delete all reports
+            reportService.deleteByExecution(e)
 
             List<File> files = []
             def execs = []

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/DBExecReportSupport.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/DBExecReportSupport.groovy
@@ -1,0 +1,8 @@
+package org.rundeck.app.data.providers
+
+/**
+ * Support for deleting all exec reports by execution id
+ */
+interface DBExecReportSupport {
+    void deleteAllByExecutionId(Long id)
+}

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormExecReportDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormExecReportDataProvider.groovy
@@ -1,7 +1,6 @@
 package org.rundeck.app.data.providers
 
 import com.google.common.collect.Lists
-import grails.gorm.DetachedCriteria
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import org.rundeck.app.data.model.v1.query.RdExecQuery
@@ -20,7 +19,7 @@ import rundeck.services.ConfigurationService
 import javax.sql.DataSource
 
 @CompileStatic(TypeCheckingMode.SKIP)
-class GormExecReportDataProvider implements ExecReportDataProvider {
+class GormExecReportDataProvider implements ExecReportDataProvider, DBExecReportSupport {
     @Autowired
     ConfigurationService configurationService
     @Autowired
@@ -178,6 +177,13 @@ class GormExecReportDataProvider implements ExecReportDataProvider {
     @Override
     void deleteAllByExecutionUuid(String executionUuid) {
         ExecReport.findAllByExecutionUuid(executionUuid).each { rpt ->
+            rpt.delete()
+        }
+    }
+
+    @Override
+    void deleteAllByExecutionId(Long id) {
+        ExecReport.findAllByExecutionId(id).each { rpt ->
             rpt.delete()
         }
     }

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecReportDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecReportDataProviderSpec.groovy
@@ -69,4 +69,19 @@ class GormExecReportDataProviderSpec extends Specification implements DataTest {
         deleted == null
 
     }
+    def "deleteAllByExecutionId should delete exec reports by execution id"() {
+        given:
+        Execution e = TestDomainFactory.createExecution(uuid: null, status: 'succeeded', dateCompleted: new Date())
+        def report = provider.saveReport(ExecReportUtil.buildSaveReportRequest(e))
+
+        when:
+        def created = provider.get(report.report.id)
+        provider.deleteAllByExecutionId(report.report.executionId)
+        def deleted = provider.get(report.report.id)
+
+        then:
+        created
+        deleted == null
+
+    }
 }

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -112,6 +112,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         provider.featureService = Mock(FeatureService){
             featurePresent(Features.CASE_INSENSITIVE_USERNAME) >> false
         }
+        service.reportService = Mock(ReportService)
     }
 
     private Map createJobParams(Map overrides = [:]) {
@@ -1266,9 +1267,6 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         execution.dateCompleted = new Date()
         execution.status = 'succeeded'
         assert execution.save()
-        ExecReport execReport = ExecReport.fromExec(execution)
-        assert execReport!=null
-        def erptid=execReport.id
         def eauth = Mock(AuthorizingExecution){
             getResource()>>execution
         }
@@ -1283,8 +1281,8 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
             getUsername()>>'auser'
         }
         1 * service.logFileStorageService.getExecutionFiles(execution,_,_)>>[:]
+        1 * service.reportService.deleteByExecution(execution)
         result.success
-        ExecReport.get(erptid)==null
     }
 
     def "delete execution running"() {
@@ -1367,6 +1365,8 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
                 [AuthConstants.ACTION_DELETE_EXECUTION, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]
         ) >> true
 
+        1 * service.reportService.deleteByExecution(execution)
+
         result.success
 
         !file1.exists()
@@ -1430,6 +1430,8 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
                 [AuthConstants.ACTION_DELETE_EXECUTION, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]
         ) >> true
 
+        1 * service.reportService.deleteByExecution(execution)
+
         result.success
     }
 
@@ -1470,6 +1472,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
                 [AuthConstants.ACTION_DELETE_EXECUTION, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]
         ) >> true
         1 * service.fileUploadService.deleteRecordsForExecution(execution)
+        1 * service.reportService.deleteByExecution(execution)
 
         result.success
 


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Fix: executions without UUID cannot be deleted


**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Support deleting by DB ID.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
