### PR TITLE
RUN-3732: change exec cleanup to hql

### DIFF
--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
@@ -150,7 +150,7 @@ class ExecutionsCleanUp implements InterruptableJob {
 
         logger.info("Searching All Executions")
 
-        Date endDate = ExecutionQuery.parseRelativeDate("${maxDaysToKeep}d")
+        Date endDate = ExecutionQuery.parseRelativeDate("${maxDaysToKeep}d", null)
 
         List<Long> jobList = Execution.executeQuery(
             """select e.id from Execution e 

--- a/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionsCleanUpIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionsCleanUpIntegrationSpec.groovy
@@ -58,18 +58,15 @@ class ExecutionsCleanUpIntegrationSpec extends Specification{
         int maxDaysToKeep = 10
         int minimumExecutionsToKeep = 0
         int maximumDeletionSize = 500
-        Date startDate = new Date(2015 - 1900, 2, 8)
-        Date endDate = ExecutionQuery.parseRelativeDate("${maxDaysToKeep}d", startDate)
-        ExecutionQuery.metaClass.static.parseRelativeDate = { String recentFilter ->
-            endDate
-        }
+
         Date execDate = new Date(2015 - 1900, 02, 03)
+        Date executionCompletionDate = ExecutionQuery.parseRelativeDate("5d", new Date())
         FrameworkService frameworkService = initNonClusterFrameworkService()
 
         ScheduledExecution se = setupJob(projName)
         ExecutionsCleanUp job = new ExecutionsCleanUp()
         when:
-        Execution execution = setupExecution(se, projName, execDate, execDate, frameworkService.getServerUUID())
+        Execution execution = setupExecution(se, projName, execDate, executionCompletionDate, frameworkService.getServerUUID())
         then:
         1 == Execution.countByProject(projName)
         1 == ExecReport.countByProject(projName)
@@ -81,6 +78,7 @@ class ExecutionsCleanUpIntegrationSpec extends Specification{
                 new ExecutionService(),
                 new JobSchedulerService(),
                 projName, maxDaysToKeep, minimumExecutionsToKeep, maximumDeletionSize)
+
         then:
         execIdsToExclude.size() == 0
         1 == Execution.countByProject(projName)
@@ -97,11 +95,6 @@ class ExecutionsCleanUpIntegrationSpec extends Specification{
         def logFileStorageService = Mock(LogFileStorageService)
         def referencedExecutionDataProvider = Mock(ReferencedExecutionDataProvider)
 
-        Date startDate = new Date(2015 - 1900, 2, 8)
-        Date endDate = ExecutionQuery.parseRelativeDate("${maxDaysToKeep}d", startDate)
-        ExecutionQuery.metaClass.static.parseRelativeDate = { String recentFilter ->
-            endDate
-        }
         Date execDate = new Date(2015 - 1900, 02, 03)
         ScheduledExecution se = setupJob(projName)
         ExecutionsCleanUp job = new ExecutionsCleanUp()
@@ -146,9 +139,7 @@ class ExecutionsCleanUpIntegrationSpec extends Specification{
 
         Date startDate = new Date(2015 - 1900, 2, 8)
         Date endDate = ExecutionQuery.parseRelativeDate("${maxDaysToKeep}d", startDate)
-        ExecutionQuery.metaClass.static.parseRelativeDate = { String recentFilter ->
-            endDate
-        }
+
         Date execDate = new Date(2015 - 1900, 02, 03)
         ScheduledExecution se = setupJob(projName)
         def mockfs=Mock(FrameworkService){


### PR DESCRIPTION
This pull request refactors the execution cleanup logic in the `ExecutionsCleanUp` job to simplify and optimize database queries. The changes replace custom criteria-based queries with direct HQL queries, improving code readability and potentially query performance. The most significant modifications are in how executions are selected for deletion and how their count is calculated.

**Database Query Refactoring:**

* Use of HQL instead of criteria to reduce query time from 30s+ for a project with 4million executions to 5s

* Replaced the use of `executionService.queryExecutions` and custom criteria closures with a direct HQL query in `Execution.executeQuery` to fetch execution IDs for cleanup, simplifying the code and reducing reliance on service methods.
* Changed the method for counting total executions from a criteria-based approach to a direct HQL count query in `totalAllExecutions`, making the query more straightforward and likely more efficient.

**Code Simplification:**

* Removed the `getExecutionsQueryCriteria` closure, eliminating complex criteria logic for building queries and reducing code complexity.
* Updated logic to work directly with lists of execution IDs and their counts, instead of handling results as maps with separate `result` and `total` keys.
* Adjusted method signatures and usages to remove unnecessary dependencies on `ExecutionService`, making the code more self-contained. [[1]](diffhunk://#diff-b4f304a7f34c05a18144144eca209da22ce9e49016562d8c74e45bbdd4b4ba2cL153-R176) [[2]](diffhunk://#diff-b4f304a7f34c05a18144144eca209da22ce9e49016562d8c74e45bbdd4b4ba2cL214-L248)