### PR TITLE
RUN-2854: rundeck: T Selenium > execution succeeds on all nodes matching the ANY filter

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/execution/CommandOnMultipleNodesSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/execution/CommandOnMultipleNodesSpec.groovy
@@ -52,7 +52,7 @@ class CommandOnMultipleNodesSpec extends SeleniumBase{
         commandPage.commandTextField.sendKeys "echo running test '" + this.class.name.toString() + "'"
         commandPage.runButton.click()
         def href = commandPage.runningButtonLink().getAttribute("href")
-        commandPage.driver.get href + "#output"
+        commandPage.driver.get href + "#outputL3"
         expect:
         executionShowPage.validatePage()
         executionShowPage.waitForElementAttributeToChange executionShowPage.executionStateDisplayLabel, 'data-execstate', 'SUCCEEDED'

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/project/ProjectEditPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/project/ProjectEditPage.groovy
@@ -216,12 +216,7 @@ class ProjectEditPage extends BasePage {
      * @param replacement
      */
     def replaceConfiguration(String original, String replacement){
-        try {
-            ((JavascriptExecutor) context.driver).executeScript("ace.edit('_id0').session.replace(ace.edit('_id0').find('${original}',{wrap: true, wholeWord: true }), '${replacement}');")
-        } catch (e) {
-            ((JavascriptExecutor) context.driver).executeScript("ace.edit('_id0').session.insert({row: ace.edit('_id0').session.getLength(), column: 0}, '\n' + '${replacement}'")
-        }
-
+        ((JavascriptExecutor) context.driver).executeScript("ace.edit('_id0').session.replace(ace.edit('_id0').find('${original}',{wrap: true, wholeWord: true }), '${replacement}');")
     }
 
     /**

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/project/ProjectEditPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/project/ProjectEditPage.groovy
@@ -216,7 +216,12 @@ class ProjectEditPage extends BasePage {
      * @param replacement
      */
     def replaceConfiguration(String original, String replacement){
-        ((JavascriptExecutor) context.driver).executeScript("ace.edit('_id0').session.replace(ace.edit('_id0').find('${original}',{wrap: true, wholeWord: true }), '${replacement}');")
+        try {
+            ((JavascriptExecutor) context.driver).executeScript("ace.edit('_id0').session.replace(ace.edit('_id0').find('${original}',{wrap: true, wholeWord: true }), '${replacement}');")
+        } catch (e) {
+            ((JavascriptExecutor) context.driver).executeScript("ace.edit('_id0').session.insert({row: ace.edit('_id0').session.getLength(), column: 0}, '\n' + '${replacement}'")
+        }
+
     }
 
     /**


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
https://app.circleci.com/pipelines/github/rundeck/rundeck?branch=RUN-2854-commandPage
Whenever virtual scroll is used, even though the element might be visible for the user, the dom might not be reflecting the latest state.

Note: the 3 failed builds are unrelated flakes.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Force the navigation to the line, to ensure that all elements are present.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
