### PR TITLE
RUN-2440 multiselect with all values selected should use values if job referenced or via api

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobSpec.groovy
@@ -38,6 +38,30 @@ class JobSpec extends BaseContainer {
         ].every({fullLog.contains(it)})
     }
 
+    def "Run job with multiselect all selected option"(){
+        given:
+        def r = JobUtils.executeJobWithOptions('213b0213-cb72-417e-9707-1371eb44dfe3', client, ["options":[:]])
+        assert r.successful
+        Execution execution = MAPPER.readValue(r.body().string(), Execution.class)
+
+        waitForExecutionFinish(execution.id)
+        String fullLog = JobUtils.getExecutionOutputText(execution.id as String, client)
+        expect:
+        fullLog.contains('var1,var2,var3,var4')
+    }
+
+    def "Run job with multiselect all selected option with custom value"(){
+        given:
+        def r = JobUtils.executeJobWithOptions('213b0213-cb72-417e-9707-1371eb44dfe3', client, ["options":['test':'var2']])
+        assert r.successful
+        Execution execution = MAPPER.readValue(r.body().string(), Execution.class)
+
+        waitForExecutionFinish(execution.id)
+        String fullLog = JobUtils.getExecutionOutputText(execution.id as String, client)
+        expect:
+        fullLog.contains('var2')
+    }
+
     def "Create the same job twice fails"() {
         given:
         def jobName = UUID.randomUUID().toString()

--- a/functional-test/src/test/resources/projects-import/TestJobs/rundeck-TestJobs/jobs/job-213b0213-cb72-417e-9707-1371eb44dfe3.xml
+++ b/functional-test/src/test/resources/projects-import/TestJobs/rundeck-TestJobs/jobs/job-213b0213-cb72-417e-9707-1371eb44dfe3.xml
@@ -1,0 +1,29 @@
+<joblist>
+  <job>
+    <context>
+      <options preserveOrder='true'>
+        <option delimiter=',' enforcedvalues='true' multivalueAllSelected='true' multivalued='true' name='test' type='text' values='var1,var2,var3,var4' valuesListDelimiter=',' />
+      </options>
+    </context>
+    <defaultTab>nodes</defaultTab>
+    <description></description>
+    <executionEnabled>true</executionEnabled>
+    <id>213b0213-cb72-417e-9707-1371eb44dfe3</id>
+    <loglevel>INFO</loglevel>
+    <name>jobOptionsSelectAllTest</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <plugins />
+    <runnerSelector>
+      <runnerFilterMode>LOCAL</runnerFilterMode>
+      <runnerFilterType>LOCAL_RUNNER</runnerFilterType>
+    </runnerSelector>
+    <scheduleEnabled>true</scheduleEnabled>
+    <schedules />
+    <sequence keepgoing='false' strategy='node-first'>
+      <command>
+        <exec>echo ${option.test}</exec>
+      </command>
+    </sequence>
+    <uuid>213b0213-cb72-417e-9707-1371eb44dfe3</uuid>
+  </job>
+</joblist>

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2844,8 +2844,12 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         if (options) {
             def defaultoptions=[:]
             options.each {OptionData opt ->
-                if (null==optparams[opt.name] && opt.defaultValue) {
-                    defaultoptions[opt.name]=opt.defaultValue
+                if (null==optparams[opt.name]) {
+                    if(opt.defaultValue) {
+                        defaultoptions[opt.name] = opt.defaultValue
+                    } else if(opt.multivalued && opt.multivalueAllSelected){
+                        defaultoptions[opt.name] = opt.valuesList
+                    }
                 }
             }
             if(defaultoptions){

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionService2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionService2Spec.groovy
@@ -445,6 +445,66 @@ class ExecutionService2Spec extends Specification implements ServiceUnitTest<Exe
         Map newmap = svc.addOptionDefaults(se, optParams)
 
         assertEquals('', newmap['test'])
+
+        expect:
+        // asserts validate above
+        1 == 1
+    }
+
+    void testAddOptionDefaults_ShouldAddMultivaluedIfAllSelected(){
+        ExecutionService svc = new ExecutionService()
+
+        ScheduledExecution se = new ScheduledExecution(
+                jobName: 'blue',
+                project: 'AProject',
+                groupPath: 'some/where',
+                description: 'a job',
+                uuid: 'abc',
+                workflow: new Workflow(keepgoing: true, commands: [new CommandExec([adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle'])])
+        )
+        def opt1 = new Option(name: 'test', enforced: false, multivalued: true, multivalueAllSelected: true, valuesList: ['a,b,c'], delimiter:',')
+        se.addToOptions(opt1)
+        if (!se.validate()) {
+        }
+        assertNotNull se.save()
+
+        Map optParams = [:]
+
+        Map newmap = svc.addOptionDefaults(se, optParams)
+
+        assertEquals('a,b,c', newmap['test'])
+
+        expect:
+        // asserts validate above
+        1 == 1
+    }
+
+    void testAddOptionDefaults_ShouldNotReplaceMultivalued(){
+        ExecutionService svc = new ExecutionService()
+
+        ScheduledExecution se = new ScheduledExecution(
+                jobName: 'blue',
+                project: 'AProject',
+                groupPath: 'some/where',
+                description: 'a job',
+                uuid: 'abc',
+                workflow: new Workflow(keepgoing: true, commands: [new CommandExec([adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle'])])
+        )
+        def opt1 = new Option(name: 'test', enforced: false, multivalued: true, multivalueAllSelected: true, valuesList: ['a,b,c'], delimiter:',')
+        se.addToOptions(opt1)
+        if (!se.validate()) {
+        }
+        assertNotNull se.save()
+
+        Map optParams = ['test':'a']
+
+        Map newmap = svc.addOptionDefaults(se, optParams)
+
+        assertEquals('a', newmap['test'])
+
+        expect:
+        // asserts validate above
+        1 == 1
     }
 
     void testCreateExecutionRetryOptionValue(){


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
When a job has options that uses multivalues and all values is selected by default, the option value is empty when called by parent job or via api

**Describe the solution you've implemented**
It add default option values if it is multivalued type and all values is selected by default

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
