### PR TITLE
[RUN-4394] cleanup OkHttpClient Response objects

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/system/MetricsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/system/MetricsSpec.groovy
@@ -85,6 +85,8 @@ class MetricsSpec extends BaseContainer {
             def response = client.doGetAcceptAll("/metrics/healthcheck")
         then:
             response.code() == 404
+        cleanup:
+            response.close()
     }
 
     def "Test legacy threads disabled by default"() {
@@ -92,6 +94,8 @@ class MetricsSpec extends BaseContainer {
             def response = client.doGetAcceptAll("/metrics/threads")
         then:
             response.code() == 404
+        cleanup:
+            response.close()
     }
 
     // ========================================================================

--- a/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/BaseContainer.groovy
@@ -54,7 +54,7 @@ abstract class BaseContainer extends Specification implements ClientProvider, Wa
 
         SLF4JBridgeHandler.install()
         //fine logging for http client closeable leaks
-        Logger.getLogger(OkHttpClient.name).setLevel(Level.FINEST)
+        Logger.getLogger(OkHttpClient.name).setLevel(Level.FINE)
     }
 
     @Shared


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
* Test code cleanup to prevent flakiness
* Cleanup OkHttpClient Response objects

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

## Release Notes

<!-- If you have suggested content that would describe this PR to other Rundeck community users, please enter it here.-->