### PR TITLE
[RUN-4328] Bump Jetty to 12.0.33 for CVE-2026-2332 (CWE-444 request smuggling)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -47,7 +47,8 @@ seleniumJavaVersion=4.36.0
 spockVersion=2.3-groovy-4.0
 testContainersVersion=1.21.4
 # For verifyBuild script only - actual runtime versions managed by Spring Boot BOM
-jetty.version=12.0.32
+# CVE-2026-2332 (CWE-444 HTTP request smuggling) - jetty-http fixed in 12.0.33+
+jetty.version=12.0.33
 # Updated from 6.2.7 - fixes CVE-2025-22228 (SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-9486467) - Authentication Bypass in BCrypt. No breaking changes, API-compatible with 6.2.7
 spring-security.version=6.5.9
 log4j2.version=2.25.3


### PR DESCRIPTION
Bump Jetty to 12.0.33 for CVE-2026-2332 (CWE-444 request smuggling)