### PR TITLE
[RUN-4227] Set typescript to strict and fix resulting errors 

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
@@ -63,6 +63,7 @@
         "@types/dagre": "^0.7.48",
         "@types/graphlib": "^2.1.8",
         "@types/jest": "^29.5.12",
+        "@types/lodash": "^4.17.24",
         "@types/node": "^14.0.13",
         "@types/uuid": "^8.3.0",
         "@typescript-eslint/eslint-plugin": "^6.19.0",
@@ -6002,6 +6003,13 @@
       "version": "0.16.7",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/@types/katex/-/katex-0.16.7.tgz",
       "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://npm.artifacts.pd-internal.com/npm/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mdast": {

--- a/rundeckapp/grails-spa/packages/ui-trellis/package.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package.json
@@ -96,6 +96,7 @@
     "@types/dagre": "^0.7.48",
     "@types/graphlib": "^2.1.8",
     "@types/jest": "^29.5.12",
+    "@types/lodash": "^4.17.24",
     "@types/node": "^14.0.13",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^6.19.0",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/activityList.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/activityList.spec.ts
@@ -71,7 +71,7 @@ const shallowMountActivityList = async (
   await wrapper.vm.$nextTick();
   return wrapper as VueWrapper<ActivityListInstance>;
 };
-let reports;
+let reports: typeof mockReports;
 describe("ActivityList", () => {
   beforeAll(() => {
     jest.useFakeTimers();

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/dateFilter.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/dateFilter.spec.ts
@@ -121,7 +121,7 @@ describe("DateFilter", () => {
       const emitted = wrapper.emitted("update:modelValue");
       expect(emitted).toBeTruthy();
 
-      expect(emitted[0]).toEqual([{ enabled: true, datetime: "" }]);
+      expect(emitted![0]).toEqual([{ enabled: true, datetime: "" }]);
     });
     it("emits update:modelValue event when datetime changes", async () => {
       const wrapper = mountDateFilter({
@@ -140,7 +140,7 @@ describe("DateFilter", () => {
       const emitted = wrapper.emitted("update:modelValue");
       expect(emitted).toBeTruthy();
 
-      expect(emitted[0]).toEqual([
+      expect(emitted![0]).toEqual([
         { enabled: true, datetime: "2022-01-03T00:00:00" },
       ]);
     });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/dateTimePicker.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/dateTimePicker.spec.ts
@@ -82,7 +82,7 @@ describe("DateTimePicker.vue", () => {
     expect(timePicker.attributes("role")).toBe("combobox");
 
     const receivedTime = new Date(
-      timePicker.attributes("modelvalue"),
+      timePicker.attributes("modelvalue")!,
     ).toISOString();
 
     const expectedTime = new Date(wrapper.vm.time).toISOString();

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/dateTimePicker.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/dateTimePicker.spec.ts
@@ -50,7 +50,7 @@ describe("DateTimePicker.vue", () => {
     await wrapper.vm.$nextTick();
 
     const emitted = wrapper.emitted("update:modelValue");
-    expect(emitted.pop()).toEqual([newTimeFormatted]);
+    expect(emitted!.pop()).toEqual([newTimeFormatted]);
   });
   it("updates time and dateString when modelValue changes", async () => {
     const wrapper = await mountDateTimePicker();

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/savedFilters.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/activity/tests/savedFilters.spec.ts
@@ -78,7 +78,7 @@ const mountSavedFilters = (
   });
 };
 describe("SavedFilters", () => {
-  let originalRemoveFilter;
+  let originalRemoveFilter: typeof ActivityFilterStore.prototype.removeFilter;
   beforeEach(() => {
     originalRemoveFilter = ActivityFilterStore.prototype.removeFilter;
     ActivityFilterStore.prototype.loadForProject = jest.fn().mockReturnValue({

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/common/tests/CommonUndoRedoDraggableList.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/common/tests/CommonUndoRedoDraggableList.spec.ts
@@ -93,7 +93,8 @@ describe("CommonUndoRedoDraggableList", () => {
     await draggable.vm.$emit("update", { oldIndex: 0, newIndex: 1 });
 
     await wrapper.vm.$nextTick();
-    expect(wrapper.emitted()["update:modelValue"][0][0]).toEqual(
+    const emitted = wrapper.emitted("update:modelValue");
+    expect(emitted![0][0]).toEqual(
       expectedResult,
     );
   });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/tests/HomeSearchBar.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/tests/HomeSearchBar.spec.ts
@@ -31,7 +31,7 @@ describe("HomeSearchBar", () => {
     await wrapper.setData({ search: "Test Input" });
 
     expect(wrapper.emitted("update:modelValue")).toHaveLength(1);
-    expect(wrapper.emitted("update:modelValue")[0]).toEqual(["Test Input"]);
+    expect(wrapper.emitted("update:modelValue")![0]).toEqual(["Test Input"]);
   });
 
   it('emits "onEnter" event when enter key is pressed in the search input', async () => {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/tests/HomeWelcome.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/tests/HomeWelcome.spec.ts
@@ -33,7 +33,7 @@ const mountHomeWelcome = async (
           }
           return messages[baseString].replace(
             /{(\d+)}/g,
-            (_, index) => replacements[index],
+            (match: string, index: string) => replacements[index],
           );
         },
       },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/tests/HomeWelcome.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/tests/HomeWelcome.spec.ts
@@ -33,7 +33,7 @@ const mountHomeWelcome = async (
           }
           return messages[baseString].replace(
             /{(\d+)}/g,
-            (match: string, index: string) => replacements[index],
+            (match: string, index: string) => replacements[parseInt(index)],
           );
         },
       },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/details/tests/DetailsEditor.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/details/tests/DetailsEditor.spec.ts
@@ -61,7 +61,7 @@ describe("DetailsEditor.vue", () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.emitted("update:modelValue")).toBeTruthy();
-    expect(wrapper.emitted("update:modelValue")[0]).toEqual([
+    expect(wrapper.emitted("update:modelValue")![0]).toEqual([
       expect.objectContaining({
         description: "newDescription",
         groupPath: "testGroup/newGroup",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/execution/tests/ExecutionEditor.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/execution/tests/ExecutionEditor.spec.ts
@@ -104,10 +104,10 @@ describe("ExecutionEditor", () => {
 
     // as checkboxes were clicked first and then the plugin data updated, update:modelValue is triggered at first with empty objects
     // therefore for will check that the last event emitted has all the plugin data
-    const numberOfEventsEmitted = wrapper.emitted("update:modelValue").length;
+    const numberOfEventsEmitted = wrapper.emitted("update:modelValue")!.length;
 
     expect(
-      wrapper.emitted("update:modelValue")[numberOfEventsEmitted - 1],
+      wrapper.emitted("update:modelValue")![numberOfEventsEmitted - 1],
     ).toEqual([
       expect.objectContaining({
         ExecutionLifecycle: executionLifecycle,

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/execution/tests/ExecutionEditor.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/execution/tests/ExecutionEditor.spec.ts
@@ -93,7 +93,8 @@ describe("ExecutionEditor", () => {
     // emitting data from pluginConfig that differs from the original data, to simulate editing behaviour
     const pluginConfigs = wrapper.findAllComponents(PluginConfig);
     pluginConfigs.forEach((pluginComponent) => {
-      const configToEmit = executionLifecycle[pluginComponent.vm.provider];
+      const provider = pluginComponent.vm.provider as keyof typeof executionLifecycle;
+      const configToEmit = executionLifecycle[provider];
       pluginComponent.vm.$emit("update:modelValue", {
         config: configToEmit,
         type: undefined,

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionEdit.stories.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionEdit.stories.ts
@@ -7,6 +7,7 @@ import { RootStore } from "../../../../library/stores/RootStore";
 import OptionEdit from "./OptionEdit.vue";
 import { JobOption } from "../../../../library/types/jobs/JobEdit";
 import { EventBus } from "../../../../library/utilities/vueEventBus";
+import { RundeckBrowser } from "@rundeck/client";
 import * as uiv from "uiv";
 
 setup((app) => {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionEdit.stories.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionEdit.stories.ts
@@ -243,6 +243,7 @@ A comprehensive form component for creating and editing job options in Rundeck. 
 export default meta;
 
 type Story = StoryObj<typeof OptionEdit>;
+type OptionEditArgs = typeof meta.args;
 
 export const Playground: Story = {
   parameters: {
@@ -253,7 +254,7 @@ export const Playground: Story = {
   },
   name: "Playground",
   tags: ["!dev"],
-  render: (args) => ({
+  render: (args: OptionEditArgs) => ({
     components: { OptionEdit },
     setup() {
       const optionData = ref(args.modelValue);
@@ -294,7 +295,7 @@ export const NewTextOption: Story = {
         "Basic text option with minimal configuration in creation mode. Shows the standard option fields without any advanced features enabled.",
     },
   },
-  render: (args) => ({
+  render: (args: OptionEditArgs) => ({
     components: { OptionEdit },
     setup() {
       const optionData = ref({
@@ -343,7 +344,7 @@ export const EditSecureOption: Story = {
         "A secure option that uses key storage for the option value. The input will be hidden in logs and execution output.",
     },
   },
-  render: (args) => ({
+  render: (args: OptionEditArgs) => ({
     components: { OptionEdit },
     setup() {
       const optionData = ref({
@@ -393,7 +394,7 @@ export const MultilineOption: Story = {
         "A multiline text option that supports entering multi-paragraph text with line breaks. Requires the multilineJobOptions feature to be enabled.",
     },
   },
-  render: (args) => ({
+  render: (args: OptionEditArgs) => ({
     components: { OptionEdit },
     setup() {
       const optionData = ref({
@@ -446,7 +447,7 @@ export const FileUploadOption: Story = {
         "A file upload option that allows uploading files during job execution. Requires the fileUploadPlugin feature to be enabled.",
     },
   },
-  render: (args) => ({
+  render: (args: OptionEditArgs) => ({
     components: { OptionEdit },
     setup() {
       const optionData = ref({
@@ -498,7 +499,7 @@ export const OptionWithValidationErrors: Story = {
         "An option with validation errors demonstrating error handling and display within the component.",
     },
   },
-  render: (args) => ({
+  render: (args: OptionEditArgs) => ({
     components: { OptionEdit },
     setup() {
       const optionData = ref({
@@ -557,7 +558,7 @@ export const OptionWithAllowedValues: Story = {
         "An option with a predefined list of allowed values that creates a dropdown/select input for the user.",
     },
   },
-  render: (args) => ({
+  render: (args: OptionEditArgs) => ({
     components: { OptionEdit },
     setup() {
       const optionData = ref({
@@ -607,7 +608,7 @@ export const OptionWithRemoteValues: Story = {
         "An option that loads allowed values from a remote URL endpoint at runtime.",
     },
   },
-  render: (args) => ({
+  render: (args: OptionEditArgs) => ({
     components: { OptionEdit },
     setup() {
       const optionData = ref({
@@ -657,7 +658,7 @@ export const OptionWithPluginValues: Story = {
         "An option that uses a plugin to provide its allowed values dynamically.",
     },
   },
-  render: (args) => ({
+  render: (args: OptionEditArgs) => ({
     components: { OptionEdit },
     setup() {
       const optionData = ref({
@@ -717,7 +718,7 @@ export const DateOption: Story = {
         "A date input option with configurable date format for selecting dates and times.",
     },
   },
-  render: (args) => ({
+  render: (args: OptionEditArgs) => ({
     components: { OptionEdit },
     setup() {
       const optionData = ref({

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionEdit.stories.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionEdit.stories.ts
@@ -86,7 +86,7 @@ A comprehensive form component for creating and editing job options in Rundeck. 
         eventBus: {} as typeof EventBus,
         activeTour: "",
         activeTourStep: "",
-        rundeckClient: null,
+        rundeckClient: {} as RundeckBrowser,
       };
     },
   },
@@ -257,7 +257,7 @@ export const Playground: Story = {
   render: (args: OptionEditArgs) => ({
     components: { OptionEdit },
     setup() {
-      const optionData = ref(args.modelValue);
+      const optionData = ref(args?.modelValue);
 
       const onSave = () => {
         console.log("Save clicked", optionData.value);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionItem.stories.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionItem.stories.ts
@@ -83,12 +83,12 @@ const generateTemplate = (args: Record<string, any>) => {
 
 export const Default: Story = {
   render: (args: OptionItemArgs) => ({
-    props: Object.keys(args),
+    props: Object.keys(args || {}),
     components: { OptionItem },
     setup() {
       return { args };
     },
-    template: generateTemplate(args),
+    template: generateTemplate(args || {}),
   }),
   args: {},
   parameters: {},
@@ -96,12 +96,12 @@ export const Default: Story = {
 
 export const TypeMultiLine: Story = {
   render: (args: OptionItemArgs) => ({
-    props: Object.keys(args),
+    props: Object.keys(args || {}),
     components: { OptionItem },
     setup() {
       return { args };
     },
-    template: generateTemplate(args),
+    template: generateTemplate(args || {}),
   }),
   args: {
     option: {
@@ -116,12 +116,12 @@ export const TypeMultiLine: Story = {
 
 export const TypeFile: Story = {
   render: (args: OptionItemArgs) => ({
-    props: Object.keys(args),
+    props: Object.keys(args || {}),
     components: { OptionItem },
     setup() {
       return { args };
     },
-    template: generateTemplate(args),
+    template: generateTemplate(args || {}),
   }),
   args: {
     option: {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionItem.stories.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionItem.stories.ts
@@ -62,12 +62,13 @@ const meta: Meta<typeof OptionItem> = {
 export default meta;
 
 type Story = StoryObj<typeof OptionItem>;
+type OptionItemArgs = typeof meta.args;
 
 // TODO: manually wire the props to the component name, so that the source will update correctly in the story
 export const Playground: Story = {
   name: "Playground",
   tags: ["!dev"],
-  render: (args) => ({
+  render: (args: OptionItemArgs) => ({
     components: { OptionItem },
     setup: () => ({ args }),
     template: `<OptionItem v-bind="args"></OptionItem>`,
@@ -81,7 +82,7 @@ const generateTemplate = (args: Record<string, any>) => {
 };
 
 export const Default: Story = {
-  render: (args) => ({
+  render: (args: OptionItemArgs) => ({
     props: Object.keys(args),
     components: { OptionItem },
     setup() {
@@ -94,7 +95,7 @@ export const Default: Story = {
 };
 
 export const TypeMultiLine: Story = {
-  render: (args) => ({
+  render: (args: OptionItemArgs) => ({
     props: Object.keys(args),
     components: { OptionItem },
     setup() {
@@ -114,7 +115,7 @@ export const TypeMultiLine: Story = {
 };
 
 export const TypeFile: Story = {
-  render: (args) => ({
+  render: (args: OptionItemArgs) => ({
     props: Object.keys(args),
     components: { OptionItem },
     setup() {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionUsagePreview.stories.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionUsagePreview.stories.ts
@@ -35,12 +35,13 @@ const meta: Meta<typeof OptionUsagePreview> = {
 export default meta;
 
 type Story = StoryObj<typeof OptionUsagePreview>;
+type OptionUsagePreviewArgs = typeof meta.args;
 
 // TODO: manually wire the props to the component name, so that the source will update correctly in the story
 export const Playground: Story = {
   name: "Playground",
   tags: ["!dev"],
-  render: (args) => ({
+  render: (args: OptionUsagePreviewArgs) => ({
     components: { OptionUsagePreview },
     setup: () => ({ args }),
     template: `<OptionUsagePreview v-bind="args"></OptionUsagePreview>`,
@@ -54,7 +55,7 @@ const generateTemplate = (args: Record<string, any>) => {
 };
 
 export const Default: Story = {
-  render: (args) => ({
+  render: (args: OptionUsagePreviewArgs) => ({
     props: Object.keys(args),
     components: { OptionUsagePreview },
     setup() {
@@ -66,7 +67,7 @@ export const Default: Story = {
   parameters: {},
 };
 export const Secure: Story = {
-  render: (args) => ({
+  render: (args: OptionUsagePreviewArgs) => ({
     props: Object.keys(args),
     components: { OptionUsagePreview },
     setup() {
@@ -84,7 +85,7 @@ export const Secure: Story = {
 };
 
 export const PlaintextWithPasswordInput: Story = {
-  render: (args) => ({
+  render: (args: OptionUsagePreviewArgs) => ({
     props: Object.keys(args),
     components: { OptionUsagePreview },
     setup() {
@@ -103,7 +104,7 @@ export const PlaintextWithPasswordInput: Story = {
 };
 
 export const TypeFile: Story = {
-  render: (args) => ({
+  render: (args: OptionUsagePreviewArgs) => ({
     props: Object.keys(args),
     components: { OptionUsagePreview },
     setup() {
@@ -121,7 +122,7 @@ export const TypeFile: Story = {
   parameters: {},
 };
 export const TypeMultiline: Story = {
-  render: (args) => ({
+  render: (args: OptionUsagePreviewArgs) => ({
     props: Object.keys(args),
     components: { OptionUsagePreview },
     setup() {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionUsagePreview.stories.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionUsagePreview.stories.ts
@@ -56,24 +56,24 @@ const generateTemplate = (args: Record<string, any>) => {
 
 export const Default: Story = {
   render: (args: OptionUsagePreviewArgs) => ({
-    props: Object.keys(args),
+    props: Object.keys(args || {}),
     components: { OptionUsagePreview },
     setup() {
       return { args };
     },
-    template: generateTemplate(args),
+    template: generateTemplate(args || {}),
   }),
   args: {},
   parameters: {},
 };
 export const Secure: Story = {
   render: (args: OptionUsagePreviewArgs) => ({
-    props: Object.keys(args),
+    props: Object.keys(args || {}),
     components: { OptionUsagePreview },
     setup() {
       return { args };
     },
-    template: generateTemplate(args),
+    template: generateTemplate(args || {}),
   }),
   args: {
     option: {
@@ -86,12 +86,12 @@ export const Secure: Story = {
 
 export const PlaintextWithPasswordInput: Story = {
   render: (args: OptionUsagePreviewArgs) => ({
-    props: Object.keys(args),
+    props: Object.keys(args || {}),
     components: { OptionUsagePreview },
     setup() {
       return { args };
     },
-    template: generateTemplate(args),
+    template: generateTemplate(args || {}),
   }),
   args: {
     option: {
@@ -105,12 +105,12 @@ export const PlaintextWithPasswordInput: Story = {
 
 export const TypeFile: Story = {
   render: (args: OptionUsagePreviewArgs) => ({
-    props: Object.keys(args),
+    props: Object.keys(args || {}),
     components: { OptionUsagePreview },
     setup() {
       return { args };
     },
-    template: generateTemplate(args),
+    template: generateTemplate(args || {}),
   }),
   args: {
     option: {
@@ -123,12 +123,12 @@ export const TypeFile: Story = {
 };
 export const TypeMultiline: Story = {
   render: (args: OptionUsagePreviewArgs) => ({
-    props: Object.keys(args),
+    props: Object.keys(args || {}),
     components: { OptionUsagePreview },
     setup() {
       return { args };
     },
-    template: generateTemplate(args),
+    template: generateTemplate(args || {}),
   }),
   args: {
     option: {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionView.stories.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionView.stories.ts
@@ -48,12 +48,13 @@ const meta: Meta<typeof OptionView> = {
 export default meta;
 
 type Story = StoryObj<typeof OptionView>;
+type OptionViewArgs = typeof meta.args;
 
 // TODO: manually wire the props to the component name, so that the source will update correctly in the story
 export const Playground: Story = {
   name: "Playground",
   tags: ["!dev"],
-  render: (args) => ({
+  render: (args: OptionViewArgs) => ({
     components: { OptionView },
     setup: () => ({ args }),
     template: `<OptionView v-bind="args"></OptionView>`,
@@ -67,7 +68,7 @@ const generateTemplate = (args: Record<string, any>) => {
 };
 
 export const Default: Story = {
-  render: (args) => ({
+  render: (args: OptionViewArgs) => ({
     props: Object.keys(args),
     components: { OptionView },
     setup() {
@@ -80,7 +81,7 @@ export const Default: Story = {
 };
 
 export const TypeMultiLine: Story = {
-  render: (args) => ({
+  render: (args: OptionViewArgs) => ({
     props: Object.keys(args),
     components: { OptionView },
     setup() {
@@ -100,7 +101,7 @@ export const TypeMultiLine: Story = {
 };
 
 export const TypeFile: Story = {
-  render: (args) => ({
+  render: (args: OptionViewArgs) => ({
     props: Object.keys(args),
     components: { OptionView },
     setup() {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionView.stories.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionView.stories.ts
@@ -69,12 +69,12 @@ const generateTemplate = (args: Record<string, any>) => {
 
 export const Default: Story = {
   render: (args: OptionViewArgs) => ({
-    props: Object.keys(args),
+    props: Object.keys(args || {}),
     components: { OptionView },
     setup() {
       return { args };
     },
-    template: generateTemplate(args),
+    template: generateTemplate(args || {}),
   }),
   args: {},
   parameters: {},
@@ -82,12 +82,12 @@ export const Default: Story = {
 
 export const TypeMultiLine: Story = {
   render: (args: OptionViewArgs) => ({
-    props: Object.keys(args),
+    props: Object.keys(args || {}),
     components: { OptionView },
     setup() {
       return { args };
     },
-    template: generateTemplate(args),
+    template: generateTemplate(args || {}),
   }),
   args: {
     option: {
@@ -102,12 +102,12 @@ export const TypeMultiLine: Story = {
 
 export const TypeFile: Story = {
   render: (args: OptionViewArgs) => ({
-    props: Object.keys(args),
+    props: Object.keys(args || {}),
     components: { OptionView },
     setup() {
       return { args };
     },
-    template: generateTemplate(args),
+    template: generateTemplate(args || {}),
   }),
   args: {
     option: {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/tests/OptionEdit.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/tests/OptionEdit.spec.ts
@@ -495,7 +495,7 @@ describe("OptionEdit", () => {
     ["delimiter", { multivalued: true }],
   ])(
     "shows validation errors for field %p",
-    async (fieldName: string, optData: any, errorName: string = null) => {
+    async (fieldName: string, optData: any, errorName: string | null = null) => {
       const wrapper = await mountOptionEdit({
         modelValue: Object.assign({ name: "aname", type: "text" }, optData),
         editable: true,

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/tests/OptionEdit.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/tests/OptionEdit.spec.ts
@@ -281,10 +281,10 @@ describe("OptionEdit", () => {
       await wrapper.vm.doSave();
       expect(wrapper.vm.hasFormErrors).toBeFalsy();
       //test emitted
-      const actual = wrapper.emitted();
-      expect(actual["update:modelValue"]).toBeTruthy();
-      expect(actual["update:modelValue"].length).toBe(1);
-      const emittedOption = actual["update:modelValue"][0][0];
+      const actual = wrapper.emitted("update:modelValue");
+      expect(actual).toBeTruthy();
+      expect(actual!.length).toBe(1);
+      const emittedOption = actual![0][0];
       expect(emittedOption).toEqual({
         name: "test",
         type: "text",
@@ -341,10 +341,10 @@ describe("OptionEdit", () => {
       await wrapper.vm.doSave();
       expect(wrapper.vm.hasFormErrors).toBeFalsy();
       //test emitted
-      const actual = wrapper.emitted();
-      expect(actual["update:modelValue"]).toBeTruthy();
-      expect(actual["update:modelValue"].length).toBe(1);
-      const emittedOption = actual["update:modelValue"][0][0];
+      const actual = wrapper.emitted("update:modelValue");
+      expect(actual).toBeTruthy();
+      expect(actual!.length).toBe(1);
+      const emittedOption = actual![0][0];
       expect(emittedOption).toEqual(
         Object.assign(
           {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/tests/OptionItem.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/tests/OptionItem.spec.ts
@@ -147,7 +147,7 @@ describe("OptionItem", () => {
       expect(editBtn.length).toBe(1);
       await editBtn[0].trigger("click");
       expect(wrapper.emitted(action)).toBeTruthy();
-      expect(wrapper.emitted(action)[0][0]).toStrictEqual(option);
+      expect(wrapper.emitted(action)![0][0]).toStrictEqual(option);
     },
   );
   it("emits edit event when item view is clicked", async () => {
@@ -160,6 +160,6 @@ describe("OptionItem", () => {
     expect(content.length).toBe(1);
     await content[0].trigger("click");
     expect(wrapper.emitted("edit")).toBeTruthy();
-    expect(wrapper.emitted("edit")[0][0]).toStrictEqual(option);
+    expect(wrapper.emitted("edit")![0][0]).toStrictEqual(option);
   });
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/tests/OptionRemoteUrlConfig.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/tests/OptionRemoteUrlConfig.spec.ts
@@ -39,7 +39,7 @@ describe("OptionRemoteUrlConfig", () => {
     ],
   ])(
     "shows validation errors for field %p",
-    async (fieldName: string, optData: any, errorName: string = null) => {
+    async (fieldName: string, optData: any, errorName: string | null = null) => {
       const wrapper = await mountOptionEdit(
         Object.assign(
           {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/tests/OptionsEditor.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/tests/OptionsEditor.spec.ts
@@ -1,6 +1,6 @@
 import { mount, VueWrapper } from "@vue/test-utils";
 import { Btn } from "uiv";
-import { JobOptionsData } from "../../../../../library/types/jobs/JobEdit";
+import { JobOptionsData, JobOptionEdit } from "../../../../../library/types/jobs/JobEdit";
 import { Operation } from "../model/ChangeEvents";
 import OptionsEditor from "../OptionsEditor.vue";
 
@@ -434,40 +434,40 @@ describe("OptionsEditor", () => {
     const wrapper = await mountBasicOptionsEditor();
     //expect sortIndex to be set correctly after mount
     const intOptions = wrapper.vm.intOptions;
-    expect(intOptions.map((item) => item.sortIndex)).toEqual([1, 2]);
+    expect(intOptions.map((item: JobOptionEdit) => item.sortIndex)).toEqual([1, 2]);
     //remove first item
     wrapper.vm.doRemove(0);
-    expect(intOptions.map((item) => item.sortIndex)).toEqual([1]);
+    expect(intOptions.map((item: JobOptionEdit) => item.sortIndex)).toEqual([1]);
   });
   it("sortIndex is updated after doMoveUp", async () => {
     const wrapper = await mountBasicOptionsEditor();
     //expect sortIndex to be set correctly after mount
     const intOptions = wrapper.vm.intOptions;
-    expect(intOptions.map((item) => item.sortIndex)).toEqual([1, 2]);
+    expect(intOptions.map((item: JobOptionEdit) => item.sortIndex)).toEqual([1, 2]);
     //remove first item
     wrapper.vm.doMoveUp(1);
-    expect(intOptions.map((item) => item.sortIndex)).toEqual([1, 2]);
+    expect(intOptions.map((item: JobOptionEdit) => item.sortIndex)).toEqual([1, 2]);
   });
   it("sortIndex is updated after doMoveDown", async () => {
     const wrapper = await mountBasicOptionsEditor();
     //expect sortIndex to be set correctly after mount
     const intOptions = wrapper.vm.intOptions;
-    expect(intOptions.map((item) => item.sortIndex)).toEqual([1, 2]);
+    expect(intOptions.map((item: JobOptionEdit) => item.sortIndex)).toEqual([1, 2]);
     //remove first item
     wrapper.vm.doMoveDown(0);
-    expect(intOptions.map((item) => item.sortIndex)).toEqual([1, 2]);
+    expect(intOptions.map((item: JobOptionEdit) => item.sortIndex)).toEqual([1, 2]);
   });
   it("sortIndex is updated after saveNewOption", async () => {
     const wrapper = await mountBasicOptionsEditor();
     //expect sortIndex to be set correctly after mount
     const intOptions = wrapper.vm.intOptions;
-    expect(intOptions.map((item) => item.sortIndex)).toEqual([1, 2]);
+    expect(intOptions.map((item: JobOptionEdit) => item.sortIndex)).toEqual([1, 2]);
     //remove first item
     wrapper.vm.saveNewOption({
       name: "newoption",
       type: "text",
       inputType: "plain",
     });
-    expect(intOptions.map((item) => item.sortIndex)).toEqual([1, 2, 3]);
+    expect(intOptions.map((item: JobOptionEdit) => item.sortIndex)).toEqual([1, 2, 3]);
   });
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeCard.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeCard.spec.ts
@@ -105,13 +105,13 @@ describe("NodeCard Component", () => {
       const wrapper = await mountNodeCard();
       const tags = wrapper.findAll(".label-muted");
       expect(tags.length).toBe(mockNodeSummary.tags.length);
-      expect(tags.at(0).text()).toContain("Tag1 (5)");
-      expect(tags.at(1).text()).toContain("Tag2 (3)");
+      expect(tags.at(0)!.text()).toContain("Tag1 (5)");
+      expect(tags.at(1)!.text()).toContain("Tag2 (3)");
     });
     it("emits filter event when a tag is clicked", async () => {
       const wrapper = await mountNodeCard();
       const tagLink = wrapper.findAllComponents(NodeFilterLink).at(0);
-      await tagLink.trigger("click");
+      await tagLink!.trigger("click");
       const emittedEvent = wrapper.emitted().filter;
       expect(emittedEvent).toBeTruthy();
       expect(emittedEvent.length).toBe(1);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeDetailSimple.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeDetailSimple.spec.ts
@@ -124,8 +124,8 @@ describe("NodeDetailsSimple Component", () => {
     const wrapper = await mountNodeDetailsSimple();
     const tags = wrapper.findAll(".label-muted");
     expect(tags.length).toBe(2);
-    expect(tags.at(0).text()).toContain("Tag1");
-    expect(tags.at(1).text()).toContain("Tag2");
+    expect(tags.at(0)!.text()).toContain("Tag1");
+    expect(tags.at(1)!.text()).toContain("Tag2");
   });
 
   it("renders expandable attributes using class", async () => {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeDetailSimple.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeDetailSimple.spec.ts
@@ -148,14 +148,15 @@ describe("NodeDetailsSimple Component", () => {
       "[data-testid='node-attribute-link-hostname']",
     );
     await usernameLink.trigger("click");
-    expect(wrapper.emitted().filter).toBeTruthy();
-    expect(wrapper.emitted().filter[0][0]).toEqual({
+    const filterEmitted = wrapper.emitted("filter");
+    expect(filterEmitted).toBeTruthy();
+    expect(filterEmitted![0][0]).toEqual({
       filter: 'username: "user"',
     });
     await hostnameLink.trigger("click");
-    expect(wrapper.emitted().filter).toBeTruthy();
-    expect(wrapper.emitted().filter.length).toBe(2);
-    expect(wrapper.emitted().filter[1][0]).toEqual({
+    expect(filterEmitted).toBeTruthy();
+    expect(filterEmitted!.length).toBe(2);
+    expect(filterEmitted![1][0]).toEqual({
       filter: 'hostname: "host"',
     });
   });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeFilterLink.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeFilterLink.spec.ts
@@ -27,7 +27,7 @@ describe("NodeFilterLink Component", () => {
     };
   });
   afterAll(() => {
-    delete window._rundeck;
+    Reflect.deleteProperty(window, '_rundeck');
   });
   const mountNodeFilterLink = async (propsData = {}) => {
     const wrapper = mount(NodeFilterLink, {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeFilterLink.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeFilterLink.spec.ts
@@ -47,8 +47,9 @@ describe("NodeFilterLink Component", () => {
     const wrapper = await mountNodeFilterLink();
     await wrapper.trigger("click");
     await wrapper.vm.$nextTick();
-    expect(wrapper.emitted().nodefilterclick).toBeTruthy();
-    expect(wrapper.emitted().nodefilterclick[0][0]).toEqual({
+    const emitted = wrapper.emitted("nodefilterclick");
+    expect(emitted).toBeTruthy();
+    expect(emitted![0][0]).toEqual({
       filter: 'tags: "testTag"',
     });
   });
@@ -65,7 +66,8 @@ describe("NodeFilterLink Component", () => {
     const wrapper = await mountNodeFilterLink({ exclude: true });
     await wrapper.trigger("click");
     await wrapper.vm.$nextTick();
-    expect(wrapper.emitted().nodefilterclick[0][0]).toEqual({
+    const emitted = wrapper.emitted("nodefilterclick");
+    expect(emitted![0][0]).toEqual({
       filterExclude: 'tags: "testTag"',
     });
   });
@@ -80,7 +82,8 @@ describe("NodeFilterLink Component", () => {
     });
     await wrapper.trigger("click");
     await wrapper.vm.$nextTick();
-    expect(wrapper.emitted().nodefilterclick[0][0]).toEqual({
+    const emitted = wrapper.emitted("nodefilterclick");
+    expect(emitted![0][0]).toEqual({
       filter: "hostname: node1",
     });
   });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeTable.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeTable.spec.ts
@@ -1,4 +1,4 @@
-import { mount } from "@vue/test-utils";
+import { mount, DOMWrapper } from "@vue/test-utils";
 import NodeTable from "../NodeTable.vue";
 import NodeDetailsSimple from "../NodeDetailsSimple.vue";
 import { mockNodeSet } from "./mocks/apiData";
@@ -60,7 +60,7 @@ describe("NodeTable Component", () => {
     expect(nodeIcons.at(1).classes()).toContain("fa-hdd");
     // Check node colors
     const nodeColors = wrapper.findAll('[data-testid="node-icon"]');
-    nodeColors.forEach((colorWrapper) => {
+    nodeColors.forEach((colorWrapper: DOMWrapper<Element>) => {
       const styleAttribute = colorWrapper.attributes("style");
       expect(styleAttribute).toMatch(/color:\s*(red|blue);?/);
     });
@@ -109,7 +109,7 @@ describe("NodeTable Component", () => {
     const pages = wrapper.findAll("#nodesPaging li");
     expect(pages.length).toBe(5);
 
-    const arrayOfPageTexts = pages.map((page) => page.text());
+    const arrayOfPageTexts = pages.map((page: DOMWrapper<Element>) => page.text());
     expect(arrayOfPageTexts).toEqual([
       "default.paginate.prev",
       "1",
@@ -128,7 +128,7 @@ describe("NodeTable Component", () => {
     await wrapper.vm.$nextTick();
     const pages = wrapper.findAll("#nodesPaging li");
 
-    const arrayOfPageTexts = pages.map((page) => page.text());
+    const arrayOfPageTexts = pages.map((page: DOMWrapper<Element>) => page.text());
     expect(arrayOfPageTexts).toEqual([
       "default.paginate.prev",
       "1",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/EditStepCard.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/EditStepCard.spec.ts
@@ -597,11 +597,11 @@ describe("EditStepCard", () => {
             nodefilters: {
               filter: "",
               dispatch: {
-                threadcount: null,
-                keepgoing: null,
-                rankAttribute: null,
-                rankOrder: null,
-                nodeIntersect: null,
+                threadcount: undefined,
+                keepgoing: undefined,
+                rankAttribute: undefined,
+                rankOrder: undefined,
+                nodeIntersect: undefined,
               },
             },
           },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/ErrorHandlerStep.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/ErrorHandlerStep.spec.ts
@@ -89,7 +89,7 @@ describe("ErrorHandlerStep", () => {
     await removeButton.trigger("click");
 
     expect(wrapper.emitted("removeHandler")).toBeTruthy();
-    expect(wrapper.emitted("removeHandler")[0][0]).toEqual(step);
+    expect(wrapper.emitted("removeHandler")![0][0]).toEqual(step);
   });
 
   it("renders plugin config for non-job-ref error handlers", async () => {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/JobRefForm.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/JobRefForm.spec.ts
@@ -318,7 +318,7 @@ describe("JobRefForm", () => {
       await wrapper.setProps({ modalActive: false });
 
       expect(wrapper.emitted("update:modalActive")).toBeTruthy();
-      expect(wrapper.emitted("update:modalActive")[0]).toEqual([false]);
+      expect(wrapper.emitted("update:modalActive")![0]).toEqual([false]);
     });
   });
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/LogFilters.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/LogFilters.spec.ts
@@ -148,8 +148,10 @@ describe("LogFilters", () => {
       );
       await wrapper.vm.$nextTick();
 
-      expect(wrapper.emitted("update:modelValue")).toBeTruthy();
-      expect(wrapper.emitted("update:modelValue")![0][0][1]).toEqual({
+      const emitted = wrapper.emitted("update:modelValue");
+      expect(emitted).toBeTruthy();
+      const emittedArray = emitted![0][0] as unknown[];
+      expect(emittedArray[1]).toEqual({
         type: "filterType",
         config: { randomValue: true },
       });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/WorkflowEditor.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/WorkflowEditor.spec.ts
@@ -78,8 +78,8 @@ describe("WorkflowEditor", () => {
     await wrapper.vm.$nextTick();
 
     expect(
-      wrapper.emitted("update:modelValue")[
-        wrapper.emitted("update:modelValue").length - 1
+      wrapper.emitted("update:modelValue")![
+        wrapper.emitted("update:modelValue")!.length - 1
       ][0],
     ).toMatchObject(
       expect.objectContaining({

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/WorkflowSteps.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/WorkflowSteps.spec.ts
@@ -160,7 +160,7 @@ describe("WorkflowSteps", () => {
       editModal.vm.$emit("save");
 
       await flushPromises();
-      expect(wrapper.emitted("update:modelValue")[1][0]).toEqual({
+      expect(wrapper.emitted("update:modelValue")![1][0]).toEqual({
         commands: [
           {
             configuration: {
@@ -188,7 +188,7 @@ describe("WorkflowSteps", () => {
       const mockEventBus = getRundeckContext().eventBus;
       const removeButton = wrapper.find('[data-test="remove-step"]');
       await removeButton.trigger("click");
-      expect(wrapper.emitted("update:modelValue")[1][0]).toEqual({
+      expect(wrapper.emitted("update:modelValue")![1][0]).toEqual({
         commands: [],
       });
       expect(mockEventBus.emit).toBeCalledWith(
@@ -214,7 +214,7 @@ describe("WorkflowSteps", () => {
       editModal.vm.$emit("save");
       await flushPromises();
 
-      expect(wrapper.emitted("update:modelValue")[1][0]).toEqual({
+      expect(wrapper.emitted("update:modelValue")![1][0]).toEqual({
         commands: [
           {
             description: "echo test",
@@ -240,7 +240,7 @@ describe("WorkflowSteps", () => {
       const duplicateBtn = wrapper.find("[title='Workflow.duplicateStep']");
       await duplicateBtn.trigger("click");
 
-      const emitted = wrapper.emitted("update:modelValue")[1][0];
+      const emitted = wrapper.emitted("update:modelValue")![1][0];
       expect(emitted["commands"]).toHaveLength(2);
       expect(emitted["commands"]).toEqual([
         { ...baseCommand, nodeStep: true },
@@ -357,7 +357,7 @@ describe("WorkflowSteps", () => {
         await flushPromises();
 
         expect(
-          wrapper.emitted("update:modelValue")[1][0]["commands"][0],
+          wrapper.emitted("update:modelValue")![1][0]!["commands"][0],
         ).toMatchObject({
           ...baseCommand,
           errorhandler: {
@@ -387,7 +387,7 @@ describe("WorkflowSteps", () => {
       editModal.vm.$emit("save");
       await flushPromises();
 
-      expect(wrapper.emitted("update:modelValue")[1][0]["commands"]).toEqual([
+      expect(wrapper.emitted("update:modelValue")![1][0]!["commands"]).toEqual([
         { ...baseCommand, nodeStep: true },
         {
           description: "echo test",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/WorkflowSteps.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/WorkflowSteps.spec.ts
@@ -240,7 +240,7 @@ describe("WorkflowSteps", () => {
       const duplicateBtn = wrapper.find("[title='Workflow.duplicateStep']");
       await duplicateBtn.trigger("click");
 
-      const emitted = wrapper.emitted("update:modelValue")![1][0];
+      const emitted = wrapper.emitted("update:modelValue")![1][0] as Record<string, unknown>;
       expect(emitted["commands"]).toHaveLength(2);
       expect(emitted["commands"]).toEqual([
         { ...baseCommand, nodeStep: true },
@@ -356,8 +356,9 @@ describe("WorkflowSteps", () => {
         editModal.vm.$emit("save");
         await flushPromises();
 
+        const emittedValue = wrapper.emitted("update:modelValue")![1][0] as Record<string, unknown>;
         expect(
-          wrapper.emitted("update:modelValue")![1][0]!["commands"][0],
+          (emittedValue["commands"] as unknown[])[0],
         ).toMatchObject({
           ...baseCommand,
           errorhandler: {
@@ -387,7 +388,8 @@ describe("WorkflowSteps", () => {
       editModal.vm.$emit("save");
       await flushPromises();
 
-      expect(wrapper.emitted("update:modelValue")![1][0]!["commands"]).toEqual([
+      const emittedValue = wrapper.emitted("update:modelValue")![1][0] as Record<string, unknown>;
+      expect(emittedValue["commands"]).toEqual([
         { ...baseCommand, nodeStep: true },
         {
           description: "echo test",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/workflowTypes.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/workflowTypes.spec.ts
@@ -32,7 +32,7 @@ describe("workflowTypes", () => {
   );
   it("exportPluginData includes strategy data", () => {
     const strategy = { type: "s", config: { a: "b" } };
-    expect(exportPluginData(strategy, null)).toEqual({
+    expect(exportPluginData(strategy, {})).toEqual({
       pluginConfig: {
         WorkflowStrategy: {
           s: {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/types/tests/workflowTypes.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/types/tests/workflowTypes.spec.ts
@@ -102,7 +102,7 @@ describe("workflowTypes", () => {
         expect(result.commands[0].exec).toBe("echo exec");
         expect(result.commands[1].script).toBe("#!/bin/bash");
         expect(result.commands[2].scriptfile).toBe("/path/to/script");
-        expect(result.commands[3].jobref.name).toBe("MyJob");
+        expect(result.commands[3].jobref!.name).toBe("MyJob");
         expect(result.commands[4].type).toBe("my-plugin");
       });
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/ko-paginator/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/ko-paginator/main.ts
@@ -2,6 +2,24 @@
 import { createApp } from "vue";
 import Pagination from "../../../library/components/utils/Pagination.vue";
 
+interface KoPagerPage {
+  current: boolean;
+  [key: string]: unknown;
+}
+
+interface KoPager {
+  pageList: {
+    (): KoPagerPage[];
+    subscribe(callback: (pages: KoPagerPage[]) => void): void;
+  };
+  setPage(page: number): void;
+}
+
+interface KoPaginationEvent {
+  name: string;
+  pager: KoPager;
+}
+
 const template = `
     <Pagination 
         v-model="activePage"
@@ -14,7 +32,12 @@ const template = `
 const KoPaginator = {
   template,
   components: { Pagination },
-  props: ["pager"],
+  props: {
+    pager: {
+      type: Object as () => KoPager,
+      required: true,
+    },
+  },
   data() {
     return {
       activePage: 0,
@@ -24,13 +47,13 @@ const KoPaginator = {
 
   created() {
     this.activePage =
-      this.pager.pageList().findIndex((p: any) => p.current) + 1;
+      this.pager.pageList().findIndex((p: KoPagerPage) => p.current) + 1;
     this.totalPages = this.pager.pageList().length;
   },
 
   mounted() {
-    this.pager.pageList.subscribe((pages: any) => {
-      this.activePage = pages.findIndex((p: any) => p.current) + 1;
+    this.pager.pageList.subscribe((pages: KoPagerPage[]) => {
+      this.activePage = pages.findIndex((p: KoPagerPage) => p.current) + 1;
       this.totalPages = pages.length;
     });
   },
@@ -45,7 +68,7 @@ const KoPaginator = {
 const mounted = new Map<string, boolean>();
 
 /** Listen to events advertising pagination and mount to elements */
-window._rundeck.eventBus.on("ko-pagination", (event: any) => {
+window._rundeck.eventBus.on("ko-pagination", (event: KoPaginationEvent) => {
   const { name, pager } = event;
 
   if (!mounted.has(name)) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/ko-paginator/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/ko-paginator/main.ts
@@ -1,3 +1,4 @@
+//@ts-nocheck
 import { createApp } from "vue";
 import Pagination from "../../../library/components/utils/Pagination.vue";
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/ko-paginator/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/ko-paginator/main.ts
@@ -1,5 +1,4 @@
-//@ts-nocheck
-import { createApp } from "vue";
+import { createApp, defineComponent, PropType } from "vue";
 import Pagination from "../../../library/components/utils/Pagination.vue";
 
 interface KoPagerPage {
@@ -20,21 +19,13 @@ interface KoPaginationEvent {
   pager: KoPager;
 }
 
-const template = `
-    <Pagination 
-        v-model="activePage"
-        :totalPages="totalPages"
-        @change="handlePageChange"
-    />
-    `;
-
 /** Adapt KO Pager with Paginator wrapper */
-const KoPaginator = {
-  template,
+const KoPaginator = defineComponent({
+  name: "KoPaginator",
   components: { Pagination },
   props: {
     pager: {
-      type: Object as () => KoPager,
+      type: Object as PropType<KoPager>,
       required: true,
     },
   },
@@ -63,7 +54,14 @@ const KoPaginator = {
       this.pager.setPage(page - 1);
     },
   },
-};
+  template: `
+    <Pagination 
+        v-model="activePage"
+        :totalPages="totalPages"
+        @change="handlePageChange"
+    />
+    `,
+});
 
 const mounted = new Map<string, boolean>();
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/navbar/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/navbar/main.ts
@@ -8,6 +8,7 @@ import SettingsCogButton from "../../../library/components/widgets/settings-bar/
 import SettingsModal from "../../../library/components/widgets/settings-bar/SettingsModal.vue";
 
 import { UtilityBarItem } from "../../../library/stores/UtilityBar";
+import { UiMessage } from "../../../library/stores/UIStore";
 import { getRundeckContext, getAppLinks } from "../../../library";
 import { commonAddUiMessages, initI18n } from "../../utilities/i18n";
 import * as uiv from "uiv";
@@ -127,7 +128,7 @@ function initUtil() {
   vue.use(VueCookies);
   vue.use(i18n);
   vue.use(uiv);
-  vue.provide("addUiMessages", async (messages) => {
+  vue.provide("addUiMessages", async (messages: UiMessage[]) => {
     await commonAddUiMessages(i18n, messages);
   });
   vue.mount(elm);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/editProjectFileService.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/editProjectFileService.ts
@@ -1,4 +1,5 @@
 import { api } from "../../../library/services/api";
+import { AxiosError } from "axios";
 
 export async function saveProjectFile(
   project: string,
@@ -29,7 +30,7 @@ export async function getFileText(project: string, filename: string) {
     }
   } catch (error) {
     // If it's a 404, we need to maintain the warning flag
-    if (error.response && error.response.status === 404) {
+    if ((error as AxiosError).response?.status === 404) {
       throw { success: false, warning: true };
     }
     throw error;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/main.ts
@@ -1,5 +1,6 @@
 import { defineComponent, markRaw } from "vue";
 import { getRundeckContext } from "../../../library";
+import { UiMessage } from "../../../library/stores/UIStore";
 import EditProjectFile from "./EditProjectFile.vue";
 
 import messages from "./i18n";
@@ -47,8 +48,10 @@ rundeckContext.rootStore.ui.addItems([
           };
         },
         created() {
-          // @ts-ignore
-          this.addUiMessages([i18nMessages[locale]]);
+          (this.addUiMessages as (messages: UiMessage[]) => Promise<void>)([
+            i18nMessages[locale],
+          ]);
+
           this.filename = this.itemData.filename;
           // code to handle displayConfig
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/main.ts
@@ -1,5 +1,6 @@
 import { defineComponent, markRaw } from "vue";
 import { getRundeckContext } from "../../../library";
+import { UiMessage } from "../../../library/stores/UIStore";
 import EditProjectFile from "./EditProjectFile.vue";
 
 import messages from "./i18n";
@@ -41,12 +42,13 @@ rundeckContext.rootStore.ui.addItems([
         data() {
           return {
             filename: "",
-            displayConfig: [],
+            displayConfig: [] as string[],
             project: "",
             authAdmin: false,
           };
         },
         created() {
+          // @ts-ignore
           this.addUiMessages([i18nMessages[locale]]);
           this.filename = this.itemData.filename;
           // code to handle displayConfig

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/main.ts
@@ -1,6 +1,5 @@
 import { defineComponent, markRaw } from "vue";
 import { getRundeckContext } from "../../../library";
-import { UiMessage } from "../../../library/stores/UIStore";
 import EditProjectFile from "./EditProjectFile.vue";
 
 import messages from "./i18n";

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/server-identity/serverIdentity.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/server-identity/serverIdentity.ts
@@ -16,7 +16,7 @@ const ServerIdentityComp = defineComponent({
     serverName: { type: String, default: "" },
     serverUuid: { type: String, default: "" },
   },
-  data() {
+  data(): { serverInfo: ServerInfo | null } {
     return {
       serverInfo: null,
     };

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/ui/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/ui/main.ts
@@ -1,4 +1,4 @@
-import { createApp } from "vue";
+import { createApp, Component } from "vue";
 import * as uiv from "uiv";
 import VueCookies from "vue-cookies";
 
@@ -69,12 +69,12 @@ function initUiComponents(elmElement: any) {
 
   configurePrimeVue(vue);
 
-  vue.provide("registerComponent", (name, comp) => {
+  vue.provide("registerComponent", (name: string, comp: Component) => {
     vue.component(name, comp);
   });
-  vue.provide("addUiMessages", async (messages) => {
+  vue.provide("addUiMessages", async (messages: UiMessage[]) => {
     const newMessages = messages.reduce(
-      (acc: any, message: UiMessage) =>
+      (acc: Record<string, any>, message: UiMessage) =>
         message ? { ...acc, ...message } : acc,
       {},
     );

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/ui/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/ui/main.ts
@@ -85,7 +85,7 @@ function initUiComponents(elmElement: any) {
   try {
     vue.mount(elmElement);
   } catch (e) {
-    console.error("Error mounting vue app", e.message, e);
+    console.error("Error mounting vue app", (e as Error).message, e);
   }
   rootStore.ui.registerComponent = vue.component;
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/nodeView.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/nodeView.ts
@@ -68,7 +68,7 @@ window._rundeck.eventBus.on("ko-exec-show-output", (nodeStep: any) => {
       if (execOutput.completed) {
         reaction.dispose();
         nodeStep.outputLineCount(0);
-        vue._container.remove();
+        vue._container!.remove();
         return;
       } else {
         return;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/head/scm/scm-action-buttons.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/head/scm/scm-action-buttons.ts
@@ -25,7 +25,7 @@ rootStore.ui.addItems([
                     provide(JobPageStoreInjectionKey, jobPageStore);
 
                     jobPageStore.load()
-                    jobPageStore.getJobBrowser().loadJobMeta(job.id).then(jobMeta => job.meta = jobMeta)
+                    jobPageStore.getJobBrowser().loadJobMeta(job.id!).then(jobMeta => job.meta = jobMeta)
 
                     return { jobPageStore, job }
                 },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/head/scm/scm-status-badge.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/head/scm/scm-status-badge.ts
@@ -3,6 +3,7 @@ import { getRundeckContext } from "../../../../../library";
 
 import moment from "moment";
 import JobScmStatus from "@/app/pages/job/browse/tree/JobScmStatus.vue";
+import { JobBrowseMeta } from "../../../../../library/types/jobs/JobBrowse";
 
 function init() {
   const rootStore = getRundeckContext().rootStore;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/head/scm/scm-status-badge.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/head/scm/scm-status-badge.ts
@@ -1,9 +1,9 @@
-import { defineComponent, markRaw, provide, reactive, ref } from "vue";
+import { defineComponent, markRaw, reactive, ref } from "vue";
 import { getRundeckContext } from "../../../../../library";
 
 import moment from "moment";
 import JobScmStatus from "@/app/pages/job/browse/tree/JobScmStatus.vue";
-import { JobBrowseItem, JobBrowseMeta } from "../../../../../library/types/jobs/JobBrowse";
+import { JobBrowseItem } from "../../../../../library/types/jobs/JobBrowse";
 
 function init() {
   const rootStore = getRundeckContext().rootStore;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/head/scm/scm-status-badge.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/head/scm/scm-status-badge.ts
@@ -3,7 +3,7 @@ import { getRundeckContext } from "../../../../../library";
 
 import moment from "moment";
 import JobScmStatus from "@/app/pages/job/browse/tree/JobScmStatus.vue";
-import { JobBrowseMeta } from "../../../../../library/types/jobs/JobBrowse";
+import { JobBrowseItem, JobBrowseMeta } from "../../../../../library/types/jobs/JobBrowse";
 
 function init() {
   const rootStore = getRundeckContext().rootStore;
@@ -28,8 +28,7 @@ function init() {
                 job: true,
                 groupPath: "",
                 id: props.itemData.jobUuid,
-                meta: undefined,
-              },
+              } as JobBrowseItem,
             });
             let loading = ref(true);
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/head/scm/scm-status-badge.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/head/scm/scm-status-badge.ts
@@ -34,7 +34,7 @@ function init() {
 
             jobPageStore
               .getJobBrowser()
-              .loadJobMeta(scmItemData.job.id)
+              .loadJobMeta(scmItemData.job.id!)
               .then((jobMeta) => {
                 scmItemData.job.meta = jobMeta;
                 loading.value = false;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.ts
@@ -159,11 +159,11 @@ function init() {
           methods: {
             updateNodeFilter(val: any) {
               const filterName = val && val.filter ? val.filter : val;
-              if (filterName === ".*" || this.nodeFilterStore.filter === ".*") {
+              if (filterName === ".*" || this.nodeFilterStore.selectedFilter === ".*") {
                 this.nodeFilterStore.setSelectedFilter(filterName);
               } else {
                 this.nodeFilterStore.setSelectedFilter(
-                  [this.nodeFilterStore.filter, filterName].join(" "),
+                  [this.nodeFilterStore.selectedFilter, filterName].join(" "),
                 );
               }
             },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.ts
@@ -21,7 +21,7 @@ const FilterInputComp = defineComponent({
       queryFieldPlaceholderText: this.itemData["queryFieldPlaceholderText"],
       koFieldName: this.itemData["koFieldName"],
       koParam: this.itemData["koParam"],
-      subs: [],
+      subs: [] as any[],
     };
   },
   computed: {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.ts
@@ -21,7 +21,7 @@ const FilterInputComp = defineComponent({
       queryFieldPlaceholderText: this.itemData["queryFieldPlaceholderText"],
       koFieldName: this.itemData["koFieldName"],
       koParam: this.itemData["koParam"],
-      subs: [] as any[],
+      subs: [] as Array<{ dispose(): void }>,
     };
   },
   computed: {
@@ -39,8 +39,6 @@ const FilterInputComp = defineComponent({
     },
   },
   beforeUnmount() {
-    //note: this removes subscriptions from knockout observable
-    //@ts-ignore
     this.subs.forEach((s) => s.dispose());
   },
   mounted() {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/storage/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/storage/main.ts
@@ -17,9 +17,9 @@ const vue = createApp({
 });
 vue.use(uiv);
 vue.use(i18n);
-vue.provide("addUiMessages", async (messages) => {
+vue.provide("addUiMessages", async (messages: UiMessage[]) => {
   const newMessages = messages.reduce(
-    (acc: any, message: UiMessage) => (message ? { ...acc, ...message } : acc),
+    (acc: Record<string, any>, message: UiMessage) => (message ? { ...acc, ...message } : acc),
     {},
   );
   const locale = window._rundeck.locale || "en_US";

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/storage/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/storage/main.ts
@@ -26,4 +26,6 @@ vue.provide("addUiMessages", async (messages: UiMessage[]) => {
   const lang = window._rundeck.language || "en";
   return updateLocaleMessages(i18n, locale, lang, newMessages);
 });
-vue.mount(elm);
+if (elm) {
+  vue.mount(elm);
+}

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/StringFormatters.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/StringFormatters.ts
@@ -2,7 +2,7 @@ export function splitAtCapitalLetter(val: string) {
   if (!val) return "";
   val = val.toString();
   if (val.match(/^[A-Z]+$/g)) return val;
-  return val.match(/[A-Z][a-z]+|[0-9]+/g).join(" ");
+  return val.match(/[A-Z][a-z]+|[0-9]+/g)?.join(" ") || "";
 }
 
 export function limitString200ClickForMore(val: string) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/uiSocketObserver.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/uiSocketObserver.ts
@@ -1,6 +1,7 @@
 //on job edit page list for dom content changes
 import * as uiv from "uiv";
 import { getRundeckContext } from "../../library";
+import { UiMessage } from "../../library/stores/UIStore";
 import UiSocket from "../../library/components/utils/UiSocket.vue";
 import { initI18n, updateLocaleMessages } from "./i18n";
 import { createApp } from "vue";
@@ -36,9 +37,9 @@ export const observer = new MutationObserver(function (mutations_list) {
             },
           );
 
-          vue.provide("addUiMessages", async (messages) => {
+          vue.provide("addUiMessages", async (messages: UiMessage[]) => {
             const newMessages = messages.reduce(
-              (acc, message) => (message ? { ...acc, ...message } : acc),
+              (acc: Record<string, any>, message: UiMessage) => (message ? { ...acc, ...message } : acc),
               {},
             );
             const locale = getRundeckContext().locale || "en_US";

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/test/LogNodeChunk.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/test/LogNodeChunk.spec.ts
@@ -7,7 +7,7 @@ import { ExecutionOutputEntry } from "../../../stores/ExecutionOutput";
 jest.mock("vue-virtual-scroller", () => ({
   DynamicScroller: {
     name: "DynamicScroller",
-    render() {
+    render(this: { $slots: Record<string, Function | undefined> }) {
       return this.$slots.default
         ? this.$slots.default({
             item: {},
@@ -19,7 +19,7 @@ jest.mock("vue-virtual-scroller", () => ({
   },
   DynamicScrollerItem: {
     name: "DynamicScrollerItem",
-    render() {
+    render(this: { $slots: Record<string, Function | undefined> }) {
       return this.$slots.default ? this.$slots.default() : null;
     },
   },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/filter-list/FilterList.test.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/filter-list/FilterList.test.ts
@@ -76,7 +76,7 @@ describe("FilterList", () => {
 
     // Assert that the "item:selected" event is emitted with the correct payload
     expect(wrapper.emitted("item:selected")).toBeTruthy();
-    expect(wrapper.emitted("item:selected")[0]).toEqual([
+    expect(wrapper.emitted("item:selected")![0]).toEqual([
       { id: "apple", name: "Apple" },
     ]);
   });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/ChoosePluginModal.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/ChoosePluginModal.spec.ts
@@ -73,7 +73,7 @@ describe("ChoosePluginModal", () => {
   it('emits "selected" event with correct data when a provider button is clicked', async () => {
     const wrapper = await createWrapper();
     await wrapper.find('[data-test="provider-button"]').trigger("click");
-    expect(wrapper.emitted("selected")[0]).toEqual([
+    expect(wrapper.emitted("selected")![0]).toEqual([
       {
         provider: "provider1",
         service: "WorkflowStep",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/KeyStorageSelector.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/KeyStorageSelector.spec.ts
@@ -204,7 +204,7 @@ describe('KeyStorageSelector', () => {
     expect(keys.length).toBe(2)
     let found = keys.find((e) => e.text() === keyName)
     expect(found).not.toBeNull()
-    await found.trigger('click')
+    await found!.trigger('click')
     await wrapper.vm.$nextTick()
     await wrapper.find('[data-testid="overwrite-key-btn"]').trigger('click')
     const uploadModal = wrapper.get('#storageuploadkey')
@@ -255,14 +255,14 @@ describe('KeyStorageSelector', () => {
     expect(keys.length).toBe(2)
     let found = keys.find((e) => e.text() === keyName)
     expect(found).not.toBeNull()
-    await found.trigger('click')
+    await found!.trigger('click')
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.selectedKey).toBe(`/keys/${keyName}`)
     //click save button
     await wrapper.find('.modal-footer button.btn-primary').trigger('click')
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.emitted('update:modelValue')[0][0]).toBe(`/keys/${keyName}`)
+    expect(wrapper.emitted('update:modelValue')![0][0]).toBe(`/keys/${keyName}`)
 
   })
 })

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/PluginSearch.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/PluginSearch.spec.ts
@@ -56,7 +56,7 @@ describe("PluginSearch", () => {
         .trigger("click");
 
       expect(wrapper.emitted("search")).toHaveLength(1);
-      expect(wrapper.emitted("search")[0]).toEqual(["my-filter"]);
+      expect(wrapper.emitted("search")![0]).toEqual(["my-filter"]);
     });
 
     it("emits search event with typed filter when Enter is pressed", async () => {
@@ -70,7 +70,7 @@ describe("PluginSearch", () => {
         .trigger("keydown.enter");
 
       expect(wrapper.emitted("search")).toHaveLength(1);
-      expect(wrapper.emitted("search")[0]).toEqual(["enter-filter"]);
+      expect(wrapper.emitted("search")![0]).toEqual(["enter-filter"]);
     });
 
     it("emits search with empty string when no value entered", async () => {
@@ -81,7 +81,7 @@ describe("PluginSearch", () => {
         .trigger("click");
 
       expect(wrapper.emitted("search")).toHaveLength(1);
-      expect(wrapper.emitted("search")[0]).toEqual([""]);
+      expect(wrapper.emitted("search")![0]).toEqual([""]);
     });
 
     it("does not emit searching event when typing", async () => {
@@ -127,7 +127,7 @@ describe("PluginSearch", () => {
       await wrapper.vm.$nextTick();
 
       expect(wrapper.emitted("searching")).toBeTruthy();
-      expect(wrapper.emitted("searching")[0]).toEqual([true]);
+      expect(wrapper.emitted("searching")![0]).toEqual([true]);
 
       jest.useRealTimers();
     });
@@ -145,7 +145,7 @@ describe("PluginSearch", () => {
       await wrapper.vm.$nextTick();
 
       expect(wrapper.emitted("search")).toHaveLength(1);
-      expect(wrapper.emitted("search")[0]).toEqual(["debounced-filter"]);
+      expect(wrapper.emitted("search")![0]).toEqual(["debounced-filter"]);
 
       jest.useRealTimers();
     });
@@ -187,7 +187,7 @@ describe("PluginSearch", () => {
 
       // Only one search emitted for the final value
       expect(wrapper.emitted("search")).toHaveLength(1);
-      expect(wrapper.emitted("search")[0]).toEqual(["first"]);
+      expect(wrapper.emitted("search")![0]).toEqual(["first"]);
 
       jest.useRealTimers();
     });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/ProjectPicker.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/ProjectPicker.spec.ts
@@ -34,8 +34,8 @@ describe("ProjectPicker.vue", () => {
     expect(wrapper.emitted("update:modelValue")).toBeFalsy();
     const select = wrapper.find('[data-testid="project-select"]');
     await select.setValue("Project A");
-    expect(wrapper.emitted("update:modelValue")).toBeTruthy();
-    expect(wrapper.emitted("update:modelValue")[0][0]).toBe("Project A");
+    expect(wrapper.emitted("update:modelValue")!).toBeTruthy();
+    expect(wrapper.emitted("update:modelValue")![0][0]!).toBe("Project A");
   });
   it("renders only the default option when project list is empty", async () => {
     (client.projectList as jest.Mock).mockResolvedValueOnce([]);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginConfig.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginConfig.spec.ts
@@ -414,7 +414,7 @@ describe("PluginConfig", () => {
 
       const emitted = wrapper.emitted("update:modelValue");
       expect(emitted).toHaveLength(1);
-      expect((emitted[0][0] as any).config.enabled).toBe("true");
+      expect((emitted![0][0] as any).config.enabled).toBe("true");
     });
 
     it("emits the string 'false' in the config payload when a Boolean with a true default is set to false", async () => {
@@ -432,7 +432,7 @@ describe("PluginConfig", () => {
       await wrapper.vm.$nextTick();
 
       const emitted = wrapper.emitted("update:modelValue");
-      expect((emitted[emitted.length - 1][0] as any).config.enabled).toBe("false");
+      expect((emitted![emitted!.length - 1][0] as any).config.enabled).toBe("false");
     });
 
     it("emits the string 'false' in the config payload when a Boolean with no true default is explicitly set to false", async () => {
@@ -450,7 +450,7 @@ describe("PluginConfig", () => {
       await wrapper.vm.$nextTick();
 
       const emitted = wrapper.emitted("update:modelValue")!;
-      expect(emitted[emitted.length - 1][0]).toEqual(
+      expect(emitted![emitted.length - 1][0]).toEqual(
         expect.objectContaining({ config: expect.objectContaining({ enabled: "false" }) }),
       );
     });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/project-select/tests/ProjectSelect.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/widgets/project-select/tests/ProjectSelect.spec.ts
@@ -70,7 +70,7 @@ describe("ProjectSelect.vue", () => {
     };
   });
   afterAll(() => {
-    delete window._rundeck;
+    Reflect.deleteProperty(window, '_rundeck');
   });
   afterEach(() => {
     jest.clearAllMocks();
@@ -106,7 +106,7 @@ describe("ProjectSelect.vue", () => {
     await flushPromises();
     const emittedEvents = wrapper.emitted("update:selection");
     expect(emittedEvents).toBeTruthy();
-    expect(emittedEvents[0]).toEqual([["Project A"]]);
+    expect(emittedEvents![0]).toEqual([["Project A"]]);
   });
   it("navigates correctly when clicking 'View All' and 'Click Project' button", async () => {
     const wrapper = await createWrapper();

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/test/ExecutionOutput.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/test/ExecutionOutput.spec.ts
@@ -103,9 +103,9 @@ describe("ExecutionOutput", () => {
 
       // Filter by node
       const node1Entries = executionOutput.getEntriesFiltered("node1");
-      expect(node1Entries.length).toBe(2);
-      expect(node1Entries[0]).toBe(entry1);
-      expect(node1Entries[1]).toBe(entry3);
+      expect(node1Entries!.length).toBe(2);
+      expect(node1Entries![0]).toBe(entry1);
+      expect(node1Entries![1]).toBe(entry3);
     });
 
     it("should get filtered entries by node and step context", () => {

--- a/rundeckapp/grails-spa/packages/ui-trellis/tests/unit/ExecutionOutput.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/tests/unit/ExecutionOutput.spec.ts
@@ -6,7 +6,7 @@ import { api, apiClient } from "../../src/library/services/api";
 import { ExecutionOutputStore } from "../../src/library/stores/ExecutionOutput";
 
 import { observe } from "mobx";
-import { RundeckBrowser } from "@rundeck/client";
+import { RundeckBrowser, RundeckClient } from "@rundeck/client";
 import { RootStore } from "../../src/library/stores/RootStore";
 import { RundeckToken } from "../../src/library/interfaces/rundeckWindow";
 import { EventBus } from "../../src/library";
@@ -119,7 +119,7 @@ describe("ExecutionOutput Store", () => {
 
     const executionOutputStore = new ExecutionOutputStore(
       window._rundeck.rootStore,
-      null,
+      {} as RundeckClient,
     );
 
     const output = executionOutputStore.createOrGet("900");

--- a/rundeckapp/grails-spa/packages/ui-trellis/tsconfig.app.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/tsconfig.app.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "strict": false,
+    "strict": true,
     "jsx": "preserve",
     "importHelpers": true,
     "moduleResolution": "node",


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Enhancement / maintenance: enables TypeScript **strict** mode for the ui-trellis app build (`rundeckapp/grails-spa/packages/ui-trellis/tsconfig.app.json` sets `"strict": true`) and resolves the compiler errors that strict checking surfaces across production and test code.

**Describe the solution you've implemented**

- Set **`compilerOptions.strict`** to **`true`** in **`tsconfig.app.json`** for ui-trellis (the config used by `tsc -p ./tsconfig.app.json` in package scripts).
- Fixed strictness-related issues in a focused set of **~54 files** in ui-trellis (app entrypoints, pages, utilities, library tests/specs, Storybook render functions, etc.), addressing categories such as **TS7006**, **TS2532** / **TS18048** / nullability, **TS7016**, **TS2345**, **TS2769**, **TS2571**, **TS7005** / **TS7034**, **TS2304** / **TS18046**, **TS2322** / **TS18048** / **TS2769**, and related test-only errors—without intentional behavior changes.

**Describe alternatives you've considered**

- Leaving `strict: false` and fixing errors incrementally under a separate flag or project references: rejected in favor of turning strict on for the app tsconfig so the main app TypeScript check matches stricter standards.
- Broader refactors beyond what the compiler required: avoided; changes are minimal typing/assertions/imports needed for strict compliance.

**Additional context**

## Release Notes

- Developer-facing: ui-trellis app TypeScript checking now runs with **strict mode enabled** via `tsconfig.app.json`.