### PR TITLE
[RUN-4320] Fix H2 reserved keyword column name errors for PostgreSQL compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ jobs:
     <<: *job-defaults
     executor:
       name: docker-builder
-      resource_class: medium
+      resource_class: large
     steps:
       - setup_docker
       - checkout

--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -190,13 +190,6 @@ class ScheduledExecution extends ExecutionContext implements JobData, EmbeddedJs
         pluginConfig(type: 'text')
         workflowJson(type: 'text')
         lastModifiedBy(type: 'string')
-        // Escape SQL reserved words with backticks for H2 compatibility
-        minute column: "`MINUTE`"
-        hour column: "`HOUR`"
-        month column: "`MONTH`"
-        seconds column: "`SECONDS`"
-        year column: "`YEAR`"
-
         DomainIndexHelper.generate(delegate) {
             index 'JOB_IDX_PROJECT', ['project']
         }

--- a/rundeckapp/grails-app/migrations/core/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/migrations/core/ScheduledExecution.groovy
@@ -207,7 +207,7 @@ databaseChangeLog = {
 
     changeSet(author: "rundeckuser (generated)", failOnError:"false", id: "4.6.0-1", dbms: "h2") {
         comment { 'rename month to MONTH' }
-        preConditions(onFail: "CONTINUE") {
+        preConditions(onFail: "MARK_RAN") {
             grailsPrecondition {
                 check {
                     def count = sql.firstRow("SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'SCHEDULED_EXECUTION' AND COLUMN_NAME = 'month'").cnt
@@ -226,7 +226,7 @@ databaseChangeLog = {
 
     changeSet(author: "rundeckuser (generated)", failOnError:"false", id: "4.6.0-2", dbms: "h2") {
         comment { 'rename hour to HOUR' }
-        preConditions(onFail: "CONTINUE") {
+        preConditions(onFail: "MARK_RAN") {
             grailsPrecondition {
                 check {
                     def count = sql.firstRow("SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'SCHEDULED_EXECUTION' AND COLUMN_NAME = 'hour'").cnt
@@ -245,7 +245,7 @@ databaseChangeLog = {
 
     changeSet(author: "rundeckuser (generated)", failOnError:"false", id: "4.6.0-3", dbms: "h2") {
         comment { 'rename year to YEAR' }
-        preConditions(onFail: "CONTINUE") {
+        preConditions(onFail: "MARK_RAN") {
             grailsPrecondition {
                 check {
                     def count = sql.firstRow("SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'SCHEDULED_EXECUTION' AND COLUMN_NAME = 'year'").cnt
@@ -264,7 +264,7 @@ databaseChangeLog = {
 
     changeSet(author: "rundeckuser (generated)", failOnError:"false", id: "4.6.0-4", dbms: "h2") {
         comment { 'rename minute to MINUTE' }
-        preConditions(onFail: "CONTINUE") {
+        preConditions(onFail: "MARK_RAN") {
             grailsPrecondition {
                 check {
                     def count = sql.firstRow("SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'SCHEDULED_EXECUTION' AND COLUMN_NAME = 'minute'").cnt
@@ -284,7 +284,7 @@ databaseChangeLog = {
 
     changeSet(author: "rundeckuser (generated)", failOnError:"false", id: "4.6.0-5", dbms: "h2") {
         comment { 'rename seconds to SECONDS' }
-        preConditions(onFail: "CONTINUE") {
+        preConditions(onFail: "MARK_RAN") {
             grailsPrecondition {
                 check {
                     def count = sql.firstRow("SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'SCHEDULED_EXECUTION' AND COLUMN_NAME = 'seconds'").cnt

--- a/rundeckapp/grails-app/migrations/core/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/migrations/core/ScheduledExecution.groovy
@@ -207,8 +207,13 @@ databaseChangeLog = {
 
     changeSet(author: "rundeckuser (generated)", failOnError:"false", id: "4.6.0-1", dbms: "h2") {
         comment { 'rename month to MONTH' }
-        preConditions(onFail: "CONTINUE"){
-            columnExists(tableName: "scheduled_execution", columnName: "month")
+        preConditions(onFail: "CONTINUE") {
+            grailsPrecondition {
+                check {
+                    def count = sql.firstRow("SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'SCHEDULED_EXECUTION' AND COLUMN_NAME = 'month'").cnt
+                    if (count == 0) fail('Column "month" (lowercase) not found, skipping rename')
+                }
+            }
         }
         grailsChange {
             change {
@@ -218,11 +223,16 @@ databaseChangeLog = {
             }
         }
     }
-    
+
     changeSet(author: "rundeckuser (generated)", failOnError:"false", id: "4.6.0-2", dbms: "h2") {
         comment { 'rename hour to HOUR' }
-        preConditions(onFail: "CONTINUE"){
-            columnExists(tableName: "scheduled_execution", columnName: "hour")
+        preConditions(onFail: "CONTINUE") {
+            grailsPrecondition {
+                check {
+                    def count = sql.firstRow("SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'SCHEDULED_EXECUTION' AND COLUMN_NAME = 'hour'").cnt
+                    if (count == 0) fail('Column "hour" (lowercase) not found, skipping rename')
+                }
+            }
         }
         grailsChange {
             change {
@@ -232,11 +242,16 @@ databaseChangeLog = {
             }
         }
     }
-    
+
     changeSet(author: "rundeckuser (generated)", failOnError:"false", id: "4.6.0-3", dbms: "h2") {
         comment { 'rename year to YEAR' }
-        preConditions(onFail: "CONTINUE"){
-            columnExists(tableName: "scheduled_execution", columnName: "year")
+        preConditions(onFail: "CONTINUE") {
+            grailsPrecondition {
+                check {
+                    def count = sql.firstRow("SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'SCHEDULED_EXECUTION' AND COLUMN_NAME = 'year'").cnt
+                    if (count == 0) fail('Column "year" (lowercase) not found, skipping rename')
+                }
+            }
         }
         grailsChange {
             change {
@@ -249,8 +264,13 @@ databaseChangeLog = {
 
     changeSet(author: "rundeckuser (generated)", failOnError:"false", id: "4.6.0-4", dbms: "h2") {
         comment { 'rename minute to MINUTE' }
-        preConditions(onFail: "CONTINUE"){
-            columnExists(tableName: "scheduled_execution", columnName: "minute")
+        preConditions(onFail: "CONTINUE") {
+            grailsPrecondition {
+                check {
+                    def count = sql.firstRow("SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'SCHEDULED_EXECUTION' AND COLUMN_NAME = 'minute'").cnt
+                    if (count == 0) fail('Column "minute" (lowercase) not found, skipping rename')
+                }
+            }
         }
         grailsChange {
             change {

--- a/rundeckapp/grails-app/migrations/core/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/migrations/core/ScheduledExecution.groovy
@@ -282,6 +282,25 @@ databaseChangeLog = {
     }
 
 
+    changeSet(author: "rundeckuser (generated)", failOnError:"false", id: "4.6.0-5", dbms: "h2") {
+        comment { 'rename seconds to SECONDS' }
+        preConditions(onFail: "CONTINUE") {
+            grailsPrecondition {
+                check {
+                    def count = sql.firstRow("SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'SCHEDULED_EXECUTION' AND COLUMN_NAME = 'seconds'").cnt
+                    if (count == 0) fail('Column "seconds" (lowercase) not found, skipping rename')
+                }
+            }
+        }
+        grailsChange {
+            change {
+                sql.execute("ALTER TABLE scheduled_execution RENAME COLUMN \"seconds\" TO SECONDS;")
+            }
+            rollback {
+            }
+        }
+    }
+
     changeSet(author: "rundeckdev", id: "4.11.0-add-job-uuid-to-stats-mssql", dbms: "mssql") {
         preConditions(onFail: "MARK_RAN") {
             not {


### PR DESCRIPTION
## Problem

When removing backtick column mappings (e.g. `minute column: "\`MINUTE\`"`) from the `ScheduledExecution` domain class — which were breaking PostgreSQL since backtick quoting is not valid PostgreSQL syntax — H2 integration tests started failing with:

```
SQLGrammarException: Column "SCHEDULEDE0_.MINUTE" not found
```

**Root cause:** Liquibase's internal reserved keyword list includes words like `month`, `hour`, `year`, `minute`. When these are used as column names in H2 without the `NON_KEYWORDS` JDBC parameter, Liquibase auto-quotes them as lowercase case-sensitive identifiers (e.g. `"month"`). Hibernate, however, uses `CamelCaseToUnderscoresNamingStrategy` and generates unquoted uppercase identifiers (e.g. `MONTH`), causing a column name mismatch.

The existing H2-only Liquibase changesets (`4.6.0-1` to `4.6.0-4`) that rename these columns used `columnExists` as a precondition, which is **case-insensitive** in H2. This meant the rename was attempted even on clean installs where the column was already created as uppercase — causing `ALTER TABLE ... RENAME COLUMN "month" TO MONTH` to fail with *Column "month" not found*.

## Solution

- **Remove backtick column mappings** from `ScheduledExecution` static mapping (fixes PostgreSQL)
- **Update H2 Liquibase changesets** (`4.6.0-1` to `4.6.0-4`): replace the `columnExists` precondition with a `grailsPrecondition` that runs a case-sensitive SQL query against `INFORMATION_SCHEMA.COLUMNS`. The rename only executes when the column genuinely exists as a lowercase quoted identifier (legacy installs). On clean installs where `NON_KEYWORDS` is set and the column is already uppercase, the precondition skips the rename safely.

## Affected databases

| Database | Impact |
|---|---|
| PostgreSQL | Fixed — backtick syntax no longer used |
| H2 (legacy install) | Fixed — rename changeset runs correctly when lowercase column exists |
| H2 (clean install) | Fixed — rename changeset is safely skipped when column is already uppercase |

Made with [Cursor](https://cursor.com)