### PR TITLE
RUN-3519: Fix for CVE-2025-4949 - jgit

### DIFF
--- a/plugins/git-plugin/build.gradle
+++ b/plugins/git-plugin/build.gradle
@@ -40,11 +40,11 @@ repositories {
 
 dependencies {
     implementation project(":core")
-    pluginLibs( "org.eclipse.jgit:org.eclipse.jgit:6.7.0.202309050840-r") {
+    pluginLibs( "org.eclipse.jgit:org.eclipse.jgit:6.10.1.202505221210-r") {
         exclude module: 'slf4j-api'
         exclude group: 'org.bouncycastle'
     }
-    pluginLibs ("org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:6.7.0.202309050840-r"){
+    pluginLibs ("org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:6.10.1.202505221210-r"){
         exclude module: 'slf4j-api'
         exclude group: 'org.bouncycastle'
     }
@@ -67,7 +67,7 @@ dependencies {
     testImplementation "cglib:cglib-nodep:2.2.2"
     testImplementation "org.spockframework:spock-core:${spockVersion}"
 
-    testImplementation( 'org.eclipse.jgit:org.eclipse.jgit:6.7.0.202309050840-r')
+    testImplementation( 'org.eclipse.jgit:org.eclipse.jgit:6.10.1.202505221210-r')
 }
 
 


### PR DESCRIPTION
Community sourced fix that updates jgit to resolve CVE-2025-4949

Thank you @Ntr0
