### PR TITLE
RUN-3130 Fix Error handler failing when is used on a Job Reference with a workflow step

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/WorkflowExecutionListenerStepMetrics.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/WorkflowExecutionListenerStepMetrics.java
@@ -52,7 +52,7 @@ public class WorkflowExecutionListenerStepMetrics implements WorkflowExecutionLi
 
     @Override
     public void finishStepExecution(StepExecutor executor, StatusResult result, StepExecutionContext context, StepExecutionItem item) {
-        if(result.isSuccess()) {
+        if(result != null && result.isSuccess()) {
             workflowMetricsWriter.markMeterStepMetric(this.getClass().getName(), "finishWorkflowStepSucceededMeter");
         } else {
             workflowMetricsWriter.markMeterStepMetric(this.getClass().getName(), "finishWorkflowStepFailedMeter");

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/WorkflowExecutionListenerStepMetricsSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/WorkflowExecutionListenerStepMetricsSpec.groovy
@@ -1,0 +1,86 @@
+package com.dtolabs.rundeck.core.execution.workflow
+
+import com.dtolabs.rundeck.core.execution.StatusResult
+import com.dtolabs.rundeck.core.execution.StepExecutionItem
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutor
+import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepExecutionItem
+import spock.lang.Specification
+
+class WorkflowExecutionListenerStepMetricsSpec extends Specification {
+
+    def workflowMetricsWriter = Mock(WorkflowMetricsWriter)
+    def listener = new WorkflowExecutionListenerStepMetrics(workflowMetricsWriter)
+
+    def "test finishStepExecution success case"() {
+        given:
+        def executor = Mock(StepExecutor)
+        def result = Mock(StatusResult) {
+            isSuccess() >> true
+        }
+        def context = Mock(StepExecutionContext)
+        def item = Mock(StepExecutionItem)
+
+        when:
+        listener.finishStepExecution(executor, result, context, item)
+
+        then:
+        1 * workflowMetricsWriter.markMeterStepMetric(_, "finishWorkflowStepSucceededMeter")
+    }
+
+    def "test finishStepExecution failure case with NodeStepExecutionItem"() {
+        given:
+        def executor = Mock(StepExecutor)
+        def result = Mock(StatusResult) {
+            isSuccess() >> false
+        }
+        def context = Mock(StepExecutionContext) {
+            getStepNumber() >> 1
+        }
+        def item = Mock(NodeStepExecutionItem) {
+            getNodeStepType() >> "testNodeStep"
+        }
+
+        when:
+        listener.finishStepExecution(executor, result, context, item)
+
+        then:
+        1 * workflowMetricsWriter.markMeterStepMetric(_, "finishWorkflowStepFailedMeter")
+    }
+
+    def "test finishStepExecution failure case with StepExecutionItem"() {
+        given:
+        def executor = Mock(StepExecutor)
+        def result = Mock(StatusResult) {
+            isSuccess() >> false
+        }
+        def context = Mock(StepExecutionContext) {
+            getStepNumber() >> 2
+        }
+        def item = Mock(StepExecutionItem) {
+            getType() >> "testStep"
+        }
+
+        when:
+        listener.finishStepExecution(executor, result, context, item)
+
+        then:
+        1 * workflowMetricsWriter.markMeterStepMetric(_, "finishWorkflowStepFailedMeter")
+    }
+
+    def "test finishStepExecution with null result"() {
+        given:
+        def executor = Mock(StepExecutor)
+        def context = Mock(StepExecutionContext) {
+            getStepNumber() >> 3
+        }
+        def item = Mock(StepExecutionItem) {
+            getType() >> "testStep"
+        }
+
+        when:
+        listener.finishStepExecution(executor, null, context, item)
+
+        then:
+        1 * workflowMetricsWriter.markMeterStepMetric(_, "finishWorkflowStepFailedMeter")
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionOutputSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionOutputSpec.groovy
@@ -247,6 +247,10 @@ line 4 final'''
         return logs
     }
 
+    @Deprecated(forRemoval = true)
+    /*
+    This method is deprecated. Use the method getAllLogs() from BaseContainer to retrieve logs.
+    * */
     private List<String> getAllLogs(execid, Function<Map, String> paramGen) {
         def logs = []
         def logging = [

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobErrorHandler.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobErrorHandler.groovy
@@ -1,0 +1,83 @@
+package org.rundeck.tests.functional.api.job
+
+import org.rundeck.util.annotations.APITest
+import org.rundeck.util.common.WaitingTime
+import org.rundeck.util.common.execution.ExecutionStatus
+import org.rundeck.util.common.jobs.JobUtils
+import org.rundeck.util.container.BaseContainer
+
+@APITest
+class JobErrorHandler extends BaseContainer{
+
+    public static final String TEST_PROJECT = "error-handler-project"
+    public static final String ARCHIVE_DIR = "/projects-import/error-handler-project"
+
+    def setupSpec() {
+        setupProjectArchiveDirectory(
+                TEST_PROJECT,
+                new File(getClass().getResource(ARCHIVE_DIR).getPath()),
+                [
+                        "importConfig": "true",
+                        "importACL": "true",
+                        "importNodesSources": "true",
+                        "jobUuidOption": "preserve"
+                ]
+        )
+    }
+
+    def "when a workflow step job is referenced and it doesn't exist if an error handler is present should be triggered"(){
+        given:
+        def jobId = "f9b34a63-ff95-41f4-9646-87d90b35fc3d"
+        def jobConfig = [
+                "loglevel": "INFO"
+        ]
+        when:
+        def response = doPost("/job/${jobId}/executions",jobConfig)
+        then:
+        verifyAll {
+            response != null
+            response.successful
+        }
+        when:
+        def json = client.jsonValue(response.body(), Map)
+        String execId = json.id
+        JobUtils.waitForExecution(
+                ExecutionStatus.SUCCEEDED.state,
+                execId,
+                client,
+                WaitingTime.EXCESSIVE
+        )
+        def logs = getAllLogs(execId){}
+        then:
+        logs.toString().contains("Job [Job to delete] not found by name, project")
+        logs.toString().contains("this is the error handler and should keep going if there is a failure WORKFLOW-STEP")
+    }
+
+    def "when a node step job is referenced and it doesn't exist if an error handler is present should be triggered"(){
+        given:
+        def jobId = "f9b34a63-ff95-41f4-9646-87d90b35fc3d"
+        def jobConfig = [
+                "loglevel": "INFO"
+        ]
+        when:
+        def response = doPost("/job/${jobId}/executions",jobConfig)
+        then:
+        verifyAll {
+            response != null
+            response.successful
+        }
+        when:
+        def json = client.jsonValue(response.body(), Map)
+        String execId = json.id
+        JobUtils.waitForExecution(
+                ExecutionStatus.SUCCEEDED.state,
+                execId,
+                client,
+                WaitingTime.EXCESSIVE
+        )
+        def logs = getAllLogs(execId){}
+        then:
+        logs.toString().contains("Job [Job to delete] not found by name, project")
+        logs.toString().contains("this is the error handler and should keep going if there is a failure NODE-STEP")
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobErrorHandler.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobErrorHandler.groovy
@@ -55,7 +55,7 @@ class JobErrorHandler extends BaseContainer{
 
     def "when a node step job is referenced and it doesn't exist if an error handler is present should be triggered"(){
         given:
-        def jobId = "f9b34a63-ff95-41f4-9646-87d90b35fc3d"
+        def jobId = "f9b34a63-ff95-41f4-9646-87d90b35fc3X"
         def jobConfig = [
                 "loglevel": "INFO"
         ]

--- a/functional-test/src/test/resources/projects-import/error-handler-project/error-handler-project/files/etc/project.properties
+++ b/functional-test/src/test/resources/projects-import/error-handler-project/error-handler-project/files/etc/project.properties
@@ -1,0 +1,28 @@
+#Wed Mar 20 17:34:45 UTC 2024
+#edit below
+project.description=
+project.disable.executions=false
+project.disable.schedule=false
+project.execution.history.cleanup.batch=500
+project.execution.history.cleanup.enabled=false
+project.execution.history.cleanup.retention.days=60
+project.execution.history.cleanup.retention.minimum=50
+project.execution.history.cleanup.schedule=0 0 0 1/1 * ? *
+project.jobs.gui.groupExpandLevel=1
+project.label=
+project.later.executions.disable=false
+project.later.executions.enable=false
+project.later.schedule.disable=false
+project.later.schedule.enable=false
+project.name=error-handler-project
+project.nodeCache.enabled=true
+project.nodeCache.firstLoadSynch=true
+project.output.allowUnsanitized=false
+project.retry-counter=30
+resources.source.1.type=local
+resources.source.2.config.file=/home/rundeck/executor/jsch-node.yaml
+resources.source.2.config.format=resourceyaml
+resources.source.2.config.requireFileExists=true
+resources.source.2.type=file
+service.FileCopier.default.provider=jsch-scp
+service.NodeExecutor.default.provider=jsch-ssh

--- a/functional-test/src/test/resources/projects-import/error-handler-project/error-handler-project/jobs/job-f9b34a63-ff95-41f4-9646-87d90b35fc3X.xml
+++ b/functional-test/src/test/resources/projects-import/error-handler-project/error-handler-project/jobs/job-f9b34a63-ff95-41f4-9646-87d90b35fc3X.xml
@@ -1,0 +1,25 @@
+<joblist>
+  <job>
+    <defaultTab>nodes</defaultTab>
+    <description>Reference Job of deleted Job with an error handler</description>
+    <executionEnabled>true</executionEnabled>
+    <id>f9b34a63-ff95-41f4-9646-87d90b35fc3X</id>
+    <loglevel>INFO</loglevel>
+    <name>Reference Job of deleted job</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <plugins />
+    <scheduleEnabled>true</scheduleEnabled>
+    <schedules />
+    <sequence keepgoing='false' strategy='node-first'>
+      <command>
+        <errorhandler keepgoingOnSuccess='true'>
+          <exec>echo 'this is the error handler and should keep going if there is a failure NODE-STEP'</exec>
+        </errorhandler>
+        <jobref name='Job to delete' nodeStep='true'>
+          <useName>true</useName>
+        </jobref>
+      </command>
+    </sequence>
+    <uuid>f9b34a63-ff95-41f4-9646-87d90b35fc3X</uuid>
+  </job>
+</joblist>

--- a/functional-test/src/test/resources/projects-import/error-handler-project/error-handler-project/jobs/job-f9b34a63-ff95-41f4-9646-87d90b35fc3d.xml
+++ b/functional-test/src/test/resources/projects-import/error-handler-project/error-handler-project/jobs/job-f9b34a63-ff95-41f4-9646-87d90b35fc3d.xml
@@ -1,0 +1,25 @@
+<joblist>
+  <job>
+    <defaultTab>nodes</defaultTab>
+    <description>Reference Job of deleted Job with an error handler</description>
+    <executionEnabled>true</executionEnabled>
+    <id>f9b34a63-ff95-41f4-9646-87d90b35fc3d</id>
+    <loglevel>INFO</loglevel>
+    <name>Reference Job of deleted job</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <plugins />
+    <scheduleEnabled>true</scheduleEnabled>
+    <schedules />
+    <sequence keepgoing='false' strategy='node-first'>
+      <command>
+        <errorhandler keepgoingOnSuccess='true'>
+          <exec>echo 'this is the error handler and should keep going if there is a failure WORKFLOW-STEP'</exec>
+        </errorhandler>
+        <jobref name='Job to delete'>
+          <useName>true</useName>
+        </jobref>
+      </command>
+    </sequence>
+    <uuid>f9b34a63-ff95-41f4-9646-87d90b35fc3d</uuid>
+  </job>
+</joblist>


### PR DESCRIPTION
**Bug Fix**
When using an error handler with the "continue on failure" option, if the job didn't exist or was deleted, and if the referenced job was of type workflow step, a null pointer exception was thrown.

**Solution**
To resolve this issue, the code was modified to validate that the variable is not null before attempting to access any data from the result. This change prevents the null pointer exception from occurring and addresses the reported bug.

Additionally, two functional tests were added. These tests verify that error handlers function correctly for both scenarios: when the referenced job is a workflow step and when it is a node step.

To test it manually use the job provided on the functional tests, on both cases the referenced job doesn't exist and since it has an error handler it should succeed showing the message added on the error handler  