### PR TITLE
[RUN-4324] fix test jdk25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,12 +203,6 @@ commands:
           step-name: Install Java JDK
           command: dependencies_install_zulu17jdk
 
-  install-java-jdk-25:
-    description: Install JDK 25 for host-side tests (BASH_ENV JAVA_HOME)
-    steps:
-      - run-build-step:
-          step-name: Install Java JDK 25
-          command: dependencies_install_zulu25jdk
 
   ## Dependency groups
 
@@ -244,13 +238,6 @@ commands:
           step-name: Install TestDeck Dependencies
           command: dependencies_testdeck_setup
 
-  install-testdeck-dependencies-jdk25:
-    description: JDK 25 on host + TestDeck extras (orchestration only; app still in Docker)
-    steps:
-      - install-java-jdk-25
-      - run-build-step:
-          step-name: Install TestDeck Dependencies
-          command: dependencies_testdeck_setup
 
 
 #### Job Definitions ####
@@ -277,6 +264,10 @@ jobs:
       jreVersion:
         type: string
         default: "openjdk-17-jre-headless"
+      jre25Publish:
+        description: Also build and push a Docker image with JRE 25
+        type: boolean
+        default: false
     steps:
       - setup_docker:
           docker_layer_caching: true
@@ -290,7 +281,15 @@ jobs:
           step-name: Build And Push Docker Images
           command: |
             rundeck_docker_build << parameters.jreVersion >>
-            rundeck_docker_push
+            rundeck_docker_push << parameters.jreVersion >>
+      - when:
+          condition: << parameters.jre25Publish >>
+          steps:
+            - run-build-step:
+                step-name: Build And Push Docker Images (JRE 25)
+                command: |
+                  rundeck_docker_build openjdk-25-jre-headless
+                  rundeck_docker_push openjdk-25-jre-headless
       - run-build-step:
           step-name: Verify Build
           command: rundeck_verify_build
@@ -599,16 +598,7 @@ jobs:
     steps:
       - setup_docker
       - checkout
-      - when:
-          condition:
-            equal: [ "25", << parameters.host_jdk_for_tests >> ]
-          steps:
-            - install-testdeck-dependencies-jdk25
-      - when:
-          condition:
-            equal: [ "17", << parameters.host_jdk_for_tests >> ]
-          steps:
-            - install-testdeck-dependencies
+      - install-testdeck-dependencies
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
@@ -634,23 +624,13 @@ jobs:
         description: Command that will execute the docker tests
         type: string
       host_jdk_for_tests:
-        description: JDK on the CI host (Docker image still uses JRE from build job)
+        description: JDK version for selecting the Docker test image
         type: enum
         enum: [ "17", "25" ]
         default: "17"
     steps:
-
       - checkout
-      - when:
-          condition:
-            equal: [ "25", << parameters.host_jdk_for_tests >> ]
-          steps:
-            - install-testdeck-dependencies-jdk25
-      - when:
-          condition:
-            equal: [ "17", << parameters.host_jdk_for_tests >> ]
-          steps:
-            - install-testdeck-dependencies
+      - install-testdeck-dependencies
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
@@ -691,23 +671,12 @@ jobs:
     steps:
       - checkout
       - restore-build-cache
-      - when:
-          condition:
-            equal: [ "25", << parameters.host_jdk_for_tests >> ]
-          steps:
-            - run-build-step:
-                step-name: Install Java JDK 25 (host Gradle)
-                command: dependencies_install_zulu25jdk
-      - when:
-          condition:
-            equal: [ "17", << parameters.host_jdk_for_tests >> ]
-          steps:
-            - install-base-dependencies
+      - install-base-dependencies
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
           step-name: Pull images
-          command: rundeck_pull_image
+          command: rundeck_pull_image << parameters.host_jdk_for_tests >>
       - run-build-step:
           step-name: Runs gradle test task << parameters.gradle-task >>
           command: |
@@ -839,6 +808,7 @@ workflows:
       # Stage 1: Build
       - build-rundeck:
           name: Build
+          jre25Publish: true
           <<: *cloudsmith-slack-defaults
 
       # Step 1: Unit tests run in parallel with Build (no gates for fast feedback)
@@ -1004,6 +974,7 @@ workflows:
       - build-rundeck:
           name: Build with Docker image using JRE 17
           jreVersion: "openjdk-17-jre-headless"
+          jre25Publish: true
       - test-docker:
           name: T Integration SSL (host JDK 25, image JRE 17)
           command: bash test/run-docker-ssl-tests.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -913,6 +913,67 @@ workflows:
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/alphaUi/**/*{.groovy,.java}"
           <<: *require-api-integration
           <<: *slack-defaults
+      - test-gradle-functional:
+          name: T Selenium - Auth & Login (host JDK 25)
+          gradle-task: seleniumCoreTest
+          resource_class: xlarge
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/{login,ldap,execution/ExecutionShowAuthSpec,jobs/ActivitySectionAuthSpec,appadmin/AccessControlSpec}/**/*{.groovy,.java}"
+          host_jdk_for_tests: "25"
+          <<: *require-build-jre-17
+      - test-gradle-functional:
+          name: T Selenium - Projects (host JDK 25)
+          gradle-task: seleniumCoreTest
+          resource_class: xlarge
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/**/*{.groovy,.java}"
+          host_jdk_for_tests: "25"
+          <<: *require-build-jre-17
+      - test-gradle-functional:
+          name: T Selenium - Jobs Core (host JDK 25)
+          gradle-task: seleniumCoreTest
+          resource_class: xlarge
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/{BasicJobsSpec,JobsSpec,JobEditSpec,JobDeleteSpec,JobSummarySpec,JobTabsSpec}.groovy"
+          host_jdk_for_tests: "25"
+          <<: *require-build-jre-17
+      - test-gradle-functional:
+          name: T Selenium - Jobs Advanced (host JDK 25)
+          gradle-task: seleniumCoreTest
+          resource_class: xlarge
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/{DuplicateJobSpec,JobReferenceSpec,ScheduledJobSpec,JobNotificationSpec,BulkJobActionsSpec,ExportImportSpec,DuplicateOptionsSpec,ExpandedJobGroupsSpec,JobActivityHistorySpec,JobAuditApiSpec,LogFilterSpec,LogViewerOutputSpec,steps}/**/*{.groovy,.java}"
+          host_jdk_for_tests: "25"
+          <<: *require-build-jre-17
+      - test-gradle-functional:
+          name: T Selenium - Execution & Other (host JDK 25)
+          gradle-task: seleniumCoreTest
+          resource_class: xlarge
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/{execution,nodes,activity,navigation,profile,appadmin/KeyStorageSpec,scm,webhook,users}/**/*{.groovy,.java}"
+          host_jdk_for_tests: "25"
+          <<: *require-build-jre-17
+      - test-gradle-functional:
+          name: T Functional API (host JDK 25)
+          gradle-task: apiTest
+          resource_class: xlarge
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/**/*{.groovy,.java}"
+          parallelism: 3
+          host_jdk_for_tests: "25"
+          <<: *require-build-jre-17
+      - test-gradle-functional:
+          name: T Functional Plugin Blocklist (host JDK 25)
+          gradle-task: pluginBlocklistTest
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/integration/**/*{.groovy,.java}"
+          host_jdk_for_tests: "25"
+          <<: *require-build-jre-17
+      - test-gradle-functional:
+          name: T Feature NodeExecutorSecureInput (host JDK 25)
+          gradle-task: apiTestNodeExecutorSecureInput
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/input/*.groovy"
+          host_jdk_for_tests: "25"
+          <<: *require-build-jre-17
+      - test-gradle-functional:
+          name: T Selenium Alpha UI (host JDK 25)
+          gradle-task: alphaUiSeleniumCoreTest
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/alphaUi/**/*{.groovy,.java}"
+          host_jdk_for_tests: "25"
+          <<: *require-build-jre-17
 
       # Row 4: Packaging, security scans, validation, and enterprise trigger
       # Nothing here matters if build and tests don't pass. Enterprise Snapshot only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -919,35 +919,35 @@ workflows:
           resource_class: xlarge
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/{login,ldap,execution/ExecutionShowAuthSpec,jobs/ActivitySectionAuthSpec,appadmin/AccessControlSpec}/**/*{.groovy,.java}"
           host_jdk_for_tests: "25"
-          <<: *require-build-jre-17
+          <<: *require-api-integration
       - test-gradle-functional:
           name: T Selenium - Projects (host JDK 25)
           gradle-task: seleniumCoreTest
           resource_class: xlarge
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/**/*{.groovy,.java}"
           host_jdk_for_tests: "25"
-          <<: *require-build-jre-17
+          <<: *require-api-integration
       - test-gradle-functional:
           name: T Selenium - Jobs Core (host JDK 25)
           gradle-task: seleniumCoreTest
           resource_class: xlarge
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/{BasicJobsSpec,JobsSpec,JobEditSpec,JobDeleteSpec,JobSummarySpec,JobTabsSpec}.groovy"
           host_jdk_for_tests: "25"
-          <<: *require-build-jre-17
+          <<: *require-api-integration
       - test-gradle-functional:
           name: T Selenium - Jobs Advanced (host JDK 25)
           gradle-task: seleniumCoreTest
           resource_class: xlarge
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/{DuplicateJobSpec,JobReferenceSpec,ScheduledJobSpec,JobNotificationSpec,BulkJobActionsSpec,ExportImportSpec,DuplicateOptionsSpec,ExpandedJobGroupsSpec,JobActivityHistorySpec,JobAuditApiSpec,LogFilterSpec,LogViewerOutputSpec,steps}/**/*{.groovy,.java}"
           host_jdk_for_tests: "25"
-          <<: *require-build-jre-17
+          <<: *require-api-integration
       - test-gradle-functional:
           name: T Selenium - Execution & Other (host JDK 25)
           gradle-task: seleniumCoreTest
           resource_class: xlarge
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/{execution,nodes,activity,navigation,profile,appadmin/KeyStorageSpec,scm,webhook,users}/**/*{.groovy,.java}"
           host_jdk_for_tests: "25"
-          <<: *require-build-jre-17
+          <<: *require-api-integration
       - test-gradle-functional:
           name: T Functional API (host JDK 25)
           gradle-task: apiTest
@@ -955,25 +955,25 @@ workflows:
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/**/*{.groovy,.java}"
           parallelism: 3
           host_jdk_for_tests: "25"
-          <<: *require-build-jre-17
+          <<: *require-api-integration
       - test-gradle-functional:
           name: T Functional Plugin Blocklist (host JDK 25)
           gradle-task: pluginBlocklistTest
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/integration/**/*{.groovy,.java}"
           host_jdk_for_tests: "25"
-          <<: *require-build-jre-17
+          <<: *require-api-integration
       - test-gradle-functional:
           name: T Feature NodeExecutorSecureInput (host JDK 25)
           gradle-task: apiTestNodeExecutorSecureInput
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/input/*.groovy"
           host_jdk_for_tests: "25"
-          <<: *require-build-jre-17
+          <<: *require-api-integration
       - test-gradle-functional:
           name: T Selenium Alpha UI (host JDK 25)
           gradle-task: alphaUiSeleniumCoreTest
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/alphaUi/**/*{.groovy,.java}"
           host_jdk_for_tests: "25"
-          <<: *require-build-jre-17
+          <<: *require-api-integration
 
       # Row 4: Packaging, security scans, validation, and enterprise trigger
       # Nothing here matters if build and tests don't pass. Enterprise Snapshot only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,12 @@ commands:
           step-name: Install Java JDK
           command: dependencies_install_zulu17jdk
 
+  install-java-jdk-25:
+    description: Install JDK 25 for host-side tests (BASH_ENV JAVA_HOME)
+    steps:
+      - run-build-step:
+          step-name: Install Java JDK 25
+          command: dependencies_install_zulu25jdk
 
   ## Dependency groups
 
@@ -238,7 +244,13 @@ commands:
           step-name: Install TestDeck Dependencies
           command: dependencies_testdeck_setup
 
-
+  install-testdeck-dependencies-jdk25:
+    description: JDK 25 on host + TestDeck extras (orchestration only; app still in Docker)
+    steps:
+      - install-java-jdk-25
+      - run-build-step:
+          step-name: Install TestDeck Dependencies
+          command: dependencies_testdeck_setup
 
 #### Job Definitions ####
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -598,7 +598,16 @@ jobs:
     steps:
       - setup_docker
       - checkout
-      - install-testdeck-dependencies
+      - when:
+          condition:
+            equal: [ "25", << parameters.host_jdk_for_tests >> ]
+          steps:
+            - install-testdeck-dependencies-jdk25
+      - when:
+          condition:
+            equal: [ "17", << parameters.host_jdk_for_tests >> ]
+          steps:
+            - install-testdeck-dependencies
       - attach_workspace:
           at: ~/workspace
       - run-build-step:
@@ -913,67 +922,6 @@ workflows:
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/alphaUi/**/*{.groovy,.java}"
           <<: *require-api-integration
           <<: *slack-defaults
-      - test-gradle-functional:
-          name: T Selenium - Auth & Login (host JDK 25)
-          gradle-task: seleniumCoreTest
-          resource_class: xlarge
-          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/{login,ldap,execution/ExecutionShowAuthSpec,jobs/ActivitySectionAuthSpec,appadmin/AccessControlSpec}/**/*{.groovy,.java}"
-          host_jdk_for_tests: "25"
-          <<: *require-api-integration
-      - test-gradle-functional:
-          name: T Selenium - Projects (host JDK 25)
-          gradle-task: seleniumCoreTest
-          resource_class: xlarge
-          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/**/*{.groovy,.java}"
-          host_jdk_for_tests: "25"
-          <<: *require-api-integration
-      - test-gradle-functional:
-          name: T Selenium - Jobs Core (host JDK 25)
-          gradle-task: seleniumCoreTest
-          resource_class: xlarge
-          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/{BasicJobsSpec,JobsSpec,JobEditSpec,JobDeleteSpec,JobSummarySpec,JobTabsSpec}.groovy"
-          host_jdk_for_tests: "25"
-          <<: *require-api-integration
-      - test-gradle-functional:
-          name: T Selenium - Jobs Advanced (host JDK 25)
-          gradle-task: seleniumCoreTest
-          resource_class: xlarge
-          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/{DuplicateJobSpec,JobReferenceSpec,ScheduledJobSpec,JobNotificationSpec,BulkJobActionsSpec,ExportImportSpec,DuplicateOptionsSpec,ExpandedJobGroupsSpec,JobActivityHistorySpec,JobAuditApiSpec,LogFilterSpec,LogViewerOutputSpec,steps}/**/*{.groovy,.java}"
-          host_jdk_for_tests: "25"
-          <<: *require-api-integration
-      - test-gradle-functional:
-          name: T Selenium - Execution & Other (host JDK 25)
-          gradle-task: seleniumCoreTest
-          resource_class: xlarge
-          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/{execution,nodes,activity,navigation,profile,appadmin/KeyStorageSpec,scm,webhook,users}/**/*{.groovy,.java}"
-          host_jdk_for_tests: "25"
-          <<: *require-api-integration
-      - test-gradle-functional:
-          name: T Functional API (host JDK 25)
-          gradle-task: apiTest
-          resource_class: xlarge
-          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/**/*{.groovy,.java}"
-          parallelism: 3
-          host_jdk_for_tests: "25"
-          <<: *require-api-integration
-      - test-gradle-functional:
-          name: T Functional Plugin Blocklist (host JDK 25)
-          gradle-task: pluginBlocklistTest
-          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/integration/**/*{.groovy,.java}"
-          host_jdk_for_tests: "25"
-          <<: *require-api-integration
-      - test-gradle-functional:
-          name: T Feature NodeExecutorSecureInput (host JDK 25)
-          gradle-task: apiTestNodeExecutorSecureInput
-          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/input/*.groovy"
-          host_jdk_for_tests: "25"
-          <<: *require-api-integration
-      - test-gradle-functional:
-          name: T Selenium Alpha UI (host JDK 25)
-          gradle-task: alphaUiSeleniumCoreTest
-          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/alphaUi/**/*{.groovy,.java}"
-          host_jdk_for_tests: "25"
-          <<: *require-api-integration
 
       # Row 4: Packaging, security scans, validation, and enterprise trigger
       # Nothing here matters if build and tests don't pass. Enterprise Snapshot only

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -71,6 +71,7 @@ tasks.register('officialBuild') {
         def args = [
             "docker",
             "build",
+            "--no-cache",
             "--platform=${findProperty('dockerPlatform') ?: System.getenv('DOCKER_DEFAULT_PLATFORM') ?: 'linux/amd64'}",
             "--label=com.rundeck.version=$resolvedVersion",
             "--label=com.rundeck.commit=$commit"
@@ -113,7 +114,7 @@ tasks.register('buildUbuntuBase') {
     doLast {
         exec {
             workingDir "./ubuntu-base"
-            commandLine "docker", "build", "--build-arg", "JRE_VERSION=$jreVersion", "-t=rundeck/ubuntu-base", "."
+            commandLine "docker", "build", "--no-cache", "--build-arg", "JRE_VERSION=$jreVersion", "-t=rundeck/ubuntu-base", "."
         }
     }
 }

--- a/gradle/java-version.gradle
+++ b/gradle/java-version.gradle
@@ -1,3 +1,3 @@
 apply plugin: 'java'
 sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_25

--- a/gradle/java-version.gradle
+++ b/gradle/java-version.gradle
@@ -1,3 +1,3 @@
 apply plugin: 'java'
 sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_25
+targetCompatibility = JavaVersion.VERSION_17

--- a/scripts/circleci/build-functions.sh
+++ b/scripts/circleci/build-functions.sh
@@ -41,7 +41,7 @@ rundeck_docker_build() {
     fi
 
     #Build image
-    ./gradlew ${GRADLE_BASE_OPTS} officialBuild -Penvironment=${ENV} -PdockerRepository=${DOCKER_REPO} -PdockerTags=latest,SNAPSHOT -PjreVersion=${jreVersion}
+    ./gradlew ${GRADLE_BASE_OPTS} cleanOfficialBuild officialBuild -Penvironment=${ENV} -PdockerRepository=${DOCKER_REPO} -PdockerTags=latest,SNAPSHOT -PjreVersion=${jreVersion}
 
     # Append -j25 suffix to tags when JRE version contains 25
     local TAG_SUFFIX=""

--- a/scripts/circleci/build-functions.sh
+++ b/scripts/circleci/build-functions.sh
@@ -43,24 +43,36 @@ rundeck_docker_build() {
     #Build image
     ./gradlew ${GRADLE_BASE_OPTS} officialBuild -Penvironment=${ENV} -PdockerRepository=${DOCKER_REPO} -PdockerTags=latest,SNAPSHOT -PjreVersion=${jreVersion}
 
-    docker tag "${DOCKER_REPO}:latest" "${DOCKER_CI_REPO}:${DOCKER_IMAGE_BUILD_TAG}"
+    # Append -j25 suffix to tags when JRE version contains 25
+    local TAG_SUFFIX=""
+    if [[ "${jreVersion}" == *"25"* ]]; then
+        TAG_SUFFIX="-j25"
+    fi
+
+    docker tag "${DOCKER_REPO}:latest" "${DOCKER_CI_REPO}:${DOCKER_IMAGE_BUILD_TAG}${TAG_SUFFIX}"
 
     # CircleCI tag builds do not have a branch set
     if [[ -n "${RUNDECK_BRANCH_CLEAN}" ]]; then
-        local CI_BRANCH_TAG=${DOCKER_CI_REPO}:${RUNDECK_BRANCH_CLEAN}
+        local CI_BRANCH_TAG=${DOCKER_CI_REPO}:${RUNDECK_BRANCH_CLEAN}${TAG_SUFFIX}
         docker tag "${DOCKER_REPO}:latest" "$CI_BRANCH_TAG"
     fi
 
 }
 
 rundeck_docker_push() {
+    local jreVersion=${1}
+    local TAG_SUFFIX=""
+    if [[ "${jreVersion}" == *"25"* ]]; then
+        TAG_SUFFIX="-j25"
+    fi
+
     docker_login
 
-    docker push "${DOCKER_CI_REPO}:${DOCKER_IMAGE_BUILD_TAG}"
+    docker push "${DOCKER_CI_REPO}:${DOCKER_IMAGE_BUILD_TAG}${TAG_SUFFIX}"
 
     # CircleCI tag builds do not have a branch set
     if [[ -n "${RUNDECK_BRANCH_CLEAN}" ]]; then
-        local CI_BRANCH_TAG=${DOCKER_CI_REPO}:${RUNDECK_BRANCH_CLEAN}
+        local CI_BRANCH_TAG=${DOCKER_CI_REPO}:${RUNDECK_BRANCH_CLEAN}${TAG_SUFFIX}
         docker push "$CI_BRANCH_TAG"
     fi
 

--- a/scripts/circleci/helper-functions.sh
+++ b/scripts/circleci/helper-functions.sh
@@ -48,11 +48,16 @@ copy_rundeck_war() {
 # Pull the image built on this build and adds a custom tag if provided as argument.
 rundeck_pull_image() {
     docker_login
-    local sourceTag="${DOCKER_CI_REPO}:${DOCKER_IMAGE_BUILD_TAG}"
+    local jreVersion=${1:-}
+    local JRE_SUFFIX=""
+    if [[ "${jreVersion}" == *"25"* ]]; then
+        JRE_SUFFIX="-j25"
+    fi
+    local sourceTag="${DOCKER_CI_REPO}:${DOCKER_IMAGE_BUILD_TAG}${JRE_SUFFIX}"
     docker pull $sourceTag
     docker tag "${sourceTag}" "rundeck/testdeck"
 
-    local customTag=${1:-}
+    local customTag=${2:-}
     if [[ -n "${customTag}" ]]; then
         docker tag "${sourceTag}" "${customTag}"
     fi


### PR DESCRIPTION
This pull request updates the CI/CD pipeline to add full support for Java JDK 25 in both Docker images and test jobs, while also improving Docker image tagging and build consistency. It removes redundant JDK 25 install logic from the host and standardizes JDK selection for test jobs. Additionally, it ensures Docker images are always built without cache and that image tags reflect the JRE version.

**CI/CD Pipeline Enhancements:**

* Added a `jre25Publish` parameter to the `build-rundeck` job, enabling the pipeline to build and push a Docker image with JRE 25 alongside the existing JRE 17 image. The workflow now builds and publishes both images, and new test jobs are configured to use JDK 25 where specified. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R267-R270) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L293-R292) [[3]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R810) [[4]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R1037)

* Expanded the test matrix to include multiple functional and Selenium test jobs running against Docker images built with JDK 25, improving test coverage for the new Java version.

**Simplification and Standardization:**

* Removed custom host-side JDK 25 installation commands and job logic, relying instead on Docker image selection for JDK versioning. Now, the `host_jdk_for_tests` parameter selects the appropriate Docker image for tests, streamlining the configuration. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L206-L211) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L247-L253) [[3]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L601-L609) [[4]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L636-L651) [[5]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L693-R678)

**Docker Build and Tagging Improvements:**

* Updated Docker build scripts and Gradle tasks to always build images with `--no-cache`, ensuring fresh builds. [[1]](diffhunk://#diff-6368947b8241a4d08807f5a510ab08167ea7fa87d243ed17e44a9bcccafc8c2dR74) [[2]](diffhunk://#diff-6368947b8241a4d08807f5a510ab08167ea7fa87d243ed17e44a9bcccafc8c2dL116-R117)

* Enhanced Docker image tagging in `rundeck_docker_build` and `rundeck_docker_push` to append a `-j25` suffix when building with JRE 25, making it clear which images use which Java version. The `rundeck_pull_image` function is also updated to pull the correct image based on the JRE version. [[1]](diffhunk://#diff-0bed00be653af63f315787ae5671186bed8a208ace2458f36b73822a5e0dfc33L44-R75) [[2]](diffhunk://#diff-6dc8fd6df13b3a75670cf821cdc4aadf005ac9898c7c36d306f578d70d271e68L51-R60)