### PR TITLE
[RUN-4386] Stabilize ReadmeSpec after project save

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/ReadmeSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/ReadmeSpec.groovy
@@ -39,6 +39,9 @@ class ReadmeSpec extends SeleniumBase{
             projectEditPage.clickNavLink(NavProjectSettings.USER_INTERFACE)
             projectEditPage.selectReadmeAllPlaces()
             projectEditPage.save()
+            // Save triggers POST + redirect; navigating immediately can abort the request so
+            // readme display settings never persist and the dashboard readme never renders.
+            projectEditPage.waitForUrlToNotContain('/configure')
             homePage.goProjectHome projectName
         then:
             projectDashboard.getCheckReadme() == readmeText

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/project/DashboardPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/project/DashboardPage.groovy
@@ -16,7 +16,8 @@ class DashboardPage extends BasePage {
     String loadPath = ""
     By projectDescriptionBy = By.className("text-project-description")
     By projectLabelBy = By.xpath("//div[@data-ko-bind='projectHome']")
-    By readmeMarkDownBy = By.className("markdown-body")
+    /** Scoped to project dashboard Vue mount to avoid matching other .markdown-body on the page. */
+    By readmeMarkDownBy = By.cssSelector("#projectHome-content .markdown-body")
     By projectSummaryBy = By.id("projectHome-summary")
     By projectSummaryCountLinkBy = By.cssSelector("#projectHome-summary a .summary-count")
     By executionCountBy = By.cssSelector(".summary-count.text-info") // Execution count


### PR DESCRIPTION
## Summary
Waits for the project configure save to finish (URL leaves `/configure`) before navigating to project home, so the POST is not aborted by an immediate `driver.get()`. Scopes the dashboard readme locator to `#projectHome-content .markdown-body` so we do not match unrelated markdown on the page.

## PR Details
- `ReadmeSpec`: wait after `projectEditPage.save()` using `waitForUrlToNotContain('/configure')`.
- `DashboardPage`: readme selector scoped to project dashboard Vue mount.

Related: rundeckpro PR will bump the submodule to this commit for CircleCI Core + pro functional tests.