### PR TITLE
RUN-2916: Fix import action of scm import plugin when importing right after enabling the plugin

### DIFF
--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
@@ -706,7 +706,8 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
                 found << trackPath(
                         walk.getPathString(),
                         trackedItemNeedsImport(walk.getPathString()),
-                        importTracker.trackedJob(walk.getPathString())
+                        importTracker.trackedJob(walk.getPathString()) ?:
+                                jobStateMap.find {String key, Map values -> values.path?.equals(walk.getPathString())}?.key?.toString() //get job id from jobStateMap if importTracker is empty
                 )
             }
             return found

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitImportPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitImportPluginSpec.groovy
@@ -266,6 +266,34 @@ class GitImportPluginSpec extends Specification {
         'import-jobs' | _
     }
 
+    def "get tracked items should assignee jobId"() {
+        given:
+        def projectName = 'GitImportPluginSpec'
+        def gitdir = new File(tempdir, 'scm')
+        def origindir = new File(tempdir, 'origin')
+        Import config = createTestConfig(gitdir, origindir)
+
+        Git git = GitExportPluginSpec.createGit(origindir)
+
+
+        git.close()
+
+        def plugin = new GitImportPlugin(config, [])
+        plugin.initialize(Mock(ScmOperationContext) {
+            getFrameworkProject() >> projectName
+        }
+        )
+        plugin.jobStateMap['0001'] = ['synch':'DELETE_NEEDED','path':'job/xy-0001.xml']
+
+        when:
+        def ret = plugin.getTrackedItemsForAction("import-jobs")
+
+        then:
+        ret
+        ret.size()==1
+        ret[0].jobId=='0001'
+    }
+
     def "perform pull on clean state withouth npe"() {
         given:
         def projectName = 'GitImportPluginSpec'


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

When importing changes using scm import plugin after enabling it via API, it returns success but no changes is imported. It happens because the tracked job ids list is empty when plugin gets the tracked items

**Describe the solution you've implemented**
If the tracked job ids list is empty, the plugin will try to get the job id from the job state map

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
