### PR TITLE
RUN-2240 Make public key download from GUI disabled as default

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -459,6 +459,7 @@ public class RundeckConfigBase {
         Enabled nodeExecutorSecureInput = new Enabled();
         Enabled alphaUi = new Enabled();
         Enabled enhancedJobTakeoverQuery = new Enabled();
+        Enabled apiPublicKeysDownload = new Enabled();
 
 
         @Data

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/StorageController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/StorageController.groovy
@@ -199,6 +199,11 @@ class StorageController extends ControllerBase{
             return renderError("unauthorized")
         }
         if((askedForContent || anyContent) && !maskContent) {
+            //check if download is enabled by feature flag
+            if(!forceDownload && !configurationService.getBoolean("feature.apiPublicKeysDownload.enabled", false)){
+                response.status=403
+                return renderError("download is not enabled")
+            }
             response.contentType=resContentType
             if(forceDownload){
                 def filename= resource.path.name
@@ -275,7 +280,7 @@ class StorageController extends ControllerBase{
      */
     public def keyStorageDownload(StorageParams storageParams){
 
-        Boolean downloadenabled = configurationService.getBoolean("gui.keystorage.downloadenabled", true)
+        Boolean downloadenabled = configurationService.getBoolean("gui.keystorage.downloadenabled", false)
         if(!downloadenabled){
             response.status=403
             return renderError("download is not enabled")

--- a/rundeckapp/grails-app/views/menu/storage.gsp
+++ b/rundeckapp/grails-app/views/menu/storage.gsp
@@ -18,7 +18,7 @@ implied. - See the License for the specific language governing permissions and -
         <meta name="tabpage" content="configure"/>
         <meta name="tabtitle" content="${g.message(code: 'gui.menu.KeyStorage')}"/>
         <title><g:message code="gui.menu.KeyStorage"/></title>
-        <g:set var="downloadenabled" value="${cfg.getBoolean(config: "gui.keystorage.downloadenabled", default: true)}"/>
+        <g:set var="downloadenabled" value="${cfg.getBoolean(config: "gui.keystorage.downloadenabled", default: false)}"/>
 
         <g:embedJSON id="storageData" data="[
                 resourcePath:params.resourcePath,


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Bugfix to prevent a security finding where an user can upload malicious content to the key storage what could be spread to other systems

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
From what was previously reviewed on this issue, our mitigations for this case is:
- As stated in their report, the customer should set up an ICAP-enabled proxy to filter and scan file upload requests before they hit the rundeck server; this alternative would be significantly simpler than adding scanning features to rundeck, as most popular proxy servers support ICAP.
- Restrict access to file upload features using access control.
- "Download" option can be disabled by configuration: https://docs.rundeck.com/docs/administration/configuration/gui-customization.html#rundeck-gui-keystorage-downloadenabled and this PR makes this configuration disabled by default
- Add a new feature flag `apiPublicKeysDownload` to disable Key Storage content retrieval at API level (it is disabled by default)


**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
