### PR TITLE
[RUN-4499] Update axios to 1.16.1 to fix security vulnerability

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
@@ -15,7 +15,7 @@
         "@primeuix/themes": "^1.0.0",
         "@rundeck/client": "^0.2.5",
         "ace-builds": "^1.23.4",
-        "axios": "1.15.2",
+        "axios": "1.16.1",
         "core-js": "^3.6.5",
         "dagre": "^0.8.5",
         "deep-object-diff": "^1.1.9",
@@ -8020,7 +8020,6 @@
       "version": "6.0.2",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -8544,13 +8543,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://npm.artifacts.pd-internal.com/npm/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://npm.artifacts.pd-internal.com/npm/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -14278,7 +14278,6 @@
       "version": "5.0.1",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"

--- a/rundeckapp/grails-spa/packages/ui-trellis/package.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package.json
@@ -48,7 +48,7 @@
     "@primeuix/themes": "^1.0.0",
     "@rundeck/client": "^0.2.5",
     "ace-builds": "^1.23.4",
-    "axios": "1.15.2",
+    "axios": "1.16.1",
     "core-js": "^3.6.5",
     "dagre": "^0.8.5",
     "deep-object-diff": "^1.1.9",


### PR DESCRIPTION
## Summary
- Update axios from 1.15.2 to 1.16.1 in ui-trellis package

## Problem
Security scanner detected vulnerability in axios@1.15.2. The vulnerability is fixed in axios@1.16.0 and later versions.

**Vulnerability Details:**
- Package: axios@1.15.2
- Path: @rundeck/ui-trellis@3.3.8 › axios@1.15.2
- Fixed in: axios@0.32.0, @1.16.0
- Exploit maturity: No known exploit

## Solution
Updated axios dependency in `rundeckapp/grails-spa/packages/ui-trellis/package.json` from 1.15.2 to 1.16.1.

## Test plan
- [ ] Verify package.json has axios 1.16.1
- [ ] Run `npm install` to update package-lock.json
- [ ] Run ui-trellis tests: `npm run test:unit`
- [ ] Verify security scanners no longer detect axios vulnerability
- [ ] Build ui-trellis: `npm run build:library`