### PR TITLE
RUN-2947: Creates baseStore 

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/BaseLocalStorageStore.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/BaseLocalStorageStore.ts
@@ -14,13 +14,37 @@ export class BaseLocalStorageStore<T> implements BaseLocalStorageInterface<T> {
         return JSON.parse(rawData);
       } catch (error) {
         localStorage.removeItem(this.key);
-        console.warn("Failed to load data from localStorage");
+        console.warn(
+          `Failed to load data from localStorage for key ${this.key}:`,
+          error,
+        );
+        return null;
       }
     }
     return {} as T;
   }
 
-  async store(data: T) {
-    localStorage.setItem(this.key, JSON.stringify(data));
+  async save(data: T) {
+    try {
+      localStorage.setItem(this.key, JSON.stringify(data));
+    } catch (error) {
+      console.warn(
+        `Error saving data to localStorage for key "${this.key}":`,
+        error,
+      );
+    }
+  }
+}
+
+export class StorageFactory {
+  private static storageInstances: {
+    [key: string]: BaseLocalStorageInterface<any>;
+  } = {};
+
+  static getStorage<T>(name: string): BaseLocalStorageInterface<T> {
+    if (!this.storageInstances[name]) {
+      this.storageInstances[name] = new BaseLocalStorageStore<T>(name);
+    }
+    return this.storageInstances[name];
   }
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/BaseLocalStorageStore.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/BaseLocalStorageStore.ts
@@ -18,7 +18,6 @@ export class BaseLocalStorageStore<T> implements BaseLocalStorageInterface<T> {
           `Failed to load data from localStorage for key ${this.key}:`,
           error,
         );
-        return null;
       }
     }
     return {} as T;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/modules/SimpleCache.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/modules/SimpleCache.ts
@@ -1,18 +1,18 @@
 import { Cache } from "../../types/stores/Cache";
 
 export class SimpleCache<T> implements Cache<T> {
-  private cache: Map<string, T> = new Map();
+  private cachedValues: Map<string, T> = new Map();
 
   get(key: string): T | null {
-    return this.cache.get(key) || null;
+    return this.cachedValues.get(key) || null;
   }
 
   set(key: string, value: T): void {
-    this.cache.set(key, value);
+    this.cachedValues.set(key, value);
   }
 
   clear(): void {
-    this.cache.clear();
+    this.cachedValues.clear();
   }
 }
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/modules/SimpleCache.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/modules/SimpleCache.ts
@@ -1,0 +1,28 @@
+import { Cache } from "../../types/stores/Cache";
+
+export class SimpleCache<T> implements Cache<T> {
+  private cache: Map<string, T> = new Map();
+
+  get(key: string): T | null {
+    return this.cache.get(key) || null;
+  }
+
+  set(key: string, value: T): void {
+    this.cache.set(key, value);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+}
+
+export class CacheFactory {
+  private static cacheInstances: { [key: string]: Cache<any> } = {};
+
+  static getCache<T>(name: string): Cache<T> {
+    if (!this.cacheInstances[name]) {
+      this.cacheInstances[name] = new SimpleCache<T>();
+    }
+    return this.cacheInstances[name];
+  }
+}

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/tests/BaseLocalStorage.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/tests/BaseLocalStorage.spec.ts
@@ -35,7 +35,7 @@ describe("BaseLocalStorageStore", () => {
 
     const result = await store.load();
 
-    expect(result).toBeNull();
+    expect(result).toEqual({});
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         `Failed to load data from localStorage for key ${testKey}:`,

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/tests/BaseLocalStorage.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/tests/BaseLocalStorage.spec.ts
@@ -1,0 +1,91 @@
+import {
+  BaseLocalStorageStore,
+  StorageFactory,
+} from "../BaseLocalStorageStore";
+
+describe("BaseLocalStorageStore", () => {
+  let store: BaseLocalStorageStore<any>;
+  const testKey = "testKey";
+
+  beforeEach(() => {
+    store = new BaseLocalStorageStore(testKey);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should load data from localStorage", async () => {
+    const testData = { foo: "bar" };
+    localStorage.setItem(testKey, JSON.stringify(testData));
+
+    const result = await store.load();
+    expect(result).toEqual(testData);
+  });
+
+  it("should return an empty object if no data in localStorage", async () => {
+    const result = await store.load();
+    expect(result).toEqual({});
+  });
+
+  it("should handle JSON parse errors when loading", async () => {
+    localStorage.setItem(testKey, "invalid JSON");
+    const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
+
+    const result = await store.load();
+
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Failed to load data from localStorage for key ${testKey}:`,
+      ),
+      expect.any(Error),
+    );
+    expect(localStorage.getItem(testKey)).toBeNull();
+  });
+
+  it("should save data to localStorage", async () => {
+    const testData = { foo: "bar" };
+    await store.save(testData);
+
+    const storedData = localStorage.getItem(testKey);
+    expect(JSON.parse(storedData)).toEqual(testData);
+  });
+
+  it("should handle errors when saving", async () => {
+    const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
+    jest.spyOn(localStorage, "setItem").mockImplementation(() => {
+      throw new Error("Storage full");
+    });
+
+    const testData = { foo: "bar" };
+    await store.save(testData);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Error saving data to localStorage for key "${testKey}":`,
+      ),
+      expect.any(Error),
+    );
+  });
+});
+
+describe("StorageFactory", () => {
+  it("should create a new storage instance if it doesn't exist", () => {
+    const storage1 = StorageFactory.getStorage("storage1");
+    expect(storage1).toBeInstanceOf(BaseLocalStorageStore);
+  });
+
+  it("should return the same instance for the same key", () => {
+    const storage1 = StorageFactory.getStorage("storage1");
+    const storage1Again = StorageFactory.getStorage("storage1");
+    expect(storage1).toBe(storage1Again);
+  });
+
+  it("should create different instances for different keys", () => {
+    const storage1 = StorageFactory.getStorage("storage1");
+    const storage2 = StorageFactory.getStorage("storage2");
+    expect(storage1).not.toBe(storage2);
+  });
+});

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/tests/BaseStore.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/tests/BaseStore.spec.ts
@@ -1,0 +1,208 @@
+import { BaseStore } from "../utils/BaseStore";
+import { CacheFactory } from "../modules/SimpleCache";
+import { StorageFactory } from "../BaseLocalStorageStore";
+
+const mockCache = { get: jest.fn(), set: jest.fn(), clear: jest.fn() };
+const mockStorage = { load: jest.fn(), save: jest.fn() };
+
+describe("BaseStore", () => {
+  let initialState: {
+    users: { [key: string]: any };
+    posts: { [key: string]: any };
+  };
+  let store: BaseStore<typeof initialState>;
+
+  beforeEach(() => {
+    // Reset mocks
+    jest.resetAllMocks();
+
+    // Deep clone the initial state to prevent mutation between tests
+    initialState = {
+      users: {
+        "1": { id: "1", name: "John Doe" },
+        "2": { id: "2", name: "Jane Doe" },
+      },
+      posts: {
+        "1": { id: "1", title: "First Post" },
+        "2": { id: "2", title: "Second Post" },
+      },
+    };
+
+    // Create a fresh instance of BaseStore for each test
+    store = new BaseStore(initialState);
+  });
+
+  it("initializes with the given state", () => {
+    expect(store["store"]).toEqual(initialState);
+    expect(store["cache"]).toBe(null);
+    expect(store["storage"]).toBe(null);
+  });
+
+  it("gets item from store", () => {
+    const item = store.getItem("users", "1");
+    expect(item).toEqual({ id: "1", name: "John Doe" });
+  });
+
+  it("initializes with cache when storageKey is provided", () => {
+    store = new BaseStore(initialState, "testKey");
+    expect(store["cache"]).not.toBe(null);
+  });
+
+  it("gets item from cache if available", () => {
+    mockCache.get = jest
+      .fn()
+      .mockReturnValue({ id: "1", name: "Cached John Doe" });
+
+    jest.spyOn(CacheFactory, "getCache").mockImplementation(() => mockCache);
+
+    store = new BaseStore(initialState, "testKey");
+    const item = store.getItem("users", "1");
+    expect(item).toEqual({ id: "1", name: "Cached John Doe" });
+    expect(mockCache.get).toHaveBeenCalledWith("users_1");
+  });
+
+  it("initializes with cache and storage when useCacheAndStorage is true", () => {
+    store = new BaseStore(initialState, "testKey", true);
+    expect(store["cache"]).not.toBe(null);
+    expect(store["storage"]).not.toBe(null);
+  });
+
+  it("sets item in store and cache", () => {
+    jest.spyOn(CacheFactory, "getCache").mockImplementation(() => mockCache);
+
+    store = new BaseStore(initialState, "testKey");
+    const newUser = { id: "3", name: "New User" };
+    store.setItem("users", newUser);
+
+    expect(store.getItem("users", "3")).toEqual(newUser);
+    expect(mockCache.set).toHaveBeenCalledWith("users_3", newUser);
+  });
+
+  it("removes item from store and cache", () => {
+    jest.spyOn(CacheFactory, "getCache").mockImplementation(() => mockCache);
+
+    store = new BaseStore(initialState, "testKey");
+    store.removeItem("users", "1");
+
+    expect(store.getItem("users", "1")).toBeNull();
+    expect(mockCache.set).toHaveBeenCalledWith("users_1", null);
+  });
+
+  it("updates item in store and cache", () => {
+    jest.spyOn(CacheFactory, "getCache").mockImplementation(() => mockCache);
+
+    store = new BaseStore(initialState, "testKey");
+    store.updateItem("users", "1", { name: "Updated John Doe" });
+
+    expect(store.getItem("users", "1")).toEqual({
+      id: "1",
+      name: "Updated John Doe",
+    });
+    expect(mockCache.set).toHaveBeenCalledWith("users_1", {
+      id: "1",
+      name: "Updated John Doe",
+    });
+  });
+
+  it("gets all items from a collection", () => {
+    const allUsers = store.getAllItems("users");
+    expect(allUsers).toEqual(initialState.users);
+  });
+
+  it("searches items in a collection", () => {
+    const result = store.searchItems("users", (user) =>
+      user.name.includes("John"),
+    );
+    expect(result).toEqual({ "1": { id: "1", name: "John Doe" } });
+  });
+
+  it("gets paginated items from a collection", () => {
+    const paginatedUsers = store.getPaginatedItems("users", 2, 1);
+    expect(paginatedUsers).toEqual([{ id: "2", name: "Jane Doe" }]);
+  });
+
+  it("loads data from localStorage on initialization", () => {
+    const storedData = {
+      users: {
+        "3": { id: "3", name: "Stored User" },
+      },
+    };
+    mockStorage.load.mockReturnValue(storedData);
+    jest
+      .spyOn(StorageFactory, "getStorage")
+      .mockImplementation(() => mockStorage);
+
+    store = new BaseStore(initialState, "testKey", true);
+
+    expect(store.getItem("users", "3")).toEqual({
+      id: "3",
+      name: "Stored User",
+    });
+    expect(mockStorage.load).toHaveBeenCalled();
+  });
+
+  it("saves data to localStorage when setItem is called", () => {
+    jest
+      .spyOn(StorageFactory, "getStorage")
+      .mockImplementation(() => mockStorage);
+
+    store = new BaseStore(initialState, "testKey", true);
+    const newUser = { id: "3", name: "New User" };
+    store.setItem("users", newUser);
+
+    expect(mockStorage.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        users: expect.objectContaining({
+          "3": newUser,
+        }),
+      }),
+    );
+  });
+
+  it("saves data to localStorage when removeItem is called", () => {
+    jest
+      .spyOn(StorageFactory, "getStorage")
+      .mockImplementation(() => mockStorage);
+
+    store = new BaseStore(initialState, "testKey", true);
+    store.removeItem("users", "1");
+
+    expect(mockStorage.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        posts: initialState.posts,
+        users: expect.not.objectContaining({
+          "1": expect.anything(),
+        }),
+      }),
+    );
+  });
+
+  it("saves data to localStorage when updateItem is called", () => {
+    jest
+      .spyOn(StorageFactory, "getStorage")
+      .mockImplementation(() => mockStorage);
+
+    store = new BaseStore(initialState, "testKey", true);
+    store.updateItem("users", "1", { name: "Updated John Doe" });
+
+    expect(mockStorage.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        users: expect.objectContaining({
+          "1": { id: "1", name: "Updated John Doe" },
+        }),
+      }),
+    );
+  });
+
+  it("does not use localStorage when useCacheAndStorage is false", () => {
+    jest
+      .spyOn(StorageFactory, "getStorage")
+      .mockImplementation(() => mockStorage);
+
+    store = new BaseStore(initialState, "testKey", false);
+    const newUser = { id: "3", name: "New User" };
+    store.setItem("users", newUser);
+
+    expect(mockStorage.save).not.toHaveBeenCalled();
+  });
+});

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/tests/SimpleCache.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/tests/SimpleCache.spec.ts
@@ -1,0 +1,84 @@
+import { SimpleCache, CacheFactory } from "../modules/SimpleCache";
+
+describe("SimpleCache", () => {
+  let cache: SimpleCache<any>;
+
+  beforeEach(() => {
+    cache = new SimpleCache();
+  });
+
+  it("should set and get a value", () => {
+    const key = "testKey";
+    const value = { foo: "bar" };
+
+    cache.set(key, value);
+    const retrievedValue = cache.get(key);
+
+    expect(retrievedValue).toEqual(value);
+  });
+
+  it("should return null for non-existent key", () => {
+    const nonExistentKey = "nonExistentKey";
+    const retrievedValue = cache.get(nonExistentKey);
+
+    expect(retrievedValue).toBeNull();
+  });
+
+  it("should overwrite existing value", () => {
+    const key = "testKey";
+    const initialValue = { foo: "bar" };
+    const newValue = { foo: "baz" };
+
+    cache.set(key, initialValue);
+    cache.set(key, newValue);
+    const retrievedValue = cache.get(key);
+
+    expect(retrievedValue).toEqual(newValue);
+  });
+
+  it("should clear all cached values", () => {
+    cache.set("key1", "value1");
+    cache.set("key2", "value2");
+
+    cache.clear();
+
+    expect(cache.get("key1")).toBeNull();
+    expect(cache.get("key2")).toBeNull();
+  });
+});
+
+describe("CacheFactory", () => {
+  beforeEach(() => {
+    (CacheFactory as any).cacheInstances = {};
+  });
+
+  it("should create a new cache instance if it doesn't exist", () => {
+    const cache1 = CacheFactory.getCache("cache1");
+    expect(cache1).toBeInstanceOf(SimpleCache);
+  });
+
+  it("should return the same cache instance for the same name", () => {
+    const cache1 = CacheFactory.getCache("cache1");
+    const cache1Again = CacheFactory.getCache("cache1");
+    expect(cache1).toBe(cache1Again);
+  });
+
+  it("should create different cache instances for different names", () => {
+    const cache1 = CacheFactory.getCache("cache1");
+    const cache2 = CacheFactory.getCache("cache2");
+    expect(cache1).not.toBe(cache2);
+  });
+
+  it("should maintain separate data for different cache instances", () => {
+    const cache1 = CacheFactory.getCache<string>("cache1");
+    const cache2 = CacheFactory.getCache<number>("cache2");
+
+    cache1.set("key1", "value1");
+    cache2.set("key2", 42);
+
+    expect(cache1.get("key1")).toBe("value1");
+    expect(cache2.get("key2")).toBe(42);
+    expect(cache1.get("key2")).toBeNull();
+    expect(cache2.get("key1")).toBeNull();
+  });
+});

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/utils/BaseStore.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/utils/BaseStore.ts
@@ -1,0 +1,151 @@
+import { BaseLocalStorageInterface } from "../../types/stores/BaseLocalStorageInterface";
+import { Cache } from "../../types/stores/Cache";
+import { CacheFactory } from "../modules/SimpleCache";
+import { StorageFactory } from "../BaseLocalStorageStore";
+
+type CollectionType = { [key: string]: any };
+
+export class BaseStore<T extends Record<string, CollectionType>> {
+  protected store: T;
+  private cache: Cache<any> | null = null;
+  private storage: BaseLocalStorageInterface<T> | null = null;
+
+  constructor(
+    initialState: T,
+    storageKey?: string,
+    useCacheAndStorage: boolean = false,
+  ) {
+    this.store = initialState;
+    if (storageKey) {
+      if (useCacheAndStorage) {
+        this.cache = CacheFactory.getCache<T>(storageKey);
+        this.storage = StorageFactory.getStorage<T>(storageKey);
+      } else {
+        this.cache = CacheFactory.getCache<T>(storageKey);
+      }
+      if (this.storage) {
+        const storedData = this.storage.load();
+        if (storedData) {
+          this.store = { ...this.store, ...storedData };
+        }
+      }
+    }
+  }
+
+  private generateCacheKey<K extends keyof T>(
+    collection: K,
+    id: string,
+  ): string {
+    return `${String(collection)}_${id}`;
+  }
+
+  getItem<K extends keyof T>(collection: K, id: string): T[K][string] | null {
+    try {
+      const cacheKey = this.generateCacheKey(collection, id);
+      if (this.cache) {
+        const cachedItem = this.cache.get(cacheKey);
+        if (cachedItem) {
+          return cachedItem;
+        }
+      }
+      const item = this.store[collection][id] || null;
+      if (this.cache && item) {
+        this.cache.set(cacheKey, item);
+      }
+      return item;
+    } catch (error) {
+      console.warn(
+        `Error getting item from collection "${String(collection)}" with id "${id}":`,
+        error,
+      );
+      return null;
+    }
+  }
+
+  setItem<K extends keyof T>(
+    collection: K,
+    item: T[K][string] & { id: string },
+  ): void {
+    try {
+      const id = item.id;
+      (this.store[collection] as CollectionType)[id] = item;
+      if (this.cache) {
+        const cacheKey = this.generateCacheKey(collection, id);
+        this.cache.set(cacheKey, item);
+      }
+      if (this.storage) {
+        this.storage.save(this.store);
+      }
+    } catch (error) {
+      console.warn(
+        `Error getting item from collection "${String(collection)}":`,
+        error,
+      );
+    }
+  }
+
+  removeItem<K extends keyof T>(collection: K, id: string): void {
+    delete this.store[collection][id];
+    if (this.cache) {
+      const cacheKey = this.generateCacheKey(collection, id);
+      this.cache.set(cacheKey, null);
+    }
+    if (this.storage) {
+      this.storage.save(this.store);
+    }
+  }
+
+  updateItem<K extends keyof T>(
+    collection: K,
+    id: string,
+    updatedItem: Partial<T[K][string]>,
+  ): void {
+    const currentItem = this.store[collection][id];
+    if (currentItem) {
+      (this.store[collection] as CollectionType)[id] = {
+        ...currentItem,
+        ...updatedItem,
+      };
+      if (this.cache) {
+        const cacheKey = this.generateCacheKey(collection, id);
+        this.cache.set(cacheKey, this.store[collection][id]);
+      }
+      if (this.storage) {
+        this.storage.save(this.store);
+      }
+    }
+  }
+
+  getAllItems<K extends keyof T>(
+    collection: K,
+  ): { [key: string]: T[K][string] } {
+    return JSON.parse(JSON.stringify(this.store[collection]));
+  }
+
+  searchItems<K extends keyof T>(
+    collection: K,
+    predicate: (value: T[K][string]) => boolean,
+  ): { [key: string]: T[K][string] } {
+    const result: { [key: string]: T[K][string] } = {};
+    for (const key in this.store[collection]) {
+      if (
+        this.store[collection].hasOwnProperty(key) &&
+        predicate(this.store[collection][key])
+      ) {
+        result[key] = this.store[collection][key];
+      }
+    }
+    return result;
+  }
+
+  getPaginatedItems<K extends keyof T>(
+    collection: K,
+    page: number,
+    pageSize: number,
+  ): T[K][string][] {
+    const allItems = Object.values(this.store[collection]);
+    const start = (page - 1) * pageSize;
+    const end = start + pageSize;
+    return allItems.slice(start, end);
+  }
+}

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/utils/BaseStore.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/utils/BaseStore.ts
@@ -144,7 +144,7 @@ export class BaseStore<T extends Record<string, CollectionType>> {
     pageSize: number,
   ): T[K][string][] {
     const allItems = Object.values(this.store[collection]);
-    const start = (page - 1) * pageSize;
+    const start = page ? (page - 1) * pageSize : 0;
     const end = start + pageSize;
     return allItems.slice(start, end);
   }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/utils/readme.md
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/utils/readme.md
@@ -1,0 +1,97 @@
+# State Management with BaseStore
+
+## Overview
+The `BaseStore` is a foundational class designed to manage state based on the Flux pattern. It is not intended to be used
+directly in Vue components or views. Instead, it serves as a base class for creating specific stores that encapsulate
+application logic and state management. This document provides guidelines on how to extend `BaseStore` to create
+custom stores, initialize them in the `RootStore`, and configure caching and local storage.
+
+## Creating a Custom Store
+To create a custom store, extend the `BaseStore` and add specific methods to manage the state. Here is an example of
+how to create a `UserStore`:
+
+### Example: UserStore
+```typescript
+import { BaseStore } from './BaseStore';
+
+interface User {
+    id: string;
+    name: string;
+    age: number;
+}
+
+interface UserStoreState {
+    users: { [key: string]: User };
+}
+
+class UserStore extends BaseStore<UserStoreState> {
+    constructor(initialState: UserStoreState, storageKey?: string, useCacheAndStorage: boolean = false) {
+    super(initialState, storageKey, useCacheAndStorage);
+    }
+
+    getUser(id: string): User | null {
+    return this.getItem('users', id);
+    }
+
+    setUser(user: User): void {
+    this.setItem('users', user);
+    }
+
+    removeUser(id: string): void {
+    this.removeItem('users', id);
+    }
+
+    updateUser(id: string, updatedUser: Partial<User>): void {
+    this.updateItem('users', id, updatedUser);
+    }
+
+    getAllUsers(): { [key: string]: User } {
+    return this.getAllItems('users');
+    }
+
+    searchUsers(predicate: (user: User) => boolean): { [key: string]: User } {
+    return this.searchItems('users', predicate);
+    }
+
+    getPaginatedUsers(page: number, pageSize: number): User[] {
+    return this.getPaginatedItems('users', page, pageSize);
+    }
+}
+```
+
+## Why a Factory is being used for cache and localStorage functionalities?
+The factory pattern is used to manage the creation and configuration of cache and storage modules. This approach
+provides several benefits:
+1. **Centralized Configuration**: Ensures consistent configuration and usage of caching and storage mechanisms
+   across different stores.
+2. **Lazy Initialization**: Cache and storage instances are created only when needed, reducing unnecessary
+   initialization.
+3. **Flexibility**: Allows for easy updates and changes to the caching and storage strategies without modifying the
+   store logic.
+
+## Initializing the Store in RootStore, with cache and localStorage functionalities
+The `RootStore` is a global place to initialize and manage all stores. This ensures that stores are only created once and can be easily accessed throughout the application. 
+Initializing the store in the `RootStore` is important because it makes the store available throughout the entire project and allows you to pass the necessary flags to enable caching and local storage if required by the new store.
+
+### Example: RootStore
+```typescript
+import { reactive, UnwrapNestedRefs } from 'vue';
+import { RundeckClient } from '@rundeck/client';
+import { UserStore } from './UserStore';
+
+export class RootStore {
+    userStore: UnwrapNestedRefs<UserStore>;
+    // Other stores...
+
+    constructor(readonly client: RundeckClient, appMeta: any = {}) {
+    this.userStore = reactive(new UserStore({ users: {} }, 'userStore', true));
+    // Initialize other stores...
+    }
+}
+```
+
+### Note:
+In the example above, 2 extra parameters are being passed along with the initial state of the UserStore:
+
+- second parameter is the storageKey, in this case, `userStore`: This is the storage key used to identify the store's data being cached. 
+- third parameter is a flag useCacheAndStorage: This flag enables both caching and local storage for the UserStore. When set to true, the store will use caching mechanisms and persist its state in local storage, under the storageKey passed as the second parameter. 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/utils/readme.md
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/utils/readme.md
@@ -30,32 +30,36 @@ class UserStore extends BaseStore<UserStoreState> {
     }
 
     getUser(id: string): User | null {
-    return this.getItem('users', id);
+        return this.getItem(this.storageKey, id);
     }
 
-    setUser(user: User): void {
-    this.setItem('users', user);
+    setUsers(users: User[]): void {
+        for (user in users) {
+           this.setItem(this.storageKey, user);
+        }
     }
 
     removeUser(id: string): void {
-    this.removeItem('users', id);
+    this.removeItem(this.storageKey, id);
     }
 
     updateUser(id: string, updatedUser: Partial<User>): void {
-    this.updateItem('users', id, updatedUser);
+    this.updateItem(this.storageKey, id, updatedUser);
     }
 
     getAllUsers(): { [key: string]: User } {
-    return this.getAllItems('users');
+    return this.getAllItems(this.storageKey);
     }
 
     searchUsers(predicate: (user: User) => boolean): { [key: string]: User } {
-    return this.searchItems('users', predicate);
+    return this.searchItems(this.storageKey, predicate);
     }
 
     getPaginatedUsers(page: number, pageSize: number): User[] {
-    return this.getPaginatedItems('users', page, pageSize);
+    return this.getPaginatedItems(this.storageKey, page, pageSize);
     }
+
+   // fetch methods would be responsible for calling the service methods to retrieve data from api. Upon succeeding, the setUsers method would be called to store the data.
 }
 ```
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/utils/readme.md
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/utils/readme.md
@@ -64,14 +64,7 @@ class UserStore extends BaseStore<UserStoreState> {
 ```
 
 ## Why a Factory is being used for cache and localStorage functionalities?
-The factory pattern is used to manage the creation and configuration of cache and storage modules. This approach
-provides several benefits:
-1. **Centralized Configuration**: Ensures consistent configuration and usage of caching and storage mechanisms
-   across different stores.
-2. **Lazy Initialization**: Cache and storage instances are created only when needed, reducing unnecessary
-   initialization.
-3. **Flexibility**: Allows for easy updates and changes to the caching and storage strategies without modifying the
-   store logic.
+This approach was necessary to mitigate the complexity introduced by global state management, particularly in large applications with numerous stores. By using the factory pattern, it is possible to create isolated instances of cache and storage for each store, thereby avoiding potential conflicts that arise when different stores require distinct configurations or behaviors.
 
 ## Initializing the Store in RootStore, with cache and localStorage functionalities
 The `RootStore` is a global place to initialize and manage all stores. This ensures that stores are only created once and can be easily accessed throughout the application. 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/types/stores/BaseLocalStorageInterface.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/types/stores/BaseLocalStorageInterface.ts
@@ -1,4 +1,4 @@
 export interface BaseLocalStorageInterface<T> {
-  load(): Promise<T>;
-  store(data: T): Promise<void>;
+  load(): Promise<T> | null;
+  save(data: T): void;
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/types/stores/Cache.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/types/stores/Cache.ts
@@ -1,0 +1,5 @@
+export interface Cache<T> {
+  get(key: string): T | null;
+  set(key: string, value: T): void;
+  clear(): void;
+}

--- a/rundeckapp/grails-spa/packages/ui-trellis/tsconfig.app.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/tsconfig.app.json
@@ -33,6 +33,7 @@
     "src/library/stories",
     "src/library/components",
     "src/library/**/*.stories.tsx",
+    "**/*.spec.ts",
     "node_modules"
   ]
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/tsconfig.build.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/tsconfig.build.json
@@ -21,6 +21,7 @@
     "**/*.stories.ts",
     "**/*.stories.tsx",
     "**/*.test.ts",
+    "**/*.spec.ts",
     "./src/library/stories/**/*"
   ]
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/tsconfig.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/tsconfig.json
@@ -20,5 +20,8 @@
     // "./src/library/**/*",
     // "tests/**/*.ts",
     // "tests/**/*.tsx"
+  ],
+  "exclude":[
+    "**/*.spec.ts"
   ]
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/tsconfig.webpack.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/tsconfig.webpack.json
@@ -26,6 +26,7 @@
     "./src/app",
     "**/*.stories.ts",
     "**/*.stories.tsx",
+    "**/*.spec.ts",
     "node_modules/**/*"
   ]
 }


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
As per https://docs.google.com/document/d/1s2k4BaLpBkxaFEqs-53nkvEgACugR_175ealC-j2HpU/edit?tab=t.xa3sd6k9kpe0#heading=h.7ieekuzay2dl

The goal of this PR is to create a boilerplate that can be used for creating stores and performing state management in the front-end.  The link to the doc that explains things in more detail is here: https://docs.google.com/document/d/1qNcdQ8hmDH-nPsypLAS0AHdHBK96T37HSdvCGZXnh0o/edit?tab=t.0, 
but I also added an initial readme that can be considered a TLDR; of sorts.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Create a baseStore based on the flux pattern, that can cache and save data in the localStorage.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
Considered to also add commits and dispatchers to the store so that people wouldn't trigger mutations (setters) or actions directly, but thought that it would be overengineering at this point.

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
Pagination and search should be optimized but will do so as soon as will implement the first store.