### PR TITLE
RUN-3508: Update setversion.sh

### DIFF
--- a/setversion.sh
+++ b/setversion.sh
@@ -7,25 +7,29 @@ echo "current NUMBER: $CUR_VERSION"
 echo "current TAG: $CUR_TAG"
 
 if [ -z "$1" ] ; then
-echo "usage: setversion.sh <version> [GA|rcX|SNAPSHOT]"
+echo "usage: setversion.sh <version> [GA|rcX]"
+echo "       setversion.sh --bump-minor"
 exit 2
 fi
 
-VNUM="$1"
-shift
-VTAG="${1:-GA}"
-
-VDATE="$(date +%Y%m%d)"
-
-if [ "$VTAG" == "SNAPSHOT" ]; then
-  IFS='.' read -r MAJOR MINOR PATCH <<< "$VNUM"
-  if [ "$PATCH" -ne 0 ]; then
-    echo "Error: For SNAPSHOT, patch version must be 0 (got $VNUM)"
-    exit 4
+if [ "$1" == "--bump-minor" ]; then
+  IFS='.' read -r MAJOR MINOR PATCH <<< "$CUR_VERSION"
+  if [ -z "$MAJOR" ] || [ -z "$MINOR" ] || [ -z "$PATCH" ]; then
+    echo "Error: Current version ($CUR_VERSION) is not in MAJOR.MINOR.PATCH format"
+    exit 3
   fi
   MINOR=$((MINOR + 1))
-  VNUM="$MAJOR.$MINOR.0"
+  PATCH=0
+  VNUM="$MAJOR.$MINOR.$PATCH"
+  VTAG="$CUR_TAG"
+  shift
+else
+  VNUM="$1"
+  shift
+  VTAG="${1:-GA}"
 fi
+
+VDATE="$(date +%Y%m%d)"
 
 if [ "$VTAG" == "GA" ] ; then
 	VNAME="$VNUM-$VDATE"

--- a/setversion.sh
+++ b/setversion.sh
@@ -7,7 +7,7 @@ echo "current NUMBER: $CUR_VERSION"
 echo "current TAG: $CUR_TAG"
 
 if [ -z "$1" ] ; then
-echo "usage: setversion.sh <version> [GA|rcX]"
+echo "usage: setversion.sh <version> [GA|rcX|SNAPSHOT]"
 exit 2
 fi
 
@@ -16,6 +16,16 @@ shift
 VTAG="${1:-GA}"
 
 VDATE="$(date +%Y%m%d)"
+
+if [ "$VTAG" == "SNAPSHOT" ]; then
+  IFS='.' read -r MAJOR MINOR PATCH <<< "$VNUM"
+  if [ "$PATCH" -ne 0 ]; then
+    echo "Error: For SNAPSHOT, patch version must be 0 (got $VNUM)"
+    exit 4
+  fi
+  MINOR=$((MINOR + 1))
+  VNUM="$MAJOR.$MINOR.0"
+fi
 
 if [ "$VTAG" == "GA" ] ; then
 	VNAME="$VNUM-$VDATE"


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Change how setversion.sh works, so that we can automate how we handle snapshot updates.

**Describe the solution you've implemented**
Add the possibility of passing the flag `--bump-minor`, which removes the need of passing arguments (still supports the existing logic though, so both ways can be used).

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
