### PR TITLE
[RUN-4502] Fix ZipResourceLoader asset path resolution for Grails 7 multi-segment paths

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/ZipResourceLoader.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/ZipResourceLoader.java
@@ -35,7 +35,7 @@ public class ZipResourceLoader implements PluginResourceLoader {
     List<String> resourcesList;
     String resourcesBasedir;
     List<String> basedirListing;
-    Properties assetManifest; // Grails 7: asset-pipeline manifest for hashed filenames
+    volatile Properties assetManifest; // Grails 7: asset-pipeline manifest for hashed filenames
 
     public ZipResourceLoader(
             final File cacheDir,
@@ -135,21 +135,21 @@ public class ZipResourceLoader implements PluginResourceLoader {
      * @return Resolved path (e.g., "menu/aclmanager-HASH.js") or original if not in manifest
      */
     private String resolveAssetPath(String path) {
-        // Load manifest on first use (lazy initialization)
-        if (assetManifest == null) {
-            assetManifest = new Properties();
-            File manifestFile = new File(cacheDir, "manifest.properties");
-            if (manifestFile.isFile()) {
-                try (FileInputStream fis = new FileInputStream(manifestFile)) {
-                    assetManifest.load(fis);
-                } catch (IOException e) {
-                    // Manifest load failed, continue without it (backwards compatible)
+        // Double-checked locking: volatile field + synchronized block ensure the manifest
+        // is fully loaded before any concurrent caller can read it.
+        Properties manifest = assetManifest;
+        if (manifest == null) {
+            synchronized (this) {
+                manifest = assetManifest;
+                if (manifest == null) {
+                    manifest = loadAssetManifest();
+                    assetManifest = manifest;
                 }
             }
         }
 
         // Try direct lookup first (backwards compatible with pre-Grails 7 plugins)
-        String resolved = assetManifest.getProperty(path);
+        String resolved = manifest.getProperty(path);
         if (resolved != null) {
             return resolved;
         }
@@ -161,7 +161,7 @@ public class ZipResourceLoader implements PluginResourceLoader {
         int slash = remaining.indexOf('/');
         while (slash >= 0) {
             remaining = remaining.substring(slash + 1);
-            String hashedPath = assetManifest.getProperty(remaining);
+            String hashedPath = manifest.getProperty(remaining);
             if (hashedPath != null) {
                 return hashedPath;
             }
@@ -170,6 +170,23 @@ public class ZipResourceLoader implements PluginResourceLoader {
 
         // Fallback: return original path (non-hashed static assets)
         return path;
+    }
+
+    /**
+     * Loads manifest.properties from the cache directory.
+     * Returns an empty Properties if the file does not exist or cannot be read.
+     */
+    private Properties loadAssetManifest() {
+        Properties manifest = new Properties();
+        File manifestFile = new File(cacheDir, "manifest.properties");
+        if (manifestFile.isFile()) {
+            try (FileInputStream fis = new FileInputStream(manifestFile)) {
+                manifest.load(fis);
+            } catch (IOException e) {
+                // Manifest load failed; fall through with empty manifest (backwards compatible)
+            }
+        }
+        return manifest;
     }
 
     /**

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/ZipResourceLoader.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/ZipResourceLoader.java
@@ -125,13 +125,14 @@ public class ZipResourceLoader implements PluginResourceLoader {
     /**
      * Resolve asset path via manifest.properties for Grails 7 hashed filenames.
      * Falls back to original path if manifest not found or path not in manifest.
-     * 
-     * Handles subdirectory paths: plugin.yaml may reference "js/common.js" while
-     * manifest.properties contains "common.js=common-HASH.js". Asset-pipeline puts
-     * hashed files at the root of resources/, not in subdirectories.
-     * 
-     * @param path Original path from plugin.yaml (e.g., "js/common.js" or "common.js")
-     * @return Resolved path (e.g., "common-HASH.js") or original path if not in manifest
+     *
+     * Asset-pipeline strips the top-level type directory (js/, css/, …) when writing
+     * manifest keys, so plugin.yaml "js/menu/aclmanager.js" maps to manifest key
+     * "menu/aclmanager.js". This method strips leading segments progressively until
+     * a manifest entry is found.
+     *
+     * @param path Original path from plugin.yaml (e.g., "js/menu/aclmanager.js")
+     * @return Resolved path (e.g., "menu/aclmanager-HASH.js") or original if not in manifest
      */
     private String resolveAssetPath(String path) {
         // Load manifest on first use (lazy initialization)
@@ -146,26 +147,28 @@ public class ZipResourceLoader implements PluginResourceLoader {
                 }
             }
         }
-        
-        // Try direct lookup first (for backwards compatibility with pre-Grails 7 plugins)
+
+        // Try direct lookup first (backwards compatible with pre-Grails 7 plugins)
         String resolved = assetManifest.getProperty(path);
         if (resolved != null) {
             return resolved;
         }
-        
-        // Try stripping subdirectory for Grails 7 asset-pipeline manifests
-        // Example: "js/common.js" -> lookup "common.js" in manifest -> "common-HASH.js"
-        // Note: Asset-pipeline places hashed files at ROOT of resources/, so we DON'T re-add subdir
-        int lastSlash = path.lastIndexOf('/');
-        if (lastSlash >= 0) {
-            String filename = path.substring(lastSlash + 1); // "common.js"
-            String hashedFilename = assetManifest.getProperty(filename);
-            if (hashedFilename != null) {
-                return hashedFilename; // "common-HASH.js" (at root, no subdir prefix)
+
+        // Progressively strip leading path segments until a manifest entry is found.
+        // "js/menu/aclmanager.js" -> try "menu/aclmanager.js" -> found -> "menu/aclmanager-HASH.js"
+        // "js/common.js"          -> try "common.js"          -> found -> "common-HASH.js"
+        String remaining = path;
+        int slash = remaining.indexOf('/');
+        while (slash >= 0) {
+            remaining = remaining.substring(slash + 1);
+            String hashedPath = assetManifest.getProperty(remaining);
+            if (hashedPath != null) {
+                return hashedPath;
             }
+            slash = remaining.indexOf('/');
         }
-        
-        // Fallback: return original path (backwards compatible for non-hashed assets)
+
+        // Fallback: return original path (non-hashed static assets)
         return path;
     }
 

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/ZipResourceLoaderSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/ZipResourceLoaderSpec.groovy
@@ -69,6 +69,81 @@ class ZipResourceLoaderSpec extends Specification {
         result == ['a', 'b']
     }
 
+    // -------------------------------------------------------------------------
+    // resolveAssetPath / openResourceStreamFor — Grails 7 manifest resolution
+    // -------------------------------------------------------------------------
+
+    def "openResourceStreamFor resolves multi-segment path via manifest"() {
+        given: "manifest maps the stripped key to a hashed filename in a subdirectory"
+        new File(cachedir, "manifest.properties").text =
+            "menu/aclmanager.js=menu/aclmanager-abc123.js\n"
+        new File(cachedir, "menu").mkdirs()
+        new File(cachedir, "menu/aclmanager-abc123.js").text = "aclmanager content"
+
+        def zrl = new ZipResourceLoader(cachedir, new File(cachedir, "dummy.zip"), null, "resources")
+
+        when: "the original path has a leading type segment stripped by asset-pipeline"
+        def stream = zrl.openResourceStreamFor("js/menu/aclmanager.js")
+
+        then: "the hashed file is returned"
+        stream.text == "aclmanager content"
+
+        cleanup:
+        stream?.close()
+    }
+
+    def "openResourceStreamFor resolves single-segment path via manifest"() {
+        given: "manifest maps stripped key to hashed filename at root"
+        new File(cachedir, "manifest.properties").text =
+            "common.js=common-abc123.js\n"
+        new File(cachedir, "common-abc123.js").text = "common content"
+
+        def zrl = new ZipResourceLoader(cachedir, new File(cachedir, "dummy.zip"), null, "resources")
+
+        when:
+        def stream = zrl.openResourceStreamFor("js/common.js")
+
+        then:
+        stream.text == "common content"
+
+        cleanup:
+        stream?.close()
+    }
+
+    def "openResourceStreamFor falls back to original path when no manifest exists"() {
+        given: "no manifest.properties in the cache dir"
+        new File(cachedir, "images").mkdirs()
+        new File(cachedir, "images/logo.png").bytes = [0x89, 0x50] as byte[]
+
+        def zrl = new ZipResourceLoader(cachedir, new File(cachedir, "dummy.zip"), null, "resources")
+
+        when:
+        def stream = zrl.openResourceStreamFor("images/logo.png")
+
+        then: "original path is used and the file is opened successfully"
+        stream != null
+
+        cleanup:
+        stream?.close()
+    }
+
+    def "openResourceStreamFor falls back to original path when key not in manifest"() {
+        given: "manifest exists but does not contain the requested key"
+        new File(cachedir, "manifest.properties").text = "other.js=other-abc123.js\n"
+        new File(cachedir, "static.js").text = "static content"
+
+        def zrl = new ZipResourceLoader(cachedir, new File(cachedir, "dummy.zip"), null, "resources")
+
+        when:
+        def stream = zrl.openResourceStreamFor("static.js")
+
+        then:
+        stream.text == "static content"
+
+        cleanup:
+        stream?.close()
+    }
+
     def "listResources zip basepath"() {
         given:
         def reslist = null


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bug fix. `ZipResourceLoader.resolveAssetPath()` fails to find manifest entries for paths with multiple segments (e.g. `js/menu/aclmanager.js`), causing a 404 for the `rundeckpro-ui-acl-manager` plugin script in Grails 7 builds.

Jira: https://pagerduty.atlassian.net/browse/RUN-4502

**Describe the solution you've implemented**

Grails 7 asset-pipeline strips the top-level type directory (`js/`, `css/`) when writing `manifest.properties` keys. The old code only stripped the **last** segment via `lastIndexOf('/')`, producing `aclmanager.js` for the path `js/menu/aclmanager.js` — which has no manifest entry.

Fix: progressively strip **leading** segments until a manifest key is found:

| Step | Value |
|---|---|
| Requested | `js/menu/aclmanager.js` |
| Try | `menu/aclmanager.js` → found ✓ |
| Returns | `menu/aclmanager-{hash}.js` |

**Describe alternatives you've considered**

Could require all plugin.yaml paths to match manifest keys exactly (i.e. already omit the type directory). Rejected: would require changes to all plugins and existing plugin.yaml files.

**Additional context**

The previous single-segment stripping (`js/common.js` → `common.js`) still works — the progressive loop handles that case on the first iteration.

## Release Notes

Fixes 404 for plugin assets with nested paths (e.g. `js/menu/aclmanager.js`) in Grails 7 deployments where asset-pipeline fingerprints files and writes a `manifest.properties`.