### PR TITLE
[RUN-4295] Put some code back that got lost with merge from main

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -80,6 +80,7 @@ import org.rundeck.app.data.model.v1.job.JobBrowseItem
 import org.rundeck.app.data.model.v1.job.workflow.WorkflowData
 import org.rundeck.app.data.providers.v1.execution.ReferencedExecutionDataProvider
 import org.rundeck.app.data.providers.v1.job.JobDataProvider
+import org.rundeck.app.data.workflow.WorkflowDataImpl
 import org.rundeck.app.spi.AuthorizedServicesProvider
 import org.rundeck.core.auth.AuthConstants
 import org.rundeck.core.auth.access.NotFound
@@ -810,7 +811,8 @@ if the step is a node step. Implicitly `"true"` if not present and not a job ste
             [AuthConstants.ACTION_READ],
             scheduledExecution.project
         )
-        def wfdata=scheduledExecutionService.getWorkflowDescriptionTree(scheduledExecution.project,scheduledExecution.workflow,readAuth,maxDepth)
+        def workflowData = scheduledExecution.getWorkflowData()
+        def wfdata=scheduledExecutionService.getWorkflowDescriptionTree(scheduledExecution.project,workflowData,readAuth,maxDepth)
         def controller = this
         withFormat {
             '*' {
@@ -819,7 +821,7 @@ if the step is a node step. Implicitly `"true"` if not present and not a job ste
                 }
             }
 
-            if (controller.isAllowXml()) {
+            if (controller.isAllowXml() && controller.rundeckJobDefinitionManager.validateJobForExport(scheduledExecution, "xml").isValid()) {
                 xml {
                     render(contentType: 'application/xml') {
                         workflow wfdata
@@ -2564,7 +2566,8 @@ Authorization required: `delete` on project resource type `job`, and `delete` on
         }
         def props=[:]
         props.putAll(execution.properties)
-        props.workflow=new Workflow(execution.workflow as WorkflowData)
+        def execWorkflowData = execution.getWorkflowData()
+        props.workflow=execWorkflowData ? WorkflowDataImpl.fromMap(execWorkflowData.toMap()) : new WorkflowDataImpl()
         if(params.failedNodes && 'true'==params.failedNodes){
             //replace the node filter with the failedNodeList from the execution
             props = props.findAll{!(it.key=~/^node(In|Ex)clude.*$/)}
@@ -2799,9 +2802,8 @@ Authorization required: `delete` on project resource type `job`, and `delete` on
             return [success:false,failed:true,error:'disabled',message:msg]
         }
 
-        if (scheduledExecution.workflow) {
-            params.workflow=new Workflow(scheduledExecution.workflow as WorkflowData)
-        }
+        def jobWorkflowData = scheduledExecution.getWorkflowData()
+        params.workflow=jobWorkflowData ? new WorkflowDataImpl().fromMap(jobWorkflowData.toMap()) : new WorkflowDataImpl()
         params.argString=scheduledExecution.argString
         params.doNodedispatch=scheduledExecution.doNodedispatch
         params.filter=scheduledExecution.asFilter()
@@ -2911,7 +2913,7 @@ Authorization required: `delete` on project resource type `job`, and `delete` on
                 newScheduledExecution.id=null
                 newScheduledExecution.uuid=null
                 //set session new workflow
-                WorkflowController.getSessionWorkflow(session,null,new Workflow(newScheduledExecution.workflow as WorkflowData))
+                WorkflowController.getSessionWorkflow(session,null, WorkflowDataImpl.fromMap(newScheduledExecution.getWorkflowData()?.toMap()))
                 if(newScheduledExecution.options){
                     def editopts = [:]
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -49,6 +49,7 @@ import org.rundeck.app.components.RundeckJobDefinitionManager
 import org.rundeck.app.components.jobs.ImportedJob
 import org.rundeck.app.components.jobs.JobDefinitionComponent
 import org.rundeck.app.components.jobs.stats.JobStatsProvider
+import org.rundeck.app.data.model.v1.job.workflow.WorkflowData
 import org.rundeck.app.data.providers.GormReferencedExecutionDataProvider
 import org.rundeck.app.data.providers.v1.execution.ReferencedExecutionDataProvider
 import org.rundeck.app.gui.UISection
@@ -4991,6 +4992,136 @@ class ScheduledExecutionControllerSpec extends Specification implements Controll
             [],
             _,
         ) >> [:]
+    }
+
+    /**
+     * Tests to verify that getWorkflowData() is called instead of accessing workflow property directly.
+     * Related to PR https://github.com/rundeck/rundeck/pull/10038
+     *
+     * Methods that call getWorkflowData():
+     * - apiJobWorkflow() - line 814 in ScheduledExecutionController.groovy (on ScheduledExecution) [TESTED]
+     * - _transientExecute() - line 2805 in ScheduledExecutionController.groovy (on ScheduledExecution) [NOT TESTED - private method]
+     * - createFromExecution() - line 2569 in ScheduledExecutionController.groovy (on Execution) [TESTED]
+     * - uploadPost() - line 2916 in ScheduledExecutionController.groovy (on ScheduledExecution) [NOT TESTED - complex form handling]
+     */
+    def "apiJobWorkflow method calls getWorkflowData instead of accessing workflow property directly"() {
+        given:
+        def se = new ScheduledExecution(
+            uuid: 'testUUID',
+            jobName: 'test1',
+            project: 'project1',
+            groupPath: 'testgroup'
+        )
+        se.setWorkflowData(new Workflow(
+                keepgoing: true,
+                commands: [
+                        new CommandExec([
+                                adhocRemoteString: 'test command',
+                                argString: '-test'
+                        ])
+                ]
+        ))
+
+        se.save()
+
+        // Track if getWorkflowData was called
+        def getWorkflowDataCalled = false
+        se.metaClass.getWorkflowData = {
+            getWorkflowDataCalled = true
+            delegate.deserializeWorkflowData(delegate.workflowJson)
+        }
+
+        controller.apiService = Mock(ApiService){
+            requireApi(_,_) >> true
+            requireApi(_,_, ApiVersions.V34) >> true
+        }
+
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor){
+            authorizeProjectJobAny(_,_,_,_) >> true
+            getAuthContextForSubjectAndProject(_,_) >> Mock(UserAndRolesAuthContext)
+        }
+
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService){
+            getByIDorUUID(_) >> se
+            getWorkflowDescriptionTree(_,{ WorkflowData d -> d != null },_,_) >> [:]
+        }
+
+        controller.frameworkService = Mock(FrameworkService){
+            isFrameworkProjectDisabled(_) >> false
+        }
+
+        when:
+        params.id = se.id.toString()
+        session.subject = new Subject()
+        controller.apiJobWorkflow()
+
+        then:
+        getWorkflowDataCalled == true
+    }
+
+    def "createFromExecution method calls getWorkflowData on Execution instead of accessing workflow property directly"() {
+        given:
+        ScheduledExecution.metaClass.static.withNewSession = {Closure c -> c.call() }
+
+        def se = new ScheduledExecution(
+            uuid: 'testUUID',
+            jobName: 'test1',
+            project: 'project1',
+            groupPath: 'testgroup'
+        )
+        se.setWorkflowData(new Workflow(
+            keepgoing: true,
+            commands: [
+                new CommandExec([
+                    adhocRemoteString: 'test command'
+                ])
+            ]
+        ))
+        se.save()
+
+        def exec = new Execution(
+            user: "testuser",
+            project: "project1",
+            loglevel: 'WARN',
+            status: 'SUCCEEDED',
+            scheduledExecution: se
+        )
+        exec.setWorkflowData(new Workflow(
+            commands: [
+                new CommandExec(adhocExecution: true, adhocRemoteString: 'a remote string')
+            ]
+        ))
+        exec.save()
+
+        // Track if getWorkflowData was called on the execution
+        def getWorkflowDataCalled = false
+        exec.metaClass.getWorkflowData = {
+            getWorkflowDataCalled = true
+            delegate.deserializeWorkflowData(delegate.workflowJson)
+        }
+
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor){
+            authorizeProjectResource(_,_,_,_) >> true
+            authorizeProjectExecutionAny(_,_,_) >> true
+            getAuthContextForSubjectAndProject(_,_) >> Mock(UserAndRolesAuthContext)
+        }
+
+        controller.frameworkService = Mock(FrameworkService){
+            getRundeckFramework() >> Mock(Framework)
+        }
+
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService){
+            prepareCreateEditJob(_,_,_,_) >> [:]
+        }
+
+        when:
+        params.executionId = exec.id.toString()
+        params.project = 'project1'
+        session.subject = new Subject()
+        controller.createFromExecution()
+
+        then:
+        getWorkflowDataCalled == true
     }
 
 }


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Pull request overview

This PR restores workflow-handling logic that was lost during a merge from `main`, aligning controller behavior with the newer JSON-backed workflow storage (`getWorkflowData`) and tightening XML export eligibility.
