### PR TITLE
[RUN-4043] Add a new index to the execution table

### DIFF
--- a/rundeckapp/grails-app/migrations/core/Execution.groovy
+++ b/rundeckapp/grails-app/migrations/core/Execution.groovy
@@ -191,4 +191,33 @@ databaseChangeLog = {
             column(name: "job_uuid")
         }
     }
+
+
+    changeSet(author: "rundeckdev", id: "add-project-stat-canc-status-index") {
+        preConditions(onFail: "MARK_RAN") {
+            not {
+                indexExists(indexName: "EXEC_IDX_PROJ_STAT_CANC_DATE", tableName: "execution")
+            }
+        }
+
+        createIndex(indexName: "EXEC_IDX_PROJ_STAT_CANC_DATE", tableName: "execution", unique: false) {
+            column(name: "project")
+            column(name: "status")
+            column(name: "cancelled")
+            column(name: "date_completed")
+        }
+    }
+
+    changeSet(author: "rundeckdev", id: "update-execution-status-true-to-succeeded") {
+        preConditions(onFail: "MARK_RAN") {
+            tableExists(tableName: "execution")
+            columnExists(tableName: "execution", columnName: "status")
+        }
+
+        update(tableName: "execution") {
+            column(name: "status", value: "succeeded")
+            where("status = 'true'")
+        }
+    }
+
 }

--- a/rundeckapp/grails-app/migrations/core/Execution.groovy
+++ b/rundeckapp/grails-app/migrations/core/Execution.groovy
@@ -208,21 +208,4 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "rundeckdev", id: "add-job-stat-canc-status-index") {
-        preConditions(onFail: "MARK_RAN") {
-            not {
-                indexExists(indexName: "EXEC_IDX_JOB_PROJ_DATE", tableName: "execution")
-            }
-        }
-
-        createIndex(indexName: "EXEC_IDX_JOB_PROJ_DATE", tableName: "execution", unique: false) {
-            column(name: "job_uuid")
-            column(name: "project")
-            column(name: "date_completed")
-            column(name: "status")
-            column(name: "cancelled")
-        }
-    }
-
-
 }

--- a/rundeckapp/grails-app/migrations/core/Execution.groovy
+++ b/rundeckapp/grails-app/migrations/core/Execution.groovy
@@ -208,4 +208,21 @@ databaseChangeLog = {
         }
     }
 
+    changeSet(author: "rundeckdev", id: "add-job-stat-canc-status-index") {
+        preConditions(onFail: "MARK_RAN") {
+            not {
+                indexExists(indexName: "EXEC_IDX_JOB_PROJ_DATE", tableName: "execution")
+            }
+        }
+
+        createIndex(indexName: "EXEC_IDX_JOB_PROJ_DATE", tableName: "execution", unique: false) {
+            column(name: "job_uuid")
+            column(name: "project")
+            column(name: "date_completed")
+            column(name: "status")
+            column(name: "cancelled")
+        }
+    }
+
+
 }

--- a/rundeckapp/grails-app/migrations/core/Execution.groovy
+++ b/rundeckapp/grails-app/migrations/core/Execution.groovy
@@ -208,16 +208,21 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "rundeckdev", id: "update-execution-status-true-to-succeeded") {
+    changeSet(author: "rundeckdev", id: "add-job-stat-canc-status-index") {
         preConditions(onFail: "MARK_RAN") {
-            tableExists(tableName: "execution")
-            columnExists(tableName: "execution", columnName: "status")
+            not {
+                indexExists(indexName: "EXEC_IDX_JOB_PROJ_DATE", tableName: "execution")
+            }
         }
 
-        update(tableName: "execution") {
-            column(name: "status", value: "succeeded")
-            where("status = 'true'")
+        createIndex(indexName: "EXEC_IDX_JOB_PROJ_DATE", tableName: "execution", unique: false) {
+            column(name: "job_uuid")
+            column(name: "project")
+            column(name: "date_completed")
+            column(name: "status")
+            column(name: "cancelled")
         }
     }
+
 
 }

--- a/rundeckapp/grails-app/migrations/core/JobFileRecord.groovy
+++ b/rundeckapp/grails-app/migrations/core/JobFileRecord.groovy
@@ -96,4 +96,21 @@ databaseChangeLog = {
             }
         }
     }
+
+    // Index to support FK validation during execution cleanup (DELETE on execution table).
+    // Without this index, PostgreSQL/MySQL perform a sequential scan of job_file_record for
+    // every deleted execution row, causing high DB CPU on large-scale deployments.
+    changeSet(author: "ltoledo", id: "5.15.0-1783252800") {
+        preConditions(onFail: "MARK_RAN") {
+            not {
+                indexExists(tableName: "job_file_record", indexName: "JFR_EXEC_ID_IDX")
+            }
+        }
+        createIndex(indexName: "JFR_EXEC_ID_IDX", tableName: "job_file_record") {
+            column(name: "execution_id")
+        }
+        rollback {
+            dropIndex(indexName: "JFR_EXEC_ID_IDX", tableName: "job_file_record")
+        }
+    }
 }

--- a/rundeckapp/grails-app/migrations/core/ReferencedExecution.groovy
+++ b/rundeckapp/grails-app/migrations/core/ReferencedExecution.groovy
@@ -61,4 +61,15 @@ databaseChangeLog = {
             column(name: "status")
         }
     }
+
+    changeSet(author: "rundeckdev", id: "add-referenced-execution-execution-id-index") {
+        preConditions(onFail: "MARK_RAN") {
+            not {
+                indexExists(indexName: "REFEXEC_IDX_EXECUTION_ID", tableName: "referenced_execution")
+            }
+        }
+        createIndex(indexName: "REFEXEC_IDX_EXECUTION_ID", tableName: "referenced_execution", unique: false) {
+            column(name: "execution_id")
+        }
+    }
 }


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Performance enhancement (RUN-4043). Adds targeted indexes to speed up execution history queries — in particular the query/sort/filter patterns used by the Execution API introduced in #9905 to power the Activity Page.

**Describe the solution you've implemented**

Adds the following indexes via Liquibase changesets:

| Index | Table | Columns | Where it's expected to help |
|---|---|---|---|
| `EXEC_IDX_PROJ_STAT_CANC_DATE` | `execution` | `project, status, cancelled, date_completed` | Primary access pattern for the Execution API (`/executions`) behind the Activity Page (#9905): filtering by project + status/cancelled, sorted by `date_completed`. |
| `EXEC_IDX_JOB_PROJ_DATE` | `execution` | `job_uuid, project, date_completed, status, cancelled` | Per-job execution history lookups (job detail view, execution counts scoped to a job) filtered by `job_uuid`/`project` and sorted/filtered by `date_completed`. |
| `REFEXEC_IDX_EXECUTION_ID` | `referenced_execution` | `execution_id` | Cross-project job reference lookups (`includeJobRef` counts added in #9905) for a given execution — avoids a full-table scan on `referenced_execution`. |
| `JFR_EXEC_ID_IDX` | `job_file_record` | `execution_id` | FK validation during execution cleanup (`DELETE` on `execution`). Without it, large deployments do a sequential scan of `job_file_record` per deleted execution row, spiking DB CPU. |

**Additional context**

- Ticket: RUN-4043
- Related: #9905 (Execution API / Activity Page changes that these indexes support)

## Release Notes

Add indexes on `execution`, `referenced_execution`, and `job_file_record` to improve the performance of execution history queries and the Execution API.
