### PR TITLE
[RUN-4404] Restore step property value colors for dark background contexts

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/StepCardContent.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/StepCards/StepCardContent.vue
@@ -301,16 +301,7 @@ export default defineComponent({
   }
 
   span[title] {
-    color: var(--colors-gray-600);
     flex: 0 0 100px;
-  }
-
-  .copiable-text {
-    color: var(--colors-gray-800);
-
-    &:hover {
-      color: var(--colors-gray-800);
-    }
   }
 }
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/Tag/tag.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/primeVue/Tag/tag.scss
@@ -15,7 +15,7 @@
 
   &.tag-node {
     background: var(--colors-blue-100);
-    color: var(--grey-800);
+    color: var(--colors-gray-800);
     font-size: 12px; // to do check with Liza
     font-weight: var(--fontWeights-normal);
     line-height: var(--lineHeights-short);
@@ -23,7 +23,7 @@
 
   &.tag-workflow {
     background: var(--colors-orange-100);
-    color: var(--grey-800);
+    color: var(--colors-gray-800);
     font-size: 12px; // to do check with Liza
     font-weight: var(--fontWeights-normal);
     line-height: var(--lineHeights-short);
@@ -31,7 +31,7 @@
 
   &.tag-code {
     background: #E9ECEF;
-    color: var(--grey-800);
+    color: var(--colors-gray-800);
     font-family: var(--fonts-mono), monospace !important;
     font-weight: var(--fontWeights-normal);
     line-height: var(--lineHeights-short);


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bug fix for [RUN-4404](https://pagerduty.atlassian.net/browse/RUN-4404) — a regression introduced in 5.20.0 where step property values in the workflow step cards became unreadable due to incorrect color overrides applied on top of the Bootstrap `text-success` class.

The workflow editor's step list uses a dark background. In 5.15.0, step property values were displayed using Bootstrap's `text-success` (green), which is readable on dark backgrounds. In 5.20.0, new CSS rules in `StepCardContent.vue` overrode `.copiable-text` with `color: var(--colors-gray-800)` (#27272A — near-black) and labels with `color: var(--colors-gray-600)` (#71717A). Both colors are invisible/barely visible on dark backgrounds.

**Describe the solution you've implemented**

Two CSS fixes:

1. **`StepCardContent.vue`:** Removed the `.copiable-text { color: var(--colors-gray-800) }` override and the `span[title] { color: var(--colors-gray-600) }` override from the `.configpair` block. This restores Bootstrap's `text-success` (green) for property values, which was the original readable color in both light and dark background contexts.

2. **`tag.scss`:** Fixed a typo where `var(--grey-800)` (undefined CSS variable) was used instead of the correct `var(--colors-gray-800)` for the `tag-node`, `tag-workflow`, and `tag-code` badge text colors. The undefined variable caused unpredictable text color rendering in these badges.

**Describe alternatives you've considered**

An alternative would be to use a lighter color like `var(--colors-gray-100)` or white for the value text in dark-background contexts. However, since the color issue exists across multiple rendering contexts (dark and potentially light), removing the overrides entirely is safer and restores the proven-readable original behavior.

**Additional context**

Regression introduced in commit `6c94578ea4` (RUN-3942: Base UI changes for conditionals, Feb 2026) which added the new step card components with incorrect color assumptions.

## Release Notes

Fixed a regression in 5.20.0 where step configuration property values in the workflow editor step cards appeared invisible or hard to read due to dark color overrides that conflicted with the dark-background step list UI. Values now render in the original readable green color (Bootstrap `text-success`) as in previous versions.

[RUN-4404]: https://pagerduty.atlassian.net/browse/RUN-4404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ