### PR TITLE
RUN-2885: add fallback behaviour for i18n in Vue

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/i18n.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/i18n.ts
@@ -34,6 +34,7 @@ const initI18n = (options = {}) => {
   // Create VueI18n instance with options
   return createI18n({
     silentTranslationWarn: true,
+    fallbackLocale: "en_US",
     locale: locale, // set locale
     messages, // set locale messages
     ...options,


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

With the vue conversion, the js files for languages other than en_US fell behind and didn't have all the keys added over time.

Describe the solution you've implemented

add a fallback setting to createI18n, more here: https://vue-i18n.intlify.dev/guide/essentials/fallback.html