### PR TITLE
RUN-3329: change sonatype urls

### DIFF
--- a/gradle/exported-project.gradle
+++ b/gradle/exported-project.gradle
@@ -99,8 +99,8 @@ publishing {
      repositories {
          maven {
              // change URLs to point to your repos, e.g. http://my.org/repo
-             def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-             def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+             def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/'
+             def snapshotsRepoUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
              url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
              credentials {
                  username findProperty('sonatypeUsername')

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -611,8 +611,8 @@ publishing {
     repositories {
          maven {
              // change URLs to point to your repos, e.g. http://my.org/repo
-             def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-             def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+             def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/'
+             def snapshotsRepoUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
              url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
              credentials {
                  username findProperty('sonatypeUsername')


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
This is maintenance since sonatype legacy system will stop working on June 30th, 2025.

**Describe the solution you've implemented**
URL's has been changed as shown on this doc
[https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration](url)
