### PR TITLE
RUN-2759: Fix step number display for steps >= 10 in node view

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/execution/ExecutionSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/execution/ExecutionSpec.groovy
@@ -621,6 +621,87 @@ class ExecutionSpec extends SeleniumBase {
         executionShowPage.logNodeSettings.size() == 0
     }
 
+    /**
+     * Regression test for RUN-2759.
+     *
+     * Verifies that step numbers >= 10 are rendered correctly in the node view.
+     * The bug was caused by using string index notation ($data.stepctx[0]) which
+     * returned only the first character, so step 10 appeared as "1.", step 11 as "1.", etc.
+     * The fix uses parseInt($data.stepctx) to extract the full number.
+     *
+     * Steps:
+     * - Creates a job with 12 steps.
+     * - Runs the job and navigates to the Nodes tab.
+     * - Expands the node and reads the rendered step number labels.
+     * - Verifies that steps 10, 11, and 12 display the full two-digit number.
+     */
+    def "step numbers with two or more digits display correctly in node view"() {
+        setup:
+        def executionShowPage = page ExecutionShowPage
+        def jobUuid = "3de51941-605c-435b-b128-4dfa8142f210"
+        JobShowPage jobShowPage = page(JobShowPage, SELENIUM_EXEC_PROJECT).forJob(jobUuid)
+        def yaml = """
+            -
+              defaultTab: nodes
+              description: ''
+              executionEnabled: true
+              id: ${jobUuid}
+              loglevel: INFO
+              name: stepNumberRegressionJob
+              nodeFilterEditable: false
+              plugins:
+                ExecutionLifecycle: {}
+              scheduleEnabled: true
+              sequence:
+                commands:
+                - exec: echo 'step 1'
+                - exec: echo 'step 2'
+                - exec: echo 'step 3'
+                - exec: echo 'step 4'
+                - exec: echo 'step 5'
+                - exec: echo 'step 6'
+                - exec: echo 'step 7'
+                - exec: echo 'step 8'
+                - exec: echo 'step 9'
+                - exec: echo 'step 10'
+                - exec: echo 'step 11'
+                - exec: echo 'step 12'
+              keepgoing: false
+              strategy: node-first
+              uuid: ${jobUuid}
+        """
+        def pathToJob = JobUtils.generateFileToImport(yaml, "yaml")
+        def multipartBody = new MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addFormDataPart("xmlBatch", new File(pathToJob).name, RequestBody.create(new File(pathToJob), MultipartBody.FORM))
+                .build()
+        client.postWithMultipart("/project/${SELENIUM_EXEC_PROJECT}/jobs/import?format=yaml&dupeOption=skip", multipartBody)
+
+        when:
+        jobShowPage.go()
+        jobShowPage.runJobBtn.click()
+        executionShowPage.validateStatus 'SUCCEEDED'
+
+        then: "navigate to nodes tab and expand the first node"
+        def nodesView = executionShowPage.nodesView
+        nodesView.expandNode(0)
+
+        when:
+        def stepNumbers = nodesView.stepNumbers
+
+        then: "all 12 steps must be present"
+        stepNumbers.size() == 12
+
+        and: "single-digit steps display correctly"
+        stepNumbers[0].trim() == "1."
+        stepNumbers[8].trim() == "9."
+
+        and: "two-digit step numbers show the full number, not just the first digit"
+        stepNumbers[9].trim() == "10."
+        stepNumbers[10].trim() == "11."
+        stepNumbers[11].trim() == "12."
+    }
+
     def cleanup() {
         deleteProject(SELENIUM_EXEC_PROJECT)
     }

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/execution/ExecutionShowPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/execution/ExecutionShowPage.groovy
@@ -161,6 +161,17 @@ class ExecutionShowPage extends BasePage  implements ActivityListTrait{
         List<String> getExecStateForSteps(){
             expandedNode.findElements(By.cssSelector(".wfnodestep")).collect { it.findElement(By.cssSelector('.execstatedisplay')).getAttribute(ExecutionShowPage.execStateAttribute) }
         }
+
+        /**
+         * Returns the step number labels (e.g. "1. ", "10. ") shown for each step in the expanded node.
+         * Used to verify that multi-digit step numbers are displayed correctly (RUN-2759).
+         */
+        List<String> getStepNumbers(){
+            execPage.waitForElementVisible(By.cssSelector(".wfnodesteps .stepident"))
+            expandedNode.findElements(By.cssSelector(".wfnodestep")).collect {
+                it.findElement(By.cssSelector('.stepident > span:first-child')).getText()
+            }
+        }
     }
 
     List<WebElement> getAutoCaret() {

--- a/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
+++ b/rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp
@@ -127,7 +127,7 @@
                                 attr: { 'data-execstate': executionState },
                                 css: { 'auto-caret-container': followingOutput(), active: followingOutput() }
                                 ">
-                              <span data-bind="text: $data.stepctx[0] + '. '"></span>
+                              <span data-bind="text: parseInt($data.stepctx) + '. '"></span>
                               <i class="auto-caret text-muted"></i>
 
                               <feature:disabled name="workflowDynamicStepSummaryGUI">


### PR DESCRIPTION
## Jira Ticket
[RUN-2759](https://pagerduty.atlassian.net/browse/RUN-2759)

## Problem
In the execution node view, steps with number >= 10 showed only the first digit.
Step 10 appeared as "1.", step 11 as "1.", etc.

## Root Cause
`_wfstateNodeModelDisplay.gsp` line 130 used JavaScript string index notation:
```js
$data.stepctx[0] + '. '
```
Since `stepctx` is a string (e.g. `"10"`), `[0]` returns the first **character** (`"1"`), not the first element.

## Fix
Replace with `parseInt($data.stepctx)`, which correctly parses the full number from the step context ID string.
This also handles Rundeck's special step context formats:
- `"10"` → `10`
- `"10e"` (error handler) → `10`
- `"10@params"` → `10`

## Changes
- `rundeckapp/grails-app/views/execution/_wfstateNodeModelDisplay.gsp`: fix `stepctx[0]` → `parseInt(stepctx)`
- `functional-test/.../ExecutionShowPage.groovy`: add `getStepNumbers()` method to `NodesView` inner class
- `functional-test/.../ExecutionSpec.groovy`: add regression test verifying steps 10, 11, 12 display correctly

## Testing
Selenium regression test added: `ExecutionSpec - "step numbers with two or more digits display correctly in node view"`
- Creates a 12-step job, runs it, expands the node view
- Asserts steps 10, 11, 12 show full two-digit numbers (not just "1.")
- Test **passes** against a local Rundeck instance

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Made with [Cursor](https://cursor.com)

[RUN-2759]: https://pagerduty.atlassian.net/browse/RUN-2759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ