### PR TITLE
RUN-3452: fix: flaky test when a JSON parse error occurs

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionSpec.groovy
@@ -134,7 +134,7 @@ class ExecutionSpec extends BaseContainer {
         cleanup:
             def retrieveExecutions = {->
                 try {
-                    return ExecutionUtils.Retrievers.executionsForProject(client, projectName).get()
+                    return ExecutionUtils.Retrievers.executionsForProjectClosure(client, projectName).call()
                 } catch (JsonParseException e) {
                     // if request doesnt return an expected json, return null to retry
                     e.printStackTrace()

--- a/functional-test/src/test/groovy/org/rundeck/util/common/execution/ExecutionUtils.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/common/execution/ExecutionUtils.groovy
@@ -95,6 +95,16 @@ class ExecutionUtils {
          * @return a closure that lists all executions for the project
          */
         static final Supplier<List<Execution>> executionsForProject(RdClient client, String projectName, String queryString = null) {
+            return executionsForProjectClosure(client, projectName, queryString) as Supplier
+        }
+        /**
+         * Returns a closure that retrieves executions for a project.
+         * @param client
+         * @param projectName name of the project or * for all projects
+         * @param queryString query string to append to the request
+         * @return a closure that lists all executions for the project
+         */
+        static final Closure<List<Execution>> executionsForProjectClosure(RdClient client, String projectName, String queryString = null) {
             { ->
                 def execsResponse = client.doGetAcceptAll("/project/${projectName}/executions" + (queryString ? "?${queryString}" : ""))
                 JobExecutionsResponse parsedResponse = OBJECT_MAPPER.readValue(execsResponse.body().string(), JobExecutionsResponse.class)


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**
Flaky test fix
**Describe the solution you've implemented**
Change utility code used by a test

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**

Because a Closure proxied as a Supplier cannot throw exceptions, an UndeclaredThrowableException happens when a JSON parse failure occurs.

The test is meant to accept that failure and skip the result, but instead fails.

Use a Closure directly to correctly see the thrown exception
