### PR TITLE
RUN-4037: Fix metric for datasource ping time

### DIFF
--- a/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
+++ b/rundeckapp/grails-app/init/rundeckapp/BootStrap.groovy
@@ -386,8 +386,8 @@ class BootStrap {
             long start=System.currentTimeMillis()
             def metricDataSource=dataSource.connection
             def valid = metricDataSource.isValid(dbPingTimeout)
-            System.currentTimeMillis()-start
             metricDataSource.close()
+            return System.currentTimeMillis()-start
         }))
         //set up some metrics collection for the Quartz scheduler
         metricRegistry.register(MetricRegistry.name("rundeck.scheduler.quartz","runningExecutions"),new CallableGauge<Integer>({


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Fix: the 'dataSource.connection.pingTime' metric value always returns `null`

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
fix code

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

## Release Notes

<!-- If you have suggested content that would describe this PR to other Rundeck community users, please enter it here.-->