### PR TITLE
RUN-3397: fix max param for activity page

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/activity/ActivitySpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/activity/ActivitySpec.groovy
@@ -1,0 +1,52 @@
+package org.rundeck.tests.functional.selenium.activity
+
+import org.rundeck.util.annotations.SeleniumCoreTest
+import org.rundeck.util.container.SeleniumBase
+import org.rundeck.util.gui.pages.activity.ActivityPage
+import org.rundeck.util.gui.pages.execution.CommandPage
+import org.rundeck.util.gui.pages.login.LoginPage
+
+@SeleniumCoreTest
+class ActivitySpec extends SeleniumBase {
+    static final String TEST_PROJECT = "ActivitySpec"
+
+    def setupSpec() {
+        setupProject(TEST_PROJECT)
+
+        //create an execution
+        def loginPage = go LoginPage
+        loginPage.login(TEST_USER, TEST_PASS)
+        def commandPage = go CommandPage, TEST_PROJECT
+        commandPage.runCommandAndWaitToBe("echo 'Hello world'", "SUCCEEDED")
+        commandPage.runCommandAndWaitToBe("echo 'Hello world2'", "SUCCEEDED")
+    }
+
+    def "activity page with default max shows all executions"() {
+        given: "specific user logs in with limited authorization"
+            def loginPage = go LoginPage
+            loginPage.login(TEST_USER, TEST_PASS)
+            assert !driver.currentUrl.contains('/user/error')
+        when: "view activity page"
+            def activityPage = go ActivityPage, TEST_PROJECT
+        then: "activity page shows 2 rows"
+            assert activityPage.getActivityRows().size() == 2
+    }
+
+    def "activity page with default max #max shows #expect rows"() {
+        given: "specific user logs in with limited authorization"
+            def loginPage = go LoginPage
+            loginPage.login(TEST_USER, TEST_PASS)
+            assert !driver.currentUrl.contains('/user/error')
+        when: "view activity page"
+            def activityPage = page ActivityPage
+            activityPage.params = "?max=${max}"
+            activityPage.loadActivityPageForProject(TEST_PROJECT)
+        then: "activity page shows 2 rows"
+            assert activityPage.getActivityRows().size() == expect
+        where:
+            max | expect
+            1   | 1
+            2   | 2
+            100 | 2
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/activity/ActivitySpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/activity/ActivitySpec.groovy
@@ -28,8 +28,9 @@ class ActivitySpec extends SeleniumBase {
             assert !driver.currentUrl.contains('/user/error')
         when: "view activity page"
             def activityPage = go ActivityPage, TEST_PROJECT
+            activityPage.waitForActivityRowsPresent()
         then: "activity page shows 2 rows"
-            assert activityPage.getActivityRows().size() == 2
+            activityPage.getActivityRows().size() == 2
     }
 
     def "activity page with default max #max shows #expect rows"() {
@@ -41,8 +42,10 @@ class ActivitySpec extends SeleniumBase {
             def activityPage = page ActivityPage
             activityPage.params = "?max=${max}"
             activityPage.loadActivityPageForProject(TEST_PROJECT)
+            activityPage.go()
+            activityPage.waitForActivityRowsPresent()
         then: "activity page shows 2 rows"
-            assert activityPage.getActivityRows().size() == expect
+            activityPage.getActivityRows().size() == expect
         where:
             max | expect
             1   | 1

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/activity/ActivitySpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/activity/ActivitySpec.groovy
@@ -28,9 +28,11 @@ class ActivitySpec extends SeleniumBase {
             assert !driver.currentUrl.contains('/user/error')
         when: "view activity page"
             def activityPage = go ActivityPage, TEST_PROJECT
-            activityPage.waitForActivityRowsPresent()
+            activityPage
+                .waitForActivityRowsPresent(ActivityPage.ActivityType.ADHOC, ActivityPage.ActivityState.SUCCEEDED)
         then: "activity page shows 2 rows"
-            activityPage.getActivityRows().size() == 2
+            activityPage
+                .getActivityRows(ActivityPage.ActivityType.ADHOC, ActivityPage.ActivityState.SUCCEEDED).size() == 2
     }
 
     def "activity page with default max #max shows #expect rows"() {
@@ -43,9 +45,11 @@ class ActivitySpec extends SeleniumBase {
             activityPage.params = "?max=${max}"
             activityPage.loadActivityPageForProject(TEST_PROJECT)
             activityPage.go()
-            activityPage.waitForActivityRowsPresent()
+            activityPage
+                .waitForActivityRowsPresent(ActivityPage.ActivityType.ADHOC, ActivityPage.ActivityState.SUCCEEDED)
         then: "activity page shows 2 rows"
-            activityPage.getActivityRows().size() == expect
+            activityPage
+                .getActivityRows(ActivityPage.ActivityType.ADHOC, ActivityPage.ActivityState.SUCCEEDED).size() == expect
         where:
             max | expect
             1   | 1

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/activity/ActivityPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/activity/ActivityPage.groovy
@@ -11,6 +11,7 @@ import org.rundeck.util.gui.pages.project.ActivityListTrait
 class ActivityPage extends BasePage implements ActivityListTrait{
 
     String loadPath = "activity"
+    String params=""
 
     By activityRowBy = By.cssSelector(".link.activity_row.autoclickable.succeed.job")
     By timeAbs = By.className("timeabs")
@@ -25,7 +26,7 @@ class ActivityPage extends BasePage implements ActivityListTrait{
     }
 
     void loadActivityPageForProject(String projectName){
-        this.loadPath = "/project/${projectName}/activity"
+        this.loadPath = "/project/${projectName}/activity${params}"
     }
 
     WebElement getExecutionCount(){

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/activity/ActivityPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/activity/ActivityPage.groovy
@@ -13,10 +13,30 @@ class ActivityPage extends BasePage implements ActivityListTrait{
     String loadPath = "activity"
     String params=""
 
-    By activityRowBy = By.cssSelector(".link.activity_row.autoclickable.succeed.job")
     By timeAbs = By.className("timeabs")
     By executionCount = By.className("summary-count")
+    enum ActivityType {
+        ANY(''),
+        JOB('.job'),
+        ADHOC('.adhoc')
+        String css
 
+        ActivityType(String css) {
+            this.css = css
+        }
+    }
+
+    enum ActivityState {
+        ANY(''),
+        SUCCEEDED('.succeed'),
+        FAILED('.failed'),
+        ABORTED('.aborted')
+        String css
+
+        ActivityState(String css) {
+            this.css = css
+        }
+    }
     ActivityPage(final SeleniumContext context) {
         super(context)
     }
@@ -33,12 +53,20 @@ class ActivityPage extends BasePage implements ActivityListTrait{
         el executionCount
     }
 
-    List<WebElement> getActivityRows() {
-        els activityRowBy
+    static By activityRowBy(ActivityType type, ActivityState state) {
+        By.cssSelector(".link.activity_row.autoclickable${state.css}${type.css}")
     }
 
-    def waitForActivityRowsPresent() {
-        waitForNumberOfElementsToBeMoreThan activityRowBy, 0
+    List<WebElement> getActivityRows() {
+        els(activityRowBy(ActivityType.JOB, ActivityState.SUCCEEDED))
+    }
+
+    List<WebElement> getActivityRows(ActivityType type, ActivityState state) {
+        els(activityRowBy(type, state))
+    }
+
+    def waitForActivityRowsPresent(ActivityType type = ActivityType.ANY, ActivityState state = ActivityState.ANY) {
+        waitForNumberOfElementsToBeMoreThan(activityRowBy(type, state), 0)
     }
 
     WebElement getTimeAbs() {

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/activity/ActivityPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/activity/ActivityPage.groovy
@@ -37,6 +37,10 @@ class ActivityPage extends BasePage implements ActivityListTrait{
         els activityRowBy
     }
 
+    def waitForActivityRowsPresent() {
+        waitForNumberOfElementsToBeMoreThan activityRowBy, 0
+    }
+
     WebElement getTimeAbs() {
         el timeAbs
     }

--- a/rundeckapp/grails-app/views/reports/index.gsp
+++ b/rundeckapp/grails-app/views/reports/index.gsp
@@ -84,7 +84,7 @@ search
             action: AuthConstants.ACTION_DELETE_EXECUTION
     ) || projAdminAuth}"/>
     <cfg:setVar var="defaultMax" defaultValue="${30}" key="pagination.default.max"/>
-    <g:set var="pageMax" value="${params.max?params.int('max',defaultMax):defaultMax}"/>
+    <g:set var="pageMax" value="${params.max?params.int('max'):defaultMax}"/>
     <g:javascript>
     window._rundeck = Object.assign(window._rundeck || {}, {
         data:{


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Fix a bug: using `?max=100` URL params on the activity page causes a 500 error

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
