### PR TITLE
Only run SNYK Scan on Main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -721,6 +721,8 @@ workflows:
           context:
             - Snyk
             - Cloudsmith
+          filters:
+            branches: { only: main }
       - wizcli-scan:
           name: WizCLI Scan Preview
           <<: *require-build


### PR DESCRIPTION
Some PRs fall behind main for a period of time.  If Snyk is scanning those branches it may be reporting on findings that are already fixed in Main.  This prevents the scan from running anywhere but the Main branch.