### PR TITLE
RUN-2897: fix: invalid job components are not reported

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/app/components/RundeckJobDefinitionManager.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/components/RundeckJobDefinitionManager.groovy
@@ -92,7 +92,7 @@ class RundeckJobDefinitionManager implements JobDefinitionManager<ScheduledExecu
                 validations[jobImport.name] = report
             }
         }
-        return new Validator.ReportSet(true, validations)
+        return new Validator.ReportSet(valid, validations)
     }
 
 


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**

Fix: if a job definition component reports an invalid configuration, it fails to invalidate the job definition

**Describe the solution you've implemented**


**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
