### PR TITLE
Fixing lack of support for file storage provider config basedir.

### DIFF
--- a/docker/official/remco/templates/rundeck-config-storage.properties
+++ b/docker/official/remco/templates/rundeck-config-storage.properties
@@ -5,10 +5,13 @@
 
 {%- macro storage_provider(provider) %}
     {%- set index = provider | base %}
-    {%- set type = getv(printf("%s/type", provider), "db") %}
-{% if type == 'db' || type == 'file' %}
+    {%- set typeValue = getv(printf("%s/type", provider), "db") %}
+{% if typeValue == 'db' || typeValue == 'file' %}
 rundeck.storage.provider.{{index}}.type={% set type = printf("%s/type", provider) %}{{ getv(type, "db")}}
 rundeck.storage.provider.{{index}}.path={% set path = printf("%s/path", provider) %}{{ getv(path, "keys")}}
+{% endif %}
+{% if typeValue == 'file' %}
+rundeck.storage.provider.{{index}}.config.baseDir={% set basedir = printf("%s/config/basedir", provider) %}{{ getv(basedir, "/home/rundeck/var/storage/")}}
 {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

It is a bug fix for the remco template for storage properties, that allows configuring the base configdir.
See #8262 

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

I changed the name of the type variable to allow testing twice (otherwise it is being reset to the reference inside of the if block, therefore disallowing an additional test).
I then test it again for file only, in order to add the config basedir property.
This then functions as expected naturally and described in #8262 's premise.

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
Apart from tweaking templates and working around, no real clean alternative was found. We'd prefer for the baseline template to be correct :) .

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

## Release Notes

<!-- If you have suggested content that would describe this PR to other Rundeck community users, please enter it here.-->
FIX: container can now use file storage provider with config basedir, using a `RUNDECK_STORAGE_PROVIDER_*_CONFIG_BASEDIR` variable