### PR TITLE
RUN-2864 : Update `object-store-plugin` dependencies to prevent CVE-2021-0341

### DIFF
--- a/plugins/object-store-plugin/build.gradle
+++ b/plugins/object-store-plugin/build.gradle
@@ -20,7 +20,7 @@ configurations{
 dependencies {
     // Use the latest Groovy version for building this library
     implementation "org.codehaus.groovy:groovy:${groovyVersion}"
-    pluginLibs("io.minio:minio:7.1.0") {
+    pluginLibs("io.minio:minio:8.5.12") {
         exclude(group: 'com.fasterxml.jackson.core')
         exclude(group: 'com.google.guava', module: 'guava')
     }

--- a/plugins/object-store-plugin/src/main/groovy/org/rundeck/plugin/objectstore/ObjectStorePlugin.groovy
+++ b/plugins/object-store-plugin/src/main/groovy/org/rundeck/plugin/objectstore/ObjectStorePlugin.groovy
@@ -72,7 +72,12 @@ class ObjectStorePlugin extends DelegateTree<ResourceMeta> implements StoragePlu
             throw new IllegalArgumentException("objectStoreUrl property is required")
         }
 
-        MinioClient mClient = region ? new MinioClient(objectStoreUrl, accessKey, secretKey, region) : new MinioClient(objectStoreUrl, accessKey, secretKey)
+        MinioClient.Builder mClientBuilder = MinioClient.builder()
+                .endpoint(objectStoreUrl)
+                .credentials(accessKey, secretKey)
+        mClientBuilder = region ? mClientBuilder.region(region) : mClientBuilder
+
+        MinioClient mClient = mClientBuilder.build()
         if(!connectionTimeout) connectionTimeout = 180L
         mClient.setTimeout(TimeUnit.SECONDS.toMillis(connectionTimeout),TimeUnit.SECONDS.toMillis(connectionTimeout),TimeUnit.SECONDS.toMillis(connectionTimeout))
         if(uncachedObjectLookup) {

--- a/plugins/object-store-plugin/src/main/groovy/org/rundeck/plugin/objectstore/stream/CloseAfterCopyStream.groovy
+++ b/plugins/object-store-plugin/src/main/groovy/org/rundeck/plugin/objectstore/stream/CloseAfterCopyStream.groovy
@@ -16,9 +16,10 @@
 package org.rundeck.plugin.objectstore.stream
 
 import com.dtolabs.utils.Streams
+import groovy.transform.CompileStatic
 import org.rundeck.storage.api.HasInputStream
 
-
+@CompileStatic
 class CloseAfterCopyStream implements HasInputStream {
     InputStream inputStream
 

--- a/plugins/object-store-plugin/src/main/groovy/org/rundeck/plugin/objectstore/stream/LazyAccessObjectStoreInputStream.groovy
+++ b/plugins/object-store-plugin/src/main/groovy/org/rundeck/plugin/objectstore/stream/LazyAccessObjectStoreInputStream.groovy
@@ -16,9 +16,12 @@
 package org.rundeck.plugin.objectstore.stream
 
 import com.dtolabs.utils.Streams
+import groovy.transform.CompileStatic
+import io.minio.GetObjectArgs
 import io.minio.MinioClient
 import org.rundeck.storage.api.HasInputStream
 
+@CompileStatic
 class LazyAccessObjectStoreInputStream implements HasInputStream {
 
     private final MinioClient mClient
@@ -33,7 +36,11 @@ class LazyAccessObjectStoreInputStream implements HasInputStream {
 
     @Override
     InputStream getInputStream() throws IOException {
-        return mClient.getObject(bucket,objectKey)
+        GetObjectArgs args = GetObjectArgs.builder()
+                .bucket(bucket)
+                .object(objectKey)
+                .build()
+        return mClient.getObject(args)
     }
 
     @Override

--- a/plugins/object-store-plugin/src/main/groovy/org/rundeck/plugin/objectstore/tree/ObjectStoreUtils.groovy
+++ b/plugins/object-store-plugin/src/main/groovy/org/rundeck/plugin/objectstore/tree/ObjectStoreUtils.groovy
@@ -16,33 +16,32 @@
 package org.rundeck.plugin.objectstore.tree
 
 import com.dtolabs.rundeck.core.storage.StorageUtil
-import io.minio.Time
-import io.minio.ObjectStat
-
-import java.time.LocalDateTime
-import java.time.ZonedDateTime
+import groovy.transform.CompileStatic
+import io.minio.StatObjectResponse
 import java.util.regex.Pattern
 
-
+@CompileStatic
 class ObjectStoreUtils {
     static Pattern createSubdirCheckForPath(String path) {
         if(!path) return ~/(.*?)\/.*/
         return ~/${path}\/(.*?)\/.*/
     }
 
-    static Map<String,String> objectStatToMap(ObjectStat objectStat) {
-        Map<String,String> meta = [:]
-        meta["etag"] = objectStat.etag()
-        Set rundeckMetaKeys = objectStat.httpHeaders().keySet().findAll { it.startsWith(ObjectStoreTree.RUNDECK_CUSTOM_HEADER_PREFIX) }
+    static Map<String, String> objectStatToMap(StatObjectResponse statObjectResponse) {
+        Map<String, String> meta = [:]
+        meta["etag"] = statObjectResponse.etag()
+        // In minio v8, the header names are capitalized. In the previous versions, they are in lower case.
+        Set rundeckMetaKeys = statObjectResponse.headers().names().findAll { it.toLowerCase().startsWith(ObjectStoreTree.RUNDECK_CUSTOM_HEADER_PREFIX) }
         rundeckMetaKeys.each { prefixedKey ->
-            meta[fixKeyName(prefixedKey)] = objectStat.httpHeaders()[prefixedKey][0]
+            String lowerCasedPrefixedKey = prefixedKey.toLowerCase()
+            meta[fixKeyName(lowerCasedPrefixedKey)] = statObjectResponse.headers().values(prefixedKey)[0]
         }
-        meta[StorageUtil.RES_META_RUNDECK_CONTENT_LENGTH] = objectStat.length().toString()
-        if(!meta.get(StorageUtil.RES_META_RUNDECK_CONTENT_CREATION_TIME)) {
-            meta[StorageUtil.RES_META_RUNDECK_CONTENT_CREATION_TIME] = StorageUtil.formatDate(Date.from(objectStat.createdTime().toInstant()))
+        meta[StorageUtil.RES_META_RUNDECK_CONTENT_LENGTH] = statObjectResponse.size().toString()
+        if (!meta.get(StorageUtil.RES_META_RUNDECK_CONTENT_CREATION_TIME)) {
+            meta[StorageUtil.RES_META_RUNDECK_CONTENT_CREATION_TIME] = StorageUtil.formatDate(Date.from(statObjectResponse.lastModified().toInstant()))
         }
-        if(!meta.get(StorageUtil.RES_META_RUNDECK_CONTENT_MODIFY_TIME)) {
-            Date lastModified = Date.from(ZonedDateTime.parse(objectStat.httpHeaders()["last-modified"][0], Time.HTTP_HEADER_DATE_FORMAT).toInstant())
+        if (!meta.get(StorageUtil.RES_META_RUNDECK_CONTENT_MODIFY_TIME)) {
+            Date lastModified = Date.from(statObjectResponse.headers().getInstant("last-modified"))
             meta[StorageUtil.RES_META_RUNDECK_CONTENT_MODIFY_TIME] = StorageUtil.formatDate(lastModified)
         }
         return meta

--- a/plugins/object-store-plugin/src/test/groovy/org/rundeck/plugin/objectstore/tree/ObjectStoreTreeWithDirectAccessDirSourceTest.groovy
+++ b/plugins/object-store-plugin/src/test/groovy/org/rundeck/plugin/objectstore/tree/ObjectStoreTreeWithDirectAccessDirSourceTest.groovy
@@ -18,8 +18,10 @@ package org.rundeck.plugin.objectstore.tree
 import com.dtolabs.rundeck.core.storage.BaseStreamResource
 import com.dtolabs.rundeck.core.storage.StorageUtil
 import com.dtolabs.utils.Streams
+import io.minio.BucketExistsArgs
 import io.minio.MinioClient
-import io.minio.PutObjectOptions
+import io.minio.PutObjectArgs
+import io.minio.StatObjectArgs
 import io.minio.errors.ErrorResponseException
 import org.rundeck.plugin.objectstore.directorysource.ObjectStoreDirectAccessDirectorySource
 import org.rundeck.plugin.objectstore.directorysource.ObjectStoreDirectorySource
@@ -28,6 +30,7 @@ import org.rundeck.storage.api.PathUtil
 import spock.lang.Shared
 import spock.lang.Specification
 import testhelpers.MinioContainer
+import testhelpers.MinioTestUtils
 
 class ObjectStoreTreeWithDirectAccessDirSourceTest extends Specification {
     String configBucket = "test-config-bucket-das"
@@ -59,7 +62,10 @@ class ObjectStoreTreeWithDirectAccessDirSourceTest extends Specification {
         new ObjectStoreTree(mClient, testInitBucket, directorySource)
 
         then:
-        mClient.bucketExists(testInitBucket)
+        BucketExistsArgs args = BucketExistsArgs.builder()
+                .bucket(testInitBucket)
+                .build();
+        mClient.bucketExists(args)
     }
 
     def "HasPath should fail for missing resource"() {
@@ -130,11 +136,9 @@ class ObjectStoreTreeWithDirectAccessDirSourceTest extends Specification {
         ifNotExistAdd("list-test/subdir/file4","content4")
         when:
         def items = store.listDirectoryResources(PathUtil.asPath("list-test"))
-
         then:
         items.size() == 3
-        items[0].path.path == "list-test/file1"
-        items[0].path.name == "file1"
+        assert items.any { it.path.path == "list-test/file1" && it.path.name == "file1" }
     }
 
     def "ListDirectoryResources Root in subdir"() {
@@ -163,20 +167,12 @@ class ObjectStoreTreeWithDirectAccessDirSourceTest extends Specification {
         def items = store.listDirectory("list-dir-test")
         then:
         items.size() == 6
-        items[0].path.path == "list-dir-test/file1"
-        items[0].path.name == "file1"
-        !items[0].isDirectory()
-        items[1].path.name == "file2"
-        !items[1].isDirectory()
-        items[2].path.name == "file3"
-        !items[2].isDirectory()
-        items[3].path.path == "list-dir-test/subdir"
-        items[3].path.name == "subdir"
-        items[3].isDirectory()
-        items[4].path.name == "subdir1"
-        items[4].isDirectory()
-        items[5].path.name == "subdir2"
-        items[5].isDirectory()
+        assert items.any { it.path.path == "list-dir-test/file1" && it.path.name == "file1" && !it.isDirectory() }
+        assert items.any { it.path.name == "file2" && !it.isDirectory() }
+        assert items.any { it.path.name == "file3" && !it.isDirectory() }
+        assert items.any { it.path.path == "list-dir-test/subdir" && it.path.name == "subdir" && it.isDirectory() }
+        assert items.any { it.path.name == "subdir1" && it.isDirectory() }
+        assert items.any { it.path.name == "subdir2" && it.isDirectory() }
 
     }
 
@@ -193,11 +189,9 @@ class ObjectStoreTreeWithDirectAccessDirSourceTest extends Specification {
         def items = store.listDirectorySubdirs("list-subdir-test")
         then:
         items.size() == 3
-        items[0].path.path == "list-subdir-test/subdir"
-        items[0].path.name == "subdir"
-        items[1].path.name == "subdir1"
-        items[1].path.path == "list-subdir-test/subdir1"
-        items[2].path.name == "subdir2"
+        assert items.any { it.path.path == "list-subdir-test/subdir" && it.path.name == "subdir" }
+        assert items.any { it.path.path == "list-subdir-test/subdir1" && it.path.name == "subdir1" }
+        assert items.any { it.path.name == "subdir2" }
     }
 
     def "DeleteResource"() {
@@ -205,7 +199,12 @@ class ObjectStoreTreeWithDirectAccessDirSourceTest extends Specification {
         ifNotExistAdd("delete-me","content1")
         when:
         store.deleteResource("delete-me")
-        mClient.statObject(configBucket,"delete-me")
+
+        StatObjectArgs statArgs = StatObjectArgs.builder()
+                .bucket(configBucket)
+                .object("delete-me")
+                .build()
+        mClient.statObject(statArgs)
         then:
         thrown(ErrorResponseException)
     }
@@ -242,22 +241,26 @@ class ObjectStoreTreeWithDirectAccessDirSourceTest extends Specification {
         "dir1/file/subdir/multiple/subdirs/file" ==~ store.nestedSubDirCheck()
     }
 
+
     private void ifNotExistAdd(String key, String content) {
         Map meta = [:]
         meta[StorageUtil.RES_META_RUNDECK_CONTENT_LENGTH] = content.bytes.length.toString()
         try {
-            mClient.statObject(configBucket,key)
-            directorySource.updateEntry(key,meta)
-        } catch(ErrorResponseException erex) {
-            if(erex.response.code() == 404) {
+            mClient.statObject(StatObjectArgs.builder().bucket(configBucket).object(key).build())
+            directorySource.updateEntry(key, meta)
+        } catch (ErrorResponseException erex) {
+            if (erex.response().code() == 404) {
                 ByteArrayInputStream inStream = new ByteArrayInputStream(content.bytes)
-                PutObjectOptions putOpts = new PutObjectOptions(content.bytes.length,-1)
-                putOpts.headers = meta
-                mClient.putObject(configBucket, key, inStream, putOpts)
-                directorySource.updateEntry(key,meta)
+                PutObjectArgs putArgs = PutObjectArgs.builder()
+                        .bucket(configBucket)
+                        .object(key)
+                        .stream(inStream, content.bytes.length, -1)
+                        .headers(meta)
+                        .build()
+                mClient.putObject(putArgs)
+                directorySource.updateEntry(key, meta)
             }
         }
-
     }
 
     private BaseStreamResource createContent(String content) {

--- a/plugins/object-store-plugin/src/test/groovy/org/rundeck/plugin/objectstore/tree/ObjectStoreTreeWithMemoryDirSourceTest.groovy
+++ b/plugins/object-store-plugin/src/test/groovy/org/rundeck/plugin/objectstore/tree/ObjectStoreTreeWithMemoryDirSourceTest.groovy
@@ -18,8 +18,10 @@ package org.rundeck.plugin.objectstore.tree
 import com.dtolabs.rundeck.core.storage.BaseStreamResource
 import com.dtolabs.rundeck.core.storage.StorageUtil
 import com.dtolabs.utils.Streams
+import io.minio.BucketExistsArgs
 import io.minio.MinioClient
-import io.minio.PutObjectOptions
+import io.minio.PutObjectArgs
+import io.minio.StatObjectArgs
 import io.minio.errors.ErrorResponseException
 import org.rundeck.plugin.objectstore.directorysource.ObjectStoreDirectorySource
 import org.rundeck.plugin.objectstore.directorysource.ObjectStoreMemoryDirectorySource
@@ -28,6 +30,7 @@ import org.rundeck.storage.api.PathUtil
 import spock.lang.Shared
 import spock.lang.Specification
 import testhelpers.MinioContainer
+import testhelpers.MinioTestUtils
 
 class ObjectStoreTreeWithMemoryDirSourceTest extends Specification {
     String configBucket = "test-config-bucket"
@@ -58,7 +61,7 @@ class ObjectStoreTreeWithMemoryDirSourceTest extends Specification {
         new ObjectStoreTree(mClient, testInitBucket, directorySource)
 
         then:
-        mClient.bucketExists(testInitBucket)
+        mClient.bucketExists(BucketExistsArgs.builder().bucket(testInitBucket).build())
     }
 
     def "HasPath should fail for missing resource"() {
@@ -130,11 +133,9 @@ class ObjectStoreTreeWithMemoryDirSourceTest extends Specification {
         ifNotExistAdd("list-test/subdir/file4","content4")
         when:
         def items = store.listDirectoryResources(PathUtil.asPath("list-test"))
-
         then:
         items.size() == 3
-        items[0].path.path == "list-test/file1"
-        items[0].path.name == "file1"
+        assert items.any { it.path.path == "list-test/file1" && it.path.name == "file1" }
     }
 
     def "ListDirectoryResources Root in subdir"() {
@@ -163,22 +164,15 @@ class ObjectStoreTreeWithMemoryDirSourceTest extends Specification {
         def items = store.listDirectory("list-dir-test")
         then:
         items.size() == 6
-        items[0].path.path == "list-dir-test/file1"
-        items[0].path.name == "file1"
-        !items[0].isDirectory()
-        items[1].path.name == "file2"
-        !items[1].isDirectory()
-        items[2].path.name == "file3"
-        !items[2].isDirectory()
-        items[3].path.path == "list-dir-test/subdir"
-        items[3].path.name == "subdir"
-        items[3].isDirectory()
-        items[4].path.name == "subdir1"
-        items[4].isDirectory()
-        items[5].path.name == "subdir2"
-        items[5].isDirectory()
 
+        assert items.any { it.path.path == "list-dir-test/file1" && it.path.name == "file1" && !it.isDirectory() }
+        assert items.any { it.path.name == "file2" && !it.isDirectory() }
+        assert items.any { it.path.name == "file3" && !it.isDirectory() }
+        assert items.any { it.path.path == "list-dir-test/subdir" && it.path.name == "subdir" && it.isDirectory() }
+        assert items.any { it.path.name == "subdir1" && it.isDirectory() }
+        assert items.any { it.path.name == "subdir2" && it.isDirectory() }
     }
+
 
     def "ListDirectorySubdirs"() {
         setup:
@@ -193,11 +187,9 @@ class ObjectStoreTreeWithMemoryDirSourceTest extends Specification {
         def items = store.listDirectorySubdirs("list-subdir-test")
         then:
         items.size() == 3
-        items[0].path.path == "list-subdir-test/subdir"
-        items[0].path.name == "subdir"
-        items[1].path.name == "subdir1"
-        items[1].path.path == "list-subdir-test/subdir1"
-        items[2].path.name == "subdir2"
+        assert items.any { it.path.path == "list-subdir-test/subdir" && it.path.name == "subdir" }
+        assert items.any { it.path.path == "list-subdir-test/subdir1" && it.path.name == "subdir1" }
+        assert items.any { it.path.path == "list-subdir-test/subdir2" && it.path.name == "subdir2" }
     }
 
     def "DeleteResource"() {
@@ -205,7 +197,11 @@ class ObjectStoreTreeWithMemoryDirSourceTest extends Specification {
         ifNotExistAdd("delete-me","content1")
         when:
         store.deleteResource("delete-me")
-        mClient.statObject(configBucket,"delete-me")
+        StatObjectArgs statArgs = StatObjectArgs.builder()
+                .bucket(configBucket)
+                .object("delete-me")
+                .build()
+        mClient.statObject(statArgs)
         then:
         thrown(ErrorResponseException)
     }
@@ -243,33 +239,35 @@ class ObjectStoreTreeWithMemoryDirSourceTest extends Specification {
     }
 
     private void ifNotExistAdd(String key, String content) {
-        Map meta = [:]
-        meta[StorageUtil.RES_META_RUNDECK_CONTENT_LENGTH] = content.bytes.length.toString()
+        Map<String, String> meta = new HashMap<>()
+        meta.put(StorageUtil.RES_META_RUNDECK_CONTENT_LENGTH, Integer.toString(content.bytes.length))
         try {
-            mClient.statObject(configBucket,key)
-            directorySource.updateEntry(key,meta)
-        } catch(ErrorResponseException erex) {
-            if(erex.response.code() == 404) {
+            mClient.statObject(StatObjectArgs.builder().bucket(configBucket).object(key).build())
+            directorySource.updateEntry(key, meta)
+        } catch (ErrorResponseException erex) {
+            if (erex.response().code() == 404) {
                 ByteArrayInputStream inStream = new ByteArrayInputStream(content.bytes)
                 try {
-                    PutObjectOptions putOpts = new PutObjectOptions(content.bytes.length, -1)
-                    putOpts.headers = meta
-                    mClient.putObject(configBucket, key, inStream, putOpts)
-                }catch(Exception e){
+                    PutObjectArgs putArgs = PutObjectArgs.builder()
+                            .bucket(configBucket)
+                            .object(key)
+                            .stream(inStream, content.bytes.length, -1)
+                            .headers(meta)
+                            .build()
+                    mClient.putObject(putArgs)
+                } catch (Exception e) {
                     System.err.println("Error: " + e)
                 }
-                directorySource.updateEntry(key,meta)
+                directorySource.updateEntry(key, meta)
             } else {
                 System.err.println("Error: " + erex)
             }
-
         }
-
     }
 
     private BaseStreamResource createContent(String content) {
         ByteArrayInputStream inputStream = new ByteArrayInputStream(content.getBytes())
-        Map meta = [:]
+        Map<String, String> meta = [:]
         meta[StorageUtil.RES_META_RUNDECK_CONTENT_LENGTH] = content.bytes.length.toString()
         meta[StorageUtil.RES_META_RUNDECK_CONTENT_CREATION_TIME] = new Date().toString()
         meta[StorageUtil.RES_META_RUNDECK_CONTENT_MODIFY_TIME] = new Date().toString()

--- a/plugins/object-store-plugin/src/test/groovy/org/rundeck/plugin/objectstore/tree/TimeoutTest.groovy
+++ b/plugins/object-store-plugin/src/test/groovy/org/rundeck/plugin/objectstore/tree/TimeoutTest.groovy
@@ -34,6 +34,8 @@ class TimeoutTest extends Specification {
         plugin.objectStoreUrl = httpServer.url("/")
         plugin.bucket = configBucket
         plugin.connectionTimeout = 5
+        plugin.accessKey = "test-key"
+        plugin.secretKey = "test-secret"
         long start = System.currentTimeMillis()
         def tree = plugin.initTree()
 
@@ -58,7 +60,5 @@ class TimeoutTest extends Specification {
 
         then:
         thrown(Exception)
-
-
     }
 }

--- a/plugins/object-store-plugin/src/test/groovy/testhelpers/MinioContainer.groovy
+++ b/plugins/object-store-plugin/src/test/groovy/testhelpers/MinioContainer.groovy
@@ -44,7 +44,17 @@ class MinioContainer extends GenericContainer<MinioContainer> {
     }
 
     MinioClient client() {
-        new MinioClient("http://${containerIpAddress}:${firstMappedPort}", accessKey, secretKey)
+        MinioClient c = MinioClient.builder()
+                .endpoint("http://${containerIpAddress}:${firstMappedPort}")
+                .credentials(accessKey, secretKey)
+                .build()
+
+        // Waiting a little gives time for the container to start and become ready to accept requests.
+        // Invoking operations on the container that is not ready results in:
+        // 503's with ErrorResponse (code = XMinioServerNotInitialized, message = Server not initialized, please try again.)
+        MinioTestUtils.ensureMinioServerInitialized(c)
+
+        return c
     }
 
     @Override


### PR DESCRIPTION
- Update of the no-longer supported `io.minio:minio:7` dependency with the latest `io.minio:minio:8`.
  - v7 is dependent on [okhttp:3.14.9](https://github.com/minio/minio-java/blob/7.1.4/build.gradle#L56) that is affected by [CVE-2021-0341](https://nvd.nist.gov/vuln/detail/CVE-2021-0341) as described [here](https://github.com/square/okhttp/issues/6724).
- Refactor code to work with the interface changes introduced in v8.

**Dependency Scan Results**
![Screenshot 2024-09-25 at 1 52 54 PM copy](https://github.com/user-attachments/assets/cdc32618-71f8-4f80-a20c-6ad85f6cceaa)



**Validation with S3**
![Screenshot 2024-09-25 at 1 05 55 PM](https://github.com/user-attachments/assets/6665d5aa-cbde-4ce7-9982-e7323091c050)

***Sample Config***

`./rundeck_config/oss/rundeck-config.properties`

```
# ObjectStorePlugin configuration
rundeck.storage.provider.1.type=object
rundeck.storage.provider.1.path=keys/objs
rundeck.storage.provider.1.config.bucket=p-run-2864-test
rundeck.storage.provider.1.config.objectStoreUrl=https\://s3.amazonaws.com
rundeck.storage.provider.1.config.region=us-east-1
rundeck.storage.provider.1.config.accessKey=AKIA****B
rundeck.storage.provider.1.config.secretKey=xw***L76
```
