### PR TITLE
RUN-3034: Temporarily excludes failing test from pro CI.

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/ExpandedJobGroupsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/ExpandedJobGroupsSpec.groovy
@@ -1,6 +1,6 @@
 package org.rundeck.tests.functional.selenium.jobs
 
-
+import org.rundeck.util.annotations.ExcludePro
 import org.rundeck.util.annotations.SeleniumCoreTest
 import org.rundeck.util.container.SeleniumBase
 import org.rundeck.util.gui.pages.home.HomePage
@@ -10,6 +10,8 @@ import org.rundeck.util.gui.pages.project.ProjectCreatePage
 import org.rundeck.util.gui.pages.project.ProjectEditPage
 import spock.lang.Stepwise
 
+// Add test back to pro as soon as we fix it in pro CI.
+@ExcludePro
 @SeleniumCoreTest
 @Stepwise
 class ExpandedJobGroupsSpec extends SeleniumBase {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
Temporarily excludes a functional test from pro CI until we can properly diagnose the issue with it.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
