### PR TITLE
RUN-3086: Upgrade Okio to 1.17.6 in azure-object-store-plugin to address CVE-2023-3635

### DIFF
--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -6,7 +6,7 @@ FROM golang:1.22.2 as remco
 
 # 2024-03-15: As of this writing, the latest remco version (v0.12.4) doesn't include the fixes for CVE-2023-44487
 # however, the following commit (fbd1eb0) includes the fix. We will use this commit until a new release is available.
-ENV REMCO_VERSION=fbd1eb066af9ca58fc452263eeceee685e2a14fd
+ENV REMCO_VERSION=0.12.4
 
 RUN go install github.com/HeavyHorst/remco/cmd/remco@$REMCO_VERSION
 

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -6,7 +6,7 @@ FROM golang:1.22.2 as remco
 
 # 2024-03-15: As of this writing, the latest remco version (v0.12.4) doesn't include the fixes for CVE-2023-44487
 # however, the following commit (fbd1eb0) includes the fix. We will use this commit until a new release is available.
-ENV REMCO_VERSION=0.12.4
+ENV REMCO_VERSION=fbd1eb066af9ca58fc452263eeceee685e2a14fd
 
 RUN go install github.com/HeavyHorst/remco/cmd/remco@$REMCO_VERSION
 

--- a/plugins/azure-object-store-plugin/build.gradle
+++ b/plugins/azure-object-store-plugin/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     constraints {
         pluginLibs "com.nimbusds:nimbus-jose-jwt:${nimbusJoseVersion}"
+        pluginLibs "com.squareup.okio:okio:1.17.6"
     }
 }
 


### PR DESCRIPTION
Jira: https://pagerduty.atlassian.net/browse/RUN-3086

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
