### PR TITLE
RUN-3106:  Yaml exported job delimiter issue

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/Option.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Option.groovy
@@ -280,7 +280,7 @@ public class Option implements Comparable, OptionData {
                 data.valuesListDelimiter=DEFAULT_DELIMITER
             }
             data.optionValues=new ArrayList<String>(values);
-            data.valuesList =values
+            data.valuesList = values
         }
 
         def multivalued = data.remove('multivalued')
@@ -311,6 +311,7 @@ public class Option implements Comparable, OptionData {
         }
 
         DataBindingUtils.bindObjectToInstance opt, data, [], [], null
+        opt.valuesList = opt.produceValuesList()
         return opt
     }
     /**

--- a/rundeckapp/grails-app/domain/rundeck/Option.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Option.groovy
@@ -325,7 +325,7 @@ public class Option implements Comparable, OptionData {
         if(optionValues) {
             valuesList = optionValues.join(valuesListDelimiter)
         }else{
-            return ''
+            return null
         }
     }
 

--- a/rundeckapp/src/main/groovy/org/rundeck/app/components/JobYAMLFormat.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/components/JobYAMLFormat.groovy
@@ -73,12 +73,15 @@ class JobYAMLFormat implements JobFormat {
         }
     }
 
-    static Object canonicalValue(Object val, boolean trimSpacesFromLines = false) {
+    static Object canonicalValue(Object val, boolean trimSpacesFromLines = false, String currentKey = null) {
         if (val instanceof Map) {
             return canonicalMap(val,trimSpacesFromLines)
         } else if (val instanceof String) {
             //set multiline strings to use unix line endings
-            if(trimSpacesFromLines) return BuilderUtil.trimAllLinesAndReplaceLineEndings(val, DumperOptions.LineBreak.UNIX.getString())
+            // Don't trim spaces for delimiter values to preserve meaningful whitespace
+            if(trimSpacesFromLines && currentKey != 'delimiter') {
+                return BuilderUtil.trimAllLinesAndReplaceLineEndings(val, DumperOptions.LineBreak.UNIX.getString())
+            }
             return BuilderUtil.replaceLineEndings(val, DumperOptions.LineBreak.UNIX.getString())
         } else if (val instanceof List) {
             return val.collect { canonicalValue(it,trimSpacesFromLines) }
@@ -90,7 +93,7 @@ class JobYAMLFormat implements JobFormat {
         def result = [:]//linked hash map has ordered keys
         input.keySet().sort().each {
             def val = input[it]
-            result[it] = canonicalValue(val,trimSpacesFromLines)
+            result[it] = canonicalValue(val,trimSpacesFromLines, it as String)
         }
         result
     }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/components/JobYAMLFormat.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/components/JobYAMLFormat.groovy
@@ -79,7 +79,7 @@ class JobYAMLFormat implements JobFormat {
         } else if (val instanceof String) {
             //set multiline strings to use unix line endings
             // Don't trim spaces for delimiter values to preserve meaningful whitespace
-            if(trimSpacesFromLines && currentKey != 'delimiter') {
+            if(trimSpacesFromLines && !['delimiter', 'valuesListDelimiter'].contains(currentKey)) {
                 return BuilderUtil.trimAllLinesAndReplaceLineEndings(val, DumperOptions.LineBreak.UNIX.getString())
             }
             return BuilderUtil.replaceLineEndings(val, DumperOptions.LineBreak.UNIX.getString())

--- a/rundeckapp/src/test/groovy/org/rundeck/app/components/JobYAMLFormatSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/components/JobYAMLFormatSpec.groovy
@@ -170,6 +170,7 @@ class JobYAMLFormatSpec extends Specification {
                 options: [
                     [
                         delimiter: delimiter,
+                        valuesListDelimiter: valuesListDelimiter,
                         multivalued: true,
                         name: 'op1'
                     ]
@@ -180,12 +181,13 @@ class JobYAMLFormatSpec extends Specification {
             sut.encode(data, options, writer)
         then:
             writer.toString().contains("delimiter: '${expectedDelimiter}'")
+            writer.toString().contains("valuesListDelimiter: '${expectedValuesListDelimiter}'")
         where:
-            delimiter | trimSpaces | expectedDelimiter
-            ' '       | false      | ' '
-            ' '       | true       | ' '
-            ','       | false      | ','
-            ','       | true       | ','
+            delimiter | valuesListDelimiter | trimSpaces | expectedDelimiter | expectedValuesListDelimiter
+            ' '       | ' '                 | false      | ' '               | ' '
+            ' '       | ' '                 | true       | ' '               | ' '
+            ','       | ','                 | false      | ','               | ','
+            ','       | ','                 | true       | ','               | ','
     }
 
     def "should return false on multiple notifs of same type in same trigger"(){

--- a/rundeckapp/src/test/groovy/org/rundeck/app/components/JobYAMLFormatSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/components/JobYAMLFormatSpec.groovy
@@ -161,6 +161,33 @@ class JobYAMLFormatSpec extends Specification {
             'a,bc' | '- a: \'a,bc\'\n'
     }
 
+    @Unroll
+    def "trimSpaces should preserve delimiter values"() {
+        given:
+            def sut = new JobYAMLFormat(trimSpacesFromLines: trimSpaces)
+            def writer = new StringWriter()
+            def data = [[
+                options: [
+                    [
+                        delimiter: delimiter,
+                        multivalued: true,
+                        name: 'op1'
+                    ]
+                ]
+            ]]
+            def options = JobFormat.options(false, null, (String) null)
+        when:
+            sut.encode(data, options, writer)
+        then:
+            writer.toString().contains("delimiter: '${expectedDelimiter}'")
+        where:
+            delimiter | trimSpaces | expectedDelimiter
+            ' '       | false      | ' '
+            ' '       | true       | ' '
+            ','       | false      | ','
+            ','       | true       | ','
+    }
+
     def "should return false on multiple notifs of same type in same trigger"(){
         given:
         Map notifMap


### PR DESCRIPTION
This PR fixes an issue with YAML exported job delimiter handling where the valuesListDelimiter property wasn't being properly applied when creating Option objects from maps containing array values.

Fixed Option.fromMap to properly join array values using the specified delimiter
Modified YAML formatting to preserve delimiter values when trimming spaces
Added comprehensive test coverage for the delimiter functionality
