### PR TITLE
RUN-2705: Notification timeouts enabled by default.

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -430,7 +430,7 @@ public class RundeckConfigBase {
         Enabled userSessionProjectsCache = new Enabled(true);
         Enabled authorizationServiceBootstrapWarmupCache = new Enabled();
         Enabled projectManagerServiceBootstrapWarmupCache = new Enabled();
-        Enabled notificationsOwnThread = new Enabled();
+        Enabled notificationsOwnThread = new Enabled(true);
         Enabled workflowDesigner = new Enabled(true);
         Enabled eventStore = new Enabled(true);
         Enabled projectKeyStorage = new Enabled(true);

--- a/rundeckapp/grails-app/conf/application.yml
+++ b/rundeckapp/grails-app/conf/application.yml
@@ -317,7 +317,7 @@ rundeck:
         projectKeyStorage:
             enabled: true
         notificationsOwnThread:
-            enabled: false #FYI FALSE
+            enabled: true
         fileUploadPlugin:
             enabled: true
     health:


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
This is a small enhancement that defaults to applying a 120s timeout for sending job notifications. 

If necessary, this timeout can be adjusted by setting `rundeck.notification.threadTimeOut` to a millisecond value.

**Describe the solution you've implemented**
Enables a timeout for processing and sending all notifications related to job execution to reduce the likelihood of "stuck" executions when a notification destination is not responding in a timely manner.

**Describe alternatives you've considered**

**Additional context**
Note: for _reasons_, the default value must be set in two different locations for everything to work properly in both OSS and Pro.
