### PR TITLE
[RUN-4354] increase resource class to medium for test-gradle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,6 +317,7 @@ jobs:
     <<: *job-defaults
     executor:
       name: docker-builder
+      resource_class: medium
     steps:
       - setup_docker
       - checkout


### PR DESCRIPTION
This pull request makes a minor update to the CircleCI configuration by specifying the `resource_class` for the `docker-builder` executor. This change helps ensure that builds use the appropriate resources for the job.

* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R320): Set the `resource_class` to `medium` for the `docker-builder` executor to better control build resources.