### PR TITLE
[RUN-4491] ci: migrate CircleCI jobs to Gen2 resource classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -639,7 +639,7 @@ jobs:
     parameters:
       resource_class:
         type: string
-        default: medium
+        default: medium.gen2
       command:
         description: Command that will execute the docker tests
         type: string
@@ -680,7 +680,7 @@ jobs:
         default: 1
       resource_class:
         type: string
-        default: medium
+        default: medium.gen2
       test_file_pattern:
         type: string
       host_jdk_for_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,15 +87,15 @@ executors:
     resource_class: << parameters.resource_class >>
 
 
-  # Machine executor
+  # Machine executor (gen2: up to 180% faster multi-threaded CPU vs gen1)
   machine-builder:
     machine:
-      image: ubuntu-2204:2025.09.1
+      image: ubuntu-2204:2026.05.1
       docker_layer_caching: << parameters.docker_layer_caching >>
     parameters:
       resource_class:
         type: string
-        default: medium
+        default: medium.gen2
       # TIP: Circle layer caching is only useful for jobs that build images.
       docker_layer_caching:
         type: boolean
@@ -270,7 +270,7 @@ jobs:
     <<: *job-defaults
     executor:
       name: docker-builder
-      resource_class: xlarge
+      resource_class: xlarge.gen2
     parameters:
       jreVersion:
         type: string
@@ -327,7 +327,7 @@ jobs:
     <<: *job-defaults
     executor:
       name: docker-builder
-      resource_class: large
+      resource_class: large.gen2
     steps:
       - setup_docker
       - checkout
@@ -398,7 +398,7 @@ jobs:
     <<: *job-defaults
     executor:
       name: docker-builder
-      resource_class: large
+      resource_class: large.gen2
     steps:
       - setup_docker:
           docker_layer_caching: true
@@ -528,7 +528,7 @@ jobs:
     <<: *job-defaults
     executor:
       name: machine-builder  # Change from docker-builder
-      resource_class: medium
+      resource_class: medium.gen2
 
     steps:
       - checkout
@@ -564,7 +564,7 @@ jobs:
     <<: *job-defaults
     executor:
       name: machine-builder  # Change from docker-builder
-      resource_class: medium
+      resource_class: medium.gen2
 
     steps:
       - checkout
@@ -869,7 +869,7 @@ workflows:
       - test-gradle-functional:
           name: T Functional API
           gradle-task: apiTest
-          resource_class: xlarge
+          resource_class: xlarge.gen2
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/**/*{.groovy,.java}"
           parallelism: 3
           <<: *require-build-and-units
@@ -892,14 +892,14 @@ workflows:
       - test-gradle-functional:
           name: T Selenium - Auth & Login
           gradle-task: seleniumCoreTest
-          resource_class: xlarge
+          resource_class: xlarge.gen2
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/{login,ldap,execution/ExecutionShowAuthSpec,jobs/ActivitySectionAuthSpec,appadmin/AccessControlSpec}/**/*{.groovy,.java}"
           <<: *require-api-integration
           <<: *slack-defaults
       - test-gradle-functional:
           name: T Selenium - Context Path
           gradle-task: seleniumCoreTest
-          resource_class: xlarge
+          resource_class: xlarge.gen2
           parallelism: 1
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/contextPath/**/*{.groovy,.java}"
           <<: *require-api-integration
@@ -907,7 +907,7 @@ workflows:
       - test-gradle-functional:
           name: T Selenium - Projects
           gradle-task: seleniumCoreTest
-          resource_class: xlarge
+          resource_class: xlarge.gen2
           parallelism: 2
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/**/*{.groovy,.java}"
           <<: *require-api-integration
@@ -915,7 +915,7 @@ workflows:
       - test-gradle-functional:
           name: T Selenium - Jobs Core
           gradle-task: seleniumCoreTest
-          resource_class: xlarge
+          resource_class: xlarge.gen2
           parallelism: 2
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/{BasicJobsSpec,JobsSpec,JobEditSpec,JobDeleteSpec,JobSummarySpec,JobTabsSpec}.groovy"
           <<: *require-api-integration
@@ -923,14 +923,14 @@ workflows:
       - test-gradle-functional:
           name: T Selenium - Jobs Advanced
           gradle-task: seleniumCoreTest
-          resource_class: xlarge
+          resource_class: xlarge.gen2
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/{DuplicateJobSpec,JobReferenceSpec,ScheduledJobSpec,JobNotificationSpec,BulkJobActionsSpec,ExportImportSpec,DuplicateOptionsSpec,ExpandedJobGroupsSpec,JobActivityHistorySpec,JobAuditApiSpec,LogFilterSpec,LogViewerOutputSpec,steps}/**/*{.groovy,.java}"
           <<: *require-api-integration
           <<: *slack-defaults
       - test-gradle-functional:
           name: T Selenium - Execution & Other
           gradle-task: seleniumCoreTest
-          resource_class: xlarge
+          resource_class: xlarge.gen2
           parallelism: 2
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/{execution,nodes,activity,navigation,profile,appadmin/KeyStorageSpec,scm,webhook,users}/**/*{.groovy,.java}"
           <<: *require-api-integration
@@ -1032,14 +1032,14 @@ workflows:
       - test-gradle-functional:
           name: T Selenium - Auth & Login (host JDK 25)
           gradle-task: seleniumCoreTest
-          resource_class: xlarge
+          resource_class: xlarge.gen2
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/{login,ldap,execution/ExecutionShowAuthSpec,jobs/ActivitySectionAuthSpec,appadmin/AccessControlSpec}/**/*{.groovy,.java}"
           host_jdk_for_tests: "25"
           <<: *require-build-jre-17
       - test-gradle-functional:
           name: T Selenium - Context Path  (host JDK 25)
           gradle-task: seleniumCoreTest
-          resource_class: xlarge
+          resource_class: xlarge.gen2
           parallelism: 1
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/contextPath/**/*{.groovy,.java}"
           host_jdk_for_tests: "25"
@@ -1047,35 +1047,35 @@ workflows:
       - test-gradle-functional:
           name: T Selenium - Projects (host JDK 25)
           gradle-task: seleniumCoreTest
-          resource_class: xlarge
+          resource_class: xlarge.gen2
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/**/*{.groovy,.java}"
           host_jdk_for_tests: "25"
           <<: *require-build-jre-17
       - test-gradle-functional:
           name: T Selenium - Jobs Core (host JDK 25)
           gradle-task: seleniumCoreTest
-          resource_class: xlarge
+          resource_class: xlarge.gen2
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/{BasicJobsSpec,JobsSpec,JobEditSpec,JobDeleteSpec,JobSummarySpec,JobTabsSpec}.groovy"
           host_jdk_for_tests: "25"
           <<: *require-build-jre-17
       - test-gradle-functional:
           name: T Selenium - Jobs Advanced (host JDK 25)
           gradle-task: seleniumCoreTest
-          resource_class: xlarge
+          resource_class: xlarge.gen2
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/{DuplicateJobSpec,JobReferenceSpec,ScheduledJobSpec,JobNotificationSpec,BulkJobActionsSpec,ExportImportSpec,DuplicateOptionsSpec,ExpandedJobGroupsSpec,JobActivityHistorySpec,JobAuditApiSpec,LogFilterSpec,LogViewerOutputSpec,steps}/**/*{.groovy,.java}"
           host_jdk_for_tests: "25"
           <<: *require-build-jre-17
       - test-gradle-functional:
           name: T Selenium - Execution & Other (host JDK 25)
           gradle-task: seleniumCoreTest
-          resource_class: xlarge
+          resource_class: xlarge.gen2
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/{execution,nodes,activity,navigation,profile,appadmin/KeyStorageSpec,scm,webhook,users}/**/*{.groovy,.java}"
           host_jdk_for_tests: "25"
           <<: *require-build-jre-17
       - test-gradle-functional:
           name: T Functional API (host JDK 25)
           gradle-task: apiTest
-          resource_class: xlarge
+          resource_class: xlarge.gen2
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/**/*{.groovy,.java}"
           parallelism: 3
           host_jdk_for_tests: "25"


### PR DESCRIPTION
## Summary

Mirrors the same Gen2 migration done in rundeckpro/rundeckpro#4715.

### Docker executor jobs (~1.4x faster)

| Job | Before | After |
|-----|--------|-------|
| `build-rundeck` | `xlarge` | `xlarge.gen2` |
| `test-snyk` | `large` | `large.gen2` |
| `test-gradle` | `large` | `large.gen2` |
| All Selenium / Functional (`test-gradle-functional`) | `xlarge` | `xlarge.gen2` |

### Machine executor jobs (up to 180% faster multi-threaded CPU)

| Job | Before | After |
|-----|--------|-------|
| `packaging-publish` | `medium` | `medium.gen2` |
| `packaging-test` | `medium` | `medium.gen2` |
| `machine-builder` default | `medium` | `medium.gen2` |

Also updates the machine executor base image: `ubuntu-2204:2025.09.1` → `ubuntu-2204:2026.05.1`

## Why Gen2?

- **Docker Gen2**: ~1.4x faster on modern compute hardware
- **Linux VM Gen2**: up to 180% faster multi-threaded CPU performance
- No IP Ranges are used in this pipeline — fully compatible
- No other config changes needed beyond the `.gen2` suffix

## Testing

CI pipeline itself is the test — compare build durations before/after on the affected jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)