### PR TITLE
RUN-2901: CVE-2024-47554

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -726,8 +726,6 @@ workflows:
           context:
             - Snyk
             - Cloudsmith
-          filters:
-            branches: { only: main }
       - wizcli-scan:
           name: WizCLI Scan Preview
           <<: *require-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,10 +401,13 @@ jobs:
             else
               echo "Skipping monitor for non-main branch - no data sent to dashboard"
             fi
-      - run-build-step:
-          step-name: Run Snyk test (ignoring scan results)
+      - run:
+          name: Run Snyk test (ignoring scan results)
           # Don't fail the build giving the Core team some time to clean the repo using the monitors
-          command: snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged || true
+          no_output_timeout: 30m
+          command: |
+            source scripts/circleci/setup.sh
+            snyk test --severity-threshold=medium --all-projects --detection-depth=10 --scan-all-unmanaged || true
 
   # Trigger pipeline in the enterprise repo
   trigger-enterprise:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,7 @@ jobs:
       - run-build-step:
           step-name: Run Snyk test (ignoring scan results)
           # Don't fail the build giving the Core team some time to clean the repo using the monitors
-          command: snyk test --severity-threshold=medium --all-projects --detection-depth=10 --scan-all-unmanaged || true
+          command: snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged || true
 
   # Trigger pipeline in the enterprise repo
   trigger-enterprise:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,40 +373,40 @@ jobs:
           command: openapi_tests
 
   #Snyk tests
-test-snyk:
-  <<: *job-defaults
-  executor:
-    name: docker-builder
-    resource_class: large
-  steps:
-    - setup_docker:
-        docker_layer_caching: true
-    - checkout
-    - restore-build-cache
-    - install-build-dependencies
-    - run-build-step:
-        step-name: Assemble rundeck
-        command: rundeck_assemble_build
-    - snyk/install
-    - run-build-step:
-        step-name: Configure Snyk
-        command: snyk config set org='rundeck-core-mtgfa3XPaKGbFtHj9aRXhg'
-    - run-build-step:
-        step-name: Run Snyk monitors to track vulnerabilities
-        command: |
-          if [ "$CIRCLE_BRANCH" = "main" ]; then
-            snyk monitor --all-projects --detection-depth=10 --scan-all-unmanaged
-          else
-            echo "Skipping monitor for non-main branch"
-          fi
-    - run-build-step:
-        step-name: Run Snyk test
-        command: |
-          if [ "$CIRCLE_BRANCH" = "main" ]; then
-            snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged || true
-          else
-            snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged --report=false || true
-          fi
+  test-snyk:
+    <<: *job-defaults
+    executor:
+      name: docker-builder
+      resource_class: large
+    steps:
+      - setup_docker:
+          docker_layer_caching: true
+      - checkout
+      - restore-build-cache
+      - install-build-dependencies
+      - run-build-step:
+          step-name: Assemble rundeck
+          command: rundeck_assemble_build
+      - snyk/install
+      - run-build-step:
+          step-name: Configure Snyk
+          command: snyk config set org='rundeck-core-mtgfa3XPaKGbFtHj9aRXhg'
+      - run-build-step:
+          step-name: Run Snyk monitors to track vulnerabilities
+          command: |
+            if [ "$CIRCLE_BRANCH" = "main" ]; then
+              snyk monitor --all-projects --detection-depth=10 --scan-all-unmanaged
+            else
+              echo "Skipping monitor for non-main branch"
+            fi
+      - run-build-step:
+          step-name: Run Snyk test
+          command: |
+            if [ "$CIRCLE_BRANCH" = "main" ]; then
+              snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged || true
+            else
+              snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged --report=false || true
+            fi
 
   # Trigger pipeline in the enterprise repo
   trigger-enterprise:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,40 +373,33 @@ jobs:
           command: openapi_tests
 
   #Snyk tests
-test-snyk:
-  <<: *job-defaults
-  executor:
-    name: docker-builder
-    resource_class: large
-  steps:
-    - setup_docker:
-        docker_layer_caching: true
-    - checkout
-    - restore-build-cache
-    - install-build-dependencies
-    - run-build-step:
-        step-name: Assemble rundeck
-        command: rundeck_assemble_build
-    - snyk/install
-    - run-build-step:
-        step-name: Configure Snyk
-        command: snyk config set org='rundeck-core-mtgfa3XPaKGbFtHj9aRXhg'
-    - run-build-step:
-        step-name: Run Snyk monitors to track vulnerabilities
-        command: |
-          if [ "$CIRCLE_BRANCH" = "main" ]; then
-            snyk monitor --all-projects --detection-depth=10 --scan-all-unmanaged
-          else
-            echo "Skipping monitor for non-main branch"
-          fi
-    - run-build-step:
-        step-name: Run Snyk test
-        command: |
-          if [ "$CIRCLE_BRANCH" = "main" ]; then
-            snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged || true
-          else
-            snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged --report=false || true
-          fi
+  test-snyk:
+    <<: *job-defaults
+    executor:
+      name: docker-builder
+      resource_class: large
+    steps:
+      - setup_docker:
+          docker_layer_caching: true
+      - checkout
+      - restore-build-cache
+      - install-build-dependencies
+      - run-build-step:
+          step-name: Assemble rundeck
+          command: rundeck_assemble_build
+      - snyk/install
+      - run-build-step:
+          step-name: Configure Snyk
+          # this will need to be updated if the project changes owners
+          command: snyk config set org='rundeck-core-mtgfa3XPaKGbFtHj9aRXhg'
+      - run-build-step:
+          step-name: Run Snyk monitors to track vulnerabilities
+          # Run monitor first to push results to webui
+          command: snyk monitor --all-projects --detection-depth=10 --scan-all-unmanaged
+      - run-build-step:
+          step-name: Run Snyk test (ignoring scan results)
+          # Don't fail the build giving the Core team some time to clean the repo using the monitors
+          command: snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged || true
 
   # Trigger pipeline in the enterprise repo
   trigger-enterprise:
@@ -728,6 +721,8 @@ workflows:
           context:
             - Snyk
             - Cloudsmith
+          filters:
+            branches: { only: main }
       - wizcli-scan:
           name: WizCLI Scan Preview
           <<: *require-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,40 +373,40 @@ jobs:
           command: openapi_tests
 
   #Snyk tests
-  test-snyk:
-    <<: *job-defaults
-    executor:
-      name: docker-builder
-      resource_class: large
-    steps:
-      - setup_docker:
-          docker_layer_caching: true
-      - checkout
-      - restore-build-cache
-      - install-build-dependencies
-      - run-build-step:
-          step-name: Assemble rundeck
-          command: rundeck_assemble_build
-      - snyk/install
-      - run-build-step:
-          step-name: Configure Snyk
-          command: snyk config set org='rundeck-core-mtgfa3XPaKGbFtHj9aRXhg'
-      - run-build-step:
-          step-name: Run Snyk monitors to track vulnerabilities
-          command: |
-            if [ "$CIRCLE_BRANCH" = "main" ]; then
-              snyk monitor --all-projects --detection-depth=10 --scan-all-unmanaged
-            else
-              echo "Skipping monitor for non-main branch"
-            fi
-      - run-build-step:
-          step-name: Run Snyk test
-          command: |
-            if [ "$CIRCLE_BRANCH" = "main" ]; then
-              snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged || true
-            else
-              snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged --report=false || true
-            fi
+test-snyk:
+  <<: *job-defaults
+  executor:
+    name: docker-builder
+    resource_class: large
+  steps:
+    - setup_docker:
+        docker_layer_caching: true
+    - checkout
+    - restore-build-cache
+    - install-build-dependencies
+    - run-build-step:
+        step-name: Assemble rundeck
+        command: rundeck_assemble_build
+    - snyk/install
+    - run-build-step:
+        step-name: Configure Snyk
+        command: snyk config set org='rundeck-core-mtgfa3XPaKGbFtHj9aRXhg'
+    - run-build-step:
+        step-name: Run Snyk monitors to track vulnerabilities
+        command: |
+          if [ "$CIRCLE_BRANCH" = "main" ]; then
+            snyk monitor --all-projects --detection-depth=10 --scan-all-unmanaged
+          else
+            echo "Skipping monitor for non-main branch"
+          fi
+    - run-build-step:
+        step-name: Run Snyk test
+        command: |
+          if [ "$CIRCLE_BRANCH" = "main" ]; then
+            snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged || true
+          else
+            snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged --report=false || true
+          fi
 
   # Trigger pipeline in the enterprise repo
   trigger-enterprise:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,11 +395,16 @@ jobs:
       - run-build-step:
           step-name: Run Snyk monitors to track vulnerabilities
           # Run monitor first to push results to webui
-          command: snyk monitor --all-projects --detection-depth=10 --scan-all-unmanaged
+          command: |
+            if [ "$CIRCLE_BRANCH" = "main" ]; then
+              snyk monitor --all-projects --detection-depth=10 --scan-all-unmanaged
+            else
+              echo "Skipping monitor for non-main branch - no data sent to dashboard"
+            fi
       - run-build-step:
           step-name: Run Snyk test (ignoring scan results)
           # Don't fail the build giving the Core team some time to clean the repo using the monitors
-          command: snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged || true
+          command: snyk test --severity-threshold=medium --all-projects --detection-depth=10 --scan-all-unmanaged || true
 
   # Trigger pipeline in the enterprise repo
   trigger-enterprise:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,33 +373,40 @@ jobs:
           command: openapi_tests
 
   #Snyk tests
-  test-snyk:
-    <<: *job-defaults
-    executor:
-      name: docker-builder
-      resource_class: large
-    steps:
-      - setup_docker:
-          docker_layer_caching: true
-      - checkout
-      - restore-build-cache
-      - install-build-dependencies
-      - run-build-step:
-          step-name: Assemble rundeck
-          command: rundeck_assemble_build
-      - snyk/install
-      - run-build-step:
-          step-name: Configure Snyk
-          # this will need to be updated if the project changes owners
-          command: snyk config set org='rundeck-core-mtgfa3XPaKGbFtHj9aRXhg'
-      - run-build-step:
-          step-name: Run Snyk monitors to track vulnerabilities
-          # Run monitor first to push results to webui
-          command: snyk monitor --all-projects --detection-depth=10 --scan-all-unmanaged
-      - run-build-step:
-          step-name: Run Snyk test (ignoring scan results)
-          # Don't fail the build giving the Core team some time to clean the repo using the monitors
-          command: snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged || true
+test-snyk:
+  <<: *job-defaults
+  executor:
+    name: docker-builder
+    resource_class: large
+  steps:
+    - setup_docker:
+        docker_layer_caching: true
+    - checkout
+    - restore-build-cache
+    - install-build-dependencies
+    - run-build-step:
+        step-name: Assemble rundeck
+        command: rundeck_assemble_build
+    - snyk/install
+    - run-build-step:
+        step-name: Configure Snyk
+        command: snyk config set org='rundeck-core-mtgfa3XPaKGbFtHj9aRXhg'
+    - run-build-step:
+        step-name: Run Snyk monitors to track vulnerabilities
+        command: |
+          if [ "$CIRCLE_BRANCH" = "main" ]; then
+            snyk monitor --all-projects --detection-depth=10 --scan-all-unmanaged
+          else
+            echo "Skipping monitor for non-main branch"
+          fi
+    - run-build-step:
+        step-name: Run Snyk test
+        command: |
+          if [ "$CIRCLE_BRANCH" = "main" ]; then
+            snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged || true
+          else
+            snyk test --severity-threshold=high --all-projects --detection-depth=10 --scan-all-unmanaged --report=false || true
+          fi
 
   # Trigger pipeline in the enterprise repo
   trigger-enterprise:
@@ -721,8 +728,6 @@ workflows:
           context:
             - Snyk
             - Cloudsmith
-          filters:
-            branches: { only: main }
       - wizcli-scan:
           name: WizCLI Scan Preview
           <<: *require-build

--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,13 @@ allprojects {
         exclude group: 'ch.qos.logback', module: 'logback-classic'
         exclude group: 'ch.qos.logback', module: 'logback-core'
     }
+    
+    // Global dependency constraints to fix security vulnerabilities
+    configurations.all {
+        resolutionStrategy {
+            force "commons-io:commons-io:${commonsIoVersion}"
+        }
+    }
 }
 
 /**

--- a/grails-persistlocale/build.gradle
+++ b/grails-persistlocale/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation "org.grails.plugins:scaffolding"
     implementation "org.grails.plugins:gsp"
     implementation "org.yaml:snakeyaml:${snakeyamlVersion}"
+    implementation "commons-io:commons-io:${commonsIoVersion}"
     implementation "io.micronaut:micronaut-inject-groovy"
     console "org.grails:grails-console"
     profile ("org.grails.profiles:web-plugin"){
@@ -61,6 +62,12 @@ dependencies {
     testImplementation "org.grails:grails-gorm-testing-support"
     testImplementation "org.mockito:mockito-core"
     testImplementation "org.grails:grails-web-testing-support"
+    
+    constraints {
+        implementation("commons-io:commons-io:${commonsIoVersion}") {
+            because "Fix CVE-2024-47554 - force newer version over transitive dependencies"
+        }
+    }
 }
 
 bootRun {

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -296,6 +296,9 @@ dependencies {
         implementation ("org.yaml:snakeyaml:${snakeyamlVersion}") {
             because "required by rundeck:repository"
         }
+        implementation("commons-io:commons-io:${commonsIoVersion}") {
+            because "Fix CVE-2024-47554 - force newer version over transitive dependencies"
+        }
     }
 
 


### PR DESCRIPTION
Add constraint for commons-io to ensure everywhere is using the proper version.

Note: This also includes a fix to CirclCI to run scans locally only (don't send back to console) so we can try to verify if fixes address the intended CVE.