### PR TITLE
RPL-82: Plugin Blocklist Enhancement

### DIFF
--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -518,6 +518,7 @@ beans={
         cache = filePluginCache
         serviceAliases = [WorkflowNodeStep: 'RemoteScriptNodeStep']
         frameworkExecutionProviderServices = ref('rundeckFrameworkExecutionProviderServices')
+        pluginBlocklist = ref("rundeckPluginBlocklist")
     }
 
     /**

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckEmbeddedPluginExtractor.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckEmbeddedPluginExtractor.groovy
@@ -16,17 +16,14 @@
 
 package com.dtolabs.rundeck.server.plugins
 
+import com.dtolabs.rundeck.core.plugins.PluginBlocklist
 import com.dtolabs.rundeck.server.plugins.loader.ApplicationContextPluginFileSource
 import com.dtolabs.rundeck.server.plugins.loader.PluginFileManifest
 import com.dtolabs.rundeck.server.plugins.loader.PluginFileSource
 import com.dtolabs.utils.Streams
-import grails.spring.BeanBuilder
-import org.rundeck.security.RundeckPluginBlocklist
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.InitializingBean
-import org.springframework.beans.factory.NoSuchBeanDefinitionException
-import org.springframework.beans.factory.annotation.Autowire
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
@@ -40,11 +37,11 @@ class RundeckEmbeddedPluginExtractor implements ApplicationContextAware, Initial
 
     ApplicationContext applicationContext
     File pluginTargetDir
-    RundeckPluginRegistry rundeckPluginRegistry
+
     @Autowired
     Collection<PluginFileSource> pluginFileSources = []
 
-    RundeckPluginBlocklist rundeckPluginBlocklist
+    PluginBlocklist rundeckPluginBlocklist
 
     RundeckEmbeddedPluginExtractor() {
     }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
@@ -25,6 +25,7 @@ import com.dtolabs.rundeck.core.plugins.CloseableProvider
 import com.dtolabs.rundeck.core.plugins.ConfiguredPlugin
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
 import com.dtolabs.rundeck.core.plugins.Plugin
+import com.dtolabs.rundeck.core.plugins.PluginBlocklist
 import com.dtolabs.rundeck.core.plugins.PluginMetadata
 import com.dtolabs.rundeck.core.plugins.PluginRegistry
 import com.dtolabs.rundeck.core.plugins.PluginResourceLoader
@@ -48,7 +49,6 @@ import com.dtolabs.rundeck.plugins.config.PluginGroup
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import com.dtolabs.rundeck.server.plugins.services.PluginBuilder
 import groovy.transform.PackageScope
-import org.rundeck.security.RundeckPluginBlocklist
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.BeanNotOfRequiredTypeException
@@ -79,12 +79,11 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
     def File pluginDirectory
     def File pluginCacheDirectory
     def RundeckEmbeddedPluginExtractor rundeckEmbeddedPluginExtractor
-    RundeckPluginBlocklist rundeckPluginBlocklist
+    PluginBlocklist rundeckPluginBlocklist
     PluginAdapter rundeckPluginAdapter
 
     @Override
     void afterPropertiesSet() throws Exception {
-        rundeckEmbeddedPluginExtractor.rundeckPluginRegistry = this
         def result = rundeckEmbeddedPluginExtractor.extractEmbeddedPlugins()
         if (!result.success) {
             log.error("Failed extracting embedded plugins: " + result.message)


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is an enhancement to [the plugin blocklist](https://docs.rundeck.com/docs/administration/security/blocklist.html) when blocking specific plugins by provider name. In the current state, when plugins for certain types of providers (e.g. `WorkflowNodeStep`) were blocked, they would still show up in various UIs and APIs. With this change, a blocked plugin will be more cleanly removed from these UIs and APIs.

**Context**
The `PluginBlocklist` / `RundeckPluginBlocklist` manages the list of blocked plugins and plugin containers (files). A few services are aware of this blocklist but the PluginRegistry is the primary one. Flows that obtain plugin information from the `PluginService` and / or the `PluginRegistry` properly filter out blocked plugins.

A number of other flows including the `/plugins/list` API and the "Installed Plugins" UI are based on the data provided by [PluginApiService.listPluginsDetailed](https://github.com/rundeck/rundeck/blob/c9436262299372134d160d7aedd1dcd9bde7bb06/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy#L60). For some service providers, this function loads up plugins via the `PluginService` (which properly applies the blocklist). For others providers, the plugins are loaded using the `PluginManagerService` (which is not aware of the blocklist).

A few other flows [including the creating / editing a workflow] also load plugins by directly calling listDescriptions() on particular services. After loading the plugins, these flows make use of `PluginControlServiceImpl` to filter out disabled plugins. However, `PluginControlServiceImpl` is currently only aware of plugins that are disabled at a Project-level. It is not aware of globally disabled plugins.

**Describe the solution you've implemented**
This solution updates the `PluginManagerService` such that it removes any plugins present in the `PluginBlocklist` before providing results.

**Describe alternatives you've considered**
See: https://github.com/rundeck/rundeck/pull/9432.

**Additional context**
This PR also updates a few services that require the `PluginBlocklist` so that they depend on the interface rather than the concrete `RundeckPluginBlocklist` class. 
