### PR TITLE
RUN-3578: Update Remco to newer commit that remediates some CVEs

### DIFF
--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -1,6 +1,6 @@
 # Build remco from specific commit
 ##################################
-FROM golang:1.24.1 as remco
+FROM golang:1.24.6 as remco
 
 # REMCO_VERSION can be a release version "v0.XX.X", commit id, tag or branch name.
 ENV REMCO_VERSION=be848fe56c2a44530e422b5f7442b0854eaaafac


### PR DESCRIPTION
## Release Notes
Enhanced Docker image security by updating Remco (the configuration management tool) to a newer version that remediates three security vulnerabilities (CVE-2025-4673, CVE-2025-22872, and CVE-2025-47906), strengthening the security posture of Rundeck container deployments.

## PR Details
CVE-2025-4673 (customer report, but not in scan)

also
CVE-2025-22872 / CVE-2025-47906 (not scan related)