### PR TITLE
Added Ansible plugin release

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 rundeck:
   plugins: # Extra plugins to bundle
-  - "com.github.rundeck-plugins:ansible-plugin:4.0.8"
+  - "com.github.rundeck-plugins:ansible-plugin:4.0.9"
   - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.9"
   - "com.github.rundeck-plugins:py-winrm-plugin:2.1.3@zip"
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.3@zip"


### PR DESCRIPTION
## JIra Ticket: https://pagerduty.atlassian.net/browse/RUN-3236

This pull request updates the `build.yaml` file to include a version bump for the Ansible plugin used in Rundeck.

* [`build.yaml`](diffhunk://#diff-2f7f69286606c0ff1642fac8ecb40ee91874b65bb544af172e32552c91a44799L4-R4): Updated the `ansible-plugin` from version `4.0.8` to `4.0.9` to ensure compatibility or include new features and fixes.