### PR TITLE
[RUN-4303] Force protobuf-java to 3.25.5 to fix CVE-2024-7254

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,7 @@ allprojects {
             
             // CVE and compatibility fixes
             force "commons-fileupload:commons-fileupload:${commonsFileuploadVersion}"
+            force "com.google.protobuf:protobuf-java:${protobufVersion}" // CVE-2024-7254 fix
             
             // Force centralized versions to prevent duplicates in WAR
             force "org.apache.ant:ant:${antVersion}"


### PR DESCRIPTION
## Summary
- Add force resolution for `com.google.protobuf:protobuf-java` in rundeck submodule `build.gradle`
- Ensures all subprojects (grails-webhooks and rundeckapp) use protobuf version 3.25.5 instead of vulnerable transitive dependency version 3.21.12

## Problem
Security scanners were detecting `com.google.protobuf:protobuf-java@3.21.12` in grails-webhooks and rundeckapp modules, even though `protobufVersion=3.25.5` is defined in gradle.properties. The root cause was that the rundeck submodule's build.gradle lacked a force resolution for protobuf, allowing older transitive dependencies to be used.

## Solution
Added `force "com.google.protobuf:protobuf-java:${protobufVersion}"` to the resolutionStrategy in the allprojects configuration block in rundeck/build.gradle, matching the pattern already used in the parent rundeckpro build.gradle.

## Test plan
- [x] Verify build succeeds: `./gradlew build -x check`
- [x] Verify protobuf version in grails-webhooks: `./gradlew grails-webhooks:dependencies --configuration runtimeClasspath | grep protobuf`
- [x] Verify protobuf version in rundeckapp: `./gradlew rundeckapp:dependencies --configuration runtimeClasspath | grep protobuf`
- [ ] Confirm security scanners no longer detect protobuf-java@3.21.12