### PR TITLE
[RUN-3336] Fix cluster member state showing as unknown on Job page

### DIFF
--- a/rundeckapp/grails-app/views/scheduledExecution/_showHead.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_showHead.gsp
@@ -96,7 +96,7 @@
                       <ui-socket
                               section="server-info-display"
                               location="main"
-                              socket-data="${enc(attr:[remoteClusterNodeUUID:remoteClusterNodeUUID,showId:false,serverName:remoteClusterNodeUUID.substring(0,8)].encodeAsJSON())}"
+                              socket-data="${enc(attr:[serverUuid:remoteClusterNodeUUID,showId:false,serverName:remoteClusterNodeUUID.substring(0,8)].encodeAsJSON())}"
                       >
                       </ui-socket>
                   </span>

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -5399,10 +5399,10 @@ class ScheduledExecutionControllerSpec extends Specification implements Controll
         // on the domain object keeps the fixture semantically consistent with reality.
         // Note: unlike detailFragmentAjax, the show action does NOT require
         // serverNodeUUID != localServerUUID to populate remoteClusterNodeUUID.
-        def remoteUUID = 'aaaa-bbbb-cccc-dddd'
-        def localUUID  = 'ffff-eeee-dddd-cccc'
+        def remoteUUID = 'aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb'
+        def localUUID  = 'ffffeeee-dddd-cccc-bbbb-aaaa11112222'
         def se = new ScheduledExecution(
-                uuid: 'test-cluster-uuid',
+                uuid: UUID.randomUUID().toString(),
                 jobName: 'test1',
                 project: 'project1',
                 groupPath: 'testgroup',
@@ -5413,7 +5413,7 @@ class ScheduledExecutionControllerSpec extends Specification implements Controll
                         keepgoing: true,
                         commands: [new CommandExec([adhocRemoteString: 'echo hi'])]
                 )
-        ).save()
+        ).save(failOnError: true)
 
         controller.frameworkService = Mock(FrameworkService) {
             filterNodeSet(_, _) >> null
@@ -5459,6 +5459,9 @@ class ScheduledExecutionControllerSpec extends Specification implements Controll
             }
         }
         controller.referencedExecutionDataProvider = new GormReferencedExecutionDataProvider()
+        controller.configurationService = Mock(ConfigurationService) {
+            getString(_) >> null
+        }
 
         params.id = se.id.toString()
         params.project = 'project1'
@@ -5473,7 +5476,7 @@ class ScheduledExecutionControllerSpec extends Specification implements Controll
 
         where:
         clusterEnabled | scheduled | expectedUUID
-        true           | true      | 'aaaa-bbbb-cccc-dddd'
+        true           | true      | 'aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb'
         true           | false     | null
         false          | true      | null
         false          | false     | null

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -5389,6 +5389,90 @@ class ScheduledExecutionControllerSpec extends Specification implements Controll
     // instead of the old incorrect: new Workflow(workflow as WorkflowData)
     // ===================================================================================
 
+    @Unroll
+    def "show job includes remoteClusterNodeUUID in model when cluster mode is #clusterEnabled and job is scheduled=#scheduled"() {
+        given:
+        ScheduledExecution.metaClass.static.withNewSession = { Closure c -> c.call() }
+
+        def clusterUUID = 'aaaa-bbbb-cccc-dddd'
+        def se = new ScheduledExecution(
+                uuid: 'test-cluster-uuid',
+                jobName: 'test1',
+                project: 'project1',
+                groupPath: 'testgroup',
+                doNodedispatch: false,
+                serverNodeUUID: clusterUUID,
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec([adhocRemoteString: 'echo hi'])]
+                )
+        ).save()
+
+        controller.frameworkService = Mock(FrameworkService) {
+            filterNodeSet(_, _) >> null
+            getRundeckFramework() >> Mock(Framework) {
+                getFrameworkNodeName() >> 'fwnode'
+            }
+            isClusterModeEnabled() >> clusterEnabled
+            _ * serverUUID >> clusterUUID
+        }
+
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+            _ * getAuthContextForSubjectAndProject(*_) >> Mock(UserAndRolesAuthContext) {
+                getUsername() >> 'admin'
+            }
+            _ * authorizeProjectJobAny(_, _, _, _) >> true
+            _ * filterAuthorizedNodes(_, _, _, _) >> { args -> args[2] }
+        }
+
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService) {
+            getByIDorUUID(_) >> se
+            isScheduled(se) >> scheduled
+            _ * calculateJobStats(_) >> Mock(JobStatsProvider.JobStats)
+        }
+        controller.notificationService = Mock(NotificationService) {
+            listNotificationPlugins() >> [:]
+        }
+        controller.orchestratorPluginService = Mock(OrchestratorPluginService) {
+            getOrchestratorPlugins() >> null
+        }
+        controller.pluginService = Mock(PluginService) {
+            listPlugins() >> []
+        }
+        controller.featureService = Mock(FeatureService)
+        controller.storageService = Mock(StorageService) {
+            storageTreeWithContext(_) >> Mock(KeyStorageTree)
+        }
+        controller.apiService = Mock(ApiService)
+        controller.optionValuesService = Mock(OptionValuesService)
+        controller.rundeckJobDefinitionManager = Mock(RundeckJobDefinitionManager) {
+            validateJobForExport(_, _) >> Mock(Validator.Report) {
+                isValid() >> true
+            }
+        }
+        controller.referencedExecutionDataProvider = new GormReferencedExecutionDataProvider()
+
+        params.id = se.id.toString()
+        params.project = 'project1'
+
+        when:
+        def model = controller.show()
+
+        then:
+        response.redirectedUrl == null
+        model != null
+        model.remoteClusterNodeUUID == expectedUUID
+
+        where:
+        clusterEnabled | scheduled | expectedUUID
+        true           | true      | 'aaaa-bbbb-cccc-dddd'
+        true           | false     | null
+        false          | true      | null
+        false          | false     | null
+    }
+
+    // ===================================================================================
+
     def "regression test - workflow fromMap toMap pattern from commit 640926f97c"() {
         given: "a job with workflow data stored in workflowJson via setWorkflowData"
         // Create a conditional step to test the scenario where workflow data

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -5394,14 +5394,21 @@ class ScheduledExecutionControllerSpec extends Specification implements Controll
         given:
         ScheduledExecution.metaClass.static.withNewSession = { Closure c -> c.call() }
 
-        def clusterUUID = 'aaaa-bbbb-cccc-dddd'
+        // The show action calls scheduledExecutionService.isScheduled() (mocked below)
+        // rather than reading scheduledExecution.scheduled directly. Setting scheduled
+        // on the domain object keeps the fixture semantically consistent with reality.
+        // Note: unlike detailFragmentAjax, the show action does NOT require
+        // serverNodeUUID != localServerUUID to populate remoteClusterNodeUUID.
+        def remoteUUID = 'aaaa-bbbb-cccc-dddd'
+        def localUUID  = 'ffff-eeee-dddd-cccc'
         def se = new ScheduledExecution(
                 uuid: 'test-cluster-uuid',
                 jobName: 'test1',
                 project: 'project1',
                 groupPath: 'testgroup',
                 doNodedispatch: false,
-                serverNodeUUID: clusterUUID,
+                scheduled: scheduled,
+                serverNodeUUID: remoteUUID,
                 workflow: new Workflow(
                         keepgoing: true,
                         commands: [new CommandExec([adhocRemoteString: 'echo hi'])]
@@ -5414,7 +5421,8 @@ class ScheduledExecutionControllerSpec extends Specification implements Controll
                 getFrameworkNodeName() >> 'fwnode'
             }
             isClusterModeEnabled() >> clusterEnabled
-            _ * serverUUID >> clusterUUID
+            _ * serverUUID >> localUUID
+            _ * getServerUUID() >> localUUID
         }
 
         controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
@@ -5469,6 +5477,8 @@ class ScheduledExecutionControllerSpec extends Specification implements Controll
         true           | false     | null
         false          | true      | null
         false          | false     | null
+        // Note: the show action does not filter by serverNodeUUID == localServerUUID,
+        // so a job scheduled on a different cluster member always gets its UUID surfaced.
     }
 
     // ===================================================================================


### PR DESCRIPTION
## Jira Ticket
[RUN-3336](https://pagerduty.atlassian.net/browse/RUN-3336)

## Summary

- Fixes the "Cluster Member State is unknown" badge and "undefined-/" tooltip on the Job show page when cluster mode is enabled.

## Root Cause

`_showHead.gsp` passed `remoteClusterNodeUUID` as the socket-data key to the `server-info-display` ui-socket, but `ServerIdentityComp` expects the prop `serverUuid`. This caused:
- `ServerDisplay` to receive `uuid = undefined`, producing an "undefined-/" tooltip
- `StatusIndicator` to call the cluster API with `/member/undefined`, which failed silently, leaving the state as `missing` ("Cluster Member State is unknown")

## Fix

Rename the socket-data key from `remoteClusterNodeUUID` to `serverUuid` in `_showHead.gsp`, aligning it with the working pattern already used in `_wfstateSummaryLine.gsp` and `heartbeat/jobs.gsp`.

## Testing

- Verified locally: cluster status badge shows correctly on the Job show page with cluster mode enabled
- Added parametrized Spock unit test in `ScheduledExecutionControllerSpec` covering all combinations of `clusterEnabled` × `isScheduled` for the `show` action model


[RUN-3336]: https://pagerduty.atlassian.net/browse/RUN-3336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ