### PR TITLE
RUN-3011: Update JAAS/jetty combined login module to allow ignoreRoles in binding context

### DIFF
--- a/docker/official/remco/templates/jaas-loginmodule.conf
+++ b/docker/official/remco/templates/jaas-loginmodule.conf
@@ -19,7 +19,9 @@
         userIdAttribute="{{ getv("/rundeck/jaas/ldap/useridattribute", "cn") }}"
         userPasswordAttribute="{{ getv("/rundeck/jaas/ldap/userpasswordattribute", "userPassword") }}"
         userObjectClass="{{ getv("/rundeck/jaas/ldap/userobjectclass", "person") }}"
+    {% if exists("/rundeck/jaas/ldap/rolebasedn") -%}
         roleBaseDn="{{ getv("/rundeck/jaas/ldap/rolebasedn") }}"
+    {% endif %}
         roleNameAttribute="{{ getv("/rundeck/jaas/ldap/rolenameattribute", "cn") }}"
         roleMemberAttribute="{{ getv("/rundeck/jaas/ldap/rolememberattribute", "uniqueMember") }}"
         roleObjectClass="{{ getv("/rundeck/jaas/ldap/roleobjectclass", "groupOfUniqueNames") }}"

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCachingLdapLoginModule.java
@@ -459,7 +459,7 @@ public class JettyCachingLdapLoginModule extends AbstractLoginModule {
     }
 
     @SuppressWarnings("unchecked")
-    private List getUserRolesByDn(DirContext dirContext, String userDn, String username) throws LoginException,
+    protected List getUserRolesByDn(DirContext dirContext, String userDn, String username) throws LoginException,
             NamingException, IOException {
         List<String> roleList = new ArrayList<String>();
 

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCombinedLdapLoginModule.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCombinedLdapLoginModule.java
@@ -87,7 +87,7 @@ public class JettyCombinedLdapLoginModule extends JettyCachingLdapLoginModule {
      * @throws NamingException
      */
     @Override
-    protected List getUserRoles(final DirContext dirContext, final String username)
+    protected List getUserRolesByDn(final DirContext dirContext, String userDn, final String username)
             throws LoginException, NamingException, IOException
     {
         if (_ignoreRoles) {
@@ -95,7 +95,7 @@ public class JettyCombinedLdapLoginModule extends JettyCachingLdapLoginModule {
             addSupplementalRoles(strings);
             return strings;
         } else {
-            return super.getUserRoles(dirContext, username);
+            return super.getUserRolesByDn(dirContext, userDn, username);
         }
     }
 

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCombinedLdapLoginModuleSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/jetty/jaas/JettyCombinedLdapLoginModuleSpec.groovy
@@ -1,0 +1,155 @@
+package com.dtolabs.rundeck.jetty.jaas
+
+import org.eclipse.jetty.jaas.JAASPrincipal
+import org.eclipse.jetty.jaas.JAASRole
+import org.eclipse.jetty.jaas.spi.AbstractLoginModule
+import spock.lang.Specification
+
+import javax.naming.NamingEnumeration
+import javax.naming.directory.*
+import javax.security.auth.Subject
+import java.util.stream.Collectors
+
+class JettyCombinedLdapLoginModuleSpec extends Specification {
+
+    private static final String user1 = "user1";
+    private static final String user2 = "user2";
+    private static final String password = "password";
+    private static final String role1 = "role1";
+    private static final String role2 = "role2";
+    private static final String nestedRole1 = "nestedRole1";
+
+    def "ignoreRoles works in binding context"() {
+        given:
+            JettyCombinedLdapLoginModule module = getJettyCachingLdapLoginModule(false)
+            module._userBaseDn = "ou=users,dc=example,dc=com"
+            module._roleBaseDn = "ou=groups,dc=example,dc=com"
+            module._ignoreRoles = ignoreRoles
+            module._forceBindingLogin = true
+            module._forceBindingLoginUseRootContextForRoles = true
+            module._contextFactory = "foo"
+            module._hostname = "foo"
+            module._port = 111
+            module._bindDn = "someDn"
+            module.rolePagination=false
+
+
+            module.userBindDirContextCreator = { final String userDn, final Object password ->
+                Mock(DirContext)
+            }
+
+        when:
+            boolean authSuccess = module.bindingLogin(user1, password);
+        then:
+            authSuccess
+        when:
+            final AbstractLoginModule.JAASUserInfo userInfo = module.getCurrentUser();
+            Subject subject = new Subject();
+            userInfo.setJAASInfo(subject);
+            List<String> actualRoles = subject
+                .getPrincipals(JAASRole.class).stream().map(JAASPrincipal::getName).collect(
+                Collectors.toList()
+            )
+        then:
+            actualRoles == expected
+        where:
+            ignoreRoles | expected
+            true        | []
+            false       | ["role1", "role2"]
+    }
+
+    JettyCombinedLdapLoginModule getJettyCachingLdapLoginModule(boolean activeDirectory) {
+        def module = new JettyCombinedLdapLoginModule()
+        module._userBaseDn = "ou=users,dc=example,dc=com"
+        module._roleBaseDn = "ou=groups,dc=example,dc=com"
+
+        def rootContext = Mock(DirContext)
+
+        // User search setup
+        rootContext.search(module._userBaseDn, _ as String, _ as Object[], _ as SearchControls) >> {
+            Mock(NamingEnumeration) {
+                hasMoreElements() >> true
+                nextElement() >> Mock(SearchResult) {
+                    getNameInNamespace() >> user1
+                    getAttributes() >> Mock(Attributes) {
+                        get(module._userPasswordAttribute) >> Mock(Attribute) {
+                            get() >> "password".bytes
+                        }
+                    }
+                }
+            }
+        }
+
+        // Role search setup
+        rootContext.search(module._roleBaseDn, _ as String, _ as Object[], _ as SearchControls) >> {
+            Mock(NamingEnumeration) {
+                hasMoreElements() >> true >> false
+                nextElement() >> Mock(SearchResult) {
+                    getAttributes() >> Mock(Attributes) {
+                        get(module._roleNameAttribute) >> Mock(Attribute) {
+                            getAll() >> Mock(NamingEnumeration) {
+                                hasMore() >> true >> true >> false
+                                next() >> role1 >> role2
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // All roles search setup
+        rootContext.search(module._roleBaseDn, module._roleMemberFilter, _ as SearchControls) >> {
+            Mock(NamingEnumeration) {
+                hasMoreElements() >> true >> true >> true >> false
+                nextElement() >> setupRoleSearchResult(role1, module) >>
+                setupRoleSearchResult(role2, module) >>
+                setupNestedRoleSearchResult(nestedRole1, role1, user2, module, activeDirectory)
+            }
+        }
+
+        module._rootContext = rootContext
+        return module
+    }
+
+    SearchResult setupRoleSearchResult(String roleName, JettyCombinedLdapLoginModule module) {
+        Mock(SearchResult) {
+            getAttributes() >> Mock(Attributes) {
+                get(module._roleNameAttribute) >> Mock(Attribute) {
+                    getAll() >> Mock(NamingEnumeration) {
+                        next() >> roleName
+                    }
+                }
+                get(module._roleMemberAttribute) >> Mock(Attribute)
+            }
+        }
+    }
+
+    SearchResult setupNestedRoleSearchResult(
+        String nestedRoleName,
+        String role1,
+        String user2,
+        JettyCombinedLdapLoginModule module,
+        boolean activeDirectory
+    ) {
+        Mock(SearchResult) {
+            getAttributes() >> Mock(Attributes) {
+                get(module._roleNameAttribute) >> Mock(Attribute) {
+                    getAll() >> Mock(NamingEnumeration) {
+                        hasMore() >> true >> false
+                        next() >> nestedRoleName
+                    }
+                }
+                get(module._roleMemberAttribute) >> Mock(Attribute) {
+                    getAll() >> Mock(NamingEnumeration) {
+                        hasMore() >> true >> false
+                        next() >> {
+                            activeDirectory ?
+                            "CN=${role1},${module._roleBaseDn}" :
+                            "cn=${role1},${module._roleBaseDn}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Fixes two issues with the JettyCombinedLdapLoginModule when configuring it to use local roles from a properties file:
1. The "roleBaseDn" attribute in the docker remco template was not optional, even when it is not needed
2. the ignoreRoles flag of JettyCombinedLdapLoginModule did not work in a binding context

this combination makes it difficult to configure the login modules to use Authentication via LDAP, but supply user roles from the local property file module.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
