### PR TITLE
[RUN-3192] Execution log runner UI (i18n + badge settings)

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/command/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/command/main.ts
@@ -2,6 +2,7 @@ import { createApp } from "vue";
 
 import LogViewer from "../../../library/components/execution-log/logViewer.vue";
 import { RootStore } from "../../../library/stores/RootStore";
+import { initI18n, commonAddUiMessages } from "../../utilities/i18n";
 
 const eventBus = window._rundeck.eventBus;
 
@@ -21,6 +22,8 @@ eventBus.on("ko-adhoc-running", (data: any) => {
         ref="viewer"
     />
     `;
+
+  const i18n = initI18n();
 
   const vue = createApp(
     {
@@ -56,6 +59,10 @@ eventBus.on("ko-adhoc-running", (data: any) => {
         stats: false,
       },
     },
+  );
+  vue.use(i18n);
+  vue.provide("addUiMessages", async (messages) =>
+    commonAddUiMessages(i18n, messages),
   );
   vue.mount(elm);
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/main.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/main.js
@@ -7,7 +7,7 @@ import * as uiv from "uiv";
 import { getRundeckContext } from "../../../library";
 import LogViewer from "../../../library/components/execution-log/logViewer.vue";
 import "./nodeView";
-import { initI18n } from "../../utilities/i18n";
+import { initI18n, commonAddUiMessages } from "../../utilities/i18n";
 import loadJobStats from "../job/show/loadJobStats";
 
 const VIEWER_CLASS = "execution-log-viewer";
@@ -95,6 +95,9 @@ function mount(e) {
   vue.use(VueCookies);
   vue.use(uiv);
   vue.use(i18n);
+  vue.provide("addUiMessages", async (messages) =>
+    commonAddUiMessages(i18n, messages),
+  );
   vue.mount(e);
 
   /** Puts line number in url HASH */

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/nodeView.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/nodeView.ts
@@ -5,6 +5,7 @@ import { autorun } from "mobx";
 import LogViewer from "../../../library/components/execution-log/logViewer.vue";
 import { getRundeckContext } from "../../../library";
 import * as uiv from "uiv";
+import { initI18n, commonAddUiMessages } from "../../utilities/i18n";
 
 const rootStore = getRundeckContext().rootStore;
 
@@ -36,6 +37,8 @@ window._rundeck.eventBus.on("ko-exec-show-output", (nodeStep: any) => {
     />
     `;
 
+  const i18n = initI18n();
+
   const vue = createApp({
     name: "NodeLogViewerApp",
     components: { LogViewer },
@@ -56,6 +59,10 @@ window._rundeck.eventBus.on("ko-exec-show-output", (nodeStep: any) => {
     template: template,
   });
   vue.use(uiv);
+  vue.use(i18n);
+  vue.provide("addUiMessages", async (messages) =>
+    commonAddUiMessages(i18n, messages),
+  );
   vue.mount(elm);
 
   /** Update the KO code when this views output starts showing up */


### PR DESCRIPTION
## Jira Ticket

[RUN-3192](https://pagerduty.atlassian.net/browse/RUN-3192)

## Summary

Ensure the execution log **“Display Runner Badge”** checkbox label shows translated copy (not the raw key `ExecutionLogSettings.badge`), and that **toggling that setting** actually affects runner badges on log lines. This PR covers the **ui-trellis** side: LogViewer-mounted Vue apps must `provide('addUiMessages', …)` using `commonAddUiMessages`, matching other app entry points.

---

## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. LogViewer roots (`execution-show`, node output, adhoc command) mounted vue-i18n but did not provide `addUiMessages`, so any ui-socket widget that injects it (e.g. runner execution log plugins) received a non-function and could not merge locale messages. Paired with rundeckpro work for RUN-3192.

**Describe the solution you've implemented**

- After `vue.use(i18n)`, call `vue.provide('addUiMessages', (messages) => commonAddUiMessages(i18n, messages))` on:
  - `app/pages/execution-show/main.js`
  - `app/pages/execution-show/nodeView.ts`
  - `app/pages/command/main.ts`
- Uses the shared helper in `app/utilities/i18n.ts`, consistent with `navbar/main.ts`.

**Describe alternatives you've considered**

- Inlining the same `reduce` + `updateLocaleMessages` in each file (rejected; duplicates `commonAddUiMessages`).

**Additional context**

- Runner plugin changes live in rundeckpro; this PR is the upstream ui-trellis dependency.

## Release Notes

Execution log: provide `addUiMessages` on LogViewer app instances so embedded plugins can merge translations without runtime errors.


[RUN-3192]: https://pagerduty.atlassian.net/browse/RUN-3192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ