### PR TITLE
RUN-2419 skip interceptor if request to an error page

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/AuditInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/AuditInterceptor.groovy
@@ -58,6 +58,7 @@ class AuditInterceptor {
     AuditInterceptor(ConfigurationService configurationService) {
         log.debug("Audit Interceptor Init")
         matchAll().excludes(controller: 'framework', action: '(createProject(Post)?|selectProject|projectSelect|noProjectAccess|(create|save|check|edit|view)ResourceModelConfig)')
+                  .excludes(controller: 'error', action: 'fiveHundred')
 
         this.configurationService = configurationService
         this.projectAccessTrackingMap = new ConcurrentHashMap<>(200, 0.5F)

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/ProjectSelectInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/ProjectSelectInterceptor.groovy
@@ -53,6 +53,7 @@ class ProjectSelectInterceptor {
 
     ProjectSelectInterceptor() {
         matchAll().excludes(controller: 'framework', action:'(createProject(Post)?|selectProject|projectSelect|noProjectAccess|(create|save|check|edit|view)ResourceModelConfig)')
+                  .excludes(controller: 'error', action: 'fiveHundred')
     }
 
 
@@ -69,9 +70,6 @@ class ProjectSelectInterceptor {
             return true
         }
         if(controllerName=='menu' && ( actionName in ['home'] )){
-            return true
-        }
-        if(controllerName=='error' && ( actionName in ['fiveHundred'] )){
             return true
         }
         if (session && session.user && session.subject && params.project) {

--- a/rundeckapp/grails-app/controllers/rundeck/interceptors/ProjectSelectInterceptor.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/interceptors/ProjectSelectInterceptor.groovy
@@ -130,9 +130,8 @@ class ProjectSelectInterceptor {
                 }
             } catch (JDBCConnectionException e) {
                 response.setStatus(503)
-                request.errorCode = 'project.select.error'
-                request.errorArgs = [params.project]
-                request.title = 'Service Unavailable' + e.message
+                request.errorCode = 'request.error.jdbc.connection'
+                request.title = 'Service Unavailable: ' + e.message
                 params.project = null
                 render(view: '/common/error')
                 AA_TimerInterceptor.afterRequest(request, response, session)

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -746,7 +746,6 @@ request.error.invalidrequest.message=The request was not allowed: [{0}]
 request.error.conflict.already-exists.message=The item already exists: {0} "{1}"
 request.error.notallowed.title=Method Not Allowed
 request.error.notallowed.message=Method Not Allowed
-request.error.jdbc.connection=Error connecting to the database
 page.notfound.message=The page you requested could not be found.
 delete.project=Delete Project
 you.are.now.logged.out=You are now logged out.

--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -746,6 +746,7 @@ request.error.invalidrequest.message=The request was not allowed: [{0}]
 request.error.conflict.already-exists.message=The item already exists: {0} "{1}"
 request.error.notallowed.title=Method Not Allowed
 request.error.notallowed.message=Method Not Allowed
+request.error.jdbc.connection=Error connecting to the database
 page.notfound.message=The page you requested could not be found.
 delete.project=Delete Project
 you.are.now.logged.out=You are now logged out.

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/AuditInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/AuditInterceptorSpec.groovy
@@ -1,12 +1,18 @@
 package rundeck.interceptors
 
 import grails.testing.web.interceptor.InterceptorUnitTest
+import rundeck.services.ConfigurationService
 import spock.lang.Specification
 
 class AuditInterceptorSpec  extends Specification implements InterceptorUnitTest<AuditInterceptor> {
     def "Skip AuditInterceptor if requesting fiveHundred action on error page"() {
         given:
         withRequest(controller: 'error', action: 'fiveHundred')
+        defineBeans {
+            configurationService(ConfigurationService) {
+                grailsApplication = grailsApplication
+            }
+        }
         when: "The interceptor check if request matches the interceptor"
 
         def result = interceptor.doesMatch()

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/AuditInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/AuditInterceptorSpec.groovy
@@ -5,14 +5,17 @@ import rundeck.services.ConfigurationService
 import spock.lang.Specification
 
 class AuditInterceptorSpec  extends Specification implements InterceptorUnitTest<AuditInterceptor> {
-    def "Skip AuditInterceptor if requesting fiveHundred action on error page"() {
-        given:
-        withRequest(controller: 'error', action: 'fiveHundred')
+    def setup(){
         defineBeans {
             configurationService(ConfigurationService) {
                 grailsApplication = grailsApplication
             }
         }
+    }
+
+    def "Skip AuditInterceptor if requesting fiveHundred action on error page"() {
+        given:
+        withRequest(controller: 'error', action: 'fiveHundred')
         when: "The interceptor check if request matches the interceptor"
 
         def result = interceptor.doesMatch()

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/AuditInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/AuditInterceptorSpec.groovy
@@ -1,0 +1,18 @@
+package rundeck.interceptors
+
+import grails.testing.web.interceptor.InterceptorUnitTest
+import spock.lang.Specification
+
+class AuditInterceptorSpec  extends Specification implements InterceptorUnitTest<AuditInterceptor> {
+    def "Skip AuditInterceptor if requesting fiveHundred action on error page"() {
+        given:
+        withRequest(controller: 'error', action: 'fiveHundred')
+        when: "The interceptor check if request matches the interceptor"
+
+        def result = interceptor.doesMatch()
+
+        then: "Should not matches"
+        !result
+
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/ProjectSelectInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/ProjectSelectInterceptorSpec.groovy
@@ -331,41 +331,15 @@ class ProjectSelectInterceptorSpec extends Specification implements InterceptorU
 
     }
 
-    def "Interceptor should return error if jdbc lose connection with database"() {
+    def "Skip Interceptor if requesting fiveHundred action on error page"() {
         given:
-            session.api_access_allowed = null
             withRequest(controller: 'error', action: 'fiveHundred')
-            request.setAttribute(GrailsApplicationAttributes.CONTROLLER_NAME_ATTRIBUTE, 'error')
-            request.setAttribute(GrailsApplicationAttributes.ACTION_NAME_ATTRIBUTE, 'fiveHundred')
-            def frameworkMock=Mock(FrameworkService) {
-                0 * existsFrameworkProject(_)
-                0 * refreshSessionProjects(_,_)
-                0 * loadSessionProjectLabel(_,'testProject')
-            }
-
-            defineBeans {
-                rundeckAuthContextEvaluator(InstanceFactoryBean,Mock(AppAuthContextEvaluator){
-                    0 * authorizeApplicationResourceAny(*_) >> true
-                })
-                frameworkService(InstanceFactoryBean,frameworkMock)
-            }
-            interceptor.interceptorHelper = Mock(InterceptorHelper) {
-                matchesAllowedAsset(_,_) >> false
-            }
-            session.user = 'bob'
-            session.subject = new Subject()
-            request.remoteUser = 'bob'
-            request.userPrincipal = Mock(Principal) {
-                getName() >> 'bob'
-            }
-            params.project = 'testProject'
         when: "A request matches the interceptor"
 
-            def result = interceptor.before()
+            def result = interceptor.doesMatch()
 
-        then: "api_access_allowed unset and result is true"
-            session.api_access_allowed == null
-            result
+        then: "Should not matches"
+            !result
 
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/interceptors/ProjectSelectInterceptorSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/interceptors/ProjectSelectInterceptorSpec.groovy
@@ -334,7 +334,7 @@ class ProjectSelectInterceptorSpec extends Specification implements InterceptorU
     def "Skip Interceptor if requesting fiveHundred action on error page"() {
         given:
             withRequest(controller: 'error', action: 'fiveHundred')
-        when: "A request matches the interceptor"
+        when: "The interceptor check if request matches the interceptor"
 
             def result = interceptor.doesMatch()
 


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
When Rundeck for some reason loses the connection with database, it causes to print a lot of errors to the log file, making its size to increase very fast

**Describe the solution you've implemented**
If a request to an error page reaches the interceptor, it should skip the interceptor validations and let the request to proceed. Then it avoid the request to be stuck in a loop that is the cause of the issue

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
Firstly, I tried to wrap part of the before method in a try-catch block to return an error status and error message to interrupt the request

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
