### PR TITLE
RUN-3491: add single retry with page refresh to scm test

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/scm/ScmStatusBadgeSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/scm/ScmStatusBadgeSpec.groovy
@@ -11,7 +11,6 @@ import org.rundeck.util.api.scm.GitScmApiClient
 import org.rundeck.util.api.scm.gitea.GiteaApiRemoteRepo
 import org.rundeck.util.api.storage.KeyStorageApiClient
 import org.rundeck.util.container.SeleniumBase
-import spock.lang.Ignore
 
 @SeleniumCoreTest
 class ScmStatusBadgeSpec extends SeleniumBase {
@@ -55,7 +54,6 @@ class ScmStatusBadgeSpec extends SeleniumBase {
         scmStatusBadge.getTooltips() == 'Not Tracked for SCM Import'
     }
 
-    @Ignore("flaky test needs to be fixed")
     def "job scm import status badge after import job changes"(){
         given:
         go(LoginPage).login(TEST_USER, TEST_PASS)

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/scm/ScmStatusBadge.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/scm/ScmStatusBadge.groovy
@@ -17,15 +17,25 @@ class ScmStatusBadge {
     static final String tooltipsAttribute = "title"
 
     ScmStatusBadge(JobShowPage jobShowPage){
-        new WebDriverWait(jobShowPage.driver, Duration.ofSeconds(10)).until(
-                ExpectedConditions.not(
-                        ExpectedConditions.textToBe(elementSelector, loadingFromServerText)
-                )
-        )
-
+        checkStatusBadge(jobShowPage)
         WebElement statusBadge = jobShowPage.driver.findElement(elementSelector)
         this.tooltips = statusBadge.getAttribute(tooltipsAttribute)
         this.badgeText = statusBadge.getText()
         this.iconClasses = statusBadge.findElement(By.tagName("i")).getAttribute("class").split(" ")
+    }
+
+    void checkStatusBadge(JobShowPage jobShowPage, boolean withRetry = true){
+        try{
+            new WebDriverWait(jobShowPage.driver, Duration.ofSeconds(10)).until(
+                    ExpectedConditions.not(
+                            ExpectedConditions.textToBe(elementSelector, loadingFromServerText)
+                    )
+            )
+        }catch(Exception e){
+            if(withRetry){
+                jobShowPage.driver.navigate().refresh()
+                checkStatusBadge(jobShowPage, false)
+            }
+        }
     }
 }


### PR DESCRIPTION
The scm test is failing due to the following exception

`org.eclipse.jgit.api.errors.JGitInternalException: Exception caught during execution of merge command. org.eclipse.jgit.errors.LockFailedException: Cannot lock /home/rundeck/projects/PScmStatusBadgeTest/ScmImport/.git/index. Ensure that no other process has an open file handle on the lock file /home/rundeck/projects/PScmStatusBadgeTest/ScmImport/.git/index.lock, then you may delete the lock file and retry.`

With this fix whenever it fails to get the scm status, it will refresh the page and try again.