### PR TITLE
RUN-3877:Clean up println statements from JobAuditApiSpec

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/JobAuditApiSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/JobAuditApiSpec.groovy
@@ -33,8 +33,6 @@ class JobAuditApiSpec extends SeleniumBase {
         def jobShowPage = page JobShowPage
         def wait = new WebDriverWait(driver, Duration.ofSeconds(8))
 
-        // Use test credentials from SeleniumBase
-
         // Create job via API for test setup
         def jobXml = JobUtils.generateScheduledExecutionXml(jobName)
         def jobCreatedResponse = JobUtils.createJob(projectName, jobXml, client)
@@ -47,7 +45,6 @@ class JobAuditApiSpec extends SeleniumBase {
 
         // Wait for successful login
         wait.until(ExpectedConditions.urlContains("/menu/home"))
-        println "✓ Successfully logged in as ${TEST_USER}"
 
         and: "navigate to job edit page"
         // Navigate to job edit page
@@ -103,11 +100,8 @@ class JobAuditApiSpec extends SeleniumBase {
 
             createdBy = createdByElem.getText()
             lastModifiedBy = lastModifiedByElem.getText()
-
-            println "✓ Using CSS selector approach for audit extraction"
         } catch (NoSuchElementException e) {
             // Fallback to regex pattern matching for compatibility
-            println "⚠ CSS selectors not found, falling back to regex pattern matching"
 
             def createdByMatch = (modalText =~ /(?i)created\s+by\s+(\w+)/)
             def lastModifiedByMatch = (modalText =~ /(?i)last\s+modified\s+by\s+(\w+)/)
@@ -117,19 +111,12 @@ class JobAuditApiSpec extends SeleniumBase {
 
             createdBy = createdByMatch.group(1)
             lastModifiedBy = lastModifiedByMatch.group(1)
-
-            println "✓ Using regex pattern approach for audit extraction"
         }
 
         // Verify audit fields populated (works with both extraction methods)
         assert createdBy?.trim()?.length() > 0, "Created By field should be populated but found: '${createdBy}'"
         assert lastModifiedBy?.trim()?.toLowerCase() == "admin",
             "Expected last modifier to be 'admin' (UI user) but found: ${lastModifiedBy}"
-
-        println "✓ Created By: '${createdBy}' (API user) - Last Modified By: '${lastModifiedBy}' (UI user)"
-
-        println "✓ SUCCESS: Audit tracking verified - Created By: ${createdBy}, Last Modified By: ${lastModifiedBy}"
-        println "✓ Audit field functionality working correctly - both creation and modification tracking functional"
     }
 
 


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
Cleanup/maintenance - removing debug statements left from development

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
These println statements were accidentally left in during the job-audit-clean feature merge. The test functionality remains unchanged - only the debug output has been removed. Test still passes as verified before this cleanup.

