### PR TITLE
RUN-2930: Removes unused code from PluginControlService

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/common/PluginControlService.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/PluginControlService.java
@@ -16,10 +16,6 @@
 
 package com.dtolabs.rundeck.core.common;
 
-import com.dtolabs.rundeck.core.plugins.configuration.Description;
-
-import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
 
 /**
@@ -27,32 +23,10 @@ import java.util.function.Predicate;
  */
 public interface PluginControlService {
     /**
-     * @return list of disabled plugins for the project, in Service:provider format
-     */
-    List<String> listDisabledPlugins();
-    Set<String> getDisabledPlugins();
-
-    /**
-     * @param plugins     descriptions list
-     * @param serviceName service name
-     * @return list of enabled plugin descriptions
-     */
-    List<Description> filterEnabledPlugins(
-        List<Description> plugins,
-        String serviceName
-    );
-
-    /**
      * @param serviceName service name
      * @return predicate for testing enabled providers for a service
      */
     Predicate<String> enabledPredicateForService(String serviceName);
-
-    /**
-     * @param serviceName service name
-     * @return predicate for testing disabled providers for a service
-     */
-    Predicate<String> disabledPredicateForService(String serviceName);
 
     /**
      * @param pluginName  provider name

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/PluginControlServiceImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/PluginControlServiceImpl.java
@@ -1,14 +1,12 @@
 package com.dtolabs.rundeck.core.common;
 
-import com.dtolabs.rundeck.core.plugins.configuration.Description;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
-/**
- * Created by rodrigo on 30-01-18.
- */
 public class PluginControlServiceImpl implements PluginControlService {
 
     public static final String DISABLED_PLUGINS = "disabled.plugins";
@@ -23,20 +21,10 @@ public class PluginControlServiceImpl implements PluginControlService {
 
 
     public static PluginControlService forProject(IFramework framework, String project) {
-
         return new PluginControlServiceImpl(framework, project);
     }
 
-    /**
-     * @return list of disabled plugins for the project, in Service:provider format
-     */
-    @Override
-    public List<String> listDisabledPlugins() {
-        return new ArrayList<>(getDisabledPlugins());
-    }
-
-    @Override
-    public Set<String> getDisabledPlugins() {
+    private Set<String> getDisabledPlugins() {
         if (null == disabledPlugins) {
             synchronized (this) {
                 if (null == disabledPlugins) {
@@ -60,23 +48,6 @@ public class PluginControlServiceImpl implements PluginControlService {
     }
 
     /**
-     * @param plugins     descriptions list
-     * @param serviceName service name
-     * @return list of enabled plugin descriptions
-     */
-    @Override
-    public List<Description> filterEnabledPlugins(
-        List<Description> plugins,
-        final String serviceName
-    ) {
-        Set<String> strings = getDisabledPlugins();
-        return plugins
-            .stream()
-            .filter(description -> !strings.contains(serviceName + ":" + description.getName()))
-            .collect(Collectors.toList());
-    }
-
-    /**
      * @param serviceName service name
      * @return predicate for testing enabled providers for a service
      */
@@ -86,16 +57,6 @@ public class PluginControlServiceImpl implements PluginControlService {
     ) {
         Set<String> strings = getDisabledPlugins();
         return name -> !strings.contains(serviceName + ":" + name);
-    }
-    /**
-     * @param serviceName service name
-     * @return predicate for testing disabled providers for a service
-     */
-    @Override
-    public Predicate<String> disabledPredicateForService(
-        final String serviceName
-    ) {
-        return enabledPredicateForService(serviceName).negate();
     }
 
     /**

--- a/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/FrameworkServiceSpec.groovy
@@ -17,44 +17,26 @@
 package rundeck.services
 
 import com.dtolabs.rundeck.app.support.ExecutionCleanerConfig
-import com.dtolabs.rundeck.core.authentication.Group
-import com.dtolabs.rundeck.core.authentication.Username
-import com.dtolabs.rundeck.core.authorization.AclRuleBuilder
-import com.dtolabs.rundeck.core.authorization.AclRuleImpl
-import com.dtolabs.rundeck.core.authorization.AclRuleSet
-import com.dtolabs.rundeck.core.authorization.AclRuleSetAuthorization
-import com.dtolabs.rundeck.core.authorization.AclRuleSetImpl
 import com.dtolabs.rundeck.core.authorization.AuthContextEvaluator
-import com.dtolabs.rundeck.core.authorization.Authorization
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.Framework
-import com.dtolabs.rundeck.core.common.FrameworkProject
-import com.dtolabs.rundeck.core.common.IFramework
 import com.dtolabs.rundeck.core.common.INodeEntry
 import com.dtolabs.rundeck.core.common.IRundeckProject
 import com.dtolabs.rundeck.core.common.IRundeckProjectConfig
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import com.dtolabs.rundeck.core.common.ProjectManager
-import com.dtolabs.rundeck.core.common.PropertyRetriever
 import com.dtolabs.rundeck.core.config.Features
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutionService
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepExecutionService
 import com.dtolabs.rundeck.core.plugins.DescribedPlugin
 import com.dtolabs.rundeck.core.plugins.PluggableProviderRegistryService
-import com.dtolabs.rundeck.core.plugins.PluggableProviderService
 import com.dtolabs.rundeck.core.plugins.configuration.Description
-import com.dtolabs.rundeck.core.plugins.configuration.DynamicProperties
 import com.dtolabs.rundeck.core.plugins.configuration.Property
-import com.dtolabs.rundeck.core.plugins.configuration.PropertyResolverFactory
-import com.dtolabs.rundeck.core.utils.IPropertyLookup
-import com.dtolabs.rundeck.core.utils.PropertyLookup
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import com.dtolabs.rundeck.plugins.util.PropertyBuilder
 import grails.events.bus.EventBus
-import grails.test.mixin.TestFor
 import grails.testing.services.ServiceUnitTest
 import org.grails.plugins.metricsweb.MetricService
-import org.rundeck.app.spi.Services
 import org.rundeck.core.auth.AuthConstants
 import org.rundeck.core.projects.ProjectConfigurable
 import rundeck.PluginStep
@@ -62,7 +44,6 @@ import rundeck.services.feature.FeatureService
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import javax.security.auth.Subject
 import javax.servlet.http.HttpSession
 
 /**
@@ -540,29 +521,6 @@ class FrameworkServiceSpec extends Specification implements ServiceUnitTest<Fram
             ['a.svc.type1.p1': 'v','a.svc2.typeA.pA': 'q'] | 'a'    | 2     | [svc: ['type1'],svc2:['typeA']] | ['svc','svc2']
             ['a.svc.type1.p1': 'v','a.svc2.typeA.pA': 'q'] | 'a'    | 2     | [svc2:['typeA']] | ['svc2']
             ['a.svc.type1.p1': 'v','a.svc2.typeA.pA': 'q'] | 'a'    | 2     | [svc: ['type1']] | ['svc']
-    }
-
-    def "get plugin control service"() {
-        given:
-            service.rundeckFramework = Mock(Framework){
-                getFrameworkProjectMgr() >> Mock(ProjectManager) {
-                    1 * getFrameworkProject(project) >> Mock(IRundeckProject) {
-                        1 * hasProperty('disabled.plugins') >> hasProp
-                        getProperty('disabled.plugins') >> propVal
-                    }
-                }
-            }
-
-            def ctrla = service.getPluginControlService(project)
-        when:
-            def pluga = ctrla.listDisabledPlugins()
-        then:
-
-            pluga == expect
-        where:
-            project    | hasProp | propVal | expect
-            'projectA' | true    | 'a,b,c' | ['a', 'b', 'c']
-            'projectB' | false   | null    | []
     }
 
     @Unroll


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is a small cleanup PR that removes unused code from `PluginControlService` before new code is added in subsequent PRs.

**Describe the solution you've implemented**
Deleted unused methods.

**Describe alternatives you've considered**
N/A

**Additional context**
N/A
