### PR TITLE
RUN-2932: Introduce wait and retry to the flaky functional CommandOnMultipleNodesSpec tests

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/execution/CommandOnMultipleNodesSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/execution/CommandOnMultipleNodesSpec.groovy
@@ -56,8 +56,8 @@ class CommandOnMultipleNodesSpec extends SeleniumBase{
         expect:
         executionShowPage.validatePage()
         executionShowPage.waitForElementAttributeToChange executionShowPage.executionStateDisplayLabel, 'data-execstate', 'SUCCEEDED'
-        // Ensures there is a log line for each node
-        executionShowPage.getExecLogLines().size() == 3
+        // Waits to ensure there is a log line for each node
+        waitFor({ executionShowPage.getExecLogLines() }, { it.size() == 3 })
     }
 
     def "execution succeeds on the specific nodes matching the filter"() {
@@ -78,7 +78,7 @@ class CommandOnMultipleNodesSpec extends SeleniumBase{
         expect:
         executionShowPage.validatePage()
         executionShowPage.waitForElementAttributeToChange executionShowPage.executionStateDisplayLabel, 'data-execstate', 'SUCCEEDED'
-        // Ensures there is a log line for each node matching the executor-test tag
-        executionShowPage.getExecLogLines().size() == 2
+        // Waits to ensure there is a log line for each node matching the executor-test tag
+        waitFor({ executionShowPage.getExecLogLines() }, { it.size() == 2 })
     }
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Flaky test fix

**Describe the solution you've implemented**
There is a race condition between the output log lines produced by the system and the tests verifying the log line count. The wait and retry logic introduced gives the system more time to produce the expected number of log lines. 
