### PR TITLE
[RUN-4297] increase ansible version to 4.0.16

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 rundeck:
   plugins: # Extra plugins to bundle
-  - "com.github.rundeck-plugins:ansible-plugin:4.0.15"
+  - "com.github.rundeck-plugins:ansible-plugin:4.0.16"
   - "com.github.rundeck-plugins:aws-s3-model-source:v1.0.10"
   - "com.github.rundeck-plugins:py-winrm-plugin:2.1.3@zip"
   - "com.github.rundeck-plugins:openssh-node-execution:2.0.4@zip"


### PR DESCRIPTION
This pull request updates the version of the Ansible plugin bundled with the project. The change ensures that the latest features and bug fixes from the Ansible plugin are included.

Dependency update:

* Updated the `ansible-plugin` dependency in `build.yaml` from version `4.0.15` to `4.0.16`.