### PR TITLE
RUN-3099: force to load the orchestrator values in the execution object in Job Notification

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -19,7 +19,7 @@ package rundeck.services
 
 import com.dtolabs.rundeck.core.logging.internal.LogFlusher
 import com.dtolabs.rundeck.app.internal.workflow.MultiWorkflowExecutionListener
-import org.hibernate.FetchMode
+import org.hibernate.sql.JoinType
 import rundeck.data.util.ExecReportUtil
 import rundeck.services.workflow.WorkflowMetricsWriterImpl
 import rundeck.support.filters.BaseNodeFilters
@@ -3241,10 +3241,10 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         def execution = event.execution
         def executionId = event.execution.id
 
-        //force load of orchestrator
-        Execution executionLoad = Execution.createCriteria().get {
+        //load stored execution to get the orchestrator data
+        Execution executionLoad = Execution.createCriteria().get() {
+            createAlias('orchestrator', 'o', JoinType.LEFT_OUTER_JOIN)
             eq('id', executionId)
-            fetchMode('orchestrator', FetchMode.JOIN)
         } as Execution
 
         //just replacing the value for the received from ExecutionJob because the status is not saved yet

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -2767,6 +2767,10 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
             receivedAbortEvent = true
         }
 
+        def myCriteria = new Expando();
+        myCriteria.get = {Closure cls -> return null}
+        Execution.metaClass.static.createCriteria = {myCriteria }
+
         when:
         def result = service.abortExecution(job, e, user, auth, asuser, forced)
 


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

force to load the orchestrator values in the execution object in Job Notification

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
