### PR TITLE
RUN-2938: Fix an exclusive test on ADMIN and APP_ADMIN when it should be one or the other

### DIFF
--- a/rundeckapp/grails-app/views/common/_navBarProjectSettingsData.gsp
+++ b/rundeckapp/grails-app/views/common/_navBarProjectSettingsData.gsp
@@ -17,6 +17,7 @@
 <%@ page import="org.rundeck.core.auth.AuthConstants" %>
 <g:set var="authAdmin" value="${auth.resourceAllowedTest(
         action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+        any: true,
         type: AuthConstants.TYPE_PROJECT,
         name: (params.project ?: request.project),
         context: AuthConstants.CTX_APPLICATION
@@ -46,8 +47,8 @@
                name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION
        )}"/>
 <g:set var="authReadAcl"
-       value="${auth.resourceAllowedTest(action: [AuthConstants.ACTION_READ, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
-               any: true,
+       value="${authAdmin || auth.resourceAllowedTest(
+               action: AuthConstants.ACTION_READ,
                type: AuthConstants.TYPE_PROJECT_ACL,
                name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION
        )}"/>

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -47,7 +47,13 @@
       </g:else>
       </g:each>
       <g:set var="adhocRunAllowed" value="${auth.adhocAllowedTest(action: AuthConstants.ACTION_RUN,project:execution.project)}"/>
-      <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: params.project, action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN])}"/>
+      <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(
+              context: AuthConstants.CTX_APPLICATION,
+              type: AuthConstants.TYPE_PROJECT,
+              name: params.project,
+              action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+              any: true
+      )}"/>
       <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: params.project, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
 
       <g:set var="defaultLastLines" value="${cfg.getInteger(config: "gui.execution.tail.lines.default", default: 20)}"/>

--- a/rundeckapp/grails-app/views/framework/_legacyEditProjectFile.gsp
+++ b/rundeckapp/grails-app/views/framework/_legacyEditProjectFile.gsp
@@ -45,7 +45,13 @@
                                 <g:submitButton name="save" value="${g.message(code: 'button.action.Save', default: 'Save')}" class="btn btn-cta reset_page_confirm"/>
                                 <g:if test="${displayConfig?.contains('none')}">
                                     <span class="text-warning text-right">
-                                        <g:set var="authAdmin" value="${auth.resourceAllowedTest( action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN], type: AuthConstants.TYPE_PROJECT, name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION )}"/>
+                                        <g:set var="authAdmin" value="${auth.resourceAllowedTest(
+                                                action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+                                                any: true,
+                                                type: AuthConstants.TYPE_PROJECT,
+                                                name: (params.project ?: request.project),
+                                                context: AuthConstants.CTX_APPLICATION
+                                        )}"/>
                                         <g:if test="${authAdmin}">
                                             <g:message code="project.edit.readme.warning.not.displayed.admin.message" />
                                             <g:link controller="framework" action="editProject" params="[project: params.project]">

--- a/rundeckapp/grails-app/views/framework/adhoc.gsp
+++ b/rundeckapp/grails-app/views/framework/adhoc.gsp
@@ -25,8 +25,19 @@
     <g:set var="projectLabel" value="${session.frameworkLabels?session.frameworkLabels[projectName]:projectName}"/>
     <title><g:message code="gui.menu.Adhoc"/> - <g:enc>${projectLabel}</g:enc></title>
 
-  <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN])}"/>
-  <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
+  <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(
+          context: AuthConstants.CTX_APPLICATION,
+          type: AuthConstants.TYPE_PROJECT,
+          name: projectName,
+          action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+          any: true
+  )}"/>
+  <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(
+          context: AuthConstants.CTX_APPLICATION,
+          type: AuthConstants.TYPE_PROJECT,
+          name: projectName,
+          action: AuthConstants.ACTION_DELETE_EXECUTION
+  ) || projAdminAuth}"/>
 
   <g:set var="eventReadAuth" value="${auth.resourceAllowedTest(
           project: projectName,

--- a/rundeckapp/grails-app/views/framework/editProjectFile.gsp
+++ b/rundeckapp/grails-app/views/framework/editProjectFile.gsp
@@ -51,7 +51,13 @@
         <tmpl:legacyEditProjectFile/>
     </g:if>
     <g:else>
-        <g:set var="authAdmin" value="${auth.resourceAllowedTest( action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN], type: AuthConstants.TYPE_PROJECT, name: (params.project ?: request.project), context: AuthConstants.CTX_APPLICATION )}"/>
+        <g:set var="authAdmin" value="${auth.resourceAllowedTest(
+                action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+                any: true,
+                type: AuthConstants.TYPE_PROJECT,
+                name: (params.project ?: request.project),
+                context: AuthConstants.CTX_APPLICATION
+        )}"/>
         <div class='vue-ui-socket'>
             <ui-socket section="edit-project-file" location="main"  :socket-data="{filename: '${filename}', displayConfig: '${displayConfig}', project: '${params.project ?: request.project}', authAdmin: '${authAdmin}'}"></ui-socket>
         </div>

--- a/rundeckapp/grails-app/views/menu/_projectConfigNavMenu.gsp
+++ b/rundeckapp/grails-app/views/menu/_projectConfigNavMenu.gsp
@@ -18,6 +18,7 @@
 
 <g:set var="authAdmin" value="${auth.resourceAllowedTest(
         action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+        any: true,
         type: AuthConstants.TYPE_PROJECT,
         name: (params.project ?: request.project),
         context: AuthConstants.CTX_APPLICATION

--- a/rundeckapp/grails-app/views/menu/_projectExportForm.gsp
+++ b/rundeckapp/grails-app/views/menu/_projectExportForm.gsp
@@ -102,7 +102,7 @@
                     <i class="glyphicon glyphicon-ban-circle"></i> ACL Policies (Unauthorized)
                   </div>
                 </auth:resourceAllowed>
-                <auth:resourceAllowed action="${[AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]}" context="${AuthConstants.CTX_APPLICATION}" type="${AuthConstants.TYPE_PROJECT}" name="${params.project}">
+                <auth:resourceAllowed action="${[AuthConstants.ACTION_CONFIGURE, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]}" any="true" context="${AuthConstants.CTX_APPLICATION}" type="${AuthConstants.TYPE_PROJECT}" name="${params.project}">
                 <div class="checkbox">
                   <g:checkBox name="exportScm" value="true"/>
                   <label for="exportScm">SCM configuration</label>
@@ -213,7 +213,7 @@
       <div class="card-footer">
         <g:submitButton name="cancel" value="${g.message(code:'button.action.Cancel',default:'Cancel')}" class="btn btn-default  btn-sm"/>
         <button type="submit" class="btn btn-cta btn-sm"><g:message code="export.archive"/> <g:icon name="download"/></button>
-        <auth:resourceAllowed action="${[AuthConstants.ACTION_PROMOTE, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]}" context="${AuthConstants.CTX_APPLICATION}" type="${AuthConstants.TYPE_PROJECT}" name="${params.project}">
+        <auth:resourceAllowed action="${[AuthConstants.ACTION_PROMOTE, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]}" any="true" context="${AuthConstants.CTX_APPLICATION}" type="${AuthConstants.TYPE_PROJECT}" name="${params.project}">
           <button type="button" data-toggle="modal" data-target="#exportModal" class="btn btn-default  btn-sm pull-right"><g:message code="export.another.instance"/></button>
         </auth:resourceAllowed>
       </div>

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -31,8 +31,19 @@
 
     <title><g:message code="gui.menu.Workflows"/> - <g:enc>${projectLabel}</g:enc></title>
 
-    <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN])}"/>
-    <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
+    <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(
+            context: AuthConstants.CTX_APPLICATION,
+            type: AuthConstants.TYPE_PROJECT,
+            name: projectName,
+            action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+            any: true
+    )}"/>
+    <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(
+            context: AuthConstants.CTX_APPLICATION,
+            type: AuthConstants.TYPE_PROJECT,
+            name: projectName,
+            action: AuthConstants.ACTION_DELETE_EXECUTION
+    ) || projAdminAuth}"/>
 
     <asset:javascript src="menu/jobs.js"/>
     <g:embedJSON data="${projectNames ?: []}" id="projectNamesData"/>

--- a/rundeckapp/grails-app/views/menu/jobs.next.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.next.gsp
@@ -9,8 +9,19 @@
     <g:set var="projectName" value="${params.project ?: request.project}"/>
     <g:set var="projectLabel" value="${session.frameworkLabels?session.frameworkLabels[projectName]:projectName}"/>
     <title><g:message code="gui.menu.Workflows"/> - <g:enc>${projectLabel}</g:enc></title>
-    <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN])}"/>
-    <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
+    <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(
+            context: AuthConstants.CTX_APPLICATION,
+            type: AuthConstants.TYPE_PROJECT,
+            name: projectName,
+            action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+            any: true
+    )}"/>
+    <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(
+            context: AuthConstants.CTX_APPLICATION,
+            type: AuthConstants.TYPE_PROJECT,
+            name: projectName,
+            action: AuthConstants.ACTION_DELETE_EXECUTION
+    ) || projAdminAuth}"/>
 
     <asset:javascript src="menu/jobs.next.js"/>
     <asset:javascript src="static/pages/project-activity.js" defer="defer"/>

--- a/rundeckapp/grails-app/views/menu/projectHome.gsp
+++ b/rundeckapp/grails-app/views/menu/projectHome.gsp
@@ -34,7 +34,12 @@
     <asset:stylesheet href="static/css/pages/project-dashboard.css"/>
     <g:jsMessages code="jobslist.date.format.ko,select.all,select.none,delete.selected.executions,cancel.bulk.delete,cancel,close,all"/>
     <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(
-                context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: params.project, action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN])}"/>
+                context: AuthConstants.CTX_APPLICATION,
+            type: AuthConstants.TYPE_PROJECT,
+            name: params.project,
+            action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+            any: true
+    )}"/>
         <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name:
                 params.project, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
         <g:set var="projectEventsAuth" value="${auth.resourceAllowedTest(kind: AuthConstants.TYPE_EVENT, project: params.project, action: AuthConstants.ACTION_READ) || projAdminAuth}"/>

--- a/rundeckapp/grails-app/views/reports/_activityLinks.gsp
+++ b/rundeckapp/grails-app/views/reports/_activityLinks.gsp
@@ -113,7 +113,12 @@
             </span>
 
         <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(
-                context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: params.project, action: [AuthConstants.ACTION_ADMIN,AuthConstants.ACTION_APP_ADMIN])}"/>
+                context: AuthConstants.CTX_APPLICATION,
+                type: AuthConstants.TYPE_PROJECT,
+                name: params.project,
+                action: [AuthConstants.ACTION_ADMIN,AuthConstants.ACTION_APP_ADMIN],
+                any: true
+        )}"/>
         <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name:
                 params.project, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
         <g:if test="${deleteExecAuth}">

--- a/rundeckapp/grails-app/views/reports/index.gsp
+++ b/rundeckapp/grails-app/views/reports/index.gsp
@@ -71,9 +71,18 @@ saved.filters
 search
 "/>
     <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(
-            context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN])}"/>
-    <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name:
-            projectName, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
+            context: AuthConstants.CTX_APPLICATION,
+            type: AuthConstants.TYPE_PROJECT,
+            name: projectName,
+            action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+            any: true
+    )}"/>
+    <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(
+            context: AuthConstants.CTX_APPLICATION,
+            type: AuthConstants.TYPE_PROJECT,
+            name: projectName,
+            action: AuthConstants.ACTION_DELETE_EXECUTION
+    ) || projAdminAuth}"/>
     <cfg:setVar var="defaultMax" defaultValue="${30}" key="pagination.default.max"/>
     <g:set var="pageMax" value="${params.max?params.int('max',defaultMax):defaultMax}"/>
     <g:javascript>

--- a/rundeckapp/grails-app/views/scheduledExecution/show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/show.gsp
@@ -139,7 +139,12 @@ search
     </script>
     <g:set var="projectName" value="${scheduledExecution.project}"/>
     <g:set var="projAdminAuth" value="${auth.resourceAllowedTest(
-            context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name: projectName, action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN])}"/>
+            context: AuthConstants.CTX_APPLICATION,
+            type: AuthConstants.TYPE_PROJECT,
+            name: projectName,
+            action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+            any: true
+    )}"/>
     <g:set var="deleteExecAuth" value="${auth.resourceAllowedTest(context: AuthConstants.CTX_APPLICATION, type: AuthConstants.TYPE_PROJECT, name:
             projectName, action: AuthConstants.ACTION_DELETE_EXECUTION) || projAdminAuth}"/>
     <g:set var="runAccess" value="${auth.jobAllowedTest(job: scheduledExecution, action: AuthConstants.ACTION_RUN)}"/>

--- a/rundeckapp/grails-app/views/user/list.gsp
+++ b/rundeckapp/grails-app/views/user/list.gsp
@@ -30,7 +30,11 @@
         <div class="col-sm-10 col-sm-offset-1">
             <h3>Users
 
-            <g:if test="${auth.resourceAllowedTest(kind: AuthConstants.TYPE_USER, action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN], context: AuthConstants.CTX_APPLICATION)}">
+            <g:if test="${auth.resourceAllowedTest(
+                    kind: AuthConstants.TYPE_USER,
+                    action: [AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN],
+                    any: true,
+                    context: AuthConstants.CTX_APPLICATION)}">
                     <g:link action="create" class="btn btn-default btn-xs">
                         <i class="glyphicon glyphicon-plus"></i>
                         New Profile &hellip;


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This should fix #9416. A resourceAllowedTest call was missing an ` any:true`  parameter so that either ` admin`  or ` app_admin` were enough to allow full access for a set of projects.

**Describe the solution you've implemented**
Added ` any: true` when both AuthConstants.ADMIN and AuthConstants.APP_ADMIN were required to a few cases similar to the one in _navBarProjectSettingsData.gsp.
I also found a similar case in _projectExportForm.gsp and aligned it with _projectImportForm.gsp

**Additional context**
There's some discrepancies in presentation throughout the code for call to auth.resourceAllowedTest and auth:resourceAllowed, I restricted my changes only close to the cases at hand.
