### PR TITLE
RUN-2730: Remove unrequired dependency installation for functional tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,10 +521,11 @@ jobs:
         default: medium
     steps:
       - checkout
-      - install-build-dependencies
-      - restore-build-cache
       - attach_workspace:
           at: ~/workspace
+      - run-build-step:
+          step-name: Install Build Dependencies
+          command: dependencies_build_setup
       - run-build-step:
           step-name: Pull images
           command: rundeck_pull_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,6 +521,7 @@ jobs:
         default: medium
     steps:
       - checkout
+      - restore-build-cache
       - attach_workspace:
           at: ~/workspace
       - run-build-step:


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is an enhancement to increase the speed of the CI pipeline and reduce points of failure. It removes the installation of node and aws cli from functional tests workflow

**Describe the solution you've implemented**
Instead of using the "install-build-dependencies" it just calls the function to install the basic stuff to run the workflow (dependencies_build_setup)