### PR TITLE
RUN-2730: Increase CI speed by splitting functional tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,6 +505,7 @@ jobs:
 
   test-gradle-functional:
     <<: *job-defaults
+    parallelism: << parameters.parallelism >>
     executor:
       name: machine-builder
       docker_layer_caching: true
@@ -516,9 +517,14 @@ jobs:
         type: string
       gradle-task:
         type: string
+      parallelism:
+        type: integer
+        default: 1
       resource_class:
         type: string
         default: medium
+      test_file_pattern:
+        type: string
     steps:
       - checkout
       - install-build-dependencies
@@ -531,12 +537,16 @@ jobs:
       - run-build-step:
           step-name: Runs gradle test task << parameters.gradle-task >>
           command: |
+            TEST_FILES=$(circleci tests glob "<< parameters.test_file_pattern >>" | circleci tests split)
+            echo $TEST_FILES | tee test_file_listing.txt
             TEST_IMAGE=<< parameters.test-image >>
             GRADLE_TASK=<< parameters.gradle-task >>
             rundeck_gradle_functional_tests
       - collect-gradle-tests
       - store_artifacts:
           path: ~/workspace/functional-test/build/test-results/images
+      - store_artifacts:
+          path: test_file_listing.txt
 
 
 
@@ -675,15 +685,20 @@ workflows:
       - test-gradle-functional:
           name: New Selenium Test
           gradle-task: seleniumCoreTest
+          parallelism: 3
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/**/*{.groovy,.java}"
           <<: *require-build
           <<: *slack-defaults
       - test-gradle-functional:
           name: New API Test
           gradle-task: apiTest
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/**/*{.groovy,.java}"
+          parallelism: 3
           <<: *require-build
           <<: *slack-defaults
       - test-gradle-functional:
           name: New Plugin Blocklist Test
           gradle-task: pluginBlocklistTest
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/integration/**/*{.groovy,.java}"
           <<: *require-build
           <<: *slack-defaults

--- a/functional-test/build.gradle
+++ b/functional-test/build.gradle
@@ -62,13 +62,47 @@ def checkWarFile(destination, fileName) {
     println "File copied from ${warFile} to ${destination + fileName}"
 }
 
+/** 
+ * Returns a function that includes only the test files specified in the `testFiles` parameter.
+ * The `testFiles` parameter is a string of paths to the source code of the tests to be run.
+ */
+def explicitTestIncluder(String testFiles) {
+    // Convert test file source code paths to compiled class paths.
+    // Example: `functional-test/src/test/groovy/org/rundeck/tests/functional/api/basic/BasicSpec.groovy`
+    // needs to become `org/rundeck/tests/functional/api/basic/BasicSpec.class`.
+    def compiledFilesToTest = testFiles
+        .split(System.lineSeparator())
+        .collect { testFilePath -> 
+            testFilePath
+            .trim()
+            .replaceFirst(".*\\/src\\/test\\/(groovy\\/|java\\/)", "")
+            .replaceFirst("(.groovy|.java)\$", ".class")
+        }
+
+    logger.info("Compiled files to test: {}", compiledFilesToTest)
+
+    return {
+        FileTreeElement e ->
+            if (e.isDirectory()) {
+                return true
+            }
+
+            compiledFilesToTest.contains(e.path)
+    }
+}
+
 task apiTest(type: Test){
     useJUnitPlatform()
     systemProperty('TEST_IMAGE', "rundeck/rundeck:SNAPSHOT")
     systemProperty("COMPOSE_PATH", "docker/compose/oss/docker-compose.yml")
     systemProperty('spock.configuration','spock-configs/IncludeAPITestsConfig.groovy')
     description = "Run API tests"
+
+    if (project.hasProperty("testFiles")) {
+        include(explicitTestIncluder(project.properties["testFiles"]))
+    }
 }
+
 task pluginBlocklistTest(type: Test){
     useJUnitPlatform()
     systemProperty('TEST_IMAGE', "rundeck/rundeck:SNAPSHOT")
@@ -83,6 +117,10 @@ task seleniumCoreTest(type: Test){
     systemProperty("COMPOSE_PATH", "docker/compose/oss/docker-compose.yml")
     systemProperty('spock.configuration', 'spock-configs/IncludeSeleniumCoreTestsConfig.groovy')
     description = "Run Rundeck OSS Selenium Tests"
+
+    if (project.hasProperty("testFiles")) {
+        include(explicitTestIncluder(project.properties["testFiles"]))
+    }
 }
 
 task ldapTest(type: Test){

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/JobTabsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/JobTabsSpec.groovy
@@ -1,9 +1,12 @@
-package org.rundeck.util.gui.pages.jobs
+package org.rundeck.tests.functional.selenium.jobs
 
 import org.rundeck.util.annotations.SeleniumCoreTest
 import org.rundeck.util.container.SeleniumBase
 import org.rundeck.util.gui.pages.execution.ExecutionShowPage
 import org.rundeck.util.gui.pages.execution.HtmlRenderedOutputPage
+import org.rundeck.util.gui.pages.jobs.JobCreatePage
+import org.rundeck.util.gui.pages.jobs.JobShowPage
+import org.rundeck.util.gui.pages.jobs.JobTab
 import org.rundeck.util.gui.pages.login.LoginPage
 
 @SeleniumCoreTest

--- a/scripts/circleci/build-functions.sh
+++ b/scripts/circleci/build-functions.sh
@@ -56,5 +56,5 @@ rundeck_verify_build() {
 }
 
 rundeck_gradle_functional_tests() {
-    TEST_IMAGE=${TEST_IMAGE:-} ./gradlew :functional-test:${GRADLE_TASK} -Penvironment="${ENV}" ${GRADLE_BUILD_OPTS} --info
+    TEST_IMAGE=${TEST_IMAGE:-} ./gradlew :functional-test:${GRADLE_TASK} -Penvironment="${ENV}" -PtestFiles="${TEST_FILES}" ${GRADLE_BUILD_OPTS} --info
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is an enhancement to increase the speed of the CI pipeline. This change splits the functional tests and executes them across multiple machines in parallel.

**Describe the solution you've implemented**
This solution splits test execution across a set of machines by:
* Using the `circleci` CLI to enumerate test source code files and split them across the set of running machines.
* Using Gradle to convert the paths of source code files into paths of compiled classes.
* Providing a custom [JUnit include function](https://docs.gradle.org/7.6.2/dsl/org.gradle.api.tasks.testing.Test.html#org.gradle.api.tasks.testing.Test:include(groovy.lang.Closure)) that matches against the set of compiled classes.

**Describe alternatives you've considered**
The alternative to this solution would be to write a Spock or JUnit extension that only executes a subset of the tests by partitioning them across the set of running machines. In an MVP of this approach we ran into some issues with accurately reporting test counts in CircleCI.

**Additional context**
I have done this but reviewer(s) should confirm that the number of tests executed before and after this change are the same.
