### PR TITLE
RUN-2376 api/job/id/executions to return referenced executions

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
@@ -1994,13 +1994,22 @@ class JobExecutionSpec extends BaseContainer {
         then:
         jobExecutionStatus.status == ExecutionStatus.SUCCEEDED.state
 
-        when: "get executions"
+        when: "get executions default behavior"
         def response = doGet("/job/${childJobId}/executions")
         then:
         verifyAll {
             response.successful
             response.code() == 200
             def json = jsonValue(response.body())
+            json.executions.size() == 0
+        }
+        when: "get executions with includeJobRef true"
+        def response1 = doGet("/job/${childJobId}/executions?includeJobRef=true")
+        then:
+        verifyAll {
+            response1.successful
+            response1.code() == 200
+            def json = jsonValue(response1.body())
             json.executions.size() == 1
             json.executions[0].id?.toString() == exec.id
         }
@@ -2011,6 +2020,16 @@ class JobExecutionSpec extends BaseContainer {
             response2.successful
             response2.code() == 200
             def json = jsonValue(response2.body())
+            json.executions.size() == 0
+        }
+        when: "get executions with api version before 50 should keep previous behavior"
+        client.apiVersion = 49
+        def response3 = doGet("/job/${childJobId}/executions?includeJobRef=true")
+        then:
+        verifyAll {
+            response3.successful
+            response3.code() == 200
+            def json = jsonValue(response3.body())
             json.executions.size() == 0
         }
     }
@@ -2135,7 +2154,7 @@ class JobExecutionSpec extends BaseContainer {
         jobExecutionStatus.status == ExecutionStatus.SUCCEEDED.state
 
         when: "get child executions"
-        def response = doGet("/job/${childJobId}/executions")
+        def response = doGet("/job/${childJobId}/executions?includeJobRef=true")
         then:
         verifyAll {
             response.successful
@@ -2145,7 +2164,7 @@ class JobExecutionSpec extends BaseContainer {
             json.executions[0].id?.toString() == exec.id
         }
         when: "get grand child executions"
-        def response1 = doGet("/job/${grandChildJobId}/executions")
+        def response1 = doGet("/job/${grandChildJobId}/executions?includeJobRef=true")
         then:
         verifyAll {
             response1.successful

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobExecutionSpec.groovy
@@ -1956,14 +1956,9 @@ class JobExecutionSpec extends BaseContainer {
                   <sequence keepgoing=\"false\" strategy=\"parallel\">
                      <command>
                          <jobref name=\"Child\">
-                           <uuid>b51275b4-71a1-4127-80c0-366fa1f76d1d</uuid>
+                           <uuid>${childJobId}</uuid>
                          </jobref>
-                     </command>
-                     <command>
-                         <jobref name=\"Child\" nodeStep=\"true\">
-                           <uuid>b51275b4-71a1-4127-80c0-366fa1f76d1d</uuid>
-                         </jobref>
-                     </command>
+                     </command>                     
                   </sequence>
                </job>
             </joblist>
@@ -2008,7 +2003,7 @@ class JobExecutionSpec extends BaseContainer {
             response.code() == 200
             def json = jsonValue(response.body())
             json.executions.size() == 1
-            json.executions[0].id == exec.id
+            json.executions[0].id?.toString() == exec.id
         }
         when: "get executions with includeJobRef false"
         def response2 = doGet("/job/${childJobId}/executions?includeJobRef=false")

--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdClient.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdClient.groovy
@@ -26,8 +26,8 @@ class RdClient {
     final ObjectMapper mapper = new ObjectMapper()
     String baseUrl
     OkHttpClient httpClient
-    int apiVersion = 49
-    static final finalApiVersion = 49
+    int apiVersion = 50
+    static final finalApiVersion = 50
 
     RdClient(String baseUrl, OkHttpClient httpClient) {
         this.baseUrl = baseUrl

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -5673,8 +5673,8 @@ return.''',
                 scheduledExecution,
                 params['status'],
                 params.offset ? params.int('offset') : 0,
-                params.max  ? params.int('max') : -1
-
+                params.max  ? params.int('max') : -1,
+                params.includeJobRef ? params.boolean('includeJobRef') : apiRequest
         )
         def resOffset = params.offset ? params.int('offset') : 0
         def resMax = params.max ?

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -5668,13 +5668,20 @@ return.''',
             )
         }
 
+        boolean includeExecutionsFromJobRef = false;
+
+        if (request.api_version >= ApiVersions.V50) {
+            if (params.includeJobRef && apiRequest) {
+                includeExecutionsFromJobRef = params.boolean('includeJobRef');
+            }
+        }
 
         def result = executionService.queryJobExecutions(
                 scheduledExecution,
                 params['status'],
                 params.offset ? params.int('offset') : 0,
                 params.max  ? params.int('max') : -1,
-                params.includeJobRef ? params.boolean('includeJobRef') : apiRequest
+                includeExecutionsFromJobRef
         )
         def resOffset = params.offset ? params.int('offset') : 0
         def resMax = params.max ?

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -5542,7 +5542,10 @@ unspecified, all results will be returned''',
                 in = ParameterIn.QUERY, schema = @Schema(type = 'integer')),
             @Parameter(name = 'offset', description = '''indicate the 0-indexed offset for the first result to 
 return.''',
-                in = ParameterIn.QUERY, schema = @Schema(type = 'integer'))
+                in = ParameterIn.QUERY, schema = @Schema(type = 'integer')),
+            @Parameter(name = 'includeJobRef', description = '''if true, include executions from the job reference
+in the results. Default is false.  Requires API version 50 or later.''',
+                in = ParameterIn.QUERY, schema = @Schema(type = 'boolean'))
         ],
         responses = @ApiResponse(
             responseCode = '200',

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
@@ -37,11 +37,12 @@ class ApiVersions {
     public static final int V47 = 47
     public static final int V48 = 48
     public static final int V49 = 49
+    public static final int V50 = 50
     public static final Map VersionMap = [:]
     public static final List Versions = [V14, V15, V16, V17, V18,
                                          V19, V20, V21, V22, V23, V24, V25, V26,
                                          V27, V28, V29, V30, V31, V32,V33,V34,V35,
-                                         V36, V37, V38, V39, V40, V41, V42, V43, V44, V45, V46, V47, V48, V49]
+                                         V36, V37, V38, V39, V40, V41, V42, V43, V44, V45, V46, V47, V48, V49, V50]
     static {
         Versions.each { VersionMap[it.toString()] = it }
     }
@@ -49,8 +50,8 @@ class ApiVersions {
 
     public final static int API_EARLIEST_VERSION = V14
     public final static int API_DEPRECATION_VERSION = V17
-    public final static int API_CURRENT_VERSION = V49
-    public final static String API_CURRENT_VERSION_STR = '49'
+    public final static int API_CURRENT_VERSION = V50
+    public final static String API_CURRENT_VERSION_STR = '50'
     public final static int API_MIN_VERSION = API_EARLIEST_VERSION
     public final static int API_MAX_VERSION = API_CURRENT_VERSION
 }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormReferencedExecutionDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormReferencedExecutionDataProvider.groovy
@@ -41,7 +41,7 @@ class GormReferencedExecutionDataProvider implements ReferencedExecutionDataProv
 
     @Override
     List<String> getExecutionUuidsByJobUuid(String jobUuid) {
-        return ReferencedExecution.findAllByJobUuid(jobUuid).collect{ it.execution.scheduledExecution.uuid }
+        return ReferencedExecution.findAllByJobUuid(jobUuid).collect{ it.execution.uuid }
     }
 
     @Override

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionController2Spec.groovy
@@ -930,7 +930,7 @@ class ScheduledExecutionController2Spec extends RundeckHibernateSpec implements 
         }
 
         sec.executionService = Mock(ExecutionService) {
-            _*queryJobExecutions(se,testStatus,testOffset,testMax,true)>>
+            _*queryJobExecutions(se,testStatus,testOffset,testMax,false)>>
                 [total: 0, result: testResultList]
 
             _*respondExecutionsJson(_,_, {it.size()==testResultSize},_)>>[result:true]

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionController2Spec.groovy
@@ -930,7 +930,7 @@ class ScheduledExecutionController2Spec extends RundeckHibernateSpec implements 
         }
 
         sec.executionService = Mock(ExecutionService) {
-            _*queryJobExecutions(se,testStatus,testOffset,testMax)>>
+            _*queryJobExecutions(se,testStatus,testOffset,testMax,true)>>
                 [total: 0, result: testResultList]
 
             _*respondExecutionsJson(_,_, {it.size()==testResultSize},_)>>[result:true]

--- a/rundeckapp/src/test/groovy/rundeck/services/ReportServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ReportServiceSpec.groovy
@@ -28,6 +28,7 @@ import org.grails.datastore.mapping.query.Query
 import org.rundeck.app.authorization.AppAuthContextEvaluator
 import org.rundeck.app.data.model.v1.execution.ExecutionData
 import org.rundeck.app.data.providers.DBExecReportSupport
+import org.rundeck.app.data.providers.GormReferencedExecutionDataProvider
 import org.rundeck.app.data.providers.v1.report.ExecReportDataProvider
 import org.springframework.context.ApplicationContext
 import rundeck.CommandExec
@@ -204,6 +205,72 @@ class ReportServiceSpec extends Specification implements ServiceUnitTest<ReportS
         true    | Query.In
         false   | Query.In
     }
+
+    def "report should include referenced executions"() {
+        given:
+        String jobUuid = UUID.randomUUID().toString()
+        service.referencedExecutionDataProvider = new GormReferencedExecutionDataProvider()
+        service.execReportDataProvider = Mock(ExecReportDataProvider)
+
+        def jobname = 'abc'
+        def group = 'path'
+        def project = 'AProject'
+        ScheduledExecution job = new ScheduledExecution(
+                uuid: jobUuid,
+                jobName: jobname,
+                project: project,
+                groupPath: group,
+                description: 'a job',
+                argString: '-args b -args2 d',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec(
+                                [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
+                        )]
+                ),
+                retry: '1'
+        )
+        job.save()
+        ScheduledExecution job2 = new ScheduledExecution(
+                uuid: UUID.randomUUID().toString(),
+                jobName: jobname,
+                project: project,
+                groupPath: group,
+                description: 'a job',
+                argString: '-args b -args2 d',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec(
+                                [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
+                        )]
+                ),
+                retry: '1'
+        )
+        job2.save()
+        Execution e1 = new Execution(
+                project: project,
+                scheduledExecution: job2,
+                user: 'bob',
+                dateStarted: new Date(),
+                dateEnded: new Date(),
+                status: 'successful'
+
+        )
+        e1.save()
+        ReferencedExecution refexec = new ReferencedExecution(status: 'success', jobUuid: job.uuid, execution: e1)
+        refexec.save()
+        ExecQuery query = new ExecQuery()
+        query.projFilter = "AProject"
+        query.jobIdFilter = "${job.id}"
+        query.execProjects = ["AProject"]
+        query.excludeJobListFilter = []
+        when:
+        def result = service.getExecutionReports(query, true)
+        then:
+        result.reports.size() == 1
+        1 * service.execReportDataProvider.getExecutionReports(_, _, _, [e1.uuid]) >> [new ExecReport(executionId: e1.id, dateCompleted: new Date())]
+    }
+
 
     def "delete by execution with uuid"() {
         given:


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
This PR fixes two issues related to referenced executions:
1- The activity tab at job page wasn't showing referenced executions as previous versions did.
2- The api endpoint api/jjob/{id}/executions to return the same result as activity tab at job page, including referenced executions

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
For the first issue listed above, it fixes the gorm data provider to collect execution uuid (instead of the job uuid).
For the second case, the criteria to build query to list executions should check also the referenced executions table. For the api calls, it is included by default but can be used the parameter includeJobRef as false if it is not desired to get the referenced executions