### PR TITLE
RUN-3563: Bump kotlin in testRuntime for CVE-2020-29582

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -279,7 +279,7 @@ dependencies {
     testRuntimeOnly "org.seleniumhq.selenium:selenium-firefox-driver"
     testRuntimeOnly "org.seleniumhq.selenium:selenium-remote-driver"
     testRuntimeOnly "org.seleniumhq.selenium:selenium-api"
-    testRuntimeOnly 'org.jetbrains.kotlin:kotlin-stdlib:1.3.70'
+    testRuntimeOnly 'org.jetbrains.kotlin:kotlin-stdlib:1.6.21'
     testRuntimeOnly 'org.aspectj:aspectjweaver:1.9.7'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
     // transitive dependencies constraints.


### PR DESCRIPTION


**Is this a bugfix, or an enhancement? Please describe.**
Security Fix

**Describe the solution you've implemented**
The Runbook Automation project (rundeckpro/rundeckpro) has a low severity Information Exposure vulnerability (CVE-2020-29582) in its CLI component. The issue affects org.jetbrains.kotlin:kotlin-stdlib version 1.6.20, though multiple versions of this library appear to be in use (1.6.20, 1.6.21, 1.8.21, 1.9.10). This vulnerability was identified on June 29, 2025, despite being a 2020 CVE.

