### PR TITLE
RUN-3757: Job Import: skip duplicate option causes 500 error

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/ExportImportSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/ExportImportSpec.groovy
@@ -107,6 +107,33 @@ class ExportImportSpec extends SeleniumBase {
         jobCreatePage.optDetails.size() == 1
         jobCreatePage.options.size() == 1
     }
+    def "import job with skip should show skip message"() {
+        setup:
+        def jobCreatePage = go JobCreatePage, SELENIUM_EXPORT_IMPORT_PROJECT
+        def jobShowPage = page JobShowPage
+        def jobListPage = page JobListPage
+        def jobUploadPage = page JobUploadPage
+        def sideBarPage = page SideBarPage
+        def jobName = 'ImportJobWithSkip'
+        when: "create basic job"
+        jobCreatePage.fillBasicJob jobName
+        jobCreatePage.createJobButton.click()
+        then: "job created"
+        jobShowPage.validatePage()
+        jobShowPage.getLink "Action" click()
+        jobShowPage.getLink "Download Job definition in YAML" click()
+        !jobListPage.jobList.isEmpty()
+        when: "upload job with dupe option skip"
+        jobListPage.getLink "Upload a Job definition" click()
+        jobUploadPage.loadPathToUploadPage SELENIUM_EXPORT_IMPORT_PROJECT
+        jobUploadPage.validatePage()
+        jobUploadPage.fileInputElement().sendKeys("${downloadFolder}${getSeparator()}${jobName}.yaml")
+        jobUploadPage.dupeOptionSkip().click()
+        jobUploadPage.fileUploadButtonElement().click()
+        then:
+        jobUploadPage.headerTextInfo.text.contains("1 Job was skipped")
+
+    }
 
     def cleanup() {
         deleteProject(SELENIUM_EXPORT_IMPORT_PROJECT)

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobUploadPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobUploadPage.groovy
@@ -21,6 +21,8 @@ class JobUploadPage extends BasePage {
     By formUploadButton = By.id(formUploadButtonId)
     By jobUploadInfoDiv = By.xpath("//div[@class='${jobUploadInfoSelectors}']")
     By headerTextSuccessBy = By.cssSelector(".card-header.text-success")
+    By headerTextInfoBy = By.cssSelector(".card-header.text-info")
+    By dupeOptionSkip = By.cssSelector("input[type=radio][name=dupeOption][value=skip]")
 
     JobUploadPage(final SeleniumContext context) {
         super(context)
@@ -34,6 +36,10 @@ class JobUploadPage extends BasePage {
         if (!driver.currentUrl.contains(loadPath)) {
             throw new IllegalStateException("Not on job upload page: " + driver.currentUrl)
         }
+    }
+
+    WebElement dupeOptionSkip(){
+        el dupeOptionSkip
     }
 
     WebElement fileInputElement(){
@@ -50,6 +56,10 @@ class JobUploadPage extends BasePage {
 
     WebElement getHeaderTextSuccess(){
         waitForElementVisible headerTextSuccessBy
+        el headerTextSuccessBy
+    }
+    WebElement getHeaderTextInfo(){
+        waitForElementVisible headerTextInfoBy
         el headerTextSuccessBy
     }
 


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
- fix bug: if "skip the uploaded job" is chosen, and any imported job is skipped, the UI shows a 500 error, although the import succeeds.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
