### PR TITLE
RUN-4016: Fix regression on popover in command page 

### DIFF
--- a/rundeckapp/grails-app/views/framework/_nodesEmbedKO.gsp
+++ b/rundeckapp/grails-app/views/framework/_nodesEmbedKO.gsp
@@ -29,6 +29,7 @@
            data-container="body"
            data-delay="{&quot;show&quot;:0,&quot;hide&quot;:200}"
            data-popover-template-class="popover-wide"
+           data-sanitize="false"
            data-bind="
                   css: $root.nodeSet().nodeCss(attributes),
                   css2: {


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Fix regression introduced by RUN-3350. 

**Describe the solution you've implemented**
We've enabled the sanitization of popovers to prevent html injection, but in the cases where we want to render html in them we need to manually disable the sanitization. The popover in the command (adhoc.gsp) is one of them, therefore adding the parameter.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

## Release Notes

<!-- If you have suggested content that would describe this PR to other Rundeck community users, please enter it here.-->