### PR TITLE
use execution uuid to lookup a scheduled execution when creating a st…

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/WorkflowService.groovy
@@ -135,15 +135,11 @@ class WorkflowService implements ApplicationContextAware{
             if (step instanceof JobExec) {
 
                 JobExec jexec = (JobExec) step
-                def searchProject = jexec.jobProject? jexec.jobProject: project
-                def schedlist = ScheduledExecution.findAllScheduledExecutions(jexec.jobGroup, jexec.jobName, searchProject)
-                if (!schedlist || 1 != schedlist.size()) {
+                ScheduledExecution se = jexec.findJob(project)
+                if (!se) {
                     //skip
                     return
                 }
-                def id = schedlist[0].id
-
-                ScheduledExecution se = ScheduledExecution.get(id)
 
                 //generate a workflow context
                 StepExecutionContext newContext=null

--- a/rundeckapp/src/test/groovy/rundeck/services/WorkflowServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/WorkflowServiceSpec.groovy
@@ -16,13 +16,14 @@
 
 package rundeck.services
 
-import com.dtolabs.rundeck.core.execution.logstorage.ExecutionFileLoader
+
 import com.dtolabs.rundeck.core.execution.logstorage.ExecutionFileState
 import com.dtolabs.rundeck.core.execution.workflow.state.WorkflowStateDataLoader
 import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
 import rundeck.CommandExec
 import rundeck.Execution
+import rundeck.JobExec
 import rundeck.Workflow
 import rundeck.services.workflow.StateMapping
 import rundeck.services.logging.WorkflowStateFileLoader
@@ -56,6 +57,19 @@ class WorkflowServiceSpec extends Specification implements ServiceUnitTest<Workf
         actual.workflowState == ['state':'statehere']
         actual.state == ExecutionFileState.AVAILABLE
         !actual.file
+    }
+
+    def "scheduled execution for the exec job is retrieved from the exec job"() {
+        setup:
+        final jobProject = 'proj1'
+        def jobExecMock = Mock(JobExec)
+        Workflow workflow = new Workflow(keepgoing: true, commands: [jobExecMock])
+
+        when:
+        service.createStateForWorkflow(workflow, jobProject, "dummyFrameworkNodeName", null, null)
+
+        then:
+        1 * jobExecMock.findJob(jobProject)
     }
 
     def "state mapping"(){


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
The bugfix for the "Job steps reporting "Running" even though the job itself is completed" problem reported by customers and described in [RUN-2570](https://pagerduty.atlassian.net/browse/RUN-2570). 

**Describe the solution you've implemented**
Replaced the custom (and erroneous) logic for finding a `ScheduledExecution` for the `JobExec` with the already implemented and tested one provided by the `JobExec` object itself.
The fallacy of the removed logic was that it did not look for the `ScheduledExecution` by `uuid`.

**Updated behaviour**
Scenario:
- Both steps are referencing a sub-job
  - Step 1: UUID -- Use jobs UUID to search the job.
  - Step 2: Name -- Use Name and group to search the job.
- The name of the sub-job is changed

![Screenshot 2024-08-09 at 2 13 58 PM](https://github.com/user-attachments/assets/49e31b56-3a0d-4534-8e7b-907a1a42a074)

[RUN-2570]: https://pagerduty.atlassian.net/browse/RUN-2570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ