### PR TITLE
[RUN-4504] Fix flaky ExecutionModeSpec disable schedules race condition

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/ExecutionModeSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/ExecutionModeSpec.groovy
@@ -293,17 +293,22 @@ class ExecutionModeSpec extends SeleniumBase{
         when:
         sideBarPage.goTo NavLinkTypes.ACTIVITY
         def executions = activityPage.getActivityRowsByJobName(jobName).size()
+        // Capture API execution count before re-enabling so we can detect new executions by count.
+        // We cannot rely on the "running" state: the echo job completes in milliseconds and may
+        // already be finished before the first poll fires on a slow CI runner.
+        def executionCountBeforeEnable = ExecutionUtils.Retrievers.executionsForProject(client, projectName).get().size()
         projectEditPage.go("/project/${projectName}/configure")
         projectEditPage.clickNavLink(NavProjectSettings.EXEC_MODE)
         projectEditPage.clickScheduleMode()
         projectEditPage.save()
-        // Waits for at least one execution to start running
+        // Wait for at least one new execution to appear (running or already finished)
         waitFor(ExecutionUtils.Retrievers.executionsForProject(client, projectName),
-                { List<Execution> execs ->  execs.any(ExecutionUtils.Verifiers.executionRunning()) },
+                { List<Execution> execs -> execs.size() > executionCountBeforeEnable },
                 WaitingTime.EXCESSIVE)
         // Waits for all executions to finish
         waitFor(ExecutionUtils.Retrievers.executionsForProject(client, projectName),
-                verifyForAll(ExecutionUtils.Verifiers.executionFinished()))
+                verifyForAll(ExecutionUtils.Verifiers.executionFinished()),
+                WaitingTime.EXCESSIVE)
         sideBarPage.goTo NavLinkTypes.ACTIVITY
         then:
         executions < activityPage.getActivityRowsByJobName(jobName).size()

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/ExecutionModeSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/project/ExecutionModeSpec.groovy
@@ -296,17 +296,19 @@ class ExecutionModeSpec extends SeleniumBase{
         // Capture API execution count before re-enabling so we can detect new executions by count.
         // We cannot rely on the "running" state: the echo job completes in milliseconds and may
         // already be finished before the first poll fires on a slow CI runner.
-        def executionCountBeforeEnable = ExecutionUtils.Retrievers.executionsForProject(client, projectName).get().size()
+        // Use max=100 to avoid the default page-size cap (20), which would prevent count-based detection
+        // from working once a project already has 20+ executions from prior schedule runs.
+        def executionCountBeforeEnable = ExecutionUtils.Retrievers.executionsForProject(client, projectName, "max=100").get().size()
         projectEditPage.go("/project/${projectName}/configure")
         projectEditPage.clickNavLink(NavProjectSettings.EXEC_MODE)
         projectEditPage.clickScheduleMode()
         projectEditPage.save()
         // Wait for at least one new execution to appear (running or already finished)
-        waitFor(ExecutionUtils.Retrievers.executionsForProject(client, projectName),
+        waitFor(ExecutionUtils.Retrievers.executionsForProject(client, projectName, "max=100"),
                 { List<Execution> execs -> execs.size() > executionCountBeforeEnable },
                 WaitingTime.EXCESSIVE)
         // Waits for all executions to finish
-        waitFor(ExecutionUtils.Retrievers.executionsForProject(client, projectName),
+        waitFor(ExecutionUtils.Retrievers.executionsForProject(client, projectName, "max=100"),
                 verifyForAll(ExecutionUtils.Verifiers.executionFinished()),
                 WaitingTime.EXCESSIVE)
         sideBarPage.goTo NavLinkTypes.ACTIVITY


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Bugfix for a flaky Selenium test in `ExecutionModeSpec`. The test `"disable schedules at project level UI"` was intermittently failing in CI because it relied on detecting the `running` state of an execution to confirm that schedules had re-enabled. The `echo hello there` job completes in ~1 second, so on loaded CI runners the job was already `succeeded` before the first poll fired — causing `waitFor(executionRunning())` to time out.

Fixes: [RUN-4504](https://pagerduty.atlassian.net/browse/RUN-4504)

**Describe the solution you've implemented**
- Capture the API execution count _before_ re-enabling schedules.
- Replace `waitFor(executionRunning())` with `waitFor(execs.size() > executionCountBeforeEnable)` — detects new executions regardless of whether they are still running or already finished.
- Add `WaitingTime.EXCESSIVE` to the second `waitFor` call (was using the default 60s timeout, which could also time out on slow runners).

**Describe alternatives you've considered**
- Using a longer `Thread.sleep()` — rejected per Selenium rules (no sleep-based flake fixes).
- Switching to a slower job to keep it in `running` state — unnecessarily couples test speed to race condition timing.

**Additional context**
Fix verified locally against a running Rundeck instance. Count-based detection is reliable regardless of job execution speed or CI runner load.

## Release Notes

<!-- No user-facing behavior change — test-only fix. -->

[RUN-4504]: https://pagerduty.atlassian.net/browse/RUN-4504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ