### PR TITLE
[RUN-4287] Fix conditional fields to accept data and global variables

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/EngineWorkflowExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/EngineWorkflowExecutor.java
@@ -577,7 +577,8 @@ public class EngineWorkflowExecutor extends BaseWorkflowExecutor {
                             stepRunTriggerState,
                             stepSkipTriggerState,
                             stepStartTriggerConditions,
-                            stepSkipTriggerConditions
+                            stepSkipTriggerConditions,
+                            profile
                     )
             );
         }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/WorkflowStrategyProfile.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/WorkflowStrategyProfile.java
@@ -1,6 +1,7 @@
 package com.dtolabs.rundeck.core.execution.workflow;
 
 import com.dtolabs.rundeck.core.rules.Condition;
+import com.dtolabs.rundeck.core.rules.MutableStateObj;
 import com.dtolabs.rundeck.core.rules.StateObj;
 
 import java.util.Set;
@@ -49,5 +50,21 @@ public interface WorkflowStrategyProfile {
             boolean isFirstStep
     );
 
+    /**
+     * Update conditional states for future steps after a step completes.
+     * This method is called after each step execution to evaluate conditionals for all
+     * subsequent steps that have conditional logic, using the updated SharedDataContext.
+     *
+     * @param completedStepNum  the step number that just completed
+     * @param sharedContext     shared data context containing data from all executed steps
+     * @param stateChanges      mutable state object to add conditional evaluation results to
+     */
+    default void updateConditionalStatesAfterStep(
+            int completedStepNum,
+            WFSharedContext sharedContext,
+            MutableStateObj stateChanges
+    ) {
+        // Default: no-op (no conditionals to update)
+    }
 
 }

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/engine/StepOperation.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/engine/StepOperation.java
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.core.execution.workflow.BaseWorkflowExecutor;
 import com.dtolabs.rundeck.core.execution.workflow.ControlBehavior;
 import com.dtolabs.rundeck.core.execution.workflow.EngineWorkflowExecutor;
 import com.dtolabs.rundeck.core.execution.workflow.WFSharedContext;
+import com.dtolabs.rundeck.core.execution.workflow.WorkflowStrategyProfile;
 import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutionResult;
 import com.dtolabs.rundeck.core.rules.*;
 import lombok.Getter;
@@ -39,6 +40,7 @@ public class StepOperation implements WorkflowSystem.Operation<WFSharedContext,O
     private StateObj skipTriggerState;
     @Getter private boolean didRun = false;
     @Getter private final String identity;
+    private final WorkflowStrategyProfile profile;
 
     public StepOperation(
             final int stepNum,
@@ -47,7 +49,8 @@ public class StepOperation implements WorkflowSystem.Operation<WFSharedContext,O
             final StateObj startTriggerState,
             final StateObj skipTriggerState,
             final Set<Condition> startTriggerConditions,
-            final Set<Condition> skipTriggerConditions
+            final Set<Condition> skipTriggerConditions,
+            final WorkflowStrategyProfile profile
     )
     {
         this.stepNum = stepNum;
@@ -58,6 +61,7 @@ public class StepOperation implements WorkflowSystem.Operation<WFSharedContext,O
         this.startTriggerConditions = startTriggerConditions;
         this.skipTriggerConditions = skipTriggerConditions;
         this.skipTriggerState = skipTriggerState;
+        this.profile = profile;
     }
 
     @Override
@@ -136,6 +140,13 @@ public class StepOperation implements WorkflowSystem.Operation<WFSharedContext,O
                         stepNum
                 ), statusString);
             }
+        }
+
+        // After step completes, evaluate conditionals for future steps
+        // Get the updated SharedDataContext from the step result
+        WFSharedContext updatedContext = stepResultCapture.getResultData();
+        if (updatedContext != null && profile != null) {
+            profile.updateConditionalStatesAfterStep(stepNum, updatedContext, stateChanges);
         }
 
         return new OperationCompleted(getIdentity(), stepNum, stateChanges, stepResultCapture, success);

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -3978,7 +3978,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                         return
                     }
                 }
-                newExecItem = executionUtilService.createExecutionItemForWorkflow(seWorkflowData, se.project, jitem.conditions)
+                newExecItem = executionUtilService.createExecutionItemForWorkflow(seWorkflowData, se.project)
 
                 try {
                     newContext = createJobReferenceContext(


### PR DESCRIPTION
## Jira Ticket

[RUN-4287](https://rundeckpro.atlassian.net/browse/RUN-4287)

## Summary

Fix variable replacement in conditional step plugin entries so that global variables (${export.*}) and data values (${data.*}) are properly replaced with their values during job execution.

## Changes

### Core Implementation
- **ConditionalEvaluator**: Updated to use SharedDataContext instead of DataContext for scope-aware variable expansion
- **Strategy Profiles**: Implemented hybrid evaluation approach with context accumulation:
  - Added `updatedSharedContext` field to accumulate context from all completed steps
  - Merge each completed step's context into accumulated context
  - Evaluate conditionals for ALL steps after each step completes
  - Use accumulated context for evaluations
- **ConditionalExecutionService**: Updated node step evaluation to use SharedDataContext

### OSS Core Changes (rundeck submodule)
- **WorkflowStrategyProfile**: Added `updateConditionalStatesAfterStep()` method
- **StepOperation**: Calls profile method after each step completes
- **EngineWorkflowExecutor**: Passes profile to StepOperation constructor
- **ExecutionService**: Removed conditions parameter from createExecutionItemForWorkflow

### Testing
- **Unit Tests**: Added 44 tests in ConditionalEvaluatorSpec covering:
  - ${export.*} global variables
  - ${data.*} from log filters
  - ${1:data.*} step-specific references
  - Nested patterns (verified NOT expanded)
  - Backward compatibility for ${option.*}, ${job.*}, ${node.*}
- **Functional Tests**: Added 2 end-to-end tests in ConditionalWorkflowProSpec:
  - Export variable test with key-value-data log filter
  - Data variable test with pattern-based log filter

## Technical Approach

The fix uses a hybrid evaluation approach:
1. Conditionals require state set BEFORE rules engine checks conditions
2. After each step completes, evaluate conditionals for future steps
3. Accumulate SharedDataContext across steps for complete data access
4. Update workflow state with evaluation results to trigger rules engine

This enables conditionals to access ${export.*} and ${data.*} from previous steps while working within the rules engine architecture.

[RUN-4287]: https://pagerduty.atlassian.net/browse/RUN-4287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ