### PR TITLE
RUN-4093: Move the logic to extract openapi spec from war into its own method

### DIFF
--- a/scripts/circleci/helper-functions.sh
+++ b/scripts/circleci/helper-functions.sh
@@ -116,11 +116,19 @@ wizcli_scan() {
     return $wizexitcode
 }
 
+# Extract OpenAPI spec from WAR file to the specified folder
+# Usage: extract_openapi_spec_from_war [target_folder]
+# Default: enterprise/build/war-contents/WEB-INF/classes/META-INF/swagger
+extract_openapi_spec_from_war() {
+    local targetDir="${1:-enterprise/build/war-contents/WEB-INF/classes/META-INF/swagger}"
+    mkdir -p "${targetDir}"
+    find "${RUNDECK_WAR_DIR}" -name '*.war' -exec jar xvf \{\} WEB-INF/classes/META-INF/swagger/rundeck-api.yml \;
+    mv WEB-INF/classes/META-INF/swagger/rundeck-api.yml "${targetDir}/"
+}
+
 openapi_tests() {
     # Extract openapi spec
-    mkdir -p openapi
-    find "${RUNDECK_WAR_DIR}" -name '*.war' -exec jar xvf \{\} WEB-INF/classes/META-INF/swagger/rundeck-api.yml \;
-    mv WEB-INF/classes/META-INF/swagger/rundeck-api.yml openapi/
+    extract_openapi_spec_from_war openapi
 
     # Redocly OpenAPI Linting
     npx -y @redocly/cli lint \


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

Follow up of RUN-4034, refactor the logic in the openapi_tests to extract the openapi spec from the war into a separate method so that both openapi_tests and the rundeckpro's job `package and release` can use it.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->


**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

## Release Notes

<!-- If you have suggested content that would describe this PR to other Rundeck community users, please enter it here.-->