### PR TITLE
[RUN-3132] Fix job import resetting dispatch mode when node filter is empty

### DIFF
--- a/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/ScheduledExecution.groovy
@@ -524,9 +524,9 @@ class ScheduledExecution extends ExecutionContext implements JobData, EmbeddedJs
                     se.successOnEmptyNodeFilter = data.nodefilters.dispatch.successOnEmptyNodeFilter
                 }
             }
-            if(data.nodefilters.filter){
+            if(data.nodefilters.containsKey('filter')){
                 se.doNodedispatch=true
-                se.filter= data.nodefilters.filter
+                se.filter= data.nodefilters.filter ?: ''
             }else{
                 def map = [include: [:], exclude: [:]]
                 if (data.nodefilters.include) {

--- a/rundeckapp/src/test/groovy/rundeck/JobsXMLCodecSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobsXMLCodecSpec.groovy
@@ -844,4 +844,59 @@ exit 0''', argString: 'elf biscuits'
             wfi.type == ScriptCommand.SCRIPT_COMMAND_TYPE
 
     }
+
+    def "decode XML with empty filter element inside nodefilters sets doNodedispatch true (RUN-3132)"() {
+        given: "XML job with <nodefilters><filter/></nodefilters> and <dispatch>"
+            def xml = """<joblist>
+  <job>
+    <id>1</id>
+    <name>test-dispatch-empty-filter</name>
+    <description>RUN-3132 regression test</description>
+    <loglevel>INFO</loglevel>
+    <context><project>test</project></context>
+    <sequence><command><exec>echo hello</exec></command></sequence>
+    <nodefilters excludeprecedence="true">
+      <filter></filter>
+    </nodefilters>
+    <dispatch>
+      <threadcount>1</threadcount>
+      <keepgoing>false</keepgoing>
+      <successOnEmptyNodeFilter>false</successOnEmptyNodeFilter>
+    </dispatch>
+  </job>
+</joblist>"""
+        when:
+            def jobs = JobsXMLCodec.decode(xml)
+        then:
+            jobs != null
+            jobs.size() == 1
+            ScheduledExecution se = jobs[0] as ScheduledExecution
+            se.doNodedispatch == true
+            se.filter == ''
+    }
+
+    def "decode XML with only dispatch block and no nodefilters keeps doNodedispatch false (backward compat)"() {
+        given: "old-format XML job with <dispatch> only and no <nodefilters> element (RUN-3132)"
+            def xml = """<joblist>
+  <job>
+    <id>2</id>
+    <name>test-local-old-format</name>
+    <description>backward compat: old XML with only dispatch block</description>
+    <loglevel>INFO</loglevel>
+    <context><project>test</project></context>
+    <sequence><command><exec>echo hello</exec></command></sequence>
+    <dispatch>
+      <threadcount>1</threadcount>
+      <keepgoing>false</keepgoing>
+    </dispatch>
+  </job>
+</joblist>"""
+        when:
+            def jobs = JobsXMLCodec.decode(xml)
+        then:
+            jobs != null
+            jobs.size() == 1
+            ScheduledExecution se = jobs[0] as ScheduledExecution
+            se.doNodedispatch == false
+    }
 }

--- a/rundeckapp/src/test/groovy/rundeck/JobsYAMLCodecSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobsYAMLCodecSpec.groovy
@@ -674,4 +674,56 @@ class JobsYAMLCodecSpec extends Specification {
             cmd3.errorHandler.argString == "err job args"
             cmd3.errorHandler.keepgoingOnSuccess
     }
+
+    def "decode YAML with dispatch block and empty filter sets doNodedispatch true (RUN-3132)"() {
+        given: "a YAML job definition with nodefilters.dispatch and an empty filter"
+            def yaml = """- name: test-dispatch-empty-filter
+  description: RUN-3132 regression test
+  loglevel: INFO
+  sequence:
+    keepgoing: false
+    strategy: node-first
+    commands:
+    - exec: echo hello
+  nodefilters:
+    dispatch:
+      threadcount: 1
+      keepgoing: false
+      excludePrecedence: true
+      successOnEmptyNodeFilter: false
+    filter: ''
+  nodesSelectedByDefault: true
+"""
+        when:
+            def list = JobsYAMLCodec.decode(yaml)
+        then:
+            list.size() == 1
+            ScheduledExecution se = list[0] as ScheduledExecution
+            se.doNodedispatch == true
+            se.filter == ''
+            se.nodesSelectedByDefault == true
+    }
+
+    def "decode YAML with dispatch block and no filter key keeps doNodedispatch false (backward compat)"() {
+        given: "a YAML job definition with nodefilters.dispatch but no filter key"
+            def yaml = """- name: test-local
+  description: backward compat test
+  loglevel: INFO
+  sequence:
+    keepgoing: false
+    strategy: node-first
+    commands:
+    - exec: echo hello
+  nodefilters:
+    dispatch:
+      threadcount: 1
+      keepgoing: false
+"""
+        when:
+            def list = JobsYAMLCodec.decode(yaml)
+        then:
+            list.size() == 1
+            ScheduledExecution se = list[0] as ScheduledExecution
+            se.doNodedispatch == false
+    }
 }

--- a/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ScheduledExecutionSpec.groovy
@@ -61,6 +61,66 @@ class ScheduledExecutionSpec extends Specification implements DataTest
             se.options.every { it.scheduledExecution == se }
     }
 
+    def "from map with dispatch block and empty filter preserves doNodedispatch"() {
+        given: "a job map with nodefilters.dispatch and an empty filter (RUN-3132)"
+            def map = [
+                jobName: 'test-dispatch',
+                nodefilters: [
+                    dispatch: [
+                        threadcount: '1',
+                        keepgoing: false,
+                        excludePrecedence: true,
+                        successOnEmptyNodeFilter: false,
+                    ],
+                    filter: '',
+                ],
+                nodesSelectedByDefault: true,
+            ]
+        when:
+            def se = ScheduledExecution.fromMap(map)
+        then: "doNodedispatch must be true even when filter is empty string"
+            se.doNodedispatch == true
+            se.filter == ''
+            se.nodesSelectedByDefault == true
+    }
+
+    def "from map with dispatch block and non-null filter preserves doNodedispatch"() {
+        given: "a job map with nodefilters.dispatch and a non-empty filter"
+            def map = [
+                jobName: 'test-dispatch',
+                nodefilters: [
+                    dispatch: [
+                        threadcount: '2',
+                        keepgoing: true,
+                    ],
+                    filter: 'hostname: myhost',
+                ],
+                nodesSelectedByDefault: true,
+            ]
+        when:
+            def se = ScheduledExecution.fromMap(map)
+        then:
+            se.doNodedispatch == true
+            se.filter == 'hostname: myhost'
+    }
+
+    def "from map with only dispatch block and no filter key keeps doNodedispatch false"() {
+        given: "old-format job map with nodefilters.dispatch but no filter key (backward compat)"
+            def map = [
+                jobName: 'test-local',
+                nodefilters: [
+                    dispatch: [
+                        threadcount: '1',
+                        keepgoing: false,
+                    ],
+                ],
+            ]
+        when:
+            def se = ScheduledExecution.fromMap(map)
+        then: "old XML jobs with only <dispatch> and no <filter> stay as Execute locally"
+            se.doNodedispatch == false
+    }
+
     def "from map notifications urls should include httpMethod and format"() {
         given:
             def map = [


### PR DESCRIPTION
## Release Notes
Fixed an issue where jobs configured as "Dispatch to nodes" with an empty node filter were silently converted to "Execute locally" after export + reimport (via YAML, XML, Job Actions upload, SCM import, project archive import, or Terraform provider).

## Jira Ticket
[RUN-3132](https://pagerduty.atlassian.net/browse/RUN-3132)

## Summary

- Fix `ScheduledExecution.fromMap()` to correctly preserve `doNodedispatch=true` when a job is imported with an empty node filter
- Add 6 new unit tests covering the bug and backward compatibility

## Problem

Jobs configured as **"Dispatch to nodes"** with an **empty node filter** were silently converted to **"Execute locally"** after export + reimport (via YAML, XML, Job Actions upload, SCM import, project archive import, or Terraform provider).

**Root cause:** `fromMap()` used a Groovy truthiness check on `nodefilters.filter`:
```groovy
if(data.nodefilters.filter) {   // "" is falsy in Groovy → never enters
    se.doNodedispatch = true
```
When the filter was an empty string `""` (valid: dispatch to all nodes), the condition evaluated to `false`, leaving `doNodedispatch=false`. `ScheduledExecutionService` then cleared all node settings, completing the regression.

## Fix

Change the check from truthiness to explicit key presence:
```groovy
if(data.nodefilters.containsKey('filter')) {
    se.doNodedispatch = true
    se.filter = data.nodefilters.filter ?: ''
```

This distinguishes between:
- **Modern format** (`filter: ''` explicitly present) → dispatch mode ✅
- **Old XML format** (`<dispatch>` only, no `<filter>` element) → stays as Execute locally ✅ (backward compatible)

## Tests Added

| File | Tests added |
|------|------------|
| `ScheduledExecutionSpec` | 3 (empty filter, non-empty filter, no filter key) |
| `JobsYAMLCodecSpec` | 2 (YAML with empty filter, YAML without filter key) |
| `JobsXMLCodecSpec` | 2 (XML with `<filter/>`, XML with only `<dispatch>`) |

All existing tests pass (106 in `JobsXMLCodecTests`, no regressions).

## Affected Import Paths

All job import paths are fixed since they share the same `fromMap()` code:
- Job Actions → Upload definition (YAML/XML)
- Project archive import
- SCM Import Plugin
- Rundeck Terraform provider `rundeck_job` resource
- REST API job import

## Versions Affected
Reported in 5.6.1 & 5.8.0; root cause has been present since v2.x.

Made with [Cursor](https://cursor.com)

[RUN-3132]: https://pagerduty.atlassian.net/browse/RUN-3132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ