### PR TITLE
RCLOUD-1427: Enhance query that returns job data for schedule takeover

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -445,6 +445,7 @@ public class RundeckConfigBase {
         Enabled caseInsensitiveUsername = new Enabled();
         Enabled newLocalNodeExecutor = new Enabled();
         Enabled alphaUi = new Enabled();
+        Enabled enhancedJobTakeoverQuery = new Enabled();
 
 
         @Data

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/util/JobTakeoverQueryBuilder.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/util/JobTakeoverQueryBuilder.groovy
@@ -1,35 +1,33 @@
 package rundeck.data.util
 
+import groovy.sql.Sql
+
 class JobTakeoverQueryBuilder {
     static String buildTakeoverQuery(String toServerUUID, String fromServerUUID, boolean selectAll, String projectFilter, List<String> jobids, ignoreInnerScheduled = false) {
         String executionQueryPart = createJobTakeoverExecutionQueryPart(selectAll,fromServerUUID, toServerUUID, projectFilter)
         String useScheduledFlagQueryPart = !ignoreInnerScheduled ? "se.scheduled = true" : null
-        String jobUuidQueryPart = jobids ? "se.uuid in (${jobids.collect{"'${it}'"}.join(",")})" : null
-        String projectPart = projectFilter ? "se.project = '${projectFilter}'" : null
+        String jobUuidQueryPart = jobids ? "se.uuid in (${safeConvertJobIds(jobids)})" : null
+        String projectPart = projectFilter ? "se.project = :projectFilter" : null
         String serverNodePart = createServerNodeQueryPart(selectAll, fromServerUUID, toServerUUID)
         String sePart = [useScheduledFlagQueryPart,jobUuidQueryPart,projectPart, serverNodePart].findAll{it}.join(" AND ")
         //return an id so that we can use ScheduledExecution.read(id) for efficiency
-        return """
-            SELECT DISTINCT se.id FROM scheduled_execution se LEFT JOIN execution e ON se.id = e.scheduled_execution_id
-            WHERE (
-            (${executionQueryPart})
-            OR 
-            (${sePart})
-        )
-        """
+        return "SELECT DISTINCT se.id FROM scheduled_execution se LEFT JOIN execution e ON se.id = e.scheduled_execution_id WHERE ((${executionQueryPart}) OR (${sePart}))"
+    }
+
+    static String safeConvertJobIds(List<String> jobids) {
+        //remove invalid characters in jobids and make sure they are 36 characters long
+        return jobids.findAll{jobid -> jobid?.replace("'","")?.replace(";","")?.length() == 36}.collect{"'${it}'"}.join(",")
     }
 
     static String createJobTakeoverExecutionQueryPart(boolean selectAll,String fromServerUUID, String toServerUUID, String projectFilter) {
-        String qry = """e.status = 'scheduled'
-                        AND e.date_completed IS NULL
-                        AND e.date_started > current_timestamp"""
+        String qry = "e.status = 'scheduled' AND e.date_completed IS NULL AND e.date_started > current_timestamp"
         if(projectFilter) {
-            qry += " AND e.project = '${projectFilter}'"
+            qry += " AND e.project = :projectFilter"
         }
         if(selectAll) {
-            qry += " AND (e.server_nodeuuid IS NULL OR e.server_nodeuuid != '${toServerUUID}')"
+            qry += " AND (e.server_nodeuuid IS NULL OR e.server_nodeuuid != :toServerUUID)"
         } else {
-            qry += fromServerUUID ? " AND e.server_nodeuuid = '${fromServerUUID}'" : " AND e.server_nodeuuid IS NULL"
+            qry += fromServerUUID ? " AND e.server_nodeuuid = :fromServerUUID" : " AND e.server_nodeuuid IS NULL"
         }
         return qry
     }
@@ -37,9 +35,9 @@ class JobTakeoverQueryBuilder {
     static String createServerNodeQueryPart(boolean selectAll, String fromServerUUID, String toServerUUID) {
         String qry = null
         if(selectAll) {
-            qry = "(se.server_nodeuuid IS NULL OR se.server_nodeuuid != '${toServerUUID}')"
+            qry = "(se.server_nodeuuid IS NULL OR se.server_nodeuuid != :toServerUUID)"
         } else {
-            qry = fromServerUUID ? "se.server_nodeuuid = '${fromServerUUID}'" : "se.server_nodeuuid IS NULL"
+            qry = fromServerUUID ? "se.server_nodeuuid = :fromServerUUID" : "se.server_nodeuuid IS NULL"
         }
         return qry
     }

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/util/JobTakeoverQueryBuilder.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/util/JobTakeoverQueryBuilder.groovy
@@ -1,0 +1,47 @@
+package rundeck.data.util
+
+class JobTakeoverQueryBuilder {
+    static String buildTakeoverQuery(String toServerUUID, String fromServerUUID, boolean selectAll, String projectFilter, List<String> jobids, ignoreInnerScheduled = false) {
+        String executionQueryPart = createJobTakeoverExecutionQueryPart(selectAll,fromServerUUID, toServerUUID, projectFilter)
+        String useScheduledFlagQueryPart = !ignoreInnerScheduled ? "se.scheduled = true" : null
+        String jobUuidQueryPart = jobids ? "se.uuid in (${jobids.collect{"'${it}'"}.join(",")})" : null
+        String projectPart = projectFilter ? "se.project = '${projectFilter}'" : null
+        String serverNodePart = createServerNodeQueryPart(selectAll, fromServerUUID, toServerUUID)
+        String sePart = [useScheduledFlagQueryPart,jobUuidQueryPart,projectPart, serverNodePart].findAll{it}.join(" AND ")
+        //return an id so that we can use ScheduledExecution.read(id) for efficiency
+        return """
+            SELECT DISTINCT se.id FROM scheduled_execution se LEFT JOIN execution e ON se.id = e.scheduled_execution_id
+            WHERE (
+            (${executionQueryPart})
+            OR 
+            (${sePart})
+        )
+        """
+    }
+
+    static String createJobTakeoverExecutionQueryPart(boolean selectAll,String fromServerUUID, String toServerUUID, String projectFilter) {
+        String qry = """e.status = 'scheduled'
+                        AND e.date_completed IS NULL
+                        AND e.date_started > current_timestamp"""
+        if(projectFilter) {
+            qry += " AND e.project = '${projectFilter}'"
+        }
+        if(selectAll) {
+            qry += " AND (e.server_nodeuuid IS NULL OR e.server_nodeuuid != '${toServerUUID}')"
+        } else {
+            qry += fromServerUUID ? " AND e.server_nodeuuid = '${fromServerUUID}'" : " AND e.server_nodeuuid IS NULL"
+        }
+        return qry
+    }
+
+    static String createServerNodeQueryPart(boolean selectAll, String fromServerUUID, String toServerUUID) {
+        String qry = null
+        if(selectAll) {
+            qry = "(se.server_nodeuuid IS NULL OR se.server_nodeuuid != '${toServerUUID}')"
+        } else {
+            qry = fromServerUUID ? "se.server_nodeuuid = '${fromServerUUID}'" : "se.server_nodeuuid IS NULL"
+        }
+        return qry
+    }
+
+}

--- a/grails-rundeck-data-shared/src/test/groovy/rundeck/data/util/JobTakeoverQueryBuilderSpec.groovy
+++ b/grails-rundeck-data-shared/src/test/groovy/rundeck/data/util/JobTakeoverQueryBuilderSpec.groovy
@@ -1,0 +1,56 @@
+package rundeck.data.util
+
+import spock.lang.Specification
+
+class JobTakeoverQueryBuilderSpec extends Specification {
+    def "BuildTakeoverQuery"() {
+        given:
+        String toServerUUID = "toServerUUID"
+        String fromServerUUID = "fromServerUUID"
+        boolean selectAll = false
+        List<String> jobids = ["7a3e4b5d-7e03-4793-af2a-849408527cb6", "60e682d7-37e0-4fd5-b47b-4f470275dee3","';DELETE FROM rduser;"]
+
+        when:
+        String result = JobTakeoverQueryBuilder.buildTakeoverQuery(toServerUUID, fromServerUUID, selectAll, projectFilter, jobids, innerSchedFlag)
+
+        then:
+        result == expectedQry
+
+        where:
+        projectFilter | innerSchedFlag | expectedQry
+        null          | true           | "SELECT DISTINCT se.id FROM scheduled_execution se LEFT JOIN execution e ON se.id = e.scheduled_execution_id WHERE ((e.status = 'scheduled' AND e.date_completed IS NULL AND e.date_started > current_timestamp AND e.server_nodeuuid = :fromServerUUID) OR (se.uuid in ('7a3e4b5d-7e03-4793-af2a-849408527cb6','60e682d7-37e0-4fd5-b47b-4f470275dee3') AND se.server_nodeuuid = :fromServerUUID))"
+        null          | false          | "SELECT DISTINCT se.id FROM scheduled_execution se LEFT JOIN execution e ON se.id = e.scheduled_execution_id WHERE ((e.status = 'scheduled' AND e.date_completed IS NULL AND e.date_started > current_timestamp AND e.server_nodeuuid = :fromServerUUID) OR (se.scheduled = true AND se.uuid in ('7a3e4b5d-7e03-4793-af2a-849408527cb6','60e682d7-37e0-4fd5-b47b-4f470275dee3') AND se.server_nodeuuid = :fromServerUUID))"
+        "one"         | true           | "SELECT DISTINCT se.id FROM scheduled_execution se LEFT JOIN execution e ON se.id = e.scheduled_execution_id WHERE ((e.status = 'scheduled' AND e.date_completed IS NULL AND e.date_started > current_timestamp AND e.project = :projectFilter AND e.server_nodeuuid = :fromServerUUID) OR (se.uuid in ('7a3e4b5d-7e03-4793-af2a-849408527cb6','60e682d7-37e0-4fd5-b47b-4f470275dee3') AND se.project = :projectFilter AND se.server_nodeuuid = :fromServerUUID))"
+        "one"         | false          | "SELECT DISTINCT se.id FROM scheduled_execution se LEFT JOIN execution e ON se.id = e.scheduled_execution_id WHERE ((e.status = 'scheduled' AND e.date_completed IS NULL AND e.date_started > current_timestamp AND e.project = :projectFilter AND e.server_nodeuuid = :fromServerUUID) OR (se.scheduled = true AND se.uuid in ('7a3e4b5d-7e03-4793-af2a-849408527cb6','60e682d7-37e0-4fd5-b47b-4f470275dee3') AND se.project = :projectFilter AND se.server_nodeuuid = :fromServerUUID))"
+    }
+
+    def "CreateJobTakeoverExecutionQueryPart"() {
+
+        when:
+        String result = JobTakeoverQueryBuilder.createJobTakeoverExecutionQueryPart(selectAll, fromServerUUID, toServerUUID, projectFilter)
+
+        then:
+        result == expectedQry
+
+        where:
+        selectAll | fromServerUUID | toServerUUID    | projectFilter | expectedQry
+        true      | null           | "dest-svr-uuid" | null          | "e.status = 'scheduled' AND e.date_completed IS NULL AND e.date_started > current_timestamp AND (e.server_nodeuuid IS NULL OR e.server_nodeuuid != :toServerUUID)"
+        true      | null           | "dest-svr-uuid" | "prj-one"     | "e.status = 'scheduled' AND e.date_completed IS NULL AND e.date_started > current_timestamp AND e.project = :projectFilter AND (e.server_nodeuuid IS NULL OR e.server_nodeuuid != :toServerUUID)"
+        false     | "src-svr-uuid" | "dest-svr-uuid" | null          | "e.status = 'scheduled' AND e.date_completed IS NULL AND e.date_started > current_timestamp AND e.server_nodeuuid = :fromServerUUID"
+    }
+
+    def "CreateServerNodeQueryPart"() {
+        when:
+        String result = JobTakeoverQueryBuilder.createServerNodeQueryPart(selectAll, fromServerUUID, toServerUUID)
+
+        then:
+        result == expectedQry
+
+        where:
+        selectAll | fromServerUUID | toServerUUID    | expectedQry
+        true      | null           | "dest-svr-uuid" | "(se.server_nodeuuid IS NULL OR se.server_nodeuuid != :toServerUUID)"
+        false     | null           | "dest-svr-uuid" | "se.server_nodeuuid IS NULL"
+        false     | "src-svr-uuid" | "dest-svr-uuid" | "se.server_nodeuuid = :fromServerUUID"
+
+    }
+}

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -779,7 +779,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         long start = System.currentTimeMillis()
         def result = closure()
         long end = System.currentTimeMillis()
-        println("Timer ${name} took ${end-start}ms")
+        log.info("Timer ${name} took ${end-start}ms")
         return result
     }
     /**
@@ -4477,7 +4477,15 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             String qry = JobTakeoverQueryBuilder.buildTakeoverQuery(toServerUUID, fromServerUUID, selectAll, projectFilter, jobids, ignoreInnerScheduled)
             var sql = new Sql(dataSource)
             List<ScheduledExecution> jobList = []
-            sql.rows(qry.toString()).each {
+            Map qryParams = ["toServerUUID":toServerUUID]
+            if(fromServerUUID){
+                qryParams["fromServerUUID"] = fromServerUUID
+            }
+            if(projectFilter){
+                qryParams["projectFilter"] = projectFilter
+            }
+
+            sql.rows(qry, qryParams).each {
                 jobList.add(ScheduledExecution.read(it.id as Serializable))
             }
             return jobList

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -17,8 +17,11 @@
 package rundeck.services
 
 import com.dtolabs.rundeck.app.api.jobs.browse.ItemMeta
+import groovy.sql.Sql
 import rundeck.data.job.reference.JobReferenceImpl
 import rundeck.data.job.reference.JobRevReferenceImpl
+import rundeck.data.util.JobTakeoverQueryBuilder
+import rundeck.services.feature.FeatureService
 import rundeck.support.filters.BaseNodeFilters
 import com.dtolabs.rundeck.app.support.ScheduledExecutionQuery
 import com.dtolabs.rundeck.core.audit.ActionTypes
@@ -152,6 +155,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     ReferencedExecutionDataProvider referencedExecutionDataProvider
     JobStatsDataProvider jobStatsDataProvider
     QuartzJobSpecifier quartzJobSpecifier
+    def dataSource
 
     public final String REMOTE_OPTION_DISABLE_JSON_CHECK = 'project.jobs.disableRemoteOptionJsonCheck'
 
@@ -218,6 +222,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     JobDataProvider jobDataProvider
     UserService userService
     RdJobService rdJobService
+    FeatureService featureService
 
     @Override
     void afterPropertiesSet() throws Exception {
@@ -770,6 +775,13 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         return [claimed: !retry, executions: claimedExecs]
     }
 
+    def timer(String name, Closure closure) {
+        long start = System.currentTimeMillis()
+        def result = closure()
+        long end = System.currentTimeMillis()
+        println("Timer ${name} took ${end-start}ms")
+        return result
+    }
     /**
      * Claim scheduling for any jobs assigned to fromServerUUID, or not assigned if it is null
      * @param toServerUUID uuid to assign to scheduled jobs
@@ -789,7 +801,9 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         def queryFromServerUUID = fromServerUUID
         def queryProject = projectFilter
         ScheduledExecution.withSession { session ->
-            def scheduledExecutions = jobSchedulesService.getSchedulesJobToClaim(toServerUUID, queryFromServerUUID, selectAll, queryProject, jobids)
+            def scheduledExecutions = timer("takeover query ") {
+                jobSchedulesService.getSchedulesJobToClaim(toServerUUID, queryFromServerUUID, selectAll, queryProject, jobids)
+            }
             scheduledExecutions.each { ScheduledExecution se ->
                 def orig = se.serverNodeUUID
                 if (!claimed[se.extid]) {
@@ -4458,7 +4472,17 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
      * @return
      */
     List<ScheduledExecution> getSchedulesJobToClaim(String toServerUUID, String fromServerUUID, boolean selectAll, String projectFilter, List<String> jobids, ignoreInnerScheduled = false) {
-
+        if(featureService.featurePresent("enhancedJobTakeoverQuery")) {
+            log.info("Using enhanced job takeover query")
+            String qry = JobTakeoverQueryBuilder.buildTakeoverQuery(toServerUUID, fromServerUUID, selectAll, projectFilter, jobids, ignoreInnerScheduled)
+            var sql = new Sql(dataSource)
+            List<ScheduledExecution> jobList = []
+            sql.rows(qry.toString()).each {
+                jobList.add(ScheduledExecution.read(it.id as Serializable))
+            }
+            return jobList
+        }
+        log.info("Using legacy job takeover query")
         return ScheduledExecution.createCriteria().listDistinct {
             or {
                 applyAdhocScheduledExecutionsCriteria(delegate, selectAll, fromServerUUID, toServerUUID, projectFilter)

--- a/rundeckapp/src/integration-test/groovy/rundeck/services/ScheduledExecutionServiceIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/services/ScheduledExecutionServiceIntegrationSpec.groovy
@@ -14,6 +14,7 @@ import rundeck.Execution
 import rundeck.Option
 import rundeck.ScheduledExecution
 import rundeck.Workflow
+import rundeck.services.feature.FeatureService
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -221,6 +222,7 @@ class ScheduledExecutionServiceIntegrationSpec extends Specification {
         def projectMock = Mock(IRundeckProject) {
             getProjectProperties() >> [:]
         }
+        service.featureService = Mock(FeatureService)
         service.executionServiceBean    = Mock(ExecutionService)
         service.fileUploadService = Mock(FileUploadService)
         service.quartzScheduler         = Mock(Scheduler)


### PR DESCRIPTION
Add a raw sql version of the query that returns jobs that should be taken over by the takeover api. The criteria query is extremely inefficient when there are lots of scheduled jobs and executions in the db and can take a very long time to complete.
This query can be turned on by using the flag: `rundeck.feature.enhancedJobTakeoverQuery.enabled=true`

This feature should be considered experimental.