### PR TITLE
RUN-2921: Add index for retry_execution_id in the execution table

### DIFF
--- a/rundeckapp/grails-app/migrations/changelog.groovy
+++ b/rundeckapp/grails-app/migrations/changelog.groovy
@@ -118,5 +118,6 @@ databaseChangeLog = {
         include file: 'core/BaseReportSpi.groovy'
         include file: 'core/RemoveFilters-5.0.groovy'
         include file: 'core/StoredEventIndexes.groovy'
+        include file: 'core/ExecutionIndexes.groovy'
 
 }

--- a/rundeckapp/grails-app/migrations/core/ExecutionIndexes.groovy
+++ b/rundeckapp/grails-app/migrations/core/ExecutionIndexes.groovy
@@ -1,0 +1,13 @@
+databaseChangeLog = {
+    changeSet(author: "cfranco", id: "5.15.0-1754578206") {
+        preConditions(onFail: "MARK_RAN") {
+            not {
+                indexExists(tableName: "execution", indexName: "EXECUTION_RETRY_EXEC_ID_IDX")
+            }
+        }
+        createIndex(indexName: "EXECUTION_RETRY_EXEC_ID_IDX", tableName: "execution") {
+            column(name: "retry_execution_id")
+        }
+    }
+
+}

--- a/rundeckapp/grails-app/migrations/core/ExecutionIndexes.groovy
+++ b/rundeckapp/grails-app/migrations/core/ExecutionIndexes.groovy
@@ -1,5 +1,5 @@
 databaseChangeLog = {
-    changeSet(author: "cfranco", id: "5.15.0-1754578206", dbms: "oracle") {
+    changeSet(author: "cfranco", id: "5.15.0-1754578206", dbms: "oracle,postgresql") {
         preConditions(onFail: "MARK_RAN") {
             not {
                 indexExists(tableName: "execution", indexName: "EXECUTION_RETRY_EXEC_ID_IDX")

--- a/rundeckapp/grails-app/migrations/core/ExecutionIndexes.groovy
+++ b/rundeckapp/grails-app/migrations/core/ExecutionIndexes.groovy
@@ -1,5 +1,5 @@
 databaseChangeLog = {
-    changeSet(author: "cfranco", id: "5.15.0-1754578206") {
+    changeSet(author: "cfranco", id: "5.15.0-1754578206", dbms: "oracle") {
         preConditions(onFail: "MARK_RAN") {
             not {
                 indexExists(tableName: "execution", indexName: "EXECUTION_RETRY_EXEC_ID_IDX")


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Customer is experiencing deadlock issues when using oracle database. It can be affected by cleaning execution job that affect the performance in the database causing the deadlocks

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
It adds a new index in the execution database for retry_execution_id that improves the performance when rundeck triggers the clean execution job and, as a side effect, this reduces deadlock cases in the database.
In a local test using postgresql, without the index, the cleaning process took 8 seconds to delete +/- 550  execution. After adding the index, it was reduced to 2 seconds.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
