### PR TITLE
RUN-2833 : Introduce wait and poll functions and rewrite a few functional tests to use them

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
@@ -130,13 +130,13 @@ class ExecutionSpec extends BaseContainer {
                 def json2 = client.jsonValue(response.body(), Map)
                 json2.executions.size() == 6
             }
-
-            // Waits for all executions to get cleaned
-            assert waitFor(ExecutionUtils.Retrievers.executionsForProject(client, projectName),
-                    {it.isEmpty()},
-            WaitingTime.EXCESSIVE).isEmpty()
-            deleteProject(projectName)
         cleanup:
+            // Waits for all executions to get cleaned
+            waitFor(ExecutionUtils.Retrievers.executionsForProject(client, projectName),
+                {it.isEmpty()},
+                WaitingTime.EXCESSIVE)
+            deleteProject(projectName)
+
             tmpjar.delete()
         where:
             version | projectName

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/util/WaitUtilsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/util/WaitUtilsSpec.groovy
@@ -1,0 +1,88 @@
+package org.rundeck.tests.functional.util
+
+import org.rundeck.util.annotations.APITest
+import org.rundeck.util.common.ResourceAcceptanceTimeoutException
+import org.rundeck.util.common.WaitUtils
+import spock.lang.Specification
+
+@APITest
+class WaitUtilsSpec extends Specification {
+
+    static final Map<String, String> TEST_VALUES = ["1": "one", "2": "two"].asImmutable()
+
+    def testWaitForThatNeverWaits() {
+        given:
+        Closure<String> retriever = { return TEST_VALUES[it] }
+
+        when:
+        String result = WaitUtils.waitForResource("1", retriever)
+
+        then:
+        result == "one"
+    }
+
+    def testWaitForThatWaitsAndFailsToGetAccepted() {
+        given:
+        Closure<String> retriever = { return "123" }
+
+        Closure<Boolean> resourceAcceptanceEvaluator = { false }
+
+        Closure<String> acceptanceFailureOutputProducer = { String key ->
+            return "Custom output $key".toString()
+        }
+
+        when:
+        WaitUtils.waitForResource("1", retriever, resourceAcceptanceEvaluator, acceptanceFailureOutputProducer)
+
+        then:
+        ResourceAcceptanceTimeoutException e = thrown(ResourceAcceptanceTimeoutException)
+        assert e.getMessage().contains("Custom output 1")
+    }
+
+    def testWaitForThatWaitsAndGetsAccepted() {
+        given:
+        int tryCounter = 0
+
+        Closure<String> retriever = { String key ->
+            if (tryCounter >= 2) {
+                return TEST_VALUES[key].toString()
+            }
+            tryCounter++
+            return null as String
+        }
+
+        Closure<Boolean> resourceAcceptanceEvaluator = { String k -> k != null }
+
+        when:
+        String result = WaitUtils.waitForResource("1", retriever, resourceAcceptanceEvaluator)
+
+        then:
+        result == "one"
+    }
+
+    def testWaitForManyThatNeverWaits() {
+        given:
+        Collection<String> ids = ["1", "2"]
+
+        when:
+        Map<String, String> result = WaitUtils.waitForAllResources(ids, { String k -> return TEST_VALUES[k] })
+
+        then:
+        result == new HashMap(["1": "one", "2": "two"])
+    }
+
+    def testWaitForManyThatWaitsAndFailsOnOneOfTheValues() {
+        given:
+        Collection<String> ids = ["1", "2"]
+
+        when:
+        WaitUtils.waitForAllResources(ids,
+                { String k -> k == "2" ? null : TEST_VALUES[k] },
+                { it != null }
+        )
+
+        then:
+        RuntimeException e = thrown(RuntimeException)
+        assert e.getMessage().contains("Timeout")
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/util/WaitUtilsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/util/WaitUtilsSpec.groovy
@@ -5,6 +5,8 @@ import org.rundeck.util.common.ResourceAcceptanceTimeoutException
 import org.rundeck.util.common.WaitUtils
 import spock.lang.Specification
 
+import java.time.Duration
+
 @APITest
 class WaitUtilsSpec extends Specification {
 
@@ -15,7 +17,11 @@ class WaitUtilsSpec extends Specification {
         Closure<String> retriever = { return TEST_VALUES[it] }
 
         when:
-        String result = WaitUtils.waitForResource("1", retriever)
+        String result = WaitUtils.waitForResource("1",
+                retriever,
+                {  true },
+                {""},
+                Duration.ofMillis(0) )
 
         then:
         result == "one"

--- a/functional-test/src/test/groovy/org/rundeck/util/common/ResourceAcceptanceTimeoutException.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/ResourceAcceptanceTimeoutException.groovy
@@ -1,0 +1,11 @@
+package org.rundeck.util.common
+
+class ResourceAcceptanceTimeoutException extends RuntimeException {
+    ResourceAcceptanceTimeoutException(String message) {
+        super(message)
+    }
+
+    ResourceAcceptanceTimeoutException(String message, Throwable cause) {
+        super(message, cause)
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/util/common/WaitBehaviour.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/WaitBehaviour.groovy
@@ -1,0 +1,40 @@
+package org.rundeck.util.common
+
+import groovy.transform.CompileStatic
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.FromString
+
+import java.time.Duration
+
+@CompileStatic
+trait WaitBehaviour {
+
+    /** Waits for the resource to be in the expected state by retrieving it and evaluating its acceptance as many times as needed.
+     * @param retryableResourceRetriever executed multiple times to retrieve the current state of the R resource.
+     * @param resourceAcceptanceEvaluator evaluates the state of the resource and and returns true if the resource is accepted.
+     * @param timeout max duration to wait for the resource to reach the expected state.
+     * @param checkPeriod time to wait between each check.
+     * @return the resource that met the acceptance criteria.
+     * @throws ResourceAcceptanceTimeoutException if the timeout is reached waiting for the resource to reach the expected state.
+     *
+     * @see WaitUtils#waitFor(Closure, Closure, Duration, Duration) for the static version of this method.
+     */
+    final  <R> R waitFor(
+            Closure<R> retryableResourceRetriever,
+            @ClosureParams(value = FromString, options = ["R"]) Closure<Boolean> resourceAcceptanceEvaluator = { !!it },
+            Duration timeout = WaitingTime.MODERATE,
+            Duration checkPeriod = WaitingTime.LOW) {
+        WaitUtils.waitFor(retryableResourceRetriever, resourceAcceptanceEvaluator, timeout, checkPeriod)
+    }
+
+    /**
+     * Converts a closure that does verification on a single resource to a closure that does the verification on a collection of such resources.
+     * @param verifier closure that verifies a single resource.
+     * @return closure that takes a collection of resources and runs the verifier on every resource, short-circuiting if needed.
+     */
+    final Closure<Boolean> verifyForAll(Closure<Boolean> verifier) {
+        { Collection<?> coll ->
+            coll?.every(verifier)
+        }
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/util/common/WaitBehaviour.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/WaitBehaviour.groovy
@@ -1,10 +1,10 @@
 package org.rundeck.util.common
 
 import groovy.transform.CompileStatic
-import groovy.transform.stc.ClosureParams
-import groovy.transform.stc.FromString
 
 import java.time.Duration
+import java.util.function.Function
+import java.util.function.Supplier
 
 @CompileStatic
 trait WaitBehaviour {
@@ -17,11 +17,12 @@ trait WaitBehaviour {
      * @return the resource that met the acceptance criteria.
      * @throws ResourceAcceptanceTimeoutException if the timeout is reached waiting for the resource to reach the expected state.
      *
-     * @see WaitUtils#waitFor(Closure, Closure, Duration, Duration) for the static version of this method.
+     * @see WaitUtils#waitFor(java.util.function.Supplier, java.util.function.Function, java.time.Duration, java.time.Duration)
+     *  for the static version of this method.
      */
     final  <R> R waitFor(
-            Closure<R> retryableResourceRetriever,
-            @ClosureParams(value = FromString, options = ["R"]) Closure<Boolean> resourceAcceptanceEvaluator = { !!it },
+            Supplier<R> retryableResourceRetriever,
+            Function<R, Boolean> resourceAcceptanceEvaluator = { it != null },
             Duration timeout = WaitingTime.MODERATE,
             Duration checkPeriod = WaitingTime.LOW) {
         WaitUtils.waitFor(retryableResourceRetriever, resourceAcceptanceEvaluator, timeout, checkPeriod)

--- a/functional-test/src/test/groovy/org/rundeck/util/common/WaitUtils.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/WaitUtils.groovy
@@ -1,0 +1,108 @@
+package org.rundeck.util.common
+
+import groovy.transform.TypeChecked
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.FirstParam
+import groovy.transform.stc.FromString
+
+import java.time.Duration
+
+class WaitUtils  {
+
+    /** Waits for the resource to be in the expected state by retrieving it and evaluating its acceptance as many times as needed.
+     * @param retryableResourceRetriever executed multiple times to retrieve the current state of the R resource.
+     * @param resourceAcceptanceEvaluator evaluates the state of the resource and and returns true if the resource is accepted.
+     * @param timeout max duration to wait for the resource to reach the expected state.
+     * @param checkPeriod time to wait between each check.
+     * @return the resource that met the acceptance criteria.
+     * @throws ResourceAcceptanceTimeoutException if the timeout is reached waiting for the resource to reach the expected state.
+     */
+    @TypeChecked
+    static <R> R waitFor(
+            Closure<R> retryableResourceRetriever,
+            @ClosureParams(value = FromString, options = ["R"]) Closure<Boolean> resourceAcceptanceEvaluator = { R r -> !!r },
+            Duration timeout = WaitingTime.MODERATE,
+            Duration checkPeriod = WaitingTime.LOW) {
+        R r = retryableResourceRetriever()
+        Boolean acceptanceResult = resourceAcceptanceEvaluator(r)
+        long initTime = System.currentTimeMillis()
+        while (!acceptanceResult) {
+            Thread.sleep(Math.min(checkPeriod.toMillis(), timeout.toMillis()))
+            if ((System.currentTimeMillis() - initTime) >= timeout.toMillis()) {
+                throw new ResourceAcceptanceTimeoutException("Timeout reached (${timeout.toSeconds()} seconds) waiting for ${r} to reach the desired state")
+            }
+            r = retryableResourceRetriever()
+            acceptanceResult = resourceAcceptanceEvaluator(r)
+        }
+        return r
+    }
+
+    /** Waits for the resource to be in the expected state by retrieving it by its identifier and evaluating its acceptance as many times as needed.
+     * @param resourceId resource identifier that is passable into the resourceRetriever as an input argument.
+     * @param resourceRetriever closure that takes the RID resourceId and returns the current state of the R resource.
+     * @param resourceAcceptanceEvaluator closure that evaluates the state of the resource by taking a R resource and returning true of the resource is accepted.
+     * @param acceptanceFailureOutputProducer closure that produces a string output when the resource acceptance evaluator returns false to be included in the exception message.
+     * @param timeout max duration to wait for the resource to reach the expected state.
+     * @param checkPeriod time to wait between each check.
+     * @return the resource that met the acceptance criteria.
+     * @throws ResourceAcceptanceTimeoutException if the timeout is reached waiting for the resource to reach the expected state.
+     */
+    @TypeChecked
+    static <RID, R> R waitForResource(RID resourceId,
+                                      @ClosureParams(FirstParam.FirstGenericType.class) Closure<R> resourceRetriever,
+                                      @ClosureParams(value = FromString, options = ["R"]) Closure<Boolean> resourceAcceptanceEvaluator = { R r -> true },
+                                      @ClosureParams(FirstParam.FirstGenericType.class) Closure<String> acceptanceFailureOutputProducer = { RID id -> "" },
+                                      Duration timeout = WaitingTime.MODERATE,
+                                      Duration checkPeriod = WaitingTime.LOW) {
+
+        try {
+            return waitFor({ resourceRetriever(resourceId) },
+                    resourceAcceptanceEvaluator,
+                    timeout,
+                    checkPeriod)
+        } catch (ResourceAcceptanceTimeoutException e) {
+            // Enriches the exception message with the acceptanceFailureOutputProducer output and wrapping the original exception
+            throw new ResourceAcceptanceTimeoutException("Timeout reached waiting for $resourceId ${acceptanceFailureOutputProducer(resourceId)} ", e)
+        }
+    }
+
+    /** Waits for all resources to be in the expected state by retrieving them using identifiers and evaluating the acceptance as many times as needed.
+     *  No guarantees are made about the order and timing of the retrieval.
+     * @param resourceIdentifiers collection of resource identifiers. Each identifier should be passable into the resourceRetriever as an input argument.
+     * @param resourceRetriever closure that takes the RID resourceId and returns the current state of the R resource.
+     * @param resourceAcceptanceEvaluator closure that evaluates the state of the resource by taking a R resource and returning true of the resource is accepted.
+     * @param timeout max duration to wait for the resource to reach the expected state.
+     * @param checkPeriod time to wait between each check.
+     * @param acceptanceFailureOutputProducer closure that produces a string output when the resource acceptance evaluator returns false to be included in the exception message.
+     * @return a map of resource identifiers and their corresponding resources once the acceptance criteria is met by all.
+     * @throws ResourceAcceptanceTimeoutException if the timeout is reached waiting for at least one resource to reach the expected state.
+     *      If multiple resources fail to reach the expected state, the exception will be thrown for one them in non-deterministic order.
+     */
+    @TypeChecked
+    static <RID, R> Map<RID, R> waitForAllResources(Collection<RID> resourceIdentifiers,
+                                                    @ClosureParams(FirstParam.FirstGenericType.class) Closure<R> resourceRetriever,
+                                                    @ClosureParams(value = FromString, options = ["R"]) Closure<Boolean> resourceAcceptanceEvaluator = { R r -> true },
+                                                    Duration timeout = WaitingTime.MODERATE,
+                                                    Duration checkPeriod = WaitingTime.LOW,
+                                                    @ClosureParams(FirstParam.FirstGenericType.class) Closure<String> acceptanceFailureOutputProducer = { RID id -> "" }) {
+
+        Map<RID, R> result = resourceIdentifiers.stream().reduce(
+                new HashMap<>(),
+                (Map<RID, R> acc, id) -> {
+                    R r = waitForResource(id,
+                            resourceRetriever,
+                            resourceAcceptanceEvaluator,
+                            acceptanceFailureOutputProducer,
+                            timeout,
+                            checkPeriod)
+                    acc.put(id, r)
+                    return acc;
+                },
+                (Map<RID, R> map1, Map<RID, R> map2) -> {
+                    map1.putAll(map2);
+                    return map1;
+                }
+        )
+        return result
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/util/common/execution/ExecutionUtils.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/execution/ExecutionUtils.groovy
@@ -1,0 +1,89 @@
+package org.rundeck.util.common.execution
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.rundeck.util.api.responses.execution.Execution
+import org.rundeck.util.api.responses.jobs.JobExecutionsResponse
+import org.rundeck.util.container.RdClient
+
+class ExecutionUtils {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+    static final List<String> EXECUTION_FINISH_STATUSES = [
+            'aborted',
+            'failed',
+            'succeeded',
+            'timedout',
+            'other'].asImmutable()
+
+    static class Verifiers {
+        /**
+         * Returns a closure that verifies if an execution passed into it is finished.
+         * @return
+         */
+        static final Closure<Boolean> executionFinished() {
+            // The verifier is untyped to be compatible with pre-existing code that uses Maps instead of typed objects
+            return {
+                EXECUTION_FINISH_STATUSES.contains(it?.status)
+            }
+        }
+
+
+        /**
+         * Returns a closure that verifies if an execution passed into it is running.
+         * @return
+         */
+        static final Closure<Boolean> executionRunning() {
+            // The verifier is untyped to be compatible with pre-existing code that uses Maps instead of typed objects
+            return {
+                ["running"].contains(it?.status)
+            }
+        }
+
+    }
+
+    static class Retrievers {
+        /**
+         * Returns a closure that retrieves an execution by its id.
+         * @param client
+         * @param executionId
+         * @return
+         */
+        static final Closure<Execution> executionById(RdClient client, String executionId) {
+            { ->
+                def r = client.doGet("/execution/${executionId}")
+                r?.successful ? OBJECT_MAPPER.readValue(r.body()?.string(), Execution.class) : null
+            }
+        }
+
+        /**
+         * Returns a closure that retrieves executions for a project.
+         * @param client
+         * @param projectName name of the project or * for all projects
+         * @param queryString query string to append to the request
+         * @return a closure that lists all executions for the project
+         */
+        static final Closure<List<Execution>> executionsForProject(RdClient client, String projectName, String queryString = null) {
+            { ->
+                def execsResponse = client.doGetAcceptAll("/project/${projectName}/executions" + (queryString ? "?${queryString}" : ""))
+                JobExecutionsResponse parsedResponse = OBJECT_MAPPER.readValue(execsResponse.body().string(), JobExecutionsResponse.class)
+                return parsedResponse.executions.isEmpty() ? [] : parsedResponse.executions as List<Execution>
+            }
+        }
+
+        /**
+         * Returns a closure that retrieves executions for a job id.
+         * @param client
+         * @param jobId id of the job
+         * @param queryString query string to append to the request
+         * @return a closure that lists all executions for the job
+         */
+        static final Closure<List<Execution>> executionsForJobId(RdClient client, String jobId, String queryString = null) {
+            { ->
+                def execsResponse = client.doGetAcceptAll("/job/${jobId}/executions" + (queryString ? "?${queryString}" : ""))
+                JobExecutionsResponse parsedResponse = OBJECT_MAPPER.readValue(execsResponse.body().string(), JobExecutionsResponse.class)
+                return parsedResponse.executions.isEmpty() ? [] : parsedResponse.executions as List<Execution>
+            }
+        }
+
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/util/common/execution/ExecutionUtils.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/execution/ExecutionUtils.groovy
@@ -5,6 +5,8 @@ import org.rundeck.util.api.responses.execution.Execution
 import org.rundeck.util.api.responses.jobs.JobExecutionsResponse
 import org.rundeck.util.container.RdClient
 
+import java.util.function.Supplier
+
 class ExecutionUtils {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
@@ -27,7 +29,6 @@ class ExecutionUtils {
             }
         }
 
-
         /**
          * Returns a closure that verifies if an execution passed into it is running.
          * @return
@@ -48,7 +49,7 @@ class ExecutionUtils {
          * @param executionId
          * @return
          */
-        static final Closure<Execution> executionById(RdClient client, String executionId) {
+        static final Supplier<Execution> executionById(RdClient client, String executionId) {
             { ->
                 def r = client.doGet("/execution/${executionId}")
                 r?.successful ? OBJECT_MAPPER.readValue(r.body()?.string(), Execution.class) : null
@@ -62,7 +63,7 @@ class ExecutionUtils {
          * @param queryString query string to append to the request
          * @return a closure that lists all executions for the project
          */
-        static final Closure<List<Execution>> executionsForProject(RdClient client, String projectName, String queryString = null) {
+        static final Supplier<List<Execution>> executionsForProject(RdClient client, String projectName, String queryString = null) {
             { ->
                 def execsResponse = client.doGetAcceptAll("/project/${projectName}/executions" + (queryString ? "?${queryString}" : ""))
                 JobExecutionsResponse parsedResponse = OBJECT_MAPPER.readValue(execsResponse.body().string(), JobExecutionsResponse.class)
@@ -77,7 +78,7 @@ class ExecutionUtils {
          * @param queryString query string to append to the request
          * @return a closure that lists all executions for the job
          */
-        static final Closure<List<Execution>> executionsForJobId(RdClient client, String jobId, String queryString = null) {
+        static final Supplier<List<Execution>> executionsForJobId(RdClient client, String jobId, String queryString = null) {
             { ->
                 def execsResponse = client.doGetAcceptAll("/job/${jobId}/executions" + (queryString ? "?${queryString}" : ""))
                 JobExecutionsResponse parsedResponse = OBJECT_MAPPER.readValue(execsResponse.body().string(), JobExecutionsResponse.class)

--- a/functional-test/src/test/groovy/org/rundeck/util/common/jobs/JobUtils.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/jobs/JobUtils.groovy
@@ -17,6 +17,7 @@ import org.rundeck.util.container.RdClient
 import java.time.Duration
 import java.time.ZoneId
 import java.util.concurrent.TimeUnit
+import java.util.function.Function
 
 @Slf4j
 class JobUtils {
@@ -168,7 +169,7 @@ class JobUtils {
         Duration timeout = WaitingTime.MODERATE,
         Duration checkPeriod = WaitingTime.LOW
     ) {
-        Closure<Boolean> resourceAcceptanceEvaluator = { Execution e -> expectedStates.contains(e?.status) }
+        Function<Execution, Boolean> resourceAcceptanceEvaluator = { Execution e -> expectedStates.contains(e?.status) }
 
         Closure<String> acceptanceFailureOutputProducer = { String id ->
             def execOutput = callSilently { getExecutionOutputText(id, client) }
@@ -176,7 +177,7 @@ class JobUtils {
         }
 
         return WaitUtils.waitForResource(executionId,
-                { String id -> ExecutionUtils.Retrievers.executionById(client, id)() },
+                { String id -> ExecutionUtils.Retrievers.executionById(client, id).get() },
                 resourceAcceptanceEvaluator,
                 acceptanceFailureOutputProducer,
                 timeout,
@@ -201,8 +202,8 @@ class JobUtils {
             Duration timeout = WaitingTime.MODERATE,
             Duration checkPeriod = WaitingTime.LOW) {
         return WaitUtils.waitForAllResources(executionIds,
-                { String id -> ExecutionUtils.Retrievers.executionById(client, id)() },
-                ExecutionUtils.Verifiers.executionFinished(),
+                { String id -> ExecutionUtils.Retrievers.executionById(client, id).get() },
+                ExecutionUtils.Verifiers.executionFinished() as Function<Execution, Boolean>,
                 timeout,
                 checkPeriod)
     }

--- a/functional-test/src/test/groovy/org/rundeck/util/common/jobs/JobUtils.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/jobs/JobUtils.groovy
@@ -1,6 +1,7 @@
 package org.rundeck.util.common.jobs
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import groovy.transform.TypeChecked
 import groovy.util.logging.Slf4j
 import okhttp3.Headers
 import org.rundeck.util.api.responses.execution.Execution
@@ -8,7 +9,9 @@ import org.rundeck.util.api.responses.execution.ExecutionOutput
 import org.rundeck.util.api.responses.jobs.JobDetails
 import org.rundeck.util.api.scm.GitScmApiClient
 import org.rundeck.util.api.scm.httpbody.ScmJobStatusResponse
+import org.rundeck.util.common.WaitUtils
 import org.rundeck.util.common.WaitingTime
+import org.rundeck.util.common.execution.ExecutionUtils
 import org.rundeck.util.container.RdClient
 
 import java.time.Duration
@@ -27,7 +30,6 @@ class JobUtils {
     static final String DUPE_OPTION_DEFAULT = "create"
 
     static final String CONTENT_TYPE_DEFAULT = "application/xml"
-
 
     static def executeJobWithArgs = (String jobId, RdClient client, String args) -> {
         return client.doPostWithoutBody("/job/${jobId}/run?argString=${args}")
@@ -147,7 +149,6 @@ class JobUtils {
         return waitForExecution([state], executionId, client, timeout, checkPeriod)
     }
 
-
     /**
      * Waits for the execution to be in one of the expected states.
      *
@@ -159,6 +160,7 @@ class JobUtils {
      * @return The Execution object representing the execution status.
      * @throws InterruptedException if the timeout is reached before the execution reaches the expected state.
      */
+    @TypeChecked
     static Execution waitForExecution(
         Collection<String> expectedStates,
         String executionId,
@@ -166,22 +168,43 @@ class JobUtils {
         Duration timeout = WaitingTime.MODERATE,
         Duration checkPeriod = WaitingTime.LOW
     ) {
-        def execDetail = client.doGet("/execution/${executionId}")
-        Execution executionStatus = OBJECT_MAPPER.readValue(execDetail.body().string(), Execution.class)
-        long initTime = System.currentTimeMillis()
-        while (!expectedStates.contains(executionStatus.status)) {
-            if ((System.currentTimeMillis() - initTime) >= timeout.toMillis()) {
-                def execOutput = callSilently { getExecutionOutputText(executionId, client) }
-                throw new InterruptedException("Timeout reached (${timeout.toSeconds()} seconds), the execution had \"${executionStatus.status}\" state. Execution output was: \n${execOutput}\n")
-            }
-            def transientExecutionResponse = client.doGet("/execution/${executionId}")
-            executionStatus = OBJECT_MAPPER.readValue(transientExecutionResponse.body().string(), Execution.class)
-            if (expectedStates.contains(executionStatus.status)) {
-                break
-            }
-            Thread.sleep(Math.min(checkPeriod.toMillis(), timeout.toMillis()))
+        Closure<Boolean> resourceAcceptanceEvaluator = { Execution e -> expectedStates.contains(e?.status) }
+
+        Closure<String> acceptanceFailureOutputProducer = { String id ->
+            def execOutput = callSilently { getExecutionOutputText(id, client) }
+            return "Execution output was: \n${execOutput}\n".toString()
         }
-        return executionStatus
+
+        return WaitUtils.waitForResource(executionId,
+                { String id -> ExecutionUtils.Retrievers.executionById(client, id)() },
+                resourceAcceptanceEvaluator,
+                acceptanceFailureOutputProducer,
+                timeout,
+                checkPeriod)
+    }
+
+    /**
+     * Waits for the execution to be in one of the expected states.
+     *
+     * @param executionIds The execution IDs to wait for.
+     * @param expectedStates A list of expected states.
+     * @param client The RdClient instance to perform the HTTP request.
+     * @param timeout The maximum duration to wait for the execution to reach the expected state.
+     * @param checkPeriod The time to wait between each check.
+     * @return The Execution object representing the execution status.
+     * @throws InterruptedException if the timeout is reached before the execution reaches the expected state.
+     */
+    @TypeChecked
+    static Map<String, Execution> waitForManyExecutionToFinish(
+            Collection<String> executionIds,
+            RdClient client,
+            Duration timeout = WaitingTime.MODERATE,
+            Duration checkPeriod = WaitingTime.LOW) {
+        return WaitUtils.waitForAllResources(executionIds,
+                { String id -> ExecutionUtils.Retrievers.executionById(client, id)() },
+                ExecutionUtils.Verifiers.executionFinished(),
+                timeout,
+                checkPeriod)
     }
 
     /**


### PR DESCRIPTION
Jira: https://pagerduty.atlassian.net/browse/RUN-2833

- Introduction of conditional sleep functionality
- deprecation of unconditional sleep functions
- conversion of selected functional tests from unconditional to conditional sleeps

## Perf Improvements

See the test suite execution timing

### Before -> After

![Screenshot 2024-09-05 at 2 25 26 PM](https://github.com/user-attachments/assets/2d604163-b449-4fe9-883f-28a9f2d79e21)

![Screenshot 2024-09-05 at 2 27 10 PM](https://github.com/user-attachments/assets/44016daf-2e87-415d-a0ab-b3a0d57055f3)

![Screenshot 2024-09-05 at 2 28 46 PM](https://github.com/user-attachments/assets/1e2e8223-93c6-4d3c-89d3-e950f3b0db6c)

![Screenshot 2024-09-05 at 4 34 33 PM](https://github.com/user-attachments/assets/3c39be38-a52e-42e3-93be-1429d944c522)

