### PR TITLE
[RUN-4406] Add Dropwizard to Micrometer metrics bridge

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/DropwizardMicrometerBridgeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/DropwizardMicrometerBridgeService.groovy
@@ -230,12 +230,11 @@ class DropwizardMicrometerBridgeService {
         )
 
         if (!enabled) {
-            log.info("Dropwizard->Micrometer bridge disabled")
+            log.debug("Dropwizard->Micrometer bridge disabled")
             return
         }
 
-        log.info("=== Initializing Dropwizard->Micrometer metrics bridge ===")
-        log.info("MetricRegistry: ${metricRegistry?.class?.name}")
+        log.debug("Initializing Dropwizard->Micrometer metrics bridge")
 
         if (!metricRegistry) {
             log.warn("Cannot initialize bridge: metricRegistry is null")
@@ -246,7 +245,6 @@ class DropwizardMicrometerBridgeService {
         MeterRegistry meterRegistry = null
         try {
             meterRegistry = grailsApplication.mainContext.getBean(MeterRegistry)
-            log.info("Found MeterRegistry: ${meterRegistry?.class?.name}")
         } catch (Exception e) {
             log.error("Cannot find MeterRegistry bean", e)
             return
@@ -265,12 +263,8 @@ class DropwizardMicrometerBridgeService {
         int histogramCount = metricRegistry.histograms.size()
         int totalMetrics = gaugeCount + counterCount + meterCount + timerCount + histogramCount
 
-        log.info("Dropwizard metrics found: ${totalMetrics} total")
-        log.info("  - ${gaugeCount} gauges")
-        log.info("  - ${counterCount} counters")
-        log.info("  - ${meterCount} meters")
-        log.info("  - ${timerCount} timers")
-        log.info("  - ${histogramCount} histograms")
+        log.debug("Dropwizard metrics found: {} total (gauges: {}, counters: {}, meters: {}, timers: {}, histograms: {})",
+                  totalMetrics, gaugeCount, counterCount, meterCount, timerCount, histogramCount)
 
         // Bridge Dropwizard metrics to Micrometer by registering them directly
         int bridged = 0
@@ -300,12 +294,10 @@ class DropwizardMicrometerBridgeService {
             try {
                 Gauge.builder("${name}.count", meter, meterCountExtractor()).register(meterRegistry)
                 Gauge.builder("${name}.rate.mean", meter, meterRateExtractor()).register(meterRegistry)
-                if (name.contains('execution')) {
-                    log.info("✅ Bridged execution meter: ${name} → ${name}.count (${meter.count})")
-                }
                 bridged += 2
+                log.debug("Bridged meter: {} -> {}.count, {}.rate.mean", name, name, name)
             } catch (Exception e) {
-                log.warn("❌ Failed to bridge meter ${name}: ${e.message}", e)
+                log.debug("Failed to bridge meter {}: {}", name, e.message)
             }
         }
 
@@ -416,7 +408,7 @@ class DropwizardMicrometerBridgeService {
                         Gauge.builder("${name}.count", meter, meterCountExtractor()).register(meterRegistry)
                     } catch (IllegalArgumentException iae) {
                         // Already registered, that's okay
-                        log.debug("Meter ${name}.count already registered")
+                        log.trace("Meter {}.count already registered", name)
                     }
 
                     // Try to register rate
@@ -424,12 +416,12 @@ class DropwizardMicrometerBridgeService {
                         Gauge.builder("${name}.rate.mean", meter, meterRateExtractor()).register(meterRegistry)
                     } catch (IllegalArgumentException iae) {
                         // Already registered, that's okay
-                        log.debug("Meter ${name}.rate.mean already registered")
+                        log.trace("Meter {}.rate.mean already registered", name)
                     }
 
-                    log.info("✅ Dynamically bridged meter: ${name} → ${name}.count, ${name}.rate.mean")
+                    log.debug("Dynamically bridged meter: {} -> {}.count, {}.rate.mean", name, name, name)
                 } catch (Exception e) {
-                    log.warn("❌ Failed to bridge meter ${name}: ${e.message}", e)
+                    log.debug("Failed to bridge meter {}: {}", name, e.message)
                 }
             }
 
@@ -453,9 +445,9 @@ class DropwizardMicrometerBridgeService {
                     Gauge.builder("${name}.50thpercentile", timer, timerP50Extractor()).register(meterRegistry)
                     Gauge.builder("${name}.95thpercentile", timer, timerP95Extractor()).register(meterRegistry)
                     Gauge.builder("${name}.99thpercentile", timer, timerP99Extractor()).register(meterRegistry)
-                    log.info("Dynamically bridged timer: ${name} with percentiles")
+                    log.debug("Dynamically bridged timer: {} with percentiles", name)
                 } catch (Exception e) {
-                    log.debug("Failed to bridge timer ${name}: ${e.message}")
+                    log.debug("Failed to bridge timer {}: {}", name, e.message)
                 }
             }
 
@@ -475,21 +467,7 @@ class DropwizardMicrometerBridgeService {
             }
         })
 
-        // Log execution-related meters for debugging
-        def executionMeters = metricRegistry.meters.keySet().findAll { it.contains('execution') }
-        if (executionMeters) {
-            log.info("📊 Found ${executionMeters.size()} execution meters:")
-            executionMeters.each { name ->
-                log.info("   - ${name}")
-            }
-        } else {
-            log.warn("⚠️  No execution meters found in MetricRegistry yet!")
-            log.warn("   Execution meters will be bridged dynamically when jobs run")
-        }
-
-        log.info("=== Dropwizard->Micrometer bridge initialized successfully ===")
-        log.info("Bridged ${bridged} existing metrics to Micrometer")
-        log.info("Listener registered to bridge new metrics dynamically")
-        log.info("Metrics will be available at /monitoring/prometheus")
+        // Single info-level summary
+        log.info("Dropwizard->Micrometer bridge initialized: bridged {} metrics, dynamic listener enabled", bridged)
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/DropwizardMicrometerBridgeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/DropwizardMicrometerBridgeService.groovy
@@ -5,6 +5,7 @@ import com.codahale.metrics.Histogram
 import com.codahale.metrics.Meter
 import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.MetricRegistryListener
+import com.codahale.metrics.Snapshot
 import com.codahale.metrics.Timer
 import grails.core.GrailsApplication
 import grails.events.annotation.Subscriber
@@ -13,6 +14,7 @@ import groovy.util.logging.Slf4j
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 
+import java.util.concurrent.ConcurrentHashMap
 import java.util.function.ToDoubleFunction
 /**
  * Bridges Dropwizard MetricRegistry to Micrometer MeterRegistry.
@@ -27,6 +29,43 @@ class DropwizardMicrometerBridgeService {
     MetricRegistry metricRegistry
     ConfigurationService configurationService
     GrailsApplication grailsApplication
+
+    // Cache snapshots to avoid recomputing during Prometheus scrapes
+    // Key: metric object identity, Value: cached snapshot with timestamp
+    private static final ConcurrentHashMap<Object, CachedSnapshot> snapshotCache = new ConcurrentHashMap<>()
+    private static final long SNAPSHOT_CACHE_TTL_MS = 1000L // 1 second
+
+    /**
+     * Wrapper to cache Timer/Histogram snapshots to avoid redundant computations during scrapes.
+     * Each timer/histogram registers 4-5 gauges (mean, p50, p95, p99, etc). Without caching,
+     * Prometheus scrape triggers 4-5 snapshot computations per metric. With caching, only 1 per second.
+     */
+    private static class CachedSnapshot {
+        final Snapshot snapshot
+        final long timestamp
+
+        CachedSnapshot(Snapshot snapshot, long timestamp) {
+            this.snapshot = snapshot
+            this.timestamp = timestamp
+        }
+
+        boolean isExpired(long now) {
+            return (now - timestamp) > SNAPSHOT_CACHE_TTL_MS
+        }
+    }
+
+    private static Snapshot getCachedSnapshot(Object metricObject, Closure<Snapshot> snapshotSupplier) {
+        long now = System.currentTimeMillis()
+        CachedSnapshot cached = snapshotCache.get(metricObject)
+
+        if (cached != null && !cached.isExpired(now)) {
+            return cached.snapshot
+        }
+
+        Snapshot freshSnapshot = snapshotSupplier.call()
+        snapshotCache.put(metricObject, new CachedSnapshot(freshSnapshot, now))
+        return freshSnapshot
+    }
 
     // Helper methods to create ToDoubleFunction for each metric type
     private static ToDoubleFunction<com.codahale.metrics.Gauge> gaugeValueExtractor() {
@@ -82,7 +121,8 @@ class DropwizardMicrometerBridgeService {
         return new ToDoubleFunction<Timer>() {
             @Override
             double applyAsDouble(Timer t) {
-                return t.snapshot.mean / 1_000_000.0 // ns to ms
+                Snapshot snapshot = getCachedSnapshot(t, { -> t.snapshot })
+                return snapshot.mean / 1_000_000.0 // ns to ms
             }
         }
     }
@@ -91,7 +131,8 @@ class DropwizardMicrometerBridgeService {
         return new ToDoubleFunction<Timer>() {
             @Override
             double applyAsDouble(Timer t) {
-                return t.snapshot.median / 1_000_000.0 // ns to ms
+                Snapshot snapshot = getCachedSnapshot(t, { -> t.snapshot })
+                return snapshot.median / 1_000_000.0 // ns to ms
             }
         }
     }
@@ -100,7 +141,8 @@ class DropwizardMicrometerBridgeService {
         return new ToDoubleFunction<Timer>() {
             @Override
             double applyAsDouble(Timer t) {
-                return t.snapshot.get95thPercentile() / 1_000_000.0 // ns to ms
+                Snapshot snapshot = getCachedSnapshot(t, { -> t.snapshot })
+                return snapshot.get95thPercentile() / 1_000_000.0 // ns to ms
             }
         }
     }
@@ -109,7 +151,8 @@ class DropwizardMicrometerBridgeService {
         return new ToDoubleFunction<Timer>() {
             @Override
             double applyAsDouble(Timer t) {
-                return t.snapshot.get99thPercentile() / 1_000_000.0 // ns to ms
+                Snapshot snapshot = getCachedSnapshot(t, { -> t.snapshot })
+                return snapshot.get99thPercentile() / 1_000_000.0 // ns to ms
             }
         }
     }
@@ -127,7 +170,8 @@ class DropwizardMicrometerBridgeService {
         return new ToDoubleFunction<Histogram>() {
             @Override
             double applyAsDouble(Histogram h) {
-                return h.snapshot.mean
+                Snapshot snapshot = getCachedSnapshot(h, { -> h.snapshot })
+                return snapshot.mean
             }
         }
     }
@@ -136,7 +180,8 @@ class DropwizardMicrometerBridgeService {
         return new ToDoubleFunction<Histogram>() {
             @Override
             double applyAsDouble(Histogram h) {
-                return h.snapshot.median
+                Snapshot snapshot = getCachedSnapshot(h, { -> h.snapshot })
+                return snapshot.median
             }
         }
     }
@@ -145,7 +190,8 @@ class DropwizardMicrometerBridgeService {
         return new ToDoubleFunction<Histogram>() {
             @Override
             double applyAsDouble(Histogram h) {
-                return h.snapshot.get95thPercentile()
+                Snapshot snapshot = getCachedSnapshot(h, { -> h.snapshot })
+                return snapshot.get95thPercentile()
             }
         }
     }
@@ -154,7 +200,8 @@ class DropwizardMicrometerBridgeService {
         return new ToDoubleFunction<Histogram>() {
             @Override
             double applyAsDouble(Histogram h) {
-                return h.snapshot.get99thPercentile()
+                Snapshot snapshot = getCachedSnapshot(h, { -> h.snapshot })
+                return snapshot.get99thPercentile()
             }
         }
     }

--- a/rundeckapp/grails-app/services/rundeck/services/DropwizardMicrometerBridgeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/DropwizardMicrometerBridgeService.groovy
@@ -12,6 +12,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.beans.factory.annotation.Autowired
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.ToDoubleFunction
@@ -26,6 +27,7 @@ import java.util.function.ToDoubleFunction
 class DropwizardMicrometerBridgeService {
 
     MetricRegistry metricRegistry
+    @Autowired
     MeterRegistry meterRegistry
     ConfigurationService configurationService
 

--- a/rundeckapp/grails-app/services/rundeck/services/DropwizardMicrometerBridgeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/DropwizardMicrometerBridgeService.groovy
@@ -67,6 +67,22 @@ class DropwizardMicrometerBridgeService {
         return freshSnapshot
     }
 
+    /**
+     * Safely removes a metric from the Micrometer registry.
+     * Handles cases where the metric may not exist or has already been removed.
+     */
+    private void removeMetricSafely(String metricName, MeterRegistry registry) {
+        try {
+            def meter = registry.find(metricName).meter()
+            if (meter != null) {
+                registry.remove(meter.id)
+            }
+        } catch (Exception e) {
+            // Metric doesn't exist or already removed - this is fine
+            log.trace("Could not remove metric ${metricName}: ${e.message}")
+        }
+    }
+
     // Helper methods to create ToDoubleFunction for each metric type
     private static ToDoubleFunction<com.codahale.metrics.Gauge> gaugeValueExtractor() {
         return new ToDoubleFunction<com.codahale.metrics.Gauge>() {
@@ -335,7 +351,12 @@ class DropwizardMicrometerBridgeService {
 
             @Override
             void onGaugeRemoved(String name) {
-                log.debug("Gauge removed from Dropwizard: ${name}")
+                try {
+                    meterRegistry.remove(meterRegistry.get(name).meter().id)
+                    log.debug("Removed bridged gauge from Micrometer: ${name}")
+                } catch (Exception e) {
+                    log.debug("Failed to remove gauge ${name} from Micrometer: ${e.message}")
+                }
             }
 
             @Override
@@ -350,7 +371,12 @@ class DropwizardMicrometerBridgeService {
 
             @Override
             void onCounterRemoved(String name) {
-                log.debug("Counter removed from Dropwizard: ${name}")
+                try {
+                    meterRegistry.remove(meterRegistry.get(name).meter().id)
+                    log.debug("Removed bridged counter from Micrometer: ${name}")
+                } catch (Exception e) {
+                    log.debug("Failed to remove counter ${name} from Micrometer: ${e.message}")
+                }
             }
 
             @Override
@@ -369,7 +395,17 @@ class DropwizardMicrometerBridgeService {
 
             @Override
             void onHistogramRemoved(String name) {
-                log.debug("Histogram removed from Dropwizard: ${name}")
+                try {
+                    // Remove all 5 histogram gauges: count, mean, p50, p95, p99
+                    removeMetricSafely("${name}.count", meterRegistry)
+                    removeMetricSafely("${name}.mean", meterRegistry)
+                    removeMetricSafely("${name}.50thpercentile", meterRegistry)
+                    removeMetricSafely("${name}.95thpercentile", meterRegistry)
+                    removeMetricSafely("${name}.99thpercentile", meterRegistry)
+                    log.debug("Removed bridged histogram metrics from Micrometer: ${name}")
+                } catch (Exception e) {
+                    log.debug("Failed to remove histogram ${name} from Micrometer: ${e.message}")
+                }
             }
 
             @Override
@@ -399,7 +435,14 @@ class DropwizardMicrometerBridgeService {
 
             @Override
             void onMeterRemoved(String name) {
-                log.debug("Meter removed from Dropwizard: ${name}")
+                try {
+                    // Remove both meter gauges: count and rate.mean
+                    removeMetricSafely("${name}.count", meterRegistry)
+                    removeMetricSafely("${name}.rate.mean", meterRegistry)
+                    log.debug("Removed bridged meter metrics from Micrometer: ${name}")
+                } catch (Exception e) {
+                    log.debug("Failed to remove meter ${name} from Micrometer: ${e.message}")
+                }
             }
 
             @Override
@@ -418,7 +461,17 @@ class DropwizardMicrometerBridgeService {
 
             @Override
             void onTimerRemoved(String name) {
-                log.debug("Timer removed from Dropwizard: ${name}")
+                try {
+                    // Remove all 5 timer gauges: count, mean, p50, p95, p99
+                    removeMetricSafely("${name}.count", meterRegistry)
+                    removeMetricSafely("${name}.mean", meterRegistry)
+                    removeMetricSafely("${name}.50thpercentile", meterRegistry)
+                    removeMetricSafely("${name}.95thpercentile", meterRegistry)
+                    removeMetricSafely("${name}.99thpercentile", meterRegistry)
+                    log.debug("Removed bridged timer metrics from Micrometer: ${name}")
+                } catch (Exception e) {
+                    log.debug("Failed to remove timer ${name} from Micrometer: ${e.message}")
+                }
             }
         })
 

--- a/rundeckapp/grails-app/services/rundeck/services/DropwizardMicrometerBridgeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/DropwizardMicrometerBridgeService.groovy
@@ -233,15 +233,10 @@ class DropwizardMicrometerBridgeService {
             return
         }
 
-        log.debug("Initializing Dropwizard->Micrometer metrics bridge")
+        log.info("Initializing Dropwizard->Micrometer metrics bridge")
 
         if (!metricRegistry) {
             log.warn("Cannot initialize bridge: metricRegistry is null")
-            return
-        }
-
-        if (!meterRegistry) {
-            log.warn("Cannot initialize bridge: meterRegistry is null")
             return
         }
 

--- a/rundeckapp/grails-app/services/rundeck/services/DropwizardMicrometerBridgeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/DropwizardMicrometerBridgeService.groovy
@@ -7,7 +7,6 @@ import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.MetricRegistryListener
 import com.codahale.metrics.Snapshot
 import com.codahale.metrics.Timer
-import grails.core.GrailsApplication
 import grails.events.annotation.Subscriber
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -27,8 +26,8 @@ import java.util.function.ToDoubleFunction
 class DropwizardMicrometerBridgeService {
 
     MetricRegistry metricRegistry
+    MeterRegistry meterRegistry
     ConfigurationService configurationService
-    GrailsApplication grailsApplication
 
     // Cache snapshots to avoid recomputing during Prometheus scrapes
     // Key: metric object identity, Value: cached snapshot with timestamp
@@ -238,15 +237,6 @@ class DropwizardMicrometerBridgeService {
 
         if (!metricRegistry) {
             log.warn("Cannot initialize bridge: metricRegistry is null")
-            return
-        }
-
-        // Get the composite MeterRegistry from Spring Boot's auto-configuration
-        MeterRegistry meterRegistry = null
-        try {
-            meterRegistry = grailsApplication.mainContext.getBean(MeterRegistry)
-        } catch (Exception e) {
-            log.error("Cannot find MeterRegistry bean", e)
             return
         }
 

--- a/rundeckapp/grails-app/services/rundeck/services/DropwizardMicrometerBridgeService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/DropwizardMicrometerBridgeService.groovy
@@ -1,0 +1,395 @@
+package rundeck.services
+
+import com.codahale.metrics.Counter
+import com.codahale.metrics.Histogram
+import com.codahale.metrics.Meter
+import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.MetricRegistryListener
+import com.codahale.metrics.Timer
+import grails.core.GrailsApplication
+import grails.events.annotation.Subscriber
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+
+import java.util.function.ToDoubleFunction
+/**
+ * Bridges Dropwizard MetricRegistry to Micrometer MeterRegistry.
+ *
+ * This allows business metrics registered via Dropwizard (throughout Rundeck codebase)
+ * to be exposed through Spring Boot Actuator endpoints like /monitoring/prometheus.
+ */
+@Slf4j
+@CompileStatic
+class DropwizardMicrometerBridgeService {
+
+    MetricRegistry metricRegistry
+    ConfigurationService configurationService
+    GrailsApplication grailsApplication
+
+    // Helper methods to create ToDoubleFunction for each metric type
+    private static ToDoubleFunction<com.codahale.metrics.Gauge> gaugeValueExtractor() {
+        return new ToDoubleFunction<com.codahale.metrics.Gauge>() {
+            @Override
+            double applyAsDouble(com.codahale.metrics.Gauge g) {
+                Object value = g.value
+                if (value instanceof Number) {
+                    return ((Number) value).doubleValue()
+                }
+                return 0.0d
+            }
+        }
+    }
+
+    private static ToDoubleFunction<Counter> counterValueExtractor() {
+        return new ToDoubleFunction<Counter>() {
+            @Override
+            double applyAsDouble(Counter c) {
+                return c.count as double
+            }
+        }
+    }
+
+    private static ToDoubleFunction<Meter> meterCountExtractor() {
+        return new ToDoubleFunction<Meter>() {
+            @Override
+            double applyAsDouble(Meter m) {
+                return m.count as double
+            }
+        }
+    }
+
+    private static ToDoubleFunction<Meter> meterRateExtractor() {
+        return new ToDoubleFunction<Meter>() {
+            @Override
+            double applyAsDouble(Meter m) {
+                return m.meanRate
+            }
+        }
+    }
+
+    private static ToDoubleFunction<Timer> timerCountExtractor() {
+        return new ToDoubleFunction<Timer>() {
+            @Override
+            double applyAsDouble(Timer t) {
+                return t.count as double
+            }
+        }
+    }
+
+    private static ToDoubleFunction<Timer> timerMeanExtractor() {
+        return new ToDoubleFunction<Timer>() {
+            @Override
+            double applyAsDouble(Timer t) {
+                return t.snapshot.mean / 1_000_000.0 // ns to ms
+            }
+        }
+    }
+
+    private static ToDoubleFunction<Timer> timerP50Extractor() {
+        return new ToDoubleFunction<Timer>() {
+            @Override
+            double applyAsDouble(Timer t) {
+                return t.snapshot.median / 1_000_000.0 // ns to ms
+            }
+        }
+    }
+
+    private static ToDoubleFunction<Timer> timerP95Extractor() {
+        return new ToDoubleFunction<Timer>() {
+            @Override
+            double applyAsDouble(Timer t) {
+                return t.snapshot.get95thPercentile() / 1_000_000.0 // ns to ms
+            }
+        }
+    }
+
+    private static ToDoubleFunction<Timer> timerP99Extractor() {
+        return new ToDoubleFunction<Timer>() {
+            @Override
+            double applyAsDouble(Timer t) {
+                return t.snapshot.get99thPercentile() / 1_000_000.0 // ns to ms
+            }
+        }
+    }
+
+    private static ToDoubleFunction<Histogram> histogramCountExtractor() {
+        return new ToDoubleFunction<Histogram>() {
+            @Override
+            double applyAsDouble(Histogram h) {
+                return h.count as double
+            }
+        }
+    }
+
+    private static ToDoubleFunction<Histogram> histogramMeanExtractor() {
+        return new ToDoubleFunction<Histogram>() {
+            @Override
+            double applyAsDouble(Histogram h) {
+                return h.snapshot.mean
+            }
+        }
+    }
+
+    private static ToDoubleFunction<Histogram> histogramP50Extractor() {
+        return new ToDoubleFunction<Histogram>() {
+            @Override
+            double applyAsDouble(Histogram h) {
+                return h.snapshot.median
+            }
+        }
+    }
+
+    private static ToDoubleFunction<Histogram> histogramP95Extractor() {
+        return new ToDoubleFunction<Histogram>() {
+            @Override
+            double applyAsDouble(Histogram h) {
+                return h.snapshot.get95thPercentile()
+            }
+        }
+    }
+
+    private static ToDoubleFunction<Histogram> histogramP99Extractor() {
+        return new ToDoubleFunction<Histogram>() {
+            @Override
+            double applyAsDouble(Histogram h) {
+                return h.snapshot.get99thPercentile()
+            }
+        }
+    }
+
+    @Subscriber("rundeck.bootstrap")
+    void initialize() {
+        boolean enabled = configurationService.getBoolean(
+            'metrics.micrometer.bridge.enabled',
+            true
+        )
+
+        if (!enabled) {
+            log.info("Dropwizard->Micrometer bridge disabled")
+            return
+        }
+
+        log.info("=== Initializing Dropwizard->Micrometer metrics bridge ===")
+        log.info("MetricRegistry: ${metricRegistry?.class?.name}")
+
+        if (!metricRegistry) {
+            log.warn("Cannot initialize bridge: metricRegistry is null")
+            return
+        }
+
+        // Get the composite MeterRegistry from Spring Boot's auto-configuration
+        MeterRegistry meterRegistry = null
+        try {
+            meterRegistry = grailsApplication.mainContext.getBean(MeterRegistry)
+            log.info("Found MeterRegistry: ${meterRegistry?.class?.name}")
+        } catch (Exception e) {
+            log.error("Cannot find MeterRegistry bean", e)
+            return
+        }
+
+        if (!meterRegistry) {
+            log.warn("Cannot initialize bridge: meterRegistry is null")
+            return
+        }
+
+        // Count existing Dropwizard metrics
+        int gaugeCount = metricRegistry.gauges.size()
+        int counterCount = metricRegistry.counters.size()
+        int meterCount = metricRegistry.meters.size()
+        int timerCount = metricRegistry.timers.size()
+        int histogramCount = metricRegistry.histograms.size()
+        int totalMetrics = gaugeCount + counterCount + meterCount + timerCount + histogramCount
+
+        log.info("Dropwizard metrics found: ${totalMetrics} total")
+        log.info("  - ${gaugeCount} gauges")
+        log.info("  - ${counterCount} counters")
+        log.info("  - ${meterCount} meters")
+        log.info("  - ${timerCount} timers")
+        log.info("  - ${histogramCount} histograms")
+
+        // Bridge Dropwizard metrics to Micrometer by registering them directly
+        int bridged = 0
+
+        // Register Dropwizard Gauges as Micrometer Gauges
+        metricRegistry.gauges.each { String name, com.codahale.metrics.Gauge gauge ->
+            try {
+                Gauge.builder(name, gauge, gaugeValueExtractor()).register(meterRegistry)
+                bridged++
+            } catch (Exception e) {
+                log.debug("Failed to bridge gauge ${name}: ${e.message}")
+            }
+        }
+
+        // Register Dropwizard Counters as Micrometer Gauges (Dropwizard counters are not monotonic)
+        metricRegistry.counters.each { String name, Counter counter ->
+            try {
+                Gauge.builder(name, counter, counterValueExtractor()).register(meterRegistry)
+                bridged++
+            } catch (Exception e) {
+                log.debug("Failed to bridge counter ${name}: ${e.message}")
+            }
+        }
+
+        // Register Dropwizard Meters as Micrometer Gauges (count and rates)
+        metricRegistry.meters.each { String name, Meter meter ->
+            try {
+                Gauge.builder("${name}.count", meter, meterCountExtractor()).register(meterRegistry)
+                Gauge.builder("${name}.rate.mean", meter, meterRateExtractor()).register(meterRegistry)
+                if (name.contains('execution')) {
+                    log.info("✅ Bridged execution meter: ${name} → ${name}.count (${meter.count})")
+                }
+                bridged += 2
+            } catch (Exception e) {
+                log.warn("❌ Failed to bridge meter ${name}: ${e.message}", e)
+            }
+        }
+
+        // Register Dropwizard Timers as Micrometer Gauges
+        metricRegistry.timers.each { String name, Timer timer ->
+            try {
+                Gauge.builder("${name}.count", timer, timerCountExtractor()).register(meterRegistry)
+                Gauge.builder("${name}.mean", timer, timerMeanExtractor()).register(meterRegistry)
+                Gauge.builder("${name}.50thpercentile", timer, timerP50Extractor()).register(meterRegistry)
+                Gauge.builder("${name}.95thpercentile", timer, timerP95Extractor()).register(meterRegistry)
+                Gauge.builder("${name}.99thpercentile", timer, timerP99Extractor()).register(meterRegistry)
+                bridged += 5
+            } catch (Exception e) {
+                log.debug("Failed to bridge timer ${name}: ${e.message}")
+            }
+        }
+
+        // Register Dropwizard Histograms as Micrometer Gauges
+        metricRegistry.histograms.each { String name, Histogram histogram ->
+            try {
+                Gauge.builder("${name}.count", histogram, histogramCountExtractor()).register(meterRegistry)
+                Gauge.builder("${name}.mean", histogram, histogramMeanExtractor()).register(meterRegistry)
+                Gauge.builder("${name}.50thpercentile", histogram, histogramP50Extractor()).register(meterRegistry)
+                Gauge.builder("${name}.95thpercentile", histogram, histogramP95Extractor()).register(meterRegistry)
+                Gauge.builder("${name}.99thpercentile", histogram, histogramP99Extractor()).register(meterRegistry)
+                bridged += 5
+            } catch (Exception e) {
+                log.debug("Failed to bridge histogram ${name}: ${e.message}")
+            }
+        }
+
+        // Add listener to bridge new metrics dynamically
+        metricRegistry.addListener(new MetricRegistryListener() {
+            @Override
+            void onGaugeAdded(String name, com.codahale.metrics.Gauge<?> gauge) {
+                try {
+                    Gauge.builder(name, gauge, gaugeValueExtractor()).register(meterRegistry)
+                    log.debug("Dynamically bridged gauge: ${name}")
+                } catch (Exception e) {
+                    log.debug("Failed to bridge gauge ${name}: ${e.message}")
+                }
+            }
+
+            @Override
+            void onGaugeRemoved(String name) {
+                log.debug("Gauge removed from Dropwizard: ${name}")
+            }
+
+            @Override
+            void onCounterAdded(String name, Counter counter) {
+                try {
+                    Gauge.builder(name, counter, counterValueExtractor()).register(meterRegistry)
+                    log.debug("Dynamically bridged counter: ${name}")
+                } catch (Exception e) {
+                    log.debug("Failed to bridge counter ${name}: ${e.message}")
+                }
+            }
+
+            @Override
+            void onCounterRemoved(String name) {
+                log.debug("Counter removed from Dropwizard: ${name}")
+            }
+
+            @Override
+            void onHistogramAdded(String name, Histogram histogram) {
+                try {
+                    Gauge.builder("${name}.count", histogram, histogramCountExtractor()).register(meterRegistry)
+                    Gauge.builder("${name}.mean", histogram, histogramMeanExtractor()).register(meterRegistry)
+                    Gauge.builder("${name}.50thpercentile", histogram, histogramP50Extractor()).register(meterRegistry)
+                    Gauge.builder("${name}.95thpercentile", histogram, histogramP95Extractor()).register(meterRegistry)
+                    Gauge.builder("${name}.99thpercentile", histogram, histogramP99Extractor()).register(meterRegistry)
+                    log.debug("Dynamically bridged histogram: ${name} with percentiles")
+                } catch (Exception e) {
+                    log.debug("Failed to bridge histogram ${name}: ${e.message}")
+                }
+            }
+
+            @Override
+            void onHistogramRemoved(String name) {
+                log.debug("Histogram removed from Dropwizard: ${name}")
+            }
+
+            @Override
+            void onMeterAdded(String name, Meter meter) {
+                try {
+                    // Try to register count
+                    try {
+                        Gauge.builder("${name}.count", meter, meterCountExtractor()).register(meterRegistry)
+                    } catch (IllegalArgumentException iae) {
+                        // Already registered, that's okay
+                        log.debug("Meter ${name}.count already registered")
+                    }
+
+                    // Try to register rate
+                    try {
+                        Gauge.builder("${name}.rate.mean", meter, meterRateExtractor()).register(meterRegistry)
+                    } catch (IllegalArgumentException iae) {
+                        // Already registered, that's okay
+                        log.debug("Meter ${name}.rate.mean already registered")
+                    }
+
+                    log.info("✅ Dynamically bridged meter: ${name} → ${name}.count, ${name}.rate.mean")
+                } catch (Exception e) {
+                    log.warn("❌ Failed to bridge meter ${name}: ${e.message}", e)
+                }
+            }
+
+            @Override
+            void onMeterRemoved(String name) {
+                log.debug("Meter removed from Dropwizard: ${name}")
+            }
+
+            @Override
+            void onTimerAdded(String name, Timer timer) {
+                try {
+                    Gauge.builder("${name}.count", timer, timerCountExtractor()).register(meterRegistry)
+                    Gauge.builder("${name}.mean", timer, timerMeanExtractor()).register(meterRegistry)
+                    Gauge.builder("${name}.50thpercentile", timer, timerP50Extractor()).register(meterRegistry)
+                    Gauge.builder("${name}.95thpercentile", timer, timerP95Extractor()).register(meterRegistry)
+                    Gauge.builder("${name}.99thpercentile", timer, timerP99Extractor()).register(meterRegistry)
+                    log.info("Dynamically bridged timer: ${name} with percentiles")
+                } catch (Exception e) {
+                    log.debug("Failed to bridge timer ${name}: ${e.message}")
+                }
+            }
+
+            @Override
+            void onTimerRemoved(String name) {
+                log.debug("Timer removed from Dropwizard: ${name}")
+            }
+        })
+
+        // Log execution-related meters for debugging
+        def executionMeters = metricRegistry.meters.keySet().findAll { it.contains('execution') }
+        if (executionMeters) {
+            log.info("📊 Found ${executionMeters.size()} execution meters:")
+            executionMeters.each { name ->
+                log.info("   - ${name}")
+            }
+        } else {
+            log.warn("⚠️  No execution meters found in MetricRegistry yet!")
+            log.warn("   Execution meters will be bridged dynamically when jobs run")
+        }
+
+        log.info("=== Dropwizard->Micrometer bridge initialized successfully ===")
+        log.info("Bridged ${bridged} existing metrics to Micrometer")
+        log.info("Listener registered to bridge new metrics dynamically")
+        log.info("Metrics will be available at /monitoring/prometheus")
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/services/DropwizardMicrometerBridgeServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/DropwizardMicrometerBridgeServiceSpec.groovy
@@ -5,10 +5,8 @@ import com.codahale.metrics.Histogram
 import com.codahale.metrics.Meter
 import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.Timer
-import grails.core.GrailsApplication
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import org.springframework.context.ApplicationContext
 import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
@@ -19,26 +17,20 @@ class DropwizardMicrometerBridgeServiceSpec extends Specification {
     MetricRegistry metricRegistry
     MeterRegistry meterRegistry
     ConfigurationService configurationService
-    GrailsApplication grailsApplication
-    ApplicationContext applicationContext
 
     def setup() {
         metricRegistry = new MetricRegistry()
         meterRegistry = new SimpleMeterRegistry()
         configurationService = Mock(ConfigurationService)
-        grailsApplication = Mock(GrailsApplication)
-        applicationContext = Mock(ApplicationContext)
 
         service = new DropwizardMicrometerBridgeService()
         service.metricRegistry = metricRegistry
+        service.meterRegistry = meterRegistry
         service.configurationService = configurationService
-        service.grailsApplication = grailsApplication
     }
 
     void setupBridgeEnabled() {
         configurationService.getBoolean('metrics.micrometer.bridge.enabled', true) >> true
-        grailsApplication.mainContext >> applicationContext
-        applicationContext.getBean(MeterRegistry) >> meterRegistry
     }
 
     def "bridge is disabled when configuration is false"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/DropwizardMicrometerBridgeServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/DropwizardMicrometerBridgeServiceSpec.groovy
@@ -1,0 +1,267 @@
+package rundeck.services
+
+import com.codahale.metrics.Counter
+import com.codahale.metrics.Histogram
+import com.codahale.metrics.Meter
+import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.Timer
+import grails.core.GrailsApplication
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.springframework.context.ApplicationContext
+import spock.lang.Specification
+
+import java.util.concurrent.TimeUnit
+
+class DropwizardMicrometerBridgeServiceSpec extends Specification {
+
+    DropwizardMicrometerBridgeService service
+    MetricRegistry metricRegistry
+    MeterRegistry meterRegistry
+    ConfigurationService configurationService
+    GrailsApplication grailsApplication
+    ApplicationContext applicationContext
+
+    def setup() {
+        metricRegistry = new MetricRegistry()
+        meterRegistry = new SimpleMeterRegistry()
+        configurationService = Mock(ConfigurationService)
+        grailsApplication = Mock(GrailsApplication)
+        applicationContext = Mock(ApplicationContext)
+
+        service = new DropwizardMicrometerBridgeService()
+        service.metricRegistry = metricRegistry
+        service.configurationService = configurationService
+        service.grailsApplication = grailsApplication
+    }
+
+    void setupBridgeEnabled() {
+        configurationService.getBoolean('metrics.micrometer.bridge.enabled', true) >> true
+        grailsApplication.mainContext >> applicationContext
+        applicationContext.getBean(MeterRegistry) >> meterRegistry
+    }
+
+    def "bridge is disabled when configuration is false"() {
+        given:
+        configurationService.getBoolean('metrics.micrometer.bridge.enabled', true) >> false
+
+        when:
+        service.initialize()
+
+        then:
+        meterRegistry.meters.size() == 0
+    }
+
+    def "bridge registers existing Dropwizard Gauge to Micrometer"() {
+        given:
+        setupBridgeEnabled()
+
+        // Register a Dropwizard gauge before initializing the bridge
+        metricRegistry.register("test.gauge", new com.codahale.metrics.Gauge<Integer>() {
+            @Override
+            Integer getValue() {
+                return 42
+            }
+        })
+
+        when:
+        service.initialize()
+
+        then:
+        def micrometerGauge = meterRegistry.get("test.gauge").gauge()
+        micrometerGauge.value() == 42.0d
+    }
+
+    def "bridge registers existing Dropwizard Counter to Micrometer"() {
+        given:
+        setupBridgeEnabled()
+
+        Counter counter = metricRegistry.counter("test.counter")
+        counter.inc(10)
+
+        when:
+        service.initialize()
+
+        then:
+        def micrometerGauge = meterRegistry.get("test.counter").gauge()
+        micrometerGauge.value() == 10.0d
+    }
+
+    def "bridge registers existing Dropwizard Meter with count and rate"() {
+        given:
+        setupBridgeEnabled()
+
+        Meter meter = metricRegistry.meter("test.meter")
+        meter.mark(5)
+
+        when:
+        service.initialize()
+
+        then:
+        def countGauge = meterRegistry.get("test.meter.count").gauge()
+        countGauge.value() == 5.0d
+
+        and:
+        def rateGauge = meterRegistry.get("test.meter.rate.mean").gauge()
+        rateGauge.value() >= 0.0d  // Rate will be positive
+    }
+
+    def "bridge registers existing Dropwizard Timer with count, mean, and percentiles"() {
+        given:
+        setupBridgeEnabled()
+
+        Timer timer = metricRegistry.timer("test.timer")
+        timer.update(100, TimeUnit.MILLISECONDS)
+        timer.update(200, TimeUnit.MILLISECONDS)
+
+        when:
+        service.initialize()
+
+        then:
+        def countGauge = meterRegistry.get("test.timer.count").gauge()
+        countGauge.value() == 2.0d
+
+        and:
+        def meanGauge = meterRegistry.get("test.timer.mean").gauge()
+        meanGauge.value() > 0.0d
+
+        and:
+        meterRegistry.get("test.timer.50thpercentile").gauge()
+        meterRegistry.get("test.timer.95thpercentile").gauge()
+        meterRegistry.get("test.timer.99thpercentile").gauge()
+    }
+
+    def "bridge registers existing Dropwizard Histogram with count, mean, and percentiles"() {
+        given:
+        setupBridgeEnabled()
+
+        Histogram histogram = metricRegistry.histogram("test.histogram")
+        histogram.update(50)
+        histogram.update(100)
+        histogram.update(150)
+
+        when:
+        service.initialize()
+
+        then:
+        def countGauge = meterRegistry.get("test.histogram.count").gauge()
+        countGauge.value() == 3.0d
+
+        and:
+        def meanGauge = meterRegistry.get("test.histogram.mean").gauge()
+        meanGauge.value() == 100.0d
+
+        and:
+        meterRegistry.get("test.histogram.50thpercentile").gauge()
+        meterRegistry.get("test.histogram.95thpercentile").gauge()
+        meterRegistry.get("test.histogram.99thpercentile").gauge()
+    }
+
+    def "bridge dynamically registers new Dropwizard Gauge added after initialization"() {
+        given:
+        setupBridgeEnabled()
+
+        when:
+        service.initialize()
+
+        and: "register a new gauge after the bridge is initialized"
+        metricRegistry.register("dynamic.gauge", new com.codahale.metrics.Gauge<Integer>() {
+            @Override
+            Integer getValue() {
+                return 99
+            }
+        })
+
+        then:
+        def micrometerGauge = meterRegistry.get("dynamic.gauge").gauge()
+        micrometerGauge.value() == 99.0d
+    }
+
+    def "bridge dynamically registers new Dropwizard Meter added after initialization"() {
+        given:
+        setupBridgeEnabled()
+
+        when:
+        service.initialize()
+
+        and: "register a new meter after the bridge is initialized"
+        Meter meter = metricRegistry.meter("dynamic.meter")
+        meter.mark(7)
+
+        then:
+        def countGauge = meterRegistry.get("dynamic.meter.count").gauge()
+        countGauge.value() == 7.0d
+
+        and:
+        meterRegistry.get("dynamic.meter.rate.mean").gauge()
+    }
+
+    def "bridge dynamically registers new Dropwizard Timer added after initialization"() {
+        given:
+        setupBridgeEnabled()
+
+        when:
+        service.initialize()
+
+        and: "register a new timer after the bridge is initialized"
+        Timer timer = metricRegistry.timer("dynamic.timer")
+        timer.update(50, TimeUnit.MILLISECONDS)
+
+        then:
+        def countGauge = meterRegistry.get("dynamic.timer.count").gauge()
+        countGauge.value() == 1.0d
+
+        and:
+        meterRegistry.get("dynamic.timer.mean").gauge()
+        meterRegistry.get("dynamic.timer.50thpercentile").gauge()
+        meterRegistry.get("dynamic.timer.95thpercentile").gauge()
+        meterRegistry.get("dynamic.timer.99thpercentile").gauge()
+    }
+
+    def "bridge handles Gauge with non-numeric value gracefully"() {
+        given:
+        setupBridgeEnabled()
+
+        metricRegistry.register("test.string.gauge", new com.codahale.metrics.Gauge<String>() {
+            @Override
+            String getValue() {
+                return "not a number"
+            }
+        })
+
+        when:
+        service.initialize()
+
+        then:
+        def micrometerGauge = meterRegistry.get("test.string.gauge").gauge()
+        micrometerGauge.value() == 0.0d  // Should default to 0.0 for non-numeric values
+    }
+
+    def "bridge registers multiple metric types in a single initialization"() {
+        given:
+        setupBridgeEnabled()
+
+        // Register one of each type
+        metricRegistry.register("test.gauge", new com.codahale.metrics.Gauge<Integer>() {
+            @Override
+            Integer getValue() { return 1 }
+        })
+        metricRegistry.counter("test.counter").inc()
+        metricRegistry.meter("test.meter").mark()
+        metricRegistry.timer("test.timer").update(10, TimeUnit.MILLISECONDS)
+        metricRegistry.histogram("test.histogram").update(5)
+
+        when:
+        service.initialize()
+
+        then:
+        meterRegistry.get("test.gauge").gauge()
+        meterRegistry.get("test.counter").gauge()
+        meterRegistry.get("test.meter.count").gauge()
+        meterRegistry.get("test.timer.count").gauge()
+        meterRegistry.get("test.histogram.count").gauge()
+
+        and: "should have bridged multiple metrics per type"
+        meterRegistry.meters.size() > 5  // At least 5 base metrics + percentiles
+    }
+}


### PR DESCRIPTION
## Jira Ticket

[RUN-4406](https://pagerduty.atlassian.net/browse/RUN-4406)

## Summary

Adds `DropwizardMicrometerBridgeService` to bridge Codahale/Dropwizard metrics to Micrometer, making them available via `/monitoring/prometheus`.

This enables Rundeck to expose metrics registered via the legacy Codahale MetricRegistry (used throughout the codebase) through Spring Boot Actuator's Micrometer-based Prometheus endpoint.

## What's included

- **Automatic bridging** of all Dropwizard metric types:
  - Gauges → Micrometer Gauge
  - Counters → Micrometer Gauge
  - Meters → Micrometer Gauge (with `.count` and `.rate.mean` suffixes)
  - Timers → Micrometer Gauge (with `.count`, `.mean`, `.50thpercentile`, `.95thpercentile`, `.99thpercentile`)
  - Histograms → Micrometer Gauge (with same percentiles as Timers)

- **Dynamic listener** that automatically bridges new metrics registered at runtime via `MetricRegistryListener`

- **Configurable** via `metrics.micrometer.bridge.enabled` (default: true)

## Why this matters

This bridge enables:
- Unified metrics collection via `/monitoring/prometheus`
- No code changes needed for existing Dropwizard metrics
- Support for both legacy (Dropwizard) and new (Micrometer) metrics in the same endpoint

[RUN-4406]: https://pagerduty.atlassian.net/browse/RUN-4406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ