### PR TITLE
RUN-3462:Fixes regression where "Change the target nodes" filter field remains…

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/BasicJobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/BasicJobsSpec.groovy
@@ -252,6 +252,7 @@ class BasicJobsSpec extends SeleniumBase {
         jobShowPage.optionValidationWarningText.getText().contains 'Option \'reqOpt1\' is required'
     }
 
+    //Added test for Fix for RUN-3462: after jobShowPage.nodeFilterOverride.click()
     def "run job modal should show node filter editable input and configure to localhost"() {
         when:
         def jobShowPage = go JobShowPage, SELENIUM_BASIC_PROJECT
@@ -259,8 +260,6 @@ class BasicJobsSpec extends SeleniumBase {
         jobShowPage.validatePage()
         jobShowPage.runJobLink '7a0d71b2-e096-4fbd-9efb-21bcbe826c0e' click()
         jobShowPage.waitForElementToBeClickable jobShowPage.nodeFilterInput
-
-
         jobShowPage.nodeFilterInput.click()
         jobShowPage.waitForElementToBeClickable jobShowPage.nodeFilterOverride
         jobShowPage.nodeFilterOverride.click()

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/BasicJobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/BasicJobsSpec.groovy
@@ -2,16 +2,11 @@ package org.rundeck.tests.functional.selenium.jobs
 
 import org.openqa.selenium.By
 import org.rundeck.util.annotations.ExcludePro
-import org.rundeck.util.gui.pages.jobs.JobCreatePage
-import org.rundeck.util.gui.pages.jobs.JobListPage
-import org.rundeck.util.gui.pages.home.HomePage
-import org.rundeck.util.gui.pages.jobs.JobShowPage
-import org.rundeck.util.gui.pages.jobs.JobTab
-import org.rundeck.util.gui.pages.jobs.NotificationEvent
-import org.rundeck.util.gui.pages.jobs.NotificationType
-import org.rundeck.util.gui.pages.login.LoginPage
 import org.rundeck.util.annotations.SeleniumCoreTest
 import org.rundeck.util.container.SeleniumBase
+import org.rundeck.util.gui.pages.home.HomePage
+import org.rundeck.util.gui.pages.jobs.*
+import org.rundeck.util.gui.pages.login.LoginPage
 import spock.lang.Stepwise
 
 @SeleniumCoreTest
@@ -29,338 +24,350 @@ class BasicJobsSpec extends SeleniumBase {
 
     def "create job has basic fields"() {
         when:
-            def jobCreatePage = go JobCreatePage, SELENIUM_BASIC_PROJECT
+        def jobCreatePage = go JobCreatePage, SELENIUM_BASIC_PROJECT
         then:
-            jobCreatePage.validatePage()
-            jobCreatePage.jobNameInput
-            jobCreatePage.groupPathInput
-            jobCreatePage.descriptionTextarea
+        jobCreatePage.validatePage()
+        jobCreatePage.jobNameInput
+        jobCreatePage.groupPathInput
+        jobCreatePage.descriptionTextarea
     }
 
     def "create job invalid empty name"() {
         when:
-            def jobCreatePage = go JobCreatePage, SELENIUM_BASIC_PROJECT
+        def jobCreatePage = go JobCreatePage, SELENIUM_BASIC_PROJECT
         then:
-            jobCreatePage.validatePage()
-            jobCreatePage.jobNameInput.clear()
-            jobCreatePage.createJobButton.click()
-            jobCreatePage.errorAlert.getText().contains('Error saving Job')
-            def validationMsg = jobCreatePage.formValidationAlert.getText()
-            validationMsg.contains('"Job Name" parameter cannot be blank')
-            validationMsg.contains('Workflow must have at least one step')
+        jobCreatePage.validatePage()
+        jobCreatePage.jobNameInput.clear()
+        jobCreatePage.createJobButton.click()
+        jobCreatePage.errorAlert.getText().contains('Error saving Job')
+        def validationMsg = jobCreatePage.formValidationAlert.getText()
+        validationMsg.contains('"Job Name" parameter cannot be blank')
+        validationMsg.contains('Workflow must have at least one step')
     }
 
     def "create job invalid empty workflow"() {
         when:
-            def jobCreatePage = go JobCreatePage, SELENIUM_BASIC_PROJECT
+        def jobCreatePage = go JobCreatePage, SELENIUM_BASIC_PROJECT
         then:
-            jobCreatePage.validatePage()
-            jobCreatePage.jobNameInput.sendKeys('a job with empty workflow')
-            jobCreatePage.createJobButton.click()
+        jobCreatePage.validatePage()
+        jobCreatePage.jobNameInput.sendKeys('a job with empty workflow')
+        jobCreatePage.createJobButton.click()
         expect:
-            jobCreatePage.errorAlert.getText().contains('Error saving Job')
-            def validationMsg = jobCreatePage.formValidationAlert.getText()
-            !validationMsg.contains('"Job Name" parameter cannot be blank')
-            validationMsg.contains('Workflow must have at least one step')
-        
+        jobCreatePage.errorAlert.getText().contains('Error saving Job')
+        def validationMsg = jobCreatePage.formValidationAlert.getText()
+        !validationMsg.contains('"Job Name" parameter cannot be blank')
+        validationMsg.contains('Workflow must have at least one step')
+
     }
 
     def "create valid job basic workflow"() {
         when:
-            def jobCreatePage = go JobCreatePage, SELENIUM_BASIC_PROJECT
-            def jobShowPage = page JobShowPage
+        def jobCreatePage = go JobCreatePage, SELENIUM_BASIC_PROJECT
+        def jobShowPage = page JobShowPage
         then:
-            jobCreatePage.fillBasicJob 'a valid job with basic workflow'
-            jobCreatePage.createJobButton.click()
+        jobCreatePage.fillBasicJob 'a valid job with basic workflow'
+        jobCreatePage.createJobButton.click()
         expect:
-            jobShowPage.validatePage()
-            jobShowPage.jobLinkTitleLabel.getText() == 'a valid job with basic workflow'
+        jobShowPage.validatePage()
+        jobShowPage.jobLinkTitleLabel.getText() == 'a valid job with basic workflow'
     }
 
     def "create valid job basic options"() {
         when:
-            def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
-            jobCreatePage.nextUi=nextUi
-            jobCreatePage.go()
-            def jobShowPage = page JobShowPage
-            def optionName = 'seleniumOption1'
+        def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
+        jobCreatePage.nextUi = nextUi
+        jobCreatePage.go()
+        def jobShowPage = page JobShowPage
+        def optionName = 'seleniumOption1'
         then:
-            jobCreatePage.fillBasicJob specificationContext.currentIteration.name+" ${nextUi ? "next ui" : "old ui"}"
-            jobCreatePage.optionButton.click()
-            jobCreatePage.optionNameNew() sendKeys optionName
-            jobCreatePage.executeScript "arguments[0].scrollIntoView(true);", jobCreatePage.saveOptionButton
-            jobCreatePage.saveOptionButton.click()
-            jobCreatePage.waitFotOptLi 0
-            jobCreatePage.createJobButton.click()
+        jobCreatePage.fillBasicJob specificationContext.currentIteration.name + " ${nextUi ? "next ui" : "old ui"}"
+        jobCreatePage.optionButton.click()
+        jobCreatePage.optionNameNew() sendKeys optionName
+        jobCreatePage.executeScript "arguments[0].scrollIntoView(true);", jobCreatePage.saveOptionButton
+        jobCreatePage.saveOptionButton.click()
+        jobCreatePage.waitFotOptLi 0
+        jobCreatePage.createJobButton.click()
         then:
-            jobCreatePage.waitForUrlToContain('/job/show')
-            jobShowPage.jobLinkTitleLabel.getText().contains('create valid job basic options')
-            jobShowPage.optionInputText(optionName) != null
+        jobCreatePage.waitForUrlToContain('/job/show')
+        jobShowPage.jobLinkTitleLabel.getText().contains('create valid job basic options')
+        jobShowPage.optionInputText(optionName) != null
         where:
-            nextUi<<[false]
+        nextUi << [false]
     }
 
     def "edit job set description"() {
         when:
-            def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
-            jobCreatePage.nextUi=nextUi
-            jobCreatePage.go()
-            def jobShowPage = page JobShowPage
-            jobShowPage.nextUi=nextUi
+        def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
+        jobCreatePage.nextUi = nextUi
+        jobCreatePage.go()
+        def jobShowPage = page JobShowPage
+        jobShowPage.nextUi = nextUi
         then:
-            jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de", nextUi
-            jobCreatePage.go()
-            jobCreatePage.descriptionTextarea.sendKeys 'a new job description'
-            jobCreatePage.updateJobButton.click()
+        jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de", nextUi
+        jobCreatePage.go()
+        jobCreatePage.descriptionTextarea.sendKeys 'a new job description'
+        jobCreatePage.updateJobButton.click()
         expect:
-            'a new job description' == jobShowPage.descriptionTextLabel.getText()
+        'a new job description' == jobShowPage.descriptionTextLabel.getText()
         where:
-            nextUi<<[false,true]
+        nextUi << [false, true]
     }
 
     def "edit job set groups"() {
         when:
-            def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
-            jobCreatePage.nextUi=nextUi
-            jobCreatePage.go()
+        def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
+        jobCreatePage.nextUi = nextUi
+        jobCreatePage.go()
         then:
-            jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de", nextUi
-            jobCreatePage.go()
-            jobCreatePage.jobGroupField.clear()
-            jobCreatePage.jobGroupField.sendKeys 'testGroup'
+        jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de", nextUi
+        jobCreatePage.go()
+        jobCreatePage.jobGroupField.clear()
+        jobCreatePage.jobGroupField.sendKeys 'testGroup'
         where:
-            nextUi<<[false,true]
+        nextUi << [false, true]
     }
 
     def "edit job set group via modal"() {
         when:
-            def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
-            jobCreatePage.nextUi=nextUi
-            jobCreatePage.go()
+        def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
+        jobCreatePage.nextUi = nextUi
+        jobCreatePage.go()
         then:
-            jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de", nextUi
-            jobCreatePage.go()
-            jobCreatePage.groupChooseButton.click()
-            jobCreatePage.waitForElementToBeClickable jobCreatePage.groupNameOption
-            jobCreatePage.groupNameOption.click()
+        jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de", nextUi
+        jobCreatePage.go()
+        jobCreatePage.groupChooseButton.click()
+        jobCreatePage.waitForElementToBeClickable jobCreatePage.groupNameOption
+        jobCreatePage.groupNameOption.click()
         expect:
-            'test' == jobCreatePage.jobGroupField.getAttribute("value")
+        'test' == jobCreatePage.jobGroupField.getAttribute("value")
         where:
-            nextUi<<[false, true]
+        nextUi << [false, true]
     }
 
     def "edit job and set schedules tab"() {
         when:
-            def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
+        def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
         then:
-            jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de"
-            jobCreatePage.go()
-            jobCreatePage.tab JobTab.SCHEDULE click()
-            jobCreatePage.scheduleRunYesField.click()
-            if (!jobCreatePage.scheduleEveryDayCheckboxField.isSelected()) {
-                jobCreatePage.scheduleEveryDayCheckboxField.click()
-            }
-            jobCreatePage.scheduleDaysCheckboxDivField.isDisplayed()
-            jobCreatePage.updateJobButton.click()
+        jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de"
+        jobCreatePage.go()
+        jobCreatePage.tab JobTab.SCHEDULE click()
+        jobCreatePage.scheduleRunYesField.click()
+        if (!jobCreatePage.scheduleEveryDayCheckboxField.isSelected()) {
+            jobCreatePage.scheduleEveryDayCheckboxField.click()
+        }
+        jobCreatePage.scheduleDaysCheckboxDivField.isDisplayed()
+        jobCreatePage.updateJobButton.click()
     }
 
     def "edit job and set executions tab"() {
         when:
-            def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
+        def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
         then:
-            jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de", nextUi
-            jobCreatePage.go()
-            jobCreatePage.tab JobTab.EXECUTION_PLUGINS click()
-            if(jobCreatePage.executionPluginsRows.size() > 1){
-                jobCreatePage.executeScript "arguments[0].scrollIntoView(true);", jobCreatePage.killHandlerPluginPreviousRow
-            }
-            if (jobCreatePage.killHandlerPluginCheckbox.isSelected()) {
-                jobCreatePage.killHandlerPluginCheckbox.click()
-                jobCreatePage.killHandlerPluginKillSpawnedCheckbox.click()
-            } else {
-                jobCreatePage.killHandlerPluginCheckbox.click()
-                jobCreatePage.killHandlerPluginCheckbox.isSelected()
-                jobCreatePage.killHandlerPluginKillSpawnedCheckbox.click()
-                jobCreatePage.killHandlerPluginKillSpawnedCheckbox.isSelected()
-            }
-            jobCreatePage.executeScript "arguments[0].scrollIntoView(true);", jobCreatePage.updateJobButton
-            jobCreatePage.updateJobButton.click()
+        jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de", nextUi
+        jobCreatePage.go()
+        jobCreatePage.tab JobTab.EXECUTION_PLUGINS click()
+        if (jobCreatePage.executionPluginsRows.size() > 1) {
+            jobCreatePage.executeScript "arguments[0].scrollIntoView(true);", jobCreatePage.killHandlerPluginPreviousRow
+        }
+        if (jobCreatePage.killHandlerPluginCheckbox.isSelected()) {
+            jobCreatePage.killHandlerPluginCheckbox.click()
+            jobCreatePage.killHandlerPluginKillSpawnedCheckbox.click()
+        } else {
+            jobCreatePage.killHandlerPluginCheckbox.click()
+            jobCreatePage.killHandlerPluginCheckbox.isSelected()
+            jobCreatePage.killHandlerPluginKillSpawnedCheckbox.click()
+            jobCreatePage.killHandlerPluginKillSpawnedCheckbox.isSelected()
+        }
+        jobCreatePage.executeScript "arguments[0].scrollIntoView(true);", jobCreatePage.updateJobButton
+        jobCreatePage.updateJobButton.click()
         where:
-            nextUi<<[false,true]
+        nextUi << [false, true]
     }
 
     def "edit job and set other tab"() {
         when:
-            def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
+        def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
         then:
-            jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de"
-            jobCreatePage.go()
-            jobCreatePage.tab JobTab.OTHER click()
-            if (jobCreatePage.multiExecFalseField.isSelected()) {
-                jobCreatePage.multiExecTrueField.click()
-                jobCreatePage.multiExecTrueField.isSelected()
-            } else {
-                jobCreatePage.multiExecFalseField.click()
-                jobCreatePage.multiExecFalseField.isSelected()
-            }
-            jobCreatePage.executeScript "arguments[0].scrollIntoView(true);", jobCreatePage.updateJobButton
-            jobCreatePage.updateJobButton.click()
+        jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de"
+        jobCreatePage.go()
+        jobCreatePage.tab JobTab.OTHER click()
+        if (jobCreatePage.multiExecFalseField.isSelected()) {
+            jobCreatePage.multiExecTrueField.click()
+            jobCreatePage.multiExecTrueField.isSelected()
+        } else {
+            jobCreatePage.multiExecFalseField.click()
+            jobCreatePage.multiExecFalseField.isSelected()
+        }
+        jobCreatePage.executeScript "arguments[0].scrollIntoView(true);", jobCreatePage.updateJobButton
+        jobCreatePage.updateJobButton.click()
     }
 
     def "edit job and set notifications"() {
         when:
-            def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
+        def jobCreatePage = page JobCreatePage, SELENIUM_BASIC_PROJECT
         then:
-            jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de", false
-            jobCreatePage.go()
-            jobCreatePage.tab JobTab.NOTIFICATIONS click()
-            jobCreatePage.addNotificationButtonByType NotificationEvent.START click()
-            jobCreatePage.notificationDropDown.click()
-            jobCreatePage.notificationByType NotificationType.MAIL click()
-            jobCreatePage.notificationConfigByPropName "recipients" sendKeys 'test@rundeck.com'
-            jobCreatePage.notificationSaveButton.click()
-            jobCreatePage.waitNotificationModal 0
-            jobCreatePage.updateJobButton.click()
+        jobCreatePage.loadEditPath SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de", false
+        jobCreatePage.go()
+        jobCreatePage.tab JobTab.NOTIFICATIONS click()
+        jobCreatePage.addNotificationButtonByType NotificationEvent.START click()
+        jobCreatePage.notificationDropDown.click()
+        jobCreatePage.notificationByType NotificationType.MAIL click()
+        jobCreatePage.notificationConfigByPropName "recipients" sendKeys 'test@rundeck.com'
+        jobCreatePage.notificationSaveButton.click()
+        jobCreatePage.waitNotificationModal 0
+        jobCreatePage.updateJobButton.click()
     }
 
     def "showing the edited job"() {
         setup:
-            def homePage = page HomePage
-            def jobListPage = page JobListPage
-            def jobShowPage = page JobShowPage
+        def homePage = page HomePage
+        def jobListPage = page JobListPage
+        def jobShowPage = page JobShowPage
         when:
-            homePage.goProjectHome"SeleniumBasic"
-            jobListPage.loadPathToShowJob SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de"
+        homePage.goProjectHome "SeleniumBasic"
+        jobListPage.loadPathToShowJob SELENIUM_BASIC_PROJECT, "b7b68386-3a52-46dc-a28b-1a4bf6ed87de"
         then:
-            jobListPage.go()
-            jobShowPage.jobDefinitionModal.click()
+        jobListPage.go()
+        jobShowPage.jobDefinitionModal.click()
         expect:
-            jobShowPage.cronLabel.size() == 2
-            jobShowPage.scheduleTimeLabel.isDisplayed()
-            jobShowPage.multipleExecField.isDisplayed()
-            jobShowPage.multipleExecYesField.getText() == 'Yes'
-            jobShowPage.notificationDefinition.getText() == 'mail to: test@rundeck.com'
-            jobShowPage.closeJobDefinitionModalButton.click()
+        jobShowPage.cronLabel.size() == 2
+        jobShowPage.scheduleTimeLabel.isDisplayed()
+        jobShowPage.multipleExecField.isDisplayed()
+        jobShowPage.multipleExecYesField.getText() == 'Yes'
+        jobShowPage.notificationDefinition.getText() == 'mail to: test@rundeck.com'
+        jobShowPage.closeJobDefinitionModalButton.click()
     }
 
     @ExcludePro
     def "run job modal should show validation error"() {
         when:
-            def jobShowPage = go JobShowPage, SELENIUM_BASIC_PROJECT
+        def jobShowPage = go JobShowPage, SELENIUM_BASIC_PROJECT
         then:
-            jobShowPage.validatePage()
-            jobShowPage.runJobLink '0088e04a-0db3-4b03-adda-02e8a4baf709' click()
-            jobShowPage.waitForElementToBeClickable jobShowPage.runFormButton
-            jobShowPage.runFormButton.click()
-            jobShowPage.waitForElementVisible jobShowPage.optionValidationWarningText
+        jobShowPage.validatePage()
+        jobShowPage.runJobLink '0088e04a-0db3-4b03-adda-02e8a4baf709' click()
+        jobShowPage.waitForElementToBeClickable jobShowPage.runFormButton
+        jobShowPage.runFormButton.click()
+        jobShowPage.waitForElementVisible jobShowPage.optionValidationWarningText
         expect:
-            jobShowPage.optionValidationWarningText.getText().contains 'Option \'reqOpt1\' is required'
+        jobShowPage.optionValidationWarningText.getText().contains 'Option \'reqOpt1\' is required'
     }
 
-    def "run job modal should show node filter editable input"(){
+    def "run job modal should show node filter editable input and configure to localhost"() {
         when:
-            def jobShowPage = go JobShowPage, SELENIUM_BASIC_PROJECT
+        def jobShowPage = go JobShowPage, SELENIUM_BASIC_PROJECT
         then:
-            jobShowPage.validatePage()
-            jobShowPage.runJobLink '7a0d71b2-e096-4fbd-9efb-21bcbe826c0e' click()
-            jobShowPage.waitForElementToBeClickable jobShowPage.nodeFilterInput
-            jobShowPage.nodeFilterInput.click()
-            jobShowPage.waitForElementToBeClickable jobShowPage.nodeFilterOverride
-            jobShowPage.nodeFilterOverride.click()
+        jobShowPage.validatePage()
+        jobShowPage.runJobLink '7a0d71b2-e096-4fbd-9efb-21bcbe826c0e' click()
+        jobShowPage.waitForElementToBeClickable jobShowPage.nodeFilterInput
+
+
+        jobShowPage.nodeFilterInput.click()
+        jobShowPage.waitForElementToBeClickable jobShowPage.nodeFilterOverride
+        jobShowPage.nodeFilterOverride.click()
+        jobShowPage.waitForElementToBeClickable jobShowPage.dropDownToggle
+        jobShowPage.dropDownToggle.click()
+        jobShowPage.waitForElementToBeClickable jobShowPage.selectAllNodesLink
+        jobShowPage.selectAllNodesLink.click()
+        jobShowPage.waitForElementToBeClickable jobShowPage.localhostNode
+        jobShowPage.localhostNode.click()
+        jobShowPage.waitForElementToBeClickable jobShowPage.nodeFilterArrowIcon
+        jobShowPage.nodeFilterArrowIcon.click()
         expect:
-            jobShowPage.schedJobNodeFilter.isDisplayed()
+        jobShowPage.schedJobNodeFilter.isDisplayed()
+        jobShowPage.nodeFilterInputValue.getDomProperty("value").trim() ==~ /name: .+/
+
     }
 
     def "job filter by name results"() {
         when:
-            def jobShowPage = go JobShowPage, SELENIUM_BASIC_PROJECT
+        def jobShowPage = go JobShowPage, SELENIUM_BASIC_PROJECT
         then:
-            jobShowPage.validatePage()
-            jobShowPage.jobSearchButton.click()
-            jobShowPage.waitForModal 1, By.cssSelector(".modal.in")
-            jobShowPage.jobSearchNameField.sendKeys 'option'
-            jobShowPage.jobSearchSubmitButton.click()
-            jobShowPage.waitForNumberOfElementsToBe jobShowPage.jobRowBy, expected.size()
-            jobShowPage.jobRowLink.size() == expected.size()
-            jobShowPage.jobRowLink.collect {
-                it.getText()
-            }.containsAll(expected)
+        jobShowPage.validatePage()
+        jobShowPage.jobSearchButton.click()
+        jobShowPage.waitForModal 1, By.cssSelector(".modal.in")
+        jobShowPage.jobSearchNameField.sendKeys 'option'
+        jobShowPage.jobSearchSubmitButton.click()
+        jobShowPage.waitForNumberOfElementsToBe jobShowPage.jobRowBy, expected.size()
+        jobShowPage.jobRowLink.size() == expected.size()
+        jobShowPage.jobRowLink.collect {
+            it.getText()
+        }.containsAll(expected)
         where:
-            expected = [
+        expected = [
                 "selenium-option-test1",
                 "predefined job with options",
 //                "create valid job basic options next ui", //todo: uncomment this line once workflow is released and alphaUI tests merged back
                 "create valid job basic options old ui"
-            ]
+        ]
     }
 
     def "job filter by name and group 1 results"() {
         when:
-            def jobShowPage = go JobShowPage, SELENIUM_BASIC_PROJECT
+        def jobShowPage = go JobShowPage, SELENIUM_BASIC_PROJECT
         then:
-            jobShowPage.validatePage()
-            jobShowPage.jobSearchButton.click()
-            jobShowPage.waitForModal 1, By.cssSelector(".modal.in")
-            jobShowPage.jobSearchNameField.sendKeys 'option'
-            jobShowPage.jobSearchGroupField.sendKeys 'test'
-            jobShowPage.jobSearchSubmitButton.click()
+        jobShowPage.validatePage()
+        jobShowPage.jobSearchButton.click()
+        jobShowPage.waitForModal 1, By.cssSelector(".modal.in")
+        jobShowPage.jobSearchNameField.sendKeys 'option'
+        jobShowPage.jobSearchGroupField.sendKeys 'test'
+        jobShowPage.jobSearchSubmitButton.click()
         expect:
-            jobShowPage.waitForNumberOfElementsToBeOne jobShowPage.jobRowBy
-            jobShowPage.jobRowLink.collect { it.getText() } == ["selenium-option-test1"]
+        jobShowPage.waitForNumberOfElementsToBeOne jobShowPage.jobRowBy
+        jobShowPage.jobRowLink.collect { it.getText() } == ["selenium-option-test1"]
     }
 
     def "job filter by name and - top group 2 results"() {
         given:
-            def jobShowPage = go JobShowPage, SELENIUM_BASIC_PROJECT
+        def jobShowPage = go JobShowPage, SELENIUM_BASIC_PROJECT
         when:
-            jobShowPage.validatePage()
-            jobShowPage.jobSearchButton.click()
-            jobShowPage.waitForModal 1, By.cssSelector(".modal.in")
-            jobShowPage.jobSearchNameField.sendKeys 'option'
-            jobShowPage.jobSearchGroupField.sendKeys '-'
-            jobShowPage.jobSearchSubmitButton.click()
+        jobShowPage.validatePage()
+        jobShowPage.jobSearchButton.click()
+        jobShowPage.waitForModal 1, By.cssSelector(".modal.in")
+        jobShowPage.jobSearchNameField.sendKeys 'option'
+        jobShowPage.jobSearchGroupField.sendKeys '-'
+        jobShowPage.jobSearchSubmitButton.click()
         then:
-            jobShowPage.waitForNumberOfElementsToBe jobShowPage.jobRowBy, expected.size()
-            def names = jobShowPage.jobRowLink.collect { it.getText() }
-            names.size() == expected.size()
-            names.containsAll expected
+        jobShowPage.waitForNumberOfElementsToBe jobShowPage.jobRowBy, expected.size()
+        def names = jobShowPage.jobRowLink.collect { it.getText() }
+        names.size() == expected.size()
+        names.containsAll expected
         where:
-            expected = [
+        expected = [
                 "predefined job with options",
 //                "create valid job basic options next ui",
                 "create valid job basic options old ui"
-            ]
+        ]
     }
 
     def "view jobs list page"() {
         when:
-            HomePage homePage = page HomePage
-            homePage.validatePage()
+        HomePage homePage = page HomePage
+        homePage.validatePage()
         then:
-            JobListPage jobsListPage = page JobListPage
-            jobsListPage.loadPathToNextUI SELENIUM_BASIC_PROJECT
-            jobsListPage.go()
+        JobListPage jobsListPage = page JobListPage
+        jobsListPage.loadPathToNextUI SELENIUM_BASIC_PROJECT
+        jobsListPage.go()
 
-            verifyAll {
-                driver.currentUrl.contains('nextUi=true')
-                driver.pageSource.contains('ui-type-next')
-            }
+        verifyAll {
+            driver.currentUrl.contains('nextUi=true')
+            driver.pageSource.contains('ui-type-next')
+        }
 
-            jobsListPage.bodyNextUI.isDisplayed()
+        jobsListPage.bodyNextUI.isDisplayed()
 
-            jobsListPage.createJobLink.isDisplayed()
+        jobsListPage.createJobLink.isDisplayed()
 
-            def actionsButton = jobsListPage.jobsActionsButton
-            actionsButton.isDisplayed()
-            actionsButton.getText().contains('Job Actions')
-            jobsListPage.jobsHeader.isDisplayed()
-            jobsListPage.activitySectionLink.isDisplayed()
-            jobsListPage.activityHeader.isDisplayed()
+        def actionsButton = jobsListPage.jobsActionsButton
+        actionsButton.isDisplayed()
+        actionsButton.getText().contains('Job Actions')
+        jobsListPage.jobsHeader.isDisplayed()
+        jobsListPage.activitySectionLink.isDisplayed()
+        jobsListPage.activityHeader.isDisplayed()
         when:
-            actionsButton.click()
+        actionsButton.click()
         then:
-            jobsListPage.getLink('Upload Definition').isDisplayed()
-            jobsListPage.getLink('Bulk Edit').isDisplayed()
+        jobsListPage.getLink('Upload Definition').isDisplayed()
+        jobsListPage.getLink('Bulk Edit').isDisplayed()
     }
 
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobShowPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobShowPage.groovy
@@ -44,6 +44,13 @@ class JobShowPage extends BasePage implements ActivityListTrait {
     By jobActionEditBy = By.xpath("//a[@title='Edit this Job']")
     By nodeFilterInputBy = By.cssSelector("#doReplaceFilters")
     By nodeFilterOverrideBy = By.cssSelector("#filterradio")
+    By nodeFilterInputValueBy = By.cssSelector('input[name="extra.nodefilter"]')
+    By dropDownToggleBy = By.cssSelector("button[data-testid='nfi-toggle']")
+    By selectAllNodesLinkBy = By.cssSelector("a.xnodefilterlink.job_edit__node_filter__filter_select_all")
+    By localhostNodeBy = By.cssSelector(".col-xs-6.node_ident.embedded_node.tight.server .fas.fa-hdd")
+    By popoverContentBy = By.cssSelector("div.popover-content")
+    By nodeFilterLinkBy = By.cssSelector("node-filter-link[params*='linkicon']")
+    By arrowIconBy = By.cssSelector("i.glyphicon-circle-arrow-right")
     By schedJobNodeFilterBy = By.cssSelector("div[class='input-group nodefilters multiple-control-input-group']")
     By jobLinkTitleBy = By.xpath("//a[contains(@class, 'job-header-link')]")
     By autocompleteJobStepDefinitionBy = By.cssSelector("#wfitem_0 > span > div > div > span > span > span.text-success")
@@ -105,16 +112,16 @@ class JobShowPage extends BasePage implements ActivityListTrait {
         this.loadPath = "/project/$project/jobs"
     }
 
-    JobShowPage forJob(String jobUuid){
+    JobShowPage forJob(String jobUuid) {
         this.loadPath = "/project/$project/job/show/$jobUuid"
         return this
     }
 
-    ExecutionShowPage runJob(boolean waitForFinalState = false){
+    ExecutionShowPage runJob(boolean waitForFinalState = false) {
         getRunJobBtn().click()
 
         ExecutionShowPage execution = new ExecutionShowPage(context)
-        if(waitForFinalState) {
+        if (waitForFinalState) {
             execution.waitForRunAgainLink()
             execution.waitForFinalState()
         }
@@ -122,11 +129,11 @@ class JobShowPage extends BasePage implements ActivityListTrait {
         return execution
     }
 
-    ScmStatusBadge getScmStatusBadge(){
+    ScmStatusBadge getScmStatusBadge() {
         return new ScmStatusBadge(this)
     }
 
-    List<WebElement> getOptionsFields(){
+    List<WebElement> getOptionsFields() {
         driver.findElements(By.xpath("//input[contains(@name, 'extra.option.')]"))
     }
 
@@ -136,15 +143,15 @@ class JobShowPage extends BasePage implements ActivityListTrait {
         }
     }
 
-    WebElement getJobExecutionDisabledIcon(){
+    WebElement getJobExecutionDisabledIcon() {
         el jobExecutionDisabledIconBy
     }
 
-    WebElement getJobDefinitionModal(){
+    WebElement getJobDefinitionModal() {
         el jobDefinitionModalBy
     }
 
-    WebElement getNotificationDefinition(){
+    WebElement getNotificationDefinition() {
         el notificationDefinitionBy
     }
 
@@ -249,6 +256,26 @@ class JobShowPage extends BasePage implements ActivityListTrait {
         el nodeFilterOverrideBy
     }
 
+    WebElement getNodeFilterInputValue() {
+        el nodeFilterInputValueBy
+    }
+
+    WebElement getDropDownToggle() {
+        el dropDownToggleBy
+    }
+
+    WebElement getSelectAllNodesLink() {
+        el selectAllNodesLinkBy
+    }
+
+    WebElement getLocalhostNode() {
+        el localhostNodeBy
+    }
+
+    WebElement getNodeFilterArrowIcon() {
+        el(popoverContentBy).findElement(nodeFilterLinkBy).findElement(arrowIconBy)
+    }
+
     WebElement getSchedJobNodeFilter() {
         el schedJobNodeFilterBy
     }
@@ -273,28 +300,28 @@ class JobShowPage extends BasePage implements ActivityListTrait {
         el jobSearchSubmitBy
     }
 
-    WebElement getRunJobBtn(){
+    WebElement getRunJobBtn() {
         el runJobBtnBy
     }
 
-    WebElement getLogOutputBtn(){
+    WebElement getLogOutputBtn() {
         el logOutputBtn
     }
 
-    WebElement getJobOptionsValuesDropdown(){
+    WebElement getJobOptionsValuesDropdown() {
         el jobOptionValuesBy
     }
 
-    WebElement getJobOptionValueListItem(String name){
+    WebElement getJobOptionValueListItem(String name) {
         waitForNumberOfElementsToBeOne(By.xpath("//option[. = '${name}']"))
         driver.findElement(By.xpath("//option[. = '${name}']"))
     }
 
-    WebElement getJobOptionValueInput(){
+    WebElement getJobOptionValueInput() {
         el jobOptionValueInputBy
     }
 
-    WebElement getJobOptionsDropdown(){
+    WebElement getJobOptionsDropdown() {
         el jobOptionsDropdownBy
     }
 
@@ -304,12 +331,12 @@ class JobShowPage extends BasePage implements ActivityListTrait {
      * @param minimum number of log entries that should contain logLineText
      * @param timeout to be waiting for results
      */
-    void waitForLogOutput (String logLineText, Integer minimum = 0, Integer timeout = 10) {
+    void waitForLogOutput(String logLineText, Integer minimum = 0, Integer timeout = 10) {
         By logLineSelector = By.xpath("//span[contains(text(),'${logLineText}')]")
         new WebDriverWait(driver, Duration.ofSeconds(timeout)).until(ExpectedConditions.numberOfElementsToBeMoreThan(logLineSelector, minimum))
     }
 
-    WebElement getExecutionOptionsDropdown(){
+    WebElement getExecutionOptionsDropdown() {
         driver.findElement(By.id("execOptFormRunButtons")).findElement(By.className("btn-secondary"))
     }
 
@@ -317,44 +344,44 @@ class JobShowPage extends BasePage implements ActivityListTrait {
         el runJobLaterBy
     }
 
-    WebElement getRunJobLaterMinuteArrowUp(){
+    WebElement getRunJobLaterMinuteArrowUp() {
         el runJobLaterMinuteArrowUpBy
     }
 
-    WebElement getRunJobLaterCreateScheduleButton(){
+    WebElement getRunJobLaterCreateScheduleButton() {
         el runJobLaterScheduleCreateButtonBy
     }
 
-    WebElement getJobStatusBar(){
+    WebElement getJobStatusBar() {
         el jobStatusBarBy
     }
 
-    void selectOptionFromOptionListByName(String optionListName,int optionNo){
+    void selectOptionFromOptionListByName(String optionListName, int optionNo) {
         def select = new Select(getOptionSelectByName(optionListName))
         select.selectByValue("option${optionNo}")
     }
 
-    WebElement getOptionSelectByName(String name){
+    WebElement getOptionSelectByName(String name) {
         driver.findElement(By.name("extra.option.${name}"))
     }
 
-    List<WebElement> getOptionSelectChildren(String name){
+    List<WebElement> getOptionSelectChildren(String name) {
         final By optionSelector = By.name("extra.option.${name}")
 
         waitForElementVisible(optionSelector)
         driver.findElements(optionSelector)
     }
 
-    void waitForLogOutput (By logOutput, Integer number, Integer seconds){
-        new WebDriverWait(driver, Duration.ofSeconds(seconds)).until(ExpectedConditions.numberOfElementsToBeMoreThan(logOutput,number))
+    void waitForLogOutput(By logOutput, Integer number, Integer seconds) {
+        new WebDriverWait(driver, Duration.ofSeconds(seconds)).until(ExpectedConditions.numberOfElementsToBeMoreThan(logOutput, number))
     }
 
-    void goToJob(String jobUuidText){
+    void goToJob(String jobUuidText) {
         go(PAGE_PATH + "/$jobUuidText")
     }
 
-    def expectNumberOfStepsToBe(int steps){
-        new WebDriverWait(driver,  Duration.ofSeconds(10)).until(
+    def expectNumberOfStepsToBe(int steps) {
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(
                 ExpectedConditions.numberOfElementsToBe(stepsInJobDefinitionBy, steps)
         )
     }
@@ -362,31 +389,31 @@ class JobShowPage extends BasePage implements ActivityListTrait {
     /**
      * It returns the list of "Actions" buttons
      */
-    def getJobActionsButtonList(){
+    def getJobActionsButtonList() {
         (el jobActionsListButtonBy)
     }
 
-    def getJobDeleteButtons(){
+    def getJobDeleteButtons() {
         (el jobDeleteButtonBy)
     }
 
-    def getJobDisableScheduleButtonBy(){
+    def getJobDisableScheduleButtonBy() {
         (el jobDisableScheduleButtonBy)
     }
 
-    def getJobEnableScheduleButtonBy(){
+    def getJobEnableScheduleButtonBy() {
         (el jobEnableScheduleButtonBy)
     }
 
-    def getJobDisableExecutionButton(){
+    def getJobDisableExecutionButton() {
         (el jobDisableExecutionButtonBy)
     }
 
-    def getJobEnableExecutionButton(){
+    def getJobEnableExecutionButton() {
         (el jobEnableExecutionButtonBy)
     }
 
-    def getJobDeleteConfirmBy(){
+    def getJobDeleteConfirmBy() {
         (el jobDeleteConfirmBy)
     }
 
@@ -396,45 +423,45 @@ class JobShowPage extends BasePage implements ActivityListTrait {
         )
     }
 
-    WebElement getJobUuid(){
+    WebElement getJobUuid() {
         el jobUuidBy
     }
 
-    WebElement getDeleteJobBtn(){
+    WebElement getDeleteJobBtn() {
         waitForElementVisible jobDeleteModalBy
         el jobDeleteModalBy findElement(By.cssSelector(".btn.btn-danger.btn-sm"))
     }
 
-    List<WebElement> getExtraOptFirsts(String optionName){
+    List<WebElement> getExtraOptFirsts(String optionName) {
         els By.name("extra.option.$optionName")
     }
 
-    WebElement getDuplicateJobButton(){
+    WebElement getDuplicateJobButton() {
         el duplicateJobButtonBy
     }
 
-    WebElement getDuplicateJobToProjectButtonBy(){
+    WebElement getDuplicateJobToProjectButtonBy() {
         el duplicateJobToProjectButtonBy
     }
 
-    void selectProjectToDuplicateJob(String projectName){
+    void selectProjectToDuplicateJob(String projectName) {
         Select selector = new Select(el(projectDropDownToDuplicateBy))
         selector.selectByValue(projectName)
     }
 
-    WebElement getDuplicateJobToProjectSubmitButton(){
+    WebElement getDuplicateJobToProjectSubmitButton() {
         el duplicateJobToProjectSubmitBy
     }
 
-    List<WebElement> getJobStatsElements(){
+    List<WebElement> getJobStatsElements() {
         els jobStatsBy
     }
 
-    List<WebElement> getOptionInputs(){
+    List<WebElement> getOptionInputs() {
         return (els optionInputBy)
     }
 
-    WebElement getJobOptionAlertBy(){
+    WebElement getJobOptionAlertBy() {
         el jobOptionAlertBy
     }
 

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -510,23 +510,11 @@
   })
 
   function init() {
-    var pageParams = loadJsonData('pageParams');
-    jQuery('body').on('click', '.nodefilterlink', function(evt) {
-      evt.preventDefault();
-      //Fix for RUN-3462: Populate node filter field when selecting a node in "Change the Target Nodes" section
-      const nodeFilterValue = jQuery(this).data('node-filter');
-      const filterInput = document.querySelector('input[name="extra.nodefilter"]');
-      if (filterInput) {
-        filterInput.value = nodeFilterValue;
-        filterInput.dispatchEvent(new Event('input', { bubbles: true }));
-        filterInput.focus();
-      }
-      if (typeof nodeFilter !== 'undefined') {
-        jQuery.data(this, 'node-filter-name', '');
-        jQuery.data(this, 'node-filter', nodeFilterValue);
-        nodeFilter.selectNodeFilterLink(this);
-      }
-    });
+      var pageParams = loadJsonData('pageParams');
+      jQuery('body').on('click', '.nodefilterlink', function (evt) {
+          evt.preventDefault();
+          nodeFilter.selectNodeFilterLink(this);
+      });
 
     jQuery('#nodesContent').on('click', '.closeoutput', function(evt) {
       evt.preventDefault();
@@ -583,10 +571,15 @@
       grouptags: loadJsonData('namegrouptagsJson'),
       nodeFilter: nodeFilter
     })
-    if (typeof (nodeFilter) !== 'undefined') {
-      kocontrollers.runformoptions.isNodeFilterVisible.subscribe(nodeFilter.nodeFiltersVisible)
-      nodeFilter.nodeFiltersVisible(kocontrollers.runformoptions.isNodeFilterVisible())
-    }
+      if (typeof (nodeFilter) !== 'undefined') {
+          kocontrollers.runformoptions.isNodeFilterVisible.subscribe(function(isVisible) {
+              nodeFilter.nodeFiltersVisible(isVisible);
+              if (isVisible) {
+                  nodeFilter.selectNodeFilter({filter: ""}, false);
+              }
+          });
+          nodeFilter.nodeFiltersVisible(kocontrollers.runformoptions.isNodeFilterVisible())
+      }
 
     jQuery('div.jobmatchednodes').on('click', 'span.obs_tag_group', function(evt) {
       var ischecked = jQuery(this).data('tagselected') != 'false';

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -18,566 +18,620 @@
 
 <g:uploadForm controller="scheduledExecution" method="post" useToken="true"
               params="[project: scheduledExecution.project]" role="form" class="exec-options-form">
-<input type="hidden" name="id" value="${enc(attr:scheduledExecution?.extid)}"/>
-<div id="exec_options_form">
-    <!-- BEGIN: firefox hack https://bugzilla.mozilla.org/show_bug.cgi?id=1119063 -->
-    <input type="text" style="display:none" class="ixnay">
-    <input type="password" style="display:none" class="ixnay">
-    <g:javascript>
-    jQuery(function(){
-        var nay=function(){jQuery('.ixnay').val('');},ix=setTimeout;
-        nay(); ix(nay,50); ix(nay,200); ix(nay, 1000);
-    });
-    </g:javascript>
-    <!-- END: firefox hack -->
-<div class="exec-options-body container-fluid">
+    <input type="hidden" name="id" value="${enc(attr: scheduledExecution?.extid)}" />
 
+    <div id="exec_options_form">
+        <!-- BEGIN: firefox hack https://bugzilla.mozilla.org/show_bug.cgi?id=1119063 -->
+        <input type="text" style="display:none" class="ixnay">
+        <input type="password" style="display:none" class="ixnay">
+        <g:javascript>
+            jQuery(function() {
+                var nay = function() {
+                    jQuery('.ixnay').val('');
+                }, ix = setTimeout;
+                nay();
+                ix(nay, 50);
+                ix(nay, 200);
+                ix(nay, 1000);
+            });
+        </g:javascript>
+        <!-- END: firefox hack -->
+        <div class="exec-options-body container-fluid">
 
+            <g:if test="${!hideHead}">
+                <div class="row exec-options-header">
+                    <div class="col-sm-12">
+                        <tmpl:showHead scheduledExecution="${scheduledExecution}" isScheduled="${isScheduled}"
+                                       iconName="icon-job"
+                                       runPage="true" jobDescriptionMode="collapsed" />
+                    </div>
+                </div>
 
-<g:if test="${!hideHead}">
-    <div class="row exec-options-header">
-        <div class="col-sm-12">
-            <tmpl:showHead scheduledExecution="${scheduledExecution}" isScheduled="${isScheduled}" iconName="icon-job"
-                           runPage="true" jobDescriptionMode="collapsed"/>
-        </div>
-    </div>
-
-</g:if>
-    <g:set var="project" value="${scheduledExecution?.project ?: params.project?:request.project?: projects?.size() == 1 ? projects[0].name : ''}"/>
-    <g:embedJSON id="filterParamsJSON" data="${[filter: query?.filter, filterAll: params.showall in ['true', true]]}"/>
-
-
-
-    <g:if test="${hideHead}">
-        <section>
-            <div class="row">
-                <g:render template="/scheduledExecution/execOptionsFormButtons"
-                          model="[scheduledExecution: scheduledExecution, hideCancel: hideCancel, showRunLater: true]"/>
-            </div>
-        </section>
-    </g:if>
-    <g:if test="${params.meta instanceof Map}">
-        <g:each in="${params.meta}" var="metaprop">
-            <g:if test="${metaprop.value}">
-                <g:hiddenField name="meta.${metaprop.key}" value="${metaprop.value}"/>
             </g:if>
-        </g:each>
-    </g:if>
-
-    <g:if test="${scheduledExecution?.options}">
-    <section class="form-horizontal section-pad-top-lg ${hideHead ? 'section-separator' : ''}">
-        <g:render template="editOptions"
-                  model="${[scheduledExecution: scheduledExecution, selectedoptsmap: selectedoptsmap, selectedargstring: selectedargstring, authorized: authorized, jobexecOptionErrors: jobexecOptionErrors, optiondependencies: optiondependencies, dependentoptions: dependentoptions, optionordering: optionordering]}"/>
-    </section>
-    </g:if>
-    <g:elseif test="${!scheduledExecution?.options }">
-        <g:render template="/common/messages"/>
-    </g:elseif>
-
-    <g:embedJSON id="jobComponentProperties" data="${jobComponentValues}"/>
-    <section class="form-horizontal section-separator">
-        <div class="vue-ui-socket">
-            <div>
-                <ui-socket section="resources-override-filter" location="top" />
-            </div>
-        </div>
-    </section>
-
-    <section class="form-horizontal section-separator section-pad-top-lg"
-             style="${wdgt.styleVisible(if: nodesetvariables && !failedNodes || nodesetempty || nodes)}">
-
-        <div class="form-group">
-            <label class="col-sm-2 control-label">
-                <g:message code="Node.plural"/>
-            </label>
+            <g:set var="project"
+                   value="${scheduledExecution?.project ?: params.project ?: request.project ?: projects?.size() == 1 ? projects[0].name : ''}" />
+            <g:embedJSON id="filterParamsJSON"
+                         data="${[filter: query?.filter, filterAll: params.showall in ['true', true]]}" />
 
 
-        <div class="col-sm-10">
-        <g:if test="${nodesetvariables && !failedNodes}">
-            %{--show node filters--}%
-            <div>
-                <span class="query form-control-static ">
-                   <code class="queryvalue text"><g:enc>${nodefilter}</g:enc></code>
-                </span>
-            </div>
 
-            <p class="form-control-static text-info">
-                <g:message code="scheduledExecution.nodeset.variable.warning"/>
-            </p>
-        </g:if>
-        <g:elseif test="${nodesetempty }">
-            <div class="alert alert-warning">
-                <g:message code="scheduledExecution.nodeset.empty.warning"/>
-            </div>
-        </g:elseif>
-
-
-            <g:set var="selectedNodes"
-                   value="${failedNodes? failedNodes.split(',').findAll{it}:selectedNodes instanceof String? selectedNodes.split(',').findAll{it}:selectedNodes instanceof Collection? selectedNodes:null}"/>
-            <g:embedJSON id="selectedNodesJson" data="${selectedNodes?:[]}"/>
-            <g:embedJSON id="allNodesJson" data="${nodes?nodes*.nodename:[]}"/>
-            <g:embedJSON id="namegroupsJson" data="${namegroups?:[:]}"/>
-            <g:embedJSON id="namegrouptagsJson" data="${grouptags?:[:]}"/>
-
-            <div class="row" data-ko-bind="runformoptions">
-                <div class="col-sm-12 ">
-
-                    <div class="checkbox checkbox-inline" data-bind="visible: canOverrideFilter() || !hasDynamicFilter()">
-                        <input name="extra._replaceNodeFilters"
-                               value="true"
-                               type="checkbox"
-                               data-bind="checked: changeTargetNodes"
-                               id="doReplaceFilters"/>
-                        <label for="doReplaceFilters">
-                            <g:message code="change.the.target.nodes"/>
-                            <!-- ko if: !isNodeFilterVisible() -->
-                            (<span data-bind="text: selectedNodes().length, css: {'text-info':selectedNodes().length,'text-danger':!selectedNodes().length}" ></span>)
-                            <!-- /ko -->
-                            <!-- ko if: isNodeFilterVisible() -->
-                            (<span data-bind="
-                                visible: isNodeFilterVisible() && nodeFilter, text: nodeFilter.total,
-                                css: {'text-info':nodeFilter.total,'text-danger':!nodeFilter.total()}" >0</span>)
-                            <!-- /ko -->
-                        </label>
-
+            <g:if test="${hideHead}">
+                <section>
+                    <div class="row">
+                        <g:render template="/scheduledExecution/execOptionsFormButtons"
+                                  model="[scheduledExecution: scheduledExecution, hideCancel: hideCancel, showRunLater: true]" />
                     </div>
-
-                        <div class="radio radio-inline" data-bind="visible: changeTargetNodes() && canOverrideFilter() && !hasDynamicFilter()">
-                            <input id="cherrypickradio"
-                                   type="radio"
-                                   name="extra.nodeoverride"
-                                   checked="checked"
-                                   value="cherrypick"
-                                   data-bind="checked: nodeOverride"/>
-                            <label for="cherrypickradio">
-                                <g:message code="select.nodes" />
-                            </label>
-                        </div>
-
-                        <div class="radio radio-inline" data-bind="visible: changeTargetNodes() && canOverrideFilter() && !hasDynamicFilter()">
-                            <input id="filterradio"
-                                   type="radio"
-                                   name="extra.nodeoverride"
-                                   value="filter"
-                                   data-bind="checked: nodeOverride"/>
-                            <label for="filterradio">
-                                <g:message code="job.run.override.node"/>
-                            </label>
-                        </div>
-
-
-                </div>
-
-            </div>
-            <div>
-                <div class=" matchednodes embed jobmatchednodes group_section " id="nodeSelect">
-                <%--
-                 split node names into groups, in several patterns
-                  .*\D(\d+)
-                  (\d+)\D.*
-                --%>
-                    <div data-ko-bind="runformoptions" data-bind="visible: isCherrypickVisible">
-
-                <g:if test="${!nodesetvariables && nodes}">
-                    <div class=" ">
-                            Select Nodes
-                            <!-- ko if: isCherrypickVisible -->
-                            (<span data-bind="text: selectedNodes().length, css: {'text-info':selectedNodes().length,'text-danger':!selectedNodes().length}" ></span>)
-                            <!-- /ko -->
-
-                        <!-- ko if: isCherrypickVisible -->
-                            <span class="btn btn-xs btn-simple  btn-hover selectall" data-bind="click: selectAllNodes">
-                                <g:icon name="check"/>
-                                <g:message code="select.all" />
-                            </span>
-                            <span class="btn btn-xs btn-simple  btn-hover selectnone"  data-bind="click: selectNoNodes">
-                                <g:icon name="unchecked"/>
-                                <g:message code="select.none" />
-                            </span>
-                            <!-- /ko -->
-                            <g:if test="${tagsummary}">
-                                <g:render template="/framework/tagsummary"
-                                          model="${[tagsummary:tagsummary,action:[classnames:'label label-muted autoclickable obs_tag_group',onclick:'']]}"/>
-                            </g:if>
-                    </div>
-                <g:if test="${namegroups}">
-                    <div>
-                    <g:each in="${namegroups.keySet().sort()}" var="group">
-                        <div class="panel panel-default">
-                      <div class="panel-heading">
-                          <g:set var="expkey" value="${g.rkey()}"/>
-                            <span data-toggle="collapse" data-target="#${expkey}" data-bind="css: {in: changeTargetNodes}">
-                                <g:if test="${group!='other'}">
-                                    <span class="prompt">
-                                    <g:enc>${namegroups[group][0]}</g:enc></span>
-                                    <g:message code="to"/>
-                                    <span class="prompt">
-                                <g:enc>${namegroups[group][-1]}</g:enc>
-                                    </span>
-                                </g:if>
-                                <g:else>
-                                    <span class="prompt"><g:enc>${namegroups.size()>1?'Other ':''}</g:enc><g:message code="matched.nodes.prompt" /></span>
-                                </g:else>
-                                <g:enc>(${namegroups[group].size()})</g:enc>
-                                <b class="glyphicon glyphicon-chevron-${selectedNodes!=null ? 'down' : 'right'}"></b>
-                            </span>
-                        </div>
-                        <div id="${enc(attr:expkey)}"  class="group_section panel-body collapse " data-bind="css: {in: changeTargetNodes}" >
-                                <g:if test="${namegroups.size()>1}">
-                                <div class="group_select_control" style="">
-
-                                    <span class="btn btn-xs btn-simple btn-hover selectall" data-bind="click: function(){groupSelectAll($element)}" data-group="${enc(attr:group)}">
-                                        <g:icon name="check"/>
-                                        <g:message code="select.all" />
-                                    </span>
-                                    <span class="btn btn-xs btn-simple  btn-hover selectnone"  data-bind="click: function(){groupSelectNone($element)}" data-group="${enc(attr:group)}" >
-                                        <g:icon name="unchecked"/>
-                                        <g:message code="select.none" />
-                                    </span>
-                                </div>
-                                </g:if>
-                                <g:if test="${grouptags && grouptags[group]}">
-                                    <g:render template="/framework/tagsummary" model="${[tagsummary:grouptags[group],action:[classnames:'label label-muted active autoclickable  obs_tag_group',onclick:'']]}"/>
-                                </g:if>
-                                    <g:each var="node" in="${nodemap.subMap(namegroups[group]).values()}" status="index">
-                                        <g:set var="nkey" value="${g.rkey()}"/>
-                                        <div class="checkbox node_select_checkbox" >
-                                          <input id="${enc(attr:nkey)}"
-                                                 type="checkbox"
-                                                 data-ident="node"
-                                                 name="extra.nodeIncludeName"
-                                                 data-bind="checked: selectedNodes, enable: changeTargetNodes"
-                                                 value="${enc(attr:node.nodename)}"
-
-                                                 data-tag="${enc(attr:node.tags?.join(' '))}"
-
-                                                 />
-                                            <label for="${enc(attr:nkey)}"
-                                                   class=" ${localNodeName && localNodeName == node.nodename ? 'server' : ''} node_ident"
-                                                   id="${enc(attr:nkey)}_key">
-
-
-                                                    <g:nodeIconStatusColor node="${node}" icon="true">
-                                                        <g:nodeIcon node="${node}">
-                                                            <i class="fas fa-hdd"></i>
-                                                        </g:nodeIcon>
-                                                    </g:nodeIconStatusColor>&nbsp;<span class="${unselectedNodes&& unselectedNodes.contains(node.nodename)?'node_unselected':''}"><g:enc>${node.nodename}</g:enc></span>
-                                                    <g:nodeHealthStatusColor node="${node}" title="${node.attributes['ui:status:text']}">
-                                                        <g:nodeStatusIcon node="${node}"/>
-                                                    </g:nodeHealthStatusColor>
-
-                                                 </label>
-
-                                        </div>
-                                    </g:each>
-                            </div>
-                        </div>
-                    </g:each>
-                    </div>
-                </g:if>
-                <g:else>
-                    <g:each var="node" in="${nodes}" status="index">
-                        <g:set var="nkey" value="${g.rkey()}"/>
-                        <div>
-                            <label for="${enc(attr:nkey)}"
-                                   class=" ${localNodeName && localNodeName == node.nodename ? 'server' : ''} node_ident  checkbox-inline"
-                                   id="${enc(attr:nkey)}_key">
-                                <input id="${enc(attr:nkey)}"
-                                       type="checkbox"
-                                       name="extra.nodeIncludeName"
-                                       data-ident="node"
-                                       data-bind="checked: selectedNodes, enable: changeTargetNodes"
-                                       value="${enc(attr:node.nodename)}"
-                                       data-tag="${enc(attr:node.tags?.join(' '))}"
-                                       /><g:enc>${node.nodename}</g:enc></label>
-
-                        </div>
-                    </g:each>
-                </g:else>
-                </g:if>
-                    </div>
-                <g:if test="${scheduledExecution.nodeFilterEditable || nodefilter == ''}">
-                <div class="subfields nodeFilterFields ">
-                    %{-- filter text --}%
-                    <div class="">
-                        <g:set var="filtvalue" value="${nodefilter}"/>
-
-                        <div id="nodefilterViewArea" data-ko-bind="nodeFilter" data-bind="visible: nodeFiltersVisible">
-                        <div class="${emptyQuery ? 'active' : ''}" id="nodeFilterInline">
-                            <div class="spacing">
-                                <div class="">
-                                    <g:form action="adhoc" class="form form-horizontal" name="searchForm" >
-                                        <g:hiddenField name="max" value="${max}"/>
-                                        <g:hiddenField name="offset" value="${offset}"/>
-                                        <g:hiddenField name="formInput" value="true"/>
-
-                                        <div class="vue-ui-socket">
-                                            <ui-socket section="job-show-page"
-                                                       location="exec-options-node-filter-input"
-                                                       socket-data="${enc(attr: [
-                                                               filter: filtvalue?:'',
-                                                               koVarName:'nodeFilter',
-                                                               filterFieldName:'extra.nodefilter',
-                                                       ].encodeAsJSON())}">
-                                            </ui-socket>
-                                        </div>
-                                    </g:form>
-
-                                </div>
-                            </div>
-
-                        </div>
-
-                        <div>
-                                <div class="spacing text-warning" id="emptyerror"
-                                     style="display: none"
-                                     data-bind="visible: !loading() && !error() && (!total() || total()==0)">
-                                    <span class="errormessage">
-                                        <g:message code="no.nodes.selected.match.nodes.by.selecting.or.entering.a.filter" />
-                                    </span>
-                                </div>
-                                <div class="spacing text-danger" id="loaderror2"
-                                     style="display: none"
-                                     data-bind="visible: error()">
-                                    <i class="glyphicon glyphicon-warning-sign"></i>
-                                    <span class="errormessage" data-bind="text: error()">
-
-                                    </span>
-                                </div>
-                                <div data-bind="visible: total()>0 || loading()" class="well well-sm inline">
-                                    <span data-bind="if: loading()" class="text-info">
-                                        <i class="glyphicon glyphicon-time"></i>
-                                        <g:message code="loading.matched.nodes" />
-                                    </span>
-                                    <span data-bind="if: !loading() && !error()">
-
-                                        <span data-bind="messageTemplate: [ total(), nodesTitle() ]"><g:message code="count.nodes.matched" /></span>.
-
-                                        <span data-bind="if: total()>maxShown()">
-                                            <span data-bind="messageTemplate: [maxShown(), total()]" class="text-strong"><g:message code="count.nodes.shown" /></span>
-                                        </span>
-                                        <span class="pull-right">
-                                            <a href="#" data-bind="attr: {href: nodesPageViewUrl }">
-                                              <g:message code="view.in.nodes.page.prompt" />
-                                          </a>
-                                        </span>
-
-                                    </span>
-                                </div>
-                                <span >
-                                    <g:render template="/framework/nodesEmbedKO"/>
-                                </span>
-                        </div>
-                    </div>
-
-
-
-                        %{-- filter text --}%
-                    </div>
-
-
-                </div>
+                </section>
+            </g:if>
+            <g:if test="${params.meta instanceof Map}">
+                <g:each in="${params.meta}" var="metaprop">
+                    <g:if test="${metaprop.value}">
+                        <g:hiddenField name="meta.${metaprop.key}" value="${metaprop.value}" />
                     </g:if>
+                </g:each>
+            </g:if>
+
+            <g:if test="${scheduledExecution?.options}">
+                <section class="form-horizontal section-pad-top-lg ${hideHead ? 'section-separator' : ''}">
+                    <g:render template="editOptions"
+                              model="${[scheduledExecution: scheduledExecution, selectedoptsmap: selectedoptsmap, selectedargstring: selectedargstring, authorized: authorized, jobexecOptionErrors: jobexecOptionErrors, optiondependencies: optiondependencies, dependentoptions: dependentoptions, optionordering: optionordering]}" />
+                </section>
+            </g:if>
+            <g:elseif test="${!scheduledExecution?.options}">
+                <g:render template="/common/messages" />
+            </g:elseif>
+
+            <g:embedJSON id="jobComponentProperties" data="${jobComponentValues}" />
+            <section class="form-horizontal section-separator">
+                <div class="vue-ui-socket">
+                    <div>
+                        <ui-socket section="resources-override-filter" location="top" />
+                    </div>
+                </div>
+            </section>
+
+            <section class="form-horizontal section-separator section-pad-top-lg"
+                     style="${wdgt.styleVisible(if: nodesetvariables && !failedNodes || nodesetempty || nodes)}">
+
+                <div class="form-group">
+                    <label class="col-sm-2 control-label">
+                        <g:message code="Node.plural" />
+                    </label>
+
+
+                    <div class="col-sm-10">
+                        <g:if test="${nodesetvariables && !failedNodes}">
+                        %{--show node filters--}%
+                            <div>
+                                <span class="query form-control-static ">
+                                    <code class="queryvalue text"><g:enc>${nodefilter}</g:enc></code>
+                                </span>
+                            </div>
+
+                            <p class="form-control-static text-info">
+                                <g:message code="scheduledExecution.nodeset.variable.warning" />
+                            </p>
+                        </g:if>
+                        <g:elseif test="${nodesetempty}">
+                            <div class="alert alert-warning">
+                                <g:message code="scheduledExecution.nodeset.empty.warning" />
+                            </div>
+                        </g:elseif>
+
+
+                        <g:set var="selectedNodes"
+                               value="${failedNodes ? failedNodes.split(',').findAll { it } : selectedNodes instanceof String ? selectedNodes.split(',').findAll { it } : selectedNodes instanceof Collection ? selectedNodes : null}" />
+                        <g:embedJSON id="selectedNodesJson" data="${selectedNodes ?: []}" />
+                        <g:embedJSON id="allNodesJson" data="${nodes ? nodes*.nodename : []}" />
+                        <g:embedJSON id="namegroupsJson" data="${namegroups ?: [:]}" />
+                        <g:embedJSON id="namegrouptagsJson" data="${grouptags ?: [:]}" />
+
+                        <div class="row" data-ko-bind="runformoptions">
+                            <div class="col-sm-12 ">
+
+                                <div class="checkbox checkbox-inline"
+                                     data-bind="visible: canOverrideFilter() || !hasDynamicFilter()">
+                                    <input name="extra._replaceNodeFilters"
+                                           value="true"
+                                           type="checkbox"
+                                           data-bind="checked: changeTargetNodes"
+                                           id="doReplaceFilters" />
+                                    <label for="doReplaceFilters">
+                                        <g:message code="change.the.target.nodes" />
+                                        <!-- ko if: !isNodeFilterVisible() -->
+                                        (<span
+                                            data-bind="text: selectedNodes().length, css: {'text-info':selectedNodes().length,'text-danger':!selectedNodes().length}"></span>)
+                                    <!-- /ko -->
+                                    <!-- ko if: isNodeFilterVisible() -->
+                                    (<span data-bind="
+                                visible: isNodeFilterVisible() && nodeFilter, text: nodeFilter.total,
+                                css: {'text-info':nodeFilter.total,'text-danger':!nodeFilter.total()}">0</span>)
+                                    <!-- /ko -->
+                                    </label>
+
+                                </div>
+
+                                <div class="radio radio-inline"
+                                     data-bind="visible: changeTargetNodes() && canOverrideFilter() && !hasDynamicFilter()">
+                                    <input id="cherrypickradio"
+                                           type="radio"
+                                           name="extra.nodeoverride"
+                                           checked="checked"
+                                           value="cherrypick"
+                                           data-bind="checked: nodeOverride" />
+                                    <label for="cherrypickradio">
+                                        <g:message code="select.nodes" />
+                                    </label>
+                                </div>
+
+                                <div class="radio radio-inline"
+                                     data-bind="visible: changeTargetNodes() && canOverrideFilter() && !hasDynamicFilter()">
+                                    <input id="filterradio"
+                                           type="radio"
+                                           name="extra.nodeoverride"
+                                           value="filter"
+                                           data-bind="checked: nodeOverride" />
+                                    <label for="filterradio">
+                                        <g:message code="job.run.override.node" />
+                                    </label>
+                                </div>
+
+                            </div>
+
+                        </div>
+
+                        <div>
+                            <div class=" matchednodes embed jobmatchednodes group_section " id="nodeSelect">
+                                <%--
+                                 split node names into groups, in several patterns
+                                  .*\D(\d+)
+                                  (\d+)\D.*
+                                --%>
+                                <div data-ko-bind="runformoptions" data-bind="visible: isCherrypickVisible">
+
+                                    <g:if test="${!nodesetvariables && nodes}">
+                                        <div class=" ">
+                                            Select Nodes
+                                            <!-- ko if: isCherrypickVisible -->
+                                            (<span
+                                                data-bind="text: selectedNodes().length, css: {'text-info':selectedNodes().length,'text-danger':!selectedNodes().length}"></span>)
+                                        <!-- /ko -->
+
+                                        <!-- ko if: isCherrypickVisible -->
+                                            <span class="btn btn-xs btn-simple  btn-hover selectall"
+                                                  data-bind="click: selectAllNodes">
+                                                <g:icon name="check" />
+                                                <g:message code="select.all" />
+                                            </span>
+                                            <span class="btn btn-xs btn-simple  btn-hover selectnone"
+                                                  data-bind="click: selectNoNodes">
+                                                <g:icon name="unchecked" />
+                                                <g:message code="select.none" />
+                                            </span>
+                                            <!-- /ko -->
+                                            <g:if test="${tagsummary}">
+                                                <g:render template="/framework/tagsummary"
+                                                          model="${[tagsummary: tagsummary, action: [classnames: 'label label-muted autoclickable obs_tag_group', onclick: '']]}" />
+                                            </g:if>
+                                        </div>
+                                        <g:if test="${namegroups}">
+                                            <div>
+                                                <g:each in="${namegroups.keySet().sort()}" var="group">
+                                                    <div class="panel panel-default">
+                                                        <div class="panel-heading">
+                                                            <g:set var="expkey" value="${g.rkey()}" />
+                                                            <span data-toggle="collapse" data-target="#${expkey}"
+                                                                  data-bind="css: {in: changeTargetNodes}">
+                                                                <g:if test="${group != 'other'}">
+                                                                    <span class="prompt">
+                                                                        <g:enc>${namegroups[group][0]}</g:enc></span>
+                                                                    <g:message code="to" />
+                                                                    <span class="prompt">
+                                                                        <g:enc>${namegroups[group][-1]}</g:enc>
+                                                                    </span>
+                                                                </g:if>
+                                                                <g:else>
+                                                                    <span class="prompt"><g:enc>${namegroups.size() > 1 ? 'Other ' : ''}</g:enc><g:message
+                                                                            code="matched.nodes.prompt" /></span>
+                                                                </g:else>
+                                                                <g:enc>(${namegroups[group].size()})</g:enc>
+                                                                <b class="glyphicon glyphicon-chevron-${selectedNodes != null ? 'down' : 'right'}"></b>
+                                                            </span>
+                                                        </div>
+
+                                                        <div id="${enc(attr: expkey)}"
+                                                             class="group_section panel-body collapse "
+                                                             data-bind="css: {in: changeTargetNodes}">
+                                                            <g:if test="${namegroups.size() > 1}">
+                                                                <div class="group_select_control" style="">
+
+                                                                    <span class="btn btn-xs btn-simple btn-hover selectall"
+                                                                          data-bind="click: function(){groupSelectAll($element)}"
+                                                                          data-group="${enc(attr: group)}">
+                                                                        <g:icon name="check" />
+                                                                        <g:message code="select.all" />
+                                                                    </span>
+                                                                    <span class="btn btn-xs btn-simple  btn-hover selectnone"
+                                                                          data-bind="click: function(){groupSelectNone($element)}"
+                                                                          data-group="${enc(attr: group)}">
+                                                                        <g:icon name="unchecked" />
+                                                                        <g:message code="select.none" />
+                                                                    </span>
+                                                                </div>
+                                                            </g:if>
+                                                            <g:if test="${grouptags && grouptags[group]}">
+                                                                <g:render template="/framework/tagsummary"
+                                                                          model="${[tagsummary: grouptags[group], action: [classnames: 'label label-muted active autoclickable  obs_tag_group', onclick: '']]}" />
+                                                            </g:if>
+                                                            <g:each var="node"
+                                                                    in="${nodemap.subMap(namegroups[group]).values()}"
+                                                                    status="index">
+                                                                <g:set var="nkey" value="${g.rkey()}" />
+                                                                <div class="checkbox node_select_checkbox">
+                                                                    <input id="${enc(attr: nkey)}"
+                                                                           type="checkbox"
+                                                                           data-ident="node"
+                                                                           name="extra.nodeIncludeName"
+                                                                           data-bind="checked: selectedNodes, enable: changeTargetNodes"
+                                                                           value="${enc(attr: node.nodename)}"
+
+                                                                           data-tag="${enc(attr: node.tags?.join(' '))}"
+
+                                                                    />
+                                                                    <label for="${enc(attr: nkey)}"
+                                                                           class=" ${localNodeName && localNodeName == node.nodename ? 'server' : ''} node_ident"
+                                                                           id="${enc(attr: nkey)}_key">
+
+                                                                        <g:nodeIconStatusColor node="${node}"
+                                                                                               icon="true">
+                                                                            <g:nodeIcon node="${node}">
+                                                                                <i class="fas fa-hdd"></i>
+                                                                            </g:nodeIcon>
+                                                                        </g:nodeIconStatusColor>&nbsp;<span
+                                                                            class="${unselectedNodes && unselectedNodes.contains(node.nodename) ? 'node_unselected' : ''}"><g:enc>${node.nodename}</g:enc></span>
+                                                                        <g:nodeHealthStatusColor node="${node}"
+                                                                                                 title="${node.attributes['ui:status:text']}">
+                                                                            <g:nodeStatusIcon node="${node}" />
+                                                                        </g:nodeHealthStatusColor>
+
+                                                                    </label>
+
+                                                                </div>
+                                                            </g:each>
+                                                        </div>
+                                                    </div>
+                                                </g:each>
+                                            </div>
+                                        </g:if>
+                                        <g:else>
+                                            <g:each var="node" in="${nodes}" status="index">
+                                                <g:set var="nkey" value="${g.rkey()}" />
+                                                <div>
+                                                    <label for="${enc(attr: nkey)}"
+                                                           class=" ${localNodeName && localNodeName == node.nodename ? 'server' : ''} node_ident  checkbox-inline"
+                                                           id="${enc(attr: nkey)}_key">
+                                                        <input id="${enc(attr: nkey)}"
+                                                               type="checkbox"
+                                                               name="extra.nodeIncludeName"
+                                                               data-ident="node"
+                                                               data-bind="checked: selectedNodes, enable: changeTargetNodes"
+                                                               value="${enc(attr: node.nodename)}"
+                                                               data-tag="${enc(attr: node.tags?.join(' '))}"
+                                                        /><g:enc>${node.nodename}</g:enc></label>
+
+                                                </div>
+                                            </g:each>
+                                        </g:else>
+                                    </g:if>
+                                </div>
+                                <g:if test="${scheduledExecution.nodeFilterEditable || nodefilter == ''}">
+                                    <div class="subfields nodeFilterFields ">
+                                        %{-- filter text --}%
+                                        <div class="">
+                                            <g:set var="filtvalue" value="${nodefilter}" />
+
+                                            <div id="nodefilterViewArea" data-ko-bind="nodeFilter"
+                                                 data-bind="visible: nodeFiltersVisible">
+                                                <div class="${emptyQuery ? 'active' : ''}" id="nodeFilterInline">
+                                                    <div class="spacing">
+                                                        <div class="">
+                                                            <g:form action="adhoc" class="form form-horizontal"
+                                                                    name="searchForm">
+                                                                <g:hiddenField name="max" value="${max}" />
+                                                                <g:hiddenField name="offset" value="${offset}" />
+                                                                <g:hiddenField name="formInput" value="true" />
+
+                                                                <div class="vue-ui-socket">
+                                                                    <ui-socket section="job-show-page"
+                                                                               location="exec-options-node-filter-input"
+                                                                               socket-data="${enc(attr: [
+                                                                                       filter         : filtvalue ?: '',
+                                                                                       koVarName      : 'nodeFilter',
+                                                                                       filterFieldName: 'extra.nodefilter',
+                                                                               ].encodeAsJSON())}">
+                                                                    </ui-socket>
+                                                                </div>
+                                                            </g:form>
+
+                                                        </div>
+                                                    </div>
+
+                                                </div>
+
+                                                <div>
+                                                    <div class="spacing text-warning" id="emptyerror"
+                                                         style="display: none"
+                                                         data-bind="visible: !loading() && !error() && (!total() || total()==0)">
+                                                        <span class="errormessage">
+                                                            <g:message
+                                                                    code="no.nodes.selected.match.nodes.by.selecting.or.entering.a.filter" />
+                                                        </span>
+                                                    </div>
+
+                                                    <div class="spacing text-danger" id="loaderror2"
+                                                         style="display: none"
+                                                         data-bind="visible: error()">
+                                                        <i class="glyphicon glyphicon-warning-sign"></i>
+                                                        <span class="errormessage" data-bind="text: error()">
+
+                                                        </span>
+                                                    </div>
+
+                                                    <div data-bind="visible: total()>0 || loading()"
+                                                         class="well well-sm inline">
+                                                        <span data-bind="if: loading()" class="text-info">
+                                                            <i class="glyphicon glyphicon-time"></i>
+                                                            <g:message code="loading.matched.nodes" />
+                                                        </span>
+                                                        <span data-bind="if: !loading() && !error()">
+
+                                                            <span data-bind="messageTemplate: [ total(), nodesTitle() ]"><g:message
+                                                                    code="count.nodes.matched" /></span>.
+
+                                                            <span data-bind="if: total()>maxShown()">
+                                                                <span data-bind="messageTemplate: [maxShown(), total()]"
+                                                                      class="text-strong"><g:message
+                                                                        code="count.nodes.shown" /></span>
+                                                            </span>
+                                                            <span class="pull-right">
+                                                                <a href="#" data-bind="attr: {href: nodesPageViewUrl }">
+                                                                    <g:message code="view.in.nodes.page.prompt" />
+                                                                </a>
+                                                            </span>
+
+                                                        </span>
+                                                    </div>
+                                                    <span>
+                                                        <g:render template="/framework/nodesEmbedKO" />
+                                                    </span>
+                                                </div>
+                                            </div>
+
+
+
+                                            %{-- filter text --}%
+                                        </div>
+
+                                    </div>
+                                </g:if>
+                            </div>
+                        </div>
+                        <g:javascript>
+
+                            jQuery('div.jobmatchednodes').on('click', 'span.selectall', function(evt) {
+                                jQuery(this).closest('.group_section').find('input').each(function(i, el) {
+                                    if (el.type == 'checkbox') {
+                                        el.checked = true;
+                                    }
+                                });
+                                jQuery(this).closest('.group_section').find('span.obs_tag_group').each(function(i, e) {
+                                    jQuery(e).data('tagselected', 'true');
+                                    jQuery(e).addClass('active');
+                                });
+
+                            });
+
+                            jQuery('div.jobmatchednodes').on('click', 'span.selectnone', function(evt) {
+                                jQuery(this).closest('.group_section').find('input').each(function(i, el) {
+                                    if (el.type == 'checkbox') {
+                                        el.checked = false;
+                                    }
+                                });
+                                jQuery(this).closest('.group_section').find('span.obs_tag_group').each(function(i, e) {
+                                    jQuery(e).data('tagselected', 'false');
+                                    jQuery(e).removeClass('active');
+                                });
+
+                            });
+
+
+                            jQuery('div.jobmatchednodes').on('click', 'div.node_select_checkbox', function(evt) {
+                                jQuery(this).closest('.group_section').find('span.obs_tag_group').each(function(i, el) {
+                                    jQuery(el).data('tagselected', 'false');
+                                    jQuery(el).removeClass('active');
+                                });
+                            });
+
+                            jQuery('#doReplaceFilters').on('change', function(evt) {
+                                var e = evt.target
+                                jQuery('div.jobmatchednodes input').each(function(i, cb) {
+                                    if (cb.type == 'checkbox') {
+                                        jQuery(cb).prop('disabled', !e.checked)
+                                        if (!e.checked) {
+                                            cb.checked = true;
+                                        }
+                                    }
+                                });
+
+                                if (!e.checked) {
+                                    jQuery('.nodeselectcount').each(function(i, e2) {
+                                        jQuery(e2).removeClass('text-info');
+                                        jQuery(e2).removeClass('text-danger');
+                                    });
+                                }
+                            });
+
+
+                            /** reset focus on click, so that IE triggers onchange event*/
+                            jQuery('#doReplaceFilters').on('click', function(evt) {
+                                jQuery(this).trigger('blur');
+                                jQuery(this).trigger('focus');
+                            });
+
+                        </g:javascript>
+
+                    </div>
+                </div>
+            </section>
+
+            <div class="error note" id="formerror" style="display:none">
+
             </div>
+
+        </div>
+
+        <g:if test="${!hideHead}">
+            <div class=" exec-options-footer container-fluid">
+                <div class="row">
+                    <div class="col-sm-12 form-inline">
+                        <g:render template="/scheduledExecution/execOptionsFormButtons"
+                                  model="[scheduledExecution: scheduledExecution, hideCancel: hideCancel]" />
+                    </div>
+                </div>
             </div>
-            <g:javascript>
-
-                jQuery('div.jobmatchednodes').on( 'click','span.selectall', function (evt) {
-                    jQuery(this).closest('.group_section').find('input').each(function (i,el) {
-                        if (el.type == 'checkbox') {
-                            el.checked = true;
-                        }
-                    });
-                    jQuery(this).closest('.group_section').find('span.obs_tag_group').each(function (i,e) {
-                        jQuery(e).data('tagselected', 'true');
-                        jQuery(e).addClass('active');
-                    });
-
-                });
-
-                jQuery('div.jobmatchednodes').on( 'click','span.selectnone', function (evt) {
-                    jQuery(this).closest('.group_section').find('input').each(function (i,el) {
-                        if (el.type == 'checkbox') {
-                            el.checked = false;
-                        }
-                    });
-                    jQuery(this).closest('.group_section').find('span.obs_tag_group').each(function (i,e) {
-                        jQuery(e).data('tagselected', 'false');
-                        jQuery(e).removeClass('active');
-                    });
-
-                });
-
-
-                jQuery('div.jobmatchednodes').on( 'click', 'div.node_select_checkbox', function (evt) {
-                    jQuery(this).closest('.group_section').find('span.obs_tag_group').each(function (i,el) {
-                        jQuery(el).data('tagselected', 'false');
-                        jQuery(el).removeClass('active');
-                    });
-                });
-
-                jQuery('#doReplaceFilters').on( 'change', function (evt) {
-                    var e = evt.target
-                    jQuery('div.jobmatchednodes input').each(function (i,cb) {
-                        if (cb.type == 'checkbox') {
-                            jQuery(cb).prop('disabled',!e.checked)
-                            if (!e.checked) {
-                                cb.checked = true;
-                            }
-                        }
-                    });
-
-                    if(!e.checked){
-                        jQuery('.nodeselectcount').each(function (i,e2) {
-                            jQuery(e2).removeClass('text-info');
-                            jQuery(e2).removeClass('text-danger');
-                        });
-                    }
-                });
-
-
-                /** reset focus on click, so that IE triggers onchange event*/
-                jQuery('#doReplaceFilters').on( 'click', function (evt) {
-                    jQuery(this).trigger('blur');
-                    jQuery(this).trigger('focus');
-                });
-
-            </g:javascript>
-
+        </g:if>
     </div>
-        </div>
-    </section>
-
-    <div class="error note" id="formerror" style="display:none">
-
-    </div>
-
-</div>
-
-<g:if test="${!hideHead}">
-<div class=" exec-options-footer container-fluid">
-    <div class="row" >
-        <div class="col-sm-12 form-inline">
-            <g:render template="/scheduledExecution/execOptionsFormButtons" model="[scheduledExecution:scheduledExecution,hideCancel:hideCancel]"/>
-        </div>
-    </div>
-</div>
-</g:if>
-</div>
 </g:uploadForm>
 
 <script lang="text/javascript">
 
-    window._rundeck.data = Object.assign(window._rundeck.data || {}, {
-        "jobComponentProperties": loadJsonData('jobComponentProperties')
+  window._rundeck.data = Object.assign(window._rundeck.data || {}, {
+    "jobComponentProperties": loadJsonData('jobComponentProperties')
+  })
+
+  function init() {
+    var pageParams = loadJsonData('pageParams');
+    jQuery('body').on('click', '.nodefilterlink', function(evt) {
+      evt.preventDefault();
+      const nodeFilterValue = jQuery(this).data('node-filter');
+      const filterInput = document.querySelector('input[name="extra.nodefilter"]');
+      if (filterInput) {
+        filterInput.value = nodeFilterValue;
+        filterInput.dispatchEvent(new Event('input', { bubbles: true }));
+        filterInput.focus();
+      }
+      if (typeof nodeFilter !== 'undefined') {
+        jQuery.data(this, 'node-filter-name', '');
+        jQuery.data(this, 'node-filter', nodeFilterValue);
+        nodeFilter.selectNodeFilterLink(this);
+      }
+    });
+
+    jQuery('#nodesContent').on('click', '.closeoutput', function(evt) {
+      evt.preventDefault();
+      closeOutputArea();
+    });
+
+
+    //setup node filters knockout bindings
+    var filterParams = loadJsonData('filterParamsJSON');
+    let kocontrollers = {}
+    var nodeFilter
+
+    <g:if test="${scheduledExecution.nodeFilterEditable || nodefilter == ''}">
+    var nodeSummary = new NodeSummary({ baseUrl: appLinks.frameworkNodes });
+    nodeFilter = new NodeFilters(
+      appLinks.frameworkAdhoc,
+      appLinks.scheduledExecutionCreate,
+      appLinks.frameworkNodes,
+      Object.assign(filterParams, {
+        nodeSummary: nodeSummary,
+        view: 'embed',
+        maxShown: 100,
+        emptyMode: 'blank',
+        project: pageParams.project,
+        nodesTitleSingular: message('Node'),
+        nodesTitlePlural: message('Node.plural')
+      }));
+    window.nodeFilter = nodeFilter
+
+    nodeSummary.reload();
+    nodeFilter.updateMatchedNodes();
+
+    var tmpfilt = {};
+    jQuery.data(tmpfilt, "node-filter-name", "");
+    jQuery.data(tmpfilt, "node-filter", "${nodefilter}");
+    nodeFilter.selectNodeFilterLink(tmpfilt);
+
+    kocontrollers.nodeFilter = nodeFilter
+
+    </g:if>
+    let hasSelectedNodes =${enc(js:selectedNodes!=null && selectedNodes)};
+    let hasSelectedByDefault =${enc(js:scheduledExecution.hasNodesSelectedByDefault())};
+    let selectedNodes = hasSelectedNodes ? loadJsonData('selectedNodesJson') : hasSelectedByDefault ? loadJsonData('allNodesJson') : [];
+    kocontrollers.runformoptions = new JobRunFormOptions({
+      debug:${enc(js:scheduledExecution?.loglevel=='DEBUG')},
+      changeTargetNodes: hasSelectedNodes || !hasSelectedByDefault,
+      canOverrideFilter:${enc(js:scheduledExecution.nodeFilterEditable|| nodefilter == '')},
+      nodeOverride: "${enc(js:!nodesetvariables && nodes?'cherrypick':'filter')}",
+      selectedNodes: selectedNodes,
+      hasDynamicFilter: ${enc(js:!!nodesetvariables)},
+      allNodes: loadJsonData('allNodesJson'),
+      hasSelectedNodes: hasSelectedNodes,
+      groups: loadJsonData('namegroupsJson'),
+      grouptags: loadJsonData('namegrouptagsJson'),
+      nodeFilter: nodeFilter
     })
-
-    function init() {
-        var pageParams = loadJsonData('pageParams');
-        jQuery('body').on('click', '.nodefilterlink', function (evt) {
-            evt.preventDefault();
-            nodeFilter.selectNodeFilterLink(this);
-        });
-        jQuery('#nodesContent').on('click', '.closeoutput', function (evt) {
-            evt.preventDefault();
-            closeOutputArea();
-        });
-
-
-        //setup node filters knockout bindings
-        var filterParams = loadJsonData('filterParamsJSON');
-        let kocontrollers={}
-        var nodeFilter
-
-        <g:if test="${scheduledExecution.nodeFilterEditable || nodefilter == ''}">
-        var nodeSummary = new NodeSummary({baseUrl:appLinks.frameworkNodes});
-        nodeFilter = new NodeFilters(
-                appLinks.frameworkAdhoc,
-                appLinks.scheduledExecutionCreate,
-                appLinks.frameworkNodes,
-                Object.assign(filterParams, {
-                    nodeSummary:nodeSummary,
-                    view: 'embed',
-                    maxShown: 100,
-                    emptyMode: 'blank',
-                    project: pageParams.project,
-                    nodesTitleSingular: message('Node'),
-                    nodesTitlePlural: message('Node.plural')
-                }));
-        window.nodeFilter = nodeFilter
-
-        nodeSummary.reload();
-        nodeFilter.updateMatchedNodes();
-
-        var tmpfilt = {};
-        jQuery.data( tmpfilt, "node-filter-name", "" );
-        jQuery.data( tmpfilt, "node-filter", "${nodefilter}" );
-        nodeFilter.selectNodeFilterLink(tmpfilt);
-
-        kocontrollers.nodeFilter = nodeFilter
-
-        </g:if>
-        let hasSelectedNodes=${enc(js:selectedNodes!=null && selectedNodes)};
-        let hasSelectedByDefault=${enc(js:scheduledExecution.hasNodesSelectedByDefault())};
-        let selectedNodes=hasSelectedNodes?loadJsonData('selectedNodesJson'):hasSelectedByDefault?loadJsonData('allNodesJson'):[];
-        kocontrollers.runformoptions = new JobRunFormOptions({
-            debug:${enc(js:scheduledExecution?.loglevel=='DEBUG')},
-            changeTargetNodes:hasSelectedNodes||!hasSelectedByDefault,
-            canOverrideFilter:${enc(js:scheduledExecution.nodeFilterEditable|| nodefilter == '')},
-            nodeOverride: "${enc(js:!nodesetvariables && nodes?'cherrypick':'filter')}",
-            selectedNodes: selectedNodes,
-            hasDynamicFilter: ${enc(js:!!nodesetvariables)},
-            allNodes:loadJsonData('allNodesJson'),
-            hasSelectedNodes: hasSelectedNodes,
-            groups:loadJsonData('namegroupsJson'),
-            grouptags:loadJsonData('namegrouptagsJson'),
-            nodeFilter: nodeFilter
-        })
-        if (typeof (nodeFilter) !== 'undefined') {
-            kocontrollers.runformoptions.isNodeFilterVisible.subscribe(nodeFilter.nodeFiltersVisible)
-            nodeFilter.nodeFiltersVisible(kocontrollers.runformoptions.isNodeFilterVisible())
-        }
-
-        jQuery('div.jobmatchednodes').on( 'click', 'span.obs_tag_group', function (evt) {
-            var ischecked = jQuery(this).data('tagselected') != 'false';
-            jQuery(this).data('tagselected', ischecked ? 'false' : 'true');
-            if (!ischecked) {
-                jQuery(this).addClass('active');
-            } else {
-                jQuery(this).removeClass('active');
-            }
-            jQuery(this).closest('.group_section').find('input[data-tag~="' + jQuery(this).data('tag') + '"]').each(function (i,el) {
-                if (el.type == 'checkbox') {
-                    el.checked = !ischecked;
-                }
-                let selectedNodes = kocontrollers.runformoptions.selectedNodes();
-                var index = selectedNodes.indexOf(el.value);
-                if (index > -1) {
-                    if (!el.checked) {selectedNodes.splice(index, 1);}
-                } else {
-                    if (el.checked) { selectedNodes.push(el.value)}
-                }
-                kocontrollers.runformoptions.selectedNodes(selectedNodes)
-            });
-            jQuery(this).closest('.group_section').find('span.obs_tag_group[data-tag="' + jQuery(this).data('tag') + '"]').each(function (i,el) {
-                jQuery(el).data('tagselected', ischecked ? 'false' : 'true');
-                if (!ischecked) {
-                    jQuery(el).addClass('active');
-                } else {
-                    jQuery(el).removeClass('active');
-                }
-            });
-
-        });
-
-        initKoBind('#exec_options_form', kocontrollers, /*'execform'*/)
-
+    if (typeof (nodeFilter) !== 'undefined') {
+      kocontrollers.runformoptions.isNodeFilterVisible.subscribe(nodeFilter.nodeFiltersVisible)
+      nodeFilter.nodeFiltersVisible(kocontrollers.runformoptions.isNodeFilterVisible())
     }
-    jQuery(document).ready(init);
+
+    jQuery('div.jobmatchednodes').on('click', 'span.obs_tag_group', function(evt) {
+      var ischecked = jQuery(this).data('tagselected') != 'false';
+      jQuery(this).data('tagselected', ischecked ? 'false' : 'true');
+      if (!ischecked) {
+        jQuery(this).addClass('active');
+      } else {
+        jQuery(this).removeClass('active');
+      }
+      jQuery(this).closest('.group_section').find('input[data-tag~="' + jQuery(this).data('tag') + '"]').each(function(i, el) {
+        if (el.type == 'checkbox') {
+          el.checked = !ischecked;
+        }
+        let selectedNodes = kocontrollers.runformoptions.selectedNodes();
+        var index = selectedNodes.indexOf(el.value);
+        if (index > -1) {
+          if (!el.checked) {
+            selectedNodes.splice(index, 1);
+          }
+        } else {
+          if (el.checked) {
+            selectedNodes.push(el.value)
+          }
+        }
+        kocontrollers.runformoptions.selectedNodes(selectedNodes)
+      });
+      jQuery(this).closest('.group_section').find('span.obs_tag_group[data-tag="' + jQuery(this).data('tag') + '"]').each(function(i, el) {
+        jQuery(el).data('tagselected', ischecked ? 'false' : 'true');
+        if (!ischecked) {
+          jQuery(el).addClass('active');
+        } else {
+          jQuery(el).removeClass('active');
+        }
+      });
+
+    });
+
+    initKoBind('#exec_options_form', kocontrollers, /*'execform'*/)
+
+  }
+
+  jQuery(document).ready(init);
 </script>
 <content tag="footScripts">
-    <asset:stylesheet src="library/bootstrap-datetimepicker.min.css" />
-    <asset:javascript src="scheduler.js" />
+<asset:stylesheet src="library/bootstrap-datetimepicker.min.css" />
+<asset:javascript src="scheduler.js" />
 </content tag="footScripts">
 
 <asset:stylesheet src="library/bootstrap-datetimepicker.min.css" />

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -513,6 +513,7 @@
     var pageParams = loadJsonData('pageParams');
     jQuery('body').on('click', '.nodefilterlink', function(evt) {
       evt.preventDefault();
+      //Fix for RUN-3462: Populate node filter field when selecting a node in "Change the Target Nodes" section
       const nodeFilterValue = jQuery(this).data('node-filter');
       const filterInput = document.querySelector('input[name="extra.nodefilter"]');
       if (filterInput) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeFilterInput.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeFilterInput.vue
@@ -252,7 +252,7 @@ export default defineComponent({
   },
   inheritAttrs: false,
   props: {
-    modelValue: {
+    value: {
       type: [String, null] as PropType<string | null>,
       required: true,
 
@@ -308,7 +308,7 @@ export default defineComponent({
       description: "if true, allow setting/removing default filter"
     },
   },
-  emits: ["filters-updated", "filter", "update:modelValue"],
+  emits: ["filters-updated", "filter", "update:value"],
   setup() {
     const outputValue = ref("");
     const selectedFilterName = ref("");
@@ -388,7 +388,7 @@ export default defineComponent({
     },
   },
   watch: {
-    modelValue: {
+    value: {
       handler(newValue) {
         const safeValue = newValue === undefined ? '' : (newValue || '');
         if (safeValue !== this.outputValue) {
@@ -463,7 +463,7 @@ export default defineComponent({
       ) {
         this.selectedFilterName = "";
       }
-      this.$emit("update:modelValue", this.outputValue);
+      this.$emit("update:value", this.outputValue);
     },
     handleNodefilter(val: any) {
       if (val.filterName) {
@@ -486,8 +486,8 @@ export default defineComponent({
       this.setDefaultFilterValue(".*");
     },
     async onMount() {
-      if (this.modelValue) {
-        this.outputValue = this.modelValue;
+      if (this.value) {
+        this.outputValue = this.value;
       }
       if (
         this.selectedFilterName &&

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeFilterInput.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeFilterInput.vue
@@ -255,6 +255,7 @@ export default defineComponent({
     modelValue: {
       type: [String, null] as PropType<string | null>,
       required: true,
+
     },
     showTitle: {
       type: Boolean,
@@ -387,18 +388,19 @@ export default defineComponent({
     },
   },
   watch: {
-    modelValue() {
-      if (this.modelValue) {
-        this.outputValue = this.modelValue;
-      }
-      if (
-        this.selectedFilterName &&
-        this.selectedFilterName !== this.matchedFilter
-      ) {
-        this.selectedFilterName = "";
-      } else if (this.matchedFilter) {
-        this.selectedFilterName = this.matchedFilter;
-      }
+    modelValue: {
+      handler(newValue) {
+        const safeValue = newValue === undefined ? '' : (newValue || '');
+        if (safeValue !== this.outputValue) {
+          this.outputValue = safeValue;
+        }
+        if (this.selectedFilterName && this.selectedFilterName !== this.matchedFilter) {
+          this.selectedFilterName = "";
+        } else if (this.matchedFilter) {
+          this.selectedFilterName = this.matchedFilter;
+        }
+      },
+      immediate: true
     },
     filterName() {
       this.selectedFilterName = this.filterName;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeFilterInput.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeFilterInput.vue
@@ -388,19 +388,18 @@ export default defineComponent({
     },
   },
   watch: {
-    value: {
-      handler(newValue) {
-        const safeValue = newValue === undefined ? '' : (newValue || '');
-        if (safeValue !== this.outputValue) {
-          this.outputValue = safeValue;
-        }
-        if (this.selectedFilterName && this.selectedFilterName !== this.matchedFilter) {
-          this.selectedFilterName = "";
-        } else if (this.matchedFilter) {
-          this.selectedFilterName = this.matchedFilter;
-        }
-      },
-      immediate: true
+    value() {
+      if (this.value) {
+        this.outputValue = this.value;
+      }
+      if (
+          this.selectedFilterName &&
+          this.selectedFilterName !== this.matchedFilter
+      ) {
+        this.selectedFilterName = "";
+      } else if (this.matchedFilter) {
+        this.selectedFilterName = this.matchedFilter;
+      }
     },
     filterName() {
       this.selectedFilterName = this.filterName;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/ResourcesEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/ResourcesEditor.vue
@@ -68,7 +68,7 @@
 
             <node-filter-input
               id="job_edit__node_filter_include"
-              v-model="modelData.filter"
+              v-model:value="modelData.filter"
               :project="modelData.project"
               :filter-name="modelData.filterName"
               :node-summary="nodeSummary"
@@ -100,7 +100,7 @@
 
             <node-filter-input
               id="job_edit__node_filter_exclude"
-              v-model="modelData.filterExclude"
+              v-model:value="modelData.filterExclude"
               :project="modelData.project"
               :filter-name="modelData.filterNameExclude"
               :node-summary="nodeSummary"

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeFilterInput.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeFilterInput.spec.ts
@@ -47,7 +47,7 @@ const mountNodeFilterInput = async (
   const wrapper = mount(NodeFilterInput, {
     props: {
       nodeSummary: mockNodeSummary,
-      modelValue: "",
+      value: "",
       project: "test-project",
       eventBus,
       ...props,
@@ -73,15 +73,15 @@ describe("NodeFilterInput Component", () => {
   });
   it("updates modelValue on input and performs search on enter keydown", async () => {
     const wrapper = await mountNodeFilterInput({
-      modelValue: "initial filter",
+      value: "initial filter",
     });
     const input = wrapper.find('input[data-testid="filter-input"]');
     await input.setValue("new filter");
     await input.trigger("blur");
-    expect(wrapper.emitted()["update:modelValue"][0]).toEqual(["new filter"]);
+    expect(wrapper.emitted()["update:value"][0]).toEqual(["new filter"]);
     await input.setValue("updated filter");
     await input.trigger("keydown.enter");
-    expect(wrapper.emitted()["update:modelValue"][1]).toEqual([
+    expect(wrapper.emitted()["update:value"][1]).toEqual([
       "updated filter",
     ]);
   });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/JobRefForm.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/JobRefForm.vue
@@ -317,7 +317,7 @@
 
           <div class="col-sm-10 vue-ui-socket">
             <node-filter-input
-              :model-value="editModel.jobref.nodefilters.filter"
+              :value="editModel.jobref.nodefilters.filter"
               :project="currentProject"
               filter-field-name="nodeFilter"
               :filter-field-id="`nodeFilterField${rkey}`"
@@ -325,7 +325,7 @@
               emit-filter-on-blur
               search-btn-type="cta"
               class="nodefilters"
-              @update:model-value="updatedValue"
+              @update:value="updatedValue"
               @filter="filterClicked"
             />
           </div>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.ts
@@ -103,14 +103,14 @@ const FilterInputComp = defineComponent({
   },
   template: `
           <node-filter-input :project="project"
-                             v-model="filterValue"
+                             v-model:value="filterValue"
                              :show-title="showInputTitle"
                              :autofocus="autofocus"
                              :filterFieldName="filterFieldName"
                              :filter-field-id="filterFieldId"
                              :query-field-placeholder-text="queryFieldPlaceholderText"
                              search-btn-type="cta"
-                             @update:model-value="updatedValue"
+                             @update:value="updatedValue"
                              @filter="filterClicked"
                              v-bind="extraAttrs"
           />


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
**Bugfix**. When users select localhost from the node filter dropdown in "Override Node Filter" mode, the input field remains empty instead of showing "name: localhost". This functionality worked in version 4.11 but regressed in newer versions.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

Added JavaScript event handling to capture node filter dropdown selections. When users click on nodes (like localhost) in the dropdown, the solution:

- Extracts the node filter value from the selected element

- Populates the input field with the correct filter syntax, like an example ("name: localhost")

- Triggers input events to ensure proper recognition

- Provides immediate visual feedback by focusing the input field

- Added comprehensive test coverage to verify the complete user flow from dropdown selection to input population.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->



**Additional context**
<!-- Add any other context or screenshots about the change here. -->

When users selected "Override Node Filter" mode and chose nodes from the dropdown (like localhost), the node filter input field remained blank instead of displaying the selected filter. This prevented users from seeing their selection.