### PR TITLE
RUN-3433 Avoid create multiple execution report if notification fails

### DIFF
--- a/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionJobIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionJobIntegrationSpec.groovy
@@ -19,6 +19,7 @@ import rundeck.services.FrameworkService
 import rundeck.services.JobSchedulerService
 import rundeck.services.JobSchedulesService
 import rundeck.services.MissingScheduledExecutionException
+import rundeck.services.events.ExecutionCompleteEvent
 import rundeck.services.execution.ThresholdValue
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -74,7 +75,7 @@ class ExecutionJobIntegrationSpec extends Specification {
             def execMap = new ExecutionService.AsyncStarted()
 
             boolean saveStateCalled = false
-            1 * mockes.saveExecutionState(
+            1 * mockes.saveExecutionState_newTransaction(
                 scheduledExecution.uuid, execution.id, {
                 it.status == 'succeeded'
                 it.cancelled == false
@@ -83,6 +84,7 @@ class ExecutionJobIntegrationSpec extends Specification {
             }, _, _
             ) >> {
                 saveStateCalled = true
+                new ExecutionCompleteEvent()
             }
             def saveStatsComplete = false
             def fail3times = throwXTimes(3)
@@ -182,11 +184,11 @@ class ExecutionJobIntegrationSpec extends Specification {
                     execMap
                 )
         then:
-            1 * mockes.saveExecutionState(
+            1 * mockes.saveExecutionState_newTransaction(
                 scheduledExecution.uuid, execution.id, {
                 it.subMap(expectresult.keySet()) == expectresult
             }, _, _
-            ) >> true
+            ) >> new ExecutionCompleteEvent()
 
             1 * mockes.updateScheduledExecStatistics(scheduledExecution.uuid, execution.id, { it > 0 }) >> true
     }
@@ -209,7 +211,7 @@ class ExecutionJobIntegrationSpec extends Specification {
             def execMap = new ExecutionService.AsyncStarted()
             def fail3times = throwXTimes(3)
 
-            2 * mockes.saveExecutionState(
+            2 * mockes.saveExecutionState_newTransaction(
                 scheduledExecution.uuid, execution.id, {
                 it.subMap(expectresult.keySet()) == expectresult
             }, _, _
@@ -324,7 +326,7 @@ class ExecutionJobIntegrationSpec extends Specification {
         when:
             job.saveState(null, mockes, execution, true, false, false, true, null, null, initMap, execMap)
         then:
-            1 * mockes.saveExecutionState(
+            1 * mockes.saveExecutionState_newTransaction(
                 null, execution.id, {
                 it.subMap(expectresult.keySet()) == expectresult
             }, execMap, _
@@ -831,7 +833,7 @@ class ExecutionJobIntegrationSpec extends Specification {
             1 * jobSchedulerServiceMock.beforeExecution(_, _, _) >> JobScheduleManager.BeforeExecutionBehavior.proceed
             1 * mockes.executeAsyncBegin(*_)>>new ExecutionService.AsyncStarted(
                 [thread: stb, scheduledExecution: se])
-            1 * mockes.saveExecutionState(*_)
+            1 * mockes.saveExecutionState_newTransaction(*_)
             1 * jobSchedulerServiceMock.afterExecution(_,_, _)
     }
 
@@ -1000,7 +1002,7 @@ class ExecutionJobIntegrationSpec extends Specification {
             job.saveState(null, mockes, execution, true, false, false, true, null, null, null, execMap)
         then:
 
-            1 * mockes.saveExecutionState(
+            1 * mockes.saveExecutionState_newTransaction(
                 null, execution.id, {
                 it.subMap(expectresult.keySet()) == expectresult
             }, execMap, _


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
When a job finishes, it creates a execution report and, in case this process fails, it will retry a couple of times. Although, in the same process it will also trigger the notification process after execution report is saved and the transaction commited. If the notification fails, it will retry all the process again and save multiple execution reports in the database

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Separate the notification process from the execution report save method so that, in case only notification fails, it will retry to trigger only notification event.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
