### PR TITLE
Fix: Add cross-spawn overrides to address Snyk security alert

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/_package-manager/package.json
+++ b/rundeckapp/grails-app/assets/javascripts/_package-manager/package.json
@@ -42,6 +42,8 @@
     "selfsigned": {
       "node-forge": "^1.3.1"
     },
-    "cross-spawn": "^7.0.6"
+    "cross-spawn": "^7.0.6",
+    "cross-spawn@^6.0.0": "6.0.6"
+
   }
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/package.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package.json
@@ -151,7 +151,9 @@
     "node-forge": "^1.3.1",
     "axios": "$axios",
     "form-data": "^4.0.4",
-    "cross-spawn": "^7.0.6"
+    "cross-spawn": "^7.0.6",
+    "cross-spawn@^6.0.0": "6.0.6"
+
   },
   "jest-junit": {
     "outputDirectory": "./build/test-results",


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
This is a security bugfix

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Added package overrides to both ui-trellis/package.json and _package-manager/package.json to force all cross-spawn dependencies to use patched versions:
**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
