### PR TITLE
RUN-2989: Add promoted/highlighted steps in the vue converted pieces for workflow

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/WorkflowSteps.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/WorkflowSteps.vue
@@ -132,6 +132,7 @@
           $t('plugin.type.WorkflowStep.title.plural'),
         ]"
         show-search
+        show-divider
         @cancel="addStepModal = false"
         @selected="chooseProviderAdd"
       >

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -937,6 +937,8 @@ const messages = {
   "workflow.search.help.string15": "property:title=value",
   "workflow.search.help.string16": "property name:",
   "workflow.search.help.string17": "property:name=value",
+  "node.step.plugin.plural": "{0} Node Step Plugins",
+  "workflow.step.plugin.plural": "{0} Workflow Step Plugins",
 };
 
 export default messages;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/ChoosePluginModal.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/ChoosePluginModal.vue
@@ -123,9 +123,10 @@ export default defineComponent({
   computed: {
     filteredServices() {
       return this.loadedServices.map((service) => {
-        const filteredProviders = service.providers.filter((provider) =>
-          this.matchesSearchQuery(provider),
-        );
+        const filteredProviders =
+          service.providers?.filter((provider) =>
+            this.matchesSearchQuery(provider),
+          ) || [];
         return {
           ...service,
           providers: filteredProviders,

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/ChoosePluginModal.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/ChoosePluginModal.vue
@@ -23,13 +23,14 @@
           >
             <p
               v-if="service.dividerIndex > 0 && index === service.dividerIndex"
+              data-testid="divider"
               class="list-group-item text-info text-strong"
             >
               {{ dividerTitle(service) }}
             </p>
             <button
               class="list-group-item"
-              data-testid="provider-button"
+              data-test="provider-button"
               @click.prevent="chooseProviderAdd(service.service, prov.name)"
             >
               <plugin-info
@@ -44,7 +45,11 @@
         </div>
       </tab>
     </tabs>
-    <div v-else-if="filteredServices.length === 1" class="list-group">
+    <div
+      v-else-if="filteredServices.length === 1"
+      class="list-group"
+      data-testid="list-view"
+    >
       <button
         v-for="prov in filteredServices[0].providers"
         class="list-group-item"
@@ -61,9 +66,9 @@
       </button>
     </div>
     <template #footer>
-      <btn data-testid="cancel-button" @click="$emit('cancel')">{{
-        $t("Cancel")
-      }}</btn>
+      <btn data-testid="cancel-button" @click="$emit('cancel')">
+        {{ $t("Cancel") }}
+      </btn>
     </template>
   </modal>
 </template>
@@ -125,7 +130,7 @@ export default defineComponent({
           ...service,
           providers: filteredProviders,
           dividerIndex: this.showDivider
-            ? this.getDividerPosition(filteredProviders)
+            ? this.calculateDividerIndex(filteredProviders)
             : undefined,
         };
       });
@@ -191,7 +196,7 @@ export default defineComponent({
     checkMatch(obj, field: string, val: string) {
       return obj[field] && val && obj[field].toLowerCase().indexOf(val) >= 0;
     },
-    getDividerPosition(providers: any) {
+    calculateDividerIndex(providers: any) {
       return providers.findIndex(
         (provider) => provider.isHighlighted === false,
       );
@@ -201,7 +206,7 @@ export default defineComponent({
         const numberOfPluginsNotHighlighted: number =
           service.providers.length - service.dividerIndex;
         let titleString: string = "node.step.plugin.plural";
-        if (service === ServiceType.WorkflowStep) {
+        if (service.service === ServiceType.WorkflowStep) {
           titleString = "workflow.step.plugin.plural";
         }
         return this.$t(titleString, [numberOfPluginsNotHighlighted]);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/ChoosePluginModal.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/ChoosePluginModal.spec.ts
@@ -1,53 +1,63 @@
-import { shallowMount, VueWrapper, flushPromises } from "@vue/test-utils";
+import { mount, VueWrapper, flushPromises } from "@vue/test-utils";
 import ChoosePluginModal from "../ChoosePluginModal.vue";
-import { Modal, Btn, Tabs, Tab } from "uiv";
-const mockServices = [
-  {
-    service: "mockService1",
-    providers: [{ name: "provider1" }, { name: "provider2" }],
-  },
-  {
-    service: "mockService2",
-    providers: [{ name: "provider3" }],
-  },
-];
+import PluginSearch from "../PluginSearch.vue";
+import { Popover, Tabs, Tab } from "uiv";
+
 jest.mock("@/library", () => ({
   getRundeckContext: jest.fn(() => ({
     rootStore: {
       plugins: {
         load: jest.fn(),
         getServicePlugins: jest.fn((service) =>
-          service === "mockService1"
-            ? [{ name: "provider1" }, { name: "provider2" }]
-            : [{ name: "provider3" }],
+          service === "WorkflowStep"
+            ? [
+                {
+                  name: "provider1",
+                  title: "plugin1",
+                  description: "done by John Doe",
+                  isHighlighted: true,
+                  highlightedOrder: 0,
+                },
+                {
+                  name: "provider2",
+                  title: "plugin2",
+                  description: "done by Jane Doe",
+                  isHighlighted: false,
+                  highlightedOrder: 0,
+                },
+              ]
+            : [
+                {
+                  name: "provider3",
+                  title: "plugin3",
+                  description: "run a script locally",
+                  isHighlighted: false,
+                },
+              ],
         ),
       },
     },
   })),
 }));
+
 const createWrapper = async (props = {}): Promise<VueWrapper<any>> => {
-  const wrapper = shallowMount(ChoosePluginModal, {
+  const wrapper = mount(ChoosePluginModal, {
     props: {
       title: "Test Title",
-      services: mockServices.map((s) => s.service),
+      services: ["WorkflowStep", "mockService2"],
       modelValue: true,
       tabNames: ["Service", "Provider"],
       ...props,
     },
     global: {
-      components: { Modal, Btn, Tabs, Tab },
-      stubs: {
-        Modal: false,
-        Btn: false,
-        Tabs: false,
-        Tab: false,
-      },
+      components: { Tabs, Tab, Popover },
     },
     attachTo: document.body,
   });
   await flushPromises();
   return wrapper;
 };
+
 describe("ChoosePluginModal", () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -55,25 +65,54 @@ describe("ChoosePluginModal", () => {
 
   it('emits "selected" event with correct data when a provider button is clicked', async () => {
     const wrapper = await createWrapper();
-    await flushPromises();
-    const providerButtons = wrapper.findAll('[data-testid="provider-button"]');
-    expect(providerButtons.length).toBe(3);
-    await providerButtons[0].trigger("click");
-    const emittedEvents = wrapper.emitted("selected");
-    expect(emittedEvents).toBeTruthy();
-    expect(emittedEvents?.[0]?.[0]).toEqual({
-      provider: "provider1",
-      service: "mockService1",
-    });
+    await wrapper.find('[data-test="provider-button"]').trigger("click");
+    expect(wrapper.emitted("selected")[0]).toEqual([
+      {
+        provider: "provider1",
+        service: "WorkflowStep",
+      },
+    ]);
   });
+
   it('emits "cancel" event when cancel button is clicked', async () => {
     const wrapper = await createWrapper();
-    await flushPromises();
     const cancelButton = wrapper.find('[data-testid="cancel-button"]');
-    expect(wrapper.text()).toContain("Cancel");
     await cancelButton.trigger("click");
-    const emittedEvents = wrapper.emitted("cancel");
-    expect(emittedEvents).toBeTruthy();
-    expect(emittedEvents?.length).toBe(1);
+    expect(wrapper.emitted("cancel")).toBeTruthy();
+  });
+
+  it("renders a list when there is a single service", async () => {
+    const wrapper = await createWrapper({ services: ["WorkflowStep"] });
+    expect(wrapper.findComponent(Tabs).exists()).toBeFalsy();
+    expect(wrapper.find('[data-testid="list-view"]').exists()).toBeTruthy();
+  });
+
+  it("renders an input for search when showSearch is true and correctly handles searches", async () => {
+    const wrapper = await createWrapper({ showSearch: true });
+    const searchComponent = wrapper.findComponent(PluginSearch);
+    expect(searchComponent.exists()).toBeTruthy();
+    searchComponent.vm.$emit("search", "plugin2");
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findAll("[data-test='provider-button']").length).toBe(1);
+    expect(wrapper.find("[data-test='provider-button']").text()).toBe(
+      "plugin2 - done by Jane Doe",
+    );
+    // when user erases the search query, reset results back to original
+    searchComponent.vm.$emit("search", "");
+    await wrapper.vm.$nextTick();
+
+    const tabsComponent = wrapper.findComponent(Tabs);
+    const tabTitles = tabsComponent.findAll('[role="tab"]');
+    expect(tabTitles[0].text()).toBe("Service (2)");
+    expect(tabTitles[1].text()).toBe("Provider (1)");
+    expect(wrapper.findAll("[data-test='provider-button']").length).toBe(3);
+  });
+
+  it("renders dividers if showDividers is true and dividerIndex for a service is different than 0", async () => {
+    const wrapper = await createWrapper({ showDivider: true });
+    const divider = wrapper.findAll('[data-testid="divider"]');
+    expect(divider.length).toBe(1);
+    expect(divider[0].text()).toBe("workflow.step.plugin.plural");
   });
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/Plugins.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/Plugins.ts
@@ -18,7 +18,7 @@ export class PluginStore {
   async load(service: string): Promise<void> {
     if (this.pluginsByService[service]) return void 0;
     const plugins = await this.client.apiRequest({
-      pathTemplate: "api/40/plugin/list",
+      pathTemplate: "api/51/plugin/list",
       queryParameters: {
         service,
       },
@@ -58,9 +58,18 @@ export class PluginStore {
 
   getServicePlugins(service: string): Plugin[] {
     return (
-      this.pluginsByService[service]?.sort((a, b) =>
-        a.title.localeCompare(b.title),
-      ) || []
+      this.pluginsByService[service]?.sort((a, b) => {
+        if (a.isHighlighted !== undefined && b.isHighlighted !== undefined) {
+          if (a.isHighlighted !== b.isHighlighted) {
+            return a.isHighlighted ? -1 : 1;
+          }
+
+          if (a.isHighlighted && b.isHighlighted) {
+            return a.highlightedOrder! - b.highlightedOrder!;
+          }
+        }
+        return a.title.localeCompare(b.title);
+      }) || []
     );
   }
 }
@@ -81,6 +90,8 @@ export interface Plugin {
     faicon?: string;
     fabicon?: string;
   };
+  isHighlighted?: boolean;
+  highlightedOrder?: number;
 }
 
 export enum ServiceType {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Follow-up of RUN-2725, consuming the exposed parameters in the /plugins/list to properly categorize the step plugins as highlighted/non-highlighted 

**Describe the solution you've implemented**
Update ChoosePluginModal to be able to handle sorting of the plugins by isHighlighted parameter and then by highlightedOrder, and finally by name.

Also, update the divider's title to match the number of non-highlighted plugins that matches the search query. 

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**

To see the changes, enable the alphaUi flag in the system config's UI (rundeck.feature.alphaUi.enabled)and the nextUi flag in the theme selector (bottom right corner).

After this PR:

![Screenshot 2024-11-27 at 2 31 36 PM](https://github.com/user-attachments/assets/4d89d4f9-4820-42e7-b7ef-731c0eabafd2)
