### PR TITLE
Use font-display swap for Muli and Jost

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/runstrap/_typography.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/runstrap/_typography.scss
@@ -292,6 +292,7 @@ a.text-danger:hover,
   src: url("../fonts/Mulish-VariableFont_wght.woff2") format("woff2");
   font-weight: 200 900;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -299,12 +300,14 @@ a.text-danger:hover,
   src: url("../fonts/Mulish-Italic-VariableFont_wght.woff2") format("woff2");
   font-weight: 200 900;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Jost";
   src: url("../fonts/Jost-VariableFont_wght.woff2") format("woff2");
   font-weight: 200 900;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -312,6 +315,7 @@ a.text-danger:hover,
   src: url("../fonts/Jost-Italic-VariableFont_wght.woff2") format("woff2");
   font-weight: 200 900;
   font-style: italic;
+  font-display: swap;
 }
 
 .download-text {


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Enhancement. This improves text rendering in the runstrap UI by reducing the time users may wait to see text while custom fonts load.

**Describe the solution you've implemented**
Added `font-display: swap` to the `@font-face` declarations for `Muli` and `Jost` in the runstrap typography stylesheet, so the browser can render text immediately with fallback fonts and swap in the custom fonts once they finish loading.

**Describe alternatives you've considered**
I considered applying the same change to `Glyphicons`, but did not include it because it is an icon font and using `swap` there can cause visible fallback glyph rendering or flicker.

I also checked the newer theme path. It uses `Inter` with a system font fallback and does not define the same webfont `@font-face` rules in this repository, so no equivalent change was needed there.

**Additional context**
This change is limited to the runstrap typography SCSS. No build logic or runtime behavior was changed.

## Release Notes

Improve runstrap UI text rendering by allowing fallback fonts to display while Muli and Jost load.
