### PR TITLE
RUN-3929: Upgrade MSSQL JDBC to fix CVE-2025-59250

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -67,3 +67,4 @@ commonsCompressVersion=1.26.2
 commonsFileuploadVersion=1.6.0
 hikariVersion=6.3.2
 minioVersion=8.6.0
+mssqlJdbcVersion=13.2.1.jre8

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -256,7 +256,7 @@ dependencies {
 
     // Database drivers
     runtimeOnly "com.h2database:h2:2.2.220"
-    runtimeOnly 'com.microsoft.sqlserver:mssql-jdbc:13.2.1.jre8'
+    runtimeOnly "com.microsoft.sqlserver:mssql-jdbc:${mssqlJdbcVersion}"
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:2.7.0'
     runtimeOnly 'org.postgresql:postgresql:42.7.2'
     runtimeOnly 'org.rundeck.hibernate:rundeck-oracle-dialect:1.0.1'


### PR DESCRIPTION
## Release Notes
Upgraded the Microsoft SQL Server JDBC driver from version 9.4.0.jre8 to 13.2.1.jre8 in the runner-agent module to address security vulnerability CVE-2025-59250.

## Ticket Details

This PR upgrades the Microsoft SQL Server JDBC driver from version 9.4.0.jre8 to 13.2.1.jre8 to address https://github.com/advisories/GHSA-m494-w24q-6f7w, a security vulnerability. This represents a major version upgrade spanning 4 major versions (9 → 13).

Key changes:

Updated mssql-jdbc dependency version from 9.4.0.jre8 to 13.2.1.jre8