### PR TITLE
RUN-4351: Fix TS7006 implicit any on addUiMessages callbacks

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/command/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/command/main.ts
@@ -1,6 +1,7 @@
 import { createApp } from "vue";
 
 import LogViewer from "../../../library/components/execution-log/logViewer.vue";
+import { UiMessage } from "../../../library/stores/UIStore";
 import { RootStore } from "../../../library/stores/RootStore";
 import { initI18n, commonAddUiMessages } from "../../utilities/i18n";
 
@@ -61,7 +62,7 @@ eventBus.on("ko-adhoc-running", (data: any) => {
     },
   );
   vue.use(i18n);
-  vue.provide("addUiMessages", async (messages) =>
+  vue.provide("addUiMessages", async (messages: UiMessage[]) =>
     commonAddUiMessages(i18n, messages),
   );
   vue.mount(elm);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/nodeView.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/nodeView.ts
@@ -3,6 +3,7 @@ import { createApp } from "vue";
 import { autorun } from "mobx";
 
 import LogViewer from "../../../library/components/execution-log/logViewer.vue";
+import { UiMessage } from "../../../library/stores/UIStore";
 import { getRundeckContext } from "../../../library";
 import * as uiv from "uiv";
 import { initI18n, commonAddUiMessages } from "../../utilities/i18n";
@@ -60,7 +61,7 @@ window._rundeck.eventBus.on("ko-exec-show-output", (nodeStep: any) => {
   });
   vue.use(uiv);
   vue.use(i18n);
-  vue.provide("addUiMessages", async (messages) =>
+  vue.provide("addUiMessages", async (messages: UiMessage[]) =>
     commonAddUiMessages(i18n, messages),
   );
   vue.mount(elm);


### PR DESCRIPTION
## Summary
TypeScript strict checking failed in CI on `runNpmBuild`: parameters `messages` in `vue.provide("addUiMessages", ...)` were implicitly `any`.

## Changes
- Type the callback parameter as `UiMessage[]` and import `UiMessage` from `UIStore`, matching `navbar/main.ts`.
- Files: `command/main.ts`, `execution-show/nodeView.ts`.

## Related
- **rundeckpro:** https://github.com/rundeckpro/rundeckpro/pull/4660

## Testing
- `./gradlew :rundeckapp:grails-spa:runNpmBuild` (or equivalent npm build in ui-trellis).