### PR TITLE
RUN-3564: Additional Fixes for CVE-2025-48976

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,7 @@ allprojects {
     configurations.all {
         resolutionStrategy {
             force "commons-io:commons-io:${commonsIoVersion}"
-            force "commons-fileupload:${commonsFileuploadVersion}"
+            force "commons-fileupload:commons-fileupload:${commonsFileuploadVersion}"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,7 @@ allprojects {
     configurations.all {
         resolutionStrategy {
             force "commons-io:commons-io:${commonsIoVersion}"
-            force "commons-fileupload:commons-fileupload:1.6.0"
+            force "commons-fileupload:${commonsFileuploadVersion}"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,7 @@ allprojects {
     configurations.all {
         resolutionStrategy {
             force "commons-io:commons-io:${commonsIoVersion}"
+            force "commons-fileupload:commons-fileupload:1.6.0"
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -64,3 +64,4 @@ mwiedeJschVersion=0.2.21
 minaCoreVersion=2.2.4
 beanutilsVersion=1.11.0
 commonsCompressVersion=1.26.2
+commonsFileuploadVersion=1.6.0

--- a/grails-persistlocale/build.gradle
+++ b/grails-persistlocale/build.gradle
@@ -67,6 +67,9 @@ dependencies {
         implementation("commons-io:commons-io:${commonsIoVersion}") {
             because "Fix CVE-2024-47554 - force newer version over transitive dependencies"
         }
+        implementation("commons-fileupload:commons-fileupload:1.6.0") {
+            because "Fix CVE-2025-48976 - force newer version over transitive dependencies from grails-web-fileupload"
+        }
     }
 }
 

--- a/grails-persistlocale/build.gradle
+++ b/grails-persistlocale/build.gradle
@@ -67,7 +67,7 @@ dependencies {
         implementation("commons-io:commons-io:${commonsIoVersion}") {
             because "Fix CVE-2024-47554 - force newer version over transitive dependencies"
         }
-        implementation("commons-fileupload:${commonsFileuploadVersion}") {
+        implementation("commons-fileupload:commons-fileupload:${commonsFileuploadVersion}") {
             because "Fix CVE-2025-48976 - force newer version over transitive dependencies from grails-web-fileupload"
         }
     }

--- a/grails-persistlocale/build.gradle
+++ b/grails-persistlocale/build.gradle
@@ -67,7 +67,7 @@ dependencies {
         implementation("commons-io:commons-io:${commonsIoVersion}") {
             because "Fix CVE-2024-47554 - force newer version over transitive dependencies"
         }
-        implementation("commons-fileupload:commons-fileupload:1.6.0") {
+        implementation("commons-fileupload:${commonsFileuploadVersion}") {
             because "Fix CVE-2025-48976 - force newer version over transitive dependencies from grails-web-fileupload"
         }
     }

--- a/grails-rundeck-data-shared/build.gradle
+++ b/grails-rundeck-data-shared/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     testImplementation "org.grails:grails-web-testing-support"
     
     constraints {
-        implementation("commons-fileupload:commons-fileupload:1.6.0") {
+        implementation("commons-fileupload:${commonsFileuploadVersion}") {
             because "Fix CVE-2025-48976 - force newer version over transitive dependencies from grails-web-fileupload"
         }
     }

--- a/grails-rundeck-data-shared/build.gradle
+++ b/grails-rundeck-data-shared/build.gradle
@@ -62,6 +62,12 @@ dependencies {
     testImplementation "org.grails:grails-gorm-testing-support"
     testImplementation "org.mockito:mockito-core"
     testImplementation "org.grails:grails-web-testing-support"
+    
+    constraints {
+        implementation("commons-fileupload:commons-fileupload:1.6.0") {
+            because "Fix CVE-2025-48976 - force newer version over transitive dependencies from grails-web-fileupload"
+        }
+    }
 }
 
 bootRun {

--- a/grails-webhooks/build.gradle
+++ b/grails-webhooks/build.gradle
@@ -67,6 +67,12 @@ dependencies {
     testImplementation "org.grails:grails-gorm-testing-support"
     testImplementation "org.mockito:mockito-core"
     testImplementation "org.grails:grails-web-testing-support"
+    
+    constraints {
+        implementation("commons-fileupload:commons-fileupload:1.6.0") {
+            because "Fix CVE-2025-48976 - force newer version over transitive dependencies from grails-web-fileupload"
+        }
+    }
 }
 
 bootRun {

--- a/grails-webhooks/build.gradle
+++ b/grails-webhooks/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     testImplementation "org.grails:grails-web-testing-support"
     
     constraints {
-        implementation("commons-fileupload:${commonsFileuploadVersion}") {
+        implementation("commons-fileupload:commons-fileupload:${commonsFileuploadVersion}") {
             because "Fix CVE-2025-48976 - force newer version over transitive dependencies from grails-web-fileupload"
         }
     }

--- a/grails-webhooks/build.gradle
+++ b/grails-webhooks/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     testImplementation "org.grails:grails-web-testing-support"
     
     constraints {
-        implementation("commons-fileupload:commons-fileupload:1.6.0") {
+        implementation("commons-fileupload:${commonsFileuploadVersion}") {
             because "Fix CVE-2025-48976 - force newer version over transitive dependencies from grails-web-fileupload"
         }
     }

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -299,6 +299,9 @@ dependencies {
         implementation("commons-io:commons-io:${commonsIoVersion}") {
             because "Fix CVE-2024-47554 - force newer version over transitive dependencies"
         }
+        implementation("commons-fileupload:commons-fileupload:1.6.0") {
+            because "Fix CVE-2025-48976 - force newer version over transitive dependencies from grails-web-fileupload"
+        }
     }
 
 

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -158,7 +158,7 @@ dependencies {
     }
     implementation 'org.owasp.encoder:encoder:1.2.1'
     implementation 'org.grails.plugins:external-config:2.0.0'
-    implementation "commons-fileupload:${commonsFileuploadVersion}"
+    implementation "commons-fileupload:commons-fileupload:${commonsFileuploadVersion}"
     implementation "commons-io:commons-io:${commonsIoVersion}"
     implementation "commons-beanutils:commons-beanutils:${beanutilsVersion}"
     implementation "commons-codec:commons-codec:${commonsCodecVersion}"

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -299,7 +299,7 @@ dependencies {
         implementation("commons-io:commons-io:${commonsIoVersion}") {
             because "Fix CVE-2024-47554 - force newer version over transitive dependencies"
         }
-        implementation("commons-fileupload:${commonsFileuploadVersion}") {
+        implementation("commons-fileupload:commons-fileupload:${commonsFileuploadVersion}") {
             because "Fix CVE-2025-48976 - force newer version over transitive dependencies from grails-web-fileupload"
         }
     }

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -158,7 +158,7 @@ dependencies {
     }
     implementation 'org.owasp.encoder:encoder:1.2.1'
     implementation 'org.grails.plugins:external-config:2.0.0'
-    implementation 'commons-fileupload:commons-fileupload:1.6.0'
+    implementation "commons-fileupload:${commonsFileuploadVersion}"
     implementation "commons-io:commons-io:${commonsIoVersion}"
     implementation "commons-beanutils:commons-beanutils:${beanutilsVersion}"
     implementation "commons-codec:commons-codec:${commonsCodecVersion}"
@@ -299,7 +299,7 @@ dependencies {
         implementation("commons-io:commons-io:${commonsIoVersion}") {
             because "Fix CVE-2024-47554 - force newer version over transitive dependencies"
         }
-        implementation("commons-fileupload:commons-fileupload:1.6.0") {
+        implementation("commons-fileupload:${commonsFileuploadVersion}") {
             because "Fix CVE-2025-48976 - force newer version over transitive dependencies from grails-web-fileupload"
         }
     }


### PR DESCRIPTION
**Summary**
Identified and fixed the commons-fileupload vulnerability issue comprehensively across the Rundeck workspace. Here's what was done:

**Root Cause**
The vulnerability was coming from transitive dependencies through the Grails framework, specifically through org.grails:grails-web-fileupload:6.1.2 which was pulling in the vulnerable commons-fileupload:1.5.

**Changes Made**
build.gradle - Added constraint to force commons-fileupload:1.6.0 for all transitive dependencies build.gradle - Added the same constraint (this was specifically mentioned in your Snyk finding) build.gradle - Added constraint since it uses grails-web-boot build.gradle - Added constraint since it uses grails-web-boot build.gradle (root) - Added global force resolution strategy to ensure all subprojects use the secure version What This Fixes
Forces all transitive dependencies of commons-fileupload to use version 1.6.0 instead of the vulnerable 1.5 Addresses CVE-2025-48976 across all Grails modules that might pull in the vulnerable dependency Provides both local constraints and global force strategy for comprehensive coverage The dependency tree now shows that the vulnerable version 1.5 is being consistently upgraded to 1.6.0 across all dependency paths, which should resolve the CVE.
