### PR TITLE
RUN-2860 Increase waiting time for check period

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
@@ -134,7 +134,7 @@ class ExecutionSpec extends BaseContainer {
             // Waits for all executions to get cleaned
             waitFor(ExecutionUtils.Retrievers.executionsForProject(client, projectName),
                 {it.isEmpty()},
-                WaitingTime.XTRA_EXCESSIVE)
+                WaitingTime.XTRA_EXCESSIVE, WaitingTime.MODERATE)
             deleteProject(projectName)
 
             tmpjar.delete()

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
@@ -1,7 +1,9 @@
 package org.rundeck.tests.functional.api.execution
 
+import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.rundeck.util.annotations.APITest
+import org.rundeck.util.api.responses.execution.Execution
 import org.rundeck.util.common.WaitingTime
 import org.rundeck.util.common.execution.ExecutionStatus
 import org.rundeck.util.common.execution.ExecutionUtils
@@ -131,9 +133,20 @@ class ExecutionSpec extends BaseContainer {
                 json2.executions.size() == 6
             }
         cleanup:
+            def executionsRetrived = {->
+                try {
+                    return ExecutionUtils.Retrievers.executionsForProject(client, projectName).get()
+                } catch (JsonParseException e) {
+                    // if request doesnt return an expected json, return null to retry
+                    return null
+                }
+            }
+
             // Waits for all executions to get cleaned
-            waitFor(ExecutionUtils.Retrievers.executionsForProject(client, projectName),
-                {it.isEmpty()},
+            waitFor(executionsRetrived,
+                {
+                    it != null && it.isEmpty()
+                }, // retry if executions are not empty or list is null
                 WaitingTime.XTRA_EXCESSIVE, WaitingTime.MODERATE)
             deleteProject(projectName)
 

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
@@ -144,9 +144,7 @@ class ExecutionSpec extends BaseContainer {
 
             // Waits for all executions to get cleaned
             waitFor(executionsRetrived,
-                {
-                    it != null && it.isEmpty()
-                }, // retry if executions are not empty or list is null
+                {it != null && it.isEmpty()}, // retry if executions are not empty or list is null
                 WaitingTime.XTRA_EXCESSIVE, WaitingTime.MODERATE)
             deleteProject(projectName)
 

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
@@ -133,17 +133,18 @@ class ExecutionSpec extends BaseContainer {
                 json2.executions.size() == 6
             }
         cleanup:
-            def executionsRetrived = {->
+            def retrieveExecutions = {->
                 try {
                     return ExecutionUtils.Retrievers.executionsForProject(client, projectName).get()
                 } catch (JsonParseException e) {
                     // if request doesnt return an expected json, return null to retry
+                    e.printStackTrace()
                     return null
                 }
             }
 
             // Waits for all executions to get cleaned
-            waitFor(executionsRetrived,
+            waitFor(retrieveExecutions,
                 {it != null && it.isEmpty()}, // retry if executions are not empty or list is null
                 WaitingTime.XTRA_EXCESSIVE, WaitingTime.MODERATE)
             deleteProject(projectName)


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Try to fix a flaky test increasing waiting time to check period to avoid hibernate exception when trying to access an object that could be removed

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
Checking log from circleci, we can see this error when get the executions from api request:
`[docker-java-stream-2080914965] INFO org.rundeck.util.container.RdContainer - STDOUT: org.hibernate.ObjectNotFoundException: No row with the given identifier exists: [rundeck.Workflow#22]
    [docker-java-stream-2080914965] INFO org.rundeck.util.container.RdContainer - STDOUT:       at org.hibernate.boot.internal.StandardEntityNotFoundDelegate.handleEntityNotFound(StandardEntityNotFoundDelegate.java:28) ~[hibernate-core-5.6.15.Final.jar!/:5.6.15.Final]
    [docker-java-stream-2080914965] INFO org.rundeck.util.container.RdContainer - STDOUT:       at org.hibernate.proxy.AbstractLazyInitializer.checkTargetState(AbstractLazyInitializer.java:298) ~[hibernate-core-5.6.15.Final.jar!/:5.6.15.Final]
    [docker-java-stream-2080914965] INFO org.rundeck.util.container.RdContainer - STDOUT:       at org.hibernate.proxy.AbstractLazyInitializer.initialize(AbstractLazyInitializer.java:187) ~[hibernate-core-5.6.15.Final.jar!/:5.6.15.Final]
    [docker-java-stream-2080914965] INFO org.rundeck.util.container.RdContainer - STDOUT:       at org.hibernate.proxy.AbstractLazyInitializer.getImplementation(AbstractLazyInitializer.java:322) ~[hibernate-core-5.6.15.Final.jar!/:5.6.15.Final]
    [docker-java-stream-2080914965] INFO org.rundeck.util.container.RdContainer - STDOUT:       at org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor.intercept(ByteBuddyInterceptor.java:45) ~[hibernate-core-5.6.15.Final.jar!/:5.6.15.Final]
    [docker-java-stream-2080914965] INFO org.rundeck.util.container.RdContainer - STDOUT:       at org.hibernate.proxy.ProxyConfiguration$InterceptorDispatcher.intercept(ProxyConfiguration.java:95) ~[hibernate-core-5.6.15.Final.jar!/:5.6.15.Final]
    [docker-java-stream-2080914965] INFO org.rundeck.util.container.RdContainer - STDOUT:       at rundeck.data.util.ExecReportUtil.summarizeJob(ExecReportUtil.groovy:58) ~[grails-rundeck-data-shared-0.1-plain.jar!/:?]
    [docker-java-stream-2080914965] INFO org.rundeck.util.container.RdContainer - STDOUT:       at rundeck.services.ExecutionService$__tt__respondExecutionsJson_closure100.doCall(ExecutionService.groovy:281) ~[classes!/:?]
    [docker-java-stream-2080914965] INFO org.rundeck.util.container.RdContainer - STDOUT:       at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
    [docker-java-stream-2080914965] INFO org.rundeck.util.container.RdContainer - STDOUT:       at rundeck.services.ExecutionService.$tt__respondExecutionsJson(ExecutionService.groovy:275) ~[classes!/:?]
    [docker-java-stream-2080914965] INFO org.rundeck.util.container.RdContainer - STDOUT:       at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
    [docker-java-stream-2080914965] INFO org.rundeck.util.container.RdContainer - STDOUT:       at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]`
