### PR TITLE
RUN-2217: Update CI pipeline to include tests using java 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -633,6 +633,10 @@ require-build: &require-build
   requires:
     - Build
 
+require-build-jre-17: &require-build-jre-17
+  requires:
+    - Build_JRE_17
+
 filters:
   all: &filter-default
     filters:
@@ -811,44 +815,37 @@ workflows:
               value: << pipeline.git.branch >>
     jobs:
       - build-rundeck:
-          name: Build with JRE 17
-          <<: *slack-defaults
+          name: Build_JRE_17
           jreVersion: "openjdk-17-jre-headless"
       - test-gradle-functional:
           name: T Selenium
           gradle-task: seleniumCoreTest
           parallelism: 3
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/**/*{.groovy,.java}"
-          <<: *require-build
-          <<: *slack-defaults
+          <<: *require-build-jre-17
       - test-gradle-functional:
           name: T Functional API
           gradle-task: apiTest
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/**/*{.groovy,.java}"
           parallelism: 3
-          <<: *require-build
-          <<: *slack-defaults
+          <<: *require-build-jre-17
       - test-gradle-functional:
           name: T Functional Plugin Blocklist
           gradle-task: pluginBlocklistTest
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/integration/**/*{.groovy,.java}"
-          <<: *require-build
-          <<: *slack-defaults
+          <<: *require-build-jre-17
       - test-gradle-functional:
           name: T Feature NewLocalExec
           gradle-task: apiTestNewLocal
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionOutputSpec.groovy"
-          <<: *require-build
-          <<: *slack-defaults
+          <<: *require-build-jre-17
       - test-gradle-functional:
           name: T Feature NodeExecutorSecureInput
           gradle-task: apiTestNodeExecutorSecureInput
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/input/*.groovy"
-          <<: *require-build
-          <<: *slack-defaults
+          <<: *require-build-jre-17
       - test-gradle-functional:
           name: T Selenium Alpha UI
           gradle-task: alphaUiSeleniumCoreTest
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/alphaUi/**/*{.groovy,.java}"
-          <<: *require-build
-          <<: *slack-defaults
+          <<: *require-build-jre-17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,6 +259,10 @@ jobs:
     executor:
       name: docker-builder
       resource_class: large
+    parameters:
+      jreVersion:
+        type: string
+        default: "openjdk-11-jre-headless"
     steps:
       - setup_docker:
           docker_layer_caching: true
@@ -271,7 +275,7 @@ jobs:
       - run-build-step:
           step-name: Build And Push Docker Images
           command: |
-            rundeck_docker_build
+            rundeck_docker_build << parameters.jreVersion >>
             rundeck_docker_push
       - run-build-step:
           step-name: Verify Build
@@ -758,6 +762,58 @@ workflows:
           command: bash test/run-docker-pam-tests.sh
           <<: *require-build
           <<: *slack-defaults
+      - test-gradle-functional:
+          name: T Selenium
+          gradle-task: seleniumCoreTest
+          parallelism: 3
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/**/*{.groovy,.java}"
+          <<: *require-build
+          <<: *slack-defaults
+      - test-gradle-functional:
+          name: T Functional API
+          gradle-task: apiTest
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/**/*{.groovy,.java}"
+          parallelism: 3
+          <<: *require-build
+          <<: *slack-defaults
+      - test-gradle-functional:
+          name: T Functional Plugin Blocklist
+          gradle-task: pluginBlocklistTest
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/integration/**/*{.groovy,.java}"
+          <<: *require-build
+          <<: *slack-defaults
+      - test-gradle-functional:
+          name: T Feature NewLocalExec
+          gradle-task: apiTestNewLocal
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionOutputSpec.groovy"
+          <<: *require-build
+          <<: *slack-defaults
+      - test-gradle-functional:
+          name: T Feature NodeExecutorSecureInput
+          gradle-task: apiTestNodeExecutorSecureInput
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/input/*.groovy"
+          <<: *require-build
+          <<: *slack-defaults
+      - test-gradle-functional:
+          name: T Selenium Alpha UI
+          gradle-task: alphaUiSeleniumCoreTest
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/alphaUi/**/*{.groovy,.java}"
+          <<: *require-build
+          <<: *slack-defaults
+
+  build_and_test_with_jre_17:
+    when:
+      and:
+        - << pipeline.git.branch >>
+        - not:
+            matches:
+              pattern: /^pull\/[0-9]+$/
+              value: << pipeline.git.branch >>
+    jobs:
+      - build-rundeck:
+          name: Build with JRE 17
+          <<: *slack-defaults
+          jreVersion: "openjdk-17-jre-headless"
       - test-gradle-functional:
           name: T Selenium
           gradle-task: seleniumCoreTest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -817,6 +817,36 @@ workflows:
       - build-rundeck:
           name: Build with Docker image using JRE 17
           jreVersion: "openjdk-17-jre-headless"
+      - test-docker:
+          name: T Docker running JRE 17
+          command: bash test/run-docker-tests.sh
+          <<: *require-build
+          <<: *slack-defaults
+      - test-docker:
+          name: T Integration SSL running JRE 17
+          command: bash test/run-docker-ssl-tests.sh
+          <<: *require-build
+          <<: *slack-defaults
+      - test-docker:
+          name: T Integration Ansible running JRE 17
+          command: bash test/run-docker-ansible-tests.sh
+          <<: *require-build
+          <<: *slack-defaults
+      - test-machine:
+          name: T Integration LDAP running JRE 17
+          command: bash test/run-docker-ldap-tests.sh
+          <<: *require-build
+          <<: *slack-defaults
+      - test-machine:
+          name: T Integration LDAP Bind running JRE 17
+          command: DOCKER_COMPOSE_SPEC=docker-compose-ldap-binding-test.yaml bash test/run-docker-ldap-tests.sh
+          <<: *require-build
+          <<: *slack-defaults
+      - test-docker:
+          name: T Integration PAM running JRE 17
+          command: bash test/run-docker-pam-tests.sh
+          <<: *require-build
+          <<: *slack-defaults
       - test-gradle-functional:
           name: T Selenium running JRE 17
           gradle-task: seleniumCoreTest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -820,33 +820,27 @@ workflows:
       - test-docker:
           name: T Docker running JRE 17
           command: bash test/run-docker-tests.sh
-          <<: *require-build
-          <<: *slack-defaults
+          <<: *require-build-jre-17
       - test-docker:
           name: T Integration SSL running JRE 17
           command: bash test/run-docker-ssl-tests.sh
-          <<: *require-build
-          <<: *slack-defaults
+          <<: *require-build-jre-17
       - test-docker:
           name: T Integration Ansible running JRE 17
           command: bash test/run-docker-ansible-tests.sh
-          <<: *require-build
-          <<: *slack-defaults
+          <<: *require-build-jre-17
       - test-machine:
           name: T Integration LDAP running JRE 17
           command: bash test/run-docker-ldap-tests.sh
-          <<: *require-build
-          <<: *slack-defaults
+          <<: *require-build-jre-17
       - test-machine:
           name: T Integration LDAP Bind running JRE 17
           command: DOCKER_COMPOSE_SPEC=docker-compose-ldap-binding-test.yaml bash test/run-docker-ldap-tests.sh
-          <<: *require-build
-          <<: *slack-defaults
+          <<: *require-build-jre-17
       - test-docker:
           name: T Integration PAM running JRE 17
           command: bash test/run-docker-pam-tests.sh
-          <<: *require-build
-          <<: *slack-defaults
+          <<: *require-build-jre-17
       - test-gradle-functional:
           name: T Selenium running JRE 17
           gradle-task: seleniumCoreTest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,7 +432,7 @@ jobs:
           at: ~/workspace
       - run-build-step:
           step-name: Build Docker Images
-          command: rundeck_docker_build
+          command: rundeck_docker_build openjdk-11-jre-headless
       - run-build-step:
           step-name: Publish Docker Images
           command: rundeck_docker_publish
@@ -635,7 +635,7 @@ require-build: &require-build
 
 require-build-jre-17: &require-build-jre-17
   requires:
-    - Build_JRE_17
+    - Build with Docker image using JRE 17
 
 filters:
   all: &filter-default
@@ -815,37 +815,37 @@ workflows:
               value: << pipeline.git.branch >>
     jobs:
       - build-rundeck:
-          name: Build_JRE_17
+          name: Build with Docker image using JRE 17
           jreVersion: "openjdk-17-jre-headless"
       - test-gradle-functional:
-          name: T Selenium
+          name: T Selenium running JRE 17
           gradle-task: seleniumCoreTest
           parallelism: 3
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/**/*{.groovy,.java}"
           <<: *require-build-jre-17
       - test-gradle-functional:
-          name: T Functional API
+          name: T Functional API running JRE 17
           gradle-task: apiTest
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/**/*{.groovy,.java}"
           parallelism: 3
           <<: *require-build-jre-17
       - test-gradle-functional:
-          name: T Functional Plugin Blocklist
+          name: T Functional Plugin Blocklist running JRE 17
           gradle-task: pluginBlocklistTest
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/integration/**/*{.groovy,.java}"
           <<: *require-build-jre-17
       - test-gradle-functional:
-          name: T Feature NewLocalExec
+          name: T Feature NewLocalExec running JRE 17
           gradle-task: apiTestNewLocal
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionOutputSpec.groovy"
           <<: *require-build-jre-17
       - test-gradle-functional:
-          name: T Feature NodeExecutorSecureInput
+          name: T Feature NodeExecutorSecureInput running JRE 17
           gradle-task: apiTestNodeExecutorSecureInput
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/input/*.groovy"
           <<: *require-build-jre-17
       - test-gradle-functional:
-          name: T Selenium Alpha UI
+          name: T Selenium Alpha UI running JRE 17
           gradle-task: alphaUiSeleniumCoreTest
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/alphaUi/**/*{.groovy,.java}"
           <<: *require-build-jre-17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -817,11 +817,11 @@ workflows:
               only:
                 - main
     when:
-      and:
-        - << pipeline.git.branch >>
+      or:
         - matches:
-              pattern: release/5\..*
-              value: << pipeline.git.branch >>
+            pattern: release/5\..*
+            value: << pipeline.git.branch >>
+        - equal: [ main, << pipeline.git.branch >> ]
     jobs:
       - build-rundeck:
           name: Build with Docker image using JRE 17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,7 +422,10 @@ jobs:
     <<: *job-defaults
     executor:
       name: docker-builder
-
+    parameters:
+      jreVersion:
+        type: string
+        default: "openjdk-11-jre-headless"
     steps:
       - setup_docker
       - checkout
@@ -432,7 +435,7 @@ jobs:
           at: ~/workspace
       - run-build-step:
           step-name: Build Docker Images
-          command: rundeck_docker_build openjdk-11-jre-headless
+          command: rundeck_docker_build << parameters.jreVersion >>
       - run-build-step:
           step-name: Publish Docker Images
           command: rundeck_docker_publish
@@ -806,12 +809,18 @@ workflows:
           <<: *slack-defaults
 
   build_and_test_with_jre_17:
+    triggers:
+      - schedule:
+          cron: "0 23 * * *"
+          filters:
+            branches:
+              only:
+                - main
     when:
       and:
         - << pipeline.git.branch >>
-        - not:
-            matches:
-              pattern: /^pull\/[0-9]+$/
+        - matches:
+              pattern: release/5\..*
               value: << pipeline.git.branch >>
     jobs:
       - build-rundeck:

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Uses the war artifact and creates the `rundeck/rundeck:SNAPSHOT` docker image:
 ./gradlew :docker:officialBuild
 ```
 
-- `-PdockerTags` adds additional tags on the image
+- `dockerTags` adds additional tags on the image
 -   - Ex: `-PdockerTags=local,local-RUN-123`
-- `-PjreVersion=openjdk-17-jre-headless` specifies the JRE version for the image
+- `jreVersion=openjdk-17-jre-headless` specifies the JRE version for the image
   - Ex: `-PjreVersion=openjdk-17-jre-headless`
 
 # Documentation

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Creates image `rundeck/rundeck:SNAPSHOT`, you can define `-PdockerTags` to add a
 
     ./gradlew :docker:officialBuild
 
+The JRE installed on the image can be configured with  `-PjreVersion=openjdk-17-jre-headless`
+
 <br />
 
 # Documentation

--- a/README.md
+++ b/README.md
@@ -55,15 +55,16 @@ Produces: `rundeckapp/build/libs/rundeck-X.Y.war`
 
 ## Docker Build
 
-Uses the war artifact and produces a docker image.
+Uses the war artifact and creates the `rundeck/rundeck:SNAPSHOT` docker image:
 
-Creates image `rundeck/rundeck:SNAPSHOT`, you can define `-PdockerTags` to add additional tags
+```
+./gradlew :docker:officialBuild
+```
 
-    ./gradlew :docker:officialBuild
-
-The JRE installed on the image can be configured with  `-PjreVersion=openjdk-17-jre-headless`
-
-<br />
+- `-PdockerTags` adds additional tags on the image
+-   - Ex: `-PdockerTags=local,local-RUN-123`
+- `-PjreVersion=openjdk-17-jre-headless` specifies the JRE version for the image
+  - Ex: `-PjreVersion=openjdk-17-jre-headless`
 
 # Documentation
 

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -12,7 +12,7 @@ project.evaluationDependsOn(":rundeckapp")
 
 def dockerRepository = findProperty("dockerRepository")?: 'rundeck/rundeck'
 def providedTags = findProperty('dockerTags')?: ''
-def jreVersion = findProperty("dockerRepository")?: 'openjdk-11-jre-headless'
+def jreVersion = findProperty("jreVersion")?: 'openjdk-11-jre-headless'
 
 def dockerTags = [].plus(providedTags.split(',').findAll())
 

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -12,6 +12,7 @@ project.evaluationDependsOn(":rundeckapp")
 
 def dockerRepository = findProperty("dockerRepository")?: 'rundeck/rundeck'
 def providedTags = findProperty('dockerTags')?: ''
+def jreVersion = findProperty("dockerRepository")?: 'openjdk-11-jre-headless'
 
 def dockerTags = [].plus(providedTags.split(',').findAll())
 
@@ -111,7 +112,7 @@ tasks.register('buildUbuntuBase') {
     doLast {
         exec {
             workingDir "./ubuntu-base"
-            commandLine "docker", "build", "-t=rundeck/ubuntu-base", "."
+            commandLine "docker", "build", "--build-arg", "JRE_VERSION=$jreVersion", "-t=rundeck/ubuntu-base", "."
         }
     }
 }

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -18,6 +18,7 @@ ARG TARGETARCH
 
 # The required JRE version args
 ARG JRE_VERSION
+RUN echo "Image JRE: ${JRE_VERSION}"
 RUN if [ -z "$JRE_VERSION" ]; then echo "Error: JRE_VERSION is not set"; exit 1; fi
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -37,7 +38,7 @@ RUN apt-get update && \
         gnupg2 \
         ssh-client \
         sudo \
-        ${JRE_VERSION} \
+        $JRE_VERSION \
         uuid-runtime \
         wget \
         unzip && \

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -16,6 +16,10 @@ FROM ubuntu:22.04
 
 ARG TARGETARCH
 
+# The required JRE version args
+ARG JRE_VERSION
+RUN if [ -z "$JRE_VERSION" ]; then echo "Error: JRE_VERSION is not set"; exit 1; fi
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
@@ -33,7 +37,7 @@ RUN apt-get update && \
         gnupg2 \
         ssh-client \
         sudo \
-        openjdk-17-jre-headless \
+        ${JRE_VERSION} \
         uuid-runtime \
         wget \
         unzip && \

--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && \
         gnupg2 \
         ssh-client \
         sudo \
-        openjdk-11-jre-headless \
+        openjdk-17-jre-headless \
         uuid-runtime \
         wget \
         unzip && \

--- a/scripts/circleci/build-functions.sh
+++ b/scripts/circleci/build-functions.sh
@@ -33,8 +33,11 @@ rundeck_gui_tests() {
 }
 
 rundeck_docker_build() {
+    # Default to the java unless specified as the first param
+    local jreVersion=${1:-"openjdk-11-jre-headless"}
+
     #Build image
-    ./gradlew ${GRADLE_BASE_OPTS} officialBuild -Penvironment=${ENV} -PdockerRepository=${DOCKER_REPO} -PdockerTags=latest,SNAPSHOT
+    ./gradlew ${GRADLE_BASE_OPTS} officialBuild -Penvironment=${ENV} -PdockerRepository=${DOCKER_REPO} -PdockerTags=latest,SNAPSHOT -PjreVersion=${jreVersion}
 
     docker tag "${DOCKER_REPO}:latest" "${DOCKER_CI_REPO}:${DOCKER_IMAGE_BUILD_TAG}"
 

--- a/scripts/circleci/build-functions.sh
+++ b/scripts/circleci/build-functions.sh
@@ -33,8 +33,12 @@ rundeck_gui_tests() {
 }
 
 rundeck_docker_build() {
-    # Default to the java unless specified as the first param
-    local jreVersion=${1:-"openjdk-11-jre-headless"}
+    # Ensure the JRE version is set
+    local jreVersion=${1}
+    if [ -z "$jreVersion" ]; then
+        echo "Error: jreVersion is not set"
+        exit 1
+    fi
 
     #Build image
     ./gradlew ${GRADLE_BASE_OPTS} officialBuild -Penvironment=${ENV} -PdockerRepository=${DOCKER_REPO} -PdockerTags=latest,SNAPSHOT -PjreVersion=${jreVersion}


### PR DESCRIPTION
This pull request introduces a new circleci workflow that executes functional tests against the Rundeck instance running on JRE 17. 

The tests are executed: 
- on the `main` branch nightly
- on any branch with the name matching the `release/5.` pattern on a build

Jira: https://pagerduty.atlassian.net/browse/RUN-2217?atlOrigin=eyJpIjoiYTJlZTJhMjg2MmIxNGUwMmFhODI4MDViNDY3YjMxNTMiLCJwIjoiaiJ9

Reviewer Note:
- Sample successful run with JRE 17: https://app.circleci.com/pipelines/github/rundeck/rundeck/17094/workflows/26028159-c625-4b1a-9195-636b1101ca4e
