### PR TITLE
RUN-2144: Fix: option remote json using jsonpath should allow array result

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -1127,9 +1127,6 @@ if the step is a node step. Implicitly `"true"` if not present and not a job ste
         def jpath = JsonPath.using(Configuration.defaultConfiguration())
         try {
             def jsonFilterResult = jpath.parse(payload).read(jobOptionConfigRemoteUrl.getJsonFilter())
-            if(jsonFilterResult instanceof ArrayList){
-                return [error: "the filter ${jobOptionConfigRemoteUrl.getJsonFilter()} return a list, please use another filter"]
-            }
             return [jsonElement: jsonFilterResult, string: jsonFilterResult.toString()]
 
         }catch (Exception e){


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
* fix: option remote JSON filtered via json path should allow array result.

e.g., JSON returns:

```json
[
  {"key":"value1"},
  {"key":"value2"}
]
```

Using json path: `$[*].key` returns an array `["value1","value2"]`. This array would be accepted without the jsonpath query, but fails when it is the result of a jsonpath query.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

Remove incorrect rejection of array results from json path query.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
