### PR TITLE
[RUN-4298] Update py-winrm-plugin to 3.1.0

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ rundeck:
   plugins: # Extra plugins to bundle
   - "org.rundeck.plugins:ansible-plugin:5.0.1"
   - "org.rundeck.plugins:aws-s3-model-source:2.0.0"
-  - "org.rundeck.plugins:py-winrm-plugin:3.0.0"
+  - "org.rundeck.plugins:py-winrm-plugin:3.1.0"
   - "org.rundeck.plugins:openssh-node-execution:3.0.0"
   - "org.rundeck.plugins:multiline-regex-datacapture-filter:2.0.0"
   - "org.rundeck.plugins:attribute-match-node-enhancer:1.0.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -115,7 +115,7 @@ commonsLang3Version=3.20.0
 # Third-party plugin versions (org.rundeck.plugins bundled in Core)
 ansiblePluginVersion=5.0.1
 awsS3ModelSourceVersion=2.0.0
-pyWinrmPluginVersion=3.0.0
+pyWinrmPluginVersion=3.1.0
 opensshNodeExecutionVersion=3.0.0
 multilineRegexDatacaptureFilterVersion=2.0.0
 attributeMatchNodeEnhancerVersion=1.0.1


### PR DESCRIPTION
## Summary

Update py-winrm-plugin from version 3.0.0 to 3.1.0 to include NO_PROXY support.

## Changes

- `gradle.properties`: `pyWinrmPluginVersion=3.1.0`
- `build.yaml`: `py-winrm-plugin:3.1.0`

## Context

The py-winrm-plugin 3.1.0 includes PR https://github.com/rundeck-plugins/py-winrm-plugin/pull/114 which adds a `No Proxy List` configuration parameter (`winrmnoproxy`) to all three WinRM plugin providers:
- **NodeExecutor** - WinRM node executor
- **FileCopier** - WinRM file copier  
- **WinRMCheck** - WinRM node check

This allows hosts/IPs/CIDRs to bypass the configured proxy and connect directly, useful for internal networks where proxy routing is unnecessary or problematic.

## Test Plan

- [x] Build verification: `./gradlew build -x check` passes
- [x] Plugin version verified in built artifacts
- [ ] CI pipeline passes

## Related

- Jira: https://pagerduty.atlassian.net/browse/RUN-4298
- Parent: https://pagerduty.atlassian.net/browse/RUN-4198
- Plugin PR: https://github.com/rundeck-plugins/py-winrm-plugin/pull/114

🤖 Generated with [Claude Code](https://claude.com/claude-code)