### PR TITLE
[RUN-4498] Fix execution deletion FK constraint when log storage is configured

### DIFF
--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
@@ -10,6 +10,7 @@ import org.rundeck.app.data.providers.v1.execution.ReferencedExecutionDataProvid
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import rundeck.Execution
+import rundeck.LogFileStorageRequest
 import rundeck.services.*
 import rundeck.services.jobs.ResolvedAuthJobService
 
@@ -124,6 +125,7 @@ class ExecutionsCleanUp implements InterruptableJob {
             Execution.findAllByRetryExecution(e).each{e2->
                 e2.retryExecution=null
             }
+            LogFileStorageRequest.findByExecution(e)?.delete(flush: true)
             e.delete(flush: true)
             //delete all files
             def deletedfiles = 0

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2220,6 +2220,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             Execution.findAllByRetryExecution(e).each{e2->
                 e2.retryExecution=null
             }
+            LogFileStorageRequest.findByExecution(e)?.delete(flush: true)
             e.delete()
             //delete all files
             def deletedfiles = 0

--- a/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionsCleanUpIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionsCleanUpIntegrationSpec.groovy
@@ -136,7 +136,7 @@ class ExecutionsCleanUpIntegrationSpec extends Specification{
         Execution.withTransaction {
             new LogFileStorageRequest(
                 execution: Execution.get(execution.id),
-                pluginName: 'com.rundeck.rundeckpro.amazon-s3',
+                pluginName: 'test1',
                 filetype: '*',
                 completed: true
             ).save(flush: true, failOnError: true)

--- a/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionsCleanUpIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionsCleanUpIntegrationSpec.groovy
@@ -28,6 +28,7 @@ import org.rundeck.app.services.ExecutionFile
 import rundeck.CommandExec
 import rundeck.ExecReport
 import rundeck.Execution
+import rundeck.LogFileStorageRequest
 import rundeck.ScheduledExecution
 import rundeck.Workflow
 import rundeck.services.ConfigurationService
@@ -119,6 +120,46 @@ class ExecutionsCleanUpIntegrationSpec extends Specification{
         execIds.size() == sucessTotal
         0 == Execution.countByProject(projName)
         0 == ExecReport.countByProject(projName)
+    }
+
+    def "deleteByExecutionList removes LogFileStorageRequest before deleting Execution to avoid FK constraint"() {
+        given:
+        String projName = 'projectTestLogStorage'
+        def logFileStorageService = Mock(LogFileStorageService)
+        def referencedExecutionDataProvider = Mock(ReferencedExecutionDataProvider)
+        Date execDate = new Date(2015 - 1900, 02, 03)
+
+        ScheduledExecution se = setupJob(projName)
+        FrameworkService frameworkService = initNonClusterFrameworkService()
+        Execution execution = setupExecution(se, projName, execDate, execDate, frameworkService.getServerUUID())
+
+        Execution.withTransaction {
+            new LogFileStorageRequest(
+                execution: Execution.get(execution.id),
+                pluginName: 'com.rundeck.rundeckpro.amazon-s3',
+                filetype: '*',
+                completed: true
+            ).save(flush: true, failOnError: true)
+        }
+
+        expect:
+        1 == Execution.countByProject(projName)
+        1 == LogFileStorageRequest.countByExecution(execution)
+
+        when:
+        ExecutionsCleanUp job = new ExecutionsCleanUp()
+        int deleted = job.deleteByExecutionList(
+            [execution.id],
+            new FileUploadService(),
+            logFileStorageService,
+            referencedExecutionDataProvider,
+            reportService
+        )
+
+        then:
+        deleted == 1
+        0 == Execution.countByProject(projName)
+        0 == LogFileStorageRequest.countByExecution(execution)
     }
 
     private FrameworkService initNonClusterFrameworkService() {

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -1512,6 +1512,57 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         result.success
 
     }
+
+    def "delete execution removes associated LogFileStorageRequest to avoid FK constraint"() {
+        given:
+        service.frameworkService = Mock(FrameworkService)
+        service.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor)
+        service.fileUploadService = Mock(FileUploadService)
+        service.logFileStorageService = Mock(LogFileStorageService) {
+            getExecutionFiles(_, _, _) >> [:]
+        }
+        def auth = Mock(AuthContext)
+        def execution = new Execution(
+            user: 'userB',
+            project: 'AProject',
+            workflow: new Workflow(
+                keepgoing: true,
+                commands: [new CommandExec(
+                    [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
+                )]
+            ),
+        )
+        execution.dateStarted = new Date()
+        execution.dateCompleted = new Date()
+        execution.status = 'succeeded'
+        assert execution.save()
+
+        def storageRequest = new LogFileStorageRequest(
+            execution: execution,
+            pluginName: 'test1',
+            filetype: '*',
+            completed: true
+        )
+        assert storageRequest.save()
+
+        expect:
+        LogFileStorageRequest.findByExecution(execution) != null
+
+        when:
+        def result = service.deleteExecution(execution, auth, 'bob')
+
+        then:
+        1 * service.rundeckAuthContextProcessor.authResourceForProject(_)
+        1 * service.rundeckAuthContextProcessor.authorizeApplicationResourceAny(
+            auth, _,
+            [AuthConstants.ACTION_DELETE_EXECUTION, AuthConstants.ACTION_ADMIN, AuthConstants.ACTION_APP_ADMIN]
+        ) >> true
+        1 * service.reportService.deleteByExecution(execution)
+
+        result.success
+        LogFileStorageRequest.findByExecution(execution) == null
+    }
+
     def "loadSecureOptionStorageDefaults"() {
         given:
         ScheduledExecution job = new ScheduledExecution(


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. When Rundeck is configured with a log storage plugin (e.g. S3/Minio), deleting an execution fails with a database foreign key constraint violation:

```
Cannot delete or update a parent row: a foreign key constraint fails
(log_file_storage_request, CONSTRAINT FK45h35d8rum4i3ruqomwgs0n49
FOREIGN KEY (execution_id) REFERENCES execution (id))
```

Jira: https://pagerduty.atlassian.net/browse/RUN-4498

**Describe the solution you've implemented**

Delete the associated `LogFileStorageRequest` record before deleting the `Execution` in two places:

1. `ExecutionService.deleteExecutionAuthorized()` — handles single execution deletion triggered via UI/API.
2. `ExecutionsCleanUp.deleteExecution()` — handles bulk deletion from the scheduled cleanup Quartz job.

The fix uses `LogFileStorageRequest.findByExecution(e)?.delete(flush: true)` before `e.delete()`. The safe-navigation operator (`?.`) ensures no failure when log storage is not configured and no `LogFileStorageRequest` exists.

**Describe alternatives you've considered**

- Adding `cascade: "all-delete-orphan"` on the `Execution` domain side: would require a schema migration and changes to GORM mapping. Riskier for a targeted bugfix.
- Adding `ON DELETE CASCADE` to the FK constraint via a new Liquibase migration: same risk profile, and would silently delete storage records without the plugin cleanup path being invoked.

**Additional context**

Root cause: `LogFileStorageRequest` declares `static belongsTo = Execution` but `Execution` has no corresponding `hasOne`/`hasMany` with cascade, so GORM/Hibernate does not cascade deletes automatically. The FK constraint on `log_file_storage_request.execution_id` defaults to `RESTRICT`.

## Release Notes

Fix: Deleting an execution no longer fails with a foreign key constraint error when a log storage plugin (e.g. S3) is configured. The associated log storage request record is now properly removed before the execution is deleted.