### PR TITLE
RUN-3108: Fix the loading icon showing when a step already succeeded

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/execution/ExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/execution/ExecutionSpec.groovy
@@ -129,6 +129,7 @@ class ExecutionSpec extends SeleniumBase {
      * Steps:
      * - Executes the command 'echo 'Hello world'' and waits for it to succeed.
      * - Navigates to the log node view and validates its contents.
+     * - Verifies that the loading spinner does not appear after execution completes.
      */
     def "viewer execution check log node view"() {
         setup:
@@ -149,6 +150,7 @@ class ExecutionSpec extends SeleniumBase {
         executionShowPage.execLogNode.isDisplayed()
         executionShowPage.execLogNode.text == "Hello world"
         executionShowPage.execLogGutterEntryAttribute.matches("\\d{2}:\\d{2}:\\d{2}")
+        executionShowPage.waitForNumberOfElementsToBe executionShowPage.nodeOutputLoadingSpinnerBy, 0
     }
 
     /**

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/execution/ExecutionShowPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/execution/ExecutionShowPage.groovy
@@ -47,6 +47,7 @@ class ExecutionShowPage extends BasePage  implements ActivityListTrait{
     static final By logContentTextBy = By.className("execution-log__content-text")
     static final By logContentTextOverflowBy = By.cssSelector(".execution-log__content-text.execution-log__content-text--overflow")
     static final By gutterLineNumberBy = By.cssSelector(".gutter.line-number")
+    static final By nodeOutputLoadingSpinnerBy = By.cssSelector(".wfnodeoutput .fa-spinner.fa-pulse")
     static final By subtitleExecutionActionMenuButtonBy = By.cssSelector("#subtitlebar .execution-head-info .btn-group button")
     static final By subtitleExecutionActionMenuBy = By.cssSelector("#subtitlebar .execution-head-info .btn-group.open ul[role=menu]")
     static final By subtitleExecutionActionLinksBy = By.cssSelector("#subtitlebar .execution-head-info .btn-group.open ul[role=menu] a")
@@ -299,5 +300,9 @@ class ExecutionShowPage extends BasePage  implements ActivityListTrait{
     }
     List<WebElement> getActionMenuLinks(){
         els subtitleExecutionActionLinksBy
+    }
+
+    WebElement getNodeOutputLoadingSpinner(){
+        el nodeOutputLoadingSpinnerBy
     }
 }

--- a/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
@@ -174,7 +174,8 @@
 
                       </div>
                   </div>
-                  <div data-bind="visible: followingOutput() && outputLineCount() < 0 " class="row row-space ">
+
+                  <div data-bind="visible: followingOutput() && outputLineCount() < 0 && (executionState() == 'RUNNING' || executionState() == 'WAITING')" class="row row-space ">
                       <div class="col-sm-12">
                           <div class="padded">
                               <span class="text-secondary">


### PR DESCRIPTION
## Release Notes

Small bug fix: When a job is running, a step that doesn't have an output shows a loading icon no matter if the step has finished running.

## Ticket Details

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

Small bug fix:  when a job is running, a step that doesn't have an output shows a loading icon no matter if the step has finished running. 

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
