### PR TITLE
RUN-2964: Code Injection Vulnerability via Project Name Label

### DIFF
--- a/rundeckapp/grails-spa/README.md
+++ b/rundeckapp/grails-spa/README.md
@@ -30,8 +30,8 @@ nvm use
 
 ### Setup
 
-* In the `rundeck-runtime/server/config/rundeck-config.properties` file
-add `grails.cors.enabled=true` to allow Storybook access to the API.
+
+* In the [`rundeck-runtime/server/config/rundeck-config.properties`](../rundeck-runtime/server/config/rundeck-config.properties) file add `grails.cors.enabled=true` to allow Storybook access to the API.
 * Start Rundeck in development mode.
 * Enter the `./packages/ui-trellis` directory; this will be your workdir.
 * Copy `.env.dist` to `.env` and replace the values to match your environment:  

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/project-select/ProjectSelectButton.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/project-select/ProjectSelectButton.vue
@@ -50,6 +50,7 @@ export default defineComponent({
     Popper,
     ProjectSelect,
   },
+  inheritAttrs: false,
   props: {
     projectLabel: { type: String },
     showDefaultLabel: {


### PR DESCRIPTION
**Describe the solution you've implemented**
- A bug fix for the code injection vulnerability via the project display name label
- Minor Storybook docs update

**Additional context**
A maliciously crafted project display name can be used to abuse the implicit Vue component attribute Inheritance and pass in executable code

The fix disables the Vue component attribute inheritance explicitly 

- Before the change: 
<img width="946" alt="Screenshot 2025-01-20 at 1 02 02 PM" src="https://github.com/user-attachments/assets/c6309d8f-572a-49c9-9c50-1cec0821364c" />

- After the change: 
<img width="995" alt="Screenshot 2025-01-20 at 1 00 34 PM" src="https://github.com/user-attachments/assets/340843c9-ff8c-4f8c-a58f-9e14e15007be" />
