### PR TITLE
[RUN-4460] Fix IntelliJ bootRun Liquibase classpath errors

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -8,6 +8,16 @@ buildscript {
         maven { url "https://repo.grails.org/grails/core" }
         maven { url "https://repo.grails.org/grails/restricted" }
     }
+    // Force Liquibase to the same pinned version used at runtime.
+    // grails-bom:{strictly 4.27.0} wins in the buildscript context (ext["liquibase.version"]
+    // only applies to the application classpath). Without this force, the Grails plugin
+    // classloader in IntelliJ dev mode loads AbstractChange from liquibase-core:4.27.0, which
+    // references ChecksumVersion — a class that doesn't exist in the runtime 4.19.0 jar.
+    configurations.all {
+        resolutionStrategy {
+            force "org.liquibase:liquibase-core:${liquibaseVersion}"
+        }
+    }
     dependencies {
         classpath platform("org.apache.grails:grails-bom:$grailsVersion")
         classpath "org.apache.grails:grails-gradle-plugins"
@@ -189,10 +199,10 @@ dependencies {
     implementation "com.mchange:mchange-commons-java:${mchangeCommonsJavaVersion}"
     implementation "com.mchange:c3p0:${c3p0Version}"
     implementation 'org.grails.plugins:mail:3.0.0'
-    
+
     // Liquibase for compile-time exception classes (runtime provided by Spring Boot)
     compileOnly "org.liquibase:liquibase-core:${liquibaseVersion}"
-    
+
     // Groovy 4: XML parsing is a separate module
     implementation "org.apache.groovy:groovy-xml:${groovyVersion}"
     
@@ -472,6 +482,13 @@ bootRun {
     //    addResources = true
     // Full resources/main so classpath:/assets/ resolves; duplicateFileMode=WARN avoids Liquibase failure on duplicate migrations
     classpath += files("$buildDir/resources/main", "$buildDir/resources/main/META-INF")
+    // Strip liquibase-commercial: it ships LicenseValidationChange (extends AbstractChange)
+    // compiled against the 4.26 API, whose bytecode references liquibase.ChecksumVersion.
+    // We pin liquibase-core to 4.19.0 for DB compatibility, so 4.26's commercial jar causes
+    // NoClassDefFoundError: liquibase/ChecksumVersion during Change introspection.
+    // The WAR works because it doesn't include this artifact. liquibase-hibernate5 must
+    // stay on the classpath — Grails' dbmigration uses HibernateDatabase.
+    classpath = classpath.filter { f -> !f.name.startsWith("liquibase-commercial-") }
     System.setProperty("logRoot",System.getProperty("rdeck.base",System.getProperty("user.dir")+"/rundeck-runtime"))
     systemProperty "rundeck.server.logDir", System.getProperty("logRoot")+"/server/logs"
 }


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bug fix. When running Rundeck under `bootRun` in IntelliJ (debug or normal), the Liquibase migration step crashes with `NoClassDefFoundError: liquibase/ChecksumVersion`. The WAR build is unaffected because it doesn't include the problematic artifacts.

Jira: https://pagerduty.atlassian.net/browse/RUN-4460
Parent epic: https://pagerduty.atlassian.net/browse/RUN-3427 (Grails 7 upgrade)

**Describe the solution you've implemented**

Two surgical changes to `rundeckapp/build.gradle`:

1. **Buildscript-scope force of `liquibase-core`.** `grails-bom:7.1.1` declares `liquibase-core` with `{strictly 4.27.0}`. In the buildscript classpath this strict constraint wins because the Spring Boot dependency-management `ext["liquibase.version"]` override only applies to application configurations. The Grails plugin classloader in IntelliJ dev mode then loads `AbstractChange` from 4.27.0, whose method signatures reference `liquibase.ChecksumVersion` — a class that does not exist in the runtime 4.19.0 jar. Adding `configurations.all { resolutionStrategy { force "org.liquibase:liquibase-core:${liquibaseVersion}" } }` inside `buildscript {}` aligns both classpaths to 4.19.0.

2. **Filter `liquibase-commercial-*.jar` out of `bootRun.classpath`.** `liquibase-commercial:4.26.0` ships `com.datical.liquibase.ext.license.LicenseValidationChange`, which extends `AbstractChange`. The class was compiled against the 4.26 API; when `ChangeFactory` registers it via `ServiceLoader` and calls `createChangeMetaData()` → `Introspector.getBeanInfo()` → `Class.getMethods()`, the JVM resolves the parameter types of inherited methods, hitting `ChecksumVersion` again. The WAR build doesn't include this artifact, which is why only `bootRun` is affected.

The third hunk in the diff is a whitespace-only cleanup around the existing `compileOnly "org.liquibase:liquibase-core"` declaration; the dependency itself is unchanged.

**Describe alternatives you've considered**

- Upgrading `liquibase-core` to 4.27.0 everywhere — rejected. The Rundeck DB schema is created with 4.19.0 checksums and we cannot upgrade Liquibase per the constraints driving this fix.
- Forcing only in `allprojects` at the rundeckpro root — this was applied in a paired rundeckpro change but does NOT fix the buildscript classpath, so it is necessary but not sufficient on its own.

**Additional context**

- Verified with `./gradlew :rundeckapp:buildEnvironment` and `:rundeckapp:dependencies --configuration runtimeClasspath` that `liquibase-core:4.27.0 -> 4.19.0` resolves consistently across both classpaths after the change.
- After this fix, the Liquibase migration completes successfully under `bootRun` ("Successfully released change log lock") and the previous `NoClassDefFoundError: liquibase/ChecksumVersion` stacktrace from `EnsureSpringBootstrapFilePreBootstrap.runChangelog` no longer occurs.

## Release Notes

Fixes `NoClassDefFoundError: liquibase/ChecksumVersion` during startup of `bootRun` (IntelliJ debug) by pinning Liquibase consistently to the runtime-supported 4.19.0 in both the buildscript and `bootRun` classpaths.
