### PR TITLE
RUN-3933: add cleanup log appender in remco log4j2.properties

### DIFF
--- a/docker/official/remco/templates/log4j2.properties
+++ b/docker/official/remco/templates/log4j2.properties
@@ -377,6 +377,25 @@ logger.messaging.name = org.rundeck.messaging.events
 logger.messaging.level = info
 logger.messaging.additivity = false
 logger.messaging.appenderRef.stdout.ref = messaging
+
+#
+# cleanup log
+# Execution Cleanup
+#
+appender.cleanup.type = {{ appender }}
+appender.cleanup.name = cleanup
+{% if strategy == "FILE" %}
+appender.cleanup.fileName = ${baseDir}/rundeck.cleanup.log
+appender.cleanup.append = true
+appender.cleanup.bufferedIO = true
+appender.cleanup.filePattern = ${baseDir}/rundeck.cleanup.log.%d{yyyy-MM-dd}.gz
+appender.cleanup.policies.type = Policies
+appender.cleanup.policies.time.type = TimeBasedTriggeringPolicy
+appender.cleanup.policies.time.interval = 1
+{% endif %}
+appender.cleanup.layout.type = PatternLayout
+appender.cleanup.layout.pattern = ${prefix} - %m%n
+
 #
 # cluster-messages log
 #


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Fixes startup error in docker image:

> ERROR Unable to locate appender "cleanup" for logger config "rundeck.quartzjobs.ExecutionsCleanUp"

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->
