### PR TITLE
RUN-2987: fix: invalid workflow step causes uncaught exception

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2644,7 +2644,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         }
         if (!execution.save(flush:true)) {
             execution.errors.allErrors.each { log.warn(it.toString()) }
-            def msg=execution.errors.allErrors.collect { ObjectError err-> lookupMessage(err.codes,err.arguments,err.defaultMessage) }.join(", ")
+            def msg=execution.errors.allErrors.collect { ObjectError err-> lookupMessage(err.codes,err.arguments?.toList(),err.defaultMessage) }.join(", ")
             log.error("unable to create execution: " + msg)
             throw new ExecutionServiceException("unable to create execution: "+msg)
         }


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Fix a bug: if a workflow step definition is not valid, at execution time the error handling causes an exception.

```
Caused by: groovy.lang.MissingMethodException: No signature of method: rundeck.services.ExecutionService.lookupMessage() is applicable for argument types: ([Ljava.lang.String;, [Ljava.lang.Object;, String) values: [[scheduledExecution.workflow.invalidstepslist.message.rundeck.Execution.scheduledExecution.workflow, ...], ...]
Possible solutions: lookupMessage([Ljava.lang.String;, java.util.List, java.lang.String), lookupMessage([Ljava.lang.String;, java.util.List), lookupMessage(java.lang.String, java.util.List, java.lang.String), lookupMessage(java.lang.String, java.util.List)
	at rundeck.services.ExecutionService._tt__int_createExecution_closure143(ExecutionService.groovy:2647)
	at groovy.lang.Closure.call(Closure.java:427)
	at groovy.lang.Closure.call(Closure.java:416)
	at rundeck.services.ExecutionService.$tt__int_createExecution(ExecutionService.groovy:2647)
	at rundeck.services.ExecutionService.int_createExecution_closure48(ExecutionService.groovy)
	at groovy.lang.Closure.call(Closure.java:427)
	at groovy.lang.Closure.call(Closure.java:416)
	at grails.gorm.transactions.GrailsTransactionTemplate$2.doInTransaction(GrailsTransactionTemplate.groovy:94)
	at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:140)
	at grails.gorm.transactions.GrailsTransactionTemplate.execute(GrailsTransactionTemplate.groovy:91)
	at rundeck.services.ExecutionService.$pub__createExecution(ExecutionService.groovy:2714)
```

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
fix method call to look up the validation error message

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
