### PR TITLE
Allow setting a custom cpu architecture when running functional tests

### DIFF
--- a/functional-test/readme.md
+++ b/functional-test/readme.md
@@ -20,7 +20,7 @@ Env vars to control docker image usage:
 - `TEST_RUNDECK_CONTAINER_CONTEXT`: The context path to use for the container (e.g. `/rundeck`). Must start with `/`. (
   default: blank)
 - `TEST_RUNDECK_CONTAINER_TOKEN`: The API token to use for authentication. (default: `admintoken`)
-- `TEST_RUNDECK_GRAILS_URL`: This value is used as `RUNDECK_GRAILS_URL` (default: `http://localhost:4440`)
+- `TEST_RUNDECK_GRAILS_URL`: This value is used as `RUNDECK_GRAILS_URL` (default: `http://rundeck:4440`)
 - `TEST_TARGET_PLATFORM`: The target platform for the rundeck container  (default: `linux/amd64`)
 - `TEST_WAR_FILE_LOCATION`: (optional for tomcatTest task) If set, it will use this path to get the war file and run the tomcatTest
   task, if not it will try to get the war from the build process

--- a/functional-test/readme.md
+++ b/functional-test/readme.md
@@ -21,6 +21,7 @@ Env vars to control docker image usage:
   default: blank)
 - `TEST_RUNDECK_CONTAINER_TOKEN`: The API token to use for authentication. (default: `admintoken`)
 - `TEST_RUNDECK_GRAILS_URL`: This value is used as `RUNDECK_GRAILS_URL` (default: `http://localhost:4440`)
+- `TEST_TARGET_PLATFORM`: The target platform for the rundeck container  (default: `linux/amd64`)
 - `TEST_WAR_FILE_LOCATION`: (optional for tomcatTest task) If set, it will use this path to get the war file and run the tomcatTest
   task, if not it will try to get the war from the build process
 

--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdContainer.groovy
@@ -19,7 +19,7 @@ class RdContainer extends DockerComposeContainer<RdContainer> implements ClientP
     public static final String STATIC_TOKEN = System.getenv("TEST_RUNDECK_CONTAINER_TOKEN") ?: 'admintoken'
     public static final String RUNDECK_IMAGE = System.getenv("TEST_IMAGE") ?: System.getProperty("TEST_IMAGE")
     public static final String LICENSE_LOCATION = System.getenv("LICENSE_LOCATION")
-    public static final String TEST_RUNDECK_GRAILS_URL = System.getenv("TEST_RUNDECK_GRAILS_URL") ?: "http://rundeck:4440"
+    public static final String TEST_RUNDECK_GRAILS_URL = System.getenv("TEST_RUNDECK_GRAILS_URL") ?: "http://localhost:4440"
     public static final String TEST_TARGET_PLATFORM = System.getenv("TEST_TARGET_PLATFORM") ?: "linux/amd64"
 
     private final Map<String, Integer> clientConfig

--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdContainer.groovy
@@ -19,7 +19,8 @@ class RdContainer extends DockerComposeContainer<RdContainer> implements ClientP
     public static final String STATIC_TOKEN = System.getenv("TEST_RUNDECK_CONTAINER_TOKEN") ?: 'admintoken'
     public static final String RUNDECK_IMAGE = System.getenv("TEST_IMAGE") ?: System.getProperty("TEST_IMAGE")
     public static final String LICENSE_LOCATION = System.getenv("LICENSE_LOCATION")
-    public static final String TEST_RUNDECK_GRAILS_URL = System.getenv("TEST_RUNDECK_GRAILS_URL") ?: "http://localhost:4440"
+    public static final String TEST_RUNDECK_GRAILS_URL = System.getenv("TEST_RUNDECK_GRAILS_URL") ?: "http://rundeck:4440"
+    public static final String TEST_TARGET_PLATFORM = System.getenv("TEST_TARGET_PLATFORM") ?: "linux/amd64"
 
     private final Map<String, Integer> clientConfig
 
@@ -38,6 +39,7 @@ class RdContainer extends DockerComposeContainer<RdContainer> implements ClientP
         withEnv("TEST_IMAGE", RUNDECK_IMAGE)
         withEnv("LICENSE_LOCATION", LICENSE_LOCATION)
         withEnv("TEST_RUNDECK_GRAILS_URL", TEST_RUNDECK_GRAILS_URL)
+        withEnv("TEST_TARGET_PLATFORM", TEST_TARGET_PLATFORM)
         withEnv("TEST_RUNDECK_FEATURE_NAME", featureName ?: 'placeholderFeatureName')
         withLogConsumer(DEFAULT_SERVICE_TO_EXPOSE, new Slf4jLogConsumer(log))
         waitingFor(DEFAULT_SERVICE_TO_EXPOSE,

--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdContainer.groovy
@@ -19,7 +19,7 @@ class RdContainer extends DockerComposeContainer<RdContainer> implements ClientP
     public static final String STATIC_TOKEN = System.getenv("TEST_RUNDECK_CONTAINER_TOKEN") ?: 'admintoken'
     public static final String RUNDECK_IMAGE = System.getenv("TEST_IMAGE") ?: System.getProperty("TEST_IMAGE")
     public static final String LICENSE_LOCATION = System.getenv("LICENSE_LOCATION")
-    public static final String TEST_RUNDECK_GRAILS_URL = System.getenv("TEST_RUNDECK_GRAILS_URL") ?: "http://localhost:4440"
+    public static final String TEST_RUNDECK_GRAILS_URL = System.getenv("TEST_RUNDECK_GRAILS_URL") ?: "http://rundeck:4440"
     public static final String TEST_TARGET_PLATFORM = System.getenv("TEST_TARGET_PLATFORM") ?: "linux/amd64"
 
     private final Map<String, Integer> clientConfig

--- a/functional-test/src/test/resources/docker/compose/oss/docker-compose-blocklist.yml
+++ b/functional-test/src/test/resources/docker/compose/oss/docker-compose-blocklist.yml
@@ -2,6 +2,7 @@ version: "3"
 services:
   rundeck:
     image: ${TEST_IMAGE}
+    platform: ${TEST_TARGET_PLATFORM:-linux/amd64}
     environment:
       RUNDECK_GRAILS_URL: ${TEST_RUNDECK_GRAILS_URL}
       RUNDECK_SERVER_FORWARDED: 'true'

--- a/functional-test/src/test/resources/docker/compose/oss/docker-compose.yml
+++ b/functional-test/src/test/resources/docker/compose/oss/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: ""
       args:
         IMAGE: ${TEST_IMAGE}
+    platform: ${TEST_TARGET_PLATFORM:-linux/amd64}
     environment:
       RUNDECK_GRAILS_URL: ${TEST_RUNDECK_GRAILS_URL}
       RUNDECK_SERVER_FORWARDED: 'true'

--- a/functional-test/src/test/resources/docker/ldap/docker-compose.yml
+++ b/functional-test/src/test/resources/docker/ldap/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: ""
       args:
         IMAGE: ${TEST_IMAGE}
+    platform: ${TEST_TARGET_PLATFORM:-linux/amd64}
     links:
       - ldap
     environment:


### PR DESCRIPTION
## About this change:

Add an environment parameter to allow specifying the target cpu architecture to use on functional tests.


## Testing

- On an ARM machine (for example an M chip Macbook), build a rundeck image from scratch. Make sure it was build as an `arm64` image.
- Set the evironment variable `TEST_TARGET_PLATFORM=linux/arm64`
- Running the functional tests locally with the image built should work correctly.