### PR TITLE
RPL-82: Alternate Plugin Blocklist Enhancement

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/common/PluginControlServiceImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/PluginControlServiceImpl.java
@@ -1,9 +1,12 @@
 package com.dtolabs.rundeck.core.common;
 
+import com.dtolabs.rundeck.core.plugins.PluginRegistry;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -12,16 +15,30 @@ public class PluginControlServiceImpl implements PluginControlService {
     public static final String DISABLED_PLUGINS = "disabled.plugins";
     private HashSet<String> disabledPlugins;
     private final IFramework framework;
+    private final PluginRegistry pluginRegistry;
     private final String project;
 
-    private PluginControlServiceImpl(IFramework framework, String project) {
+    private PluginControlServiceImpl(IFramework framework, PluginRegistry pluginRegistry, String project) {
         this.framework = framework;
+        this.pluginRegistry = pluginRegistry;
         this.project = project;
     }
 
 
+    /**
+     * Creates a PluginControlService that only checks for disabled plugins at the project level. This version of the
+     * service is deprecated and the PluginRegistry aware version of the service should be preferred.
+     */
+    @Deprecated
     public static PluginControlService forProject(IFramework framework, String project) {
-        return new PluginControlServiceImpl(framework, project);
+        return new PluginControlServiceImpl(framework, null, project);
+    }
+
+    /**
+     * Creates a PluginControlService that checks for disabled plugins at both the global and project levels.
+     */
+    public static PluginControlService forProject(IFramework framework, PluginRegistry pluginRegistry, String project) {
+        return new PluginControlServiceImpl(framework, pluginRegistry, project);
     }
 
     private Set<String> getDisabledPlugins() {
@@ -55,8 +72,20 @@ public class PluginControlServiceImpl implements PluginControlService {
     public Predicate<String> enabledPredicateForService(
         final String serviceName
     ) {
-        Set<String> strings = getDisabledPlugins();
-        return name -> !strings.contains(serviceName + ":" + name);
+        Optional<PluginRegistry> globalRegistry = Optional.ofNullable(pluginRegistry);
+        Set<String> pluginsDisabledByProject = getDisabledPlugins();
+
+        return (String name) -> {
+            boolean blockedByRegistry = globalRegistry
+                    .map(r -> r.isBlockedPlugin(serviceName, name))
+                    .orElse(false);
+
+            if (blockedByRegistry) {
+                return false;
+            }
+
+            return !pluginsDisabledByProject.contains(serviceName + ":" + name);
+        };
     }
 
     /**
@@ -66,6 +95,14 @@ public class PluginControlServiceImpl implements PluginControlService {
      */
     @Override
     public boolean isDisabledPlugin(String pluginName, final String serviceName) {
+        boolean blockedByRegistry = Optional.ofNullable(pluginRegistry)
+                .map(r -> r.isBlockedPlugin(serviceName, pluginName))
+                .orElse(false);
+
+        if (blockedByRegistry) {
+            return true;
+        }
+
         return getDisabledPlugins().contains(serviceName + ":" + pluginName);
     }
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginRegistry.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginRegistry.java
@@ -285,4 +285,6 @@ public interface PluginRegistry {
      * @return true if the plugin was registered
      */
     boolean hasRegisteredPlugin(String type, String name);
+
+    boolean isBlockedPlugin(String serviceName, String providerName);
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginRegistry.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/PluginRegistry.java
@@ -286,5 +286,9 @@ public interface PluginRegistry {
      */
     boolean hasRegisteredPlugin(String type, String name);
 
+    /**
+     * Indicates whether a particular plugin provider is blocked (disabled).
+     * @return true if the plugin provider is blocked.
+     */
     boolean isBlockedPlugin(String serviceName, String providerName);
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/common/PluginControlServiceImplSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/common/PluginControlServiceImplSpec.groovy
@@ -1,0 +1,86 @@
+package com.dtolabs.rundeck.core.common
+
+import com.dtolabs.rundeck.core.plugins.PluginRegistry
+import spock.lang.Specification
+
+import static com.dtolabs.rundeck.core.common.PluginControlServiceImpl.DISABLED_PLUGINS
+import static com.dtolabs.rundeck.plugins.ServiceNameConstants.WorkflowNodeStep
+
+class PluginControlServiceImplSpec extends Specification {
+    static def PROJECT_NAME = "some-test-project"
+
+    def enabledPluginName = "enabled-plugin-name"
+    def globallyDisabledPluginName = "globally-disabled-plugin-name"
+    def projectDisabledPluginName = "project-disabled-plugin-name"
+    def mockFrameworkProject = Mock(IRundeckProject) {
+        getProperty(DISABLED_PLUGINS) >> "${WorkflowNodeStep}:${projectDisabledPluginName}"
+        hasProperty(DISABLED_PLUGINS) >> true
+    }
+
+    def framework = Mock(IFramework) {
+        getFrameworkProjectMgr() >> Mock(ProjectManager) {
+            getFrameworkProject(PROJECT_NAME) >> mockFrameworkProject
+        }
+    }
+
+    def mockPluginRegistry = Mock(PluginRegistry) {
+        isBlockedPlugin(WorkflowNodeStep, globallyDisabledPluginName) >> true
+        isBlockedPlugin(_ as String, _ as String) >> false
+    }
+
+    def "is aware of both project-specific and global plugin blocks"() {
+        given: "PluginRegistry aware PluginControlService"
+        def sut = PluginControlServiceImpl.forProject(framework, mockPluginRegistry, PROJECT_NAME)
+        when:
+        def enabledProviderChecker = sut.enabledPredicateForService(WorkflowNodeStep)
+
+        then: "project-specific plugins are disabled"
+        verifyAll {
+            !enabledProviderChecker.test(projectDisabledPluginName)
+            sut.isDisabledPlugin(projectDisabledPluginName, WorkflowNodeStep)
+        }
+
+        and: "global plugins are disabled"
+        verifyAll {
+            !enabledProviderChecker.test(globallyDisabledPluginName)
+            sut.isDisabledPlugin(globallyDisabledPluginName, WorkflowNodeStep)
+        }
+
+        and: "enabled plugins are enabled"
+        verifyAll {
+            enabledProviderChecker.test(enabledPluginName)
+            !sut.isDisabledPlugin(enabledPluginName, WorkflowNodeStep)
+        }
+
+        and: "it does not match partial plugin names"
+        verifyAll {
+            enabledProviderChecker.test("project-disabled-plu")
+            !sut.isDisabledPlugin("project-disabled-plu", WorkflowNodeStep)
+        }
+    }
+
+    def "is aware of only project-specific blocks"() {
+        given: "PluginControlService"
+        def sut = PluginControlServiceImpl.forProject(framework, PROJECT_NAME)
+        when:
+        def enabledProviderChecker = sut.enabledPredicateForService(WorkflowNodeStep)
+
+        then: "project-specific plugins are disabled"
+        verifyAll {
+            !enabledProviderChecker.test(projectDisabledPluginName)
+            sut.isDisabledPlugin(projectDisabledPluginName, WorkflowNodeStep)
+        }
+
+        and: "global plugins are enabled"
+        verifyAll {
+            enabledProviderChecker.test(globallyDisabledPluginName)
+            !sut.isDisabledPlugin(globallyDisabledPluginName, WorkflowNodeStep)
+        }
+
+        and: "enabled plugins are enabled"
+        verifyAll {
+            enabledProviderChecker.test(enabledPluginName)
+            !sut.isDisabledPlugin(enabledPluginName, WorkflowNodeStep)
+        }
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/integration/BlocklistSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/integration/BlocklistSpec.groovy
@@ -7,32 +7,59 @@ import org.rundeck.util.container.BaseContainer
 class BlocklistSpec extends BaseContainer {
 
 
-    public static final int EXPECTED_PLUGIN_LIST_SIZE = 65
+    public static final int EXPECTED_PLUGIN_LIST_SIZE = 62
     static List<String> BLOCKED_NAMES = [
-        'cyberark',
-        'openssh',
-        'ansible',
-        'copyfile',
-        'localexec',
-        'rundeck-script'
+            'cyberark',
+            'openssh',
+            'ansible',
+            'copyfile',
+            'localexec',
+            'rundeck-script'
+    ]
+
+    static Map<String, List<String>> BLOCKED_PROVIDERS = [
+            "NodeExecutor": [
+                    "local",
+                    "sshj-ssh"
+            ],
+            "FileCopier": [
+                    "script-copy",
+                    "sshj-scp"
+            ],
+            "ResourceModelSource": [
+                    "directory",
+                    "file",
+                    "local",
+                    "script"
+            ]
     ]
 
     def "test blocklist does not contain blocked plugins"() {
+        given:
+        def isBlockedPlugin = { plugin ->
+            BLOCKED_PROVIDERS.containsKey(plugin["service"]) &&
+                    BLOCKED_PROVIDERS.getOrDefault(plugin["service"], List.of()).contains(plugin["name"])
+        }
+
         when:
-            List<Map> response = get("/plugin/list", List)
-            def artifactNames = response*.artifactName.collect { it.toString().toLowerCase() }
-        then:
-            verifyAll {
-                for (String name : BLOCKED_NAMES) {
-                    artifactNames.find { it.contains(name) } == null
-                }
+        List<Map> response = get("/plugin/list", List)
+        def artifactNames = response*.artifactName.collect { it.toString().toLowerCase() }
+
+        then: "plugins blocked by jar file are not listed"
+        verifyAll {
+            for (String name : BLOCKED_NAMES) {
+                artifactNames.find { it.contains(name) } == null
             }
+        }
+
+        and: "individual plugins blocked by name are not listed"
+        response.forEach { plugin -> assert !isBlockedPlugin(plugin) }
     }
 
     def "test expected plugin count"() {
         when:
-            List<Map> response = get("/plugin/list", List)
+        List<Map> response = get("/plugin/list", List)
         then:
-            response.size() == EXPECTED_PLUGIN_LIST_SIZE
+        response.size() == EXPECTED_PLUGIN_LIST_SIZE
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -32,6 +32,7 @@ import com.dtolabs.rundeck.core.execution.service.NodeExecutorService
 import com.dtolabs.rundeck.core.options.RemoteJsonOptionRetriever
 import com.dtolabs.rundeck.core.plugins.PluggableProviderRegistryService
 import com.dtolabs.rundeck.core.plugins.PluggableProviderService
+import com.dtolabs.rundeck.core.plugins.PluginRegistry
 import com.dtolabs.rundeck.core.plugins.configuration.*
 import com.dtolabs.rundeck.core.resources.ResourceModelSourceFactory
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
@@ -81,7 +82,7 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService, F
     ExecutionService executionService
     MetricService metricService
     Framework rundeckFramework
-    def rundeckPluginRegistry
+    PluginRegistry rundeckPluginRegistry
     PluginService pluginService
     PluginControlService pluginControlService
     def scheduledExecutionService
@@ -693,7 +694,7 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService, F
     }
 
     def PluginControlService getPluginControlService(String project) {
-        PluginControlServiceImpl.forProject(getRundeckFramework(), project)
+        PluginControlServiceImpl.forProject(getRundeckFramework(), rundeckPluginRegistry, project)
     }
 
     static Map<String,String> parseOptsFromString(String argstring){

--- a/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
@@ -73,7 +73,7 @@ class PluginApiService {
         Map<String, List<Description>> pluginDescs = [:]
 
         //framework level plugin descriptions
-        //TODO: use pluginService.listPlugins for these services/plugintypes
+        //TODO: use pluginService.listPlugins for this service / plugintype
         StepExecutionService ses = framework.getStepExecutionService()
         pluginDescs[ses.name] = ses.listDescriptions()
                 .sort {a,b -> a.name <=> b.name }
@@ -97,7 +97,9 @@ class PluginApiService {
         pluginDescs['ResourceModelSource'] = pluginService.listPlugins(
                 ResourceModelSourceFactory,
                 framework.getResourceModelSourceService()
-        ).collect { it.value.description }.sort { a, b -> a.name <=> b.name }
+        )
+                .collect { it.value.description }
+                .sort { a, b -> a.name <=> b.name }
 
         pluginDescs[ServiceNameConstants.NodeEnhancer]=pluginService.listPlugins(NodeEnhancerPlugin).collect {
             it.value.description

--- a/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
@@ -76,22 +76,22 @@ class PluginApiService {
         StepExecutionService ses = framework.getStepExecutionService()
         pluginDescs[ses.name] = pluginService.listPlugins(StepExecutor, ses)
                 .findAll { it.value.description != null }
-                .collect {it.value.description }
+                .collect { it.value.description }
                 .sort {a,b -> a.name <=> b.name }
 
         NodeExecutorService nes = framework.getNodeExecutorService()
         pluginDescs[nes.name] = pluginService.listPlugins(NodeExecutor, nes)
-                .collect {it.value.description }
+                .collect { it.value.description }
                 .sort { a, b -> a.name <=> b.name }
 
         NodeStepExecutionService nses = framework.getNodeStepExecutorService()
         pluginDescs[nses.name] = pluginService.listPlugins(NodeStepExecutor, nses)
-                .collect {it.value.description }
+                .collect { it.value.description }
                 .sort { a, b -> a.name <=> b.name }
 
         FileCopierService fcs = framework.getFileCopierService()
         pluginDescs[fcs.name] = pluginService.listPlugins(FileCopier, fcs)
-                .collect {it.value.description }
+                .collect { it.value.description }
                 .sort { a, b -> a.name <=> b.name }
 
         ResourceModelSourceService rmss = framework.getResourceModelSourceService()

--- a/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
@@ -18,6 +18,7 @@ import com.dtolabs.rundeck.core.plugins.configuration.Property
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyScope
 import com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants
 import com.dtolabs.rundeck.core.resources.ResourceModelSourceFactory
+import com.dtolabs.rundeck.core.resources.ResourceModelSourceService
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
 import com.dtolabs.rundeck.plugins.audit.AuditEventListenerPlugin
 import com.dtolabs.rundeck.plugins.config.PluginGroup
@@ -72,10 +73,10 @@ class PluginApiService {
 
         Map<String, List<Description>> pluginDescs = [:]
 
-        //framework level plugin descriptions
-        //TODO: use pluginService.listPlugins for this service / plugintype
         StepExecutionService ses = framework.getStepExecutionService()
-        pluginDescs[ses.name] = ses.listDescriptions()
+        pluginDescs[ses.name] = pluginService.listPlugins(StepExecutor, ses)
+                .findAll { it.value.description != null }
+                .collect {it.value.description }
                 .sort {a,b -> a.name <=> b.name }
 
         NodeExecutorService nes = framework.getNodeExecutorService()
@@ -93,11 +94,9 @@ class PluginApiService {
                 .collect {it.value.description }
                 .sort { a, b -> a.name <=> b.name }
 
-        //load via pluginService to include spring-based app plugins
-        pluginDescs['ResourceModelSource'] = pluginService.listPlugins(
-                ResourceModelSourceFactory,
-                framework.getResourceModelSourceService()
-        )
+        ResourceModelSourceService rmss = framework.getResourceModelSourceService()
+        pluginDescs[rmss.name] = pluginService.listPlugins(ResourceModelSourceFactory, rmss)
+                .findAll { it.value.description != null }
                 .collect { it.value.description }
                 .sort { a, b -> a.name <=> b.name }
 

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/plugins/RundeckPluginRegistry.groovy
@@ -801,4 +801,9 @@ class RundeckPluginRegistry implements ApplicationContextAware, PluginRegistry, 
         }
         rundeckServerServiceProviderLoader.getPluginMetadata service, provider
     }
+
+    @Override
+    boolean isBlockedPlugin(String serviceName, String providerName) {
+        return rundeckPluginBlocklist.isPluginProviderPresent(serviceName, providerName)
+    }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/PluginServiceTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/PluginServiceTests.groovy
@@ -277,6 +277,11 @@ class PluginServiceTests extends Specification {
         boolean hasRegisteredPlugin(final String type, final String name) {
             return false
         }
+
+        @Override
+        boolean isBlockedPlugin(String serviceName, String providerName) {
+            return false
+        }
     }
 
     void testGetPluginDNE() {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is an enhancement to [the plugin blocklist](https://docs.rundeck.com/docs/administration/security/blocklist.html) when blocking specific plugins by provider name. In the current state, when plugins for certain types of providers (e.g. WorkflowNodeStep) were blocked, they would still show up in various UIs and APIs. With this change, a blocked plugin will be more cleanly removed from these UIs and APIs.

**Context**
The `PluginBlocklist` / `RundeckPluginBlocklist` manages the list of blocked plugins and plugin containers (files). A few services are aware of this blocklist but the PluginRegistry is the primary one. Flows that obtain plugin information from the `PluginService` and / or the `PluginRegistry` properly filter out blocked plugins.

A number of other flows including the `/plugins/list` API and the "Installed Plugins" UI are based on the data provided by [PluginApiService.listPluginsDetailed](https://github.com/rundeck/rundeck/blob/c9436262299372134d160d7aedd1dcd9bde7bb06/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy#L60). For some service providers, this function loads up plugins via the `PluginService` (which properly applies the blocklist). For others providers, the plugins are loaded using the `PluginManagerService` (which is not aware of the blocklist).

A few other flows [including the creating / editing a workflow] also load plugins by directly calling listDescriptions() on particular services. After loading the plugins, these flows make use of `PluginControlServiceImpl` to filter out disabled plugins. However, `PluginControlServiceImpl` is currently only aware of plugins that are disabled at a Project-level. It is not aware of globally disabled plugins.

**Describe the solution you've implemented**
This solution more clearly filters out blocked plugins by making changes in two areas:
* Updating the [PluginApiService.listPluginsDetailed()](https://github.com/rundeck/rundeck/blob/6f8d475276bb76d49f27270ee92f542d42eb26e1/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy#L66-L77) method to load more plugin types via `PluginService.listPlugins` instead of via the `DescribableService` itself.
* Updating the [PluginControlServiceImpl](https://github.com/rundeck/rundeck/blob/6f8d475276bb76d49f27270ee92f542d42eb26e1/core/src/main/java/com/dtolabs/rundeck/core/common/PluginControlServiceImpl.java#L10) such that the service is aware of plugins blocked globally and plugins blocked at the project-level.

This solution is cleaner than the one that was introduced in https://github.com/rundeck/rundeck/pull/9397 because it makes use of or enhances plugin-related services that were already [at least partially] aware of the blocklist: `PluginControlServiceImpl`, `PluginService`, `RundeckPluginRegistry`, etc. while leaving the `PluginManagerService` as a lower-level service responsible for actually loading and providing plugins.

**Describe alternatives you've considered**
See: https://github.com/rundeck/rundeck/pull/9397

**Additional context**
This change stops short of updating all flows that use `PluginControlServiceImpl` due to the complexity involved with getting the `PluginRegistry` into `ExecutionContextImpl`.
