### PR TITLE
[RUN-4417] Add prepare-community-pr workflow for fork-friendly CI (maintenance)

### DIFF
--- a/.github/workflows/prepare-community-pr.yml
+++ b/.github/workflows/prepare-community-pr.yml
@@ -8,12 +8,10 @@
 # - Do NOT checkout the PR branch as the workspace root (no execution of PR-supplied
 #   Action config from the PR ref as the checked-out tree for later steps).
 # - Use only numeric PR id, default base branch, and a 40-hex SHA from the event.
-# - Approval is enforced via github.event.pull_request.review_decision (see job if:).
-#   That field is populated when the repository uses required reviews / review decision
-#   on the PR; if the job never runs after labeling, check branch protection settings.
-# - pull_request_target is required so GITHUB_TOKEN can push for fork-based PRs (read-only
-#   on pull_request / pull_request_review for forks per GitHub docs).
-# - Changed paths are enumerated with git diff (no gh api); merge uses refs/pull/<N>/head.
+# - Require at least one APPROVED review for the current head commit before proceeding.
+# - Approval is verified via 'gh pr view --json reviews' (no manual API pagination).
+# - Changed files are enumerated with 'git diff' (no API calls, path traversal checks).
+# - pull_request_target is required so GITHUB_TOKEN can push for fork-based PRs.
 name: Prepare community PR
 
 on:
@@ -31,8 +29,7 @@ jobs:
       github.event.pull_request.state == 'open' &&
       github.event.pull_request.draft == false &&
       github.event.label.name == 'prepare-community-pr' &&
-      github.event.pull_request.base.ref == github.event.repository.default_branch &&
-      github.event.pull_request.review_decision == 'APPROVED'
+      github.event.pull_request.base.ref == github.event.repository.default_branch
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -56,6 +53,39 @@ jobs:
             exit 1
           fi
 
+      - name: Verify approval for current PR head
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          head_lc="${HEAD_SHA,,}"
+          
+          # Use gh pr view to get all reviews without manual pagination
+          reviews_json="$(gh pr view "${PR_NUMBER}" --repo "${REPO_FULL}" --json reviews,headRefOid)"
+          
+          # Verify the PR head matches what we expect
+          pr_head="$(jq -r '.headRefOid // ""' <<<"${reviews_json}")"
+          pr_head_lc="${pr_head,,}"
+          if [[ "${pr_head_lc}" != "${head_lc}" ]]; then
+            echo "PR head from view (${pr_head}) does not match event head.sha ${HEAD_SHA}." >&2
+            exit 1
+          fi
+          
+          # Count APPROVED reviews for the current head commit
+          approved_for_head="$(
+            jq --arg head "${head_lc}" '
+              [.reviews[]? | select(.state == "APPROVED" and (((.commit.oid // "") | ascii_downcase) == $head))]
+              | length
+            ' <<<"${reviews_json}"
+          )"
+          
+          if [[ "${approved_for_head}" -lt 1 ]]; then
+            echo "PR #${PR_NUMBER} has no APPROVED review recorded for head ${HEAD_SHA}." >&2
+            echo "Push a new commit or re-request review, then remove and re-apply the label." >&2
+            exit 1
+          fi
+
       - name: Check out default base branch (trusted ref only)
         uses: actions/checkout@v4
         with:
@@ -63,7 +93,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - name: Verify changed files (git only), merge PR head, push integration branch
+      - name: Verify changed files and merge PR head
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -84,12 +114,14 @@ jobs:
             exit 1
           fi
 
+          # Verify changed files using git diff (no API pagination needed)
           diff_file="$(mktemp)"
           if ! git diff --name-only "origin/${BASE_REF}...FETCH_HEAD" >"${diff_file}"; then
             echo "git diff --name-only failed (bad refs?)." >&2
             rm -f "${diff_file}"
             exit 1
           fi
+          
           mapfile -t files <"${diff_file}"
           rm -f "${diff_file}"
 
@@ -98,6 +130,7 @@ jobs:
             exit 1
           fi
 
+          # Check for path traversal attacks
           for f in "${files[@]}"; do
             if [[ -z "${f}" ]]; then
               continue

--- a/.github/workflows/prepare-community-pr.yml
+++ b/.github/workflows/prepare-community-pr.yml
@@ -114,15 +114,15 @@ jobs:
             exit 1
           fi
 
-          # Verify changed files using git diff (no API pagination needed)
+          # Verify changed files using git diff with NUL delimiter (prevents newline injection)
           diff_file="$(mktemp)"
-          if ! git diff --name-only "origin/${BASE_REF}...FETCH_HEAD" >"${diff_file}"; then
+          if ! git diff --name-only -z "origin/${BASE_REF}...FETCH_HEAD" >"${diff_file}"; then
             echo "git diff --name-only failed (bad refs?)." >&2
             rm -f "${diff_file}"
             exit 1
           fi
           
-          mapfile -t files <"${diff_file}"
+          mapfile -d '' -t files <"${diff_file}"
           rm -f "${diff_file}"
 
           if [[ "${#files[@]}" -eq 0 || ( "${#files[@]}" -eq 1 && -z "${files[0]}" ) ]]; then
@@ -130,13 +130,23 @@ jobs:
             exit 1
           fi
 
-          # Check for path traversal attacks
+          # Security checks on changed files
           for f in "${files[@]}"; do
             if [[ -z "${f}" ]]; then
               continue
             fi
+            
+            # Block path traversal attacks
             if [[ "${f}" == *".."* ]]; then
-              echo "Rejecting suspicious path containing '..': ${f}" >&2
+              echo "SECURITY: Rejecting path containing '..': ${f}" >&2
+              exit 1
+            fi
+            
+            # Block workflow/action file changes (prevents secret exfiltration)
+            if [[ "${f}" == .github/workflows/* ]] || [[ "${f}" == .github/actions/* ]]; then
+              echo "SECURITY: Rejecting workflow/action file change: ${f}" >&2
+              echo "Workflow changes from community PRs are not allowed." >&2
+              echo "Submit workflow changes in a separate PR from a rundeck org member." >&2
               exit 1
             fi
           done

--- a/.github/workflows/prepare-community-pr.yml
+++ b/.github/workflows/prepare-community-pr.yml
@@ -8,7 +8,12 @@
 # - Do NOT checkout the PR branch as the workspace root (no execution of PR-supplied
 #   Action config from the PR ref as the checked-out tree for later steps).
 # - Use only numeric PR id, default base branch, and a 40-hex SHA from the event.
-# - Require at least one APPROVED review for the current head commit before proceeding.
+# - Approval is enforced via github.event.pull_request.review_decision (see job if:).
+#   That field is populated when the repository uses required reviews / review decision
+#   on the PR; if the job never runs after labeling, check branch protection settings.
+# - pull_request_target is required so GITHUB_TOKEN can push for fork-based PRs (read-only
+#   on pull_request / pull_request_review for forks per GitHub docs).
+# - Changed paths are enumerated with git diff (no gh api); merge uses refs/pull/<N>/head.
 name: Prepare community PR
 
 on:
@@ -26,7 +31,8 @@ jobs:
       github.event.pull_request.state == 'open' &&
       github.event.pull_request.draft == false &&
       github.event.label.name == 'prepare-community-pr' &&
-      github.event.pull_request.base.ref == github.event.repository.default_branch
+      github.event.pull_request.base.ref == github.event.repository.default_branch &&
+      github.event.pull_request.review_decision == 'APPROVED'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -50,77 +56,6 @@ jobs:
             exit 1
           fi
 
-      - name: Verify approval for current PR head
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          head_lc="${HEAD_SHA,,}"
-          page=1
-          approved_for_head=0
-          while true; do
-            chunk="$(
-              gh api "repos/${REPO_FULL}/pulls/${PR_NUMBER}/reviews?per_page=100&page=${page}"
-            )"
-            n="$(jq 'length' <<<"${chunk}")"
-            if [[ "${n}" -eq 0 ]]; then
-              break
-            fi
-            cnt="$(
-              jq --arg head "${head_lc}" '
-                [.[] | select(.state == "APPROVED" and (((.commit_id // "") | ascii_downcase) == $head))]
-                | length
-              ' <<<"${chunk}"
-            )"
-            approved_for_head=$((approved_for_head + cnt))
-            if [[ "${n}" -lt 100 ]]; then
-              break
-            fi
-            page=$((page + 1))
-          done
-          if [[ "${approved_for_head}" -lt 1 ]]; then
-            echo "PR #${PR_NUMBER} has no APPROVED review recorded for head ${HEAD_SHA}." >&2
-            echo "Push a new commit or re-request review, then remove and re-apply the label." >&2
-            exit 1
-          fi
-
-      - name: Verify PR lists at least one changed file
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          page=1
-          total=0
-          while true; do
-            mapfile -t files < <(
-              gh api "repos/${REPO_FULL}/pulls/${PR_NUMBER}/files?per_page=100&page=${page}" --jq '.[].filename'
-            )
-            if [[ "${#files[@]}" -eq 0 ]]; then
-              if [[ "${page}" -eq 1 ]]; then
-                echo "PR has no changed files; nothing to prepare." >&2
-                exit 1
-              fi
-              break
-            fi
-            for f in "${files[@]}"; do
-              if [[ "${f}" == *".."* ]]; then
-                echo "Rejecting suspicious path containing '..': ${f}" >&2
-                exit 1
-              fi
-            done
-            total=$((total + ${#files[@]}))
-            if [[ "${#files[@]}" -lt 100 ]]; then
-              break
-            fi
-            page=$((page + 1))
-          done
-          if [[ "${total}" -lt 1 ]]; then
-            echo "PR has no changed files; nothing to prepare." >&2
-            exit 1
-          fi
-
       - name: Check out default base branch (trusted ref only)
         uses: actions/checkout@v4
         with:
@@ -128,7 +63,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - name: Fast-forward to latest base and merge PR head
+      - name: Verify changed files (git only), merge PR head, push integration branch
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -148,6 +83,30 @@ jobs:
             echo "Fetched PR head ${fetched} does not match event head.sha ${HEAD_SHA}; refusing to merge." >&2
             exit 1
           fi
+
+          diff_file="$(mktemp)"
+          if ! git diff --name-only "origin/${BASE_REF}...FETCH_HEAD" >"${diff_file}"; then
+            echo "git diff --name-only failed (bad refs?)." >&2
+            rm -f "${diff_file}"
+            exit 1
+          fi
+          mapfile -t files <"${diff_file}"
+          rm -f "${diff_file}"
+
+          if [[ "${#files[@]}" -eq 0 || ( "${#files[@]}" -eq 1 && -z "${files[0]}" ) ]]; then
+            echo "PR has no changed files relative to ${BASE_REF}; nothing to prepare." >&2
+            exit 1
+          fi
+
+          for f in "${files[@]}"; do
+            if [[ -z "${f}" ]]; then
+              continue
+            fi
+            if [[ "${f}" == *".."* ]]; then
+              echo "Rejecting suspicious path containing '..': ${f}" >&2
+              exit 1
+            fi
+          done
 
           prep_branch="bot/prep-community-pr-${PR_NUMBER}"
           git checkout -B "${prep_branch}"

--- a/.github/workflows/prepare-community-pr.yml
+++ b/.github/workflows/prepare-community-pr.yml
@@ -1,0 +1,209 @@
+# pull_request_target runs this workflow file from the base branch (e.g. main), not the PR
+# branch. Edits here only affect CI after they land on the default branch.
+#
+# Prepares an integration branch + PR so full CI runs (including jobs that need repo
+# secrets) for approved community PRs that are difficult to validate directly from forks.
+#
+# Security model:
+# - Do NOT checkout the PR branch as the workspace root (no execution of PR-supplied
+#   Action config from the PR ref as the checked-out tree for later steps).
+# - Use only numeric PR id, default base branch, and a 40-hex SHA from the event.
+# - Require at least one APPROVED review for the current head commit before proceeding.
+name: Prepare community PR
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+concurrency:
+  group: prepare-community-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    name: Open integration PR
+    if: >-
+      github.event.pull_request.state == 'open' &&
+      github.event.pull_request.draft == false &&
+      github.event.label.name == 'prepare-community-pr' &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      REPO_FULL: ${{ github.repository }}
+    steps:
+      - name: Validate event inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${HEAD_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "head.sha is not a 40-hex SHA; refusing to continue." >&2
+            exit 1
+          fi
+          if [[ ! "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "pull_request.number is not numeric; refusing to continue." >&2
+            exit 1
+          fi
+
+      - name: Verify approval for current PR head
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          head_lc="${HEAD_SHA,,}"
+          page=1
+          approved_for_head=0
+          while true; do
+            chunk="$(
+              gh api "repos/${REPO_FULL}/pulls/${PR_NUMBER}/reviews?per_page=100&page=${page}"
+            )"
+            n="$(jq 'length' <<<"${chunk}")"
+            if [[ "${n}" -eq 0 ]]; then
+              break
+            fi
+            cnt="$(
+              jq --arg head "${head_lc}" '
+                [.[] | select(.state == "APPROVED" and (((.commit_id // "") | ascii_downcase) == $head))]
+                | length
+              ' <<<"${chunk}"
+            )"
+            approved_for_head=$((approved_for_head + cnt))
+            if [[ "${n}" -lt 100 ]]; then
+              break
+            fi
+            page=$((page + 1))
+          done
+          if [[ "${approved_for_head}" -lt 1 ]]; then
+            echo "PR #${PR_NUMBER} has no APPROVED review recorded for head ${HEAD_SHA}." >&2
+            echo "Push a new commit or re-request review, then remove and re-apply the label." >&2
+            exit 1
+          fi
+
+      - name: Verify PR lists at least one changed file
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          page=1
+          total=0
+          while true; do
+            mapfile -t files < <(
+              gh api "repos/${REPO_FULL}/pulls/${PR_NUMBER}/files?per_page=100&page=${page}" --jq '.[].filename'
+            )
+            if [[ "${#files[@]}" -eq 0 ]]; then
+              if [[ "${page}" -eq 1 ]]; then
+                echo "PR has no changed files; nothing to prepare." >&2
+                exit 1
+              fi
+              break
+            fi
+            for f in "${files[@]}"; do
+              if [[ "${f}" == *".."* ]]; then
+                echo "Rejecting suspicious path containing '..': ${f}" >&2
+                exit 1
+              fi
+            done
+            total=$((total + ${#files[@]}))
+            if [[ "${#files[@]}" -lt 100 ]]; then
+              break
+            fi
+            page=$((page + 1))
+          done
+          if [[ "${total}" -lt 1 ]]; then
+            echo "PR has no changed files; nothing to prepare." >&2
+            exit 1
+          fi
+
+      - name: Check out default base branch (trusted ref only)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Fast-forward to latest base and merge PR head
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin "${BASE_REF}"
+          git reset --hard "origin/${BASE_REF}"
+
+          git fetch origin "pull/${PR_NUMBER}/head"
+          fetched="$(git rev-parse FETCH_HEAD)"
+          head_lc="${HEAD_SHA,,}"
+          fetched_lc="${fetched,,}"
+          if [[ "${fetched_lc}" != "${head_lc}" ]]; then
+            echo "Fetched PR head ${fetched} does not match event head.sha ${HEAD_SHA}; refusing to merge." >&2
+            exit 1
+          fi
+
+          prep_branch="bot/prep-community-pr-${PR_NUMBER}"
+          git checkout -B "${prep_branch}"
+
+          merge_msg="Prepare CI: merge community PR #${PR_NUMBER}"
+          if ! git merge --no-ff FETCH_HEAD -m "${merge_msg}"; then
+            body_file="$(mktemp)"
+            {
+              printf '%s\n\n' "The \`prepare-community-pr\` workflow could not merge this PR into \`${prep_branch}\`."
+              printf '%s\n' "Resolve conflicts against the default branch, then remove and re-apply the label."
+            } >"${body_file}"
+            gh pr comment "${PR_NUMBER}" --repo "${REPO_FULL}" --body-file "${body_file}"
+            rm -f "${body_file}"
+            exit 1
+          fi
+
+          git push --force-with-lease origin "HEAD:${prep_branch}"
+
+      - name: Open or refresh integration pull request
+        if: success()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          prep_branch="bot/prep-community-pr-${PR_NUMBER}"
+          origin_url="https://github.com/${REPO_FULL}/pull/${PR_NUMBER}"
+          title="Prepare CI for community PR #${PR_NUMBER}"
+          body_file="$(mktemp)"
+          {
+            printf '%s\n\n' "This PR was opened automatically so default-branch CI (including jobs that need repository secrets) can run on the merged result."
+            printf '%s\n' "Source (community) PR: ${origin_url}"
+          } >"${body_file}"
+
+          existing="$(
+            gh pr list \
+              --repo "${REPO_FULL}" \
+              --head "${prep_branch}" \
+              --base "${BASE_REF}" \
+              --state open \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+
+          if [[ -n "${existing}" ]]; then
+            gh pr edit "${existing}" \
+              --repo "${REPO_FULL}" \
+              --title "${title}" \
+              --body-file "${body_file}"
+            echo "Updated existing PR #${existing}."
+          else
+            gh pr create \
+              --repo "${REPO_FULL}" \
+              --base "${BASE_REF}" \
+              --head "${prep_branch}" \
+              --title "${title}" \
+              --body-file "${body_file}"
+          fi
+          rm -f "${body_file}"


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

**Enhancement (maintainer / CI workflow).** Adds automation so an **approved** community pull request can be merged into a **`bot/prep-community-pr-<N>`** integration branch and a follow-up PR opened, so **default-branch CI** (including jobs that need **repository secrets**) can run in a first-party context. This addresses the case where fork-based PRs do not get the same CI signal as branches on `rundeck/rundeck`.

**Describe the solution you've implemented**

- New workflow **`.github/workflows/prepare-community-pr.yml`**.
- **Trigger:** `pull_request_target` + label **`prepare-community-pr`** (required so `GITHUB_TOKEN` can push when the source PR is from a fork).
- **Guards:** PR open, not draft, base is repo **default** branch; `head.sha` must be a 40-hex SHA; PR number numeric; at least one **APPROVED** review whose `commit_id` matches current head; PR must list at least one changed file; filenames must not contain `..`.
- **Behavior:** checkout **base** only, fast-forward to `origin/<base>`, fetch `pull/<N>/head`, verify SHA matches event, `git merge --no-ff`, push **`bot/prep-community-pr-<N>`** with `--force-with-lease`, then **`gh pr create` / `gh pr edit`** using a generated body file (no contributor-controlled strings interpolated into shell for `gh`).
- **Git identity:** same **`github-actions[bot]`** + email as **`update_packaging_submodule_to_main.yml`** (`git config --global`).
- **Merge conflicts:** comment on the source PR and fail the job.

**Describe alternatives you've considered**

- Doing this in **rundeckpro** with a path filter on the `rundeck` submodule — that was the wrong repository for this intent; the automation belongs on **OSS** so it governs core CI directly.
- Using `pull_request` + PAT checkout of the PR head (like submodule-to-main flows) — different security posture; this workflow intentionally merges via `refs/pull/<N>/head` without checking out the PR tree as the job workspace.

**Additional context**

- **Draft PR** so maintainers can confirm branch protection for `bot/*`, required labels, and any org policy before merge.
- After merge to `main`, validation is: open a test PR from a fork (or use an existing one), approve at current head, apply **`prepare-community-pr`**, confirm integration PR and CI.

## Release Notes

Internal only: adds a maintainer-triggered GitHub Action to prepare integration PRs for community contributions; no end-user product behavior change.
