### PR TITLE
[RUN-4282] Fix misleading execution cleanup message

### DIFF
--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -1909,6 +1909,7 @@ execution.history.cleanup.retention.days=Days to keep executions. Default: 60
 execution.history.cleanup.retention.minimum=Minimum executions to keep. Default: 50
 execution.history.cleanup.batch=Maximum size of the deletion. Default: 500
 execution.history.cleanup.schedule=Schedule clean history job (Cron expression). Default: 0 0 0 1/1 * ? * (Every days on 12:00 AM)
+project.execution.cleanup.default.enabled=Execution cleanup is now enabled for this project
 job.view.stats.label=Stats
 job.view.history.label=History
 run.with.debug.output=Run with Debug Output

--- a/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
+++ b/rundeckapp/grails-app/views/framework/_editProjectForm.gsp
@@ -100,7 +100,7 @@
     </div>
     <g:if test="${enableCleanHistory}">
         <div class="alert alert-info">
-            <i class="fas fa-info-circle"></i> <g:message code="project.execution.cleanup.default.enabled" default="Execution cleanup is enabled by default for new projects"/>
+            <i class="fas fa-info-circle"></i> <g:message code="project.execution.cleanup.default.enabled" default="Execution cleanup is now enabled for this project"/>
         </div>
     </g:if>
   </div>


### PR DESCRIPTION
## Summary
[RUN-4282](https://pagerduty.atlassian.net/browse/RUN-4282)
- Fixed misleading UI message that incorrectly implied execution cleanup is enabled by default for all new projects
- Changed message from "enabled by default for new projects" to "now enabled for this project"

## Changes
- Updated message text in `messages.properties` 
- Updated GSP template with corrected wording

## Test plan
- [x] All unit tests pass
- [ ] Manual verification: Enable cleanup in project settings and confirm message displays correctly
- [ ] Manual verification: Create new project and confirm cleanup respects feature flag
 

[RUN-4282]: https://pagerduty.atlassian.net/browse/RUN-4282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ