### PR TITLE
RUN-2929: Remove build dependency on local Groovy SDK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ commands:
             - ~/.npm/_cacache
           key: cache-{{ .Environment.BUILD_CACHE_VERSION }}-build-cache-{{ .Branch }}-<<pipeline.number>>
 
-
+  ## Deps Installers quick references.
   # Install node
   install-node:
     description: Install Node
@@ -210,12 +210,28 @@ commands:
           step-name: Install Groovy SDK
           command: dependencies_install_groovy
 
+  ## Dependency groups
+
+  # Install base dependencies
+  install-base-dependencies:
+    description: Install Build Dependencies
+    steps:
+      - install-java-jdk
+
+  # Install dependencies required for building
+  install-build-dependencies:
+    description: Install Build Dependencies
+    steps:
+      - install-base-dependencies
+      - install-node
+#      - install-groovy-sdk
+
   # Install dependencies required for packaging
   install-packaging-dependencies:
     description: Install Packaging Dependencies
     steps:
+      - install-base-dependencies
       - aws-cli/install
-      - install-java-jdk
       - run-build-step:
           step-name: Install Packaging Dependencies
           command: dependencies_packaging_setup
@@ -224,7 +240,7 @@ commands:
   install-testdeck-dependencies:
     description: Install TestDeck Dependencies
     steps:
-      - install-java-jdk
+      - install-base-dependencies
       - run-build-step:
           step-name: Install TestDeck Dependencies
           command: dependencies_testdeck_setup
@@ -255,9 +271,7 @@ jobs:
           docker_layer_caching: true
       - checkout
       - restore-build-cache
-      - install-node
-      - install-java-jdk
-      - install-groovy-sdk
+      - install-build-dependencies
       - run-build-step:
           step-name: Build War
           command: rundeck_war_build
@@ -295,8 +309,7 @@ jobs:
     steps:
       - setup_docker
       - checkout
-      - install-node
-      - install-java-jdk
+      - install-build-dependencies
       - restore-build-cache
       - attach_workspace:
           at: ~/workspace
@@ -339,8 +352,7 @@ jobs:
       name: docker-builder
     steps:
       - checkout
-      - install-node
-      - install-java-jdk
+      - install-build-dependencies
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
@@ -372,7 +384,7 @@ jobs:
     steps:
       - setup_docker
       - checkout
-      - install-java-jdk
+      - install-base-dependencies
       - restore-build-cache
       - attach_workspace:
           at: ~/workspace
@@ -392,8 +404,7 @@ jobs:
     steps:
       - setup_docker
       - checkout
-      - aws-cli/install
-      - install-java-jdk
+      - install-packaging-dependencies
       - restore-build-cache
       - attach_workspace:
           at: ~/workspace
@@ -548,7 +559,7 @@ jobs:
     steps:
       - checkout
       - restore-build-cache
-      - install-java-jdk
+      - install-base-dependencies
       - attach_workspace:
           at: ~/workspace
       - run-build-step:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ executors:
   # Machine executor
   machine-builder:
     machine:
-      image: default
+      image: ubuntu-2204:current
       docker_layer_caching: << parameters.docker_layer_caching >>
     parameters:
       resource_class:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,7 +356,7 @@ jobs:
       name: docker-builder
     steps:
       - checkout
-      - install-build-dependencies
+      - install-node
       - attach_workspace:
           at: ~/workspace
       - run-build-step:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,9 +146,10 @@ commands:
           when: << parameters.when >>
           command: |
             source scripts/circleci/setup.sh
-            echo "=== ENV ===" && env && echo "=== ENV END ==="
+            echo "=== ENV ===" && env && echo "=== ENV END $(date)==="
             set -x            
             <<parameters.command>>
+            echo "=== Finished $(date) ==="
 
   # Save gradle test results
   collect-gradle-tests:
@@ -357,6 +358,7 @@ jobs:
     steps:
       - checkout
       - install-node
+      - install-java-jdk
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
@@ -388,7 +390,6 @@ jobs:
     steps:
       - setup_docker
       - checkout
-#      - install-build-dependencies
       - install-java-jdk
       - restore-build-cache
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,6 @@ commands:
   install-build-dependencies:
     description: Install Build Dependencies
     steps:
-#      - aws-cli/install
       - install-node
       - install-java-jdk
       - install-groovy-sdk
@@ -223,8 +222,6 @@ commands:
   install-test-dependencies:
     description: Install Test Dependencies
     steps:
-#      - aws-cli/install
-#      - install-node
       - install-java-jdk
       - install-groovy-sdk
 
@@ -233,7 +230,6 @@ commands:
     description: Install Packaging Dependencies
     steps:
       - aws-cli/install
-#      - install-node
       - install-java-jdk
       - run-build-step:
           step-name: Install Packaging Dependencies
@@ -243,8 +239,6 @@ commands:
   install-testdeck-dependencies:
     description: Install TestDeck Dependencies
     steps:
-#      - aws-cli/install
-#      - install-node
       - install-java-jdk
       - run-build-step:
           step-name: Install TestDeck Dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,14 +202,6 @@ commands:
           step-name: Install Java JDK
           command: dependencies_install_zulu11jdk
 
-  # Install Groovy SDK
-  install-groovy-sdk:
-      description: Install Groovy SDK
-      steps:
-      - run-build-step:
-          step-name: Install Groovy SDK
-          command: dependencies_install_groovy
-
   ## Dependency groups
 
   # Install base dependencies
@@ -224,7 +216,6 @@ commands:
     steps:
       - install-base-dependencies
       - install-node
-#      - install-groovy-sdk
 
   # Install dependencies required for packaging
   install-packaging-dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,22 +193,47 @@ commands:
           use-nvm-cache: true
           nvm-cache-key: cache-{{ .Environment.BUILD_CACHE_VERSION }}-nvm-{{ checksum ".nvmrc" }}
 
+  # Install Java JDK
+  install-java-jdk:
+    description: Install JDK
+    steps:
+      - run-build-step:
+          step-name: Install Java JDK
+          command: dependencies_install_zulu11jdk
+
+  # Install Groovy SDK
+  install-groovy-sdk:
+      description: Install Groovy SDK
+      steps:
+      - run-build-step:
+          step-name: Install Groovy SDK
+          command: dependencies_install_groovy
+
   # Install dependencies required for gradle builds.
   install-build-dependencies:
     description: Install Build Dependencies
     steps:
-      - aws-cli/install
+#      - aws-cli/install
       - install-node
-      - run-build-step:
-          step-name: Install Build Dependencies
-          command: dependencies_build_setup
+      - install-java-jdk
+      - install-groovy-sdk
+
+  # Install dependencies required for gradle builds.
+  install-test-dependencies:
+    description: Install Test Dependencies
+    steps:
+#      - aws-cli/install
+#      - install-node
+      - install-java-jdk
+      - install-groovy-sdk
 
   # Install dependencies required for packaging
   install-packaging-dependencies:
     description: Install Packaging Dependencies
     steps:
       - aws-cli/install
-      - install-node
+#      - install-node
+      - install-java-jdk
       - run-build-step:
           step-name: Install Packaging Dependencies
           command: dependencies_packaging_setup
@@ -217,8 +242,9 @@ commands:
   install-testdeck-dependencies:
     description: Install TestDeck Dependencies
     steps:
-      - aws-cli/install
-      - install-node
+#      - aws-cli/install
+#      - install-node
+      - install-java-jdk
       - run-build-step:
           step-name: Install TestDeck Dependencies
           command: dependencies_testdeck_setup
@@ -287,7 +313,7 @@ jobs:
     steps:
       - setup_docker
       - checkout
-      - install-build-dependencies
+      - install-test-dependencies
       - restore-build-cache
       - attach_workspace:
           at: ~/workspace
@@ -362,7 +388,8 @@ jobs:
     steps:
       - setup_docker
       - checkout
-      - install-build-dependencies
+#      - install-build-dependencies
+      - install-java-jdk
       - restore-build-cache
       - attach_workspace:
           at: ~/workspace
@@ -382,7 +409,8 @@ jobs:
     steps:
       - setup_docker
       - checkout
-      - install-build-dependencies
+#      - install-build-dependencies
+      - install-java-jdk
       - restore-build-cache
       - attach_workspace:
           at: ~/workspace
@@ -539,9 +567,7 @@ jobs:
       - restore-build-cache
       - attach_workspace:
           at: ~/workspace
-      - run-build-step:
-          step-name: Install Build Dependencies
-          command: dependencies_build_setup
+      - install-test-dependencies
       - run-build-step:
           step-name: Pull images
           command: rundeck_pull_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,7 +313,7 @@ jobs:
     steps:
       - setup_docker
       - checkout
-      - install-test-dependencies
+      - install-build-dependencies
       - restore-build-cache
       - attach_workspace:
           at: ~/workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,21 +210,6 @@ commands:
           step-name: Install Groovy SDK
           command: dependencies_install_groovy
 
-  # Install dependencies required for gradle builds.
-  install-build-dependencies:
-    description: Install Build Dependencies
-    steps:
-      - install-node
-      - install-java-jdk
-      - install-groovy-sdk
-
-  # Install dependencies required for gradle builds.
-  install-test-dependencies:
-    description: Install Test Dependencies
-    steps:
-      - install-java-jdk
-      - install-groovy-sdk
-
   # Install dependencies required for packaging
   install-packaging-dependencies:
     description: Install Packaging Dependencies
@@ -269,8 +254,9 @@ jobs:
       - setup_docker:
           docker_layer_caching: true
       - checkout
-      - install-build-dependencies
       - restore-build-cache
+      - install-node
+      - install-java-jdk
       - run-build-step:
           step-name: Build War
           command: rundeck_war_build
@@ -279,6 +265,8 @@ jobs:
           command: |
             rundeck_docker_build
             rundeck_docker_push
+      # groovy sdk is needed for running verify build.
+      - install-groovy-sdk
       - run-build-step:
           step-name: Verify Build
           command: rundeck_verify_build
@@ -308,7 +296,8 @@ jobs:
     steps:
       - setup_docker
       - checkout
-      - install-build-dependencies
+      - install-node
+      - install-java-jdk
       - restore-build-cache
       - attach_workspace:
           at: ~/workspace
@@ -404,7 +393,7 @@ jobs:
     steps:
       - setup_docker
       - checkout
-#      - install-build-dependencies
+      - aws-cli/install
       - install-java-jdk
       - restore-build-cache
       - attach_workspace:
@@ -560,9 +549,9 @@ jobs:
     steps:
       - checkout
       - restore-build-cache
+      - install-java-jdk
       - attach_workspace:
           at: ~/workspace
-      - install-test-dependencies
       - run-build-step:
           step-name: Pull images
           command: rundeck_pull_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ executors:
   # Main docker executor
   docker-builder:
     docker:
-      - image: cimg/base:2023.10-22.04
+      - image: cimg/base:current-22.04
     parameters:
       # we set the resource class to small by default
       # however, any job that uses the setup_remote_docker step will be

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,6 +257,7 @@ jobs:
       - restore-build-cache
       - install-node
       - install-java-jdk
+      - install-groovy-sdk
       - run-build-step:
           step-name: Build War
           command: rundeck_war_build
@@ -265,8 +266,6 @@ jobs:
           command: |
             rundeck_docker_build
             rundeck_docker_push
-      # groovy sdk is needed for running verify build.
-      - install-groovy-sdk
       - run-build-step:
           step-name: Verify Build
           command: rundeck_verify_build

--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,23 @@ subprojects {
     eclipse.project.name = "${project.getParent().eclipse.project.name}:${name}"
 }
 
+/*
+ Root project Configurations
+ */
+configurations{
+    // dependencies for running groovy scripts
+    groovyScript
+}
+
+dependencies{
+
+    // dependencies for running groovy scripts
+    groovyScript localGroovy()
+    groovyScript "org.codehaus.groovy:groovy-cli-commons:${GroovySystem.version}"
+    groovyScript "org.codehaus.groovy:groovy-yaml:${GroovySystem.version}"
+}
+
+
 /**
  * Enable incremental Groovy compile
  */
@@ -265,4 +282,12 @@ tasks.register('printBootWarPath') {
         def bootArchiveFile = rundeckapp.bootWar.archiveFile.get()
         println "${bootArchiveFile}"
     }
+}
+
+tasks.register('verifyBuild', JavaExec) {
+    classpath = configurations.groovyScript
+    mainClass = 'groovy.ui.GroovyMain'
+    args "testbuild.groovy",
+        "--buildType=${ext.environment}",
+        "--debug"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -295,5 +295,5 @@ tasks.register('verifyBuild', JavaExec) {
     mainClass = 'groovy.ui.GroovyMain'
     args "testbuild.groovy",
         "--buildType=${project.ext.environment}",
-        "--debug"
+        "-debug"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,12 @@ subprojects {
 /*
  Root project Configurations
  */
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
 configurations{
     // dependencies for running groovy scripts
     groovyScript
@@ -288,6 +294,6 @@ tasks.register('verifyBuild', JavaExec) {
     classpath = configurations.groovyScript
     mainClass = 'groovy.ui.GroovyMain'
     args "testbuild.groovy",
-        "--buildType=${ext.environment}",
+        "--buildType=${project.ext.environment}",
         "--debug"
 }

--- a/scripts/circleci/build-functions.sh
+++ b/scripts/circleci/build-functions.sh
@@ -52,7 +52,9 @@ rundeck_docker_publish() {
 }
 
 rundeck_verify_build() {
-    groovy testbuild.groovy --buildType="${ENV}" -debug
+    ./gradlew ${GRADLE_BASE_OPTS} \
+        -Penvironment="${ENV}" \
+        verifyBuild
 }
 
 rundeck_gradle_functional_tests() {

--- a/scripts/circleci/dependencies-functions.sh
+++ b/scripts/circleci/dependencies-functions.sh
@@ -29,21 +29,6 @@ dependencies_install_groovy() {
 
 }
 
-# Install nodejs
-dependencies_install_nodejs() {
-  node_version=$(cat .nvmrc)
-  curl -sSl -o /tmp/node.tar.xz "https://nodejs.org/dist/${node_version}/node-${node_version}-linux-x64.tar.xz" && \
-  echo '592eb35c352c7c0c8c4b2ecf9c19d615e78de68c20b660eb74bd85f8c8395063 /tmp/node.tar.xz' | sha256sum --check && \
-  sudo mkdir -p /usr/local/nodejs && \
-  sudo tar --strip 1 -xvf /tmp/node.tar.xz --directory /usr/local/nodejs && \
-  sudo ln --symbolic /usr/local/nodejs/bin/node /usr/local/bin/node && \
-  sudo ln --symbolic /usr/local/nodejs/bin/npm /usr/local/bin/npm && \
-  sudo ln --symbolic /usr/local/nodejs/bin/npx /usr/local/bin/npx && \
-  sudo ln --symbolic /usr/local/nodejs/bin/corepack /usr/local/bin/corepack
-  rm -f /tmp/node.tar.xz
-}
-
-
 # Install dependencies needed for packaging
 dependencies_packaging_setup() {
 

--- a/scripts/circleci/dependencies-functions.sh
+++ b/scripts/circleci/dependencies-functions.sh
@@ -29,20 +29,20 @@ dependencies_install_groovy() {
 
 }
 
-## Install dependencies needed for building
-## Deprecated.
-#dependencies_build_setup() {
-#
-#    # Azul Zulu JDK Install
-#    dependencies_install_zulu11-jdk
-#
-#    # Node and aws installed by circle orb.
-#
-#    # Install groovy
-#    dependencies_install_groovy
-#
-##    mkdir -p "$HOME/.gradle"
-#}
+# Install nodejs
+dependencies_install_nodejs() {
+  node_version=$(cat .nvmrc)
+  curl -sSl -o /tmp/node.tar.xz "https://nodejs.org/dist/${node_version}/node-${node_version}-linux-x64.tar.xz" && \
+  echo '592eb35c352c7c0c8c4b2ecf9c19d615e78de68c20b660eb74bd85f8c8395063 /tmp/node.tar.xz' | sha256sum --check && \
+  sudo mkdir -p /usr/local/nodejs && \
+  sudo tar --strip 1 -xvf /tmp/node.tar.xz --directory /usr/local/nodejs && \
+  sudo ln --symbolic /usr/local/nodejs/bin/node /usr/local/bin/node && \
+  sudo ln --symbolic /usr/local/nodejs/bin/npm /usr/local/bin/npm && \
+  sudo ln --symbolic /usr/local/nodejs/bin/npx /usr/local/bin/npx && \
+  sudo ln --symbolic /usr/local/nodejs/bin/corepack /usr/local/bin/corepack
+  rm -f /tmp/node.tar.xz
+}
+
 
 # Install dependencies needed for packaging
 dependencies_packaging_setup() {

--- a/scripts/circleci/dependencies-functions.sh
+++ b/scripts/circleci/dependencies-functions.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
 set -e
 
-# Install dependencies needed for building
-dependencies_build_setup() {
+# Install Azul Zulu JDK
+dependencies_install_zulu11jdk() {
+      # Azul Zulu JDK Install
+      sudo apt-get update
+      sudo apt install gnupg ca-certificates curl
+      curl -s https://repos.azul.com/azul-repo.key | sudo gpg --dearmor -o /usr/share/keyrings/azul.gpg
+      echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | sudo tee /etc/apt/sources.list.d/zulu.list
 
-    # Azul Zulu JDK Install
-    sudo apt-get update
-    sudo apt install gnupg ca-certificates curl
-    curl -s https://repos.azul.com/azul-repo.key | sudo gpg --dearmor -o /usr/share/keyrings/azul.gpg
-    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | sudo tee /etc/apt/sources.list.d/zulu.list
+      sudo apt-get update
+      sudo apt-get -y --no-install-recommends install zulu11-jdk-headless
 
-    sudo apt-get update
-    sudo apt-get -y --no-install-recommends install zulu11-jdk-headless
+}
 
-    # Node and aws installed by orb.
-
+# Install groovy SDK
+dependencies_install_groovy() {
     # Install groovy
     GROOVY_VERSION=3.0.19
     curl -sSL -o /tmp/groovy.zip "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" &&
@@ -26,16 +27,28 @@ dependencies_build_setup() {
         sudo ln --symbolic "/usr/local/groovy/bin/groovysh" /usr/local/bin/groovysh &&
         sudo ln --symbolic "/usr/local/groovy/bin/groovyc" /usr/local/bin/groovyc
 
-    mkdir -p "$HOME/.gradle"
 }
+
+## Install dependencies needed for building
+## Deprecated.
+#dependencies_build_setup() {
+#
+#    # Azul Zulu JDK Install
+#    dependencies_install_zulu11-jdk
+#
+#    # Node and aws installed by circle orb.
+#
+#    # Install groovy
+#    dependencies_install_groovy
+#
+##    mkdir -p "$HOME/.gradle"
+#}
 
 # Install dependencies needed for packaging
 dependencies_packaging_setup() {
 
-    dependencies_build_setup
-
+    sudo apt-get update
     sudo apt-get -y --no-install-recommends install \
-        openjdk-11-jdk-headless \
         dpkg \
         xmlstarlet \
         expect \
@@ -43,7 +56,6 @@ dependencies_packaging_setup() {
         dpkg-sig \
         gnupg2 \
         ruby-dev
-
 }
 
 # Install dependencies needed for testdeck
@@ -52,9 +64,7 @@ dependencies_testdeck_setup() {
     sudo apt-get update
     sudo apt-get -y --no-install-recommends install \
         xmlstarlet \
-        openjdk-11-jdk-headless \
         file \
         dpkg \
         jq
-
 }

--- a/scripts/circleci/dependencies-functions.sh
+++ b/scripts/circleci/dependencies-functions.sh
@@ -14,21 +14,6 @@ dependencies_install_zulu11jdk() {
 
 }
 
-# Install groovy SDK
-dependencies_install_groovy() {
-    # Install groovy
-    GROOVY_VERSION=3.0.19
-    curl -sSL -o /tmp/groovy.zip "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" &&
-        echo '6ff5e1fde0ca7dbea06bc5241502574014a64af734c4910acdb4218b4c504230 /tmp/groovy.zip' | sha256sum --check &&
-        unzip /tmp/groovy.zip -d /tmp &&
-        rm -f /tmp/groovy.zip &&
-        sudo mv "/tmp/groovy-${GROOVY_VERSION}" "/usr/local/groovy" &&
-        sudo ln --symbolic "/usr/local/groovy/bin/groovy" /usr/local/bin/groovy &&
-        sudo ln --symbolic "/usr/local/groovy/bin/groovysh" /usr/local/bin/groovysh &&
-        sudo ln --symbolic "/usr/local/groovy/bin/groovyc" /usr/local/bin/groovyc
-
-}
-
 # Install dependencies needed for packaging
 dependencies_packaging_setup() {
 

--- a/testbuild.groovy
+++ b/testbuild.groovy
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import groovy.cli.commons.CliBuilder
-
 
 //Test the result of the build to verify expected artifacts are created
 


### PR DESCRIPTION
This PR provides some improvements on the build and pipeline:

* Removes dependency on a local groovy sdk, using gradle directly to run groovy scripts.
* Improve encapsulation of some dependency installation functions.
* Remove unnecessary node and awscli installation from many jobs.
* Explicitely set all circleci job images to latest ubuntu 22.
