### PR TITLE
Add project key deletion request to function test's BaseContainer

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
@@ -454,6 +454,23 @@ abstract class BaseContainer extends Specification implements ClientProvider, Wa
     }
 
     /**
+     * Deletes the specified project key.
+     * This method sends a DELETE request to remove the project key with the given name.
+     * If the deletion operation fails, a RuntimeException is thrown.
+     *
+     * @param projectName the name of the key's parent project to be deleted. Must not be null.
+     * @param keyPath the path of the project key to be deleted. Must not be null.
+     * @throws RuntimeException if the project deletion fails.
+     *         The exception contains a detailed message obtained from the server's response.
+     */
+    void deleteProjectKey(String projectName, String keyPath) {
+        def response = client.doDelete("/storage/keys/project/${projectName}/${keyPath}")
+        if (!response.successful) {
+            throw new RuntimeException("Failed to delete project key: ${response.body().string()}")
+        }
+    }
+
+    /**
      * Updates the configuration of a project with the provided settings.
      *
      * This method sends a PUT request to update the configuration of the specified project

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/storage/KeyStorageView.vue
@@ -213,6 +213,7 @@
               <tbody>
                 <tr v-for="directory in directories" :key="directory.name">
                   <td
+                    data-testid="keyDirectoryButton"
                     class="action"
                     colspan="2"
                     @click="loadDir(directory.path)"


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

### Is this a bugfix, or an enhancement? Please describe.
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

This is an enhancement to better allow testing of key storage in selenium tests.

### Describe the solution you've implemented
<!-- A clear and concise description of what you want to happen. -->

I've added a data-testid attribute to the key directory button for better discoverability in test suites and added the key deletion request to the selenium BaseContainer class.

### Describe alternatives you've considered
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

I could have defined the key deletion request directly in a test but making it available for wider use seems wise, especially since there are similar functions in this class already.

### Additional context
<!-- Add any other context or screenshots about the change here. -->
N/A
