### PR TITLE
RUN-2949: UI: Project Dashboard: Fix: activity summary should not be shown for 0 counts

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-dashboard/components/activitySummary.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-dashboard/components/activitySummary.spec.ts
@@ -1,0 +1,103 @@
+//@ts-nocheck
+import { mount } from "@vue/test-utils";
+import ActivitySummary from "./activitySummary.vue";
+
+const mountActivitySummary = async (props = {}) => {
+  return mount(ActivitySummary, {
+    props: {
+      project: {},
+      rdBase: "",
+      ...props,
+    },
+    global: {
+      mocks: {
+        $t: (msg) => msg,
+        $tc: (msg, count) => {
+          return `${msg}/${count}`;
+        },
+      },
+    },
+  });
+};
+
+describe("EditProjectFile", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("links to project activity", async () => {
+    const wrapper = await mountActivitySummary({
+      project: { name: "test" },
+      rdBase: "http://localhost:9999/",
+    });
+    expect(wrapper.find(".card-content a.h4").attributes()["href"]).toBe(
+      "http://localhost:9999/project/test/activity",
+    );
+  });
+
+  it.each([0, 1, 2])("renders summary count %d", async (execCount) => {
+    const wrapper = await mountActivitySummary({
+      project: { execCount, name: "test", userCount: 0 },
+    });
+    expect(wrapper.find(".card-content .summary-count").text()).toContain(
+      execCount.toString(),
+    );
+    expect(wrapper.find(".card-content a.h4").text()).toContain(
+      execCount.toString() + " execution/" + execCount.toString(),
+    );
+  });
+  it.each([1, 2])("renders failed count %d", async (failedCount) => {
+    const wrapper = await mountActivitySummary({
+      project: { failedCount, name: "test" },
+      rdBase: "http://localhost:9999/",
+    });
+    expect(
+      wrapper.find(`.card-content [data-test-id="failed-count"]`).text(),
+    ).toContain(`(${failedCount.toString()} Failed)`);
+    expect(
+      wrapper
+        .find(`.card-content [data-test-id="failed-count"] a`)
+        .attributes()["href"],
+    ).toBe("http://localhost:9999/project/test/activity?statFilter=fail");
+  });
+  it("does not failed count 0", async () => {
+    const wrapper = await mountActivitySummary({
+      project: { failedCount: 0, name: "test" },
+      rdBase: "http://localhost:9999/",
+    });
+    expect(
+      wrapper.findAll(`.card-content [data-test-id="failed-count"]`).length,
+    ).toBe(0);
+  });
+  it.each([1, 2])("renders user count %d", async (userCount) => {
+    const wrapper = await mountActivitySummary({
+      project: { userCount, name: "test" },
+      rdBase: "http://localhost:9999/",
+    });
+    expect(
+      wrapper.find(`.card-content [data-test-id="user-count"]`).text(),
+    ).toContain(`by ${userCount.toString()} Users`);
+  });
+  it.each([["a"], ["a", "b"], ["a", "b", "c"]])(
+    "renders user list",
+    async (userSummary) => {
+      const wrapper = await mountActivitySummary({
+        project: { userSummary, userCount: userSummary.length, name: "test" },
+        rdBase: "http://localhost:9999/",
+      });
+      expect(
+        wrapper.findAll(`.card-content [data-test-id="user-count"] ul.users li`)
+          .length,
+      ).toBe(userSummary.length);
+    },
+  );
+  it("does not show user count 0", async () => {
+    const wrapper = await mountActivitySummary({
+      project: { userCount: 0, name: "test" },
+      rdBase: "http://localhost:9999/",
+    });
+    expect(
+      wrapper.findAll(`.card-content [data-test-id="user-count"]`).length,
+    ).toBe(0);
+  });
+});

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-dashboard/components/activitySummary.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-dashboard/components/activitySummary.spec.ts
@@ -16,6 +16,13 @@ const mountActivitySummary = async (props = {}) => {
           return `${msg}/${count}`;
         },
       },
+      stubs: {
+        "i18n-t": {
+          props: ["keypath"],
+          template:
+            'i18n-t: {{keypath}} <slot name="count"></slot> <slot name="users"></slot>',
+        },
+      },
     },
   });
 };
@@ -53,7 +60,7 @@ describe("EditProjectFile", () => {
     });
     expect(
       wrapper.find(`.card-content [data-test-id="failed-count"]`).text(),
-    ).toContain(`(${failedCount.toString()} Failed)`);
+    ).toContain(`project.activitySummary.failedCount`);
     expect(
       wrapper
         .find(`.card-content [data-test-id="failed-count"] a`)
@@ -76,7 +83,9 @@ describe("EditProjectFile", () => {
     });
     expect(
       wrapper.find(`.card-content [data-test-id="user-count"]`).text(),
-    ).toContain(`by ${userCount.toString()} Users`);
+    ).toContain(
+      `i18n-t: project.activitySummary.userCount ${userCount} users.plural/${userCount}`,
+    );
   });
   it.each([["a"], ["a", "b"], ["a", "b", "c"]])(
     "renders user list",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-dashboard/components/activitySummary.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-dashboard/components/activitySummary.vue
@@ -15,7 +15,7 @@
 
           {{ $t("In the last Day") }}
 
-          <span :if="project.failedCount > 0">
+          <span v-if="project.failedCount > 0" data-test-id="failed-count">
             <a
               :class="{
                 'text-warning': project.failedCount > 0,
@@ -26,11 +26,11 @@
               ({{ project.failedCount }} Failed)
             </a>
           </span>
-          <div :if="project.userCount > 0">
+          <div v-if="project.userCount > 0" data-test-id="user-count">
             by
-            <span class="text-info">{{ project.userCount }}</span> &nbsp;
+            <span class="text-info">{{ project.userCount + " " }} </span>
             <span>{{ pluralUsers }}</span
-            >: &nbsp;
+            >:
             <ul class="users">
               <li v-for="user in project.userSummary" :key="user">
                 {{ user }}

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-dashboard/components/activitySummary.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-dashboard/components/activitySummary.vue
@@ -23,14 +23,20 @@
               }"
               :href="`${rdBase}project/${project.name}/activity?statFilter=fail`"
             >
-              ({{ project.failedCount }} Failed)
+              {{
+                $t("project.activitySummary.failedCount", [project.failedCount])
+              }}
             </a>
           </span>
           <div v-if="project.userCount > 0" data-test-id="user-count">
-            by
-            <span class="text-info">{{ project.userCount + " " }} </span>
-            <span>{{ pluralUsers }}</span
-            >:
+            <i18n-t keypath="project.activitySummary.userCount" tag="p">
+              <template #count>
+                <span class="text-info">{{ project.userCount }}</span>
+              </template>
+              <template #users>
+                {{ $tc("users.plural", project.userCount) }}
+              </template>
+            </i18n-t>
             <ul class="users">
               <li v-for="user in project.userSummary" :key="user">
                 {{ user }}

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -143,6 +143,9 @@ const messages = {
   "info.newexecutions.since.0":
     "1 New Result. Click to load. | {0} New Results. Click to load.",
   "In the last Day": "In the last Day",
+  "project.activitySummary.failedCount": "({0} Failed)",
+  "project.activitySummary.userCount": "by {count} {users}:",
+  "users.plural": "User|Users",
   Referenced: "Referenced",
   "job.has.been.deleted.0": "(Job {0} has been deleted)",
   Filters: "Filters",


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

- Fix: if userCount or failedCount was 0 it should not show the related text. The Vue "v-if" was used incorrectly.
- Fix i18n
- Add unit tests for activitySummary.vue

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
