### PR TITLE
[RUN-4413] Update follow-redirects for CVE-2026-40895

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
@@ -90,7 +90,7 @@
         "eslint-plugin-vuejs-accessibility": "^2.2.0",
         "eslint-webpack-plugin": "^4.2.0",
         "fetch-mock": "^9.10.1",
-        "follow-redirects": "1.15.6",
+        "follow-redirects": "1.16.0",
         "identity-obj-proxy": "^3.0.0",
         "isomorphic-fetch": "^3.0.0",
         "jest": "^29.7.0",
@@ -8554,26 +8554,6 @@
         "proxy-from-env": "^2.1.0"
       }
     },
-    "node_modules/axios/node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://npm.artifacts.pd-internal.com/npm/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -13184,16 +13164,16 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://npm.artifacts.pd-internal.com/npm/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "dev": true,
+      "version": "1.16.0",
+      "resolved": "https://npm.artifacts.pd-internal.com/npm/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },

--- a/rundeckapp/grails-spa/packages/ui-trellis/package.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package.json
@@ -123,7 +123,7 @@
     "eslint-plugin-vuejs-accessibility": "^2.2.0",
     "eslint-webpack-plugin": "^4.2.0",
     "fetch-mock": "^9.10.1",
-    "follow-redirects": "1.15.6",
+    "follow-redirects": "1.16.0",
     "identity-obj-proxy": "^3.0.0",
     "isomorphic-fetch": "^3.0.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
## Release Notes
Updates the follow-redirects dependency to version 1.16.0 to address security vulnerability CVE-2026-40895.

## PR Details
Security update to address CVE-2026-40895 in the follow-redirects package.

### Changes
- Updated follow-redirects to 1.16.0 in ui-trellis package
- Updated package-lock.json with security fix

### Testing
- Verify no regression in functionality that uses HTTP redirects
- Confirm CVE scanner no longer flags follow-redirects vulnerability