### PR TITLE
Install node directly from nodejs.org instead of orb/nvm.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ parameters:
 
 orbs:
   aws-cli: circleci/aws-cli@1.0.0
-  node: circleci/node@6.1.0
   trigger: rundeck/trigger-pipeline@0.0.5
   slack: circleci/slack@4.4.0
   browser-tools: circleci/browser-tools@1.4.8
@@ -189,7 +188,9 @@ commands:
   install-node:
     description: Install Node
     steps:
-      - node/install
+      - run-build-step:
+          step-name: Install Node
+          command: dependencies_install_nodejs
 
   # Install dependencies required for gradle builds.
   install-build-dependencies:

--- a/scripts/circleci/dependencies-functions.sh
+++ b/scripts/circleci/dependencies-functions.sh
@@ -29,6 +29,21 @@ dependencies_build_setup() {
     mkdir -p "$HOME/.gradle"
 }
 
+# Install nodejs
+dependencies_install_nodejs() {
+  node_version=$(cat .nvmrc)
+  curl -sSl -o /tmp/node.tar.xz "https://nodejs.org/dist/${node_version}/node-${node_version}-linux-x64.tar.xz" && \
+  echo '592eb35c352c7c0c8c4b2ecf9c19d615e78de68c20b660eb74bd85f8c8395063 /tmp/node.tar.xz' | sha256sum --check && \
+  sudo mkdir -p /usr/local/nodejs && \
+  sudo tar --strip 1 -xvf /tmp/node.tar.xz --directory /usr/local/nodejs && \
+  sudo ln --symbolic /usr/local/nodejs/bin/node /usr/local/bin/node && \
+  sudo ln --symbolic /usr/local/nodejs/bin/npm /usr/local/bin/npm && \
+  sudo ln --symbolic /usr/local/nodejs/bin/npx /usr/local/bin/npx && \
+  sudo ln --symbolic /usr/local/nodejs/bin/corepack /usr/local/bin/corepack
+  rm -f /tmp/node.tar.xz
+}
+
+
 # Install dependencies needed for packaging
 dependencies_packaging_setup() {
 


### PR DESCRIPTION
Download node directly, skipping dependency on nvm.