### PR TITLE
RCLOUD-1413 Removes unused template invocation in login page.

### DIFF
--- a/rundeckapp/grails-app/views/user/login.gsp
+++ b/rundeckapp/grails-app/views/user/login.gsp
@@ -159,9 +159,6 @@
                           </div>
                     </g:if>
                     <!--/SSO Login Feature-->
-                    <g:templateExists name="extendedlogin">
-                      <g:render template="extendedlogin" />
-                    </g:templateExists>
                     <g:showLocalLogin>
 
                     <g:set var="loginmsg" value="${cfg.getString(config: "gui.login.welcome",  default: g.message(code: 'gui.login.welcome', default: ''))}"/>


### PR DESCRIPTION
The code change will remove a template invocation in login.gsp, the login page. As far as we know it is only used for a rundeckpro functionality that is being removed.

There is a related commit for this same issue on rundeckpro.

See original changes that introduced this on the UI on RCLOUD-561 and RCLOUD-596.
