### PR TITLE
RCLOUD-1560: Adds resilience to new takeover method.

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -17,6 +17,8 @@
 package rundeck.services
 
 import com.dtolabs.rundeck.app.api.jobs.browse.ItemMeta
+import com.dtolabs.rundeck.core.utils.ResourceAcceptanceTimeoutException
+import com.dtolabs.rundeck.core.utils.WaitUtils
 import org.springframework.jdbc.core.RowCallbackHandler
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
@@ -138,7 +140,9 @@ import java.sql.ResultSet
 import java.sql.SQLException
 import java.text.MessageFormat
 import java.text.SimpleDateFormat
+import java.time.Duration
 import java.util.concurrent.TimeUnit
+import java.util.function.Supplier
 import java.util.stream.Collectors
 
 
@@ -1070,9 +1074,13 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             def originalServerId = se.serverNodeUUID
 
             try {
-                def claimResult = ScheduledExecution.withNewTransaction { status ->
-                    return claimScheduledJob(se, toServerUuid)
-                }
+                def claimResult = WaitUtils.waitFor(
+                        scheduledJobClaimer(se, toServerUuid),
+                        { it != null },
+                        Duration.ofSeconds(30),
+                        Duration.ofSeconds(5)
+                )
+
                 // Note that the ScheduledExecution in se does not contain the updates from the previous transaction.
                 // Use with care.
 
@@ -1082,8 +1090,9 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                         previousServerId: originalServerId,
                         executions      : claimResult.executions
                 ]
-            } catch (Exception e) {
-                log.error("Error claiming scheduled execution ${se.extid}.", e)
+
+            } catch (ResourceAcceptanceTimeoutException ex) {
+                log.error("Error claiming scheduled execution ${se.extid} before the timeout", ex)
 
                 claimed[se.extid] = [
                         success         : false,
@@ -1118,6 +1127,26 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
         }
 
         return claimed
+    }
+
+    /**
+     * A function that attempts to claim a ScheduledExecution by a server in an isolated transaction.
+     */
+    private Supplier<Map> scheduledJobClaimer(ScheduledExecution se, String toServerUuid) {
+        return {
+            def claimResult
+            try {
+                claimResult = ScheduledExecution.withNewTransaction { status ->
+                    return claimScheduledJob(se, toServerUuid)
+                }
+
+            } catch (Exception e) {
+                log.warn("Unable to claim scheduled execution ${se.extid}.", e)
+                claimResult = null
+            }
+
+            return claimResult
+        }
     }
 
     private def scheduleAdHocExecutionsForJob(ScheduledExecution se, String targetServerUUID) {

--- a/rundeckapp/src/integration-test/groovy/rundeck/services/ScheduledExecutionServiceIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/services/ScheduledExecutionServiceIntegrationSpec.groovy
@@ -19,6 +19,9 @@ import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
 /**
  * Integration tests for the ScheduledExecutionService.
  */
@@ -53,6 +56,8 @@ class ScheduledExecutionServiceIntegrationSpec extends Specification {
         def project = 'testProject'
         def seOneId = UUID.randomUUID().toString()
 
+        // Create the resource in a separate transaction so that it can be seen by the separate transactions
+        // in the takeover.
         def se = ScheduledExecution.withNewTransaction {
             def workflow = new Workflow(commands: []).save(flush: true, failOnError: true)
             return new ScheduledExecution(
@@ -77,6 +82,66 @@ class ScheduledExecutionServiceIntegrationSpec extends Specification {
         service.jobSchedulesService = Mock(JobSchedulesService) {
             1 * getSchedulesJobToClaim(TEST_UUID2, null, true, null, null) >> [se]
             isScheduled(se.uuid) >> se.scheduled
+        }
+
+        when:
+        def results = service.reclaimAndScheduleJobByJob()
+
+        then:
+        def actualScheduledExecution = ScheduledExecution.get(se.id)
+
+        results[seOneId]["success"] == true
+        actualScheduledExecution.serverNodeUUID == TEST_UUID2
+    }
+
+    def "reclaimAndScheduleJobByJob retries claim job on failure"() {
+        given:
+        def project = 'testProject'
+        def seOneId = UUID.randomUUID().toString()
+
+        // Create the resource in a separate transaction so that it can be seen by the separate transactions
+        // in the takeover.
+        def se = ScheduledExecution.withNewTransaction {
+            def workflow = new Workflow(commands: []).save(flush: true, failOnError: true)
+            return new ScheduledExecution(
+                    jobName: 'callisto-two',
+                    groupPath: 'group/reclaimAndScheduleJobByJob',
+                    uuid: seOneId,
+                    serverNodeUUID: TEST_UUID1,
+                    project: project,
+                    workflow: workflow,
+                    scheduled: true
+            ).save(flush: true, failOnError: true)
+        }
+
+        // Hold a lock on the resource that gets released after at least one retry.
+        CountDownLatch testLatch = new CountDownLatch(1)
+        CountDownLatch lockLatch = new CountDownLatch(2)
+        Thread.start {
+            ScheduledExecution.withNewTransaction {
+                // Acquire a lock and hold it until the latch is released.
+                ScheduledExecution.get(se.id).lock()
+                testLatch.countDown()
+                lockLatch.await(1, TimeUnit.MINUTES)
+            }
+        }
+        // Continue the test after the lock is acquired.
+        testLatch.await(1, TimeUnit.MINUTES)
+
+        service.frameworkService = Stub(FrameworkService) {
+            existsFrameworkProject(project) >> true
+            isClusterModeEnabled() >> true
+            getServerUUID() >> TEST_UUID2
+        }
+        service.executionServiceBean = Mock(ExecutionService) {
+            getExecutionsAreActive() >> true
+        }
+        service.jobSchedulesService = Mock(JobSchedulesService) {
+            1 * getSchedulesJobToClaim(TEST_UUID2, null, true, null, null) >> [se]
+            (2.._) * isScheduled(se.uuid) >> {
+                lockLatch.countDown()
+                se.scheduled
+            }
         }
 
         when:

--- a/rundeckapp/src/integration-test/groovy/rundeck/services/ScheduledExecutionServiceIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/services/ScheduledExecutionServiceIntegrationSpec.groovy
@@ -62,7 +62,7 @@ class ScheduledExecutionServiceIntegrationSpec extends Specification {
                     serverNodeUUID: TEST_UUID1,
                     project: project,
                     workflow: workflow,
-                    scheduled: false
+                    scheduled: true
             ).save(flush: true, failOnError: true)
         }
 
@@ -76,13 +76,17 @@ class ScheduledExecutionServiceIntegrationSpec extends Specification {
         }
         service.jobSchedulesService = Mock(JobSchedulesService) {
             1 * getSchedulesJobToClaim(TEST_UUID2, null, true, null, null) >> [se]
+            isScheduled(se.uuid) >> se.scheduled
         }
 
         when:
         def results = service.reclaimAndScheduleJobByJob()
 
         then:
+        def actualScheduledExecution = ScheduledExecution.get(se.id)
+
         results[seOneId]["success"] == true
+        actualScheduledExecution.serverNodeUUID == TEST_UUID2
     }
 
     def "reclaiming scheduled jobs includes ad hoc scheduled"() {


### PR DESCRIPTION
**Is this a bugfix, or an enhancement? Please describe.**
This is a follow up to add additional resilience to the takeover mechanism implemented in https://github.com/rundeck/rundeck/pull/9522.

**Describe the solution you've implemented**
This change surrounds the "claim job" and "schedule job" portions of the new takeover method with retries.

In the current implementation of the `reclaimAndScheduleJobByJob` function, the individual operations must be retried individually because they are committed individually. For example, if the "claim job" portion of the takeover succeeds, retrying the entire takeover would miss this job in the "find jobs to takeover" stage.

**Describe alternatives you've considered**
An alternate approach to this problem would be to implement a takeover with an inverted order of operations (schedule job -> claim job) along with a change that stops a newly scheduled job from unscheduling itself if it triggers before claim job commits.

**Additional context**

* I have tested that this works properly locally by:
  * Manually locking a Scheduled Execution record to force the "claim job" retries to kick in.
  * Manually deleting a Misfire Tracker record causing the "schedule job" retries to kick in.
