### PR TITLE
RUN-2771: Fix shortened waiting times causing ROI and K8S tests to fail.

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
@@ -284,7 +284,7 @@ class JobExecutionSpec extends BaseContainer {
         assert enabledJobsResponse.successful
 
         // Necessary since the api needs to breathe after enable execs
-        Thread.sleep(WaitingTime.LOW.duration.toMillis())
+        Thread.sleep(WaitingTime.LOW.toMillis())
 
         def jobExecResponseFor1AfterEnable = JobUtils.executeJob(job1Id, client)
         assert jobExecResponseFor1AfterEnable.successful
@@ -392,7 +392,7 @@ class JobExecutionSpec extends BaseContainer {
         assert enabledJobsResponse.successful
 
         // Necessary since the api needs to breathe after enable execs
-        Thread.sleep(WaitingTime.LOW.duration.toMillis())
+        Thread.sleep(WaitingTime.LOW.toMillis())
 
         def jobExecResponseFor1AfterEnable = JobUtils.executeJob(job1Id, client)
         assert jobExecResponseFor1AfterEnable.successful
@@ -459,7 +459,7 @@ class JobExecutionSpec extends BaseContainer {
         then:
         job2Detail?.executionEnabled
 
-        Thread.sleep(WaitingTime.LOW.duration.toMillis()) // As the original test says
+        Thread.sleep(WaitingTime.LOW.toMillis()) // As the original test says
 
         when: "TEST: bulk job schedule disable"
         Object idList = [

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/appadmin/KeyStorageSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/appadmin/KeyStorageSpec.groovy
@@ -22,7 +22,7 @@ class KeyStorageSpec extends SeleniumBase {
         then:
             keyStoragePage.waitForModal 1
             keyStoragePage.addPasswordType 'root', 'git', 'git.pass'
-            sleep WaitingTime.MODERATE.duration.toMillis()
+            sleep WaitingTime.MODERATE.toMillis()
             keyStoragePage.waitForModal 0
             keyStoragePage.checkKeyExists 'git.pass', 'git'
     }

--- a/functional-test/src/test/groovy/org/rundeck/util/common/WaitingTime.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/WaitingTime.groovy
@@ -2,19 +2,23 @@ package org.rundeck.util.common
 
 import java.time.Duration
 
-enum WaitingTime {
+/**
+ * Collection of common time durations for waiting.
+ */
+final class WaitingTime {
 
-    LOW("A Second", Duration.ofSeconds(1)),
-    MODERATE("Five Seconds", Duration.ofSeconds(5)),
-    EXCESSIVE("Sixty seconds", Duration.ofSeconds(60)),
-    XTRA_EXCESSIVE("One-hundred twenty seconds", Duration.ofSeconds(120))
+    /** Waiting time of 1 second */
+    public static final Duration LOW = Duration.ofSeconds(1)
 
+    /** Waiting time of 5 seconds */
+    public static final Duration MODERATE = Duration.ofSeconds(5)
 
-    public final String label
-    public final Duration duration
+    /** Waiting time of 1 minute */
+    public static final Duration EXCESSIVE = Duration.ofSeconds(60)
 
-    WaitingTime(String label, Duration duration) {
-        this.label = label
-        this.duration = duration
-    }
+    /** Waiting time of 2 minutes */
+    public static final Duration XTRA_EXCESSIVE = Duration.ofSeconds(120)
+
+    // prevent instantiation.
+    private WaitingTime() {}
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/common/jobs/JobUtils.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/jobs/JobUtils.groovy
@@ -143,33 +143,10 @@ class JobUtils {
             String executionId,
             ObjectMapper mapper,
             RdClient client,
-            WaitingTime iterationGap,
-            WaitingTime timeout
+            Duration iterationGap = WaitingTime.LOW,
+            Duration timeout = WaitingTime.MODERATE
     ) {
-        return waitForExecutionToBe([state], executionId, mapper, client, iterationGap.duration, timeout.duration)
-    }
-
-    /**
-     * Waits for the execution to be in one of the expected states.
-     *
-     * @param expectedStates A list of expected states.
-     * @param executionId The execution ID to query.
-     * @param mapper The ObjectMapper instance to parse the response.
-     * @param client The RdClient instance to perform the HTTP request.
-     * @param iterationGap The duration to wait between each check.
-     * @param timeout The maximum duration to wait for the execution to reach the expected state.
-     * @return The Execution object representing the execution status.
-     * @throws InterruptedException if the timeout is reached before the execution reaches the expected state.
-     */
-    static Execution waitForExecutionToBe(
-            Collection<String> expectedStates,
-            String executionId,
-            ObjectMapper mapper,
-            RdClient client,
-            WaitingTime iterationGap,
-            WaitingTime timeout
-    ) {
-        return waitForExecutionToBe(expectedStates, executionId, mapper, client, iterationGap.duration, timeout.duration)
+        return waitForExecutionToBe([state], executionId, mapper, client, iterationGap, timeout)
     }
 
 
@@ -190,12 +167,11 @@ class JobUtils {
         String executionId,
         ObjectMapper mapper,
         RdClient client,
-        Duration iterationGap,
-        Duration timeout
+        Duration iterationGap = WaitingTime.LOW,
+        Duration timeout = WaitingTime.MODERATE
     ) {
-        Execution executionStatus
         def execDetail = client.doGet("/execution/${executionId}")
-        executionStatus = mapper.readValue(execDetail.body().string(), Execution.class)
+        Execution executionStatus = mapper.readValue(execDetail.body().string(), Execution.class)
         long initTime = System.currentTimeMillis()
         while (!expectedStates.contains(executionStatus.status)) {
             if ((System.currentTimeMillis() - initTime) >= timeout.toMillis()) {

--- a/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
@@ -364,10 +364,10 @@ abstract class BaseContainer extends Specification implements ClientProvider {
         }
 
         Execution execution = MAPPER.readValue(r.body().string(), Execution.class)
-        waitForExecutionStatus(execution.id as String)
+        waitForExecutionStatus(execution.id as String, WaitingTime.EXCESSIVE)
 
         // Maintains the data contract for the Map return type
-        client.get("/execution/${execution.id}/output", Map)
+        return client.get("/execution/${execution.id}/output", Map)
     }
 
     /**
@@ -376,7 +376,7 @@ abstract class BaseContainer extends Specification implements ClientProvider {
      * @param timeout wait timeout
      * @return
      */
-    Execution waitForExecutionStatus(String executionId, WaitingTime timeout = WaitingTime.MODERATE) {
+    Execution waitForExecutionStatus(String executionId, Duration timeout = WaitingTime.MODERATE) {
         final List<String> statusesToWaitFor = [
                 'aborted',
                 'failed',
@@ -384,7 +384,7 @@ abstract class BaseContainer extends Specification implements ClientProvider {
                 'timedout',
                 'other']
 
-        JobUtils.waitForExecutionToBe(statusesToWaitFor, executionId, MAPPER, client, WaitingTime.LOW, timeout)
+        return JobUtils.waitForExecutionToBe(statusesToWaitFor, executionId, MAPPER, client, WaitingTime.LOW, timeout)
     }
 
     /**

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobReferenceStep.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobReferenceStep.groovy
@@ -44,6 +44,6 @@ class JobReferenceStep implements JobStep {
             jobCreatePage.driver.findElement(By.className("_wfiedit")).findElement(By.name("uuid")).sendKeys(childJobUuid)
         }
 
-        Thread.sleep(WaitingTime.LOW.duration.toMillis())
+        Thread.sleep(WaitingTime.LOW.toMillis())
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/scm/PerformScmActionPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/scm/PerformScmActionPage.groovy
@@ -38,7 +38,7 @@ class PerformScmActionPage extends BasePage {
         String resultText = waitForResultMessageBox().getText()
 
         if(shouldWaitAfterCommit)
-            Thread.sleep(WaitingTime.MODERATE.duration.toMillis())
+            Thread.sleep(WaitingTime.MODERATE.toMillis())
 
         return resultText
     }


### PR DESCRIPTION
RUN-2771: Fix shortened waiting times causing ROI and K8S tests to fail.

- Switch all waiting times to java.time.Duration for a more flexible api.
- Changes `runJobAndWait()` to wait longer

