### PR TITLE
Fix logic on method waitForModal

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/appadmin/AccessControlSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/appadmin/AccessControlSpec.groovy
@@ -1,5 +1,6 @@
 package org.rundeck.tests.functional.selenium.appadmin
 
+import org.openqa.selenium.By
 import org.rundeck.util.gui.pages.appadmin.AccessControlPage
 import org.rundeck.util.gui.pages.login.LoginPage
 import org.rundeck.util.annotations.SeleniumCoreTest
@@ -20,7 +21,7 @@ class AccessControlSpec extends SeleniumBase {
             def aclPage = go AccessControlPage
         when:
             aclPage.uploadButton.click()
-            aclPage.waitForModal 1
+            aclPage.waitForModal 1, By.cssSelector(".modal.in")
             aclPage.uploadSubmitButton.click()
         then:
             aclPage.alertsFields.size() == 3
@@ -36,7 +37,7 @@ class AccessControlSpec extends SeleniumBase {
             def aclPage = go AccessControlPage
         when:
             aclPage.uploadButton.click()
-            aclPage.waitForModal 1
+            aclPage.waitForModal 1, By.cssSelector(".modal.in")
             aclPage.uploadSubmitButton.click()
             aclPage.uploadNameField.sendKeys 'some-file-name'
             aclPage.uploadFileField.sendKeys createTempYamlFile('invalid acl content test data')
@@ -54,7 +55,7 @@ class AccessControlSpec extends SeleniumBase {
             def aclPage = go AccessControlPage
         when:
             aclPage.uploadButton.click()
-            aclPage.waitForModal 1
+            aclPage.waitForModal 1, By.cssSelector(".modal.in")
             aclPage.uploadSubmitButton.click()
             aclPage.uploadFileField.sendKeys createTempYamlFile(validPolicyData)
             aclPage.uploadNameField.clear()
@@ -73,7 +74,7 @@ class AccessControlSpec extends SeleniumBase {
             def aclPage = go AccessControlPage
         when:
             aclPage.uploadButton.click()
-            aclPage.waitForModal 1
+            aclPage.waitForModal 1, By.cssSelector(".modal.in")
             aclPage.uploadSubmitButton.click()
             aclPage.uploadFileField.sendKeys createTempYamlFile(validPolicyData)
             aclPage.uploadNameField.clear()

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/appadmin/KeyStorageSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/appadmin/KeyStorageSpec.groovy
@@ -1,5 +1,6 @@
 package org.rundeck.tests.functional.selenium.appadmin
 
+import org.openqa.selenium.By
 import org.rundeck.util.gui.pages.appadmin.KeyStoragePage
 import org.rundeck.util.gui.pages.login.LoginPage
 import org.rundeck.util.annotations.SeleniumCoreTest
@@ -20,10 +21,10 @@ class KeyStorageSpec extends SeleniumBase {
             keyStoragePage.waitForElementVisible keyStoragePage.addUploadKeyField
             keyStoragePage.addUploadKeyField.click()
         then:
-            keyStoragePage.waitForModal 1
+            keyStoragePage.waitForModal 1, By.cssSelector(".modal.in")
             keyStoragePage.addPasswordType 'root', 'git', 'git.pass'
             sleep WaitingTime.MODERATE.toMillis()
-            keyStoragePage.waitForModal 0
+            keyStoragePage.waitForModal 0, By.cssSelector(".modal.in")
             keyStoragePage.checkKeyExists 'git.pass', 'git'
     }
 
@@ -35,7 +36,7 @@ class KeyStorageSpec extends SeleniumBase {
         when:
             keyStoragePage.refresh()
             keyStoragePage.clickOverwriteKey 'git', 'git.pass'
-            keyStoragePage.waitForModal 1
+            keyStoragePage.waitForModal 1 , By.cssSelector(".modal.in")
         then:
             keyStoragePage.overwriteKey 'new-root'
     }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/appadmin/KeyStorageSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/appadmin/KeyStorageSpec.groovy
@@ -24,7 +24,6 @@ class KeyStorageSpec extends SeleniumBase {
             keyStoragePage.waitForModal 1, By.cssSelector(".modal.in")
             keyStoragePage.addPasswordType 'root', 'git', 'git.pass'
             sleep WaitingTime.MODERATE.toMillis()
-            keyStoragePage.waitForModal 0, By.cssSelector(".modal.in")
             keyStoragePage.checkKeyExists 'git.pass', 'git'
     }
 

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/BasicJobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/BasicJobsSpec.groovy
@@ -1,5 +1,6 @@
 package org.rundeck.tests.functional.selenium.jobs
 
+import org.openqa.selenium.By
 import org.rundeck.util.annotations.ExcludePro
 import org.rundeck.util.gui.pages.jobs.JobCreatePage
 import org.rundeck.util.gui.pages.jobs.JobListPage
@@ -276,7 +277,7 @@ class BasicJobsSpec extends SeleniumBase {
         then:
             jobShowPage.validatePage()
             jobShowPage.jobSearchButton.click()
-            jobShowPage.waitForModal 1
+            jobShowPage.waitForModal 1, By.cssSelector(".modal.in")
             jobShowPage.jobSearchNameField.sendKeys 'option'
             jobShowPage.jobSearchSubmitButton.click()
             jobShowPage.waitForNumberOfElementsToBe jobShowPage.jobRowBy, expected.size()
@@ -299,7 +300,7 @@ class BasicJobsSpec extends SeleniumBase {
         then:
             jobShowPage.validatePage()
             jobShowPage.jobSearchButton.click()
-            jobShowPage.waitForModal 1
+            jobShowPage.waitForModal 1, By.cssSelector(".modal.in")
             jobShowPage.jobSearchNameField.sendKeys 'option'
             jobShowPage.jobSearchGroupField.sendKeys 'test'
             jobShowPage.jobSearchSubmitButton.click()
@@ -314,7 +315,7 @@ class BasicJobsSpec extends SeleniumBase {
         when:
             jobShowPage.validatePage()
             jobShowPage.jobSearchButton.click()
-            jobShowPage.waitForModal 1
+            jobShowPage.waitForModal 1, By.cssSelector(".modal.in")
             jobShowPage.jobSearchNameField.sendKeys 'option'
             jobShowPage.jobSearchGroupField.sendKeys '-'
             jobShowPage.jobSearchSubmitButton.click()

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/BasePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/BasePage.groovy
@@ -157,9 +157,9 @@ abstract class BasePage {
 
     def waitForModal(int expected) {
         try {
-            new WebDriverWait(driver, Duration.ofSeconds(30)).until {
+            new WebDriverWait(driver, Duration.ofSeconds(30)).until (
                 ExpectedConditions.numberOfElementsToBe(modalField, expected)
-            }
+            )
         } catch (TimeoutException e) {
             throw new RuntimeException("Timed out waiting for the modal to have ${expected} elements.", e)
         }

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/BasePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/BasePage.groovy
@@ -155,19 +155,11 @@ abstract class BasePage {
                 .until(ExpectedConditions.attributeContains(locator, attribute, value))
     }
 
-    def waitForModal(int expected, By modalFieldCssSelector = null) {
-        By defaultModalFieldCssSelector = modalField
-
-        try {
-            new WebDriverWait(driver, Duration.ofSeconds(30)).until (
-                    ExpectedConditions.numberOfElementsToBe(
-                            modalFieldCssSelector ?: defaultModalFieldCssSelector,
-                            expected
-                    )
-            )
-        } catch (TimeoutException e) {
-            throw new RuntimeException("Timed out waiting for the modal to have ${expected} elements.", e)
-        }
+    def waitForModal(int expected, By modalFieldCssSelector = modalField) {
+        new WebDriverWait(driver, Duration.ofSeconds(30)).until (
+                ExpectedConditions.numberOfElementsToBe(
+                        modalFieldCssSelector, expected )
+        )
     }
 
     WebElement byAndWait(By locator) {

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/BasePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/BasePage.groovy
@@ -155,10 +155,15 @@ abstract class BasePage {
                 .until(ExpectedConditions.attributeContains(locator, attribute, value))
     }
 
-    def waitForModal(int expected) {
+    def waitForModal(int expected, By modalFieldCssSelector = null) {
+        By defaultModalFieldCssSelector = modalField
+
         try {
             new WebDriverWait(driver, Duration.ofSeconds(30)).until (
-                ExpectedConditions.numberOfElementsToBe(modalField, expected)
+                    ExpectedConditions.numberOfElementsToBe(
+                            modalFieldCssSelector ?: defaultModalFieldCssSelector,
+                            expected
+                    )
             )
         } catch (TimeoutException e) {
             throw new RuntimeException("Timed out waiting for the modal to have ${expected} elements.", e)


### PR DESCRIPTION
Jira ticket: https://pagerduty.atlassian.net/browse/RUN-2822

Context: Modifications were made to the waitForModal method in the RunnerResourceModelSpec class to enhance its flexibility and eliminate redundant usage.

Changes Made:

Refactoring of waitForModal Method:

The original waitForModal method took an expected parameter and waited for the modal to contain exactly that number of elements before proceeding. If the condition wasn’t met within a specified timeout, a TimeoutException was thrown.
The method was modified to include a second optional parameter, modalFieldCssSelector, which allows specifying a custom CSS selector to identify the modal. This enhances the method's flexibility by enabling it to work with different modals on the same page.
Removal of Redundant waitForModal Calls:

Several redundant calls to waitForModal(0) were removed. These calls were previously checking that the modal was not present before performing certain actions. By optimizing these checks elsewhere in the code, the need for these specific calls was eliminated, reducing code complexity and test execution time.
