### PR TITLE
RCLOUD-1557: Reclaim and schedule in smaller transactions

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -40,6 +40,7 @@ public class RundeckConfigBase {
     RundeckProjectServiceConfig projectService;
     RundeckProjectManagerServiceConfig projectManagerService;
     RundeckLogFileStorageServiceConfig logFileStorageService;
+    RundeckScheduledExecutionServiceConfig scheduledExecutionService;
     FileUploadServiceConfig fileUploadService;
     RundeckAuthorizationServiceConfig authorizationService;
     RundeckReportServiceConfig reportService;
@@ -296,6 +297,15 @@ public class RundeckConfigBase {
         @Data
         public static class ResumeIncomplete {
             String strategy;
+        }
+    }
+
+    @Data
+    public static class RundeckScheduledExecutionServiceConfig {
+        Startup startup;
+        @Data
+        public static class Startup {
+            String rescheduleMode;
         }
     }
 

--- a/rundeckapp/grails-app/domain/rundeck/Execution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Execution.groovy
@@ -136,6 +136,9 @@ class Execution extends ExecutionContext implements EmbeddedJsonData, ExecutionD
         isScheduledAdHoc {
             eq 'status', ExecutionService.EXECUTION_SCHEDULED
         }
+        withScheduledExecution { se ->
+            eq 'scheduledExecution', se
+        }
         withServerNodeUUID { uuid ->
             eq 'serverNodeUUID', uuid
         }

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -304,12 +304,14 @@ class ExecutionJob implements InterruptableJob {
                     }else{
                         initMap.jobShouldNotRun="Job ${initMap.scheduledExecution.extid} will run on server ID ${initMap.scheduledExecution.serverNodeUUID}, removing schedule on this server (${serverUUID})."
                     }
+                    log.info("Deleting job ${context.jobDetail.key} for reason: ${initMap.jobShouldNotRun}")
                     context.getScheduler().deleteJob(context.jobDetail.key)
                     return initMap
                 }else{
                     //verify run on this node but scheduled disabled
                     if(!initMap.jobSchedulesService.shouldScheduleExecution(initMap.scheduledExecution.uuid)){
                         initMap.jobShouldNotRun = "Job ${initMap.scheduledExecution.extid} schedule has been disabled, removing schedule on this server (${serverUUID})."
+                        log.info("Deleting job ${context.jobDetail.key} for reason: ${initMap.jobShouldNotRun}")
                         context.getScheduler().deleteJob(context.jobDetail.key)
                         return initMap
                     }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -1050,6 +1050,84 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     }
 
     /**
+     * An alternate method of claiming and scheduling all jobs to the current server. This method updates each
+     * scheduled execution one-by-one to avoid a number of potential race conditions that can occur when scheduling
+     * the job before committing the corresponding ScheduledExecution updates.
+     */
+    def reclaimAndScheduleJobByJob() {
+        String toServerUuid = frameworkService.getServerUUID()
+        Map claimed = [:]
+        def scheduledExecutions = timer("takeover query ") {
+            jobSchedulesService.getSchedulesJobToClaim(toServerUuid, null, true, null, null)
+        }
+
+        scheduledExecutions.each { ScheduledExecution se ->
+            if (claimed[se.extid]) {
+                return
+            }
+
+            def originalServerId = se.serverNodeUUID
+
+            try {
+                def claimResult = ScheduledExecution.withNewTransaction { status ->
+                    return claimScheduledJob(se, toServerUuid)
+                }
+
+                claimed[se.extid] = [
+                        success         : claimResult.claimed,
+                        jobId           : se.extid,
+                        previousServerId: originalServerId,
+                        executions      : claimResult.executions
+                ]
+            } catch (Exception e) {
+                log.error("Error claiming scheduled execution ${se.extid}.", e)
+
+                claimed[se.extid] = [
+                        success         : false,
+                        jobId           : se.extid,
+                        previousServerId: originalServerId,
+                        executions      : []
+                ]
+            }
+
+            if (claimed[se.extid]["success"]) {
+                // ScheduledExecution was updated and committed in the previous nested transaction.
+                // Refresh it before moving forward.
+                se.refresh()
+            } else {
+                log.warn("Scheduled execution ${se.extid} was not successfully claimed. It will not be scheduled.")
+                return
+            }
+
+            try {
+                ScheduledExecution.withNewTransaction { status ->
+                    // Schedule the job on quartz.
+                    scheduleJob(se, null, null, true)
+
+                    // Schedule any ad-hoc executions for the job on quartz.
+                    scheduleAdHocExecutionsForJob(se, toServerUuid)
+                }
+                log.info("Rescheduled job in project ${se.project}: ${se.extid}")
+            } catch (Exception e) {
+                log.error("Job not rescheduled in project ${se.project}: ${se.extid}: ${e.message}", e)
+                claimed[se.extid]["success"] = false
+            }
+        }
+
+        return claimed
+    }
+
+    private def scheduleAdHocExecutionsForJob(ScheduledExecution se, String targetServerUUID) {
+        // Reschedule any executions which were scheduled ad hoc
+        def executionList = Execution.isScheduledAdHoc()
+                .withScheduledExecution(se)
+                .withServerNodeUUID(targetServerUUID)
+                .list()
+
+        rescheduleOnetimeExecutions(executionList)
+    }
+
+    /**
      *  Return a Map with a tree structure of the available grouppaths, and their job counts
      * <pre>
           [


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This PR contains a few required pieces for implementing an improved execution takeover for rundeckpro running in cluster mode. More detail to come soon.

**Describe the solution you've implemented**
* Adds a new takeover function that commits claimed executions before scheduling them to run on the server.
* The `rundeck.scheduledExecutionService.startup.rescheduleMode` configuration property actually works now.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
