### PR TITLE
[RUN-4318] Prevent saving job when workflow step is in edit mode

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_createForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_createForm.gsp
@@ -62,8 +62,13 @@
                 <g:submitButton name="Create" value="${g.message(code: 'button.action.Create')}"
                                     class="btn btn-cta reset_page_confirm" />
 
-                <span data-bind="if: errorTabs().length" class="text-warning">
-                    <g:message code="job.editor.workflow.unsavedchanges.warning" />
+                <span class="vue-ui-socket">
+                  <ui-socket section="job-editor" location="workflow-edit-warning"
+                    socket-data="${enc(attr: g.message(code: 'job.editor.workflow.unsavedchanges.warning'))}">
+                    <span data-bind="if: errorTabs().length" class="text-warning">
+                      <g:message code="job.editor.workflow.unsavedchanges.warning" />
+                    </span>
+                  </ui-socket>
                 </span>
             </div>
             <div id="schedCreateSpinner" class="spinner block" style="display:none;">

--- a/rundeckapp/grails-app/views/scheduledExecution/_createForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_createForm.gsp
@@ -63,8 +63,7 @@
                                     class="btn btn-cta reset_page_confirm" />
 
                 <span class="vue-ui-socket">
-                  <ui-socket section="job-editor" location="workflow-edit-warning"
-                    socket-data="${enc(attr: g.message(code: 'job.editor.workflow.unsavedchanges.warning'))}">
+                  <ui-socket section="job-editor" location="workflow-edit-warning">
                     <span data-bind="if: errorTabs().length" class="text-warning">
                       <g:message code="job.editor.workflow.unsavedchanges.warning" />
                     </span>

--- a/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_edit.gsp
@@ -484,6 +484,16 @@ function getCurSEID(){
                  }
                  valid= false;
              }
+             
+             // Check Vue workflow editor state
+             if(window._workflowEditState && window._workflowEditState.isEditing && !wascancelled){
+                 jobeditor.addError('workflow');
+                 valid= false;
+             } else if(window._workflowEditState && !window._workflowEditState.isEditing){
+                 // Clear the error when not editing
+                 jobeditor.clearError('workflow');
+             }
+             
             var optedit= jQuery(form).find('div.optEditForm');
             if (optedit.length && !wascancelled) {
                 jobeditor.addError('option');

--- a/rundeckapp/grails-app/views/scheduledExecution/_editForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editForm.gsp
@@ -83,8 +83,13 @@
                       class="btn btn-default reset_page_confirm"
                       action="Cancel"/>
       <g:actionSubmit value="${g.message(code: 'button.action.Save')}" action="Update" class="btn btn-cta reset_page_confirm " id="jobUpdateSaveButton"/>
-        <span data-bind="if: inPageError()" class="text-warning">
-            <g:message code="job.editor.workflow.unsavedchanges.warning" />
+        <span class="vue-ui-socket">
+          <ui-socket section="job-editor" location="workflow-edit-warning"
+            socket-data="${enc(attr: g.message(code: 'job.editor.workflow.unsavedchanges.warning'))}">
+            <span data-bind="if: inPageError()" class="text-warning">
+              <g:message code="job.editor.workflow.unsavedchanges.warning" />
+            </span>
+          </ui-socket>
         </span>
     </div>
 

--- a/rundeckapp/grails-app/views/scheduledExecution/_editForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_editForm.gsp
@@ -84,8 +84,7 @@
                       action="Cancel"/>
       <g:actionSubmit value="${g.message(code: 'button.action.Save')}" action="Update" class="btn btn-cta reset_page_confirm " id="jobUpdateSaveButton"/>
         <span class="vue-ui-socket">
-          <ui-socket section="job-editor" location="workflow-edit-warning"
-            socket-data="${enc(attr: g.message(code: 'job.editor.workflow.unsavedchanges.warning'))}">
+          <ui-socket section="job-editor" location="workflow-edit-warning">
             <span data-bind="if: inPageError()" class="text-warning">
               <g:message code="job.editor.workflow.unsavedchanges.warning" />
             </span>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/WorkflowSteps.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/WorkflowSteps.vue
@@ -312,6 +312,9 @@ export default defineComponent({
     };
   },
   computed: {
+    isEditingStep(): boolean {
+      return !!(this.editStepModal || this.editJobRefModal);
+    },
     modalAttributes() {
       if (this.editStepModal) {
         return {
@@ -354,6 +357,10 @@ export default defineComponent({
         this.notify();
       },
       deep: true,
+    },
+    isEditingStep(val: boolean) {
+      window._workflowEditState = { isEditing: val, hasUnsavedChanges: val };
+      eventBus.emit("workflow-editing-state-changed", { isEditing: val });
     },
   },
   async mounted() {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/WorkflowSteps.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/WorkflowSteps.spec.ts
@@ -422,4 +422,72 @@ describe("WorkflowSteps", () => {
       );
     });
   });
+
+  describe("editing state", () => {
+    it("emits workflow-editing-state-changed with isEditing true when a step edit opens", async () => {
+      const mockEventBus = getRundeckContext().eventBus;
+      wrapper = await createWrapper({ commands: [] });
+
+      await wrapper.find('[data-testid="add-button"]').trigger("click");
+      const chooseModal = wrapper.findComponent(ChoosePluginModal);
+      chooseModal.vm.$emit("selected", { service: "a", provider: "b" });
+      await wrapper.vm.$nextTick();
+
+      expect(mockEventBus.emit).toHaveBeenCalledWith(
+        "workflow-editing-state-changed",
+        { isEditing: true },
+      );
+    });
+
+    it("sets window._workflowEditState.isEditing true when a step edit opens", async () => {
+      wrapper = await createWrapper({ commands: [] });
+
+      await wrapper.find('[data-testid="add-button"]').trigger("click");
+      const chooseModal = wrapper.findComponent(ChoosePluginModal);
+      chooseModal.vm.$emit("selected", { service: "a", provider: "b" });
+      await wrapper.vm.$nextTick();
+
+      expect((window as any)._workflowEditState).toEqual({
+        isEditing: true,
+        hasUnsavedChanges: true,
+      });
+    });
+
+    it("emits workflow-editing-state-changed with isEditing false when a step edit is cancelled", async () => {
+      const mockEventBus = getRundeckContext().eventBus;
+      wrapper = await createWrapper({ commands: [] });
+
+      await wrapper.find('[data-testid="add-button"]').trigger("click");
+      const chooseModal = wrapper.findComponent(ChoosePluginModal);
+      chooseModal.vm.$emit("selected", { service: "a", provider: "b" });
+      await wrapper.vm.$nextTick();
+
+      const editModal = wrapper.findComponent(EditPluginModal);
+      editModal.vm.$emit("cancel");
+      await wrapper.vm.$nextTick();
+
+      expect(mockEventBus.emit).toHaveBeenLastCalledWith(
+        "workflow-editing-state-changed",
+        { isEditing: false },
+      );
+    });
+
+    it("sets window._workflowEditState.isEditing false when a step edit is cancelled", async () => {
+      wrapper = await createWrapper({ commands: [] });
+
+      await wrapper.find('[data-testid="add-button"]').trigger("click");
+      const chooseModal = wrapper.findComponent(ChoosePluginModal);
+      chooseModal.vm.$emit("selected", { service: "a", provider: "b" });
+      await wrapper.vm.$nextTick();
+
+      const editModal = wrapper.findComponent(EditPluginModal);
+      editModal.vm.$emit("cancel");
+      await wrapper.vm.$nextTick();
+
+      expect((window as any)._workflowEditState).toEqual({
+        isEditing: false,
+        hasUnsavedChanges: false,
+      });
+    });
+  });
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/WorkflowEditWarning.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/WorkflowEditWarning.vue
@@ -1,0 +1,47 @@
+<template>
+  <span v-if="isEditing" class="text-warning">{{ message }}</span>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { getRundeckContext } from "@/library";
+
+export default defineComponent({
+  name: "WorkflowEditWarning",
+  props: {
+    itemData: {
+      type: [String, Object],
+      default: () => ({}),
+    },
+  },
+  data() {
+    return {
+      isEditing: false,
+    };
+  },
+  computed: {
+    message(): string {
+      const d = this.itemData as any;
+      if (typeof d === "string") return d;
+      return d?.message || "";
+    },
+  },
+  mounted() {
+    const ctx = getRundeckContext();
+    if (ctx?.eventBus) {
+      ctx.eventBus.on("workflow-editing-state-changed", this.onStateChange);
+    }
+  },
+  unmounted() {
+    const ctx = getRundeckContext();
+    if (ctx?.eventBus) {
+      ctx.eventBus.off("workflow-editing-state-changed", this.onStateChange);
+    }
+  },
+  methods: {
+    onStateChange({ isEditing }: { isEditing: boolean }) {
+      this.isEditing = isEditing;
+    },
+  },
+});
+</script>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/WorkflowEditWarning.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/WorkflowEditWarning.vue
@@ -1,42 +1,27 @@
 <template>
-  <span v-if="isEditing" class="text-warning">{{ message }}</span>
+  <span v-if="isEditing" data-testid="workflow-edit-warning" class="text-warning">
+    {{ $t('job.editor.workflow.unsavedchanges.warning') }}
+  </span>
 </template>
 
 <script lang="ts">
 import { defineComponent } from "vue";
 import { getRundeckContext } from "@/library";
 
+const eventBus = getRundeckContext().eventBus;
+
 export default defineComponent({
   name: "WorkflowEditWarning",
-  props: {
-    itemData: {
-      type: [String, Object],
-      default: () => ({}),
-    },
-  },
   data() {
     return {
       isEditing: false,
     };
   },
-  computed: {
-    message(): string {
-      const d = this.itemData as any;
-      if (typeof d === "string") return d;
-      return d?.message || "";
-    },
-  },
   mounted() {
-    const ctx = getRundeckContext();
-    if (ctx?.eventBus) {
-      ctx.eventBus.on("workflow-editing-state-changed", this.onStateChange);
-    }
+    eventBus.on("workflow-editing-state-changed", this.onStateChange);
   },
   unmounted() {
-    const ctx = getRundeckContext();
-    if (ctx?.eventBus) {
-      ctx.eventBus.off("workflow-editing-state-changed", this.onStateChange);
-    }
+    eventBus.off("workflow-editing-state-changed", this.onStateChange);
   },
   methods: {
     onStateChange({ isEditing }: { isEditing: boolean }) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/main.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/main.js
@@ -1,6 +1,6 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
-import { createApp, defineComponent, markRaw } from "vue";
+import { createApp, markRaw } from "vue";
 import { createPinia } from "pinia";
 import VueCookies from "vue-cookies";
 import * as uiv from "uiv";

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/main.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/main.js
@@ -149,14 +149,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
         section: "job-editor",
         location: "workflow-edit-warning",
         visible: true,
-        widget: markRaw(
-          defineComponent({
-            name: "WorkflowEditWarningWrapper",
-            components: { WorkflowEditWarning },
-            props: ["itemData"],
-            template: `<WorkflowEditWarning :item-data="itemData" />`,
-          }),
-        ),
+        widget: markRaw(WorkflowEditWarning),
       },
     ]);
   }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/main.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/main.js
@@ -1,6 +1,6 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
-import { createApp } from "vue";
+import { createApp, defineComponent, markRaw } from "vue";
 import { createPinia } from "pinia";
 import VueCookies from "vue-cookies";
 import * as uiv from "uiv";
@@ -18,6 +18,7 @@ import { loadJsonData } from "@/app/utilities/loadJsonData";
 import DetailsEditorSection from "@/app/pages/job/editor/DetailsEditorSection.vue";
 import ExecutionEditorSection from "./ExecutionEditorSection.vue";
 import WorkflowEditorSection from "@/app/pages/job/editor/WorkflowEditorSection.vue";
+import WorkflowEditWarning from "@/app/pages/job/editor/WorkflowEditWarning.vue";
 import "primeicons/primeicons.css";
 import HeaderSection from "@/app/pages/job/editor/HeaderSection.vue";
 import { configurePrimeVue } from "@/library/utilities/primeVueConfig";
@@ -138,5 +139,25 @@ window.addEventListener("DOMContentLoaded", (event) => {
   const elem = document.querySelector("#workflowContent .pflowlist.edit");
   if (elem) {
     observer.observe(elem, { subtree: true, childList: true });
+  }
+
+  // Register workflow-edit-warning UiSocket widget
+  const rootStore = getRundeckContext()?.rootStore;
+  if (rootStore) {
+    rootStore.ui.addItems([
+      {
+        section: "job-editor",
+        location: "workflow-edit-warning",
+        visible: true,
+        widget: markRaw(
+          defineComponent({
+            name: "WorkflowEditWarningWrapper",
+            components: { WorkflowEditWarning },
+            props: ["itemData"],
+            template: `<WorkflowEditWarning :item-data="itemData" />`,
+          }),
+        ),
+      },
+    ]);
   }
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/tests/WorkflowEditWarning.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/tests/WorkflowEditWarning.spec.ts
@@ -1,0 +1,92 @@
+import { mount } from "@vue/test-utils";
+import WorkflowEditWarning from "../WorkflowEditWarning.vue";
+import { getRundeckContext } from "../../../../../library";
+
+jest.mock("@/library", () => {
+  const mittLib = require("mitt");
+  const mittFn = mittLib.default || mittLib;
+  const bus = mittFn();
+  const eventBus = {
+    on: jest.fn(bus.on.bind(bus)),
+    off: jest.fn(bus.off.bind(bus)),
+    emit: jest.fn(bus.emit.bind(bus)),
+  };
+  return {
+    getRundeckContext: jest.fn(() => ({ eventBus })),
+  };
+});
+
+const createWrapper = async () => {
+  const wrapper = mount(WorkflowEditWarning);
+  await wrapper.vm.$nextTick();
+  return wrapper;
+};
+
+describe("WorkflowEditWarning", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("initial state", () => {
+    it("does not render the warning when mounted", async () => {
+      const wrapper = await createWrapper();
+
+      expect(wrapper.find('[data-testid="workflow-edit-warning"]').exists()).toBe(false);
+    });
+  });
+
+  describe("event bus integration", () => {
+    it("registers workflow-editing-state-changed listener on mount", async () => {
+      await createWrapper();
+
+      expect(getRundeckContext().eventBus.on).toHaveBeenCalledWith(
+        "workflow-editing-state-changed",
+        expect.any(Function),
+      );
+    });
+
+    it("unregisters the listener on unmount", async () => {
+      const wrapper = await createWrapper();
+      wrapper.unmount();
+
+      expect(getRundeckContext().eventBus.off).toHaveBeenCalledWith(
+        "workflow-editing-state-changed",
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe("warning visibility", () => {
+    it("shows the warning when workflow-editing-state-changed fires with isEditing true", async () => {
+      const wrapper = await createWrapper();
+
+      getRundeckContext().eventBus.emit("workflow-editing-state-changed", { isEditing: true });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="workflow-edit-warning"]').exists()).toBe(true);
+    });
+
+    it("hides the warning after isEditing transitions back to false", async () => {
+      const wrapper = await createWrapper();
+
+      getRundeckContext().eventBus.emit("workflow-editing-state-changed", { isEditing: true });
+      await wrapper.vm.$nextTick();
+
+      getRundeckContext().eventBus.emit("workflow-editing-state-changed", { isEditing: false });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="workflow-edit-warning"]').exists()).toBe(false);
+    });
+
+    it("renders the i18n warning message key when visible", async () => {
+      const wrapper = await createWrapper();
+
+      getRundeckContext().eventBus.emit("workflow-editing-state-changed", { isEditing: true });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="workflow-edit-warning"]').text()).toBe(
+        "job.editor.workflow.unsavedchanges.warning",
+      );
+    });
+  });
+});

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -955,6 +955,8 @@ const messages = {
   "scheduledExecution.jobName.label": "Job Name",
   "scheduledExecution.property.description.label": "Description",
   "job.editor.preview.runbook": "Preview Readme",
+  "job.editor.workflow.unsavedchanges.warning":
+    "Some changes to the workflow have not been completed.",
   "choose.action.label": "Choose",
   "scheduledExecution.property.description.plain.description":
     "The description will be shown in plain text",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/window.d.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/window.d.ts
@@ -7,5 +7,9 @@ declare global {
     _rundeck: RundeckContext;
     appLinks: AppLinks;
     ProWebhookComponents: Component[];
+    _workflowEditState: {
+      isEditing: boolean;
+      hasUnsavedChanges: boolean;
+    };
   }
 }


### PR DESCRIPTION
## Jira Ticket

[RUN-4318](https://pagerduty.atlassian.net/browse/RUN-4318)

## Summary

Restore the functionality from the old GSP/JavaScript workflow editor that prevents users from saving a job while a workflow step is actively being edited, preventing unsaved step changes from being lost.

## Changes

- **_edit.gsp**: Updated `validateJobEditForm()` to check `window._workflowEditState.isEditing` and clear errors when not editing
- **_editForm.gsp / _createForm.gsp**: Added ui-socket mount point for `WorkflowEditWarning` component
- **WorkflowEditWarning.vue**: New Vue component that listens to event bus and displays warning message
- **main.js**: Registered `WorkflowEditWarning` component for ui-socket
- **WorkflowSteps.vue**: Added watcher to update global state
- **en_US.js**: Added i18n key for warning message
- **Tests**: Added comprehensive test coverage for warning component and state management

## Implementation

This is part of a two-repo change:
- **Rundeck Core** (this PR): Form validation, warning component, ui-socket integration

Together, these changes restore the UX validation that was lost during the Vue conversion.

## Test Plan

- [ ] Edit a workflow step
- [ ] Try to save job - should be prevented with warning message
- [ ] Save/cancel the step
- [ ] Warning should disappear
- [ ] Try to save job - should succeed
- [ ] Test with conditional steps and nested steps
- [ ] Verify backwards compatibility with Knockout.js workflow editor


Made with [Cursor](https://cursor.com)

[RUN-4318]: https://pagerduty.atlassian.net/browse/RUN-4318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ