### PR TITLE
RUN-3327: Issues with Ansible inline workflow executions where it shows an unwanted output

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 rundeck:
   plugins: # Extra plugins to bundle
-  - "com.github.rundeck-plugins:ansible-plugin:4.0.11"
+  - "com.github.rundeck-plugins:ansible-plugin:4.0.12"
   - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.10"
   - "com.github.rundeck-plugins:py-winrm-plugin:2.1.3@zip"
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.4@zip"


### PR DESCRIPTION
## Release Notes

Resolved an issue where Ansible inline workflow executions displayed unwanted output by properly sanitizing group names to comply with Ansible requirements, filtering out reserved host attributes that could conflict with Ansible's internal variables, and ensuring only valid host entries are processed during execution.


## PR details

This pull request updates the version of the Ansible plugin used in the project. The change ensures that the build will now use the latest version of the plugin.

Plugin update:

* Updated the Ansible plugin version from `4.0.11` to `4.0.12` in `build.yaml` to include the latest fixes and features.<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->

