### PR TITLE
RUN-3720: project config load refactor 

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkBase.java
@@ -283,6 +283,28 @@ public class FrameworkBase implements IFramework{
         return null;
     }
 
+    /**
+     * Retrieves the global properties defined for the framework (framework.globals.*) The prefix (xxx.globals.) will be
+     * stripped from the property name.
+     *
+     * @return Map with global variables.
+     */
+    public Map<String, String> getFrameworkGlobals() {
+        Map<String, String> globalsMap = new HashMap<>();
+        final Map<?,?> propertiesMap = getPropertyLookup().getPropertiesMap();
+        final Set<?> set = propertiesMap.keySet();
+        set.stream().filter(key -> key.toString().startsWith(FRAMEWORK_GLOBALS_PROP))
+           .forEach(key -> {
+                        String skey = key.toString();
+                        String varName = skey.substring(FRAMEWORK_GLOBALS_PROP.length());
+                        if (varName.isEmpty()) {
+                            return;
+                        }
+                        globalsMap.put(varName, propertiesMap.get(key).toString());
+                    }
+           );
+        return globalsMap;
+    }
 
     /**
     * Retrieves the global properties defined for the specified project.
@@ -298,7 +320,7 @@ public class FrameworkBase implements IFramework{
     public Map<String, String> getProjectGlobals(final String project) {
 
         // Final property map.
-        Map<String, String> projectGlobalsMap = new HashMap<>();
+        Map<String, String> projectGlobalsMap = getFrameworkGlobals();
 
         // Transitional map for project global variables.
         Map<String, String> projectGlobs = new HashMap<>();
@@ -312,12 +334,7 @@ public class FrameworkBase implements IFramework{
             Map<String, String> curMap;
             String varName;
 
-            if(propEntry.getKey().startsWith(FRAMEWORK_GLOBALS_PROP)) {
-                // Search for framework globals and extract var name.
-                curMap = projectGlobalsMap;
-                varName = propEntry.getKey().substring(FRAMEWORK_GLOBALS_PROP.length());
-            }
-            else if(propEntry.getKey().startsWith(PROJECT_GLOBALS_PROP)) {
+            if (propEntry.getKey().startsWith(PROJECT_GLOBALS_PROP)) {
                 // Search for project globals and extract var name.
                 curMap = projectGlobs;
                 varName = propEntry.getKey().substring(PROJECT_GLOBALS_PROP.length());

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/FrameworkFactory.java
@@ -79,6 +79,7 @@ public class FrameworkFactory {
             public IProjectNodes getNodes(final String name) {
 
                 return new ProjectNodeSupport(
+                        new File(filesystemFramework.getBaseDir(), "var"),
                         loadFrameworkProjectConfig(
                                 name,
                                 new File(filesystemFramework.getFrameworkProjectsBaseDir(), name),

--- a/core/src/main/java/com/dtolabs/rundeck/core/common/ProjectNodeSupport.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/common/ProjectNodeSupport.java
@@ -60,6 +60,7 @@ public class ProjectNodeSupport implements IProjectNodes, Closeable {
     private ResourceModelSourceService                                             resourceModelSourceService;
     private NodeSourceLoader     nodeSourceLoader;
     private boolean                                                                sourcesOpened;
+    private File varDir;
 
     /**
      * @param projectConfig
@@ -67,11 +68,14 @@ public class ProjectNodeSupport implements IProjectNodes, Closeable {
      * @param nodeSourceLoader model source provider
      */
     public ProjectNodeSupport(
-        final IRundeckProjectConfig projectConfig,
-        final ResourceFormatGeneratorService resourceFormatGeneratorService,
-        final ResourceModelSourceService resourceModelSourceService,
-        final NodeSourceLoader     nodeSourceLoader
-    ) {
+            final File varDir,
+            final IRundeckProjectConfig projectConfig,
+            final ResourceFormatGeneratorService resourceFormatGeneratorService,
+            final ResourceModelSourceService resourceModelSourceService,
+            final NodeSourceLoader nodeSourceLoader
+    )
+    {
+        this.varDir = varDir;
         this.projectConfig = projectConfig;
         this.resourceFormatGeneratorService = resourceFormatGeneratorService;
         this.resourceModelSourceService = resourceModelSourceService;
@@ -81,13 +85,15 @@ public class ProjectNodeSupport implements IProjectNodes, Closeable {
     /**
      * @param projectConfig
      * @param resourceFormatGeneratorService
-     * @deprecated use {@link #ProjectNodeSupport(IRundeckProjectConfig, ResourceFormatGeneratorService, ResourceModelSourceService, Function)}
+     * @deprecated use {@link #ProjectNodeSupport(File, IRundeckProjectConfig, ResourceFormatGeneratorService, ResourceModelSourceService, NodeSourceLoader)}
      */
     public ProjectNodeSupport(
+        final File varDir,
         final IRundeckProjectConfig projectConfig,
         final ResourceFormatGeneratorService resourceFormatGeneratorService,
         final ResourceModelSourceService resourceModelSourceService
     ) {
+        this.varDir = varDir;
         this.projectConfig = projectConfig;
         this.resourceFormatGeneratorService = resourceFormatGeneratorService;
         this.resourceModelSourceService = resourceModelSourceService;
@@ -313,7 +319,6 @@ public class ProjectNodeSupport implements IProjectNodes, Closeable {
 
 
     private File getResourceModelSourceFileCacheForType(String ident) {
-        String varDir = projectConfig.getProperty("framework.var.dir");
         File file = new File(varDir, "resourceModelSourceCache/" + projectConfig.getName() + "/" + ident + ".xml");
         if (!file.getParentFile().exists() && !file.getParentFile().mkdirs()) {
             logger.warn("Failed to create cache dirs for source file cache");

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/common/ProjectNodeSupportSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/common/ProjectNodeSupportSpec.groovy
@@ -49,6 +49,7 @@ class ProjectNodeSupportSpec extends Specification {
     def "reloads after closed"() {
         given:
         Date modifiedTime = new Date()
+        File varDir = File.createTempFile("ProjectNodeSupportSpec-varDir", "-tmp")
         def config = Mock(IRundeckProjectConfig) {
             getName() >> PROJECT_NAME
             getProperties() >> ([
@@ -64,7 +65,7 @@ class ProjectNodeSupportSpec extends Specification {
         def generatorService = ResourceFormatGeneratorService.getInstanceForFramework(framework,framework)
         def sourceService = ResourceModelSourceService.getInstanceForFramework(framework,framework)
 
-        def support = new ProjectNodeSupport(config, generatorService, sourceService)
+        def support = new ProjectNodeSupport(varDir, config, generatorService, sourceService)
 
         when:
 
@@ -88,6 +89,7 @@ class ProjectNodeSupportSpec extends Specification {
 
         given:
         Date modifiedTime = new Date()
+        File varDir = File.createTempFile("ProjectNodeSupportSpec-varDir", "-tmp")
         def config = Mock(IRundeckProjectConfig) {
             getName() >> PROJECT_NAME
             getProperties() >> (
@@ -105,7 +107,7 @@ class ProjectNodeSupportSpec extends Specification {
         def generatorService = ResourceFormatGeneratorService.getInstanceForFramework(framework,framework)
         def sourceService = ResourceModelSourceService.getInstanceForFramework(framework,framework)
 
-        def support = new ProjectNodeSupport(config, generatorService, sourceService, null)
+        def support = new ProjectNodeSupport(varDir, config, generatorService, sourceService, null)
 
         when:
 

--- a/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/FrameworkService.groovy
@@ -1388,13 +1388,14 @@ class FrameworkService implements ApplicationContextAware, ClusterInfoService, F
         return (PluggableProviderService<T>)storagePluginProviderService
     }
 
-    public File getFirstLoginFile() {
-        String vardir
-        if(rundeckFramework.hasProperty('framework.var.dir')) {
-            vardir = rundeckFramework.getProperty('framework.var.dir')
+    public File getFrameworkVarDir() {
+        if (rundeckFramework.hasProperty('framework.var.dir')) {
+            return new File(rundeckFramework.getProperty('framework.var.dir'))
         } else {
-            vardir = getRundeckBase()+"/var"
+            return new File(getRundeckBase(), "var")
         }
-        return new File(vardir, FIRST_LOGIN_FILE)
+    }
+    public File getFirstLoginFile() {
+        return new File(getFrameworkVarDir(), FIRST_LOGIN_FILE)
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NodeService.groovy
@@ -126,6 +126,17 @@ class NodeService implements InitializingBean, ProjectConfigurable, IProjectNode
                     }
             );
 
+
+    private File _frameworkVarDir
+
+    private File getFrameworkVarDir(){
+        if (null == _frameworkVarDir) {
+            // loaded after startup to avoid repeated queries for framework props value which would not change
+            _frameworkVarDir = frameworkService.getFrameworkVarDir()
+        }
+        return _frameworkVarDir
+    }
+
     @Override
     void afterPropertiesSet() throws Exception {
         def spec = configurationService?.getString('nodeService.nodeCache.spec', DEFAULT_CACHE_SPEC)?:DEFAULT_CACHE_SPEC
@@ -232,6 +243,7 @@ class NodeService implements InitializingBean, ProjectConfigurable, IProjectNode
         def resourceModelSourceService = framework.getResourceModelSourceService()
 
         def nodeSupport = new ProjectNodeSupport(
+            getFrameworkVarDir(),
             rdprojectconfig,
             framework.getResourceFormatGeneratorService(),
             resourceModelSourceService,

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -547,17 +547,6 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
         rundeckNodeService.refreshProjectNodes(projectName)
     }
 
-    private IPropertyLookup createProjectPropertyLookup(String projectName, Properties config) {
-        final Properties ownProps = new Properties();
-        ownProps.setProperty("project.name", projectName);
-        def create = PropertyLookup.create(
-                createDirectProjectPropertyLookup(projectName,config),
-                frameworkService.getRundeckFramework().propertyLookup
-        )
-
-        create.expand()
-        return create
-    }
     private static IPropertyLookup createDirectProjectPropertyLookup(String projectName, Properties config) {
         final Properties ownProps = new Properties();
         ownProps.setProperty("project.name", projectName);
@@ -610,7 +599,6 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
         }
         def res = storeProjectConfig(projectName, null, storedProps)
         def rdprojectconfig = new RundeckProjectConfig(projectName,
-                                                       createProjectPropertyLookup(projectName, res.config ?: new Properties()),
                                                        createDirectProjectPropertyLookup(projectName, res.config ?: new Properties()),
                                                        res.lastModified, res.creationTime
         )
@@ -677,7 +665,6 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
         }
         def resource=mergeProjectProperties(project.name,properties,removePrefixes)
         def rdprojectconfig = new RundeckProjectConfig(project.name,
-                                                       createProjectPropertyLookup(project.name, resource.config ?: new Properties()),
                                                        createDirectProjectPropertyLookup(project.name, resource.config ?: new Properties()),
                                                        resource.lastModified,
                                                         resource.creationTime
@@ -728,7 +715,6 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
     void setProjectProperties(final RundeckProject project, final Properties properties) {
         def resource=setProjectProperties(project.name,properties)
         def rdprojectconfig = new RundeckProjectConfig(project.name,
-                                                       createProjectPropertyLookup(project.name, resource.config ?: new Properties()),
                                                        createDirectProjectPropertyLookup(project.name, resource.config ?: new Properties()),
                                                        resource.lastModified,
                 resource.creationTime
@@ -760,10 +746,6 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
     IRundeckProjectConfig loadProjectConfig(final String project) {
         def resource = loadProjectConfigResource(project)
         def rdprojectconfig = new RundeckProjectConfig(project,
-                                                 createProjectPropertyLookup(
-                                                         project,
-                                                         resource.config ?: new Properties()
-                                                 ),
                                                  createDirectProjectPropertyLookup(
                                                          project,
                                                          resource.config ?: new Properties()

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/projects/RundeckProjectConfig.java
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/server/projects/RundeckProjectConfig.java
@@ -30,19 +30,16 @@ public class RundeckProjectConfig implements IRundeckProjectConfig {
     private String name;
     private Date lastModifiedTime;
     private Date createdTime;
-    private IPropertyLookup lookup;
     private IPropertyLookup projectLookup;
 
     public RundeckProjectConfig(
             final String name,
-            final IPropertyLookup lookup,
             final IPropertyLookup projectLookup,
             final Date lastModifiedTime,
             final Date createdTime
     )
     {
         this.name = name;
-        this.setLookup(lookup);
         this.setProjectLookup(projectLookup);
         this.setLastModifiedTime(lastModifiedTime);
         this.setCreatedTime(createdTime);
@@ -94,11 +91,7 @@ public class RundeckProjectConfig implements IRundeckProjectConfig {
     }
 
     public IPropertyLookup getLookup() {
-        return lookup;
-    }
-
-    public void setLookup(final IPropertyLookup lookup) {
-        this.lookup = lookup;
+        return projectLookup;
     }
 
     public IPropertyLookup getProjectLookup() {

--- a/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ProjectManagerServiceSpec.groovy
@@ -22,7 +22,6 @@ import com.dtolabs.rundeck.core.storage.StorageTree
 import com.dtolabs.rundeck.core.storage.StorageUtil
 import com.dtolabs.rundeck.core.utils.PropertyLookup
 import com.dtolabs.rundeck.server.projects.RundeckProject
-import com.dtolabs.rundeck.server.projects.RundeckProjectConfig
 import com.google.common.cache.LoadingCache
 import grails.events.bus.EventBus
 import grails.testing.gorm.DataTest
@@ -110,7 +109,10 @@ class ProjectManagerServiceSpec extends Specification implements ServiceUnitTest
         0*service.rundeckNodeService.getNodes('test1')
         result!=null
         'test1'==result.name
-        'fwkvalue'==result.getProperty('fwkprop')
+
+        //framework props no longer used as defaults in project config
+        null == result.getProperty('fwkprop')
+
         'test1'==result.getProperty('project.name')
         1==result.getProjectProperties().size()
         'test1'==result.getProjectProperties().get('project.name')
@@ -151,7 +153,8 @@ class ProjectManagerServiceSpec extends Specification implements ServiceUnitTest
         0*service.rundeckNodeService.getNodes('test1')
         result!=null
         'test1'==result.name
-        'fwkvalue'==result.getProperty('fwkprop')
+        //framework props no longer used as defaults in project config
+        null == result.getProperty('fwkprop')
         'test1'==result.getProperty('project.name')
         'projval'==result.getProperty('projkey')
         3==result.getProjectProperties().size()
@@ -210,7 +213,8 @@ class ProjectManagerServiceSpec extends Specification implements ServiceUnitTest
         0*service.rundeckNodeService.getNodes('test1')
         result!=null
         'test1'==result.name
-        'fwkvalue'==result.getProperty('fwkprop')
+        //framework props no longer used as defaults in project config
+        null == result.getProperty('fwkprop')
         'test1'==result.getProperty('project.name')
         'projval'==result.getProperty('projkey')
         3==result.getProjectProperties().size()
@@ -254,7 +258,8 @@ class ProjectManagerServiceSpec extends Specification implements ServiceUnitTest
         0*service.rundeckNodeService.getNodes('test1')
         result!=null
         'test1'==result.name
-        'fwkvalue'==result.getProperty('fwkprop')
+        //framework props no longer used as defaults in project config
+        null == result.getProperty('fwkprop')
         'test1'==result.getProperty('project.name')
         !result.hasProperty('projkey')
         1==result.getProjectProperties().size()


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
- restore reverted change to avoid loading full framework config for project configs
  - this change inadvertently broke the behavior of framework globals, since they were implicitly always included in the project config
- fix framework globals by loading them explicitly

**Describe the solution you've implemented**

- get framework globals directly 

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
