### PR TITLE
[RUN-3050] Fix node filter attributes incorrectly wrapped in double quotes

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeFilterLink.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/NodeFilterLink.vue
@@ -102,18 +102,28 @@ export default defineComponent({
 
     getFilter() {
       if (this.nodeFilter) {
-        let nodeFilterCpy = this.nodeFilter.trim();
-        const idxKey = nodeFilterCpy.indexOf(": ") + 2;
-        if (nodeFilterCpy.slice(idxKey).includes(" ")) {
-          nodeFilterCpy += '"';
-          nodeFilterCpy =
-            nodeFilterCpy.slice(0, idxKey) + '"' + nodeFilterCpy.slice(idxKey);
-
+        const nodeFilterCpy = this.nodeFilter.trim();
+        const sepIdx = nodeFilterCpy.indexOf(": ");
+        if (sepIdx < 0) {
           return nodeFilterCpy;
         }
-        return this.nodeFilter;
+        const valueStart = sepIdx + 2;
+        const valueAndRest = nodeFilterCpy.slice(valueStart);
+        // Already quoted — leave as-is to avoid double-quoting
+        if (valueAndRest.startsWith('"')) {
+          return nodeFilterCpy;
+        }
+        // Multi-attribute filter (e.g. "osFamily: unix name: localhost") —
+        // detected by a space followed by an optional ! and an attribute name + colon.
+        // Do NOT quote: the space is a separator between attributes, not part of a value.
+        const hasMultipleAttrs = /\s+!?\w[\w.-]*:/.test(valueAndRest);
+        if (!hasMultipleAttrs && valueAndRest.includes(" ")) {
+          // Single attribute whose value contains spaces — quote it
+          return nodeFilterCpy.slice(0, valueStart) + '"' + valueAndRest + '"';
+        }
+        return nodeFilterCpy;
       } else if (this.filterKey && this.filterVal) {
-        return `${this.filterKey}: \"${this.filterVal}\"`;
+        return `${this.filterKey}: "${this.filterVal}"`;
       }
     },
   },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeFilterLink.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/resources/tests/NodeFilterLink.spec.ts
@@ -87,4 +87,68 @@ describe("NodeFilterLink Component", () => {
       filter: "hostname: node1",
     });
   });
+
+  describe("getFilter — multi-attribute and quoting", () => {
+    const filterCases: [string, string, string][] = [
+      // [description, nodeFilter input, expected output]
+      [
+        "does not quote multi-attribute filter (no-space values)",
+        "osFamily: unix name:localhost",
+        "osFamily: unix name:localhost",
+      ],
+      [
+        "does not quote multi-attribute filter (space after colon)",
+        "osFamily: unix name: localhost",
+        "osFamily: unix name: localhost",
+      ],
+      [
+        "does not quote multi-attribute filter with three attributes",
+        "name: node1 tags: linux osFamily: unix",
+        "name: node1 tags: linux osFamily: unix",
+      ],
+      [
+        "does not double-quote when values are already quoted",
+        'osArch: "aarch64" osName: "Mac OS X"',
+        'osArch: "aarch64" osName: "Mac OS X"',
+      ],
+      [
+        "does not double-quote single attribute with quoted value",
+        'osName: "Mac OS X"',
+        'osName: "Mac OS X"',
+      ],
+      [
+        "quotes single attribute whose unquoted value contains spaces",
+        "osName: Mac OS X",
+        'osName: "Mac OS X"',
+      ],
+      [
+        "does not modify single attribute without spaces",
+        "osFamily: unix",
+        "osFamily: unix",
+      ],
+      [
+        "does not modify the all-nodes wildcard",
+        ".*",
+        ".*",
+      ],
+      [
+        "does not quote multi-attribute exclude filter",
+        "name: node1 !tags: windows",
+        "name: node1 !tags: windows",
+      ],
+      [
+        "does not quote namespace attribute with multi-attribute filter",
+        "ui:status:text: active name: node1",
+        "ui:status:text: active name: node1",
+      ],
+    ];
+
+    it.each(filterCases)("%s", async (_, nodeFilter, expected) => {
+      const wrapper = await mountNodeFilterLink({ nodeFilter });
+      await wrapper.trigger("click");
+      await wrapper.vm.$nextTick();
+      const emitted = wrapper.emitted("nodefilterclick");
+      expect(emitted![0][0]).toEqual({ filter: expected });
+    });
+  });
 });


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. When a user saves a node filter containing multiple attributes (e.g. `osFamily: unix name:localhost`) or attributes with already-quoted values (e.g. `osArch: "aarch64" osName: "Mac OS X"`), Rundeck incorrectly wraps the entire remainder of the filter string in double quotes, treating it as a single attribute value instead of preserving the original multi-attribute structure.

Fixes [RUN-3050](https://pagerduty.atlassian.net/browse/RUN-3050)

**Describe the solution you've implemented**

The root cause is in `NodeFilterLink.getFilter()`. The method searches for the first `: ` separator to locate the attribute value, then checks whether the rest of the string contains a space. If it does, it wraps the entire remainder in quotes — without checking whether those spaces are attribute separators or part of a single value.

This causes two failure modes:

1. **Multi-attribute filter quoted as one:** `osFamily: unix name:localhost` → `osFamily: "unix name:localhost"`
2. **Already-quoted values double-quoted:** `osArch: "aarch64" osName: "Mac OS X"` → `osArch: ""aarch64" osName: "Mac OS X""`

**Fix:** Before quoting, two guards are now checked:

- **`alreadyQuoted`** — if the value portion starts with `"`, it is already quoted; return as-is to prevent double-quoting.
- **`hasMultipleAttrs`** — if the value portion matches `/\s+!?\w[\w.-]*:/`, it contains another attribute key (e.g. ` name:`, ` !tags:`, ` osName:`); this is a multi-attribute filter and must not be quoted.

Only when neither guard triggers and the value contains spaces is it wrapped in quotes — which is the correct behaviour for a single attribute with a space-containing value (e.g. `osName: Mac OS X` → `osName: "Mac OS X"`).

The regex handles all Rundeck filter attribute name variants: standard names, custom names with hyphens/dots (`custom-attr`), namespace attributes (`ui:status:text`), and exclude prefixes (`!tags`).

**Describe alternatives you've considered**

Removing quoting entirely was considered but rejected — single-attribute values with spaces (e.g. `osName: Mac OS X`) genuinely need quotes to be parsed correctly by the Rundeck filter engine.



## Release Notes

Fix node filter: saving a filter with multiple attributes (e.g. `osFamily: unix name:localhost`) no longer incorrectly wraps them in double quotes. Pre-quoted values are also preserved correctly when re-loading a saved filter.


[RUN-3050]: https://pagerduty.atlassian.net/browse/RUN-3050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ