### PR TITLE
Improve stability of SCM tests

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginSetupSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginSetupSpec.groovy
@@ -32,7 +32,7 @@ class ScmPluginSetupSpec extends BaseContainer {
         GitExportSetupRequest requestBody = new GitExportSetupRequest([config: scmSetupProps])
 
         when:
-        SetupIntegrationResponse response = scmClient.callSetupIntegration(requestBody).response
+        SetupIntegrationResponse response = scmClient.callSetupIntegration(requestBody, 400..400).response
 
         then:
         !response.success
@@ -106,7 +106,7 @@ class ScmPluginSetupSpec extends BaseContainer {
         scmClient.callSetupIntegration(requestBody).response.success
 
         when:
-        SetupIntegrationResponse disablePluginResult = scmClient.callSetEnabledStatusForPlugin(false,'wrong-plugin').response
+        SetupIntegrationResponse disablePluginResult = scmClient.callSetEnabledStatusForPlugin(false,'wrong-plugin', 400..400).response
 
         then:
         verifyAll {
@@ -128,7 +128,7 @@ class ScmPluginSetupSpec extends BaseContainer {
         GitExportSetupRequest requestBody = GitExportSetupRequest.defaultRequest().withRepo(remoteRepo).forProject(projectName)
 
         when:
-        SetupIntegrationResponse disablePluginResult = scmClient.callSetEnabledStatusForPlugin(false).response
+        SetupIntegrationResponse disablePluginResult = scmClient.callSetEnabledStatusForPlugin(false, scmClient.pluginName, 400..400).response
 
         then:
         !disablePluginResult.success
@@ -229,7 +229,7 @@ class ScmPluginSetupSpec extends BaseContainer {
         GitScmApiClient scmClient = new GitScmApiClient(clientProvider).forIntegration(integration).forProject(projectName)
 
         when:
-        RundeckResponse.ApiError scmPlugins = scmClient.callGetPluginsList().error
+        RundeckResponse.ApiError scmPlugins = scmClient.callGetPluginsList(200..299, false).error
 
         then:
         verifyAll {

--- a/functional-test/src/test/groovy/org/rundeck/util/api/responses/common/RundeckResponse.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/api/responses/common/RundeckResponse.groovy
@@ -9,19 +9,34 @@ class RundeckResponse<T> {
     int httpCode
     ApiError error
 
-    RundeckResponse(Response response, Class<T> clazz){
-        this.httpCode = response.code()
-        String bodyText = response.body().string()
+    /**
+     * Instantiates a new Rundeck response of type T.
+     *
+     * The `response` attribute is set if the provided http response is valid (appears in validResponseHttpCodes) and body can be parsed to type T.
+     * Otherwise, the `error` attribute  is set or an exception is thrown if throwOnInvalidHttpCode is true.
+     * @param httpResponse the http response
+     * @param clazz Type a valid response should be deserialized to
+     * @param validResponseHttpCodes a range of response http codes that are considered valid
+     * @param throwOnInvalidHttpCode if true, the the http response not in the range will throw
+     * @throws IllegalStateException if ensure2xxResponse and the http response is not successful
+     */
+    RundeckResponse(Response httpResponse, Class<T> clazz, IntRange validResponseHttpCodes = 200..299, throwOnInvalidHttpCode = true)  {
+        this.httpCode = httpResponse.code()
+        String bodyText = httpResponse.body().string()
         try {
-            this.response = new ObjectMapper().readValue(
-                    bodyText,
-                    clazz
-            )
+            if (validResponseHttpCodes.contains(httpResponse.code())) {
+                this.response = new ObjectMapper().readValue(
+                        bodyText,
+                        clazz
+                )
+            } else {
+                if (throwOnInvalidHttpCode) {
+                    throw new IllegalStateException("HTTP response must be 2xx, but it's: ${httpResponse.code()} - ${bodyText}")
+                }
+                this.error = new ObjectMapper().readValue(bodyText, ApiError.class)
+            }
         } catch (UnrecognizedPropertyException ignored){
-            this.error = new ObjectMapper().readValue(
-                    bodyText,
-                    ApiError.class
-            )
+            this.error = new ObjectMapper().readValue(bodyText, ApiError.class)
         }
     }
 

--- a/functional-test/src/test/groovy/org/rundeck/util/api/scm/GitScmApiClient.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/api/scm/GitScmApiClient.groovy
@@ -10,7 +10,6 @@ import org.rundeck.util.api.scm.httpbody.ScmJobStatusResponse
 import org.rundeck.util.api.scm.httpbody.ScmPluginInputFieldsResponse
 import org.rundeck.util.api.scm.httpbody.ScmPluginsListResponse
 import org.rundeck.util.api.scm.httpbody.ScmProjectConfigResponse
-import org.rundeck.util.api.scm.httpbody.GitExportSetupRequest
 import org.rundeck.util.api.scm.httpbody.SetupIntegrationResponse
 import org.rundeck.util.common.scm.ScmActionId
 import org.rundeck.util.common.scm.ScmIntegration
@@ -42,66 +41,65 @@ class GitScmApiClient {
         return this
     }
 
-    RundeckResponse<SetupIntegrationResponse> callSetupIntegration(GitSetupRequest requestBody){
-        Response resp = client.doPost("/project/${project}/scm/${integration}/plugin/${pluginName}/setup", requestBody)
-
-        return new RundeckResponse(resp, SetupIntegrationResponse)
+    RundeckResponse<SetupIntegrationResponse> callSetupIntegration(GitSetupRequest requestBody, IntRange validResponseHttpCodes = 200..299){
+        try (Response resp = client.doPost("/project/${project}/scm/${integration}/plugin/${pluginName}/setup", requestBody)) {
+            return new RundeckResponse(resp, SetupIntegrationResponse, validResponseHttpCodes)
+        }
     }
 
     RundeckResponse<IntegrationStatusResponse> callGetIntegrationStatus() {
-        Response resp = client.doGet("/project/${project}/scm/${integration}/status")
-
-        return new RundeckResponse(resp, IntegrationStatusResponse)
+        try (Response resp = client.doGet("/project/${project}/scm/${integration}/status")) {
+            return new RundeckResponse(resp, IntegrationStatusResponse)
+        }
     }
 
     RundeckResponse<ScmActionInputFieldsResponse> callGetFieldsForAction(ScmActionId actionId) {
-        Response resp = client.doGet("/project/${project}/scm/${integration}/action/${actionId.name}/input")
-
-        return new RundeckResponse(resp, ScmActionInputFieldsResponse)
+        try (Response resp = client.doGet("/project/${project}/scm/${integration}/action/${actionId.name}/input")) {
+            return new RundeckResponse(resp, ScmActionInputFieldsResponse)
+        }
     }
 
     RundeckResponse<SetupIntegrationResponse> callPerformAction(String actionId, ScmActionPerformRequest requestBody ) {
-        Response resp = client.doPost("/project/${project}/scm/${integration}/action/${actionId}", requestBody)
-
-        return new RundeckResponse(resp, SetupIntegrationResponse)
+        try (Response resp = client.doPost("/project/${project}/scm/${integration}/action/${actionId}", requestBody)) {
+            return new RundeckResponse(resp, SetupIntegrationResponse)
+        }
     }
 
-    RundeckResponse<ScmPluginsListResponse> callGetPluginsList(){
-        Response resp = client.doGet("/project/${project}/scm/${integration}/plugins")
-
-        return new RundeckResponse(resp, ScmPluginsListResponse)
+    RundeckResponse<ScmPluginsListResponse> callGetPluginsList(IntRange validResponseHttpCodes = 200..299, throwOnInvalidHttpCode = true){
+        try (Response resp = client.doGet("/project/${project}/scm/${integration}/plugins")) {
+            return new RundeckResponse(resp, ScmPluginsListResponse, validResponseHttpCodes, throwOnInvalidHttpCode)
+        }
     }
 
-    RundeckResponse<SetupIntegrationResponse> callSetEnabledStatusForPlugin(boolean enablePlugin, String pluginName = this.pluginName){
-        Response resp = client.doPost("/project/${project}/scm/${integration}/plugin/${pluginName}/${enablePlugin? 'enable' : 'disable'}")
-
-        return new RundeckResponse(resp, SetupIntegrationResponse)
+    RundeckResponse<SetupIntegrationResponse> callSetEnabledStatusForPlugin(boolean enablePlugin, String pluginName = this.pluginName, IntRange validResponseHttpCodes = 200..299){
+        try (Response resp = client.doPost("/project/${project}/scm/${integration}/plugin/${pluginName}/${enablePlugin? 'enable' : 'disable'}")) {
+            return new RundeckResponse(resp, SetupIntegrationResponse, validResponseHttpCodes)
+        }
     }
 
     RundeckResponse<ScmPluginInputFieldsResponse> callGetInputFieldsForPlugin(){
-        Response resp = client.doGet("/project/${project}/scm/${integration}/plugin/${pluginName}/input")
-
-        return new RundeckResponse(resp, ScmPluginInputFieldsResponse)
+        try (Response resp = client.doGet("/project/${project}/scm/${integration}/plugin/${pluginName}/input")) {
+            return new RundeckResponse(resp, ScmPluginInputFieldsResponse)
+        }
     }
 
     RundeckResponse<ScmProjectConfigResponse> callGetProjectScmConfig(){
-        Response resp = client.doGet("/project/${project}/scm/${integration}/config")
-
-        return new RundeckResponse(resp, ScmProjectConfigResponse)
+        try (Response resp = client.doGet("/project/${project}/scm/${integration}/config")) {
+            return new RundeckResponse(resp, ScmProjectConfigResponse)
+        }
     }
 
     RundeckResponse<SetupIntegrationResponse> callPerformJobAction(String actionId, ScmActionPerformRequest requestBody, String jobId ) {
-        Response resp = client.doPost("/job/${jobId}/scm/${integration}/action/${actionId}", requestBody)
-
-        return new RundeckResponse(resp, SetupIntegrationResponse)
+        try (Response resp = client.doPost("/job/${jobId}/scm/${integration}/action/${actionId}", requestBody)) {
+            return new RundeckResponse(resp, SetupIntegrationResponse)
+        }
     }
 
     RundeckResponse<ScmJobStatusResponse> callGetJobStatus(String jobId) {
-        Response resp = client.doGet("/job/${jobId}/scm/${integration}/status")
-
-        return new RundeckResponse(resp, ScmJobStatusResponse)
+        try (Response resp = client.doGet("/job/${jobId}/scm/${integration}/status")) {
+            return new RundeckResponse(resp, ScmJobStatusResponse)
+        }
     }
-
 
     String getPluginName() {
         return pluginName

--- a/functional-test/src/test/groovy/org/rundeck/util/api/scm/gitea/GiteaApiRemoteRepo.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/api/scm/gitea/GiteaApiRemoteRepo.groovy
@@ -32,7 +32,11 @@ class GiteaApiRemoteRepo {
     }
 
     GiteaApiRemoteRepo setupRepo(){
-        doPost(CREATE_REPO_ENDPOINT, new CreateRepoRequest(name: this.repoName))
+        try (Response response = doPost(CREATE_REPO_ENDPOINT, new CreateRepoRequest(name: this.repoName))) {
+            if (!response.isSuccessful()) {
+                throw new IllegalStateException("Failed to create repository: " + response.code() + " " + response.body().string())
+            }
+        }
         return this
     }
 
@@ -159,8 +163,6 @@ class GiteaApiRemoteRepo {
     String getRepoUrlForRundeck(){
         return "${GITEA_RD_BASE_URL}/${GITEA_USER}/${repoName}.git"
     }
-
-
 
     /**
      *

--- a/functional-test/src/test/resources/docker/compose/oss/gitea/start.sh
+++ b/functional-test/src/test/resources/docker/compose/oss/gitea/start.sh
@@ -8,6 +8,10 @@ while true; do
     STATUS_CODE=$(curl -LI localhost:3000 -o /dev/null -w '%{http_code}\n' -s)
     if [ $STATUS_CODE = "200" ]; then
         su -c "gitea admin user create --admin --username ${GITEA_ADMIN_USER} --password ${GITEA_ADMIN_PASSWORD} --email your@email.org --must-change-password=false" git
+        if [ $? -ne 0 ]; then
+            echo "Failed to create the admin ${GITEA_ADMIN_USER}  user "
+            exit 2
+        fi
         exit 0
     elif [ $ATTEMPT = $MAX_ATTEMPT ]; then
         echo "Maximum attempts (${MAX_ATTEMPT}) has been reached with gitea server response: ${STATUS_CODE}"


### PR DESCRIPTION
Jira tickets:
- https://pagerduty.atlassian.net/browse/RUN-3093
- https://pagerduty.atlassian.net/browse/RUN-3103
- https://pagerduty.atlassian.net/browse/RUN-3104

Multiple SCM functional tests have been flaky for a long time and underwent various fix attempts. However, by looking at them holistically, I'm starting to be further convinced that the problem is not in the tests themselves. 

My theory is that (sometimes):
1. the `gitea` container is not fully up or configured when the tests are executed by circleci
2. the overly optimistic `GitScmApiClient` (that ignores unsuccessful API responses), masks point 1 above by "swallowing" errors during the tests setup.

This PR might not fix the flaky tests since it does not address point 1 above directly.
It mostly deals with point 2 and is expected to provide us better visibility and understanding of the test failures.

Improvements:
- Add error checking to gitea container setup
- Add error checking to scm tests setup
- Add error handling to GitScmApi client