### PR TITLE
RUN-2950: Create new rest API endpoint that uses logic from nodesQueryAjax/nodesFragmentData

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -20,6 +20,8 @@ package rundeck.controllers
 import com.dtolabs.rundeck.app.api.project.sources.Resources
 import com.dtolabs.rundeck.app.api.project.sources.Source
 import com.dtolabs.rundeck.app.api.project.sources.Sources
+import com.dtolabs.rundeck.app.api.tag.TagForNodes
+import com.dtolabs.rundeck.app.api.tag.TagsForNodesResponse
 import com.dtolabs.rundeck.app.support.ExecutionCleanerConfigImpl
 import com.dtolabs.rundeck.app.support.PluginConfigParams
 import com.dtolabs.rundeck.core.authorization.AuthContext
@@ -469,6 +471,8 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
 
         return model
     }
+
+    @Deprecated
     def nodeSummaryAjax(String project){
 
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,project)
@@ -3522,24 +3526,11 @@ Since: v14''',
                                                            code: 'api.error.invalid.request', args: [query.errors.allErrors.collect { g.message(error: it) }.join("; ")]])
         }
         IFramework framework = frameworkService.getRundeckFramework()
-        if(!params.project){
-            return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_BAD_REQUEST,
-                                                           code: 'api.error.parameter.required', args: ['project']])
 
-        }
-        def exists=frameworkService.existsFrameworkProject(params.project)
-        if(!exists){
-            return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_NOT_FOUND,
-                                                           code: 'api.error.item.doesnotexist', args: ['project',params.project]])
-
-
-        }
         AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,params.project)
-        if (!rundeckAuthContextProcessor.authorizeProjectResource(authContext, AuthConstants.RESOURCE_TYPE_NODE,
-                AuthConstants.ACTION_READ, params.project)) {
-            return apiService.renderErrorFormat(response, [status: HttpServletResponse.SC_FORBIDDEN,
-                                                           code: 'api.error.item.unauthorized', args: ['Read Nodes', 'Project', params.project]])
-
+        def projectVerificationErrors = verifyProjectQueryParam(authContext, AuthConstants.RESOURCE_TYPE_NODE, AuthConstants.ACTION_READ, 'Read Nodes')
+        if (!projectVerificationErrors.isEmpty()) {
+            return apiService.renderErrorFormat(response, projectVerificationErrors)
         }
 
         //convert api parameters to node filter parameters
@@ -3564,6 +3555,42 @@ Since: v14''',
                 authContext
         )
         return apiRenderNodeResult(readnodes, framework, params.project)
+    }
+
+    @Get(uri='/project/{project}/nodes/tags', produces = io.micronaut.http.MediaType.APPLICATION_JSON)
+    @Operation(
+            method='GET',
+            summary='List tags for project nodes',
+            description='''List tags for project nodes.
+
+Since: v52''',
+            tags=['project','nodes'],
+            parameters = [
+                    @Parameter(name = 'project', description = 'Project Name', required = true, in = ParameterIn.PATH, schema = @Schema(type = 'string'))
+            ])
+    @ApiResponse(
+                    responseCode='200',
+                    description='''The tags for nodes.''',
+                    content = @Content(
+                            mediaType = io.micronaut.http.MediaType.APPLICATION_JSON,
+                            schema=@Schema(implementation=TagsForNodesResponse)
+                    )
+    )
+    def apiTagsForNodes(String project){
+
+        if (!apiService.requireApi(request, response)) {
+            return
+        }
+
+        AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject,params.project)
+        def projectVerificationErrors = verifyProjectQueryParam(authContext, AuthConstants.RESOURCE_TYPE_NODE, AuthConstants.ACTION_READ, 'Read Nodes')
+        if (!projectVerificationErrors.isEmpty()) {
+            return apiService.renderErrorFormat(response, projectVerificationErrors)
+        }
+
+        def tagSummary = frameworkService.summarizeTags(frameworkService.getFrameworkProject(project).getNodeSet().nodes)
+        def tagNodes = tagSummary.collect {new TagForNodes(name: it.getKey(), nodeCount: it.getValue()) }
+        respond(new TagsForNodesResponse(tags: tagNodes), formats: ['json'])
     }
 
     def handleInvalidMimeType(InvalidMimeTypeException e) {
@@ -4244,5 +4271,31 @@ by:
         removedPlugins.each { plugin ->
             frameworkService.grailsEventBus.notify(PROJECT_PLUGINS_REMOVED_EVENT + '.' + plugin['type'], [ plugin: plugin, project: project ])
         }
+    }
+
+    /**
+     * Verifies the validity of project parameter in the request query and authorization to access the project resources in the provided auth context.
+     * @param authContext
+     * @param projectResourceType
+     * @param projectResourceAction
+     * @param actionErrorArg
+     * @return a map of verification errors or an empty map
+     */
+    private def verifyProjectQueryParam(AuthContext authContext, Map<String, String> projectResourceType, String projectResourceAction, String actionErrorArg) {
+        if(!params.project){
+            return [status: HttpServletResponse.SC_BAD_REQUEST, code: 'api.error.parameter.required', args: ['project']]
+
+        }
+        def exists=frameworkService.existsFrameworkProject(params.project)
+        if(!exists){
+            return [status: HttpServletResponse.SC_NOT_FOUND, code: 'api.error.item.doesnotexist', args: ['project',params.project]]
+
+        }
+        if (!rundeckAuthContextProcessor.authorizeProjectResource(authContext, projectResourceType,
+                projectResourceAction, params.project)) {
+            return [status: HttpServletResponse.SC_FORBIDDEN, code: 'api.error.item.unauthorized', args: [actionErrorArg, 'Project', params.project]]
+        }
+
+        return Collections.EMPTY_MAP
     }
 }

--- a/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
+++ b/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
@@ -168,6 +168,9 @@ class UrlMappings {
         "/api/$api_version/project/$project/resources"(controller: 'framework') {
             action = [GET: "apiResourcesv2",/* PUT: "update", DELETE: "delete", POST: "apiProjectResourcesPost"*/]
         }
+        "/api/$api_version/project/$project/nodes/tags"(controller: 'framework') {
+            action = [GET: "apiTagsForNodes"]
+        }
         "/api/$api_version/project/$project/jobs"(controller: 'menu', action: 'apiJobsListv2')
         "/api/$api_version/project/$project/resource/$name"(controller: 'framework',action:"apiResourcev14")
         "/api/$api_version/project/$project/run/command"(controller: 'scheduledExecution', action: 'apiRunCommandv14')

--- a/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
+++ b/rundeckapp/grails-app/controllers/rundeckapp/UrlMappings.groovy
@@ -171,6 +171,8 @@ class UrlMappings {
         "/api/$api_version/project/$project/nodes/tags"(controller: 'framework') {
             action = [GET: "apiTagsForNodes"]
         }
+        "/api/$api_version/project/$project/nodes"(controller: 'framework', action: 'apiNodes')
+
         "/api/$api_version/project/$project/jobs"(controller: 'menu', action: 'apiJobsListv2')
         "/api/$api_version/project/$project/resource/$name"(controller: 'framework',action:"apiResourcev14")
         "/api/$api_version/project/$project/run/command"(controller: 'scheduledExecution', action: 'apiRunCommandv14')

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/node/Node.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/node/Node.groovy
@@ -1,0 +1,66 @@
+package com.dtolabs.rundeck.app.api.node
+
+import com.dtolabs.rundeck.app.api.marshall.ApiResource
+import com.dtolabs.rundeck.core.common.INodeEntry
+import groovy.transform.EqualsAndHashCode
+import io.swagger.v3.oas.annotations.media.Schema
+
+@ApiResource
+@Schema(description = "Node")
+@EqualsAndHashCode
+class Node {
+
+    @Schema(description = "Name of the node, this must be a unique Identifier across nodes within a project", example = "infra-node-1", requiredMode = Schema.RequiredMode.REQUIRED)
+    String nodename
+
+    @Schema(description = "Hostname of the node. This can be any IP Address or hostname to address the node.", example = "10.10.10.10:4001", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    String hostname
+
+    @Schema(description = "User name to connect to the node via SSH", example = "bob", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    String username
+
+    @Schema(description = "A description of the Node", example = "Infra node", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    String description
+
+    @Schema(description = "A list of tags associated with the node", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    List<String> tags
+
+    @Schema(description = "An OS Family of the node", example = "Unix", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    String osFamily
+
+    @Schema(description = "OS Architecture", example = "amd64", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    String osArch
+
+    @Schema(description = "OS Name", example = "Linux", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    String osName
+
+    @Schema(description = "OS Version", example = "5.15.49-linuxkit", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    String osVersion
+
+    @Schema(description = "URL to an external resource model service", example = "http://example.com/resource", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    String editUrl
+
+    @Schema(description = "URL to an external resource model editor service", example = "http://example.com/editor", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    String remoteUrl
+
+    @Schema(description = "A map of additional attributes for the node", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    Map<String, String> attributes
+
+    /**
+     * Create a Node from an INodeEntry
+     */
+    static Node from(INodeEntry iNodeEntry) {
+        new Node(
+                nodename: iNodeEntry.getNodename(),
+                hostname: iNodeEntry.getHostname(),
+                username: iNodeEntry.getUsername(),
+                description: iNodeEntry.getDescription(),
+                tags: iNodeEntry.getTags().collect { it.toString() },
+                osFamily: iNodeEntry.getOsFamily(),
+                osArch: iNodeEntry.getOsArch(),
+                osName: iNodeEntry.getOsName(),
+                osVersion: iNodeEntry.getOsVersion(),
+                attributes: iNodeEntry.getAttributes()
+        )
+    }
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/node/NodesResponse.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/node/NodesResponse.groovy
@@ -1,0 +1,12 @@
+package com.dtolabs.rundeck.app.api.node
+
+import com.dtolabs.rundeck.app.api.marshall.ApiResource
+import io.swagger.v3.oas.annotations.media.Schema
+
+@ApiResource
+@Schema(description = "Nodes")
+class NodesResponse {
+
+    @Schema(description = "List of nodes", requiredMode = Schema.RequiredMode.REQUIRED)
+    List<Node> nodes
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/tag/TagForNodes.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/tag/TagForNodes.groovy
@@ -1,0 +1,16 @@
+package com.dtolabs.rundeck.app.api.tag
+
+import com.dtolabs.rundeck.app.api.marshall.ApiResource
+import groovy.transform.EqualsAndHashCode
+import io.swagger.v3.oas.annotations.media.Schema
+
+@ApiResource
+@Schema(description = "Tag with node count")
+@EqualsAndHashCode
+class TagForNodes {
+    @Schema(description = "Tag name", example = "infra", requiredMode = Schema.RequiredMode.REQUIRED)
+    String name
+
+    @Schema(description = "Count of nodes associated with the tag", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
+    Integer nodeCount
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/tag/TagsForNodesResponse.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/tag/TagsForNodesResponse.groovy
@@ -1,0 +1,12 @@
+package com.dtolabs.rundeck.app.api.tag
+
+import com.dtolabs.rundeck.app.api.marshall.ApiResource
+import io.swagger.v3.oas.annotations.media.Schema
+
+@ApiResource
+@Schema(description = "Tags")
+class TagsForNodesResponse {
+
+    @Schema(description = "List of tags", requiredMode = Schema.RequiredMode.REQUIRED)
+    List<TagForNodes> tags
+}

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -16,6 +16,9 @@
 
 package rundeck.controllers
 
+import com.dtolabs.rundeck.app.api.tag.TagForNodes
+import com.dtolabs.rundeck.app.api.tag.TagsForNodesResponse
+import com.fasterxml.jackson.databind.ObjectMapper
 import rundeck.support.filters.ExtNodeFilters
 import com.dtolabs.rundeck.core.authorization.RuleSetValidation
 import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
@@ -56,6 +59,8 @@ import static org.rundeck.core.auth.AuthConstants.*
  * Created by greg on 7/28/15.
  */
 class FrameworkControllerSpec extends Specification implements ControllerUnitTest<FrameworkController>, DataTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
 
     def setupSpec() { mockDomains User }
 
@@ -840,6 +845,9 @@ class FrameworkControllerSpec extends Specification implements ControllerUnitTes
                 map.status==404
             })>>{it[0].status=it[1].status}
         }
+        controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
+            1 * getAuthContextForSubjectAndProject(_, _) >> Mock(UserAndRolesAuthContext)
+        }
         def query = new ExtNodeFilters(project: 'test')
         params.project="test"
         when:
@@ -894,6 +902,72 @@ class FrameworkControllerSpec extends Specification implements ControllerUnitTes
 
         then:
         response.contentType == 'text/xml;charset=UTF-8'
+    }
+
+    def "get tags for project nodes"() {
+        setup:
+        def authCtx = Mock(UserAndRolesAuthContext)
+        def nodeSet = new NodeSetImpl()
+        def projectName = 'testproj'
+        def nodesTags = [t1: 1, t2: 0]
+
+        controller.frameworkService = Mock(FrameworkService) {
+            1 * existsFrameworkProject(projectName) >> true
+            1 * getFrameworkProject(projectName) >> Mock(IRundeckProject) {
+                1 * getNodeSet() >> nodeSet
+            }
+            1 * summarizeTags(nodeSet.nodes) >> nodesTags
+        }
+
+        controller.apiService = Mock(ApiService) {
+            1 * requireApi(_, _) >> true
+        }
+
+        controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
+            1 * authorizeProjectResource(authCtx, [type: 'resource', kind: 'node'], 'read', projectName) >> true
+            1 * getAuthContextForSubjectAndProject(_, projectName) >> authCtx
+        }
+        params.project = projectName
+        when:
+        response.format = 'json'
+        controller.apiTagsForNodes(projectName)
+
+        then:
+        response.contentType == 'application/json;charset=UTF-8'
+        def respObject = OBJECT_MAPPER.readValue(response.getContentAsString(), TagsForNodesResponse)
+        respObject.tags.toSet() ==  [new TagForNodes(name: "t1", nodeCount: 1  ), new TagForNodes( name: "t2", nodeCount: 0)] as Set<TagForNodes>
+    }
+
+    def "get tags for project nodes when no tags exist"() {
+        setup:
+        def authCtx = Mock(UserAndRolesAuthContext)
+        def projectName = 'testproj'
+
+        controller.frameworkService = Mock(FrameworkService) {
+            1 * existsFrameworkProject(projectName) >> true
+            1 * getFrameworkProject(projectName) >> Mock(IRundeckProject) {
+                1 * getNodeSet() >> new NodeSetImpl()
+            }
+            1 * summarizeTags(_) >> [:]
+        }
+
+        controller.apiService = Mock(ApiService) {
+            1 * requireApi(_, _) >> true
+        }
+
+        controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
+            1 * authorizeProjectResource(authCtx, [type: 'resource', kind: 'node'], 'read', projectName) >> true
+            1 * getAuthContextForSubjectAndProject(_, projectName) >> authCtx
+        }
+        params.project = projectName
+        when:
+        response.format = 'json'
+        controller.apiTagsForNodes(projectName)
+
+        then:
+        response.contentType == 'application/json;charset=UTF-8'
+        def respObject = OBJECT_MAPPER.readValue(response.getContentAsString(), TagsForNodesResponse)
+        respObject.tags.isEmpty()
     }
 
     @Unroll


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Adds a new GET project/{project}/nodes API endpoint to get a project nodes

**Additional context**
- Docs PR: <TODO>

**Testing**

***Project with nodes***

```
GET http://localhost:4440/api/50/project/P1/nodes

HTTP/1.1 200 OK
Content-Type: application/json;charset=utf-8

{
  "nodes": [
    {
      "osVersion": "14.7",
      "osName": "Mac OS X",
      "osFamily": "unix",
      "attributes": {
        "nodename": "localhost",
        "hostname": "localhost",
        "osFamily": "unix",
        "osVersion": "14.7",
        "framework.node.tags": "local,local_node",
        "osArch": "aarch64",
        "description": "Rundeck server node",
        "osName": "Mac OS X",
        "username": "",
        "tags": ""
      },
      "editUrl": null,
      "tags": [],
      "description": "Rundeck server node",
      "username": "",
      "hostname": "localhost",
      "remoteUrl": null,
      "osArch": "aarch64",
      "nodename": "localhost"
    },
    {
      "osVersion": "",
      "osName": "",
      "osFamily": "",
      "attributes": {
        "nodename": "stb-0",
        "hostname": "stbhost",
        "osFamily": "",
        "osVersion": "",
        "osArch": "",
        "description": "",
        "osName": "",
        "node-executor": "stub",
        "file-copier": "stub",
        "username": "stbuser",
        "tags": "stub, stub2"
      },
      "editUrl": null,
      "tags": [
        "stub",
        "stub2"
      ],
      "description": "",
      "username": "stbuser",
      "hostname": "stbhost",
      "remoteUrl": null,
      "osArch": "",
      "nodename": "stb-0"
    },
    {
      "osVersion": "",
      "osName": "",
      "osFamily": "",
      "attributes": {
        "nodename": "stb-1",
        "hostname": "stbhost",
        "osFamily": "",
        "osVersion": "",
        "osArch": "",
        "description": "",
        "osName": "",
        "node-executor": "stub",
        "file-copier": "stub",
        "username": "stbuser",
        "tags": "stub, stub2"
      },
      "editUrl": null,
      "tags": [
        "stub",
        "stub2"
      ],
      "description": "",
      "username": "stbuser",
      "hostname": "stbhost",
      "remoteUrl": null,
      "osArch": "",
      "nodename": "stb-1"
    },
    {
      "osVersion": "",
      "osName": "",
      "osFamily": "",
      "attributes": {
        "nodename": "stb-2",
        "hostname": "stbhost",
        "osFamily": "",
        "osVersion": "",
        "osArch": "",
        "description": "",
        "osName": "",
        "node-executor": "stub",
        "file-copier": "stub",
        "username": "stbuser",
        "tags": "stub, stub2"
      },
      "editUrl": null,
      "tags": [
        "stub",
        "stub2"
      ],
      "description": "",
      "username": "stbuser",
      "hostname": "stbhost",
      "remoteUrl": null,
      "osArch": "",
      "nodename": "stb-2"
    }
  ]
}
```

***API Specs***
![Screenshot 2024-12-04 at 3 49 17 PM](https://github.com/user-attachments/assets/65b05cb8-afde-4415-b04d-96856b0ecdeb)
