### PR TITLE
[RUN-4437] Grails 7 upgrade breaks /menu/welcome — Metadata.getProperties(String) removed

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -1857,11 +1857,12 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         def buildDataKeys = []
         def buildMap = [:]
 
-        def properties = grailsApplication.metadata.getProperties("build")
-
-        properties.each {key, value->
-            buildDataKeys.add("build."+key)
-            buildMap.put("build."+key, value)
+        grailsApplication.metadata.getProperties().each { key, value ->
+            def k = key?.toString()
+            if (k?.startsWith('build.')) {
+                buildDataKeys << k
+                buildMap[k] = value
+            }
         }
 
         render(view:'welcome',model: [buildData: buildMap, buildDataKeys: buildDataKeys])

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -3363,4 +3363,24 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
         artefactInstance.getClass().getDeclaredMethods().find { it.name == name }.getAnnotation(clazz)
     }
 
+    def "welcome action renders without MissingMethodException"() {
+        when:
+        controller.welcome()
+
+        then:
+        noExceptionThrown()
+        model.buildData != null
+        model.buildDataKeys != null
+    }
+
+    def "welcome action model contains only build.* prefixed keys"() {
+        when:
+        controller.welcome()
+
+        then:
+        noExceptionThrown()
+        model.buildData.keySet().every { (it as String).startsWith('build.') }
+        model.buildDataKeys.every { (it as String).startsWith('build.') }
+        (model.buildDataKeys as Set) == model.buildData.keySet()
+    }
 }


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bug fix. `GET /menu/welcome` crashes with `MissingMethodException` after the Grails 7.1.1 upgrade because `grails.util.Metadata.getProperties(String prefix)` was removed in Grails 7. The welcome action called `grailsApplication.metadata.getProperties("build")` to retrieve a sub-map of build properties — a method that no longer exists. Fixes [RUN-4437](https://pagerduty.atlassian.net/browse/RUN-4437).

**Describe the solution you've implemented**

In `MenuController.welcome()`, replaced the removed `getProperties(String)` call with the no-arg `getProperties()` and a filter on keys starting with `"build."`. Since the metadata keys are already fully-qualified (`"build.number"`, `"build.date"`, etc.), the strip-and-re-add prefix dance was also simplified:

```groovy
// Before
def properties = grailsApplication.metadata.getProperties("build")
properties.each { key, value ->
    buildDataKeys.add("build." + key)
    buildMap.put("build." + key, value)
}

// After
grailsApplication.metadata.getProperties().each { key, value ->
    def k = key?.toString()
    if (k?.startsWith('build.')) {
        buildDataKeys << k
        buildMap[k] = value
    }
}
```

Two regression tests were added to `MenuControllerSpec`:
- `"welcome action renders without MissingMethodException"` — direct regression guard; would have failed before this fix
- `"welcome action model contains only build.* prefixed keys"` — verifies the filtering contract

**Describe alternatives you've considered**

<!-- A clear and concise description of any alternative solutions or features you've considered. -->

The Grails 7 `Metadata` API no longer exposes a prefix-filtered view. An alternative was to use `grailsApplication.config` to read build info, but that would require moving the build metadata into the config layer. Filtering `getProperties()` directly is the minimal, equivalent replacement.

**Additional context**

<!-- Add any other context or screenshots about the change here. -->

The `Metadata.getProperties(String prefix)` method was available in Grails 5/6 via the `PropertySourcesConfig` base class. It was removed as part of the Grails 7 / Micronaut environment refactor.

## Release Notes

Fixes a `MissingMethodException` crash on `GET /menu/welcome` introduced by the Grails 7.1.1 upgrade. The welcome page now loads correctly.


[RUN-4437]: https://pagerduty.atlassian.net/browse/RUN-4437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ