### PR TITLE
RUN-3890: Fix example value in set-project-config documentation

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ProjectController.groovy
@@ -2472,7 +2472,7 @@ Authorization required: `configure` access for `project` resource type or `admin
                                             @ExampleObject(
                                                     name = 'set-project-config',
                                                     summary = "Replace an individual config settings",
-                                                    value = '''{ "[KEY]" : "key value" }'''
+                                                    value = '''{ "value" : "key value" }'''
                                             )
                                     ]
                             ),


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
- fix: API spec shows incorrect example
    - request body should have a key named `value`  

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
