### PR TITLE
RUN-3945: Remove Duplicate Tags

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -3514,7 +3514,6 @@ Note: This endpoint has the same query parameters and response as the `/executio
             )
         ]
     )
-    @Tag(name = 'Job Executions')
     /**
      * Placeholder method to annotate for openapi spec generation.
      * Note: this method will never be used.

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -1576,7 +1576,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
             description = """Create/update list-based plugin configurations (e.g. Resource Model Sources).
 Authorization required: `configure` on the project.
 Since: v55""",
-            tags = ["Project", "Configuration"],
+            tags = ["Project"],
             parameters = [
                     @Parameter(
                             name = "project",

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -3822,7 +3822,6 @@ Each job entry contains:
             )
         ]
     )
-    @Tag(name = "Jobs")
     /**
      * API: /api/14/project/NAME/jobs/import
      */


### PR DESCRIPTION
Only 1 tag per endpoint for clean OpenAPI spec and SDK generation

Fixed /project/{project}/executions/metrics - Removed duplicate @Tag annotation

Fixed /project/{project}/jobs/import - Removed duplicate @Tag annotation

Fixed /project/{project}/plugins/save - Removed "Configuration" tag, kept only "Project"
