### PR TITLE
RUN-2937: Fix the project export right managing both export and delete action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ parameters:
 
 orbs:
   aws-cli: circleci/aws-cli@1.0.0
-  node: circleci/node@6.1.0
+  node: circleci/node@6.3.0
   trigger: rundeck/trigger-pipeline@0.0.5
   slack: circleci/slack@4.4.0
   browser-tools: circleci/browser-tools@1.4.8
@@ -189,7 +189,9 @@ commands:
   install-node:
     description: Install Node
     steps:
-      - node/install
+      - node/install:
+          use-nvm-cache: true
+          nvm-cache-key: cache-{{ .Environment.BUILD_CACHE_VERSION }}-nvm-{{ checksum ".nvmrc" }}
 
   # Install dependencies required for gradle builds.
   install-build-dependencies:

--- a/rundeckapp/grails-app/views/common/_navBarProjectSettingsData.gsp
+++ b/rundeckapp/grails-app/views/common/_navBarProjectSettingsData.gsp
@@ -166,7 +166,7 @@
             link: '${createLink(controller: "menu", action: "projectDelete", params: [project: params.project])}',
             label: '${g.message(code:"delete.project")}',
             active: false,
-            enabled: ${authExport == true},
+            enabled: ${authDelete == true},
         },
         <g:ifMenuItems type="PROJECT_CONFIG"  project="${params.project}">
             <g:forMenuItems type="PROJECT_CONFIG" var="item" project="${params.project}">


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This should fix #9414. That was looking like a simple copy/paste error as the export/import rights are managed just above the delete action.

**Describe the solution you've implemented**
Switched from authExport to authDelete in the link enabled attribute