### PR TITLE
[RUN-4203] Support brackets in PR title validation

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -28,4 +28,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.html_url }}
-      
+
+      - name: PR requires at least one ticket number before title
+        if: (github.event.action == 'edited' && github.event.changes.title) || contains(fromJSON('["opened", "reopened", "synchronize"]'), github.event.action)
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          if [[ ! "$TITLE" =~ ^(\[?RUN-[0-9]{3,6}\]?( \[?RUN-[0-9]{3,6}\]?)*):? ]]; then
+            echo "::error::PR title must start with ticket number(s) in format 'RUN-####:' or '[RUN-####]'. Multiple tickets can be separated by space (e.g., 'RUN-2921: Title', '[RUN-2921] Title', or 'RUN-2921 RUN-2922: Title')."
+            exit 1
+          fi
+          echo "::notice::PR title format is valid"
+

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -33,8 +33,9 @@ jobs:
         if: (github.event.action == 'edited' && github.event.changes.title) || contains(fromJSON('["opened", "reopened", "synchronize"]'), github.event.action)
         run: |
           TITLE="${{ github.event.pull_request.title }}"
-          if [[ ! "$TITLE" =~ ^(\[?RUN-[0-9]{3,6}\]?( \[?RUN-[0-9]{3,6}\]?)*):? ]]; then
-            echo "::error::PR title must start with ticket number(s) in format 'RUN-####:' or '[RUN-####]'. Multiple tickets can be separated by space (e.g., 'RUN-2921: Title', '[RUN-2921] Title', or 'RUN-2921 RUN-2922: Title')."
+          # Match either: RUN-###: Title OR [RUN-###] Title (balanced brackets, proper separators)
+          if [[ ! "$TITLE" =~ ^(RUN-[0-9]{3,6}( RUN-[0-9]{3,6})*:\ |\[RUN-[0-9]{3,6}\](\ \[RUN-[0-9]{3,6}\])*\ )[^[:space:]].* ]]; then
+            echo "::error::PR title must start with ticket number(s) followed by a separator and non-empty title. Accepted formats: 'RUN-####: Title' (colon+space required) or '[RUN-####] Title' (space required). Multiple tickets: 'RUN-123 RUN-456: Title' or '[RUN-123] [RUN-456] Title'."
             exit 1
           fi
           echo "::notice::PR title format is valid"

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,3 +1,5 @@
+# pull_request_target runs this workflow file from the base branch (e.g. main), not the PR
+# branch. Edits here only affect CI after they land on the default branch.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, milestoned, demilestoned, edited]
@@ -31,10 +33,12 @@ jobs:
 
       - name: PR requires at least one ticket number before title
         if: (github.event.action == 'edited' && github.event.changes.title) || contains(fromJSON('["opened", "reopened", "synchronize"]'), github.event.action)
+        env:
+          # Never interpolate the title into the script body (command injection via PR title).
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
           # Match: [RUN-###] Title (optional additional [RUN-###] tokens, space before title)
-          if [[ ! "$TITLE" =~ ^\[RUN-[0-9]{3,6}\](\ \[RUN-[0-9]{3,6}\])*\ [^[:space:]].* ]]; then
+          if [[ ! "$PR_TITLE" =~ ^\[RUN-[0-9]{3,6}\](\ \[RUN-[0-9]{3,6}\])*\ [^[:space:]].* ]]; then
             echo "::error::PR title must start with ticket number(s) in brackets, a space, then a non-empty title. Format: '[RUN-####] Title'. Multiple tickets: '[RUN-123] [RUN-456] Title'."
             exit 1
           fi

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -33,9 +33,9 @@ jobs:
         if: (github.event.action == 'edited' && github.event.changes.title) || contains(fromJSON('["opened", "reopened", "synchronize"]'), github.event.action)
         run: |
           TITLE="${{ github.event.pull_request.title }}"
-          # Match either: RUN-###: Title OR [RUN-###] Title (balanced brackets, proper separators)
-          if [[ ! "$TITLE" =~ ^(RUN-[0-9]{3,6}( RUN-[0-9]{3,6})*:\ |\[RUN-[0-9]{3,6}\](\ \[RUN-[0-9]{3,6}\])*\ )[^[:space:]].* ]]; then
-            echo "::error::PR title must start with ticket number(s) followed by a separator and non-empty title. Accepted formats: 'RUN-####: Title' (colon+space required) or '[RUN-####] Title' (space required). Multiple tickets: 'RUN-123 RUN-456: Title' or '[RUN-123] [RUN-456] Title'."
+          # Match: [RUN-###] Title (optional additional [RUN-###] tokens, space before title)
+          if [[ ! "$TITLE" =~ ^\[RUN-[0-9]{3,6}\](\ \[RUN-[0-9]{3,6}\])*\ [^[:space:]].* ]]; then
+            echo "::error::PR title must start with ticket number(s) in brackets, a space, then a non-empty title. Format: '[RUN-####] Title'. Multiple tickets: '[RUN-123] [RUN-456] Title'."
             exit 1
           fi
           echo "::notice::PR title format is valid"


### PR DESCRIPTION
## Jira Ticket

[RUN-4203](https://pagerduty.atlassian.net/browse/RUN-4203)

## Summary

Extends the PR Hygiene Check workflow (`.github/workflows/check-pr.yml`) with a title rule: pull requests targeting `main` must start with one or more bracketed Runbook Automation tickets in the form **`[RUN-####]`** (3–6 digits), then a space and a non-empty title. Examples: `[RUN-4203] Fix flaky test`, `[RUN-123] [RUN-456] Shared dependency bump`.

The legacy **`RUN-####:`** prefix is intentionally **not** accepted so titles stay aligned with tooling that opens PRs as `[RUN-####] …`.

## Why `pull_request_target` and when this runs

This job stays on **`pull_request_target`** so GitHub executes the workflow definition from the **default branch**, not from the head branch of a fork. That avoids a common abuse pattern where a public PR replaces workflow YAML to run malicious steps with repository token access.

A consequence is that **new or changed steps in this file only apply to CI after the change is merged to `main`**. Until then, the title check does not run on open PRs (there is no title step on `main` today).

## Security: PR title handling

Pull request titles are untrusted input (especially from forks). The workflow does **not** interpolate `${{ github.event.pull_request.title }}` into the shell script body, which would let shell metacharacters in the title become **command injection**. Instead the title is passed through a step **`env`** entry (`PR_TITLE`) and referenced as `"$PR_TITLE"` in bash, matching GitHub’s recommended pattern for untrusted workflow data ([Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable)).

## Accepted vs rejected examples

**Accepted**

- `[RUN-4203] Support brackets in PR title validation`
- `[RUN-123] [RUN-456] Two tickets in one change`

**Rejected**

- `RUN-4203: Colon-prefixed title` (old format)
- `[RUN-4203]` (missing descriptive title after the space)
- `No ticket prefix at all`

## When the check runs

The title step runs on `opened`, `reopened`, and `synchronize`, and when the PR is **`edited`** and the **title** field changed (so retitling a PR re-validates). Milestone logic is unchanged.


[RUN-4203]: https://pagerduty.atlassian.net/browse/RUN-4203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUN-4203]: https://pagerduty.atlassian.net/browse/RUN-4203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUN-123]: https://pagerduty.atlassian.net/browse/RUN-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUN-456]: https://pagerduty.atlassian.net/browse/RUN-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUN-4203]: https://pagerduty.atlassian.net/browse/RUN-4203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ