### PR TITLE
RUN-2847: Flaky - rundeck: T Selenium > disable schedules at project level

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/project/ProjectEditPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/project/ProjectEditPage.groovy
@@ -216,7 +216,11 @@ class ProjectEditPage extends BasePage {
      * @param replacement
      */
     def replaceConfiguration(String original, String replacement){
-        ((JavascriptExecutor) context.driver).executeScript("ace.edit('_id0').session.replace(ace.edit('_id0').find('${original}',{wrap: true, wholeWord: true }), '${replacement}');")
+        try {
+            ((JavascriptExecutor) context.driver).executeScript("ace.edit('_id0').session.replace(ace.edit('_id0').find('${original}',{wrap: true, wholeWord: true }), '${replacement}');")
+        } catch (e) {
+            ((JavascriptExecutor) context.driver).executeScript("ace.edit('_id0').session.insert({row: ace.edit('_id0').session.getLength(), column: 0}, '\n' + '${replacement}'")
+        }
     }
 
     /**


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
https://app.circleci.com/pipelines/github/rundeck/rundeck?branch=RUN-2847-ace
Sometimes the test fails as the setting that needs to be disabled isn't set in the project config.

**Describe the solution you've implemented**
Add a try-catch, so that if setting isn't available, it will be added anyway at the end of the config.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
