### PR TITLE
RCLOUD-1427: Improve validation of JobId parameter

### DIFF
--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/util/JobTakeoverQueryBuilder.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/util/JobTakeoverQueryBuilder.groovy
@@ -1,12 +1,10 @@
 package rundeck.data.util
 
-import groovy.sql.Sql
-
 class JobTakeoverQueryBuilder {
     static String buildTakeoverQuery(String toServerUUID, String fromServerUUID, boolean selectAll, String projectFilter, List<String> jobids, ignoreInnerScheduled = false) {
         String executionQueryPart = createJobTakeoverExecutionQueryPart(selectAll,fromServerUUID, toServerUUID, projectFilter)
         String useScheduledFlagQueryPart = !ignoreInnerScheduled ? "se.scheduled = true" : null
-        String jobUuidQueryPart = jobids ? "se.uuid in (${safeConvertJobIds(jobids)})" : null
+        String jobUuidQueryPart = jobids ? filteredJobIdsPart(jobids) : null
         String projectPart = projectFilter ? "se.project = :projectFilter" : null
         String serverNodePart = createServerNodeQueryPart(selectAll, fromServerUUID, toServerUUID)
         String sePart = [useScheduledFlagQueryPart,jobUuidQueryPart,projectPart, serverNodePart].findAll{it}.join(" AND ")
@@ -14,9 +12,14 @@ class JobTakeoverQueryBuilder {
         return "SELECT DISTINCT se.id FROM scheduled_execution se LEFT JOIN execution e ON se.id = e.scheduled_execution_id WHERE ((${executionQueryPart}) OR (${sePart}))"
     }
 
-    static String safeConvertJobIds(List<String> jobids) {
-        //remove invalid characters in jobids and make sure they are 36 characters long
-        return jobids.findAll{jobid -> jobid?.replace("'","")?.replace(";","")?.length() == 36}.collect{"'${it}'"}.join(",")
+    static String filteredJobIdsPart(List<String> jobids) {
+        var joinedValidJobIds = jobids.findAll{jobid -> isValidUUID(jobid)}.collect{"'${it}'"}.join(",")
+        if (joinedValidJobIds.isEmpty()) {
+            // This will force this part of the condition to be false
+            return "1=0"
+        } else {
+            return "se.uuid in (${joinedValidJobIds})"
+        }
     }
 
     static String createJobTakeoverExecutionQueryPart(boolean selectAll,String fromServerUUID, String toServerUUID, String projectFilter) {
@@ -42,4 +45,10 @@ class JobTakeoverQueryBuilder {
         return qry
     }
 
+    static boolean isValidUUID(String val) {
+        if (null == val) return false;
+        try { return null!= UUID.fromString(val) } catch (IllegalArgumentException e) {
+            return false
+        }
+    }
 }

--- a/grails-rundeck-data-shared/src/test/groovy/rundeck/data/util/JobTakeoverQueryBuilderSpec.groovy
+++ b/grails-rundeck-data-shared/src/test/groovy/rundeck/data/util/JobTakeoverQueryBuilderSpec.groovy
@@ -8,7 +8,7 @@ class JobTakeoverQueryBuilderSpec extends Specification {
         String toServerUUID = "toServerUUID"
         String fromServerUUID = "fromServerUUID"
         boolean selectAll = false
-        List<String> jobids = ["7a3e4b5d-7e03-4793-af2a-849408527cb6", "60e682d7-37e0-4fd5-b47b-4f470275dee3","';DELETE FROM rduser;"]
+        List<String> jobids = ["7a3e4b5d-7e03-4793-af2a-849408527cb6", "60e682d7-37e0-4fd5-b47b-4f470275dee3", "';DELETE FROM rduser;", "", null]
 
         when:
         String result = JobTakeoverQueryBuilder.buildTakeoverQuery(toServerUUID, fromServerUUID, selectAll, projectFilter, jobids, innerSchedFlag)
@@ -53,4 +53,5 @@ class JobTakeoverQueryBuilderSpec extends Specification {
         false     | "src-svr-uuid" | "dest-svr-uuid" | "se.server_nodeuuid = :fromServerUUID"
 
     }
+
 }


### PR DESCRIPTION
Instead of attempting to identify problematic characters, this PR adjusts the validation to only accept valid UUIDs.