### PR TITLE
RUN-2885: add english to the dictionary of available languages so that fallback behaviour works correctly (follow-up)

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/i18n.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/i18n.ts
@@ -29,6 +29,7 @@ const initI18n = (options = {}) => {
         internationalization["en_US"] ||
         {},
     ),
+    ["en_US"]: internationalization["en_US"],
   };
 
   // Create VueI18n instance with options


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting a Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
RUN-2885's PR enabled the i18n to fallback to English in case the key wasn't available, but didn't notice that English wasn't permanently enabled when another language was selected, which prevented the fallback from working.

**Describe the solution you've implemented**
Adds English to the dictionary of available languages.

**Describe alternatives you've considered**
Another alternative would be to merge English first in the dictionary of the selected locale and then the remainder of the chosen locale (that then would overwrite the keys that were translated), but this isn't recommended as there's a better approach with the fallback.

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
Before:
![image](https://github.com/user-attachments/assets/0cfbb712-fb87-403d-a101-29e8503bcbb4)

After:
![Screenshot 2024-10-21 at 9 10 15 AM](https://github.com/user-attachments/assets/baeac08f-7c64-4782-98f6-6e6938afa634)

