### PR TITLE
[RUN-3547] Fix nodes view log display - virtual scroller height and lifecycle

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/nodeView.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/nodeView.ts
@@ -48,7 +48,7 @@ window._rundeck.eventBus.on("ko-exec-show-output", (nodeStep: any) => {
         class="wfnodestep"
         executionId="${execId}"
         node="${node}"
-        stepCtx="${stepCtx}"
+        ${stepCtx ? `stepCtx="${stepCtx}"` : ""}
         :showSettings="false"
         ref="viewer"
         :config="config"
@@ -95,7 +95,14 @@ window._rundeck.eventBus.on("ko-exec-show-output", (nodeStep: any) => {
       if (execOutput.completed) {
         reaction.dispose();
         nodeStep.outputLineCount(0);
-        vue._container!.remove();
+        // Unmount the app and restore the elm container so Knockout can reuse it.
+        // Do NOT call vue._container!.remove() since _container is elm itself
+        // (.wfnodeoutput), and removing it from the DOM breaks subsequent
+        // expand/collapse cycles in the nodes view.
+        vue.unmount();
+        mountedNodeApps.delete(appKey);
+        elm.style.height = "";
+        elm.style.overflow = "";
         return;
       } else {
         return;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/nodeView.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/nodeView.ts
@@ -10,6 +10,8 @@ import { UiMessage } from "../../../library/stores/UIStore";
 
 const rootStore = getRundeckContext().rootStore;
 
+const mountedNodeApps = new Map<string, ReturnType<typeof createApp>>();
+
 window._rundeck.eventBus.on("ko-exec-show-output", (nodeStep: any) => {
   const execId = nodeStep.flow.executionId();
   const stepCtx = nodeStep.stepctx;
@@ -22,9 +24,24 @@ window._rundeck.eventBus.on("ko-exec-show-output", (nodeStep: any) => {
     .filter((e) => e)
     .join("");
 
-  const div = document.createElement("div");
-  const elm = document.querySelector(query)!;
-  elm.appendChild(div);
+  const elm = document.querySelector(query) as HTMLElement;
+
+  // The wfnodeoutput element has no explicit height in the Knockout template.
+  // The LogViewer's entire height:100% chain (execution-log → scroller → node-chunk
+  // → DynamicScroller) collapses to auto without a concrete parent height.
+  // Without a fixed height, vue-virtual-scroller cannot measure its viewport and
+  // attempts to render all items at once, crashing when item count exceeds its limit.
+  elm.style.height = "600px";
+  elm.style.overflow = "hidden";
+
+  // Unmount any existing viewer for this node/step to avoid stacking
+  // multiple LogViewer instances on the same container.
+  const appKey = `${execId}::${node}::${stepCtx}`;
+  const existingApp = mountedNodeApps.get(appKey);
+  if (existingApp) {
+    existingApp.unmount();
+    mountedNodeApps.delete(appKey);
+  }
 
   const template = `\
     <LogViewer
@@ -64,7 +81,9 @@ window._rundeck.eventBus.on("ko-exec-show-output", (nodeStep: any) => {
   vue.provide("addUiMessages", async (messages: UiMessage[]) =>
     commonAddUiMessages(i18n, messages),
   );
+  // Mount on elm directly (preserving its CSS height/overflow for the virtual scroller)
   vue.mount(elm);
+  mountedNodeApps.set(appKey, vue);
 
   /** Update the KO code when this views output starts showing up */
   const execOutput = rootStore.executionOutputStore.createOrGet(execId);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
@@ -110,7 +110,7 @@ export default defineComponent({
       default: false,
     },
   },
-  emits: ["line-select", "jumped"],
+  emits: ["line-select", "jumped", "follow-change"],
   data() {
     return {
       emitResize: true as boolean,
@@ -118,11 +118,14 @@ export default defineComponent({
   },
   watch: {
     entries(newEntries: ExecutionOutputEntry[] | undefined) {
-      if (this.follow && newEntries && newEntries.length > 0) {
-        this.$nextTick(() => {
+      if (!this.follow || !newEntries || newEntries.length === 0) return;
+      this.$nextTick(() => {
+        // Re-check inside $nextTick: the user may have toggled follow off
+        // between when this watcher fired and when the DOM updated.
+        if (this.follow) {
           (this.$refs.scroller as any)?.scrollToBottom?.();
-        });
-      }
+        }
+      });
     },
   },
   computed: {
@@ -162,6 +165,18 @@ export default defineComponent({
     if (this.jumpToLine && !this.jumped) {
       this.$emit("line-select", this.jumpToLine);
       this.$emit("jumped");
+    }
+    // Detect manual scrolling inside the DynamicScroller so the parent can
+    // disable follow when the user scrolls away from the bottom.
+    const scrollerEl = (this.$refs.scroller as any)?.$el as HTMLElement | undefined;
+    if (scrollerEl) {
+      scrollerEl.addEventListener("scroll", this.onScrollerScroll);
+    }
+  },
+  beforeUnmount() {
+    const scrollerEl = (this.$refs.scroller as any)?.$el as HTMLElement | undefined;
+    if (scrollerEl) {
+      scrollerEl.removeEventListener("scroll", this.onScrollerScroll);
     }
   },
   methods: {
@@ -218,6 +233,15 @@ export default defineComponent({
     },
     onSelectLine(index: number) {
       this.$emit("line-select", index);
+    },
+    onScrollerScroll(ev: Event) {
+      const el = ev.target as HTMLElement;
+      // If the user scrolled away from the bottom, notify the parent to disable follow.
+      const atBottom =
+        el.scrollTop + el.clientHeight >= el.scrollHeight - 10;
+      if (!atBottom && this.follow) {
+        this.$emit("follow-change", false);
+      }
     },
     scrollToLine() {
       if (this.follow) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
@@ -245,10 +245,20 @@ export default defineComponent({
     },
     onScrollerScroll(ev: Event) {
       const el = ev.target as HTMLElement;
-      // If the user scrolled away from the bottom, notify the parent to disable follow.
-      const atBottom =
-        el.scrollTop + el.clientHeight >= el.scrollHeight - 10;
-      if (!atBottom && this.follow) {
+      const prevScrollTop = (this as any)._prevScrollTop as number | undefined;
+      const currentScrollTop = el.scrollTop;
+      (this as any)._prevScrollTop = currentScrollTop;
+
+      // Only disable follow when the user is actively scrolling UP.
+      // Programmatic scrollToBottom() increases scrollTop (downward), so it
+      // will NOT trigger this condition. Relying on direction instead of
+      // position prevents follow from being disabled during scroll animations
+      // triggered by our own scrollToBottom() calls.
+      if (
+        prevScrollTop !== undefined &&
+        currentScrollTop < prevScrollTop &&
+        this.follow
+      ) {
         this.$emit("follow-change", false);
       }
     },

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
@@ -116,6 +116,15 @@ export default defineComponent({
       emitResize: true as boolean,
     };
   },
+  watch: {
+    entries(newEntries: ExecutionOutputEntry[] | undefined) {
+      if (this.follow && newEntries && newEntries.length > 0) {
+        this.$nextTick(() => {
+          (this.$refs.scroller as any)?.scrollToBottom?.();
+        });
+      }
+    },
+  },
   computed: {
     opts() {
       return {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
@@ -166,18 +166,19 @@ export default defineComponent({
       this.$emit("line-select", this.jumpToLine);
       this.$emit("jumped");
     }
-    // Detect manual scrolling inside the DynamicScroller so the parent can
-    // disable follow when the user scrolls away from the bottom.
-    const scrollerEl = (this.$refs.scroller as any)?.$el as HTMLElement | undefined;
-    if (scrollerEl) {
-      scrollerEl.addEventListener("scroll", this.onScrollerScroll);
-    }
+    this._tryAttachScrollListener();
+  },
+  updated() {
+    // The DynamicScroller is inside a v-if, so it may not exist at mounted().
+    // Re-try attaching the listener on every update until it succeeds.
+    this._tryAttachScrollListener();
   },
   beforeUnmount() {
     const scrollerEl = (this.$refs.scroller as any)?.$el as HTMLElement | undefined;
     if (scrollerEl) {
       scrollerEl.removeEventListener("scroll", this.onScrollerScroll);
     }
+    (this as any)._scrollListenerAdded = false;
   },
   methods: {
     entryTitle(newEntry: ExecutionOutputEntry) {
@@ -230,6 +231,14 @@ export default defineComponent({
         selected: this.selectedLine === index + 1,
       };
       return newEntry;
+    },
+    _tryAttachScrollListener() {
+      if ((this as any)._scrollListenerAdded) return;
+      const scrollerEl = (this.$refs.scroller as any)?.$el as HTMLElement | undefined;
+      if (scrollerEl) {
+        scrollerEl.addEventListener("scroll", this.onScrollerScroll);
+        (this as any)._scrollListenerAdded = true;
+      }
     },
     onSelectLine(index: number) {
       this.$emit("line-select", index);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/LogNodeChunk.vue
@@ -120,12 +120,21 @@ export default defineComponent({
     entries(newEntries: ExecutionOutputEntry[] | undefined) {
       if (!this.follow || !newEntries || newEntries.length === 0) return;
       this.$nextTick(() => {
-        // Re-check inside $nextTick: the user may have toggled follow off
-        // between when this watcher fired and when the DOM updated.
         if (this.follow) {
           (this.$refs.scroller as any)?.scrollToBottom?.();
         }
       });
+    },
+    follow(newVal: boolean) {
+      // Scroll to bottom immediately when follow is re-enabled, even if no
+      // new entries have arrived since the last update.
+      if (newVal) {
+        this.$nextTick(() => {
+          if (this.follow) {
+            (this.$refs.scroller as any)?.scrollToBottom?.();
+          }
+        });
+      }
     },
   },
   computed: {
@@ -249,17 +258,22 @@ export default defineComponent({
       const currentScrollTop = el.scrollTop;
       (this as any)._prevScrollTop = currentScrollTop;
 
-      // Only disable follow when the user is actively scrolling UP.
-      // Programmatic scrollToBottom() increases scrollTop (downward), so it
-      // will NOT trigger this condition. Relying on direction instead of
-      // position prevents follow from being disabled during scroll animations
-      // triggered by our own scrollToBottom() calls.
-      if (
-        prevScrollTop !== undefined &&
-        currentScrollTop < prevScrollTop &&
-        this.follow
-      ) {
+      if (prevScrollTop === undefined) return;
+
+      const scrollingUp = currentScrollTop < prevScrollTop;
+      const atBottom =
+        currentScrollTop + el.clientHeight >= el.scrollHeight - 10;
+
+      // Disable follow when the user scrolls UP (not from programmatic
+      // scrollToBottom, which increases scrollTop).
+      if (scrollingUp && this.follow) {
         this.$emit("follow-change", false);
+        return;
+      }
+      // Re-enable follow when the user scrolls back to the bottom.
+      // logViewer.vue only honors this in node view (onNodeFollowChange).
+      if (atBottom && !this.follow) {
+        this.$emit("follow-change", true);
       }
     },
     scrollToLine() {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
@@ -169,6 +169,7 @@
           <h5>No output</h5>
         </div>
         <LogNodeChunk
+          v-if="!overSize"
           ref="logEntryChunk"
           class="execution-log__node-chunk"
           :event-bus="eventBus"

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
@@ -188,7 +188,7 @@
           :follow="mfollow"
           @line-select="handleLineSelect"
           @jumped="jumped = true"
-          @follow-change="mfollow = $event"
+          @follow-change="onNodeFollowChange"
         />
       </div>
     </div>
@@ -557,6 +557,14 @@ export default defineComponent({
       }
 
       _scroller.scrollTop = offset - 24; // Insure under stick header
+    },
+    onNodeFollowChange(val: boolean) {
+      // Only honor follow-change events from LogNodeChunk when in node view.
+      // In the log output view, addScrollBlocker + the Follow button manage
+      // mfollow; the DynamicScroller scroll listener must not interfere.
+      if (this.node) {
+        this.mfollow = val;
+      }
     },
     handleLineSelect(idx: number) {
       if (this.overSize) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
@@ -206,7 +206,7 @@
 import { CancelToken } from "@esfx/canceltoken";
 import { autorun, IReactionDisposer } from "mobx";
 
-import { defineComponent, toRaw } from "vue";
+import { defineComponent } from "vue";
 import RdDrawer from "../containers/drawer/Drawer.vue";
 import UiSocket from "../utils/UiSocket.vue";
 import { EventBus } from "../../utilities/vueEventBus";

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
@@ -98,6 +98,7 @@
         'execution-log--no-transition': logLines > 1000,
         'ansicolor-on': settings.ansiColor,
       }"
+      :style="node ? { height: '600px', flex: 'none', overflowY: 'hidden' } : {}"
     >
       <div ref="log" class="execution-log__scroller-item-container">
         <div
@@ -202,8 +203,9 @@
 
 <script lang="ts">
 import { CancelToken } from "@esfx/canceltoken";
+import { autorun, IReactionDisposer } from "mobx";
 
-import { defineComponent } from "vue";
+import { defineComponent, toRaw } from "vue";
 import RdDrawer from "../containers/drawer/Drawer.vue";
 import UiSocket from "../utils/UiSocket.vue";
 import { EventBus } from "../../utilities/vueEventBus";
@@ -343,6 +345,8 @@ export default defineComponent({
       entries: [],
       entriesFromViewer: [],
       viewerEntriesByNodeCtx: null,
+      viewerFilteredEntries: [] as any[],
+      autorunDisposer: null as IReactionDisposer | null,
     };
   },
   computed: {
@@ -386,12 +390,7 @@ export default defineComponent({
         return [];
       }
       if (this.node) {
-        if (this.stepCtx && this.viewerEntriesByNodeCtx) {
-          return this.viewerEntriesByNodeCtx[
-            `${this.node}:${JobWorkflow.cleanContextId(this.stepCtx)}`
-          ];
-        }
-        return this.viewerEntriesByNode[this.node];
+        return this.viewerFilteredEntries;
       }
       return this.entriesFromViewer;
     },
@@ -423,26 +422,31 @@ export default defineComponent({
     viewer: {
       handler(newVal) {
         this.entriesFromViewer = newVal.entries;
-        this.viewerEntriesByNodeCtx = this.entriesFromViewer.reduce(
-          (acc, entry) => ({
-            ...acc,
-            [`${entry.node}:${entry.stepctx ? JobWorkflow.cleanContextId(entry.stepctx) : ""}`]:
-              [
-                ...(acc[
-                  `${entry.node}:${entry.stepctx ? JobWorkflow.cleanContextId(entry.stepctx) : ""}`
-                ] || []),
-                entry,
-              ],
-          }),
-          {},
-        );
       },
       deep: true,
     },
   },
   beforeMount() {
     this.loadConfig();
-    this.viewer = rootStore.executionOutputStore.createOrGet(this.executionId);
+    // Capture the raw ExecutionOutput reference before Vue wraps it in a
+    // reactive proxy, so MobX can properly track ObservableGroupMap accesses
+    // inside the autorun callback.
+    const rawViewer = rootStore.executionOutputStore.createOrGet(this.executionId);
+    this.viewer = rawViewer;
+    if (this.node) {
+      const node = this.node;
+      const stepCtx = this.stepCtx;
+      this.autorunDisposer = autorun(() => {
+        const filtered = rawViewer.getEntriesFiltered(node, stepCtx);
+        this.viewerFilteredEntries = filtered ? [...filtered] : [];
+      });
+    }
+  },
+  beforeUnmount() {
+    if (this.autorunDisposer) {
+      this.autorunDisposer();
+      this.autorunDisposer = null;
+    }
   },
   async mounted() {
     await this.viewer.init();

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/execution-log/logViewer.vue
@@ -188,6 +188,7 @@
           :follow="mfollow"
           @line-select="handleLineSelect"
           @jumped="jumped = true"
+          @follow-change="mfollow = $event"
         />
       </div>
     </div>
@@ -453,7 +454,14 @@ export default defineComponent({
     await this.viewer.init();
 
     this.startTime = Date.now();
-    this.addScrollBlocker();
+    // In node view the outer scroller has overflow:hidden and the DynamicScroller
+    // handles its own scrolling. Applying addScrollBlocker there would call
+    // ev.preventDefault() on bubbled wheel events and prevent the DynamicScroller
+    // from scrolling. The LogNodeChunk handles follow detection via its own scroll
+    // listener and emits 'follow-change' instead.
+    if (!this.node) {
+      this.addScrollBlocker();
+    }
 
     this.updateProgress();
 


### PR DESCRIPTION
## Release Notes

<!-- 
To include as part of release notes, label as "release-notes/include" and fill in this section.
-->

## Before submitting this PR:

- [x] Jira ticket is present in the title or in the description
- [x] All items marked FILL IN are filled
- [ ] Any required labels are applied
- [x] Testing/reviewer instructions are filled out

## About this change:

**Jira Ticket**: [RUN-3547](https://pagerduty.atlassian.net/browse/RUN-3547)

### Purpose of the Changes:

Fix the nodes view in the execution show page so it displays the complete log output instead of being capped at ~1000 lines, and prevents the view from breaking when switching between the "nodes" and "log output" tabs.

<details>
  <summary>
    More details and context about this PR
  </summary>
  <br />

**Customer Impact:**

Customers were unable to see the full log output in the nodes view. After running a job producing 9000+ lines, the nodes view showed only ~1000 lines. Additionally, switching from the log output tab back to the nodes tab would show only 0-100 lines until a full page refresh.

**Kind of Change**

- [x] Bug Fix

**Development Checklist**

- [ ] Unit Tests added for modified/added code
- [x] Documentation Not needed

**Root Causes and Fixes:**

Three independent root causes were identified and fixed:

### 1. MobX/Vue Reactivity (`logViewer.vue`)

The nodes view used a static snapshot (`viewerEntriesByNodeCtx`) that was only built once on mount. It failed to update reactively as new log entries arrived from the shared `ExecutionOutputStore`.

**Fix**: Added MobX `autorun` in `beforeMount()` that watches `rawViewer.getEntriesFiltered(node, stepCtx)` and updates `viewerFilteredEntries`. Using `toRaw()` ensures MobX tracks the observable without Vue's reactive proxy interfering. A `beforeUnmount()` hook disposes the reaction to prevent memory leaks.

### 2. Vue Component Lifecycle (`nodeView.ts`)

Multiple `LogViewer` instances were being mounted on the same `.wfnodeoutput` DOM element without unmounting previous ones (when the user expanded/collapsed a node step multiple times). This caused `TypeError: Cannot set properties of null (setting '__vnode')`.

**Fix**: Introduced a `mountedNodeApps` Map keyed by `execId::node::stepCtx`. Before mounting a new app, any existing one is explicitly `unmount()`ed.

### 3. Virtual Scroller Height (`logViewer.vue` + `nodeView.ts`)

The `.wfnodeoutput` element in the Knockout template has no explicit height. `DynamicScroller` (vue-virtual-scroller) needs a concrete viewport height to virtualize items. Without it, `element.clientHeight` is 0, and the scroller tries to render all items at once, throwing `Error: Rendered items limit reached` with 1000+ items.

The `height: 100%` chain through flex containers and `overflow: auto` parents does not reliably resolve to a pixel value without an explicit ancestor height.

**Fix**: 
- Set `elm.style.height = '600px'` on the `.wfnodeoutput` container in `nodeView.ts`
- Apply inline style `{ height: '600px', flex: 'none', overflowY: 'hidden' }` to `.execution-log__scroller` when the `node` prop is set in `logViewer.vue`, giving `DynamicScroller` a concrete 600px viewport to virtualize against

GUI Changes:

- [x] No GUI Changes (behavior fix only — the UI looks the same but now shows complete logs)
</details>

## Testing:

<details>
  <summary>
    Information for testing
  </summary>
  <br />

**Docker Usage**:

  > Note: After the CircleCI "Build" step completes, this branch can be tested in Docker with:

  ~~~bash
  docker run -P -p 4440:4440 \
      -e RUNDECK_SERVER_ADDRESS=0.0.0.0 \
      -e RUNDECK_GRAILS_URL=http://localhost:4440 \
      rundeckpro/ci:RUN-3547-fix-nodes-view-log-display
  ~~~

**Testing setup:**

1. Create and run a job that produces 9000+ log lines (e.g., a script with `for i in $(seq 1 9000); do echo "Line $i"; done`)
2. Open the execution show page
3. Expand the node step in the "Nodes" tab

**Acceptance Criteria:**

- [x] Nodes view displays **all** log lines (not capped at 1000)
- [x] Switching from "Log Output" tab back to "Nodes" tab shows complete log (no regression to 100 lines)
- [x] No `Error: Rendered items limit reached` in browser console
- [x] No `TypeError: Cannot set properties of null (setting '__vnode')` in browser console
- [x] Nodes view does not crash when expanding/collapsing the same node step multiple times

**QA/Bug Bash Needed?**

- [x] Not needed

**Manual QA Notes:**

Test with a single-node, single-step job producing a large number of lines (9000+) to reproduce the original issue.

**Reviewer Checklist**

Functionality (choose one):

- [ ] I built and tested locally and code behaves as expected
- [ ] I tested via Docker image
- [ ] It was not necessary, reason:

Code:

- [ ] Meets quality and style guidelines
  - [ ] Has complete Unit tests
  - [ ] Has complete Functional Tests
</details>

Made with [Cursor](https://cursor.com)

[RUN-3547]: https://pagerduty.atlassian.net/browse/RUN-3547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ