### PR TITLE
[RUN-4273] EA job conditional: inline script editor cursor / font CSS

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/BaseStepCard.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/BaseStepCard.vue
@@ -100,12 +100,6 @@ export default defineComponent({
   border-radius: var(--radii-md);
   border: 1px solid var(--colors-gray-300-original);
 
-  p,
-  a,
-  span:not(.glyphicon, .fa, .pi, .ace_identifier) {
-    font-family: Inter, var(--fonts-body2) !important;
-  }
-
   .p-card-body {
     padding: var(--sizes-4);
   }


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. When `rundeck.feature.earlyAccessJobConditional.enabled=true`, the inline script Ace editor caret appears in the wrong horizontal position. Fixes RUN-4273.

**Describe the solution you've implemented**

Removed an overly broad CSS rule from `BaseStepCard.vue` that applied `font-family: Inter !important` to all `p`, `a`, and `span:not(.glyphicon, .fa, .pi, .ace_identifier)` elements inside `.baseStepCard`. Ace relies on monospace character-width measurements to position the cursor; overriding the font with a proportional typeface (Inter) breaks those measurements. The exclusion list only covered `.ace_identifier` — other token classes (`.ace_keyword`, `.ace_string`, `.ace_operator`, etc.) were still affected.

**Describe alternatives you've considered**

- Extending the `:not()` exclusion list to cover all Ace span classes — fragile and incomplete.
- Adding a font-family reset inside `AceEditorVue.vue` — treats the symptom rather than the cause.

**Additional context**

Inter font for card chrome elements (headers, labels) is already applied via targeted rules in `StepCardHeader.vue` and `ConfigSection.vue`, so removing the catch-all has no visual impact on non-editor content.

Jira: [RUN-4273](https://pagerduty.atlassian.net/browse/RUN-4273)

## Release Notes

Fixed inline script editor cursor misalignment when the early-access job conditional workflow feature is enabled.

[RUN-4273]: https://pagerduty.atlassian.net/browse/RUN-4273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ