### PR TITLE
RUN-3212: Add method to delete api tokens by user

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
@@ -880,14 +880,16 @@ class ApiService implements WebUtilService{
     }
 
     /**
-     * Find and remove AuthTokens created by creator
-     * @param creator
+     * Find and remove AuthTokens by user id
+     * @param userId
      * @return
      */
     @Transactional
     @CompileStatic
-    def removeAllTokensByCreator(String creator) {
-        List<AuthenticationToken> tokenlist = tokenDataProvider.findAllByCreator(creator)
+    def removeAllTokensByUser(String userId) {
+        log.debug("Attempting to remove tokens for user: ${userId}")
+
+        List<AuthenticationToken> tokenlist = tokenDataProvider.findAllByUser(userId)
 
         if(tokenlist) {
             tokenlist.forEach { token -> tokenDataProvider.delete(token.uuid)}

--- a/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
@@ -880,6 +880,22 @@ class ApiService implements WebUtilService{
     }
 
     /**
+     * Find and remove AuthTokens created by creator
+     * @param creator
+     * @return
+     */
+    @Transactional
+    @CompileStatic
+    def removeAllTokensByCreator(String creator) {
+        List<AuthenticationToken> tokenlist = tokenDataProvider.findAllByCreator(creator)
+
+        if(tokenlist) {
+            tokenlist.forEach { token -> tokenDataProvider.delete(token.uuid)}
+        }
+        tokenlist.size()
+    }
+
+    /**
      * Find and remove AuthTokens created by creator that are expired
      * @param creator
      * @return

--- a/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
@@ -54,6 +54,8 @@ class UserService {
         return userDataProvider.findByLogin(login)?.email
     }
 
+    String getUserId(String login) {return userDataProvider.findByLogin(login)?.id}
+
     def registerLogin(String login, String sessionId){
         try {
             return userDataProvider.registerLogin(login, sessionId)

--- a/rundeckapp/src/test/groovy/rundeck/services/UserServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/UserServiceSpec.groovy
@@ -343,6 +343,30 @@ class UserServiceSpec extends Specification implements ServiceUnitTest<UserServi
 
     }
 
+    def "getUserId returns correct id for existing user"() {
+        setup:
+        String login = "testuser"
+        User user = new User(login: login)
+        user.save(flush: true)
+
+        when:
+        def result = service.getUserId(login)
+
+        then:
+        result == user.id.toString()
+    }
+
+    def "getUserId returns null for non-existent user"() {
+        setup:
+        String login = "nonexistentuser"
+
+        when:
+        def result = service.getUserId(login)
+
+        then:
+        result == null
+    }
+
     def "findWithFilters no user found with logged only"() {
         given:
         def userToSearch = 'admin'


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Enhancement - add method to apiService to allow deleting API tokens when deleting a user. 

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
New method + tests. The method doesn't check if the user id is valid as the controller won't reach the method in such scenarios.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
Considered to expire the tokens and then use the existing method to remove expired tokens, but discarded as this could delete other tokens that weren't requested to be removed as a side-effect (due to being expired).

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
