### PR TITLE
[RUN-2811] Fix KeyStorageSelector state not resetting on reopen

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/KeyStorageSelector.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/KeyStorageSelector.vue
@@ -120,6 +120,7 @@ export default defineComponent({
       this.modalOpen = false;
     },
     openSelector() {
+      this.clean();
       this.modalOpen = true;
     },
     openEditor(uploadSetting: UploadSetting) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/KeyStorageSelector.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/KeyStorageSelector.spec.ts
@@ -226,6 +226,58 @@ describe('KeyStorageSelector', () => {
       })
 
   })
+  it('initializes selectedKey from modelValue when the selector is opened', async () => {
+    const modelValue = 'keys/existing-key'
+    const wrapper = await mountKeyStorageSelectorStub({ modelValue })
+
+    await wrapper.find('[data-testid="open-selector-btn"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const displayedValue = wrapper.find('[data-testid="modelValue"]')
+    expect(displayedValue.text()).toBe(modelValue)
+  })
+
+  it('does not emit stale key when selector is reopened after a cancelled selection', async () => {
+    const originalKey = 'keys/original-key'
+    const wrapper = mount(KeyStorageSelector, {
+      props: { modelValue: originalKey, readOnly: false, allowUpload: true },
+      global: {
+        components: { Modal },
+        stubs: {
+          KeyStorageView: {
+            name: 'KeyStorageView',
+            props: ['storageFilter', 'modelValue', 'readOnly', 'allowUpload', 'rootPath'],
+            emits: ['update:model-value'],
+            template:
+              '<div data-testid="mock-key-storage-view">' +
+              '<button data-testid="pick-key-btn" @click="$emit(\'update:model-value\', \'keys/temp-key\')">pick</button>' +
+              '</div>',
+          },
+          KeyStorageEdit: true,
+        },
+      },
+    })
+
+    // First open: simulate selecting a different key without saving
+    await wrapper.find('[data-testid="open-selector-btn"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    await wrapper.find('[data-testid="pick-key-btn"]').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    // Cancel — close without saving
+    await wrapper.find('.modal-footer button.btn-default').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    // Reopen and save immediately (no new selection)
+    await wrapper.find('[data-testid="open-selector-btn"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    await wrapper.find('.modal-footer button.btn-primary').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    // After clean() on reopen, selectedKey === modelValue so nothing should be emitted
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+  })
+
   it.each([
     'myKey',
     'key2'


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. When creating a PagerDuty V3 webhook in Rundeck, selecting a key from the Key Storage popup (Advanced tab → Shared Secret Key → "Select") closes the modal but the field remains empty.

Fixes [RUN-2811](https://pagerduty.atlassian.net/browse/RUN-2811)

**Describe the solution you've implemented**

`KeyStorageSelector.vue` is a Vue 3 component that emits `update:modelValue`. Its `openSelector()` method did not call `clean()` before opening, meaning that if a user opened the selector, made a selection, then cancelled and reopened, the internal `selectedKey` state still held the previous (unsaved) value rather than the current `modelValue`.

Added a `clean()` call inside `openSelector()` so the component always initialises `selectedKey` from the current `modelValue` before the modal is shown.

Note: the main binding fix (Vue 2 `@input`/`:value` → Vue 3 `@update:model-value`/`:model-value`) is in the companion PR in `rundeckpro/rundeckpro`.

**Describe alternatives you've considered**

Watching `modelValue` to keep `selectedKey` in sync — rejected as unnecessarily complex for the problem at hand.

## Release Notes

Fix PagerDuty V3 webhook: selecting a key from the Key Storage selector now correctly populates the Shared Secret Key field.


[RUN-2811]: https://pagerduty.atlassian.net/browse/RUN-2811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ