### PR TITLE
i18n: add missing key gui.menu.FindPlugins to messages.properties and…

### DIFF
--- a/rundeckapp/grails-app/i18n/messages.properties
+++ b/rundeckapp/grails-app/i18n/messages.properties
@@ -699,6 +699,7 @@ gui.menu.SystemInfo=System Report
 gui.menu.Security=Security
 gui.menu.SystemConfig=System Configuration
 gui.menu.UserProfiles=User Profiles
+gui.menu.FindPlugins=Find Plugins
 gui.menu.InstalledPlugins=Installed Plugins
 gui.menu.UploadPlugin=Upload Plugin
 gui.menu.ListPlugins=List Plugins

--- a/rundeckapp/grails-app/i18n/messages_ja.properties
+++ b/rundeckapp/grails-app/i18n/messages_ja.properties
@@ -659,6 +659,7 @@ gui.menu.SystemInfo=\u30b7\u30b9\u30c6\u30e0\u30ec\u30dd\u30fc\u30c8
 gui.menu.Security=\u30bb\u30ad\u30e5\u30ea\u30c6\u30a3
 gui.menu.SystemConfig=\u30b7\u30b9\u30c6\u30e0\u69cb\u6210
 gui.menu.UserProfiles=\u30e6\u30fc\u30b6\u30fc\u30d7\u30ed\u30d5\u30a1\u30a4\u30eb
+gui.menu.FindPlugins=\u30d7\u30e9\u30b0\u30a4\u30f3\u3092\u691c\u7d22
 gui.menu.InstalledPlugins=Installed Plugins
 gui.menu.UploadPlugin=Upload Plugin
 gui.menu.ListPlugins=List Plugins


### PR DESCRIPTION
**Is this a bugfix, or an enhancement?**

Bugfix. The i18n key `gui.menu.FindPlugins` was missing from both `messages.properties` and `messages_ja.properties`, causing the menu item title to display the raw key name instead of a translated label when `pluginRead && repoEnabled` is true.

**Describe the solution you've implemented**

Added the missing key to both files:
- `messages.properties`: `gui.menu.FindPlugins=Find Plugins`
- `messages_ja.properties`: `gui.menu.FindPlugins=プラグインを検索`

Adjacent keys `gui.menu.InstalledPlugins` and `gui.menu.UploadPlugin` were already defined; this key was simply omitted.

**Describe alternatives you've considered**

Adding a `default=` attribute to the `g.message()` call in `_sysConfigNavMenuJson.gsp` as a fallback, but adding the key to the message bundle is the correct approach.

**Additional context**

Verified by code inspection. Display not confirmed due to lack of an environment with `repoEnabled=true`.

Note: `gui.menu.InstalledPlugins` and `gui.menu.UploadPlugin` remain untranslated in `messages_ja.properties` — out of scope for this fix.

**Release Notes**

Fix: menu item "Find Plugins" displaying raw i18n key name (`gui.menu.FindPlugins`) when plugin repository is enabled.