### PR TITLE
RUN-2810: Fix execution modal when nextUi mode is enabled

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/BulkJobActionsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/BulkJobActionsSpec.groovy
@@ -187,31 +187,28 @@ class BulkJobActionsSpec extends SeleniumBase {
         ExecutionShowPage executionShowPage = page ExecutionShowPage
         executionShowPage.validatePage()
     }
+    
+    def "job can be executed from the Job List Page modal with nextUI"() {
+        given:
+        String jobToExecute = generateJob(["opt1-required": "false", "opt2-required": "false"])
 
-//    /**
-//     * Once  nextUI is fixed, running this test will result in a green test run
-//     */
-//    def "job can be executed from the Job List Page modal with nextUI"() {
-//        given:
-//        String jobToExecute = generateJob(["opt1-required": "false", "opt2-required": "false"])
-//
-//        JobListPage jobsListPage = page JobListPage
-//
-//        jobsListPage.loadPathToNextUI SELENIUM_BASIC_PROJECT
-//        jobsListPage.go()
-//
-//        when:
-//        def job1RunButton = jobsListPage.waitIgnoringForElementToBeClickable(jobsListPage.getExecuteJobInModalButton(jobToExecute))
-//        job1RunButton.click()
-//
-//        def runJobNowButton = jobsListPage.waitIgnoringForElementToBeClickable(jobsListPage.getExecuteJobModalRunJobNowButton(), Duration.ofSeconds(2))
-//        runJobNowButton.click()
-//        jobsListPage.waitForUrlToContain('/execution/show/')
-//
-//        then:
-//        ExecutionShowPage executionShowPage = page ExecutionShowPage
-//        executionShowPage.validatePage()
-//    }
+        JobListPage jobsListPage = page JobListPage
+
+        jobsListPage.loadPathToNextUI SELENIUM_BASIC_PROJECT
+        jobsListPage.go()
+
+        when:
+        def job1RunButton = jobsListPage.waitIgnoringForElementToBeClickable(jobsListPage.getExecuteJobInModalButton(jobToExecute))
+        job1RunButton.click()
+
+        def runJobNowButton = jobsListPage.waitIgnoringForElementToBeClickable(jobsListPage.getExecuteJobModalRunJobNowButton(), Duration.ofSeconds(2))
+        runJobNowButton.click()
+        jobsListPage.waitForUrlToContain('/execution/show/')
+
+        then:
+        ExecutionShowPage executionShowPage = page ExecutionShowPage
+        executionShowPage.validatePage()
+    }
 
     /**
      * Should be in JobUtils, but it's going through a refactor, thus it's here for now

--- a/rundeckapp/grails-app/assets/javascripts/menu/jobs.next.js
+++ b/rundeckapp/grails-app/assets/javascripts/menu/jobs.next.js
@@ -21,6 +21,8 @@
 //= require scheduledExecution/jobRunFormOptionsKO
 //= require knockout.min
 //= require koBind
+//= require nodeFiltersKO
+
 /*
 Next gen UI, this code should be migrated eventually to Vue
  */

--- a/rundeckapp/grails-app/views/menu/jobs.next.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.next.gsp
@@ -26,6 +26,7 @@
     <asset:javascript src="menu/jobs.next.js"/>
     <asset:javascript src="static/pages/project-activity.js" defer="defer"/>
     <asset:javascript src="static/pages/job/browse.js" defer="defer"/>
+    <asset:javascript src="static/pages/nodes.js" defer="defer"/>
     <asset:stylesheet href="static/css/pages/job/browse.css" />
 
     <g:jsMessages code="Node,Node.plural,job.starting.execution,job.scheduling.execution,option.value.required,options.remote.dependency.missing.required,,option.default.button.title,option.default.button.text,option.select.choose.text"/>
@@ -236,6 +237,7 @@
 })
     </g:javascript>
     <g:embedJSON id="pageQueryParams" data="${[queryParams:params]}"/>
+    <g:embedJSON id="pageParams" data="${[project: params.project?:request.project]}"/>
 </head>
 
 <body>

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -78,7 +78,7 @@
     <section class="form-horizontal section-separator">
         <div class="vue-ui-socket">
             <div>
-                <ui-socket section="resources-override-filter" location="top" :event-bus="EventBus" />
+                <ui-socket section="resources-override-filter" location="top" />
             </div>
         </div>
     </section>

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -83,7 +83,7 @@
         </div>
     </section>
 
-    <section class="form-horizontal section-separator"
+    <section class="form-horizontal section-separator section-pad-top-lg"
              style="${wdgt.styleVisible(if: nodesetvariables && !failedNodes || nodesetempty || nodes)}">
 
         <div class="form-group">
@@ -126,7 +126,7 @@
                         <input name="extra._replaceNodeFilters"
                                value="true"
                                type="checkbox"
-                               data-bind="checked: changeTargetNodes"
+                               data-bind="checked: changeTargetNodes, attr: {disabled: !canOverrideFilter()}"
                                id="doReplaceFilters"/>
                         <label for="doReplaceFilters">
                             <g:message code="change.the.target.nodes"/>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/runstrap/_checkbox-radio.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/runstrap/_checkbox-radio.scss
@@ -59,8 +59,13 @@
   opacity: 1;
 }
 
+.checkbox input[type="checkbox"]:disabled {
+  cursor: not-allowed;
+}
+
 .checkbox input[type="checkbox"]:disabled + label {
   color: #cfcfcf;
+  cursor: not-allowed;
 }
 
 .checkbox input[type="checkbox"]:disabled + label::before {


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Fixes the problem where the execution modal would be broken if the UI currently uses the nextUi flag enabled, as it would fail to load the UI for overriding nodes for the job.

The problem consisted of 2 separate matters:

- with the nextUi enabled, the UI loads a different gsp page than the default one, which was missing 2 imports for correctly loading the UI for overriding nodes and an embedJson called pageParams;
- besides that, the UI for the execution modal was allowing users to override the nodes as long as the initial filter wasn't a dynamic one (ie `name: ${options.name}`), but wasn't initiating the required scripts for this functionality if the job was set to not allow node changes (filter overrides). 

**Describe the solution you've implemented**
To solve both matters, the following was done:

- add missing imports and embedJson;
- disable the checkbox that would allow the override when job is set to not allow filter overrides;

plus: 
- added a small padding on the top of the nodes section in the execution modal;
- removed an event bus parameter that was triggering an warning in the console;

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

I've considered to tweak the scripts initialization instead of blocking the checkbox, but upon speaking with the team, the conclusion was that it was better to prioritize honoring the flag for filter overrides being disabled.

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
Screenshot of results:
![Screenshot 2024-11-21 at 12 46 12 PM](https://github.com/user-attachments/assets/bef9278d-f271-4322-b196-57dc2295af0e)

![Screenshot 2024-11-21 at 12 46 25 PM](https://github.com/user-attachments/assets/d1829d71-7969-43ba-b867-4ae24cc2009e)

![Screenshot 2024-11-21 at 12 46 33 PM](https://github.com/user-attachments/assets/33d4b84c-5daf-46bf-965f-9e094d6c890f)

![Screenshot 2024-11-21 at 12 46 49 PM](https://github.com/user-attachments/assets/7ff97f3d-d249-4485-a4eb-439114b6639e)

![Screenshot 2024-11-21 at 12 47 33 PM](https://github.com/user-attachments/assets/7d41c2b5-6d17-4e82-b0ba-087859be83ee)



