### PR TITLE
[RUN-2939] nodes view show step as NOT_STARTED

### DIFF
--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStateImpl.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStateImpl.groovy
@@ -563,13 +563,18 @@ class MutableWorkflowStateImpl implements MutableWorkflowState {
         if(fromState==toState){
             return
         }
+        //NOT_STARTED is an inferred state: it is assigned at finalization to any node/step
+        //that had no observed activity yet. A genuine state event that arrives afterwards
+        //(e.g. a node step completion delivered just after the workflow is reported complete)
+        //must be allowed to override it, otherwise the step is shown as "not started" even
+        //though it actually ran and produced output (RUN-2939).
         def allowed=[
                 (ExecutionState.WAITING):[null,ExecutionState.WAITING],
-                (ExecutionState.RUNNING): [null, ExecutionState.WAITING,ExecutionState.RUNNING],
-                (ExecutionState.RUNNING_HANDLER):[null,ExecutionState.WAITING,ExecutionState.FAILED, ExecutionState.RUNNING,ExecutionState.RUNNING_HANDLER],
+                (ExecutionState.RUNNING): [null, ExecutionState.WAITING,ExecutionState.RUNNING, ExecutionState.NOT_STARTED],
+                (ExecutionState.RUNNING_HANDLER):[null,ExecutionState.WAITING,ExecutionState.FAILED, ExecutionState.RUNNING,ExecutionState.RUNNING_HANDLER, ExecutionState.NOT_STARTED],
         ]
         ExecutionState.values().findAll{it.isCompletedState()}.each{
-            allowed[it]= [it,ExecutionState.RUNNING, ExecutionState.RUNNING_HANDLER, ExecutionState.WAITING]
+            allowed[it]= [it,ExecutionState.RUNNING, ExecutionState.RUNNING_HANDLER, ExecutionState.WAITING, ExecutionState.NOT_STARTED]
         }
         if (errorHandler) {
             allowed[ExecutionState.RUNNING] << ExecutionState.FAILED

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStateImplSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/internal/workflow/MutableWorkflowStateImplSpec.groovy
@@ -95,6 +95,41 @@ class MutableWorkflowStateImplSpec extends Specification {
         mutableWorkflowState.stepStates[0].subWorkflowState.stepStates[0].nodeStateMap[nodeB].executionState.toString()=='RUNNING'
 
     }
+    def "RUN-2939: late node step completion overrides an inferred NOT_STARTED state"() {
+        given:
+        def date = new Date()
+        def nodeA = 'TargetNode1'
+        def nodeB = 'TargetNode2'
+        def serverNode = 'server'
+
+        //single node step running on two nodes (the last step of the job)
+        def mutableStep1 = new MutableWorkflowStepStateImpl(stepIdentifier(1))
+        mutableStep1.nodeStep = true
+        def wf = new MutableWorkflowStateImpl([nodeA, nodeB], 1, [0: mutableStep1], null, serverNode)
+
+        //workflow + step begin
+        wf.updateWorkflowState(ExecutionState.RUNNING, date, [nodeA, nodeB])
+        wf.updateStateForStep(stepIdentifier(1), 0, stepStateChange(stepState(ExecutionState.RUNNING)), date)
+
+        //nodeA runs and completes normally
+        wf.updateStateForStep(stepIdentifier(1), 0, stepStateChange(stepState(ExecutionState.RUNNING), nodeA), date)
+        wf.updateStateForStep(stepIdentifier(1), 0, stepStateChange(stepState(ExecutionState.SUCCEEDED), nodeA), date)
+
+        //nodeB also ran (its output exists) but its state events have not been delivered yet
+
+        when: "the overall workflow is reported SUCCEEDED before nodeB's completion event"
+        wf.updateWorkflowState(ExecutionState.SUCCEEDED, date, null)
+
+        then: "nodeB is inferred as NOT_STARTED at finalization"
+        wf.stepStates[0].nodeStateMap[nodeB].executionState.toString() == 'NOT_STARTED'
+
+        when: "the real (late) completion event for nodeB finally arrives"
+        wf.updateStateForStep(stepIdentifier(1), 0, stepStateChange(stepState(ExecutionState.SUCCEEDED), nodeB), date)
+
+        then: "the inferred NOT_STARTED is corrected to the observed SUCCEEDED"
+        wf.stepStates[0].nodeStateMap[nodeA].executionState.toString() == 'SUCCEEDED'
+        wf.stepStates[0].nodeStateMap[nodeB].executionState.toString() == 'SUCCEEDED'
+    }
     def "captured state test of above"(){
         given:
         def date = new Date()


### PR DESCRIPTION
This pull request addresses a workflow state handling issue where late node step completion events could be incorrectly ignored if a step was previously inferred as `NOT_STARTED`. The changes ensure that genuine state events arriving after workflow completion can override an inferred `NOT_STARTED` state, preventing incorrect display of step statuses.

**Workflow state transition logic improvements:**

* Updated the allowed state transitions in `MutableWorkflowStateImpl` so that a real state event (e.g., `RUNNING`, `RUNNING_HANDLER`, or a completed state) can override an inferred `NOT_STARTED` state. This prevents steps from being shown as "not started" when they have actually run and produced output, addressing the issue described in RUN-2939.

**Testing and validation:**

* Added a new test case in `MutableWorkflowStateImplSpec` to verify that a late node step completion event correctly updates the state from `NOT_STARTED` to the observed state (e.g., `SUCCEEDED`), ensuring the fix works as intended.