### PR TITLE
RCLOUD-1425: Prevent bootstrap event when starting Rundeck with -m

### DIFF
--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -38,6 +38,7 @@ import org.grails.plugins.metricsweb.CallableGauge
 import org.quartz.Scheduler
 import rundeck.services.LogFileStorageService
 import rundeck.services.feature.FeatureService
+import rundeckapp.cli.CommandLineSetup
 import webhooks.Webhook
 
 import javax.servlet.ServletContext
@@ -492,7 +493,11 @@ class BootStrap {
             }
 
         }
-        grailsEventBus.notify('rundeck.bootstrap')
+        if(System.getProperty(CommandLineSetup.SYS_PROP_MIGRATE_ONLY) != "true") {
+            grailsEventBus.notify('rundeck.bootstrap')
+        } else {
+            log.info("Migrate only detected. Skipping bootstrap event.")
+        }
         log.info("Rundeck startup finished in ${System.currentTimeMillis()-bstart}ms")
     }
 

--- a/rundeckapp/grails-app/init/rundeckapp/cli/CommandLineSetup.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/cli/CommandLineSetup.groovy
@@ -35,6 +35,7 @@ class CommandLineSetup {
     //system props for launcher config
     private static final String SYS_PROP_RUNDECK_LAUNCHER_DEBUG     = "rundeck.launcher.debug";
     private static final String SYS_PROP_RUNDECK_LAUNCHER_REWRITE   = "rundeck.launcher.rewrite";
+    public static final String SYS_PROP_MIGRATE_ONLY               = "migrate.only";
 
     public static final String FLAG_INSTALLONLY = "installonly";
     public static final String FLAG_SKIPINSTALL = "skipinstall";
@@ -197,6 +198,9 @@ class CommandLineSetup {
         if(!StringUtil.isEmpty(cliOptions.tag))
             cliOptions.rollback = true
         cliOptions.migrate = cl.hasOption('m')
+        if(cliOptions.migrate) {
+            System.setProperty(SYS_PROP_MIGRATE_ONLY, "true")
+        }
         return cliOptions
 
     }


### PR DESCRIPTION
When Rundeck is started in migration mode there's no need to emit the bootstrap event which might have side effects.
This PR prevents the bootstrap event when Rundeck is started with the `-m` command line flag.