### PR TITLE
[RUN-4441] Fix flaky ContextPathLoginSpec - replace pageSource.contains("404") with element visibility check

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/contextPath/ContextPathLoginSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/contextPath/ContextPathLoginSpec.groovy
@@ -45,7 +45,7 @@ class ContextPathLoginSpec extends SeleniumBase {
             currentUrl.contains("${contextPath}/user/login")
 
         and: "page has loaded successfully (no 404 or asset loading errors)"
-            loginPage.loginBtn.isDisplayed()
+            loginPage.waitForElementVisible(loginPage.loginBtnBy).isDisplayed()
 
         and: "assets do NOT contain [:] placeholder (RUN-4332 fix verification)"
             !pageSource.contains("[:]")

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/contextPath/ContextPathLoginSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/contextPath/ContextPathLoginSpec.groovy
@@ -45,9 +45,7 @@ class ContextPathLoginSpec extends SeleniumBase {
             currentUrl.contains("${contextPath}/user/login")
 
         and: "page has loaded successfully (no 404 or asset loading errors)"
-            pageSource.contains("Login") || pageSource.contains("login")
-            !pageSource.contains("404")
-            !pageSource.contains("Not Found")
+            loginPage.loginBtn.isDisplayed()
 
         and: "assets do NOT contain [:] placeholder (RUN-4332 fix verification)"
             !pageSource.contains("[:]")


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix for a flaky Selenium test in `ContextPathLoginSpec`. The test `"login with context-path configured"` was failing intermittently in CI due to an unreliable `pageSource.contains("404")` assertion.

Fixes [RUN-4441](https://pagerduty.atlassian.net/browse/RUN-4441)

**Describe the solution you've implemented**

Replaced the three unreliable `pageSource.contains()` assertions:

```groovy
// Before (flaky)
pageSource.contains("Login") || pageSource.contains("login")
!pageSource.contains("404")
!pageSource.contains("Not Found")
```

With a single Page Object element visibility check:

```groovy
// After (reliable)
loginPage.loginBtn.isDisplayed()
```

**Root cause:** `pageSource` returns the full rendered HTML including all linked/inline JavaScript bundles. Minified JS bundles routinely contain `"404"` as a string literal for HTTP status code handling (e.g. `statusCode===404`), causing the `!pageSource.contains("404")` assertion to fail even when the login page loads correctly.

Using `loginPage.loginBtn.isDisplayed()` verifies the login form actually rendered — if the button is visible, the page loaded with correct content and cannot be a 404 error page. This approach also benefits from the 10-second implicit wait configured in `BasePage`.

**Describe alternatives you've considered**

- Checking `driver.title` for "404" — more targeted than `pageSource` but still indirect.
- The element visibility check via the Page Object is the most semantically correct and robust approach per our Selenium best practices.

**Additional context**

The `!pageSource.contains("Not Found")` assertion was removed for the same reason — it could also appear in JS bundle error-handling strings.

The browser console log check on lines 60–69 that also references `"404"` is **not affected** — it filters `driver.manage().logs()` entries (browser events), not `pageSource`.

## Release Notes

<!-- Internal CI/test reliability fix — no user-facing changes. -->


[RUN-4441]: https://pagerduty.atlassian.net/browse/RUN-4441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ