### PR TITLE
RUN-3859: remove the flaky T Docker CI test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -748,11 +748,6 @@ workflows:
           <<: *require-build
           <<: *slack-fail-post-step
       - test-docker:
-          name: T Docker
-          command: bash test/run-docker-tests.sh
-          <<: *require-build
-          <<: *slack-defaults
-      - test-docker:
           name: T Integration SSL
           command: bash test/run-docker-ssl-tests.sh
           <<: *require-build
@@ -834,10 +829,6 @@ workflows:
       - build-rundeck:
           name: Build with Docker image using JRE 17
           jreVersion: "openjdk-17-jre-headless"
-      - test-docker:
-          name: T Docker running JRE 17
-          command: bash test/run-docker-tests.sh
-          <<: *require-build-jre-17
       - test-docker:
           name: T Integration SSL running JRE 17
           command: bash test/run-docker-ssl-tests.sh


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Remove "T Docker" CI test target temporarily, the test cases will be moved to the functional test suite

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
