### PR TITLE
Print output log if waiting for execution fails in functional tests

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
@@ -1577,7 +1577,7 @@ class JobExecutionSpec extends BaseContainer {
                 WaitingTime.MODERATE
         ).status == ExecutionStatus.SUCCEEDED.state
 
-        def entries = getExecutionOutput(readExecId)
+        def entries = getExecutionOutputLines(readExecId)
 
         then: "test that errorhandler output was correct"
         FileHelpers.assertLinesInsideEntries(
@@ -1637,7 +1637,7 @@ class JobExecutionSpec extends BaseContainer {
                 WaitingTime.MODERATE
         ).status == ExecutionStatus.SUCCEEDED.state
 
-        def entries2 = getExecutionOutput(readExecId2)
+        def entries2 = getExecutionOutputLines(readExecId2)
 
         then: "test that errorhandler output was correct"
         FileHelpers.assertLinesInsideEntries(
@@ -1697,7 +1697,7 @@ class JobExecutionSpec extends BaseContainer {
                 WaitingTime.MODERATE
         ).status == ExecutionStatus.SUCCEEDED.state
 
-        def entries3 = getExecutionOutput(readExecId3)
+        def entries3 = getExecutionOutputLines(readExecId3)
 
         then: "test that errorhandler output was correct"
         FileHelpers.assertLinesInsideEntries(
@@ -1756,7 +1756,7 @@ class JobExecutionSpec extends BaseContainer {
                 WaitingTime.MODERATE
         ).status == ExecutionStatus.SUCCEEDED.state
 
-        def entries4 = getExecutionOutput(readExecId4)
+        def entries4 = getExecutionOutputLines(readExecId4)
 
         then: "test that errorhandler output was correct"
         FileHelpers.assertLinesInsideEntries(
@@ -1815,7 +1815,7 @@ class JobExecutionSpec extends BaseContainer {
                 WaitingTime.MODERATE
         ).status == ExecutionStatus.SUCCEEDED.state
 
-        def entries5 = getExecutionOutput(readExecId5)
+        def entries5 = getExecutionOutputLines(readExecId5)
 
         then: "test that errorhandler output was correct"
         FileHelpers.assertLinesInsideEntries(

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
@@ -1979,7 +1979,6 @@ class JobExecutionSpec extends BaseContainer {
         )
 
         then:
-        then:
         jobExecutionStatus.status == ExecutionStatus.SUCCEEDED.state
         // Verify that all steps on the first (and the only) node are in the SUCCEEDED state
         client.jsonValue(client.doGetAcceptAll("/execution/$jobExecutionStatus.id/state").body(), Map).nodes.values()[0].every({val -> val.executionState == "SUCCEEDED"} )

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobSpec.groovy
@@ -22,8 +22,8 @@ class JobSpec extends BaseContainer {
             assert r.successful
             Execution execution = MAPPER.readValue(r.body().string(), Execution.class)
 
-            waitForExecutionStatus(execution.id)
-            String fullLog = JobUtils.getExecutionOutput(execution.id, client)
+            waitForExecutionStatus(execution.id as String)
+            String fullLog = JobUtils.getExecutionOutputText(execution.id as String, client)
         expect:
             [
                     'hello there',

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/project/ExecuteScriptSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/project/ExecuteScriptSpec.groovy
@@ -108,7 +108,7 @@ class ExecuteScriptSpec extends BaseContainer{
         )
         assert readJobSucceeded.status == ExecutionStatus.SUCCEEDED.state
         String execId = readJobRunResponse.id
-        def entries = getExecutionOutput(execId)
+        def entries = getExecutionOutputLines(execId)
 
         //Extract local nodename, this name have to be the only line in output file
         def systemInfoResponse = doGet("/system/info")

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/project/RunCommandSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/project/RunCommandSpec.groovy
@@ -25,7 +25,7 @@ class RunCommandSpec extends BaseContainer {
         def runResponse = client.doPostWithoutBody("/project/$projectName/run/command?exec=${execArgs}")
         def runResponseBody = runResponse.body().string()
         def parsedResponseBody = mapper.readValue(runResponseBody, RunCommand.class)
-        def newExecId = parsedResponseBody.execution.id
+        String newExecId = parsedResponseBody.execution.id
         def completedExecution = waitForExecutionStatus(newExecId)
 
         then:

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/workflowSteps/FileUrlScriptStepSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/workflowSteps/FileUrlScriptStepSpec.groovy
@@ -3,13 +3,10 @@ package org.rundeck.tests.functional.api.workflowSteps
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.rundeck.util.annotations.APITest
-import org.rundeck.util.api.responses.execution.ExecutionOutput
 import org.rundeck.util.common.WaitingTime
 import org.rundeck.util.common.execution.ExecutionStatus
 import org.rundeck.util.common.jobs.JobUtils
 import org.rundeck.util.container.BaseContainer
-
-import java.util.stream.Collectors
 
 @APITest
 class FileUrlScriptStepSpec extends BaseContainer{
@@ -69,7 +66,7 @@ class FileUrlScriptStepSpec extends BaseContainer{
                 WaitingTime.EXCESSIVE
         )
         String execId = json.id
-        def entries = getExecutionOutput(execId)
+        def entries = getExecutionOutputLines(execId)
         entries.contains("Hello, World!")
 
     }
@@ -102,7 +99,7 @@ class FileUrlScriptStepSpec extends BaseContainer{
                 WaitingTime.EXCESSIVE
         )
         String execId = json.id
-        def entries = getExecutionOutput(execId)
+        def entries = getExecutionOutputLines(execId)
         entries.contains("Hello, World!")
 
     }

--- a/functional-test/src/test/groovy/org/rundeck/util/common/jobs/JobUtils.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/jobs/JobUtils.groovy
@@ -229,10 +229,11 @@ class JobUtils {
      * Retrieves the execution output for the specified execution ID.
      * @param execId The execution ID to query.
      * @param client The RdClient instance to perform the HTTP request.
+     * @param lastLinesCount The number of last lines to retrieve. Defaults to 0 (unlimited).
      * @return The ExecutionOutput object representing the execution output.
      */
-    static ExecutionOutput getExecutionOutput(String execId, RdClient client) {
-        def execOutputResponse = client.doGetAcceptAll("/execution/${execId}/output")
+    static ExecutionOutput getExecutionOutput(String execId, RdClient client, int lastLinesCount = 0) {
+        def execOutputResponse = client.doGetAcceptAll("/execution/${execId}/output?lastlines=${lastLinesCount}")
         ExecutionOutput execOutput = OBJECT_MAPPER.readValue(execOutputResponse.body().string(), ExecutionOutput.class)
         return execOutput
     }
@@ -241,23 +242,15 @@ class JobUtils {
      * Retrieves the execution output the specified execution ID as plain a text string.
      * @param execId The execution ID to query.
      * @param client The RdClient instance to perform the HTTP request.
+     * @param lastLinesCount The number of last lines to retrieve. Defaults to 0 (unlimited).
      * @return The execution output as a plain text string.
      */
-    static String getExecutionOutputText(String execId, RdClient client) {
-        def execOutputResponse = client.doGetAddHeaders("/execution/${execId}/output",
+    static String getExecutionOutputText(String execId, RdClient client, int lastLinesCount = 0) {
+        def execOutputResponse = client.doGetAddHeaders("/execution/${execId}/output?lastlines=${lastLinesCount}",
             Headers.of("Accept", "text/plain"))
         return execOutputResponse.body().string()
     }
 
-    static String getExecutionOutput(int executionId,  RdClient client, int lastLinesCount = 100) {
-        def resp = client.doGetAcceptAll("/execution/${executionId}/output?lastlines=${lastLinesCount}")
-
-       if (!resp.successful) {
-           throw new IllegalArgumentException("Unsuccessful API call:  " + resp);
-       }
-
-        resp.body().string()
-    }
 
     static ScmJobStatusResponse waitForJobStatusToBe(
             String jobId,

--- a/functional-test/src/test/groovy/org/rundeck/util/common/jobs/JobUtils.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/jobs/JobUtils.groovy
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import groovy.util.logging.Slf4j
 import okhttp3.Headers
 import org.rundeck.util.api.responses.execution.Execution
+import org.rundeck.util.api.responses.execution.ExecutionOutput
 import org.rundeck.util.api.responses.jobs.Job
 import org.rundeck.util.api.scm.GitScmApiClient
 import org.rundeck.util.api.scm.httpbody.ScmJobStatusResponse
@@ -224,6 +225,24 @@ class JobUtils {
         }
     }
 
+    /**
+     * Retrieves the execution output for the specified execution ID.
+     * @param execId The execution ID to query.
+     * @param client The RdClient instance to perform the HTTP request.
+     * @return The ExecutionOutput object representing the execution output.
+     */
+    static ExecutionOutput getExecutionOutput(String execId, RdClient client) {
+        def execOutputResponse = client.doGetAcceptAll("/execution/${execId}/output")
+        ExecutionOutput execOutput = OBJECT_MAPPER.readValue(execOutputResponse.body().string(), ExecutionOutput.class)
+        return execOutput
+    }
+
+    /**
+     * Retrieves the execution output the specified execution ID as plain a text string.
+     * @param execId The execution ID to query.
+     * @param client The RdClient instance to perform the HTTP request.
+     * @return The execution output as a plain text string.
+     */
     static String getExecutionOutputText(String execId, RdClient client) {
         def execOutputResponse = client.doGetAddHeaders("/execution/${execId}/output",
             Headers.of("Accept", "text/plain"))

--- a/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
@@ -10,6 +10,7 @@ import org.rundeck.util.api.responses.execution.ExecutionOutput
 import org.rundeck.util.api.storage.KeyStorageApiClient
 import org.rundeck.util.common.WaitingTime
 import org.rundeck.util.common.jobs.JobUtils
+import org.rundeck.util.common.jobs.JobUtils
 import spock.lang.Specification
 
 import java.text.SimpleDateFormat
@@ -18,7 +19,6 @@ import java.util.function.Consumer
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
-import java.util.stream.Collectors
 
 /**
  * Base class for tests, starts a shared static container for all tests

--- a/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
@@ -6,10 +6,8 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
 import org.rundeck.util.api.responses.execution.Execution
-import org.rundeck.util.api.responses.execution.ExecutionOutput
 import org.rundeck.util.api.storage.KeyStorageApiClient
 import org.rundeck.util.common.WaitingTime
-import org.rundeck.util.common.jobs.JobUtils
 import org.rundeck.util.common.jobs.JobUtils
 import spock.lang.Specification
 
@@ -188,11 +186,14 @@ abstract class BaseContainer extends Specification implements ClientProvider {
         tempFile.delete()
     }
 
-    List getExecutionOutput(String execId) {
-        def execOutputResponse = client.doGetAcceptAll("/execution/${execId}/output")
-        ExecutionOutput execOutput = safelyMap(execOutputResponse, ExecutionOutput.class)
-        def entries = execOutput.entries.stream().map { it.log }.collect(Collectors.toList())
-        return entries
+    /**
+     * Retrieves the execution output for the specified execution ID as a list of strings. One line per element.
+     * @param execId The identifier of the execution to retrieve the output from.
+     * @return A list of strings, each representing a line of the execution output.
+     */
+    List<String> getExecutionOutputLines(String execId) {
+        def execOutput = JobUtils.getExecutionOutput(execId, client)
+        return execOutput.entries.collect { it.log }
     }
 
     /**
@@ -363,7 +364,7 @@ abstract class BaseContainer extends Specification implements ClientProvider {
         }
 
         Execution execution = MAPPER.readValue(r.body().string(), Execution.class)
-        waitForExecutionStatus(execution.id)
+        waitForExecutionStatus(execution.id as String)
 
         // Maintains the data contract for the Map return type
         client.get("/execution/${execution.id}/output", Map)
@@ -375,7 +376,7 @@ abstract class BaseContainer extends Specification implements ClientProvider {
      * @param timeout wait timeout
      * @return
      */
-    Execution waitForExecutionStatus(int executionId, WaitingTime timeout = WaitingTime.MODERATE) {
+    Execution waitForExecutionStatus(String executionId, WaitingTime timeout = WaitingTime.MODERATE) {
         final List<String> statusesToWaitFor = [
                 'aborted',
                 'failed',
@@ -383,7 +384,7 @@ abstract class BaseContainer extends Specification implements ClientProvider {
                 'timedout',
                 'other']
 
-        JobUtils.waitForExecutionToBe(statusesToWaitFor, "$executionId", MAPPER, client, WaitingTime.LOW, timeout)
+        JobUtils.waitForExecutionToBe(statusesToWaitFor, executionId, MAPPER, client, WaitingTime.LOW, timeout)
     }
 
     /**


### PR DESCRIPTION
Improves execution status check handling to get the execution output log when a test check fails.