### PR TITLE
[RUN-4396] jre25 build and pusblish only for schedule runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -829,7 +829,6 @@ workflows:
       # Stage 1: Build
       - build-rundeck:
           name: Build
-          jre25Publish: true
           <<: *cloudsmith-slack-defaults
 
       # Step 1: Unit tests run in parallel with Build (no gates for fast feedback)


### PR DESCRIPTION
This pull request makes a minor update to the CircleCI configuration by removing the `jre25Publish` parameter from the `build-rundeck` job. This change likely reflects a simplification or deprecation of that publishing step.