### PR TITLE
RUN-3779: Add option based filter for jobs activity  

### DIFF
--- a/rundeckapp/grails-app/views/reports/index.gsp
+++ b/rundeckapp/grails-app/views/reports/index.gsp
@@ -44,6 +44,7 @@
             'userFilter',
             'statFilter',
             'filter',
+            'optionFilter',
             'recentFilter',
             'startbeforeFilter',
             'startafterFilter',
@@ -62,6 +63,7 @@ jobquery.title.jobIdFilter
 jobquery.title.userFilter
 jobquery.title.statFilter
 jobquery.title.filter
+jobquery.title.optionFilter
 jobquery.title.recentFilter
 jobquery.title.startbeforeFilter
 jobquery.title.startafterFilter

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityFilter.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityFilter.vue
@@ -215,7 +215,7 @@
         </div>
         <div class="base-filters">
           <div class="row">
-            <div class="col-xs-12 col-sm-4">
+            <div class="col-xs-12 col-sm-12">
               <div class="form-group">
                 <label for="optionFilter" class="sr-only">
                   {{ $t("jobquery.title.optionFilter") }}
@@ -225,9 +225,8 @@
                     type="text"
                     name="optionFilter"
                     class="form-control"
-                    :placeholder="$t('jobquery.title.optionFilter')"
+                    :placeholder="$t('jobquery.title.optionFilter.label')"
                     data-test-id="option-filter"
-                    title="Search job options. Single: -sleep 10, Multiple: -app myapp -env prod (order independent)"
                 />
               </div>
             </div>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityFilter.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityFilter.vue
@@ -134,24 +134,6 @@
           <div class="row">
             <div class="col-xs-12 col-sm-4">
               <div class="form-group">
-                <label for="optionFilter" class="sr-only">
-                  {{ $t("jobquery.title.optionFilter") }}
-                </label>
-                <input
-                  v-model="query.optionFilter"
-                  type="text"
-                  name="optionFilter"
-                  class="form-control"
-                  :placeholder="$t('jobquery.title.optionFilter')"
-                  data-test-id="option-filter"
-                  title="Search job options. Single: -sleep 10, Multiple: -app myapp -env prod (order independent)"
-                />
-              </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-xs-12 col-sm-4">
-              <div class="form-group">
                 <label for="titleFilter" class="sr-only">
                   {{ $t("jobquery.title.titleFilter") }}
                 </label>
@@ -228,6 +210,26 @@
               <date-filter v-model="df.filter">{{
                 $t("jobquery.title." + df.name)
               }}</date-filter>
+            </div>
+          </div>
+        </div>
+        <div class="base-filters">
+          <div class="row">
+            <div class="col-xs-12 col-sm-4">
+              <div class="form-group">
+                <label for="optionFilter" class="sr-only">
+                  {{ $t("jobquery.title.optionFilter") }}
+                </label>
+                <input
+                    v-model="query.optionFilter"
+                    type="text"
+                    name="optionFilter"
+                    class="form-control"
+                    :placeholder="$t('jobquery.title.optionFilter')"
+                    data-test-id="option-filter"
+                    title="Search job options. Single: -sleep 10, Multiple: -app myapp -env prod (order independent)"
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityFilter.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityFilter.vue
@@ -134,6 +134,24 @@
           <div class="row">
             <div class="col-xs-12 col-sm-4">
               <div class="form-group">
+                <label for="optionFilter" class="sr-only">
+                  {{ $t("jobquery.title.optionFilter") }}
+                </label>
+                <input
+                  v-model="query.optionFilter"
+                  type="text"
+                  name="optionFilter"
+                  class="form-control"
+                  :placeholder="$t('jobquery.title.optionFilter')"
+                  data-test-id="option-filter"
+                  title="Search job options. Single: -sleep 10, Multiple: -app myapp -env prod (order independent)"
+                />
+              </div>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-xs-12 col-sm-4">
+              <div class="form-group">
                 <label for="titleFilter" class="sr-only">
                   {{ $t("jobquery.title.titleFilter") }}
                 </label>
@@ -282,6 +300,7 @@ export default defineComponent({
         "execnodeFilter",
         "titleFilter",
         "statFilter",
+        "optionFilter",
         "startafterFilter",
         "startbeforeFilter",
         "endafterFilter",
@@ -324,6 +343,7 @@ export default defineComponent({
         execnodeFilter: "",
         titleFilter: "",
         statFilter: "",
+        optionFilter: "",
         recentFilter: "",
         startafterFilter: "",
         startbeforeFilter: "",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityList.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/activityList.vue
@@ -726,6 +726,7 @@ export default defineComponent({
         execnodeFilter: "",
         titleFilter: "",
         statFilter: "",
+        optionFilter: "",
         recentFilter: "",
         filterName: "",
       } as { [key: string]: string },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -401,7 +401,9 @@ const messages = {
   "jobquery.title.adhocRemoteStringFilter": "Shell Command",
   "jobquery.title.adhocFilepathFilter": "Script File Path",
   "jobquery.title.argStringFilter": "Script File Arguments",
-  "jobquery.title.optionFilter": "Job Options (e.g. -sleep 10 or -app myapp -env prod)",
+  "jobquery.title.optionFilter": "Options",
+  "jobquery.title.optionFilter.label":
+    "Job Options (e.g. -sleep 10 or -app myapp -env prod)",
   "page.unsaved.changes": "You have unsaved changes",
   "edit.nodes.file": "Edit Nodes File",
   "project.node.file.source.label": "Source",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -401,6 +401,7 @@ const messages = {
   "jobquery.title.adhocRemoteStringFilter": "Shell Command",
   "jobquery.title.adhocFilepathFilter": "Script File Path",
   "jobquery.title.argStringFilter": "Script File Arguments",
+  "jobquery.title.optionFilter": "Job Options (e.g. -sleep 10 or -app myapp -env prod)",
   "page.unsaved.changes": "You have unsaved changes",
   "edit.nodes.file": "Edit Nodes File",
   "project.node.file.source.label": "Source",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -403,7 +403,7 @@ const messages = {
   "jobquery.title.argStringFilter": "Script File Arguments",
   "jobquery.title.optionFilter": "Options",
   "jobquery.title.optionFilter.label":
-    "Job Options (e.g. -sleep 10 or -app myapp -env prod)",
+    "Job Options by pair, name or value (e.g. -sleep 10 or -debug 1 -env prod or -debug)",
   "page.unsaved.changes": "You have unsaved changes",
   "edit.nodes.file": "Edit Nodes File",
   "project.node.file.source.label": "Source",

--- a/rundeckapp/src/integration-test/groovy/rundeck/OptionFilterIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/OptionFilterIntegrationSpec.groovy
@@ -1,0 +1,255 @@
+package rundeck
+
+import grails.gorm.transactions.Rollback
+import grails.testing.mixin.integration.Integration
+import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.Specification
+import rundeck.services.ReportService
+import com.dtolabs.rundeck.app.support.ExecQuery
+
+@Integration
+@Rollback
+class OptionFilterIntegrationSpec extends Specification {
+
+    @Autowired
+    ReportService reportService
+
+    def "optionFilter integration test - full stack with real database"() {
+        given: "executions with different option arguments"
+        def job1 = new ScheduledExecution(
+            jobName: 'test-job-1',
+            project: 'testproject',
+            groupPath: 'test',
+            description: 'Test job',
+            workflow: new Workflow(commands: [new CommandExec(adhocRemoteString: 'echo test')]).save(flush: true, failOnError: true)
+        ).save(flush: true, failOnError: true)
+
+        def job2 = new ScheduledExecution(
+            jobName: 'test-job-2',
+            project: 'testproject',
+            groupPath: 'test',
+            description: 'Test job 2',
+            workflow: new Workflow(commands: [new CommandExec(adhocRemoteString: 'echo test2')]).save(flush: true, failOnError: true)
+        ).save(flush: true, failOnError: true)
+
+        // Create executions with different argStrings
+        def exec1 = new Execution(
+            uuid: UUID.randomUUID().toString(),
+            project: 'testproject',
+            user: 'testuser',
+            status: 'succeeded',
+            dateStarted: new Date(),
+            dateCompleted: new Date(),
+            scheduledExecution: job1,
+            argString: '-APPLICATION_NAME myapp -ENV production -VERSION 1.2.3'
+        ).save(flush: true, failOnError: true)
+
+        def exec2 = new Execution(
+            uuid: UUID.randomUUID().toString(),
+            project: 'testproject',
+            user: 'testuser',
+            status: 'succeeded',
+            dateStarted: new Date(),
+            dateCompleted: new Date(),
+            scheduledExecution: job1,
+            argString: '-APPLICATION_NAME otherapp -ENV staging -DEBUG true'
+        ).save(flush: true, failOnError: true)
+
+        def exec3 = new Execution(
+            uuid: UUID.randomUUID().toString(),
+            project: 'testproject',
+            user: 'testuser',
+            status: 'succeeded',
+            dateStarted: new Date(),
+            dateCompleted: new Date(),
+            scheduledExecution: job2,
+            argString: '-SERVICE_NAME backend -ENV production -TIMEOUT 30'
+        ).save(flush: true, failOnError: true)
+
+        // Create corresponding ExecReports
+        def report1 = new ExecReport(
+            jcJobId: job1.uuid,
+            jcExecId: exec1.id,
+            executionUuid: exec1.uuid,
+            executionId: exec1.id,
+            status: 'succeed',
+            actionType: 'job',
+            project: 'testproject',
+            reportId: job1.jobName,
+            tags: 'test',
+            author: 'testuser',
+            title: 'Test execution 1',
+            dateStarted: exec1.dateStarted,
+            dateCompleted: exec1.dateCompleted,
+            node: 'localhost',
+            message: 'Test execution completed',
+            maprefUri: exec1.argString
+        ).save(flush: true, failOnError: true)
+
+        def report2 = new ExecReport(
+            jcJobId: job1.uuid,
+            jcExecId: exec2.id,
+            executionUuid: exec2.uuid,
+            executionId: exec2.id,
+            status: 'succeed',
+            actionType: 'job',
+            project: 'testproject',
+            reportId: job1.jobName,
+            tags: 'test',
+            author: 'testuser',
+            title: 'Test execution 2',
+            dateStarted: exec2.dateStarted,
+            dateCompleted: exec2.dateCompleted,
+            node: 'localhost',
+            message: 'Test execution completed',
+            maprefUri: exec2.argString
+        ).save(flush: true, failOnError: true)
+
+        def report3 = new ExecReport(
+            jcJobId: job2.uuid,
+            jcExecId: exec3.id,
+            executionUuid: exec3.uuid,
+            executionId: exec3.id,
+            status: 'succeed',
+            actionType: 'job',
+            project: 'testproject',
+            reportId: job2.jobName,
+            tags: 'test',
+            author: 'testuser',
+            title: 'Test execution 3',
+            dateStarted: exec3.dateStarted,
+            dateCompleted: exec3.dateCompleted,
+            node: 'localhost',
+            message: 'Test execution completed',
+            maprefUri: exec3.argString
+        ).save(flush: true, failOnError: true)
+
+        when: "searching with single option filter"
+        def query1 = new ExecQuery()
+        query1.projFilter = 'testproject'
+        query1.optionFilter = '-APPLICATION_NAME myapp'
+        def result1 = reportService.getExecutionReports(query1, true)
+
+        then: "should find only executions with matching APPLICATION_NAME"
+        result1.reports.size() == 1
+        result1.reports[0].executionId == exec1.id
+
+        when: "searching with multiple option filter"
+        def query2 = new ExecQuery()
+        query2.projFilter = 'testproject'
+        query2.optionFilter = '-APPLICATION_NAME myapp -ENV production'
+        def result2 = reportService.getExecutionReports(query2, true)
+
+        then: "should find only executions matching both options"
+        result2.reports.size() == 1
+        result2.reports[0].executionId == exec1.id
+
+        when: "searching with different option"
+        def query3 = new ExecQuery()
+        query3.projFilter = 'testproject'
+        query3.optionFilter = '-SERVICE_NAME backend'
+        def result3 = reportService.getExecutionReports(query3, true)
+
+        then: "should find execution with different job"
+        result3.reports.size() == 1
+        result3.reports[0].executionId == exec3.id
+
+        when: "searching with non-existent option"
+        def query4 = new ExecQuery()
+        query4.projFilter = 'testproject'
+        query4.optionFilter = '-NONEXISTENT value'
+        def result4 = reportService.getExecutionReports(query4, true)
+
+        then: "should find no results"
+        result4.reports.size() == 0
+
+        when: "searching with case insensitive match"
+        def query5 = new ExecQuery()
+        query5.projFilter = 'testproject'
+        query5.optionFilter = '-APPLICATION_NAME MYAPP'  // uppercase
+        def result5 = reportService.getExecutionReports(query5, true)
+
+        then: "should find case insensitive match"
+        result5.reports.size() == 1
+        result5.reports[0].executionId == exec1.id
+
+        when: "combining optionFilter with other filters"
+        def query6 = new ExecQuery()
+        query6.projFilter = 'testproject'
+        query6.optionFilter = '-ENV production'
+        query6.userFilter = 'testuser'
+        def result6 = reportService.getExecutionReports(query6, true)
+
+        then: "should apply both filters correctly"
+        result6.reports.size() == 2  // Both exec1 and exec3 have ENV=production
+        result6.reports.collect { it.executionId }.sort() == [exec1.id, exec3.id].sort()
+    }
+
+    def "optionFilter handles edge cases gracefully"() {
+        given: "execution with options"
+        def job = new ScheduledExecution(
+            jobName: 'edge-case-job',
+            project: 'testproject2',
+            groupPath: 'test',
+            description: 'Edge case test',
+            workflow: new Workflow(commands: [new CommandExec(adhocRemoteString: 'echo test')]).save(flush: true, failOnError: true)
+        ).save(flush: true, failOnError: true)
+
+        def exec = new Execution(
+            uuid: UUID.randomUUID().toString(),
+            project: 'testproject2',
+            user: 'testuser',
+            status: 'succeeded',
+            dateStarted: new Date(),
+            dateCompleted: new Date(),
+            scheduledExecution: job,
+            argString: '-TEST_OPTION value'
+        ).save(flush: true, failOnError: true)
+
+        def report = new ExecReport(
+            jcJobId: job.uuid,
+            jcExecId: exec.id,
+            executionUuid: exec.uuid,
+            executionId: exec.id,
+            status: 'succeed',
+            actionType: 'job',
+            project: 'testproject2',
+            reportId: job.jobName,
+            tags: 'test',
+            author: 'testuser',
+            title: 'Edge case execution',
+            dateStarted: exec.dateStarted,
+            dateCompleted: exec.dateCompleted,
+            node: 'localhost',
+            message: 'Test execution completed',
+            maprefUri: exec.argString
+        ).save(flush: true, failOnError: true)
+
+        when: "optionFilter is empty string"
+        def query1 = new ExecQuery()
+        query1.projFilter = 'testproject2'
+        query1.optionFilter = ''
+        def result1 = reportService.getExecutionReports(query1, true)
+
+        then: "should return all results"
+        result1.reports.size() >= 1  // At least our test execution
+
+        when: "optionFilter is null"
+        def query2 = new ExecQuery()
+        query2.projFilter = 'testproject2'
+        query2.optionFilter = null
+        def result2 = reportService.getExecutionReports(query2, true)
+
+        then: "should return all results without error"
+        result2.reports.size() >= 1
+
+        when: "optionFilter is whitespace only"
+        def query3 = new ExecQuery()
+        query3.projFilter = 'testproject2'
+        query3.optionFilter = '   '
+        def result3 = reportService.getExecutionReports(query3, true)
+
+        then: "should return all results without error"
+        result3.reports.size() >= 1
+    }
+}

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ExecQuery.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ExecQuery.groovy
@@ -61,6 +61,7 @@ class ExecQuery extends ReportQuery implements Validateable, RdExecQuery{
         excludeJobListFilter(nullable: true)
         statFilter(nullable:true,inList:["succeed","fail","cancel","missed"])
         execnodeFilter(nullable: true)
+        optionFilter(nullable: true)
         execIdFilter(nullable:true)
         execProjects(nullable:true)
         sortBy(nullable:true,inList:[

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ReportQuery.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ReportQuery.groovy
@@ -58,6 +58,7 @@ class ReportQuery extends BaseQuery implements Validateable{
     String tagsFilter
     String abortedByFilter
     String execnodeFilter
+    String optionFilter
 
     public static final ArrayList<String> exportProps = [
              'startafterFilter',
@@ -87,6 +88,7 @@ class ReportQuery extends BaseQuery implements Validateable{
              'tagsFilter',
              'abortedByFilter',
              'execnodeFilter',
+             'optionFilter',
     ]
 
     def Map toMap(){

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormExecReportDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormExecReportDataProvider.groovy
@@ -88,18 +88,18 @@ class GormExecReportDataProvider implements ExecReportDataProvider, DBExecReport
         if(execQuery?.optionFilter){
             def searchTerm = execQuery.optionFilter.toString().trim()
 
-            def optionPairs = []
+            def massagedOptions = []
             def tokens = searchTerm.split(/\s+/)
 
             for (int i = 0; i < tokens.length - 1; i++) {
                 if (tokens[i].startsWith('-') && !tokens[i + 1].startsWith('-')) {
-                    optionPairs << "${tokens[i]} ${tokens[i + 1]}"
+                    massagedOptions << "${tokens[i]} ${tokens[i + 1]}"
                     i++
                 }
             }
 
-            if (optionPairs.empty) {
-                optionPairs << searchTerm
+            if (massagedOptions.empty) {
+                massagedOptions << searchTerm
             }
             
             try {
@@ -107,8 +107,10 @@ class GormExecReportDataProvider implements ExecReportDataProvider, DBExecReport
                     projections {
                         property('id')
                     }
-                    optionPairs.each { pair ->
-                        ilike('argString', "%${pair}%")
+                    or {
+                        massagedOptions.each { option ->
+                            ilike('argString', "%${option}%")
+                        }
                     }
                 }
             } catch (Exception e) {
@@ -129,18 +131,18 @@ class GormExecReportDataProvider implements ExecReportDataProvider, DBExecReport
             if(query?.optionFilter){
                 def searchTerm = query.optionFilter.toString().trim()
 
-                def optionPairs = []
+                def massagedOptions = []
                 def tokens = searchTerm.split(/\s+/)
 
                 for (int i = 0; i < tokens.length - 1; i++) {
                     if (tokens[i].startsWith('-') && !tokens[i + 1].startsWith('-')) {
-                        optionPairs << "${tokens[i]} ${tokens[i + 1]}"
+                        massagedOptions << "${tokens[i]} ${tokens[i + 1]}"
                         i++
                     }
                 }
 
-                if (optionPairs.empty) {
-                    optionPairs << searchTerm
+                if (massagedOptions.empty) {
+                    massagedOptions << searchTerm
                 }
 
                 try {
@@ -148,8 +150,10 @@ class GormExecReportDataProvider implements ExecReportDataProvider, DBExecReport
                         projections {
                             property('id')
                         }
-                        optionPairs.each { pair ->
-                            ilike('argString', "%${pair}%")
+                        or {
+                            massagedOptions.each { option ->
+                                ilike('argString', "%${option}%")
+                            }
                         }
                     }
                 } catch (Exception e) {
@@ -210,19 +214,19 @@ class GormExecReportDataProvider implements ExecReportDataProvider, DBExecReport
             def searchTerm = query.optionFilter.toString().trim()
 
             // Parse multiple options: "-app myapp -env prod" -> ["-app myapp", "-env prod"]
-            def optionPairs = []
+            def massagedOptions = []
             def tokens = searchTerm.split(/\s+/)
 
             for (int i = 0; i < tokens.length - 1; i++) {
                 if (tokens[i].startsWith('-') && !tokens[i + 1].startsWith('-')) {
-                    optionPairs << "${tokens[i]} ${tokens[i + 1]}"
+                    massagedOptions << "${tokens[i]} ${tokens[i + 1]}"
                     i++ // Skip the value token
                 }
             }
 
-            if (optionPairs.empty) {
+            if (massagedOptions.empty) {
                 // Fallback to simple search if no valid pairs found
-                optionPairs << searchTerm
+                massagedOptions << searchTerm
             }
 
             // Query Execution table for argString matches
@@ -231,9 +235,10 @@ class GormExecReportDataProvider implements ExecReportDataProvider, DBExecReport
                     projections {
                         property('id')
                     }
-                    // Each option pair must be found somewhere in argString
-                    optionPairs.each { pair ->
-                        ilike('argString', "%${pair}%")
+                    or {
+                        massagedOptions.each { option ->
+                            ilike('argString', "%${option}%")
+                        }
                     }
                 }
             } catch (Exception e) {

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormExecReportDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormExecReportDataProvider.groovy
@@ -83,16 +83,83 @@ class GormExecReportDataProvider implements ExecReportDataProvider, DBExecReport
 
     @Override
     int countExecutionReports(RdExecQuery execQuery) {
+        // Handle optionFilter BEFORE the main count query (same logic as getExecutionReports)
+        def optionFilterExecutionIds = []
+        if(execQuery?.optionFilter){
+            def searchTerm = execQuery.optionFilter.toString().trim()
+
+            def optionPairs = []
+            def tokens = searchTerm.split(/\s+/)
+
+            for (int i = 0; i < tokens.length - 1; i++) {
+                if (tokens[i].startsWith('-') && !tokens[i + 1].startsWith('-')) {
+                    optionPairs << "${tokens[i]} ${tokens[i + 1]}"
+                    i++
+                }
+            }
+
+            if (optionPairs.empty) {
+                optionPairs << searchTerm
+            }
+            
+            try {
+                optionFilterExecutionIds = rundeck.Execution.createCriteria().list {
+                    projections {
+                        property('id')
+                    }
+                    optionPairs.each { pair ->
+                        ilike('argString', "%${pair}%")
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("Error querying executions for optionFilter: ${e.message}")
+                optionFilterExecutionIds = []
+            }
+        }
+
         return ExecReport.createCriteria().count {
-            applyExecutionCriteria(execQuery, delegate)
+            applyExecutionCriteria(execQuery, delegate, true, null, [], optionFilterExecutionIds)
         }
     }
 
     @Override
     int countExecutionReportsWithTransaction(RdExecQuery query, boolean isJobs, String jobId) {
         return ExecReport.withTransaction {
+            def optionFilterExecutionIds = []
+            if(query?.optionFilter){
+                def searchTerm = query.optionFilter.toString().trim()
+
+                def optionPairs = []
+                def tokens = searchTerm.split(/\s+/)
+
+                for (int i = 0; i < tokens.length - 1; i++) {
+                    if (tokens[i].startsWith('-') && !tokens[i + 1].startsWith('-')) {
+                        optionPairs << "${tokens[i]} ${tokens[i + 1]}"
+                        i++
+                    }
+                }
+
+                if (optionPairs.empty) {
+                    optionPairs << searchTerm
+                }
+
+                try {
+                    optionFilterExecutionIds = rundeck.Execution.createCriteria().list {
+                        projections {
+                            property('id')
+                        }
+                        optionPairs.each { pair ->
+                            ilike('argString', "%${pair}%")
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("Error querying executions for optionFilter: ${e.message}")
+                    optionFilterExecutionIds = []
+                }
+            }
+
             ExecReport.createCriteria().count {
-                applyExecutionCriteria(query, delegate, isJobs, jobId, [])
+                applyExecutionCriteria(query, delegate, isJobs, jobId, [], optionFilterExecutionIds)
             }
         }
     }
@@ -136,6 +203,45 @@ class GormExecReportDataProvider implements ExecReportDataProvider, DBExecReport
         filters.putAll(txtfilters)
         filters.putAll(eqfilters)
 
+        // Handle optionFilter BEFORE the main criteria query
+        def optionFilterExecutionIds = []
+        if(query?.optionFilter){
+            // Two-step approach supporting order-independent matching
+            def searchTerm = query.optionFilter.toString().trim()
+
+            // Parse multiple options: "-app myapp -env prod" -> ["-app myapp", "-env prod"]
+            def optionPairs = []
+            def tokens = searchTerm.split(/\s+/)
+
+            for (int i = 0; i < tokens.length - 1; i++) {
+                if (tokens[i].startsWith('-') && !tokens[i + 1].startsWith('-')) {
+                    optionPairs << "${tokens[i]} ${tokens[i + 1]}"
+                    i++ // Skip the value token
+                }
+            }
+
+            if (optionPairs.empty) {
+                // Fallback to simple search if no valid pairs found
+                optionPairs << searchTerm
+            }
+
+            // Query Execution table for argString matches
+            try {
+                optionFilterExecutionIds = rundeck.Execution.createCriteria().list {
+                    projections {
+                        property('id')
+                    }
+                    // Each option pair must be found somewhere in argString
+                    optionPairs.each { pair ->
+                        ilike('argString', "%${pair}%")
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("Error querying executions for optionFilter: ${e.message}")
+                optionFilterExecutionIds = []
+            }
+        }
+
         return ExecReport.createCriteria().list {
 
             if (query?.max) {
@@ -146,7 +252,7 @@ class GormExecReportDataProvider implements ExecReportDataProvider, DBExecReport
             if (query?.offset) {
                 firstResult(query.offset.toInteger())
             }
-            applyExecutionCriteria(query, delegate,isJobs, jobId, execUuids)
+            applyExecutionCriteria(query, delegate,isJobs, jobId, execUuids, optionFilterExecutionIds)
 
             if (query && query.sortBy && filters[query.sortBy]) {
                 order(filters[query.sortBy], query.sortOrder == 'ascending' ? 'asc' : 'desc')
@@ -188,7 +294,7 @@ class GormExecReportDataProvider implements ExecReportDataProvider, DBExecReport
         }
     }
 
-    def applyExecutionCriteria(RdExecQuery query, delegate, boolean isJobs=true, String seId=null, List<String> execUuids=[]){
+    def applyExecutionCriteria(RdExecQuery query, delegate, boolean isJobs=true, String seId=null, List<String> execUuids=[], List<Long> optionFilterExecutionIds=[]){
         def eqfilters = [
                 stat: 'status',
                 reportId: 'reportId',
@@ -382,6 +488,16 @@ class GormExecReportDataProvider implements ExecReportDataProvider, DBExecReport
                     ilike("filterApplied", '%' + query.execnodeFilter + '%')
                 }
 
+            }
+
+            // Handle optionFilter results from pre-query
+            if(query?.optionFilter){
+                if (optionFilterExecutionIds && !optionFilterExecutionIds.empty) {
+                    'in'('executionId', optionFilterExecutionIds)
+                } else {
+                    // No matches found - return empty result
+                    eq('id', -1L) // Impossible condition
+                }
             }
         }
         if(fixCancel){

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/support/ExecQuerySpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/support/ExecQuerySpec.groovy
@@ -73,4 +73,29 @@ class ExecQuerySpec extends Specification {
         'qq54q51y'      | _
         'wrong &lt;' | _
     }
+
+    def "optionFilter field can be set and retrieved"() {
+        given:
+        def query = new ExecQuery()
+
+        when:
+        query.optionFilter = "-APPLICATION_NAME app1"
+
+        then:
+        query.optionFilter == "-APPLICATION_NAME app1"
+        !query.hasErrors()
+    }
+
+    def "optionFilter field can be null"() {
+        given:
+        def query = new ExecQuery()
+
+        when:
+        query.optionFilter = null
+        query.validate()
+
+        then:
+        query.optionFilter == null
+        !query.hasErrors()
+    }
 }

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecReportDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecReportDataProviderSpec.groovy
@@ -290,4 +290,38 @@ class GormExecReportDataProviderSpec extends Specification implements DataTest {
         results.size() == 1
         results[0].executionId == exec1.id
     }
+
+    def "getExecutionReports with optionFilter - handles empty and null values"() {
+        given:
+        def exec1 = TestDomainFactory.createExecution(
+            argString: "-APPLICATION_NAME app1",
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec1))
+
+        when: "empty optionFilter"
+        def query1 = new ExecQuery()
+        query1.optionFilter = ""
+        def results1 = provider.getExecutionReports(query1, true, null, [])
+
+        then: "should return all results"
+        results1.size() == 1
+
+        when: "null optionFilter"
+        def query2 = new ExecQuery()
+        query2.optionFilter = null
+        def results2 = provider.getExecutionReports(query2, true, null, [])
+
+        then: "should return all results"
+        results2.size() == 1
+
+        when: "whitespace only optionFilter"
+        def query3 = new ExecQuery()
+        query3.optionFilter = "   "
+        def results3 = provider.getExecutionReports(query3, true, null, [])
+
+        then: "should return all results"
+        results3.size() == 1
+    }
 }

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecReportDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecReportDataProviderSpec.groovy
@@ -143,11 +143,11 @@ class GormExecReportDataProviderSpec extends Specification implements DataTest {
         }
 
         where:
-        description                              | searchTerm                        | expectedCount | expectedMatches
-        "multiple options - all match with OR"  | "-APP myapp -ENV production"      | 4            | { data -> [data[0].execution.id, data[1].execution.id, data[2].execution.id, data[3].execution.id] }
-        "exact option-value pair"               | "-SLEEP 10"                       | 2            | { data -> [data[0].execution.id, data[2].execution.id] }
-        "option name only"                      | "-SLEEP"                          | 3            | { data -> [data[0].execution.id, data[2].execution.id, data[3].execution.id] }
-        "argument order independent"            | "-FIRST value1 -SECOND value2"    | 2            | { data -> [data[1].execution.id, data[2].execution.id] }
+        description                                     | searchTerm                        | expectedCount | expectedMatches
+        "multiple options, everything match due to OR"  | "-APP myapp -ENV production"      | 4            | { data -> [data[0].execution.id, data[1].execution.id, data[2].execution.id, data[3].execution.id] }
+        "exact option-value pair"                       | "-SLEEP 10"                       | 2            | { data -> [data[0].execution.id, data[2].execution.id] }
+        "option name only, partial match"               | "-ENV"                            | 5            | { data -> [data[0].execution.id, data[1].execution.id, data[2].execution.id, data[3].execution.id, data[4].execution.id] }
+        "multiple options, independent of order"        | "-FIRST value1 -SECOND value2"    | 2            | { data -> [data[1].execution.id, data[2].execution.id] }
     }
 
     private List setupExecutions() {
@@ -155,7 +155,8 @@ class GormExecReportDataProviderSpec extends Specification implements DataTest {
             [execution: TestDomainFactory.createExecution(argString: "-APP myapp -ENV production -SLEEP 10", status: 'succeeded', dateCompleted: new Date())],
             [execution: TestDomainFactory.createExecution(argString: "-APP otherapp -ENV production -FIRST value1 -SECOND value2", status: 'succeeded', dateCompleted: new Date())],
             [execution: TestDomainFactory.createExecution(argString: "-APP myapp -ENV staging -SLEEP 10 -SECOND value2 -FIRST value1", status: 'succeeded', dateCompleted: new Date())],
-            [execution: TestDomainFactory.createExecution(argString: "-ENV production -OTHER option -DIFFERENT value -SLEEP 30", status: 'succeeded', dateCompleted: new Date())]
+            [execution: TestDomainFactory.createExecution(argString: "-ENV production -OTHER option -DIFFERENT value -SLEEP 30", status: 'succeeded', dateCompleted: new Date())],
+            [execution: TestDomainFactory.createExecution(argString: "-ENVIRONMENT staging", status: 'succeeded', dateCompleted: new Date())]
         ]
     }
 
@@ -196,7 +197,7 @@ class GormExecReportDataProviderSpec extends Specification implements DataTest {
         def results = provider.getExecutionReports(query, true, null, [])
 
         then: "should return all results without filtering"
-        results.size() == 4
+        results.size() == 5
 
         where:
         description        | filterValue

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecReportDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecReportDataProviderSpec.groovy
@@ -28,7 +28,7 @@ class GormExecReportDataProviderSpec extends Specification implements DataTest {
         provider.configurationService = Mock(rundeck.services.ConfigurationService) {
             getInteger("pagination.default.max", 20) >> 20
         }
-
+    }
 
     def "CreateReportFromExecution"() {
         given:

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecReportDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecReportDataProviderSpec.groovy
@@ -22,12 +22,13 @@ class GormExecReportDataProviderSpec extends Specification implements DataTest {
 
     def setupSpec() {
         mockDomains(Execution, ExecReport, Workflow, CommandExec, PluginStep, JobExec, ScheduledExecution)
-
+    }
+    
     def setup() {
         provider.configurationService = Mock(rundeck.services.ConfigurationService) {
             getInteger("pagination.default.max", 20) >> 20
         }
-    }
+
 
     def "CreateReportFromExecution"() {
         given:

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecReportDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/providers/GormExecReportDataProviderSpec.groovy
@@ -1,5 +1,6 @@
 package org.rundeck.app.data.providers
 
+import com.dtolabs.rundeck.app.support.ExecQuery
 import grails.testing.gorm.DataTest
 import org.springframework.context.MessageSource
 import rundeck.CommandExec
@@ -7,6 +8,7 @@ import rundeck.ExecReport
 import rundeck.Execution
 import rundeck.JobExec
 import rundeck.PluginStep
+import rundeck.ScheduledExecution
 import rundeck.Workflow
 import rundeck.data.report.SaveReportRequestImpl
 import rundeck.data.util.ExecReportUtil
@@ -19,8 +21,12 @@ class GormExecReportDataProviderSpec extends Specification implements DataTest {
     GormExecReportDataProvider provider = new GormExecReportDataProvider()
 
     def setupSpec() {
-        mockDomains(Execution, ExecReport, Workflow, CommandExec, PluginStep, JobExec)
+        mockDomains(Execution, ExecReport, Workflow, CommandExec, PluginStep, JobExec, ScheduledExecution)
 
+    def setup() {
+        provider.configurationService = Mock(rundeck.services.ConfigurationService) {
+            getInteger("pagination.default.max", 20) >> 20
+        }
     }
 
     def "CreateReportFromExecution"() {
@@ -83,5 +89,204 @@ class GormExecReportDataProviderSpec extends Specification implements DataTest {
         created
         deleted == null
 
+    }
+
+    def "getExecutionReports with optionFilter - single option"() {
+        given:
+        // Create executions with different argStrings
+        def exec1 = TestDomainFactory.createExecution(
+            argString: "-APPLICATION_NAME app1 -ENV production",
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+        def exec2 = TestDomainFactory.createExecution(
+            argString: "-APPLICATION_NAME app2 -ENV staging",
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+        def exec3 = TestDomainFactory.createExecution(
+            argString: "-OTHER_OPTION value -ENVIRONMENT test",
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+
+        // Create corresponding ExecReports
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec1))
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec2))
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec3))
+
+        when:
+        def query = new ExecQuery()
+        query.optionFilter = "-APPLICATION_NAME app1"
+        def results = provider.getExecutionReports(query, true, null, [])
+
+        then:
+        results.size() == 1
+        results[0].executionId == exec1.id
+    }
+
+    def "getExecutionReports with optionFilter - multiple options order independent"() {
+        given:
+        def exec1 = TestDomainFactory.createExecution(
+            argString: "-APPLICATION_NAME app1 -ENV production -VERBOSE true",
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+        def exec2 = TestDomainFactory.createExecution(
+            argString: "-ENV production -APPLICATION_NAME app2 -DEBUG false",
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+        def exec3 = TestDomainFactory.createExecution(
+            argString: "-APPLICATION_NAME app1 -ENV staging",
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec1))
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec2))
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec3))
+
+        when:
+        def query = new ExecQuery()
+        query.optionFilter = "-APPLICATION_NAME app1 -ENV production"  // Multiple options
+        def results = provider.getExecutionReports(query, true, null, [])
+
+        then:
+        results.size() == 1
+        results[0].executionId == exec1.id
+    }
+
+    def "getExecutionReports with optionFilter - exact option value search"() {
+        given:
+        def exec1 = TestDomainFactory.createExecution(
+            argString: "-SLEEP 10 -ENV production -VERBOSE true",
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+        def exec2 = TestDomainFactory.createExecution(
+            argString: "-SLEEP 5 -ENV production -DEBUG false",
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+        def exec3 = TestDomainFactory.createExecution(
+            argString: "-OTHER option -SLEEP 10 -MORE stuff",
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec1))
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec2))
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec3))
+
+        when:
+        def query = new ExecQuery()
+        query.optionFilter = "-SLEEP 10"
+        def results = provider.getExecutionReports(query, true, null, [])
+
+        then:
+        results.size() == 2
+        results.collect { it.executionId }.sort() == [exec1.id, exec3.id].sort()
+    }
+
+    def "getExecutionReports with optionFilter - no matches"() {
+        given:
+        def exec1 = TestDomainFactory.createExecution(
+            argString: "-APPLICATION_NAME app1 -ENV production",
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec1))
+
+        when:
+        def query = new ExecQuery()
+        query.optionFilter = "-NONEXISTENT_OPTION value"
+        def results = provider.getExecutionReports(query, true, null, [])
+
+        then:
+        results.size() == 0
+    }
+
+
+    def "getExecutionReports with optionFilter - case insensitive matching"() {
+        given:
+        def exec1 = TestDomainFactory.createExecution(
+            argString: "-APPLICATION_NAME MyApp -ENV Production",
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec1))
+
+        when:
+        def query = new ExecQuery()
+        query.optionFilter = "-APPLICATION_NAME myapp"
+        def results = provider.getExecutionReports(query, true, null, [])
+
+        then:
+        results.size() == 1
+        results[0].executionId == exec1.id
+    }
+
+    def "getExecutionReports with optionFilter - different argument order matches"() {
+        given:
+        def exec1 = TestDomainFactory.createExecution(
+            argString: "-FIRST value1 -SECOND value2 -THIRD value3",
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+        def exec2 = TestDomainFactory.createExecution(
+            argString: "-SECOND value2 -THIRD different -FIRST value1",
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+        def exec3 = TestDomainFactory.createExecution(
+            argString: "-FIRST value1 -THIRD different",  // Missing SECOND value2
+            status: 'succeeded',
+            dateCompleted: new Date()
+        )
+
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec1))
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec2))
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec3))
+
+        when:
+        def query = new ExecQuery()
+        query.optionFilter = "-FIRST value1 -SECOND value2"  // Search for both options
+        def results = provider.getExecutionReports(query, true, null, [])
+
+        then:
+        results.size() == 2  // Should match exec1 and exec2, not exec3
+        results.collect { it.executionId }.sort() == [exec1.id, exec2.id].sort()
+    }
+
+    def "getExecutionReports with optionFilter - combined with other filters"() {
+        given:
+        def exec1 = TestDomainFactory.createExecution(
+            argString: "-APPLICATION_NAME app1 -ENV production",
+            status: 'succeeded',
+            dateCompleted: new Date(),
+            user: 'testuser'
+        )
+        def exec2 = TestDomainFactory.createExecution(
+            argString: "-APPLICATION_NAME app1 -ENV staging",
+            status: 'succeeded',
+            dateCompleted: new Date(),
+            user: 'otheruser'
+        )
+
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec1))
+        provider.saveReport(ExecReportUtil.buildSaveReportRequest(exec2))
+
+        when:
+        def query = new ExecQuery()
+        query.optionFilter = "-APPLICATION_NAME app1"
+        query.userFilter = "testuser"
+        def results = provider.getExecutionReports(query, true, null, [])
+
+        then:
+        results.size() == 1
+        results[0].executionId == exec1.id
     }
 }


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Part of steptember, add the functionality to filter executions by option name, option value or both. 

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

Add a new input in the search modal within activity page, that accepts the following values:

- `-optionName optionVale`;
- `-optionName`;
- `optionValue`;
- `-optionName optionVale -optionName2 optionVale2` (in the presence of multiple values, each will be considered an OR);

This filter can be combined with others.  

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
