### PR TITLE
call sync with the filepath to only sync that file when enable sync is set to true

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/steps/node/impl/DefaultScriptFileNodeStepUtils.java
@@ -513,7 +513,7 @@ public class DefaultScriptFileNodeStepUtils implements ScriptFileNodeStepUtils {
             if(BooleanUtils.toBoolean(nodeAttribute.get(NODE_ATTR_ENABLE_SYNC_COMMAND))) {
                 //perform sync to prevent the file from being busy when running
                 final NodeExecutorResult nodeExecutorSyncResult = framework.getExecutionService().executeCommand(
-                        context, ExecArgList.fromStrings(featureQuotingBackwardCompatible , false, "sync"), node);
+                        context, ExecArgList.fromStrings(featureQuotingBackwardCompatible , false, "sync", filepath), node);
 
                 if (!nodeExecutorSyncResult.isSuccess()) {
                     return nodeExecutorSyncResult;


### PR DESCRIPTION

**Is this a bugfix, or an enhancement? Please describe.**
Enhancement.  

After a recent hardware upgrade and mandated security software upgrade on our servers, we have noticed that using enable-sync=true on the rundeck localhost node is causing massive performance issues.  For example. we have a job that runs across around 20 nodes takes around 6 minutes with enable-sync=false, but takes around an hour with enable-sync=true.

This change keeps the enable-sync=true behaviour that fixes the "text file busy" issue we were seeing, but keeps the performance on par with enable-sync=false.

see https://github.com/rundeck/rundeck/issues/9544

**Describe the solution you've implemented**
sync is now called with filepath so that it only syncs that specific file of all outstanding changes, see the sync docs for more info:

https://man7.org/linux/man-pages/man1/sync.1.html

Without the filepath, the sync command synchronizes all cached data for the current user to the permanent memory.

 
**Describe alternatives you've considered**
see rundeck google group discussion:
https://groups.google.com/g/rundeck-discuss/c/Eqetx33hKgM

I have been testing with enable-sync=false and file-busy-err-retry=true in hopes that this would prevent the text file busy issue while also disabling the sync command.  This did not work.

I also tried setting
   file-copy-destination-dir="/var/lib/rundeck/rundeckTmpfs"

and mounting a tmpfs filesystem.  

I would have thought setting this along with enable-sync=false could workaround our problem, as the tmpfs location would be in memory and the sync shouldn't be needed/have no effect.  This also didn't fix the issue.  We still see intermittent text file busy failures.
