### PR TITLE
RUN-3768: Add feature flags for disabling roi and job metrics plugins

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
@@ -46,7 +46,9 @@ public enum Features implements FeaturesDefinition{
     NEW_LOCAL_NODE_EXECUTOR("newLocalNodeExecutor"),
     NODE_EXECUTOR_SECURE_INPUT("nodeExecutorSecureInput"),
     PUBLIC_KEYS_DOWNLOAD("publicKeysDownload"),
-    GUI_HIDE_ROI_INSTRUCTIONS("guiHideRoiInstructions")
+    GUI_HIDE_ROI_INSTRUCTIONS("guiHideRoiInstructions"),
+    GUI_DISABLE_ROI_SUMMARY("guiDisableRoiSummary"),
+    GUI_DISABLE_JOB_METRICS("guiDisableJobMetrics")
     ;
 
     private final String propertyName;

--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -461,6 +461,8 @@ public class RundeckConfigBase {
         Enabled enhancedJobTakeoverQuery = new Enabled();
         Enabled publicKeysDownload = new Enabled();
         Enabled guiHideRoiInstructions = new Enabled();
+        Enabled guiDisableRoiSummary = new Enabled();
+        Enabled guiDisableJobMetrics = new Enabled();
 
 
         @Data


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

Add two new feature flags:

`rundeck.feature.guiDisableRoiSummary.enabled` and `rundeck.feature.guiDisableJobMetrics.enabled`

that will be used to disable the roi summary plugin and the job metrics plugin.

Follow up PR with implementation (will add in a moment)

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
