### PR TITLE
Enable MEDIUM severity in WizCli scans

### DIFF
--- a/scripts/circleci/helper-functions.sh
+++ b/scripts/circleci/helper-functions.sh
@@ -109,16 +109,18 @@ wizcli_scan() {
     # Aggregate high and critical vulnerabilities from osPackages and libraries
     local high_vulns=$(jq '[.result.osPackages[].vulnerabilities[]?, .result.libraries[].vulnerabilities[]? | select(.severity == "HIGH") | .name] | length' wizcli_scan_result.json)
     local crit_vulns=$(jq '[.result.osPackages[].vulnerabilities[]?, .result.libraries[].vulnerabilities[]? | select(.severity == "CRITICAL") | .name] | length' wizcli_scan_result.json)
+    local med_vulns=$(jq '[.result.osPackages[].vulnerabilities[]?, .result.libraries[].vulnerabilities[]? | select(.severity == "MEDIUM") | .name] | length' wizcli_scan_result.json)
 
-    echo "High Vulnerabilities: $high_vulns"
     echo "Critical Vulnerabilities: $crit_vulns"
+    echo "High Vulnerabilities: $high_vulns"
+    echo "Medium Vulnerabilities: $med_vulns"
 
     # Check if there are any high or critical vulnerabilities and return a non-zero exit code if found
-    if [[ $high_vulns -gt 0 || $crit_vulns -gt 0 ]]; then
-        echo "==> Security Alert: Found high or critical vulnerabilities."
+    if [[ $high_vulns -gt 0 || $crit_vulns -gt 0 || $med_vulns -gt 0 ]]; then
+        echo "==> Security Alert: Vulnerabilities found."
         return 1
     else
-        echo "==> No high or critical vulnerabilities found."
+        echo "==> No vulnerabilities found."
         return 0
     fi
 }

--- a/scripts/convert_wiz_junit.sh
+++ b/scripts/convert_wiz_junit.sh
@@ -24,7 +24,7 @@ convert_wiz_junit() {
 END
 
     # Concatenate vulnerabilities from osPackages and libraries, then filter for high and critical
-    jq -c '.result.osPackages[]?, .result.libraries[]? | . as $pkg | ($pkg.vulnerabilities[]? | select(.severity == "HIGH" or .severity == "CRITICAL") | . + {packageName: $pkg.name, packageVersion: $pkg.version})' < "$IN" |
+    jq -c '.result.osPackages[]?, .result.libraries[]? | . as $pkg | ($pkg.vulnerabilities[]? | select(.severity == "CRITICAL" or .severity == "HIGH" or .severity == "MEDIUM") | . + {packageName: $pkg.name, packageVersion: $pkg.version, packagePath: $pkg.path})' < "$IN" |
     while IFS= read -r vuln; do
         local name=$(echo "$vuln" | jq -r '.name')
         local severity=$(echo "$vuln" | jq -r '.severity')
@@ -32,6 +32,7 @@ END
         local link=$(echo "$vuln" | jq -r '.source // "No source provided"')
         local packageName=$(echo "$vuln" | jq -r '.packageName')
         local packageVersion=$(echo "$vuln" | jq -r '.packageVersion')
+        local packagePath=$(echo "$vuln" | jq -r '.packagePath')
 
         cat <<END
     <testcase name="${packageName} ${packageVersion}: ${name}" severity="${severity}" link="${link}">
@@ -41,6 +42,7 @@ Package: ${packageName}
 Version: ${packageVersion}
 Description: ${description}
 Link: ${link}
+Path: ${packagePath}
 ]]>
       </failure>
     </testcase>

--- a/scripts/convert_wiz_junit.sh
+++ b/scripts/convert_wiz_junit.sh
@@ -12,6 +12,7 @@ convert_wiz_junit() {
     local mediumCount=$(jq -r '.result.analytics.vulnerabilities.mediumCount // 0' < "$IN")
     local highCount=$(jq -r '.result.analytics.vulnerabilities.highCount // 0' < "$IN")
     local criticalCount=$(jq -r '.result.analytics.vulnerabilities.criticalCount // 0' < "$IN")
+    local failureCount=$((mediumCount + highCount + criticalCount))
 
     local time=$(jq -r '.createdAt' < "$IN" | cut -d'T' -f1)
 
@@ -19,8 +20,8 @@ convert_wiz_junit() {
 
     cat <<END
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites failures="$((highCount + criticalCount))" tests="$totalCount" timestamp="$time">
-  <testsuite name="Wiz Scan Vulnerabilities" tests="$totalCount" failures="$((highCount + criticalCount))">
+<testsuites failures="$failureCount" tests="$totalCount" timestamp="$time">
+  <testsuite name="Wiz Scan Vulnerabilities" tests="$totalCount" failures="$failureCount">
 END
 
     # Concatenate vulnerabilities from osPackages and libraries, then filter for high and critical


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**

Enhancement: Enables reporting of medium severity CVEs in WizCli Scan.

