### PR TITLE
RUN-4029: Add selenium test to ensure that popover is rendering a table with node details

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/execution/CommandSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/execution/CommandSpec.groovy
@@ -182,23 +182,22 @@ class CommandSpec extends SeleniumBase {
         commandPage.nodeFilterTextField.click()
         commandPage.nodeFilterTextField.sendKeys".*"
         commandPage.filterNodeButton.click()
-            
+
         then: "Nodes should be loaded and visible"
         commandPage.waitForElementToBeClickable commandPage.commandTextField
         def nodes = commandPage.getNodeElements()
         nodes.size() > 0
-            
+
         when: "User clicks on the first node"
         commandPage.clickNode(0)
 
         then: "Popover should appear with node details table"
-        commandPage.waitForPopoverToAppear()
         def nodeDetailsTable = commandPage.getNodeDetailsTable()
         nodeDetailsTable.isDisplayed()
 
         expect: "Node details should have visible key-value structure with content"
         def keyCells = commandPage.getNodeDetailsKeyCells()
         keyCells.size() > 0
-        keyCells.any { it.text?.trim() }
+        keyCells.every { it.text?.trim() }
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/execution/CommandPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/execution/CommandPage.groovy
@@ -33,9 +33,7 @@ class CommandPage extends BasePage {
     By popoverContainerBy = By.cssSelector(".popover")
     By popoverContentBy = By.cssSelector(".popover-content")
     By nodeDetailsTableBy = By.cssSelector(".popover-content .node-details-simple")
-    By popoverParameterRowsBy = By.cssSelector(".popover-content .node-details-simple tbody tr")
     By parameterKeyBy = By.cssSelector(".key")
-    By parameterValueBy = By.cssSelector(".value")
 
     CommandPage(final SeleniumContext context) {
         super(context)
@@ -143,52 +141,22 @@ class CommandPage extends BasePage {
         waitForElementVisible popoverContentBy
     }
 
-    WebElement getPopoverContent() {
-        waitForPopoverToAppear()
-        el popoverContentBy
-    }
-
-    List<WebElement> getPopoverParameterRows() {
-        waitForPopoverToAppear()
-        // Wait for at least one parameter row to be present and visible
-        waitForNumberOfElementsToBeMoreThan(popoverParameterRowsBy, 0)
-        waitForElementVisible popoverParameterRowsBy
-        els popoverParameterRowsBy
-    }
-
-    String getParameterKey(WebElement row) {
-        try {
-            def keyElement = row.findElement(parameterKeyBy)
-            return keyElement.text.trim()
-        } catch (Exception e) {
-            return null
-        }
-    }
-
-    String getParameterValue(WebElement row) {
-        try {
-            def valueElement = row.findElement(parameterValueBy)
-            return valueElement.text.trim()
-        } catch (Exception e) {
-            // Try to get text from the row itself if value cell doesn't exist
-            return row.text.trim()
-        }
-    }
-
-    boolean isParameterRowVisible(WebElement row) {
-        try {
-            return row.isDisplayed()
-        } catch (Exception e) {
-            return false
-        }
-    }
-
+    /**
+     * Gets the node details table element from the popover.
+     * Waits for the popover to appear and for the table to be visible.
+     * @return The node details table WebElement
+     */
     WebElement getNodeDetailsTable() {
         waitForPopoverToAppear()
         waitForElementVisible nodeDetailsTableBy
         el nodeDetailsTableBy
     }
 
+    /**
+     * Gets all visible key cells from the node details table.
+     * Key cells contain labels like "Operating System", "User & Host", etc.
+     * @return List of visible key cell WebElements
+     */
     List<WebElement> getNodeDetailsKeyCells() {
         def table = getNodeDetailsTable()
         def keyCells = table.findElements(parameterKeyBy)


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Add selenium test for the fix done in https://github.com/rundeck/rundeck/pull/9930

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Check that the popover renders and has the table with the node details injected correctly.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
Considered to add an extra node that would be common in between local and pipelines so that could check all values.

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

## Release Notes

<!-- If you have suggested content that would describe this PR to other Rundeck community users, please enter it here.-->