### PR TITLE
[RUN-4453] Fix clickElementSafely to retry on NoSuchElementException

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/BasePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/BasePage.groovy
@@ -4,6 +4,7 @@ import groovy.transform.CompileStatic
 import org.openqa.selenium.By
 import org.openqa.selenium.Dimension
 import org.openqa.selenium.JavascriptExecutor
+import org.openqa.selenium.NoSuchElementException
 import org.openqa.selenium.StaleElementReferenceException
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
@@ -320,8 +321,8 @@ abstract class BasePage {
         waitForElementToBeClickable(locator)
         try {
             el(locator).click()
-        } catch (StaleElementReferenceException e) {
-            // Re-find and click if element became stale
+        } catch (StaleElementReferenceException | NoSuchElementException e) {
+            // Re-find and click if element became stale or was momentarily absent
             waitForElementToBeClickable(locator)
             el(locator).click()
         }


### PR DESCRIPTION
## Summary

- `clickElementSafely(By)` in `BasePage` catches `StaleElementReferenceException` on the retry but not `NoSuchElementException`
- After `waitForElementToBeClickable` succeeds, a fast Vue re-render can briefly remove then re-add the element (e.g. `#userLabel` in the mainbar after login)
- `el(locator).click()` then throws `NoSuchElementException`, which was not being retried
- Extends the catch block to cover both `StaleElementReferenceException` and `NoSuchElementException`

## Affected tests
- `BasicLoginSpec` – "successful login with logout"
- `ActivitySectionAuthSpec` – cleanup block logout flow

## Test plan
- [ ] Run `BasicLoginSpec` in CI and verify no `NoSuchElementException: Unable to locate element #userLabel` failures
- [ ] Run `ActivitySectionAuthSpec` in CI and verify no logout-related `NoSuchElementException` failures

Related: https://pagerduty.atlassian.net/browse/RUN-4453

🤖 Generated with [Claude Code](https://claude.com/claude-code)