### PR TITLE
RUN-2725 : Expose additional plugin properties in `*/plugin/list` API responses

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/PluginController.groovy
@@ -199,6 +199,8 @@ Since: v33
                         pluginVersion: p.pluginVersion,
                         title: p.title,
                         description: p.description,
+                        isHighlighted: p.isHighlighted,
+                        highlightedOrder: p.highlightedOrder,
                         author: p.pluginAuthor,
                         iconUrl: p.iconUrl,
                         providerMetadata: p.providerMetadata,

--- a/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/PluginApiService.groovy
@@ -303,6 +303,8 @@ class PluginApiService {
                  name         : provider.name,
                  title        : provider.title,
                  description  : provider.description,
+                 isHighlighted  : provider.isHighlighted(),
+                 highlightedOrder      : provider.getOrder(),
                  builtin      : builtin,
                  pluginVersion: ver,
                  pluginAuthor : author,

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/plugins/ApiPluginListProvider.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/plugins/ApiPluginListProvider.groovy
@@ -21,4 +21,12 @@ class ApiPluginListProvider {
     @ApiVersion(40)
     @Schema(description = 'Map of metadata about the plugin if present. Since: v40')
     Map<String, String> providerMetadata
+
+    @ApiVersion(50)
+    @Schema(description = 'Indication of whether the plugin is marked as highlighted. Since: v50')
+    Boolean isHighlighted
+
+    @ApiVersion(50)
+    @Schema(description = 'Order of the highlighted plugin. Since: v50')
+    Integer highlightedOrder
 }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/plugins/ApiPluginListProvider.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/plugins/ApiPluginListProvider.groovy
@@ -22,11 +22,11 @@ class ApiPluginListProvider {
     @Schema(description = 'Map of metadata about the plugin if present. Since: v40')
     Map<String, String> providerMetadata
 
-    @ApiVersion(50)
-    @Schema(description = 'Indication of whether the plugin is marked as highlighted. Since: v50')
+    @ApiVersion(51)
+    @Schema(description = 'Indication of whether the plugin is marked as highlighted. Since: v51')
     Boolean isHighlighted
 
-    @ApiVersion(50)
-    @Schema(description = 'Order of the highlighted plugin. Since: v50')
+    @ApiVersion(51)
+    @Schema(description = 'Order of the highlighted plugin. Since: v51')
     Integer highlightedOrder
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/PluginControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/PluginControllerSpec.groovy
@@ -265,6 +265,48 @@ class PluginControllerSpec extends Specification implements ControllerUnitTest<P
             'WebhookEvent'   | 2
     }
 
+    def "plugin list returns isHighlighted and highlightedOrder properties"() {
+        given:
+        controller.pluginService = Mock(PluginService)
+        controller.pluginApiService = Mock(PluginApiService)
+        controller.uiPluginService = Mock(UiPluginService)
+        params.service = null
+
+        def plugins = [
+                [
+                        service  : 'WebhookEvent',
+                        providers: [
+                                [isHighlighted   : true,
+                                 highlightedOrder: 123
+                                ],
+                                [:]],
+                ],
+                [
+                        service  : 'Foo',
+                        providers: [
+                                [isHighlighted   : Boolean.FALSE,
+                                 highlightedOrder: Integer.valueOf(321)
+                                ]
+                        ]
+                ]
+        ]
+
+        when:
+        controller.listPlugins()
+        then:
+        1 * controller.pluginApiService.listPlugins() >> plugins
+        response.json.size() == 3
+
+        response.json[0].isHighlighted == true
+        response.json[0].highlightedOrder == 123
+
+        !response.json[1].isHighlighted
+        !response.json[1].highlightedOrder
+
+        response.json[2].isHighlighted == false
+        response.json[2].highlightedOrder == 321
+    }
+
     def "plugin service descriptions"() {
         given:
         controller.pluginService = Mock(PluginService)

--- a/rundeckapp/src/test/groovy/rundeck/services/PluginApiServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/PluginApiServiceSpec.groovy
@@ -84,6 +84,8 @@ class PluginApiServiceSpec extends Specification implements ServiceUnitTest<Plug
         entry.name == "fake"
         entry.title == "Fake Plugin"
         entry.description == "This is the best fake plugin"
+        entry.highlightedOrder == 1
+        entry.isHighlighted == true
         entry.builtin == false
         entry.pluginVersion == "1.0"
         entry.pluginDate == 1534253342000
@@ -382,6 +384,16 @@ class PluginApiServiceSpec extends Specification implements ServiceUnitTest<Plug
         @Override
         String getDescription() {
             return "This is the best fake plugin"
+        }
+
+        @Override
+        boolean isHighlighted() {
+            return true
+        }
+
+        @Override
+        int getOrder() {
+            return 1
         }
 
         @Override


### PR DESCRIPTION
The enhancement to extend the responses of the `*/plugin/list API` to include `isHighlighted` and `highlightedOrder` properties.


**QA**

***Sample Response:***
```
GET http://localhost:4440/api/50/plugin/list
Accept:*/*
X-Rundeck-Auth-token:<...>
```

```
[
  {
    "iconUrl": "http://localhost:4440/plugin/icon/WorkflowStep/WinRMCheck",
    "title": "WinRM Check Step",
    "builtin": false,
    "id": "59ed572534b2",
    "providerMetadata": null,
    "service": "WorkflowStep",
    "highlightedOrder": 0,
    "artifactName": "py-winrm-plugin",
    "pluginVersion": "2.1.3",
    "description": "Check the connection with a remote node using winrm-python",
    "isHighlighted": false,
    "name": "WinRMCheck",
    "author": "© 2022, Pagerduty, Inc."
  },
  {
    "iconUrl": "http://localhost:4440/plugin/icon/WorkflowNodeStep/script-inline",
    "title": "Script",
    "builtin": false,
    "id": "4ca0a4eec11b",
    "providerMetadata": {
      "NodeStepPluginAdapter.DeprecatedConfigurationMode": "skip"
    },
    "service": "WorkflowNodeStep",
    "highlightedOrder": 1,
    "artifactName": "Script Node Step Plugin",
    "pluginVersion": "5.8.0-SNAPSHOT",
    "description": "Execute an inline script",
    "isHighlighted": true,
    "name": "script-inline",
    "author": "Rundeck, Inc."
  },
  {
    "iconUrl": null,
    "title": "Data Node Step",
    "builtin": false,
    "id": "44d92ebf4a8f",
    "providerMetadata": {
      "faicon": "database",
      "EnvironmentType": "localRunner"
    }
]
```
