### PR TITLE
fix: add 72-char limit for BCRYPT passwords to address CVE-2025-22228

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/security/JettyCompatibleSpringSecurityPasswordEncoder.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/security/JettyCompatibleSpringSecurityPasswordEncoder.groovy
@@ -25,18 +25,25 @@ class JettyCompatibleSpringSecurityPasswordEncoder implements PasswordEncoder {
     String getUsername() {
         WebUtils.retrieveGrailsWebRequest().getCurrentRequest().getParameter("j_username")
     }
+
     @Override
     String encode(final CharSequence rawPassword) {
         //does not encode password
         return rawPassword
     }
+
     @Override
     boolean matches(final CharSequence rawPass, final String encPass) {
-        if(!encPass || !rawPass) return false
-        if(encPass.startsWith("MD5:")) return Credential.MD5.digest(rawPass.toString()) == encPass
-        if(encPass.startsWith("OBF:")) return Password.obfuscate(rawPass.toString()) == encPass
-        if(encPass.startsWith("CRYPT:")) return Credential.Crypt.crypt(username, rawPass.toString()) == encPass
-        if(encPass.startsWith("BCRYPT:")) return new BcryptCredentialProvider().getCredential(encPass).check(rawPass)
+        if (!encPass || !rawPass) return false
+        if (encPass.startsWith("MD5:")) return Credential.MD5.digest(rawPass.toString()) == encPass
+        if (encPass.startsWith("OBF:")) return Password.obfuscate(rawPass.toString()) == encPass
+        if (encPass.startsWith("CRYPT:")) return Credential.Crypt.crypt(username, rawPass.toString()) == encPass
+        if(encPass.startsWith("BCRYPT:")) {
+            // Applying 72-character limit only for BCrypt passwords
+            if (rawPass.length() > 72) return false
+            return new BcryptCredentialProvider().getCredential(encPass).check(rawPass)
+        }
         return encPass == rawPass
     }
 }
+


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
