### PR TITLE
RUN-3515: Addresses CVE-2025-48734 by updating beanutils to version 1.11.0

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     api 'org.apache.ant:ant:1.10.14',
         'org.slf4j:slf4j-api:1.7.32',
         "commons-codec:commons-codec:${commonsCodecVersion}",
-        'commons-beanutils:commons-beanutils:1.9.4',
+        "commons-beanutils:commons-beanutils:${beanutilsVersion}",
         'commons-collections:commons-collections:3.2.2',
         'commons-lang:commons-lang:2.6',
         'jaxen:jaxen:1.2.0',

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,3 +62,4 @@ commonsIoVersion=2.14.0
 jschVersion=0.1.55
 mwiedeJschVersion=0.2.21
 minaCoreVersion=2.2.4
+beanutilsVersion=1.11.0

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -160,7 +160,7 @@ dependencies {
     implementation 'org.grails.plugins:external-config:2.0.0'
     implementation 'commons-fileupload:commons-fileupload:1.5'
     implementation "commons-io:commons-io:${commonsIoVersion}"
-    implementation 'commons-beanutils:commons-beanutils:1.9.4'
+    implementation "commons-beanutils:commons-beanutils:${beanutilsVersion}"
     implementation "commons-codec:commons-codec:${commonsCodecVersion}"
 
     implementation "org.yaml:snakeyaml:${snakeyamlVersion}"


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
