### PR TITLE
RUN-573/RUN-575: fix edge case in pluginPropEdit update

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/execution/ExecutionEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/execution/ExecutionEditor.vue
@@ -39,6 +39,7 @@
                   <template #description>
                     <plugin-details
                       :description="header.detail!.description"
+                      description-css="ml-5"
                       extended-css=""
                       allow-html
                       inline-description

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/execution/ExecutionEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/execution/ExecutionEditor.vue
@@ -29,7 +29,7 @@
               />
               <label :for="`executionLifecyclePluginEnabled_${plugin.name}`">
                 <plugin-info
-                  v-if="header.detail.desc"
+                  v-if="header.detail.description"
                   :show-title="header.inputShowTitle"
                   :show-icon="header.inputShowIcon || false"
                   :show-description="header.inputShowDescription || false"
@@ -38,7 +38,7 @@
                 >
                   <template #description>
                     <plugin-details
-                      :description="header.detail!.desc"
+                      :description="header.detail!.description"
                       extended-css=""
                       allow-html
                       inline-description

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/execution/tests/ExecutionEditor.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/execution/tests/ExecutionEditor.spec.ts
@@ -2,6 +2,7 @@ import { flushPromises, shallowMount, VueWrapper } from "@vue/test-utils";
 import ExecutionEditor from "../ExecutionEditor.vue";
 import { executionLifecycle, pluginsInitialData } from "./mocks";
 import PluginConfig from "../../../../../library/components/plugins/pluginConfig.vue";
+import PluginDetails from "../../../../../library/components/plugins/PluginDetails.vue";
 
 jest.mock("@/library/modules/rundeckClient", () => ({
   client: {},
@@ -22,7 +23,13 @@ const createWrapper = async (propsData = {}): Promise<VueWrapper<any>> => {
       },
       stubs: {
         pluginConfig: {
-          props: ["showIcon", "showTitle", "showDescription", "provider"],
+          props: [
+            "showIcon",
+            "showTitle",
+            "showDescription",
+            "provider",
+            "modelValue",
+          ],
           data() {
             return {
               inputShowTitle: this.showTitle !== null ? this.showTitle : true,
@@ -30,7 +37,10 @@ const createWrapper = async (propsData = {}): Promise<VueWrapper<any>> => {
               inputShowDescription:
                 this.showDescription !== null ? this.showDescription : true,
               detail: {
-                desc: this.provider || "", // bypassing to avoid mocking up all api calls
+                description:
+                  pluginsInitialData.filter(
+                    (plugin) => plugin.name === this.provider,
+                  )[0].description || "", // bypassing to avoid mocking up all api calls
               },
             };
           },
@@ -41,6 +51,8 @@ const createWrapper = async (propsData = {}): Promise<VueWrapper<any>> => {
             detail,
           }"></slot></div>`,
         },
+        pluginInfo: false,
+        pluginDetails: false,
       },
     },
   });
@@ -96,5 +108,28 @@ describe("ExecutionEditor", () => {
         ExecutionLifecycle: executionLifecycle,
       }),
     ]);
+  });
+
+  it("renders plugin descriptions", async () => {
+    const wrapper = await createWrapper();
+
+    // as the initial data is coming from gsp, the component is initially mounted without the initialData
+    // therefore using setProps to simulate this behaviour
+    await wrapper.setProps({
+      initialData: {
+        pluginsInitialData,
+        ExecutionLifecycle: {},
+      },
+    });
+    await wrapper.vm.$nextTick();
+    const inlineDescriptions = wrapper.findAll(
+      "[data-testid='inline-description']",
+    );
+    expect(inlineDescriptions.length).toEqual(5);
+
+    const blockDescriptions = wrapper.findAll(
+      "[data-testid='block-description']",
+    );
+    expect(blockDescriptions.length).toEqual(3);
   });
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/PluginDetails.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/PluginDetails.vue
@@ -1,12 +1,14 @@
 <template>
-  <span
-    v-if="showDescription && !inlineDescription"
-    :class="descriptionCss"
-    style="margin-left: 5px"
-    data-testid="block-description"
+  <slot
+    v-if="
+      (showDescription && !inlineDescription) ||
+      (showDescription && inlineDescription && extraDescription.length === 0)
+    "
   >
-    {{ shortDescription }}
-  </span>
+    <span :class="descriptionCss" data-testid="block-description">
+      {{ shortDescription }}
+    </span>
+  </slot>
   <details
     v-if="showDescription && showExtended && extraDescription"
     class="more-info"
@@ -67,7 +69,7 @@ export default defineComponent({
     },
     descriptionCss: {
       type: String,
-      default: "",
+      default: "m",
       required: false,
     },
     extendedCss: {
@@ -133,6 +135,9 @@ export default defineComponent({
 <style scoped>
 .m-0 {
   margin: 0 !important;
+}
+.ml-5 {
+  margin-left: 5px;
 }
 .p-0 {
   padding: 0 !important;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/PluginDetails.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/PluginDetails.vue
@@ -69,7 +69,7 @@ export default defineComponent({
     },
     descriptionCss: {
       type: String,
-      default: "m",
+      default: "",
       required: false,
     },
     extendedCss: {


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
During the changes of RUN-573 and RUN-575, PluginPropEdit component had redundant code replaced with the updated version of PluginDetail. Changes seemed fine at first but it turned out that the execution plugin tab had an edge case where the short description should still be displayed when there is no extra description available, even though the "inline mode" is set.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
This PR updates PluginDetail to be able to handle this edge case and adds an extra unit test to cover it.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
