### PR TITLE
[RUN-4430] increase ansible version to 5.0.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -113,7 +113,7 @@ c3p0Version=0.13.0
 protobufVersion=3.25.5
 commonsLang3Version=3.20.0
 # Third-party plugin versions (org.rundeck.plugins bundled in Core)
-ansiblePluginVersion=5.0.0
+ansiblePluginVersion=5.0.1
 awsS3ModelSourceVersion=2.0.0
 pyWinrmPluginVersion=3.0.0
 opensshNodeExecutionVersion=3.0.0


### PR DESCRIPTION
This pull request updates a third-party plugin version in the `gradle.properties` file.

Dependency version update:

* Updated the `ansiblePluginVersion` from `5.0.0` to `5.0.1` in `gradle.properties` to use the latest patch version of the Ansible plugin.