### PR TITLE
RUN:3564: Update File Commons Version

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -158,7 +158,7 @@ dependencies {
     }
     implementation 'org.owasp.encoder:encoder:1.2.1'
     implementation 'org.grails.plugins:external-config:2.0.0'
-    implementation 'commons-fileupload:commons-fileupload:1.6'
+    implementation 'commons-fileupload:commons-fileupload:1.6.0'
     implementation "commons-io:commons-io:${commonsIoVersion}"
     implementation "commons-beanutils:commons-beanutils:${beanutilsVersion}"
     implementation "commons-codec:commons-codec:${commonsCodecVersion}"

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -158,7 +158,7 @@ dependencies {
     }
     implementation 'org.owasp.encoder:encoder:1.2.1'
     implementation 'org.grails.plugins:external-config:2.0.0'
-    implementation 'commons-fileupload:commons-fileupload:1.5'
+    implementation 'commons-fileupload:commons-fileupload:1.6'
     implementation "commons-io:commons-io:${commonsIoVersion}"
     implementation "commons-beanutils:commons-beanutils:${beanutilsVersion}"
     implementation "commons-codec:commons-codec:${commonsCodecVersion}"


### PR DESCRIPTION
CVE-2025-48976 is a Denial of Service (DoS) vulnerability in Apache Commons FileUpload versions 1.0 through 1.5. The vulnerability is caused by allocation of resources for multipart headers with insufficient limits, which allows attackers to cause a DoS attack.

Key Details:
Severity: DoS vulnerability (CWE-770: Allocation of Resources Without Limits or Throttling)

Affected versions: 1.0 to 1.5 (excluding 1.6)

Fixed in: Version 1.6 and 2.0.0-M4+