### PR TITLE
RUN-3205 Add project name to params to get plugin details

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/gui/common/navigation/NavProjectSettings.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/common/navigation/NavProjectSettings.groovy
@@ -5,7 +5,8 @@ enum NavProjectSettings {
     EXEC_MODE("Execution Mode"),
     USER_INTERFACE("User Interface"),
     DEFAULT_FILE_COPIER("Default File Copier"),
-    DEFAULT_NODE_EXECUTOR("Default Node Executor")
+    DEFAULT_NODE_EXECUTOR("Default Node Executor"),
+    PLUGINS("Plugins")
 
     String tabLink
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/services/plugins.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/services/plugins.ts
@@ -1,9 +1,36 @@
 import { api } from "./api";
 
 export async function getPluginDetail(serviceName: string, provider: string) {
-  const resp = await api.get(`/plugin/detail/${serviceName}/${provider}`);
+  let projectName: string = "";
+  const params = await getParameters();
+
+  if (params.project) {
+    projectName = params.project;
+  }
+  console.log("getPluginDetail" + " params: ", params);
+  const resp = await api.get(
+    `/plugin/detail/${serviceName}/${provider}?project=${projectName}`,
+  );
   if (resp.status !== 200) {
     throw { message: resp.data.message, response: resp };
   }
   return resp.data;
 }
+
+const getParameters = (): Promise<{ [key: string]: string }> => {
+  return new Promise((resolve, reject) => {
+    if (
+      window._rundeck &&
+      window._rundeck.rdBase &&
+      window._rundeck.apiVersion
+    ) {
+      resolve({
+        apiBase: `${window._rundeck.rdBase}/api/${window._rundeck.apiVersion}`,
+        rdBase: window._rundeck.rdBase,
+        project: window._rundeck.projectName,
+      });
+    } else {
+      reject(new Error("No rdBase found"));
+    }
+  });
+};


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
After some refactoring made on frontend and vue code, the request to retrieve plugin details is not including project name on query parameters when it is performed on project context. It makes plugins that have any property with dynamic defaults not be processed and the property is empty when loaded

**Describe the solution you've implemented**
This PR fix the behavior so that project name is included to the plugin details request.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
