### PR TITLE
RUN-3625: Update Quartz for CVE-2019-5427

### DIFF
--- a/grails-execution-mode-timer/build.gradle
+++ b/grails-execution-mode-timer/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 
     implementation project(":core")
 
-    implementation 'org.quartz-scheduler:quartz:2.3.1'
+    implementation 'org.quartz-scheduler:quartz:2.3.2'
     implementation 'org.grails.plugins:quartz:2.0.13'
 
     implementation "org.springframework.boot:spring-boot-starter-log4j2"


### PR DESCRIPTION
update Quartz to 2.3.2