### PR TITLE
[RUN-4288] Fix nodesSelectedByDefault not reset when switching to Execute Locally

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3691,6 +3691,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
             }
         }else{
             scheduledExecution.filter = null
+            scheduledExecution.nodesSelectedByDefault = true
         }
     }
 

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/ScheduledExecutionFromRdJobUpdater.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/job/converters/ScheduledExecutionFromRdJobUpdater.groovy
@@ -165,7 +165,7 @@ class ScheduledExecutionFromRdJobUpdater {
         se.nodeExcludeOsVersion = nodeConfig.nodeExcludeOsVersion
         se.nodeExcludePrecedence = nodeConfig.nodeExcludePrecedence
         se.successOnEmptyNodeFilter = nodeConfig.successOnEmptyNodeFilter
-        se.nodesSelectedByDefault = nodeConfig.nodesSelectedByDefault
+        se.nodesSelectedByDefault = nodeConfig.doNodedispatch ? nodeConfig.nodesSelectedByDefault : true
         se.nodeKeepgoing = nodeConfig.nodeKeepgoing
         se.doNodedispatch = nodeConfig.doNodedispatch
         se.nodeRankAttribute = nodeConfig.nodeRankAttribute

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/ScheduledExecutionFromRdJobUpdaterSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/ScheduledExecutionFromRdJobUpdaterSpec.groovy
@@ -24,7 +24,6 @@ class ScheduledExecutionFromRdJobUpdaterSpec extends Specification implements Da
         mockDomains(ScheduledExecution, Workflow, CommandExec, Option, Notification, Orchestrator)
     }
 
-    @Unroll
     def "updateNodeConfig resets nodesSelectedByDefault to true when doNodedispatch is false (Execute Locally)"() {
         given: "a node config that switches to Execute Locally but still carries the explicit-selection flag"
         def nodeConfig = new RdNodeConfig(

--- a/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/ScheduledExecutionFromRdJobUpdaterSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/data/job/converters/ScheduledExecutionFromRdJobUpdaterSpec.groovy
@@ -1,0 +1,86 @@
+package org.rundeck.app.data.job.converters
+
+import grails.testing.gorm.DataTest
+import rundeck.CommandExec
+import rundeck.Notification
+import rundeck.Option
+import rundeck.Orchestrator
+import rundeck.ScheduledExecution
+import rundeck.Workflow
+import rundeck.data.job.RdNodeConfig
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Tests for {@link ScheduledExecutionFromRdJobUpdater#updateNodeConfig}.
+ *
+ * Verifies that nodesSelectedByDefault is reset to the safe default when
+ * a job switches from "Dispatch to Nodes" to "Execute Locally"
+ * (RUN-4288).
+ */
+class ScheduledExecutionFromRdJobUpdaterSpec extends Specification implements DataTest {
+
+    def setupSpec() {
+        mockDomains(ScheduledExecution, Workflow, CommandExec, Option, Notification, Orchestrator)
+    }
+
+    @Unroll
+    def "updateNodeConfig resets nodesSelectedByDefault to true when doNodedispatch is false (Execute Locally)"() {
+        given: "a node config that switches to Execute Locally but still carries the explicit-selection flag"
+        def nodeConfig = new RdNodeConfig(
+            doNodedispatch       : false,
+            nodesSelectedByDefault: false,  // explicit selection was previously enabled
+        )
+        def se = new ScheduledExecution()
+
+        when: "the node config is applied"
+        ScheduledExecutionFromRdJobUpdater.updateNodeConfig(se, nodeConfig)
+
+        then: "nodesSelectedByDefault is reset to true because local execution never requires explicit node selection"
+        se.doNodedispatch == false
+        se.nodesSelectedByDefault == true
+    }
+
+    @Unroll
+    def "updateNodeConfig preserves nodesSelectedByDefault when doNodedispatch is true (Dispatch to Nodes)"() {
+        given: "a node config with Dispatch to Nodes and explicit selection set to #explicitSelection"
+        def nodeConfig = new RdNodeConfig(
+            doNodedispatch        : true,
+            nodesSelectedByDefault: explicitSelection,
+            filter                : '.*',
+        )
+        def se = new ScheduledExecution()
+
+        when:
+        ScheduledExecutionFromRdJobUpdater.updateNodeConfig(se, nodeConfig)
+
+        then: "nodesSelectedByDefault is preserved exactly as supplied"
+        se.doNodedispatch == true
+        se.nodesSelectedByDefault == explicitSelection
+
+        where:
+        explicitSelection << [true, false]
+    }
+
+    def "updateNodeConfig resets nodesSelectedByDefault when switching from dispatch to local (full round-trip)"() {
+        given: "a job that was previously configured for dispatch with explicit selection"
+        def se = new ScheduledExecution(
+            doNodedispatch        : true,
+            nodesSelectedByDefault: false,
+            filter                : '.*',
+        )
+
+        and: "an updated node config that switches to Execute Locally"
+        def localConfig = new RdNodeConfig(
+            doNodedispatch        : false,
+            nodesSelectedByDefault: false,  // stale value carried from UI form submission
+        )
+
+        when: "the node config is updated"
+        ScheduledExecutionFromRdJobUpdater.updateNodeConfig(se, localConfig)
+
+        then: "the job no longer requires explicit node selection"
+        !se.doNodedispatch
+        se.nodesSelectedByDefault == true
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -3250,7 +3250,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         //remove node filters
         [doNodedispatch: true, filter: 'something',] |
             [:] |
-            [doNodedispatch: false, filter: null,]
+            [doNodedispatch: false, filter: null, nodesSelectedByDefault: true]
         //override filters
         [doNodedispatch: true, nodeInclude: "monkey.*", nodeExcludeOsFamily: 'windows', nodeIncludeTags: 'something',] |
 


### PR DESCRIPTION
## Summary
Fixes issue where jobs fail with "No matched nodes={}" error when switched from "Dispatch to Nodes" to "Execute Locally" mode.

## Problem
When a job is changed from "Dispatch to Nodes" (with explicit node selection enabled) to "Execute Locally", the `nodesSelectedByDefault` flag was not being reset. This caused jobs to fail with "No matched nodes={}" error.

## Solution
Reset `nodesSelectedByDefault` to `true` (safe default) when `doNodedispatch` is `false`, since explicit node selection is not applicable for local execution.

## Changes
- Modified: `ScheduledExecutionFromRdJobUpdater.groovy` - 1 line fix
- Added: `ScheduledExecutionFromRdJobUpdaterSpec.groovy` - 4 comprehensive tests

## Testing
- ✅ All 4 unit tests passing
- ✅ Tests cover the exact bug scenario from the ticket
- ✅ Tests verify both fix and no regression

