### PR TITLE
[RUN-4420] Align Versions and pro fixes from Renovate updates to ant, jaxen, objenesis and document Grails BOM Spring/Groovy pinning

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@
 group=org.rundeck
 currentVersion = 6.0.0
 grailsVersion=7.0.10
+# springBootVersion / springVersion / groovyVersion must match the published org.apache.grails:grails-bom for grailsVersion (Grails pins Spring aggressively).
 # Core framework versions - prefer BOM-managed versions where possible
 # Required for plugin declaration in build.gradle
 springBootVersion=3.5.13
@@ -90,15 +91,15 @@ mssqlJdbcVersion=13.2.1.jre11
 mockitoInlineVersion=5.14.2
 mockitoAllVersion=1.10.19
 cglibNoDepVersion=3.3.0
-objenesisVersion=3.3
+objenesisVersion=3.5
 byteBuddyVersion=1.18.8
 # Grails 7 dependency resolution versions
 kotlinVersion=1.9.25
-antVersion=1.10.17
+antVersion=1.10.15
 guavaVersion=33.4.8-jre
 asmVersion=9.9
 micrometerVersion=1.15.10
-jaxenVersion=2.0.1
+jaxenVersion=2.0.0
 failureAccessVersion=1.0.3
 # CVE-specific dependency versions - will re-enable constraints after Grails 7 baseline is stable
 # Focus on framework compatibility first, then layer security hardening back in


### PR DESCRIPTION
## Summary
- Set `antVersion` to **1.10.15** and `jaxenVersion` to **2.0.0** so the enterprise WAR does not ship two versions of the same library (verifyBuild stem uniqueness).
- Bump `objenesisVersion` to **3.5** (Renovate alignment).
- Add a short comment in `gradle.properties` that `springBootVersion` / `springVersion` / `groovyVersion` must stay aligned with the published `org.apache.grails:grails-bom` for the chosen `grailsVersion`.

## Related
- Pairs with the rundeckpro PR that bumps this submodule and fixes enterprise `verifyBuild` / UI zip packaging.