### PR TITLE
RUN-3939: Fix Firefox scroll behavior on execution output tab

### DIFF
--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -142,6 +142,9 @@ search
         .affix .affixed-shown.affixed-shown-inline {
             display: inline;
         }
+        #output:target {
+            display: block !important;
+        }
       </style>
       <g:set var="projectName" value="${execution.project}"/>
       <g:javascript>
@@ -858,7 +861,7 @@ search
                                       </div>
                                   </div>
 
-                                  <div style="height: calc(100vh - 250px); display: none; contain: layout;"
+                                  <div style="height: calc(100vh - 250px); contain: layout; display: none;"
                                        id="output"
                                        class="card-content-full-width"
                                        data-bind="visible: activeTab() === 'output' || activeTab().startsWith('outputL')"


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

Firefox was attempting to scroll to #output before Knockout's visible binding rendered the element, causing scroll failures on direct navigation to execution output URLs.

Changes:
  - Add CSS :target pseudo-class to display #output immediately when hash matches, bypassing JS timing issues

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->