### PR TITLE
RUN-3684: Fix: repeated exceptions after SCM is disabled

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
@@ -11,9 +11,9 @@ import grails.events.bus.EventBusAware
 import grails.gorm.transactions.Transactional
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
+import org.rundeck.app.config.ConfigService
 import rundeck.ScheduledExecution
 import rundeck.data.job.reference.JobRevReferenceImpl
-import rundeck.services.ConfigurationService
 import rundeck.services.FrameworkService
 
 import rundeck.services.ScheduledExecutionService
@@ -32,7 +32,7 @@ class ScmLoaderService implements EventBusAware {
     FrameworkService frameworkService
     ScmService scmService
     ScheduledExecutionService scheduledExecutionService
-    ConfigurationService configurationService
+    ConfigService configurationService
     public static final long DEFAULT_LOADER_DELAY = 0
     public static final long DEFAULT_LOADER_INTERVAL_SEC = 20
     public static final long INIT_RETRY_TIMES = 5
@@ -109,65 +109,92 @@ class ScmLoaderService implements EventBusAware {
 
         return false
     }
+    /**
+     * Project SCM Loader
+     * This class is responsible for loading the SCM configuration and processing the import/export operations.
+     */
+    static class ProjectScmLoader implements Runnable{
+        String project
+        String integration
+        ScmLoaderService service
+
+        ScmLoaderState state = new ScmLoaderStateImpl()
+        private long retryTimes
+        private long retryDelay
+
+        ProjectScmLoader(String project, String integration, ScmLoaderService service, long delay, long retryCount) {
+            this.project = project
+            this.integration = integration
+            this.service = service
+            retryDelay = delay
+            retryTimes = retryCount
+        }
+
+        @Override
+        void run() {
+            String projectIntegration = service.getProjectIntegration(project, integration)
+            ScmPluginConfigData pluginConfigData = service.scmService.loadScmConfig(project, integration)
+            if(!service.scmPluginMeta.get(projectIntegration)){
+                service.scmPluginMeta.put(projectIntegration, pluginConfigData)
+            }
+            if(pluginConfigData && pluginConfigData.enabled){
+                boolean process = false
+                int retryCount = 0
+
+                if (pluginConfigData.properties.get("flagToReturnProcess")) {
+                    pluginConfigData.properties.remove("flagToReturnProcess")
+                    service.scmService.storeConfig(pluginConfigData, project, integration)
+                }
+
+                while (!process){
+                    try {
+                        if (integration == service.scmService.EXPORT) {
+                            service.processScmExportLoader(project, pluginConfigData, state)
+                        }else{
+                            service.processScmImportLoader(project, pluginConfigData, state)
+                        }
+                        process = true
+
+                    } catch (Throwable t) {
+                        if(retryCount>= retryTimes){
+                            service.scmFailedProjectInit.put(projectIntegration, pluginConfigData)
+                            process = true
+                            service.scmToFalse(pluginConfigData, project, integration)
+                            service.removingLoaderProcess(
+                                project,
+                                integration,
+                                "Error initializing SCM: " + t.message
+                            )
+                        }else{
+                            retryCount++
+                            log.error("Error initializing SCM for: $project/$integration: ${t.message}. Retrying ${retryCount}/${retryTimes}")
+                            Thread.sleep(this.retryDelay)
+                        }
+                    }
+                }
+
+            }else{
+                service.removingLoaderProcess(project, integration, "SCM disabled or project removed")
+            }
+        }
+    }
 
     def startScmLoader(String project, String integration){
 
-        def state = new ScmLoaderStateImpl()
+        def loader = createProjectLoader(project, integration)
         //enable project integration cache loader
         def scheduler = scheduledExecutor.scheduleAtFixedRate(
             {
                     try {
-                        String projectIntegration = getProjectIntegration(project, integration)
-                        ScmPluginConfigData pluginConfigData = scmService.loadScmConfig(project, integration)
-                        if(!scmPluginMeta.get(projectIntegration)){
-                            scmPluginMeta.put(projectIntegration, pluginConfigData)
-                        }
-                        if(pluginConfigData && pluginConfigData.enabled){
-                            boolean process = false
-                            int retryCount = 0
-                            long retryTimes = getScmLoaderInitialRetryTimes()
-                            long retryDelay = getScmLoaderInitialRetryDelay()
-
-                            if (pluginConfigData.properties.get("flagToReturnProcess")) {
-                                pluginConfigData.properties.remove("flagToReturnProcess")
-                                scmService.storeConfig(pluginConfigData, project, integration)
-                            }
-
-                            while (!process){
-                                try {
-                                    if (integration == scmService.EXPORT) {
-                                        processScmExportLoader(project, pluginConfigData, state)
-                                    }else{
-                                        processScmImportLoader(project, pluginConfigData, state)
-                                    }
-                                    process = true
-
-                                } catch (Throwable t) {
-                                    if(retryCount>=retryTimes){
-                                        scmFailedProjectInit.put(projectIntegration, pluginConfigData)
-                                        process = true
-                                        scmToFalse(pluginConfigData, project, integration)
-                                        removingLoaderProcess(
-                                            project,
-                                            integration,
-                                            "Error initializing SCM: " + t.message
-                                        )
-                                    }else{
-                                        retryCount++
-                                        log.error("Error initializing SCM for: $project/$integration: ${t.message}. Retrying ${retryCount}/${retryTimes}")
-                                        Thread.sleep(retryDelay)
-                                    }
-                                }
-                            }
-
-                        }else{
-                            removingLoaderProcess(project, integration, "SCM disabled or project removed")
-                        }
+                        loader.run()
                     } catch (CancelTaskException throwable) {
                         log.warn("Stopping loader process for ${project}/${integration}: ${throwable.message}", throwable)
                         throw throwable
                     } catch (Throwable throwable) {
-                        log.error("Error initializing SCM project loader for ${project}/${integration}: ${throwable.message}", throwable)
+                        log.error(
+                            "Error initializing SCM project loader for ${project}/${integration}: ${throwable.message}",
+                            throwable
+                        )
                     }
                 },
                 scmLoaderInitialDelaySeconds,
@@ -175,6 +202,10 @@ class ScmLoaderService implements EventBusAware {
                 TimeUnit.SECONDS
         )
         scheduler
+    }
+
+    ProjectScmLoader createProjectLoader(String project, String integration) {
+        new ProjectScmLoader(project, integration, this, this.getScmLoaderInitialRetryDelay(), this.getScmLoaderInitialRetryTimes())
     }
 
     def scmToFalse(ScmPluginConfigData scmPluginConfig, String project, String integration) {
@@ -205,11 +236,13 @@ class ScmLoaderService implements EventBusAware {
 
 
     long getScmLoaderInitialRetryTimes() {
-        configurationService?.getLong('scmLoader.init.retry', INIT_RETRY_TIMES) ?: INIT_RETRY_TIMES
+        def result = configurationService?.getLong('scmLoader.init.retry', INIT_RETRY_TIMES)
+        result != null ? result : INIT_RETRY_TIMES
     }
 
     long getScmLoaderInitialRetryDelay() {
-        configurationService?.getLong('scmLoader.init.delay', INIT_RETRY_TIMES_DELAY) ?: INIT_RETRY_TIMES_DELAY
+        def result = configurationService?.getLong('scmLoader.init.delay', INIT_RETRY_TIMES_DELAY)
+        result != null ? result : INIT_RETRY_TIMES_DELAY
     }
 
     long getScmLoaderIntervalSeconds() {

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/job/metadata/JobScmMetadataComponent.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/job/metadata/JobScmMetadataComponent.groovy
@@ -109,7 +109,7 @@ class JobScmMetadataComponent implements JobMetadataComponent {
                         }
                     }
                 }
-            } catch (ScmPluginException e) {
+            } catch (Throwable e) {
                 log.warn("Failed to get SCM Export status: ${e.message}")
             }
         }
@@ -137,7 +137,7 @@ class JobScmMetadataComponent implements JobMetadataComponent {
                         }
                     }
                 }
-            } catch (ScmPluginException e) {
+            } catch (Throwable e) {
                 log.warn("Failed to get SCM Import status: ${e.message}")
             }
         }


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**

bugfix: if SCM is disabled/broken for a project, it can cause repeated error logs stating "SCM disabled or project removed"

**Describe the solution you've implemented**
fix behavior where where Exception is thrown in order to cause the loader task to finish

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
[A change in 5.12.0](https://github.com/rundeck/rundeck/pull/9639) caused the behavior to change, where a RuntimeException was intentionally used to stop the scheduled task
