### PR TITLE
[RUN-4346] Fix: test packaging failure 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "packaging/packaging"]
 	path = packaging/packaging
 	url = git@github.com:rundeck/packaging.git
-	branch = main
+	branch = maint-5.x


### PR DESCRIPTION
https://pagerduty.atlassian.net/browse/RUN-4346

## Problem

Backport PRs in `rundeckpro` targeting `maint-5.x` were failing the packaging CI test with:

**deb:**
```
dpkg: dependency problems prevent configuration of rundeckpro-enterprise:
 rundeckpro-enterprise depends on java17-runtime-headless | java17-runtime
```

**rpm:**
```
error: Failed dependencies:
        java-17-headless is needed by rundeck-0:5.21.0~SNAPSHOT-1.noarch
```

## Root Cause

The `.gitmodules` in `maint-5.x` had the `packaging/packaging` submodule pointing to `branch = main` of `rundeck/packaging`. When `packaging_setup` runs `git submodule update --remote`, it pulls the `main` branch of `rundeck/packaging`, which produces packages that require **only Java 17**.

However, `maint-5.x` still runs on **Java 11** (`JAVA_HOME: /usr/lib/jvm/zulu11`), and the packaging test Docker images only have Java 11 installed — causing the install to fail.

## Fix

Changed `.gitmodules` to point the `packaging/packaging` submodule to `branch = maint-5.x` of `rundeck/packaging`.

The `maint-5.x` branch of `rundeck/packaging` produces packages that accept `java11-runtime-headless OR java17-runtime-headless`, which correctly matches the `maint-5.x` runtime and allows the packaging test Docker images (Java 11) to pass.