### PR TITLE
RUN-2787: Add retry for packaging signing test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,7 +463,7 @@ jobs:
           command: packaging_create_packages
       - run-build-step:
           step-name: Sign Packages
-          command: packaging_sign
+          command: packaging_sign_retry
       - run-build-step:
           step-name: T Packages
           command: packaging_test_packages

--- a/scripts/circleci/packaging-functions.sh
+++ b/scripts/circleci/packaging-functions.sh
@@ -18,7 +18,23 @@ packaging_create_packages() {
     LIB_DIR="${PACKAGING_DIR}/lib"
     ./gradlew ${GRADLE_BASE_OPTS} -PlibsDir=${LIB_DIR} -PpackageRelease=$RELEASE_NUM clean packageArtifacts
 }
+packaging_sign_retry(){
+    N=${1:-5} # default 5
+    total=$N
+    while true; do
+      N=$(( N - 1 ))
+      if packaging_sign; then
+        echo "Succeeded."
+        exit 0
+      fi
+      [ $N -gt 0 ] || break
+      echo "Retrying package signing in 10 seconds..."
+      sleep 10
+    done
 
+    echo "FAILED after $total tries."
+    exit 1
+}
 packaging_sign() {
     fetch_ci_shared_resources
 

--- a/scripts/circleci/packaging-functions.sh
+++ b/scripts/circleci/packaging-functions.sh
@@ -24,8 +24,8 @@ packaging_sign_retry(){
     while true; do
       N=$(( N - 1 ))
       if packaging_sign; then
-        echo "Succeeded."
-        exit 0
+        echo "Succeeded. (force retry)"
+#        exit 0
       fi
       [ $N -gt 0 ] || break
       echo "Retrying package signing in 10 seconds..."

--- a/scripts/circleci/packaging-functions.sh
+++ b/scripts/circleci/packaging-functions.sh
@@ -29,6 +29,8 @@ packaging_sign_retry(){
       fi
       [ $N -gt 0 ] || break
       echo "Retrying package signing in 10 seconds..."
+      #clean up old files
+      find "${PACKAGING_DIR}/packaging/build/distributions" -name '*.sig' -delete
       sleep 10
     done
 

--- a/scripts/circleci/packaging-functions.sh
+++ b/scripts/circleci/packaging-functions.sh
@@ -30,6 +30,8 @@ packaging_sign_retry(){
       [ $N -gt 0 ] || break
       echo "Retrying package signing in 10 seconds..."
       #clean up old files
+      pwd
+      find "${PACKAGING_DIR}/packaging/build/distributions" -name '*.sig'
       find "${PACKAGING_DIR}/packaging/build/distributions" -name '*.sig' -delete
       sleep 10
     done

--- a/scripts/circleci/packaging-functions.sh
+++ b/scripts/circleci/packaging-functions.sh
@@ -30,8 +30,6 @@ packaging_sign_retry(){
       [ $N -gt 0 ] || break
       echo "Retrying package signing in 10 seconds..."
       #clean up old files
-      pwd
-      find "${PACKAGING_DIR}/packaging/build/distributions" -name '*.sig'
       find "${PACKAGING_DIR}/packaging/build/distributions" -name '*.sig' -delete
       sleep 10
     done

--- a/scripts/circleci/packaging-functions.sh
+++ b/scripts/circleci/packaging-functions.sh
@@ -24,8 +24,8 @@ packaging_sign_retry(){
     while true; do
       N=$(( N - 1 ))
       if packaging_sign; then
-        echo "Succeeded. (force retry)"
-#        exit 0
+        echo "Succeeded."
+        exit 0
       fi
       [ $N -gt 0 ] || break
       echo "Retrying package signing in 10 seconds..."


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Add retry loop for signing test which is flaky

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
