### PR TITLE
[RUN-4393] update ansible version to 4.0.15

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 rundeck:
   plugins: # Extra plugins to bundle
-  - "com.github.rundeck-plugins:ansible-plugin:4.0.14"
+  - "com.github.rundeck-plugins:ansible-plugin:4.0.15"
   - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.10"
   - "com.github.rundeck-plugins:py-winrm-plugin:2.1.3@zip"
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.4@zip"


### PR DESCRIPTION
This pull request makes a minor update to the `build.yaml` file, upgrading the version of the `ansible-plugin` dependency from `4.0.14` to `4.0.15`.