### PR TITLE
RUN-2741: Add LDAP rolePagination config option

### DIFF
--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -24,6 +24,7 @@
         roleMemberAttribute="{{ getv("/rundeck/jaas/ldap/rolememberattribute", "uniqueMember") }}"
         roleObjectClass="{{ getv("/rundeck/jaas/ldap/roleobjectclass", "groupOfUniqueNames") }}"
         rolePrefix="{{ getv("/rundeck/jaas/ldap/roleprefix", "") }}"
+        rolePagination="{{ getv("/rundeck/jaas/ldap/rolepagination", "true") }}"
         cacheDurationMillis="{{ getv("/rundeck/jaas/ldap/cachedurationmillis", "600000") }}"
         reportStatistics="{{ getv("/rundeck/jaas/ldap/reportstatistics", "true") }}"
 {% if exists("/rundeck/jaas/ldap/roleusernamememberattribute") %}


### PR DESCRIPTION
Recreate https://github.com/rundeck/rundeck/pull/8822

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

* enable rolePagination config via docker 
 
> Some LDAP servers don't support pagination in the search queries so that rolePagination must be disabled to fix “error code 12 - Unavailable Critical Extension” in the LDAP search.



**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
