### PR TITLE
RUN-3682: Remediate CVE-2025-59952

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -66,3 +66,4 @@ beanutilsVersion=1.11.0
 commonsCompressVersion=1.26.2
 commonsFileuploadVersion=1.6.0
 hikariVersion=6.3.2
+minioVersion=8.6.0

--- a/plugins/object-store-plugin/build.gradle
+++ b/plugins/object-store-plugin/build.gradle
@@ -29,7 +29,7 @@ configurations.all {
 dependencies {
     // Use the latest Groovy version for building this library
     implementation "org.codehaus.groovy:groovy:${groovyVersion}"
-    pluginLibs("io.minio:minio:8.5.12") {
+    pluginLibs("io.minio:minio:${minioVersion}") {
         exclude(group: 'com.fasterxml.jackson.core')
         exclude(group: 'com.google.guava', module: 'guava')
         exclude(group: 'commons-io', module: 'commons-io')


### PR DESCRIPTION
Dependency Upgraded: Successfully upgraded io.minio:minio from version 8.5.12 (vulnerable) to 8.6.0 (fixed)

Property-Based Version Management: Implemented best practice by using ${minioVersion} property from [gradle.properties](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of hardcoding the version

Build Verification:

✅ Code compiles successfully
✅ Dependency resolution works correctly
✅ Confirmed minio 8.6.0 is being used in the final build