### PR TITLE
RUN-3894: update sshj-plugin to 0.1.20

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -7,4 +7,4 @@ rundeck:
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.4@zip"
   - "org.rundeck.plugins:multiline-regex-datacapture-filter:1.1.5"
   - "org.rundeck.plugins:attribute-match-node-enhancer:0.2.3"
-  - "com.github.rundeck-plugins:sshj-plugin:v0.1.19"
+  - "com.github.rundeck-plugins:sshj-plugin:v0.1.20"


### PR DESCRIPTION
This pull request updates the version of the `sshj-plugin` used by Rundeck in the `build.yaml` file. The change ensures the project uses the latest available version of the plugin.

Dependency update:

* Upgraded `com.github.rundeck-plugins:sshj-plugin` from version `v0.1.19` to `v0.1.20` in `build.yaml` to incorporate recent improvements and bug fixes.