### PR TITLE
RUN-3135: cache some API response in GUI

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginConfig.vue
@@ -540,7 +540,7 @@ export default defineComponent({
     async loadProvider(provider: any) {
       try {
         const data =
-          await getRundeckContext().rootStore.plugins.getServiceProviderDescription(
+          await getRundeckContext().rootStore.plugins.getPluginDetail(
             this.serviceName,
             provider,
           );

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginConfig.vue
@@ -200,6 +200,7 @@
 </template>
 
 <script lang="ts">
+import { getRundeckContext } from "../../rundeckService";
 import { defineComponent } from "vue";
 
 import AceEditor from "../utils/AceEditor.vue";
@@ -214,7 +215,6 @@ import { diff } from "deep-object-diff";
 
 import {
   getPluginProvidersForService,
-  getServiceProviderDescription,
   validatePluginConfig,
 } from "../../modules/pluginService";
 
@@ -539,10 +539,11 @@ export default defineComponent({
     },
     async loadProvider(provider: any) {
       try {
-        const data: any = await getServiceProviderDescription(
-          this.serviceName,
-          provider,
-        );
+        const data =
+          await getRundeckContext().rootStore.plugins.getServiceProviderDescription(
+            this.serviceName,
+            provider,
+          );
         if (data.props) {
           this.loadPluginData(data);
         }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginConfig.vue
@@ -90,7 +90,7 @@
         v-else-if="isShowConfigForm && inputLoaded"
         class="col-xs-12 col-sm-12 form-horizontal"
       >
-        <div class="form-group" v-if="$slots.extraProperties">
+        <div v-if="$slots.extraProperties" class="form-group">
           <div class="col-sm-12">
             <slot name="extraProperties"></slot>
           </div>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/ChoosePluginModal.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/ChoosePluginModal.spec.ts
@@ -2,7 +2,14 @@ import { mount, VueWrapper, flushPromises } from "@vue/test-utils";
 import ChoosePluginModal from "../ChoosePluginModal.vue";
 import PluginSearch from "../PluginSearch.vue";
 import { Popover, Tabs, Tab } from "uiv";
-
+jest.mock("@/library/rundeckService", () => ({
+  getRundeckContext: jest.fn().mockImplementation(() => ({
+    eventBus: { on: jest.fn(), emit: jest.fn() },
+    rdBase: "http://localhost:4440/",
+    projectName: "testProject",
+    apiVersion: "44",
+  })),
+}));
 jest.mock("@/library", () => ({
   getRundeckContext: jest.fn(() => ({
     rootStore: {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/services/plugins.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/services/plugins.ts
@@ -1,0 +1,9 @@
+import { api } from "./api";
+
+export async function getPluginDetail(serviceName: string, provider: string) {
+  const resp = await api.get(`/plugin/detail/${serviceName}/${provider}`);
+  if (resp.status !== 200) {
+    throw { message: resp.data.message, response: resp };
+  }
+  return resp.data;
+}

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/Plugins.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/Plugins.ts
@@ -1,13 +1,15 @@
-import { RootStore } from "./RootStore";
 import { RundeckClient } from "@rundeck/client";
+import { getPluginDetail } from "../services/plugins";
 
 import { Serial } from "../utilities/Async";
+import { RootStore } from "./RootStore";
 
 export class PluginStore {
   plugins: Plugin[] = [];
 
   pluginsByService: { [key: string]: Plugin[] } = {};
   pluginsById: { [key: string]: Plugin[] } = {};
+  pluginDetailLoader: { [key: string]: Promise<any> } = {};
 
   constructor(
     readonly root: RootStore,
@@ -32,6 +34,23 @@ export class PluginStore {
     });
     this._refreshPluginGroups();
     return void 0;
+  }
+
+  /**
+   * Get the plugin detail for a service provider, caching the result
+   * @param serviceName
+   * @param provider
+   */
+  getServiceProviderDescription(serviceName: string, provider: string) {
+    if (this.pluginDetailLoader[`${serviceName}/${provider}`] !== undefined) {
+      return this.pluginDetailLoader[`${serviceName}/${provider}`];
+    }
+
+    this.pluginDetailLoader[`${serviceName}/${provider}`] = getPluginDetail(
+      serviceName,
+      provider,
+    );
+    return this.pluginDetailLoader[`${serviceName}/${provider}`];
   }
 
   _refreshPluginGroups() {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/Plugins.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/Plugins.ts
@@ -41,7 +41,7 @@ export class PluginStore {
    * @param serviceName
    * @param provider
    */
-  getServiceProviderDescription(serviceName: string, provider: string) {
+  getPluginDetail(serviceName: string, provider: string) {
     if (this.pluginDetailLoader[`${serviceName}/${provider}`] !== undefined) {
       return this.pluginDetailLoader[`${serviceName}/${provider}`];
     }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/RootStore.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/RootStore.ts
@@ -1,20 +1,21 @@
-import { ExecutionOutputStore, ExecutionOutput } from "./ExecutionOutput";
+import { RundeckClient } from "@rundeck/client";
+import { reactive, UnwrapNestedRefs } from "vue";
+import { api } from "../services/api";
+import { ExecutionOutputStore } from "./ExecutionOutput";
 
 import { JobPageStore } from "./JobPageStore";
-import { WorkflowStore } from "./Workflow";
 import { NavBar } from "./NavBar";
-import { UtilityBar } from "./UtilityBar";
-import { SystemStore } from "./System";
-import { RundeckClient } from "@rundeck/client";
-import { Releases } from "./Releases";
-import { ProjectStore } from "./Projects";
 import { NewsStore } from "./News";
-import { PluginStore } from "./Plugins";
-import { WebhookStore } from "./Webhooks";
-import { ThemeStore } from "./Theme";
 import { NodeSourceFile } from "./NodeSourceFile";
+import { PluginStore } from "./Plugins";
+import { ProjectStore } from "./Projects";
+import { Releases } from "./Releases";
+import { SystemStore } from "./System";
+import { ThemeStore } from "./Theme";
 import { UIStore } from "./UIStore";
-import { reactive, UnwrapNestedRefs } from "vue";
+import { UtilityBar } from "./UtilityBar";
+import { WebhookStore } from "./Webhooks";
+import { WorkflowStore } from "./Workflow";
 
 export class RootStore {
   executionOutputStore: ExecutionOutputStore;
@@ -31,6 +32,7 @@ export class RootStore {
   ui: UnwrapNestedRefs<UIStore>;
   nodeSourceFile: UnwrapNestedRefs<NodeSourceFile>;
   jobPageStore: UnwrapNestedRefs<JobPageStore>;
+  requestCache: { [key: string]: Promise<any> } = {};
 
   constructor(
     readonly client: RundeckClient,
@@ -51,5 +53,18 @@ export class RootStore {
     this.ui = reactive(new UIStore());
     this.nodeSourceFile = reactive(new NodeSourceFile(this, client));
     this.jobPageStore = reactive(new JobPageStore());
+  }
+
+  /**
+   * Get API response for a path, caching the result
+   * @param path API url path
+   */
+  api(path: string) {
+    if (this.requestCache[path] !== undefined) {
+      return this.requestCache[path];
+    }
+
+    this.requestCache[path] = api.get(path);
+    return this.requestCache[path];
   }
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/RootStore.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/RootStore.ts
@@ -58,6 +58,7 @@ export class RootStore {
   /**
    * Get API response for a path, caching the result
    * @param path API url path
+   * @returns Promise<any>
    */
   api(path: string) {
     if (this.requestCache[path] !== undefined) {
@@ -66,5 +67,13 @@ export class RootStore {
 
     this.requestCache[path] = api.get(path);
     return this.requestCache[path];
+  }
+
+  /**
+   * Invalidate a cached API response
+   * @param path
+   */
+  invalidatePath(path: string) {
+    delete this.requestCache[path];
   }
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/RootStore.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/RootStore.ts
@@ -60,7 +60,7 @@ export class RootStore {
    * @param path API url path
    * @returns Promise<any>
    */
-  api(path: string) {
+  cachedApi(path: string) {
     if (this.requestCache[path] !== undefined) {
       return this.requestCache[path];
     }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/test/mocks/mockPluginData.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/test/mocks/mockPluginData.ts
@@ -1,6 +1,100 @@
 // @ts-ignore
 import { Plugin, ServiceType } from "../../Plugins";
 
+export const mockPluginDetail:any = {
+  "title": "Script",
+  "targetHostCompatibility": "all",
+  "ver": null,
+  "id": "21a0270b7f66",
+  "providerMetadata": {
+    "faicon": "file-alt"
+  },
+  "dynamicProps": null,
+  "thirdPartyDependencies": null,
+  "name": "script",
+  "desc": null,
+  "iconUrl": null,
+  "projectMapping": {},
+  "vueConfigComponent": null,
+  "props": [
+    {
+      "allowed": [
+        "resourcexml",
+        "resourcejson",
+        "resourceyaml"
+      ],
+      "defaultValue": null,
+      "desc": "Resources document format that the script will produce",
+      "name": "format",
+      "options": null,
+      "required": true,
+      "scope": null,
+      "selectLabels": null,
+      "staticTextDefaultValue": "",
+      "title": "Resource Format",
+      "type": "FreeSelect"
+    },
+    {
+      "allowed": null,
+      "defaultValue": null,
+      "desc": "Path to script file to execute",
+      "name": "file",
+      "options": null,
+      "required": true,
+      "scope": null,
+      "selectLabels": null,
+      "staticTextDefaultValue": "",
+      "title": "Script File Path",
+      "type": "String"
+    },
+    {
+      "allowed": null,
+      "defaultValue": null,
+      "desc": "Command interpreter to use (optional)",
+      "name": "interpreter",
+      "options": null,
+      "required": false,
+      "scope": null,
+      "selectLabels": null,
+      "staticTextDefaultValue": "",
+      "title": "Interpreter",
+      "type": "String"
+    },
+    {
+      "allowed": null,
+      "defaultValue": null,
+      "desc": "Arguments to pass to the script (optional)",
+      "name": "args",
+      "options": null,
+      "required": false,
+      "scope": null,
+      "selectLabels": null,
+      "staticTextDefaultValue": "",
+      "title": "Arguments",
+      "type": "String"
+    },
+    {
+      "allowed": null,
+      "defaultValue": "false",
+      "desc": "If true, pass script file and args as a single argument to interpreter, otherwise, pass as multiple arguments",
+      "name": "argsQuoted",
+      "options": null,
+      "required": false,
+      "scope": null,
+      "selectLabels": null,
+      "staticTextDefaultValue": "false",
+      "title": "Quote Interpreter Args",
+      "type": "Boolean"
+    }
+  ],
+  "rundeckCompatibilityVersion": "unspecified",
+  "license": "unspecified",
+  "pluginVersion": "5.10.0-SNAPSHOT",
+  "description": "Run a script to produce resource model data",
+  "sourceLink": null,
+  "fwkMapping": {},
+  "dynamicDefaults": null
+}
 export const mockWorkflowStepPlugins: Plugin[] = [
   {
     id: "f39ba031afe7",


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
* Enables caching API response for plugin details in the GUI.
* Improves browser behavior on some pages

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
