### PR TITLE
RUN-3011: Fix: JettyRolePropertyFileLoginModule supported in docker

### DIFF
--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -86,6 +86,8 @@ rundeck {
             {{ PropertyFileLoginModule("ReloadablePropertyFileLoginModule") }}
         {% elif module == "PropertyFileLoginModule" -%}
             {{ PropertyFileLoginModule("PropertyFileLoginModule") }}
+        {% elif module == "JettyRolePropertyFileLoginModule" -%}
+            {{ PropertyFileLoginModule("JettyRolePropertyFileLoginModule") }}
         {% endif %}
     {% endfor %}
 

--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -72,6 +72,7 @@
     {% endif %}
         {{ getv("/rundeck/jaas/file/required", "required") }}
         debug="true"
+        useFirstPass="{{ getv("/rundeck/jaas/file/usefirstpass", "false") }}"
         file="{{ rundeckHome }}/server/config/realm.properties";
 {% endmacro %}
 


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Fixes #8255 

Enable "JettyRolePropertyFileLoginModule" in the docker template.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Enable support for the JettyRolePropertyFileLoginModule.

To test:

You can use the this docker-zoo branch: https://github.com/rundeck/docker-zoo/pull/43

1. specify the image: `rundeck/ci:RUN-3011`
2. Login as admin/admin or build/build
3. observe the user profile displays groups as defined in the realm.properties here: https://github.com/rundeck/docker-zoo/pull/43/files#diff-b0f66ddc03aa3bd7f06998d3e6bfd143422909a8a929b1344f0fe0466634aa3d

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
