### PR TITLE
RUN-2744: Fix pagination calculation by casting string into number

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeTable.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeTable.vue
@@ -284,7 +284,7 @@
                     :href="browseNodesPageUrl(num)"
                     @click.prevent="browseNodesPage(num)"
                   >
-                    {{ num + 1 }}
+                    {{ calculatePageNumber(num) }}
                   </a>
                 </li>
                 <li :class="{ disabled: page === maxPages || loading }">
@@ -535,6 +535,9 @@ export default defineComponent({
     stopNodeRemoteEdit() {
       this.remoteUrl = null;
       this.remoteEditNodename = null;
+    },
+    calculatePageNumber(page: string): number {
+      return parseInt(page) + 1;
     },
   },
 });


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

With the recent work done with runners, the node table got updated to fix some type errors happening on Pro. With the typing, the page number got concatenated instead of being added one.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Move the logic to a method, cast the string into an integer, and add one.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
After:
![image](https://github.com/user-attachments/assets/2c344cbb-9bb1-4d96-9f4e-61bf9ceac017)
