### PR TITLE
RUN-2853: Fix race condition between the quartz scheduler and the web server thread that creates ScheduledExecution

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/utils/ResourceAcceptanceTimeoutException.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/utils/ResourceAcceptanceTimeoutException.java
@@ -1,0 +1,15 @@
+package com.dtolabs.rundeck.core.utils;
+
+/**
+ * Thrown when the timeout is reached waiting for a resource to reach the expected state.
+ */
+public class ResourceAcceptanceTimeoutException extends RuntimeException {
+
+  public ResourceAcceptanceTimeoutException(String message) {
+      super(message);
+    }
+
+  public ResourceAcceptanceTimeoutException(String message, Throwable cause) {
+      super(message, cause);
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/utils/WaitUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/utils/WaitUtils.java
@@ -1,0 +1,38 @@
+package com.dtolabs.rundeck.core.utils;
+
+import java.time.Duration;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class WaitUtils {
+
+    /**
+     * Waits for the resource to be in the expected state by retrieving it and evaluating its acceptance as many times as needed.
+     *
+     * @param retryableResourceRetriever executed multiple times to retrieve the current state of the R resource.
+     * @param resourceAcceptanceEvaluator evaluates the state of the resource and returns true if the resource is accepted.
+     * @param timeout max duration to wait for the resource to reach the expected state.
+     * @param checkPeriod time to wait between each check.
+     * @return the resource that met the acceptance criteria.
+     * @throws ResourceAcceptanceTimeoutException if the timeout is reached waiting for the resource to reach the expected state.
+     * @throws InterruptedException if the thread sleep was interrupted.
+     */
+    public static <R> R waitFor(
+            Supplier<R> retryableResourceRetriever,
+            Function<R, Boolean> resourceAcceptanceEvaluator,
+            Duration timeout,
+            Duration checkPeriod) throws InterruptedException {
+        R r = retryableResourceRetriever.get();
+        Boolean acceptanceResult = resourceAcceptanceEvaluator.apply(r);
+        long initTime = System.currentTimeMillis();
+        while (!acceptanceResult) {
+            Thread.sleep(Math.min(checkPeriod.toMillis(), timeout.toMillis()));
+            if ((System.currentTimeMillis() - initTime) >= timeout.toMillis()) {
+                throw new ResourceAcceptanceTimeoutException("Timeout reached (" + timeout.toMillis() + "ms) waiting for value: " + r + " to reach the desired state");
+            }
+            r = retryableResourceRetriever.get();
+            acceptanceResult = resourceAcceptanceEvaluator.apply(r);
+        }
+        return r;
+    }
+}

--- a/core/src/main/java/com/dtolabs/rundeck/core/utils/WaitUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/utils/WaitUtils.java
@@ -26,6 +26,11 @@ public class WaitUtils {
         Boolean acceptanceResult = resourceAcceptanceEvaluator.apply(r);
         long initTime = System.currentTimeMillis();
         while (!acceptanceResult) {
+            // Check timeout prior to sleep to avoid sleep that is not necessary
+            if ((System.currentTimeMillis() - initTime) >= timeout.toMillis()) {
+                throw new ResourceAcceptanceTimeoutException("Timeout reached (" + timeout.toMillis() + "ms) waiting for value: " + r + " to reach the desired state");
+            }
+            // Check timeout right after sleep to short circuit execution on timeout expiration
             Thread.sleep(Math.min(checkPeriod.toMillis(), timeout.toMillis()));
             if ((System.currentTimeMillis() - initTime) >= timeout.toMillis()) {
                 throw new ResourceAcceptanceTimeoutException("Timeout reached (" + timeout.toMillis() + "ms) waiting for value: " + r + " to reach the desired state");

--- a/core/src/test/groovy/com/dtolabs/utils/WaitUtilsSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/utils/WaitUtilsSpec.groovy
@@ -12,13 +12,13 @@ class WaitUtilsSpec extends Specification {
         given:
 
         int closure_loop_counter = 0
-        Closure<Integer> retriever = {  ->
+        Closure<Integer> retriever = { ->
             closure_loop_counter++
             return 0
         }
 
         when:
-        WaitUtils.waitFor(retriever, { !!it}, Duration.ofMillis(500), Duration.ofMillis(110) )
+        WaitUtils.waitFor(retriever, { !!it }, Duration.ofMillis(500), Duration.ofMillis(110))
 
         then:
         def e = thrown(ResourceAcceptanceTimeoutException)
@@ -26,17 +26,35 @@ class WaitUtilsSpec extends Specification {
         closure_loop_counter == 5
     }
 
+    def testWaitForWithZeroTimeout() {
+        given:
+
+        int closure_loop_counter = 0
+        Closure<Integer> retriever = { ->
+            closure_loop_counter++
+            return 0
+        }
+
+        when:
+        WaitUtils.waitFor(retriever, { !!it }, Duration.ofMillis(0), Duration.ofMillis(0))
+
+        then:
+        def e = thrown(ResourceAcceptanceTimeoutException)
+        e.message == "Timeout reached (0ms) waiting for value: 0 to reach the desired state"
+        closure_loop_counter == 1
+    }
+
     def testWaitForThatAcceptsRightAway() {
         given:
 
         int closure_loop_counter = 0
-        Closure<Integer> retriever = {  ->
+        Closure<Integer> retriever = { ->
             closure_loop_counter++
             return 1
         }
 
         when:
-        Integer result = WaitUtils.waitFor(retriever, { !!it}, Duration.ofSeconds(1), Duration.ofMillis(100) )
+        Integer result = WaitUtils.waitFor(retriever, { !!it }, Duration.ofSeconds(1), Duration.ofMillis(100))
 
         then:
         result == 1
@@ -48,13 +66,13 @@ class WaitUtilsSpec extends Specification {
 
         int closure_loop_counter = 0
         def vals = [null, 1]
-        Closure<Integer> retriever = {  ->
+        Closure<Integer> retriever = { ->
             closure_loop_counter++
             return vals[closure_loop_counter - 1]
         }
 
         when:
-        Integer result = WaitUtils.waitFor(retriever, { !!it}, Duration.ofSeconds(1), Duration.ofMillis(100) )
+        Integer result = WaitUtils.waitFor(retriever, { !!it }, Duration.ofSeconds(1), Duration.ofMillis(100))
 
         then:
         result == 1

--- a/core/src/test/groovy/com/dtolabs/utils/WaitUtilsSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/utils/WaitUtilsSpec.groovy
@@ -1,0 +1,63 @@
+package com.dtolabs.utils
+
+import com.dtolabs.rundeck.core.utils.ResourceAcceptanceTimeoutException
+import com.dtolabs.rundeck.core.utils.WaitUtils
+import spock.lang.Specification
+
+import java.time.Duration
+
+class WaitUtilsSpec extends Specification {
+
+    def testWaitForThatNeverAccepts() {
+        given:
+
+        int closure_loop_counter = 0
+        Closure<Integer> retriever = {  ->
+            closure_loop_counter++
+            return 0
+        }
+
+        when:
+        WaitUtils.waitFor(retriever, { !!it}, Duration.ofMillis(500), Duration.ofMillis(110) )
+
+        then:
+        def e = thrown(ResourceAcceptanceTimeoutException)
+        e.message == "Timeout reached (500ms) waiting for value: 0 to reach the desired state"
+        closure_loop_counter == 5
+    }
+
+    def testWaitForThatAcceptsRightAway() {
+        given:
+
+        int closure_loop_counter = 0
+        Closure<Integer> retriever = {  ->
+            closure_loop_counter++
+            return 1
+        }
+
+        when:
+        Integer result = WaitUtils.waitFor(retriever, { !!it}, Duration.ofSeconds(1), Duration.ofMillis(100) )
+
+        then:
+        result == 1
+        closure_loop_counter == 1
+    }
+
+    def testWaitForThatAcceptsEventually() {
+        given:
+
+        int closure_loop_counter = 0
+        def vals = [null, 1]
+        Closure<Integer> retriever = {  ->
+            closure_loop_counter++
+            return vals[closure_loop_counter - 1]
+        }
+
+        when:
+        Integer result = WaitUtils.waitFor(retriever, { !!it}, Duration.ofSeconds(1), Duration.ofMillis(100) )
+
+        then:
+        result == 1
+        closure_loop_counter == 2
+    }
+}

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -27,6 +27,8 @@ import com.dtolabs.rundeck.core.execution.WorkflowExecutionServiceThread
 import com.dtolabs.rundeck.core.execution.workflow.WorkflowExecutionResult
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepResult
 import com.dtolabs.rundeck.core.schedule.JobScheduleManager
+import com.dtolabs.rundeck.core.utils.ResourceAcceptanceTimeoutException
+import com.dtolabs.rundeck.core.utils.WaitUtils
 import grails.core.GrailsApplication
 import grails.gorm.transactions.Transactional
 import groovy.transform.CompileStatic
@@ -42,6 +44,7 @@ import rundeck.services.execution.ThresholdValue
 import rundeck.services.logging.LoggingThreshold
 
 import java.sql.Timestamp
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 
@@ -126,12 +129,10 @@ class ExecutionJob implements InterruptableJob {
                 log.error("Unable to start Job execution: ${es.message ?: 'no message'}")
                 return
             } else {
-                log.error("Unable to start Job execution: ${es.message ?: 'no message'}", es)
-                throw es
+                throw new ExecutionServiceException("Unable to start Job execution", es)
             }
-        }catch(ScheduledExecutionDeletedException sede){
-            log.error("ScheduledExecution not found on DB: ${sede.message?sede.message:'no message'}",sede)
-            throw sede
+        }catch(MissingScheduledExecutionException e){
+            throw e
         }
         catch(Throwable t){
             markStartExecutionFailure(context)
@@ -658,24 +659,40 @@ class ExecutionJob implements InterruptableJob {
     def ScheduledExecution fetchScheduledExecution(JobDataMap jobDataMap, JobExecutionContext context) {
         String seid = requireEntry(jobDataMap, "scheduledExecutionId", String)
         String projectName = requireEntry(jobDataMap, "project", String)
-        ScheduledExecution se = ScheduledExecution.findByUUID(seid).find()
-        if(se && se instanceof ScheduledExecution){
-            se.refreshOptions() //force fetch options and option values before return object
-        }
 
-        if (!se) {
-            context.getScheduler().deleteJob(context.jobDetail.key)
-            throw new ScheduledExecutionDeletedException("Failed to lookup scheduledException object from job data map: id: ${seid} , job will be unscheduled")
-        }
-        else if(!projectName.equals(se.project)){
-            context.getScheduler().deleteJob(context.jobDetail.key)
-            throw new RuntimeException("ScheduledExecution found but it does not match the original project name to schedule. Project name was : ${projectName} , Project name now : ${se.project}")
-        }
+        /**
+         * The `findByUUID` retry is a mitigation for the race condition between this quartz scheduler thread that gets
+         * ScheduledExecution ID from the memory store and the web server thread that puts the ID into the memory
+         * store AND creates the ScheduledExecution object in the DB.
+         * The issue occurs when the quartz thread starts processioning the associated job and attempts to fetch the
+         * newly (almost) created ScheduledExecution object from the DB BEFORE the DB transaction is committed by the web server thread.
+         */
+        try {
+            ScheduledExecution se = WaitUtils.<ScheduledExecution>waitFor(
+                    {ScheduledExecution.findByUUID(seid).find()},
+                    {it != null},
+                    Duration.ofSeconds(10),
+                    Duration.ofSeconds(1)
+            )
 
-        if (! se instanceof ScheduledExecution) {
-            throw new RuntimeException("JobDataMap contained invalid ScheduledExecution type: " + se.getClass().getName())
+            if(se instanceof ScheduledExecution){
+                se.refreshOptions() //force fetch options and option values before return object
+            } else {
+                // Legacy logic. Is this even possible?
+                throw new RuntimeException("JobDataMap contained invalid ScheduledExecution type: " + se.getClass().getName())
+            }
+
+            if(!projectName.equals(se.project)){
+                context.getScheduler().deleteJob(context.jobDetail.key)
+                throw new RuntimeException("ScheduledExecution found but it does not match the original project name to schedule. Project name was : ${projectName} , Project name now : ${se.project}")
+            }
+
+            return se
+
+        } catch (ResourceAcceptanceTimeoutException e) {
+            context.getScheduler().deleteJob(context.jobDetail.key)
+            throw new MissingScheduledExecutionException("Failed to lookup ScheduledExecution object from job data map: id: ${seid} in db, job will be unscheduled", e)
         }
-        return se
     }
 
 

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -664,7 +664,7 @@ class ExecutionJob implements InterruptableJob {
          * The `findByUUID` retry is a mitigation for the race condition between this quartz scheduler thread that gets
          * ScheduledExecution ID from the memory store and the web server thread that puts the ID into the memory
          * store AND creates the ScheduledExecution object in the DB.
-         * The issue occurs when the quartz thread starts processioning the associated job and attempts to fetch the
+         * The issue occurs when the quartz thread starts processing the associated job and attempts to fetch the
          * newly (almost) created ScheduledExecution object from the DB BEFORE the DB transaction is committed by the web server thread.
          */
         try {
@@ -684,7 +684,7 @@ class ExecutionJob implements InterruptableJob {
 
             if(!projectName.equals(se.project)){
                 context.getScheduler().deleteJob(context.jobDetail.key)
-                throw new RuntimeException("ScheduledExecution found but it does not match the original project name to schedule. Project name was : ${projectName} , Project name now : ${se.project}")
+                throw new RuntimeException("ScheduledExecution found but it does not match the original project name to schedule. Project name was : ${projectName} , Project name now : ${se.project}. ${seid} job will be unscheduled")
             }
 
             return se

--- a/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionJobIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionJobIntegrationSpec.groovy
@@ -18,7 +18,7 @@ import rundeck.services.ExecutionUtilService
 import rundeck.services.FrameworkService
 import rundeck.services.JobSchedulerService
 import rundeck.services.JobSchedulesService
-import rundeck.services.ScheduledExecutionDeletedException
+import rundeck.services.MissingScheduledExecutionException
 import rundeck.services.execution.ThresholdValue
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -434,8 +434,8 @@ class ExecutionJobIntegrationSpec extends Specification {
 
             job.initialize(context, contextMock)
         then:
-            ScheduledExecutionDeletedException e = thrown()
-            e.message == "Failed to lookup scheduledException object from job data map: id: 1 , job will be unscheduled"
+        MissingScheduledExecutionException e = thrown()
+            e.message == "Failed to lookup ScheduledExecution object from job data map: id: 1 in db, job will be unscheduled"
 
     }
 

--- a/rundeckapp/src/main/groovy/rundeck/services/MissingScheduledExecutionException.java
+++ b/rundeckapp/src/main/groovy/rundeck/services/MissingScheduledExecutionException.java
@@ -1,0 +1,12 @@
+package rundeck.services;
+
+public class MissingScheduledExecutionException extends Exception {
+
+    public MissingScheduledExecutionException(String message) {
+        super(message);
+    }
+
+    public MissingScheduledExecutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/rundeckapp/src/main/groovy/rundeck/services/ScheduledExecutionDeletedException.java
+++ b/rundeckapp/src/main/groovy/rundeck/services/ScheduledExecutionDeletedException.java
@@ -1,9 +1,0 @@
-package rundeck.services;
-
-public class ScheduledExecutionDeletedException extends Exception{
-
-    public ScheduledExecutionDeletedException(String s) {
-        super(s);
-    }
-
-}

--- a/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
@@ -23,6 +23,7 @@ import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.core.execution.WorkflowExecutionServiceThread
 import com.dtolabs.rundeck.core.execution.workflow.StepExecutionContext
 import com.dtolabs.rundeck.core.schedule.JobScheduleManager
+import com.dtolabs.rundeck.core.utils.ResourceAcceptanceTimeoutException
 import grails.testing.gorm.DataTest
 import org.quartz.*
 import org.rundeck.app.data.providers.GormJobStatsDataProvider
@@ -32,7 +33,7 @@ import rundeck.services.ExecutionUtilService
 import rundeck.services.FrameworkService
 import rundeck.services.JobSchedulerService
 import rundeck.services.JobSchedulesService
-import rundeck.services.ScheduledExecutionDeletedException
+import rundeck.services.MissingScheduledExecutionException
 import spock.lang.Specification
 
 import java.sql.Timestamp
@@ -63,8 +64,9 @@ class ExecutionJobSpec extends Specification implements DataTest {
         job.execute(context)
 
         then:
-        ScheduledExecutionDeletedException e = thrown()
-        e.message == "Failed to lookup scheduledException object from job data map: id: 123 , job will be unscheduled"
+        MissingScheduledExecutionException e = thrown()
+        e.message == "Failed to lookup ScheduledExecution object from job data map: id: 123 in db, job will be unscheduled"
+        e.getCause() instanceof ResourceAcceptanceTimeoutException
     }
 
     def "execute retrieves execution id"() {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is a bugfix (mitigation) for the race condition between the quartz scheduler thread that gets ScheduledExecution ID from the memory store and the web server thread that puts the ID into the memory store AND creates the ScheduledExecution object in the DB. The issue occurs when the quartz thread processes the associated job and attempts to fetch the newly (almost) created ScheduledExecution object from the DB **BEFORE** the DB transaction is committed.

**Describe the solution you've implemented**
The problem is mitigated by retrying the DB fetch operation multiple times (with a timeout) giving the web server thread additional time to commit.

**Describe alternatives you've considered**
The proper alternative would be to wait for the txn to commit prior to scheduling the corresponding job in Quartz.
However, the code to CRUD ScheduledExecution is very intermingled with job scheduling and refactoring it would require significant effort.

**Additional context**
Fixes the "flaky" ScheduledJobSpec` test