### PR TITLE
RCLOUD-1588: Ability to sideload plugins into Docker image.

### DIFF
--- a/docker/official/Dockerfile
+++ b/docker/official/Dockerfile
@@ -6,9 +6,9 @@ COPY --chown=rundeck:root .build .
 RUN java -jar rundeck.war --installonly
 
 # Directories and permissions
-RUN mkdir -p libext etc var/logs \
+RUN mkdir -p libext etc plugins-to-sideload var/logs \
         # Adjust permissions for OpenShift
-        && chmod -R 0775 libext server user-assets etc var
+        && chmod -R 0775 libext plugins-to-sideload server user-assets etc var
 
 COPY --chown=rundeck:root remco /etc/remco
 COPY --chown=rundeck:root lib docker-lib

--- a/docker/official/README.md
+++ b/docker/official/README.md
@@ -82,6 +82,11 @@ RUNDECK_JAAS_FILE_*
 By convention the module name matches the name in the docs, and the config keys match
 the config options listed in the docs uppercase, and all one word.
 
+## Sideloading Plugins
+In certain containerized deployments, you may wish to mount the dynamic portions of Rundeck's filesystem on a separate volume.
+To include external plugins in such a deployment, place them in the `/home/rundeck/plugins-to-sideload/` directory and 
+they will be included during container startup.
+
 ## Extending Configuration
 [Remco](https://github.com/HeavyHorst/remco) is used to generate configuration files
 from templates. It supports different key/value sources such as vault, etcd, and dynamodb.

--- a/docker/official/lib/includes/110_sideload_plugins.sh
+++ b/docker/official/lib/includes/110_sideload_plugins.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eou pipefail
+
+# Copy the plugins instead of moving them since it requires fewer permissions
+# And typically does not actually save space in a containerized environment.
+find /home/rundeck/plugins-to-sideload/ -mindepth 1 -name '*' -exec cp -r {} /home/rundeck/libext/ \;


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is a small enhancement to allow for "sideloading" external plugins  when using Rundeck in complex containerized environments.

In certain containerized runtimes like Kubernetes, it can be desirable to mount any dynamic portions of each container's filesystem on a separate volume. In these scenarios, [the volume](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/) is typically empty at the time the container is created, making it difficult to get external plugins into the container.

**Describe the solution you've implemented**
This solution introduces a `plugins-to-sideload/` directory to Rundeck home. External plugins can be placed here [either by extending the Rundeck image or mounting an external directory]. Plugins in this directory are then copied into Rundeck's external plugin directory `libext` as the container starts up.

**Describe alternatives you've considered**
* Modifying the Rundeck plugin system to load plugins from multiple directories.
* Changing how Rundeck handles bundled plugins.

Both of these alternatives seemed to require more effort than the chosen solution for such a container-specific use-case.

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
