### PR TITLE
RUN-2898: fix: flaky test, timing might cause failure

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/ExecutionModeSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/ExecutionModeSpec.groovy
@@ -207,7 +207,7 @@ class ExecutionModeSpec extends SeleniumBase{
         waitFor(ExecutionUtils.Retrievers.executionsForProject(client, projectName),
                 { List<Execution> execs ->  execs.any(ExecutionUtils.Verifiers.executionRunning()) },
                 WaitingTime.EXCESSIVE)
-        // Waits for at least one execution to start running
+        // Waits for all executions to finish
         waitFor(ExecutionUtils.Retrievers.executionsForProject(client, projectName),
                 verifyForAll(ExecutionUtils.Verifiers.executionFinished()),
                 WaitingTime.EXCESSIVE)

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/ExecutionModeSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/ExecutionModeSpec.groovy
@@ -209,7 +209,7 @@ class ExecutionModeSpec extends SeleniumBase{
                 WaitingTime.EXCESSIVE)
         // Waits for at least one execution to start running
         waitFor(ExecutionUtils.Retrievers.executionsForProject(client, projectName),
-                { List<Execution> execs ->  execs.any(ExecutionUtils.Verifiers.executionFinished()) },
+                verifyForAll(ExecutionUtils.Verifiers.executionFinished()),
                 WaitingTime.EXCESSIVE)
         sideBarPage.goTo NavLinkTypes.ACTIVITY
         then:


### PR DESCRIPTION
The test should should test for all executions to finish, otherwise it's possible it will proceed when the running execution has not yet completed, because it only verifies if *any* execution has finished.

this change aligns with the following test case "disable schedules at project level UI" which uses "verifyForAll"

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Fix a flaky test

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
