### PR TITLE
[RUN-4456] Update MySQL image version to 8.4 in Docker Compose files

### DIFF
--- a/functional-test/src/test/resources/docker/compose/oss/docker-compose-context-path.yml
+++ b/functional-test/src/test/resources/docker/compose/oss/docker-compose-context-path.yml
@@ -61,7 +61,7 @@ services:
       - "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
 
   rundeck-db:
-    image: mysql:8
+    image: mysql:8.4
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_DATABASE=rundeck

--- a/functional-test/src/test/resources/docker/compose/oss/docker-compose.yml
+++ b/functional-test/src/test/resources/docker/compose/oss/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
 
   rundeck-db:
-    image: mysql:8
+    image: mysql:8.4
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_DATABASE=rundeck


### PR DESCRIPTION
## Jira Ticket

[RUN-4456](https://pagerduty.atlassian.net/browse/RUN-4456)

## Summary

Update testdeck docker-compose files to use MySQL 8.4 instead of the generic `mysql:8` tag for improved version consistency and testing accuracy in functional and Selenium test environments.

## Changes

Updated 2 docker-compose files in the rundeck functional-test suite:
- `functional-test/src/test/resources/docker/compose/oss/docker-compose.yml` - Updated mysql:8 to mysql:8.4
- `functional-test/src/test/resources/docker/compose/oss/docker-compose-context-path.yml` - Updated mysql:8 to mysql:8.4

## Related PR

This PR is part of a coordinated update across both repositories:
- **RundeckPro PR:** https://github.com/rundeckpro/rundeckpro/pull/4690

## Testing Notes

This change affects testdeck testing framework only, not production configurations. MySQL 8.4 is backward compatible with MySQL 8.0, so no breaking changes are expected.

## Verification

✅ All mysql:8 references updated to mysql:8.4 in rundeck functional-test files  
✅ No mysql:8 references remain  
⏳ CI pipeline will validate MySQL 8.4 compatibility

[RUN-4456]: https://pagerduty.atlassian.net/browse/RUN-4456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ