### PR TITLE
RUN-4031: Update vue3-markdown package

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/package.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package.json
@@ -69,7 +69,7 @@
     "vue-router": "^4.1.6",
     "vue-scrollto": "^2.17.1",
     "vue-virtual-scroller": "^2.0.0-beta.8",
-    "vue3-markdown": "^1.1.9",
+    "vue3-markdown": "^1.2.17",
     "vuedraggable": "^4.1.0",
     "vuex": "^4.1.0",
     "webpack-node-externals": "^3.0.0"


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
This is a vulnerability fix about vue3-markdown dependency on dopmpurify version.
The version 3.0.2 of dompurify is marked as not secure, see https://security.snyk.io/package/npm/dompurify/3.0.2

**Describe the solution you've implemented**
To be coherent, I upgrade dompurify as the same version than the root dependencies.

**Describe alternatives you've considered**
None

**Additional context**
None

## Release Notes

  * Security upgrade of vue3-markdown lib to 1.2.17