### PR TITLE
[RUN-4215] Fix deprecated config dot-notation access in error page GSPs

### DIFF
--- a/rundeckapp/grails-app/views/404.gsp
+++ b/rundeckapp/grails-app/views/404.gsp
@@ -46,12 +46,13 @@
   <g:render template="/common/css"/>
   <asset:javascript src="bootstrap.js" />
 </head>
-
+<g:set var="titleLink" value="${grailsApplication.config.getProperty('rundeck.gui.titleLink', String)}"/>
+<g:set var="hideSpaceCat" value="${grailsApplication.config.getProperty('rundeck.feature.fourOhFour.hideSpaceCat', Boolean, false)}"/>
 <body id="four-oh-four-page">
     <div class="four-oh-four">
       <div class="nav-bar">
         <a
-          href="${grailsApplication.config.getProperty('rundeck.gui.titleLink', String) ? enc(attr:grailsApplication.config.getProperty('rundeck.gui.titleLink', String)) : g.createLink(uri: '/')}">
+          href="${titleLink ? enc(attr:titleLink) : g.createLink(uri: '/')}">
           <img src="${resource(dir: 'images', file: 'rundeck-full-logo-white.png')}" alt="Rundeck"
             style="height: 20px; width: auto;" />
         </a>
@@ -59,7 +60,7 @@
       <div style="padding-top:16vh;">
         <div>
           <div class="col-xs-12 col-sm-6 space-cat-container">
-            <g:if test="${!grailsApplication.config.getProperty('rundeck.feature.fourOhFour.hideSpaceCat', Boolean, false)}">
+            <g:if test="${!hideSpaceCat}">
               <asset:image src="spacecat/saucer-cat.png" class="img-responsive"
                 alt="Space Cat" />
             </g:if>
@@ -69,7 +70,7 @@
             <h2>
               <g:message code="request.error.notfound.title" />
             </h2>
-            <g:if test="${!grailsApplication.config.getProperty('rundeck.feature.fourOhFour.hideSpaceCat', Boolean, false)}">
+            <g:if test="${!hideSpaceCat}">
               <h3>"We must be purrr-fectly lost"</h3>
             </g:if>
             <div>
@@ -81,7 +82,7 @@
               </h5>
             </div>
             <div>
-              <a href="${grailsApplication.config.getProperty('rundeck.gui.titleLink', String) ? enc(attr:grailsApplication.config.getProperty('rundeck.gui.titleLink', String)) : g.createLink(uri: '/')}"
+              <a href="${titleLink ? enc(attr:titleLink) : g.createLink(uri: '/')}"
                 class="
                 btn btn-lg return-button">Return to Rundeck</a>
             </div>

--- a/rundeckapp/grails-app/views/404.gsp
+++ b/rundeckapp/grails-app/views/404.gsp
@@ -51,7 +51,7 @@
     <div class="four-oh-four">
       <div class="nav-bar">
         <a
-          href="${grailsApplication.config.rundeck.gui.titleLink ? enc(attr:grailsApplication.config.rundeck.gui.titleLink) : g.createLink(uri: '/')}">
+          href="${grailsApplication.config.getProperty('rundeck.gui.titleLink', String) ? enc(attr:grailsApplication.config.getProperty('rundeck.gui.titleLink', String)) : g.createLink(uri: '/')}">
           <img src="${resource(dir: 'images', file: 'rundeck-full-logo-white.png')}" alt="Rundeck"
             style="height: 20px; width: auto;" />
         </a>
@@ -59,7 +59,7 @@
       <div style="padding-top:16vh;">
         <div>
           <div class="col-xs-12 col-sm-6 space-cat-container">
-            <g:if test="${!grailsApplication.config.rundeck?.feature?.fourOhFour?.hideSpaceCat in [true, 'true']}">
+            <g:if test="${!grailsApplication.config.getProperty('rundeck.feature.fourOhFour.hideSpaceCat', Boolean, false)}">
               <asset:image src="spacecat/saucer-cat.png" class="img-responsive"
                 alt="Space Cat" />
             </g:if>
@@ -69,7 +69,7 @@
             <h2>
               <g:message code="request.error.notfound.title" />
             </h2>
-            <g:if test="${!grailsApplication.config.rundeck?.feature?.fourOhFour?.hideSpaceCat in [true, 'true']}">
+            <g:if test="${!grailsApplication.config.getProperty('rundeck.feature.fourOhFour.hideSpaceCat', Boolean, false)}">
               <h3>"We must be purrr-fectly lost"</h3>
             </g:if>
             <div>
@@ -81,7 +81,7 @@
               </h5>
             </div>
             <div>
-              <a href="${grailsApplication.config.rundeck.gui.titleLink ? enc(attr:grailsApplication.config.rundeck.gui.titleLink) : g.createLink(uri: '/')}"
+              <a href="${grailsApplication.config.getProperty('rundeck.gui.titleLink', String) ? enc(attr:grailsApplication.config.getProperty('rundeck.gui.titleLink', String)) : g.createLink(uri: '/')}"
                 class="
                 btn btn-lg return-button">Return to Rundeck</a>
             </div>

--- a/rundeckapp/grails-app/views/405.gsp
+++ b/rundeckapp/grails-app/views/405.gsp
@@ -50,7 +50,7 @@
     <div class="four-oh-four">
       <div class="nav-bar">
         <a
-          href="${grailsApplication.config.rundeck.gui.titleLink ? enc(attr:grailsApplication.config.rundeck.gui.titleLink) : g.createLink(uri: '/')}">
+          href="${grailsApplication.config.getProperty('rundeck.gui.titleLink', String) ? enc(attr:grailsApplication.config.getProperty('rundeck.gui.titleLink', String)) : g.createLink(uri: '/')}">
           <img src="${resource(dir: 'images', file: 'rundeck-full-logo-white.png')}" alt="Rundeck"
             style="height: 20px; width: auto;" />
         </a>
@@ -63,7 +63,7 @@
             <h2><g:message code="request.error.notallowed.message" />
             </h2>
             <div>
-              <a href="${grailsApplication.config.rundeck.gui.titleLink ? enc(attr:grailsApplication.config.rundeck.gui.titleLink) : g.createLink(uri: '/')}"
+              <a href="${grailsApplication.config.getProperty('rundeck.gui.titleLink', String) ? enc(attr:grailsApplication.config.getProperty('rundeck.gui.titleLink', String)) : g.createLink(uri: '/')}"
                 class="
                 btn btn-lg return-button">Return to Rundeck</a>
             </div>
@@ -71,7 +71,7 @@
         </div>
       </div>
           <div class="laser-cat-container">
-            <g:if test="${!grailsApplication.config.rundeck?.feature?.fourOhFour?.hideSpaceCat in [true, 'true']}">
+            <g:if test="${!grailsApplication.config.getProperty('rundeck.feature.fourOhFour.hideSpaceCat', Boolean, false)}">
               <asset:image src="spacecat/laser-cat.png" class="img-responsive"
                 alt="Laser Cat" />
             </g:if>

--- a/rundeckapp/grails-app/views/405.gsp
+++ b/rundeckapp/grails-app/views/405.gsp
@@ -46,11 +46,13 @@
   <asset:javascript src="bootstrap.js" />
 </head>
 
+<g:set var="titleLink" value="${grailsApplication.config.getProperty('rundeck.gui.titleLink', String)}"/>
+<g:set var="hideSpaceCat" value="${grailsApplication.config.getProperty('rundeck.feature.fourOhFour.hideSpaceCat', Boolean, false)}"/>
 <body id="four-oh-four-page">
     <div class="four-oh-four">
       <div class="nav-bar">
         <a
-          href="${grailsApplication.config.getProperty('rundeck.gui.titleLink', String) ? enc(attr:grailsApplication.config.getProperty('rundeck.gui.titleLink', String)) : g.createLink(uri: '/')}">
+          href="${titleLink ? enc(attr:titleLink) : g.createLink(uri: '/')}">
           <img src="${resource(dir: 'images', file: 'rundeck-full-logo-white.png')}" alt="Rundeck"
             style="height: 20px; width: auto;" />
         </a>
@@ -63,7 +65,7 @@
             <h2><g:message code="request.error.notallowed.message" />
             </h2>
             <div>
-              <a href="${grailsApplication.config.getProperty('rundeck.gui.titleLink', String) ? enc(attr:grailsApplication.config.getProperty('rundeck.gui.titleLink', String)) : g.createLink(uri: '/')}"
+              <a href="${titleLink ? enc(attr:titleLink) : g.createLink(uri: '/')}"
                 class="
                 btn btn-lg return-button">Return to Rundeck</a>
             </div>
@@ -71,7 +73,7 @@
         </div>
       </div>
           <div class="laser-cat-container">
-            <g:if test="${!grailsApplication.config.getProperty('rundeck.feature.fourOhFour.hideSpaceCat', Boolean, false)}">
+            <g:if test="${!hideSpaceCat}">
               <asset:image src="spacecat/laser-cat.png" class="img-responsive"
                 alt="Laser Cat" />
             </g:if>

--- a/rundeckapp/grails-app/views/5xx.gsp
+++ b/rundeckapp/grails-app/views/5xx.gsp
@@ -77,7 +77,8 @@
               </h5>
             </div>
             <div>
-              <a href="${grailsApplication.config.getProperty('rundeck.gui.titleLink', String) ? enc(attr:grailsApplication.config.getProperty('rundeck.gui.titleLink', String)) : g.createLink(uri: '/')}"
+              <g:set var="titleLink" value="${grailsApplication.config.getProperty('rundeck.gui.titleLink', String)}"/>
+              <a href="${titleLink ? enc(attr:titleLink) : g.createLink(uri: '/')}"
                 class="
                 btn btn-lg return-button">Return to Home Page</a>
             </div>

--- a/rundeckapp/grails-app/views/5xx.gsp
+++ b/rundeckapp/grails-app/views/5xx.gsp
@@ -57,7 +57,7 @@
       <div style="padding-top:16vh;">
         <div>
           <div class="col-xs-12 col-sm-6 space-cat-container">
-            <g:if test="${!grailsApplication.config.rundeck?.feature?.fourOhFour?.hideSpaceCat in [true, 'true']}">
+            <g:if test="${!grailsApplication.config.getProperty('rundeck.feature.fourOhFour.hideSpaceCat', Boolean, false)}">
               <asset:image src="spacecat/saucer-cat.png" class="img-responsive"
                 alt="Space Cat" />
             </g:if>
@@ -77,7 +77,7 @@
               </h5>
             </div>
             <div>
-              <a href="${grailsApplication.config.rundeck.gui.titleLink ? enc(attr:grailsApplication.config.rundeck.gui.titleLink) : g.createLink(uri: '/')}"
+              <a href="${grailsApplication.config.getProperty('rundeck.gui.titleLink', String) ? enc(attr:grailsApplication.config.getProperty('rundeck.gui.titleLink', String)) : g.createLink(uri: '/')}"
                 class="
                 btn btn-lg return-button">Return to Home Page</a>
             </div>


### PR DESCRIPTION
Replace NavigableMap dot-notation config access with getProperty() API in 404.gsp, 405.gsp, and 5xx.gsp to eliminate Grails deprecation warnings.

Remove warnings like:
> Accessing config key '[titleLink]' through dot notation is deprecated. Use 'config.getProperty(key, targetClass)' instead.

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

## Release Notes

<!-- If you have suggested content that would describe this PR to other Rundeck community users, please enter it here.-->