### PR TITLE
[RUN-4315] Add isEditView prop to ConfigSection

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/ConfigSection.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/ConfigSection.vue
@@ -1,13 +1,30 @@
 <template>
-  <div class="config-section" :class="{ 'has-chips': modelValue.length > 0, 'edit-view': isEditView }">
-
+  <div
+    class="config-section"
+    :class="{ 'has-chips': modelValue.length > 0, 'edit-view': isEditView }"
+  >
     <template v-if="isEditView">
       <div class="section-header">
-        <p class="section-title text-heading--md text-heading--semibold" data-testid="config-section-title">{{ title }}</p>
-        <p v-if="tooltip" class="section-description text-body text-body--secondary" data-testid="config-section-description">{{ tooltip }}</p>
+        <p
+          class="section-title text-heading--md text-heading--semibold"
+          data-testid="config-section-title"
+        >
+          {{ title }}
+        </p>
+        <p
+          v-if="tooltip"
+          class="section-description text-body text-body--secondary"
+          data-testid="config-section-description"
+        >
+          {{ tooltip }}
+        </p>
       </div>
       <slot name="extra">
-        <div v-if="modelValue.length > 0" class="chips-row" data-testid="config-section-chips-row">
+        <div
+          v-if="modelValue.length > 0"
+          class="chips-row"
+          data-testid="config-section-chips-row"
+        >
           <transition-group name="chip-list" tag="div" class="chips-container">
             <Chip
               v-for="(element, index) in modelValue"
@@ -21,25 +38,25 @@
           </transition-group>
           <button
             v-if="!hideWhenSingle"
-            @click.prevent="handleAdd"
             class="edit-view-add-btn text-body--sm text-body--medium text-body--primary"
             type="button"
             data-testid="config-section-add-btn"
+            @click.prevent="handleAdd"
           >
             <i class="pi pi-plus" />
-            {{ $t('message_add') }}
+            {{ $t("message_add") }}
           </button>
         </div>
       </slot>
       <button
         v-if="modelValue.length === 0"
-        @click.prevent="handleAdd"
         class="edit-view-add-btn text-body--sm text-body--medium text-body--primary"
         type="button"
         data-testid="config-section-add-btn"
+        @click.prevent="handleAdd"
       >
         <i class="pi pi-plus" />
-        {{ $t('message_add') }}
+        {{ $t("message_add") }}
       </button>
       <slot name="content" />
     </template>
@@ -49,19 +66,19 @@
         <p data-testid="config-section-title">
           {{ title }}
           <template v-if="tooltip">
-            <i class="pi pi-info-circle" v-tooltip="{ value: tooltip }"></i> :
+            <i v-tooltip="{ value: tooltip }" class="pi pi-info-circle"></i> :
           </template>
         </p>
         <slot name="header">
           <transition name="inline-button-fade">
             <button
               v-if="modelValue.length === 0"
-              @click.prevent="handleAdd"
               class="inline-button link-button text-body--sm text-body--primary"
               type="button"
               data-testid="config-section-add-btn"
+              @click.prevent="handleAdd"
             >
-              + {{ $t('message_add') }}
+              + {{ $t("message_add") }}
             </button>
           </transition>
         </slot>
@@ -69,8 +86,16 @@
 
       <transition name="chips-slide" mode="out-in">
         <slot name="extra">
-          <div v-if="modelValue.length > 0" class="chips-row" data-testid="config-section-chips-row">
-            <transition-group name="chip-list" tag="div" class="chips-container">
+          <div
+            v-if="modelValue.length > 0"
+            class="chips-row"
+            data-testid="config-section-chips-row"
+          >
+            <transition-group
+              name="chip-list"
+              tag="div"
+              class="chips-container"
+            >
               <Chip
                 v-for="(element, index) in modelValue"
                 :key="element.name || element.type || index"
@@ -84,19 +109,18 @@
             <button
               v-if="!hideWhenSingle"
               v-show="!hideWhenSingle || modelValue.length !== 1"
-              @click.prevent="handleAdd"
               class="link-button text-body--sm text-body--primary"
               data-testid="config-section-add-more-btn"
               type="button"
+              @click.prevent="handleAdd"
             >
-              + {{ $t('message_add') }}
+              + {{ $t("message_add") }}
             </button>
           </div>
         </slot>
       </transition>
       <slot name="content" />
     </template>
-
   </div>
 </template>
 
@@ -165,7 +189,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .config-section {
-  border-bottom: 1px solid var(--p-accordion-panel-border-color);
+  border-bottom: 1px solid var(--colors-gray-300-original);
   padding: var(--sizes-4) 0;
 
   .header-row {
@@ -226,9 +250,15 @@ export default defineComponent({
   &.edit-view {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 24px;
     padding: 0;
     border-bottom: none;
+
+    + .config-section {
+      margin-top: 24px;
+      padding-top: 24px;
+      border-top: 1px solid var(--colors-gray-300-original);
+    }
 
     .section-header {
       display: flex;
@@ -249,7 +279,7 @@ export default defineComponent({
       align-self: flex-start;
       align-items: center;
       gap: 4px;
-      background: var(--colors-blue-50, #f5f9ff);
+      background: var(--colors-blue-50);
       padding: 5px 9px;
       border-radius: 6px;
       cursor: pointer;
@@ -280,7 +310,7 @@ export default defineComponent({
     }
 
     &:focus-visible {
-      outline: 2px solid var(--colors-blue-500, #0052cc);
+      outline: 2px solid var(--colors-blue-500);
       outline-offset: 1px;
       border-radius: 2px;
     }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/ConfigSection.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/ConfigSection.vue
@@ -214,7 +214,7 @@ export default defineComponent({
   .chips-row {
     display: flex;
     align-items: center;
-    gap: var(--sizes-1);
+    gap: var(--sizes-1\.5);
     margin-top: var(--sizes-2);
     flex-wrap: wrap;
   }
@@ -256,7 +256,7 @@ export default defineComponent({
 
     + .config-section {
       margin-top: 24px;
-      padding-top: 24px;
+      padding: 24px 0;
       border-top: 1px solid var(--colors-gray-300-original);
     }
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/ConfigSection.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/ConfigSection.vue
@@ -27,7 +27,7 @@
             data-testid="config-section-add-btn"
           >
             <i class="pi pi-plus" />
-            Add
+            {{ $t('message_add') }}
           </button>
         </div>
       </slot>
@@ -39,7 +39,7 @@
         data-testid="config-section-add-btn"
       >
         <i class="pi pi-plus" />
-        Add
+        {{ $t('message_add') }}
       </button>
       <slot name="content" />
     </template>
@@ -61,7 +61,7 @@
               type="button"
               data-testid="config-section-add-btn"
             >
-              + Add
+              + {{ $t('message_add') }}
             </button>
           </transition>
         </slot>
@@ -89,7 +89,7 @@
               data-testid="config-section-add-more-btn"
               type="button"
             >
-              + Add
+              + {{ $t('message_add') }}
             </button>
           </div>
         </slot>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/ConfigSection.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/ConfigSection.vue
@@ -1,26 +1,11 @@
 <template>
-  <div class="config-section" :class="{ 'has-chips': modelValue.length > 0 }">
-    <div class="header-row">
-      <p data-testid="config-section-title">
-        {{ title }}
-        <i class="pi pi-info-circle" v-tooltip="{ value: tooltip }"></i> :
-      </p>
-      <slot name="header">
-        <transition name="inline-button-fade">
-          <button
-            v-if="modelValue.length === 0"
-            @click.prevent="handleAdd"
-            class="inline-button link-button"
-            type="button"
-            data-testid="config-section-add-btn"
-          >
-            + Add
-          </button>
-        </transition>
-      </slot>
-    </div>
+  <div class="config-section" :class="{ 'has-chips': modelValue.length > 0, 'edit-view': isEditView }">
 
-    <transition name="chips-slide" mode="out-in">
+    <template v-if="isEditView">
+      <div class="section-header">
+        <p class="section-title text-heading--md text-heading--semibold" data-testid="config-section-title">{{ title }}</p>
+        <p v-if="tooltip" class="section-description text-body text-body--secondary" data-testid="config-section-description">{{ tooltip }}</p>
+      </div>
       <slot name="extra">
         <div v-if="modelValue.length > 0" class="chips-row" data-testid="config-section-chips-row">
           <transition-group name="chip-list" tag="div" class="chips-container">
@@ -36,18 +21,82 @@
           </transition-group>
           <button
             v-if="!hideWhenSingle"
-            v-show="!hideWhenSingle || modelValue.length !== 1"
             @click.prevent="handleAdd"
-            class="link-button"
-            data-testid="config-section-add-more-btn"
+            class="edit-view-add-btn text-body--sm text-body--medium text-body--primary"
             type="button"
+            data-testid="config-section-add-btn"
           >
-            + Add
+            <i class="pi pi-plus" />
+            Add
           </button>
         </div>
       </slot>
-    </transition>
-    <slot name="content" />
+      <button
+        v-if="modelValue.length === 0"
+        @click.prevent="handleAdd"
+        class="edit-view-add-btn text-body--sm text-body--medium text-body--primary"
+        type="button"
+        data-testid="config-section-add-btn"
+      >
+        <i class="pi pi-plus" />
+        Add
+      </button>
+      <slot name="content" />
+    </template>
+
+    <template v-else>
+      <div class="header-row">
+        <p data-testid="config-section-title">
+          {{ title }}
+          <template v-if="tooltip">
+            <i class="pi pi-info-circle" v-tooltip="{ value: tooltip }"></i> :
+          </template>
+        </p>
+        <slot name="header">
+          <transition name="inline-button-fade">
+            <button
+              v-if="modelValue.length === 0"
+              @click.prevent="handleAdd"
+              class="inline-button link-button text-body--sm text-body--primary"
+              type="button"
+              data-testid="config-section-add-btn"
+            >
+              + Add
+            </button>
+          </transition>
+        </slot>
+      </div>
+
+      <transition name="chips-slide" mode="out-in">
+        <slot name="extra">
+          <div v-if="modelValue.length > 0" class="chips-row" data-testid="config-section-chips-row">
+            <transition-group name="chip-list" tag="div" class="chips-container">
+              <Chip
+                v-for="(element, index) in modelValue"
+                :key="element.name || element.type || index"
+                :label="getElementLabel(element)"
+                :icon="hideIcon ? undefined : getElementIcon(element)"
+                removable
+                @remove="handleRemove(index)"
+                @click="handleEdit(index)"
+              />
+            </transition-group>
+            <button
+              v-if="!hideWhenSingle"
+              v-show="!hideWhenSingle || modelValue.length !== 1"
+              @click.prevent="handleAdd"
+              class="link-button text-body--sm text-body--primary"
+              data-testid="config-section-add-more-btn"
+              type="button"
+            >
+              + Add
+            </button>
+          </div>
+        </slot>
+      </transition>
+      <slot name="content" />
+    </template>
+
   </div>
 </template>
 
@@ -65,7 +114,8 @@ export default defineComponent({
     },
     tooltip: {
       type: String,
-      required: true,
+      required: false,
+      default: "",
     },
     modelValue: {
       type: Array as PropType<object[]>,
@@ -76,6 +126,10 @@ export default defineComponent({
       default: false,
     },
     hideIcon: {
+      type: Boolean,
+      default: false,
+    },
+    isEditView: {
       type: Boolean,
       default: false,
     },
@@ -92,20 +146,16 @@ export default defineComponent({
       this.$emit("removeElement", index);
     },
     handleEdit(index: number) {
-      // Guard: check if element exists
       if (!this.modelValue[index]) {
         return;
       }
-      // Emit both the filter object and index so parent can use either
       const element = this.modelValue[index];
       this.$emit("editElement", element, index);
     },
     getElementLabel(element: any): string {
-      // Support both enriched data (title) and raw filter data (type)
       return element.title || element.type || "Unknown";
     },
     getElementIcon(element: any): string {
-      // Support both enriched data (providerMetadata.faicon) and raw data (default icon)
       const icon = element.providerMetadata?.faicon || "filter";
       return `fa fa-${icon}`;
     },
@@ -173,20 +223,70 @@ export default defineComponent({
     padding-bottom: 0;
   }
 
+  &.edit-view {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 0;
+    border-bottom: none;
+
+    .section-header {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .section-title {
+      margin: 0;
+    }
+
+    .section-description {
+      margin: 0;
+    }
+
+    .edit-view-add-btn {
+      display: inline-flex;
+      align-self: flex-start;
+      align-items: center;
+      gap: 4px;
+      background: var(--colors-blue-50, #f5f9ff);
+      padding: 5px 9px;
+      border-radius: 6px;
+      cursor: pointer;
+      border: none;
+      appearance: none;
+
+      .pi {
+        font-size: 12px;
+      }
+
+      &:hover {
+        opacity: 0.85;
+      }
+
+      &:focus-visible {
+        outline: 2px solid var(--colors-blue-500, #0052cc);
+        outline-offset: 1px;
+      }
+    }
+  }
+
   .link-button {
     all: unset;
-    color: #0052CC;
     cursor: pointer;
-    font-weight: 400;
-    font-size: 12px;
 
     &:hover {
       text-decoration: underline;
     }
+
+    &:focus-visible {
+      outline: 2px solid var(--colors-blue-500, #0052cc);
+      outline-offset: 1px;
+      border-radius: 2px;
+    }
   }
 }
 
-// Transition animations
 .chips-slide-enter-active,
 .chips-slide-leave-active {
   transition: all 0.25s ease-out;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/tests/ConfigSection.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/tests/ConfigSection.spec.ts
@@ -20,24 +20,34 @@ describe("ConfigSection", () => {
   describe("title", () => {
     it("shows the section title so users know what they are configuring", async () => {
       const wrapper = await createWrapper({ title: "Error Handlers" });
-      expect(wrapper.find('[data-testid="config-section-title"]').text()).toContain("Error Handlers");
+      expect(
+        wrapper.find('[data-testid="config-section-title"]').text(),
+      ).toContain("Error Handlers");
     });
   });
 
   describe("add button", () => {
     it("shows the add button when the list is empty so users can add the first item", async () => {
       const wrapper = await createWrapper({ modelValue: [] });
-      expect(wrapper.find('[data-testid="config-section-add-btn"]').exists()).toBe(true);
+      expect(
+        wrapper.find('[data-testid="config-section-add-btn"]').exists(),
+      ).toBe(true);
     });
 
     it("hides the add button when items are already present", async () => {
-      const wrapper = await createWrapper({ modelValue: [{ type: "logging/mask-passwords" }] });
-      expect(wrapper.find('[data-testid="config-section-add-btn"]').exists()).toBe(false);
+      const wrapper = await createWrapper({
+        modelValue: [{ type: "logging/mask-passwords" }],
+      });
+      expect(
+        wrapper.find('[data-testid="config-section-add-btn"]').exists(),
+      ).toBe(false);
     });
 
     it("emits addElement when the user clicks the add button", async () => {
       const wrapper = await createWrapper({ modelValue: [] });
-      await wrapper.find('[data-testid="config-section-add-btn"]').trigger("click");
+      await wrapper
+        .find('[data-testid="config-section-add-btn"]')
+        .trigger("click");
       await wrapper.vm.$nextTick();
 
       expect(wrapper.emitted("addElement")).toHaveLength(1);
@@ -47,12 +57,18 @@ describe("ConfigSection", () => {
   describe("chips row", () => {
     it("does not show the chips row when the list is empty", async () => {
       const wrapper = await createWrapper({ modelValue: [] });
-      expect(wrapper.find('[data-testid="config-section-chips-row"]').exists()).toBe(false);
+      expect(
+        wrapper.find('[data-testid="config-section-chips-row"]').exists(),
+      ).toBe(false);
     });
 
     it("shows the chips row when items are present so users can see and manage them", async () => {
-      const wrapper = await createWrapper({ modelValue: [{ type: "logging/mask-passwords" }] });
-      expect(wrapper.find('[data-testid="config-section-chips-row"]').exists()).toBe(true);
+      const wrapper = await createWrapper({
+        modelValue: [{ type: "logging/mask-passwords" }],
+      });
+      expect(
+        wrapper.find('[data-testid="config-section-chips-row"]').exists(),
+      ).toBe(true);
     });
 
     it("renders one chip per item in the list", async () => {
@@ -71,14 +87,18 @@ describe("ConfigSection", () => {
       const wrapper = await createWrapper({
         modelValue: [{ title: "My Filter", type: "logging/mask-passwords" }],
       });
-      expect(wrapper.findAllComponents(Chip)[0].props("label")).toBe("My Filter");
+      expect(wrapper.findAllComponents(Chip)[0].props("label")).toBe(
+        "My Filter",
+      );
     });
 
     it("falls back to the element type as chip label when there is no title", async () => {
       const wrapper = await createWrapper({
         modelValue: [{ type: "logging/jsonData" }],
       });
-      expect(wrapper.findAllComponents(Chip)[0].props("label")).toBe("logging/jsonData");
+      expect(wrapper.findAllComponents(Chip)[0].props("label")).toBe(
+        "logging/jsonData",
+      );
     });
 
     it("shows Unknown as chip label when the element has neither title nor type", async () => {
@@ -154,7 +174,9 @@ describe("ConfigSection", () => {
         modelValue: [{ title: "First" }, { title: "Second" }],
         hideWhenSingle: false,
       });
-      expect(wrapper.find('[data-testid="config-section-add-more-btn"]').exists()).toBe(true);
+      expect(
+        wrapper.find('[data-testid="config-section-add-more-btn"]').exists(),
+      ).toBe(true);
     });
 
     it("hides the add more button entirely when hideWhenSingle is true", async () => {
@@ -162,7 +184,9 @@ describe("ConfigSection", () => {
         modelValue: [{ title: "First" }],
         hideWhenSingle: true,
       });
-      expect(wrapper.find('[data-testid="config-section-add-more-btn"]').exists()).toBe(false);
+      expect(
+        wrapper.find('[data-testid="config-section-add-more-btn"]').exists(),
+      ).toBe(false);
     });
 
     it("emits addElement when the user clicks the add more button", async () => {
@@ -170,7 +194,9 @@ describe("ConfigSection", () => {
         modelValue: [{ title: "First" }],
         hideWhenSingle: false,
       });
-      await wrapper.find('[data-testid="config-section-add-more-btn"]').trigger("click");
+      await wrapper
+        .find('[data-testid="config-section-add-more-btn"]')
+        .trigger("click");
       await wrapper.vm.$nextTick();
 
       expect(wrapper.emitted("addElement")).toHaveLength(1);
@@ -186,20 +212,30 @@ describe("ConfigSection", () => {
         title: "Step Error Handler",
         tooltip: "Runs after a step fails",
       });
-      expect(withTooltip.find('[data-testid="config-section-title"]').text()).toBe("Step Error Handler");
-      expect(withTooltip.find('[data-testid="config-section-description"]').text()).toBe("Runs after a step fails");
+      expect(
+        withTooltip.find('[data-testid="config-section-title"]').text(),
+      ).toBe("Step Error Handler");
+      expect(
+        withTooltip.find('[data-testid="config-section-description"]').text(),
+      ).toBe("Runs after a step fails");
 
       const withoutTooltip = await createEditViewWrapper({
         title: "Step Error Handler",
         tooltip: "",
       });
-      expect(withoutTooltip.find('[data-testid="config-section-description"]').exists()).toBe(false);
+      expect(
+        withoutTooltip
+          .find('[data-testid="config-section-description"]')
+          .exists(),
+      ).toBe(false);
     });
 
     it("clicking the Add button emits addElement; button hides only when hideWhenSingle is true with an existing item", async () => {
-      const withItem = await createEditViewWrapper({ modelValue: [{ type: "exec" }] });
+      const withItem = await createEditViewWrapper({
+        modelValue: [{ type: "exec" }],
+      });
       const btn = withItem.find('[data-testid="config-section-add-btn"]');
-      expect(btn.text()).toContain("Add");
+      expect(btn.text()).toContain("message_add");
 
       await btn.trigger("click");
       await withItem.vm.$nextTick();
@@ -209,7 +245,11 @@ describe("ConfigSection", () => {
         modelValue: [{ type: "exec" }],
         hideWhenSingle: true,
       });
-      expect(hiddenWhenSingle.find('[data-testid="config-section-add-btn"]').exists()).toBe(false);
+      expect(
+        hiddenWhenSingle
+          .find('[data-testid="config-section-add-btn"]')
+          .exists(),
+      ).toBe(false);
     });
 
     it("clicking a chip emits editElement with the element and its index", async () => {
@@ -225,7 +265,9 @@ describe("ConfigSection", () => {
     it("removing a chip emits removeElement with the index and update:modelValue without that item", async () => {
       const first = { type: "exec" };
       const second = { type: "mask-passwords" };
-      const wrapper = await createEditViewWrapper({ modelValue: [first, second] });
+      const wrapper = await createEditViewWrapper({
+        modelValue: [first, second],
+      });
 
       await wrapper.findAllComponents(Chip)[0].vm.$emit("remove");
       await wrapper.vm.$nextTick();

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/tests/ConfigSection.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/tests/ConfigSection.spec.ts
@@ -176,4 +176,62 @@ describe("ConfigSection", () => {
       expect(wrapper.emitted("addElement")).toHaveLength(1);
     });
   });
+
+  describe("isEditView layout", () => {
+    const createEditViewWrapper = async (props = {}) =>
+      createWrapper({ isEditView: true, ...props });
+
+    it("shows the title and description; hides description when no tooltip is provided", async () => {
+      const withTooltip = await createEditViewWrapper({
+        title: "Step Error Handler",
+        tooltip: "Runs after a step fails",
+      });
+      expect(withTooltip.find('[data-testid="config-section-title"]').text()).toBe("Step Error Handler");
+      expect(withTooltip.find('[data-testid="config-section-description"]').text()).toBe("Runs after a step fails");
+
+      const withoutTooltip = await createEditViewWrapper({
+        title: "Step Error Handler",
+        tooltip: "",
+      });
+      expect(withoutTooltip.find('[data-testid="config-section-description"]').exists()).toBe(false);
+    });
+
+    it("clicking the Add button emits addElement; button hides only when hideWhenSingle is true with an existing item", async () => {
+      const withItem = await createEditViewWrapper({ modelValue: [{ type: "exec" }] });
+      const btn = withItem.find('[data-testid="config-section-add-btn"]');
+      expect(btn.text()).toContain("Add");
+
+      await btn.trigger("click");
+      await withItem.vm.$nextTick();
+      expect(withItem.emitted("addElement")).toHaveLength(1);
+
+      const hiddenWhenSingle = await createEditViewWrapper({
+        modelValue: [{ type: "exec" }],
+        hideWhenSingle: true,
+      });
+      expect(hiddenWhenSingle.find('[data-testid="config-section-add-btn"]').exists()).toBe(false);
+    });
+
+    it("clicking a chip emits editElement with the element and its index", async () => {
+      const element = { type: "exec", config: { exec: "echo hello" } };
+      const wrapper = await createEditViewWrapper({ modelValue: [element] });
+
+      await wrapper.findAllComponents(Chip)[0].trigger("click");
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted("editElement")![0]).toEqual([element, 0]);
+    });
+
+    it("removing a chip emits removeElement with the index and update:modelValue without that item", async () => {
+      const first = { type: "exec" };
+      const second = { type: "mask-passwords" };
+      const wrapper = await createEditViewWrapper({ modelValue: [first, second] });
+
+      await wrapper.findAllComponents(Chip)[0].vm.$emit("remove");
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted("removeElement")![0]).toEqual([0]);
+      expect(wrapper.emitted("update:modelValue")![0]).toEqual([[second]]);
+    });
+  });
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/tokens-rundeck.css
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/tokens-rundeck.css
@@ -1,4 +1,5 @@
 :root {
+    --colors-blue-50: #F5F9FF;
     --colors-blue-100:  #DCE6FB;
     --colors-blue-100-original: #BEE3F8;
     --colors-blue-500: #285ED2;


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Enhancement. This is the OSS-side support PR for RUN-4315, which introduces inline editing of error handlers and log filters in the conditional workflow step editor (Rundeck Pro). The OSS change here adds an `isEditView` prop to the shared `ConfigSection` component so the Pro plugin can render the section in inline-edit mode (section header, description, and a compact `+ Add` button) instead of the legacy chip-row layout.

**Describe the solution you've implemented**

- `ConfigSection.vue` — added an `isEditView` prop and a corresponding template branch matching the Figma design: a compact section layout with a light-blue `+ Add` button (`--colors-blue-50` background, link-blue text). When chips exist, the `+ Add` renders inline on the same row as the chips; when empty, it renders standalone.
- Added Jest coverage for the new `isEditView` layout and its add/edit/remove events.

**Describe alternatives you've considered**

- Adding the inline-edit styling only inside the Pro plugin: rejected because `ConfigSection` is the shared component and the Pro plugin already imports it from ui-trellis.

**Additional context**

This PR pairs with rundeckpro/rundeckpro#4682, which uses this `isEditView` mode to power the inline error-handler/log-filter UI in the conditional workflow plugin.

## Release Notes

Added an `isEditView` mode to the shared `ConfigSection` component to support inline editing of error handlers and log filters in the step editor.