### PR TITLE
fix(i18n): register dynamic messages into fallback locale (en_US) in …

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/i18n.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/i18n.ts
@@ -50,6 +50,13 @@ const updateLocaleMessages = async (i18n: I18n, locale: string, lang: string, me
   //include previously loaded messages
   const merged = mergeDeep((i18n.global.getLocaleMessage(locale) as Record<string, any>) || {}, messages);
   i18n.global.setLocaleMessage(locale, merged);
+  // Also register into the fallback locale (en_US) so that dynamically added
+  // messages (e.g. from plugins) are resolvable when a locale-specific
+  // translation is missing.
+  if (locale !== "en_US") {
+    const mergedFallback = mergeDeep((i18n.global.getLocaleMessage("en_US") as Record<string, any>) || {}, messages);
+    i18n.global.setLocaleMessage("en_US", mergedFallback);
+  }
   return nextTick();
 };
 /**


### PR DESCRIPTION
**Is this a bugfix, or an enhancement?**

Bugfix. When `updateLocaleMessages` is called to dynamically register messages (e.g. from plugins via `addUiMessages`), messages are only added to the active locale (e.g. `ja_JP`). If a key has no translation in that locale, vue-i18n attempts to fall back to `en_US`, but since the key was never registered there either, the raw key name is displayed in the UI instead of the English label.

**Describe the solution you've implemented**

In `updateLocaleMessages`, after merging into the target locale, also merge the same messages into `en_US` (skipped when the target locale is already `en_US`). This ensures dynamically added keys are always resolvable via the fallback chain.

**Describe alternatives you've considered**

Requiring all callers of `updateLocaleMessages` / `addUiMessages` to explicitly register into `en_US` as well — but this would require changes at every call site (`ui/main.ts`, `storage/main.ts`, `uiSocketObserver.ts`, `navbar/main.ts`, etc.) and is error-prone. Fixing it once in `updateLocaleMessages` is safer.

**Additional context**

`addUiMessages` is the DI-injected function used by plugin components to register their i18n messages at runtime. The bug affects any non-`en_US` locale where a plugin provides a partial translation — keys missing from the locale file fall through to `en_US`, but since `en_US` also lacks them, the key name is rendered as-is.

Note: the three call sites that bypass `commonAddUiMessages` and call `updateLocaleMessages` directly (`ui/main.ts`, `storage/main.ts`, `uiSocketObserver.ts`) also benefit from this fix without any changes. Consolidating those to use `commonAddUiMessages` is a separate cleanup.

**Release Notes**

Fix: dynamically registered i18n messages (e.g. from plugins) now correctly fall back to English when a locale-specific translation is missing, preventing raw key names from appearing in the UI.