### PR TITLE
RUN-3619: CVE-2025-52999 update Jackson to use updated version everywhere.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -116,7 +116,6 @@ dependencies {
     constraints {
         implementation ("org.jetbrains.kotlin:kotlin-stdlib:1.6.21")
     }
-
 }
 
 


### PR DESCRIPTION
**CVE-2025-52999 Fix Summary**
Forced update to Jackson libraries.