### PR TITLE
RUN-3735: Re-enable ignored scm functional test fix flakiness

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/scm/ScmStatusBadgeSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/scm/ScmStatusBadgeSpec.groovy
@@ -68,7 +68,8 @@ class ScmStatusBadgeSpec extends ScmSeleniumBase {
         configureScmPage.disableScmExport()
         configureScmPage.enableScmImport()
 
-        // Wait for SCM import to sync job status after enabling
+        // Wait for SCM import to initialize and start syncing job status after mode switch
+        // This allows the SCM system to detect the committed job in the repository
         Thread.sleep(WaitingTime.MODERATE.toMillis())
 
         JobShowPage jobShowPage = page(JobShowPage, PROJECT_NAME).forJob(jobUuid)

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/scm/ScmStatusBadge.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/scm/ScmStatusBadge.groovy
@@ -26,6 +26,11 @@ class ScmStatusBadge {
 
     void checkStatusBadge(JobShowPage jobShowPage, boolean withRetry = true){
         try{
+            // First wait for the element to be present on the page
+            new WebDriverWait(jobShowPage.driver, Duration.ofSeconds(15)).until(
+                    ExpectedConditions.presenceOfElementLocated(elementSelector)
+            )
+            // Then wait for it to finish loading (text should not be "Loading SCM Status...")
             new WebDriverWait(jobShowPage.driver, Duration.ofSeconds(10)).until(
                     ExpectedConditions.not(
                             ExpectedConditions.textToBe(elementSelector, loadingFromServerText)


### PR DESCRIPTION
JIRA TICKET: https://pagerduty.atlassian.net/browse/RUN-3735

This pull request improves the reliability of SCM status badge tests by addressing flakiness and adding more robust waiting logic to ensure the SCM system has time to sync job status changes. The most important changes are grouped below:

**Test Stability Improvements:**

* Removed the `@Ignore` annotation from the previously flaky `"job scm import status badge after import job changes"` test, re-enabling it for execution.
* Added a wait after enabling SCM import to allow the SCM system to initialize and start syncing job status, reducing timing-related test failures.

**Waiting Logic Enhancements:**

* Enhanced the `checkStatusBadge` method in `ScmStatusBadge` to first wait for the badge element to be present, then wait for it to finish loading, making the test less likely to fail due to race conditions.

**Imports and Dependencies:**

* Added import of `WaitingTime` to support configurable wait durations in the test.