### PR TITLE
[RUN-4410] Upgrade log4J to 2.25.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -51,7 +51,7 @@ testContainersVersion=1.21.4
 jetty.version=12.0.33
 # Updated from 6.2.7 - fixes CVE-2025-22228 (SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-9486467) - Authentication Bypass in BCrypt. No breaking changes, API-compatible with 6.2.7
 spring-security.version=6.5.9
-log4j2.version=2.25.3
+log4j2.version=2.25.4
 assetPluginVersion=5.0.34
 dbMigrationPluginVersion=5.0.0
 metricsVersion=4.2.37


### PR DESCRIPTION
# Release Notes

Fix CVE-2026-34478 and CVE-2026-34480 by upgrading to 2.25.4