### PR TITLE
Change footer PagerDuty link to HTTPS

### DIFF
--- a/rundeckapp/grails-app/views/common/_footer.gsp
+++ b/rundeckapp/grails-app/views/common/_footer.gsp
@@ -53,7 +53,7 @@
     </div>
     <div class="footer__group footer__group--right">
         <div class="copyright">
-            &copy; Copyright ${java.time.LocalDate.now().getYear()} <a href="http://pagerduty.com">PagerDuty, Inc.</a>
+            &copy; Copyright ${java.time.LocalDate.now().getYear()} <a href="https://pagerduty.com">PagerDuty, Inc.</a>
 
             All rights reserved.
         </div>


### PR DESCRIPTION
This is a mostly inconsequential change, but fixes a "Mixed Content" warning when running with SSL.

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Very minor bugfix.

**Describe the solution you've implemented**
Change the default protocol for the link.

**Describe alternatives you've considered**
None.

**Additional context**
This was originally flagged during a security audit, despite not actually being vulnerable at all. It's a silly finding in my opinion, but the fix is simple and sane.

## Release Notes

<!-- If you have suggested content that would describe this PR to other Rundeck community users, please enter it here.-->