### PR TITLE
RUN-3602:  update commons-compress version

### DIFF
--- a/functional-test/build.gradle
+++ b/functional-test/build.gradle
@@ -16,6 +16,16 @@ testlogger {
 
 project.evaluationDependsOn(":rundeckapp")
 
+configurations.all {
+    resolutionStrategy {
+        // Force safe commons-compress versions to fix CVE-2024-25710
+        // Only force artifacts that exist for version 1.21
+        force "org.apache.commons:commons-compress:${commonsCompressVersion}"
+    }
+    exclude group: 'org.apache.commons:commons-compress:1.21'
+}
+
+
 dependencies {
     testImplementation "org.spockframework:spock-core:${spockVersion}"
     testImplementation "org.testcontainers:testcontainers:${testContainersVersion}"
@@ -26,6 +36,9 @@ dependencies {
     testImplementation "org.seleniumhq.selenium:selenium-java:${seleniumJavaVersion}"
     testImplementation "com.squareup.okhttp3:okhttp-urlconnection:${okhttpUrlConnectionVersion}"
     testImplementation group: 'com.jcraft', name: 'jsch', version: "${jschVersion}"
+
+    testImplementation "org.apache.commons:commons-compress:${commonsCompressVersion}"
+
 }
 
 //This prevents tasks from being cached

--- a/gradle.properties
+++ b/gradle.properties
@@ -63,3 +63,4 @@ jschVersion=0.1.55
 mwiedeJschVersion=0.2.21
 minaCoreVersion=2.2.4
 beanutilsVersion=1.11.0
+commonsCompressVersion=1.26.2

--- a/plugins/object-store-plugin/build.gradle
+++ b/plugins/object-store-plugin/build.gradle
@@ -17,6 +17,15 @@ configurations{
     }
 }
 
+configurations.all {
+    resolutionStrategy {
+        // Force safe commons-compress versions to fix CVE-2024-25710
+        // Only force artifacts that exist for version 1.21
+        force "org.apache.commons:commons-compress:${commonsCompressVersion}"
+    }
+    exclude group: 'org.apache.commons:commons-compress:1.21'
+}
+
 dependencies {
     // Use the latest Groovy version for building this library
     implementation "org.codehaus.groovy:groovy:${groovyVersion}"
@@ -25,6 +34,8 @@ dependencies {
         exclude(group: 'com.google.guava', module: 'guava')
         exclude(group: 'commons-io', module: 'commons-io')
     }
+
+    implementation "org.apache.commons:commons-compress:${commonsCompressVersion}"
 
     // Use the awesome Spock testing and specification framework
     testImplementation "org.spockframework:spock-core:${spockVersion}"


### PR DESCRIPTION

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
force using org.apache.commons:commons-compress 1.26.2 used mainly as a dependency of org.grails.plugins:database-migration

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
