### PR TITLE
RUN-3422: fix: blank string value for "Options" property type causes Exception

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterImpl.java
@@ -14,6 +14,7 @@ import lombok.Setter;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Plugin adapter implementation
@@ -694,7 +695,9 @@ public class PluginAdapterImpl
             final List<String> splitList;
             if (value instanceof String) {
                 String valstring = (String) value;
-                splitList = Arrays.asList(valstring.split(", *"));
+                splitList = Arrays.stream(valstring.split(", *"))
+                                  .filter(s -> !s.isBlank())
+                                  .collect(Collectors.toList());
             } else if (value instanceof List) {
                 splitList = (List<String>) value;
             } else if (value instanceof Set) {

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtilitySpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/configuration/PluginAdapterUtilitySpec.groovy
@@ -17,12 +17,7 @@
 package com.dtolabs.rundeck.core.plugins.configuration
 
 import com.dtolabs.rundeck.core.plugins.Plugin
-import com.dtolabs.rundeck.plugins.descriptions.PluginMeta
-import com.dtolabs.rundeck.plugins.descriptions.PluginMetadata
-import com.dtolabs.rundeck.plugins.descriptions.PluginProperty
-import com.dtolabs.rundeck.plugins.descriptions.ReplaceDataVariablesWithBlanks
-import com.dtolabs.rundeck.plugins.descriptions.SelectLabels
-import com.dtolabs.rundeck.plugins.descriptions.SelectValues
+import com.dtolabs.rundeck.plugins.descriptions.*
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder
 import spock.lang.Specification
 
@@ -113,7 +108,7 @@ class PluginAdapterUtilitySpec extends Specification {
     }
 
 
-    def "configure options field string"() {
+    def "configure options field string value #value"() {
         given:
         Configuretest1 test = new Configuretest1();
         when:
@@ -130,6 +125,7 @@ class PluginAdapterUtilitySpec extends Specification {
         'a'     | _
         'a,b'   | _
         'a,b,c' | _
+        ''      | _
     }
     def "configure options field boxed Boolean"() {
         given:


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**

If an Option type PluginProperty is configured with a blank string value, it causes an exception.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
