### PR TITLE
fix flaky test(?) avoid repeated query

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/JobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/JobsSpec.groovy
@@ -592,23 +592,19 @@ class JobsSpec extends SeleniumBase {
         jobShowPage.selectOptionFromOptionListByName(optionListOfNames, selection)
         jobShowPage.waitForElementToBeClickable(jobShowPage.getOptionSelectByName(optionListOfValues))
         jobShowPage.waitForNumberOfElementsToBe(By.name("extra.option.search"), Integer.valueOf(selection))
-        def flag = true
-        (0..(selection-1)).each{
-            if(!jobShowPage.getOptionSelectChildren(optionListOfValues)[it].isSelected()) flag = false
-        }
-        noUnselectedOptions = flag
+        def children = jobShowPage.getOptionSelectChildren(optionListOfValues)
 
         then:
-        jobShowPage.validatePage()
+        children.every{it.isSelected()}
 
         cleanup:
         deleteProject(projectName)
 
         where:
-        selection   | noUnselectedOptions
-        2           | true
-        3           | true
-        4           | true
+        selection   | _
+        2           | _
+        3           | _
+        4           | _
 
     }
 


### PR DESCRIPTION
- fix incorrect check condition
- avoid repeating the getOptionSelectChildren query multiple times
- simplify test checks and setup

flaky failure:

> org.openqa.selenium.StaleElementReferenceException: stale element reference: stale element not found in the current frame ...
> Element: ... -> name: extra.option.search]
> at org.rundeck.tests.functional.selenium.jobs.JobsSpec.Select all json list options by default_closure2(JobsSpec.groovy:597)

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
