### PR TITLE
[RUN-4494] Add Selenium tests for mainbar sys-config and user menu visibility

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/navigation/MainbarMenuSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/navigation/MainbarMenuSpec.groovy
@@ -1,0 +1,81 @@
+package org.rundeck.tests.functional.selenium.navigation
+
+import org.rundeck.util.annotations.SeleniumCoreTest
+import org.rundeck.util.container.SeleniumBase
+import org.rundeck.util.gui.common.navigation.NavLinkTypes
+import org.rundeck.util.gui.pages.MainbarMenuPage
+import org.rundeck.util.gui.pages.home.HomePage
+import org.rundeck.util.gui.pages.login.LoginPage
+import org.rundeck.util.gui.pages.project.SideBarPage
+
+/**
+ * Verifies that the top mainbar's system config menu (gear icon) and user menu
+ * (user icon) are rendered by Vue on the pages most likely to expose UiSocket
+ * mounting regressions: home, project home, and project configuration.
+ */
+@SeleniumCoreTest
+class MainbarMenuSpec extends SeleniumBase {
+
+    def setupSpec() {
+        setupProjectArchiveDirectoryResource(SELENIUM_BASIC_PROJECT, "/projects-import/${SELENIUM_BASIC_PROJECT}")
+    }
+
+    def setup() {
+        def loginPage = go LoginPage
+        loginPage.login(TEST_USER, TEST_PASS)
+    }
+
+    def "sys config and user menus are visible on the home page"() {
+        setup:
+            def mainbarPage = page MainbarMenuPage
+        when:
+            go HomePage
+        then:
+            mainbarPage.isSysConfigMenuDisplayed()
+            mainbarPage.isUserMenuDisplayed()
+    }
+
+    def "sys config and user menus are visible on a project home page"() {
+        setup:
+            def homePage = page HomePage
+            def mainbarPage = page MainbarMenuPage
+        when:
+            homePage.goProjectHome SELENIUM_BASIC_PROJECT
+        then:
+            mainbarPage.isSysConfigMenuDisplayed()
+            mainbarPage.isUserMenuDisplayed()
+    }
+
+    def "sys config and user menus are visible on the project configuration page"() {
+        setup:
+            def homePage = page HomePage
+            def sideBarPage = page SideBarPage
+            def mainbarPage = page MainbarMenuPage
+        when:
+            homePage.goProjectHome SELENIUM_BASIC_PROJECT
+            sideBarPage.goTo NavLinkTypes.PROJECT_CONFIG
+        then:
+            mainbarPage.isSysConfigMenuDisplayed()
+            mainbarPage.isUserMenuDisplayed()
+    }
+
+    def "clicking the sys config toggle opens its dropdown"() {
+        setup:
+            def mainbarPage = page MainbarMenuPage
+        when:
+            go HomePage
+            mainbarPage.clickSysConfigMenu()
+        then:
+            mainbarPage.isSysConfigDropdownOpen()
+    }
+
+    def "clicking the user menu toggle opens its dropdown"() {
+        setup:
+            def mainbarPage = page MainbarMenuPage
+        when:
+            go HomePage
+            mainbarPage.clickUserMenu()
+        then:
+            mainbarPage.isUserMenuDropdownOpen()
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/MainbarMenuPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/MainbarMenuPage.groovy
@@ -78,10 +78,12 @@ class MainbarMenuPage extends BasePage {
     }
 
     boolean isSysConfigDropdownOpen() {
-        els(sysConfigOpenBy).size() > 0
+        waitForElementVisible(sysConfigOpenBy)
+        el(sysConfigOpenBy).isDisplayed()
     }
 
     boolean isUserMenuDropdownOpen() {
-        els(userMenuOpenBy).size() > 0
+        waitForElementVisible(userMenuOpenBy)
+        el(userMenuOpenBy).isDisplayed()
     }
 }

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/MainbarMenuPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/MainbarMenuPage.groovy
@@ -1,0 +1,87 @@
+package org.rundeck.util.gui.pages
+
+import groovy.transform.CompileStatic
+import org.openqa.selenium.By
+import org.openqa.selenium.WebElement
+import org.rundeck.util.container.SeleniumContext
+
+/**
+ * Component page object for the top mainbar's system config and user menus.
+ * Both menus are rendered via Vue UiSocket, so all checks use explicit waits
+ * to account for async mounting.
+ *
+ * Has no load path — attach to any page after navigation.
+ */
+@CompileStatic
+class MainbarMenuPage extends BasePage {
+
+    String loadPath = ""
+
+    /** Rendered Vue component for the system config (gear) menu. */
+    By sysConfigMenuBy = By.id("appSysConfigMenu")
+
+    /** Rendered Vue component for the user menu. */
+    By userMenuBy = By.id("appUserMenu")
+
+    /** Toggle button inside the sys config component. */
+    By sysConfigToggleBy = By.cssSelector("#appSysConfigMenu [data-testid='mainbar-menu-toggle']")
+
+    /** Toggle button inside the user menu component. */
+    By userMenuToggleBy = By.cssSelector("#appUserMenu [data-testid='mainbar-menu-toggle']")
+
+    /**
+     * The uiv Dropdown component adds class "open" to its root element when the
+     * dropdown is expanded. Since the id attribute falls through to that root div,
+     * "#appSysConfigMenu.open" is a reliable open-state indicator.
+     */
+    By sysConfigOpenBy = By.cssSelector("#appSysConfigMenu.open")
+
+    /** @see #sysConfigOpenBy */
+    By userMenuOpenBy = By.cssSelector("#appUserMenu.open")
+
+    MainbarMenuPage(SeleniumContext context) {
+        super(context)
+    }
+
+    /**
+     * Waits up to 30 s for the sys config menu component to be visible.
+     * The component renders asynchronously via Vue UiSocket after DOMContentLoaded.
+     */
+    WebElement waitForSysConfigMenuVisible() {
+        waitForElementVisible(sysConfigMenuBy)
+    }
+
+    /**
+     * Waits up to 30 s for the user menu component to be visible.
+     * The component renders asynchronously via Vue UiSocket after DOMContentLoaded.
+     */
+    WebElement waitForUserMenuVisible() {
+        waitForElementVisible(userMenuBy)
+    }
+
+    boolean isSysConfigMenuDisplayed() {
+        waitForSysConfigMenuVisible()
+        el(sysConfigMenuBy).isDisplayed()
+    }
+
+    boolean isUserMenuDisplayed() {
+        waitForUserMenuVisible()
+        el(userMenuBy).isDisplayed()
+    }
+
+    void clickSysConfigMenu() {
+        byAndWaitClickable(sysConfigToggleBy).click()
+    }
+
+    void clickUserMenu() {
+        byAndWaitClickable(userMenuToggleBy).click()
+    }
+
+    boolean isSysConfigDropdownOpen() {
+        els(sysConfigOpenBy).size() > 0
+    }
+
+    boolean isUserMenuDropdownOpen() {
+        els(userMenuOpenBy).size() > 0
+    }
+}


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Enhancement — adds a Selenium regression test suite to guard the mainbar Vue UiSocket rendering fix (308ac3f7b5).

The fix changed a `return` to `continue` in `src/app/components/ui/main.ts` so that encountering a `.vue-ui-socket` element inside a `.vue-ui-socket-deferred` container no longer aborts processing all subsequent socket elements. Without that fix the system config menu and user menu were not rendered on the Project Configuration page.

**Describe the solution you've implemented**

Two new files:

- `functional-test/…/gui/pages/MainbarMenuPage.groovy` — component page object with explicit-wait selectors for `#appSysConfigMenu` and `#appUserMenu` (the rendered Vue components), toggle-click helpers, and open-state checks via the `uiv` `.dropdown.open` class.
- `functional-test/…/selenium/navigation/MainbarMenuSpec.groovy` — five tests:
  1. Both menus visible on the home page (project list)
  2. Both menus visible on a project home page
  3. Both menus visible on the project configuration page *(the regression target)*
  4. Clicking the sys-config toggle opens its dropdown
  5. Clicking the user-menu toggle opens its dropdown

**Describe alternatives you've considered**

A unit test on the JS loop would be faster but doesn't catch the DOM-order interaction between the deferred plugin config fields and the mainbar socket elements — only a full-page functional test can reproduce that.

**Additional context**

Related fix commit: 308ac3f7b5 ("Fix: not all vue-ui-sockets are loaded on page")

## Release Notes

Added Selenium functional tests verifying the mainbar system config and user menus render correctly on the home, project home, and project configuration pages.