### PR TITLE
RUN-3892: Added new ansible-plugin release version

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 rundeck:
   plugins: # Extra plugins to bundle
-  - "com.github.rundeck-plugins:ansible-plugin:4.0.10"
+  - "com.github.rundeck-plugins:ansible-plugin:4.0.11"
   - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.10"
   - "com.github.rundeck-plugins:py-winrm-plugin:2.1.3@zip"
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.4@zip"


### PR DESCRIPTION
JIRA TICKET: https://pagerduty.atlassian.net/browse/RUN-3893

This pull request updates the version of the Ansible plugin bundled with Rundeck. The change ensures the project uses the latest available version for improved features or bug fixes.

* Upgraded the Ansible plugin from version `4.0.10` to `4.0.11` in `build.yaml`.

## Release Notes

- Update to the way the Ansible plugin handles ad-hoc command execution, specifically replacing the deprecated -t argument with environment variables for callback configuration, and modernizing inventory argument handling. It also adds and improves tests to ensure these changes work as intended and that user-provided environment variables are respected.