### PR TITLE
[RUN-4329] add feature flag for parallel bootstrap pro

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
@@ -42,7 +42,8 @@ public enum Features implements FeaturesDefinition{
     GUI_HIDE_ROI_INSTRUCTIONS("guiHideRoiInstructions"),
     EXECUTION_CLEANUP_ENABLE("defaultExecutionCleanup"),
     MULTILINE_JOB_OPTIONS("multilineJobOptions"),
-    EARLY_ACCESS_JOB_CONDITIONAL("earlyAccessJobConditional");
+    EARLY_ACCESS_JOB_CONDITIONAL("earlyAccessJobConditional"),
+    PARALLEL_PRO_BOOTSTRAP("parallelProBootstrap");
 
     private final String propertyName;
 


### PR DESCRIPTION
This pull request adds a new feature flag to the `Features` enum in the `Features.java` file. This change will allow the application to toggle the new "parallelProBootstrap" feature using feature flags.

Feature flag addition:

* Added `PARALLEL_PRO_BOOTSTRAP` to the `Features` enum to support toggling the "parallelProBootstrap" feature.