### PR TITLE
[RUN-3427] Fix Next UI Jobs page activity list showing 0 executions

### DIFF
--- a/rundeckapp/grails-app/views/menu/jobs.next.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.next.gsp
@@ -221,9 +221,6 @@
             pagination:{
                 max: ${enc(js:params.max?params.int('max',10):10)}
         },
-        query:{
-            jobIdFilter:'!null'
-          },
           filterOpts: {
               showFilter: false,
               showRecentFilter: true,


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bug fix: When the Next UI (Early Access) mode is enabled, the Jobs page activity list shows 0 executions.

This is caused by a stale `jobIdFilter:'!null'` query parameter hardcoded in `jobs.next.gsp` that filters out all executions when passed to the activity endpoint.

Jira: https://pagerduty.atlassian.net/browse/RUN-3427

**Describe the solution you've implemented**

Removed the `query: { jobIdFilter: '!null' }` block from `_rundeck.data` in `jobs.next.gsp`. This block was inadvertently filtering out all executions in the activity list shown on the Next UI Jobs page.

The affected file is `rundeckapp/grails-app/views/menu/jobs.next.gsp` (the Next UI variant of the jobs list page).

**Describe alternatives you've considered**

Could have changed the filter value rather than removing it, but the intent of the activity list on the jobs page is to show all recent executions for the project, not filter by job — so removing the filter entirely is the correct fix.

**Additional context**

This fix is part of a broader set of pro plugin compatibility fixes for Next UI (Early Access). The pro plugin changes are in a separate rundeckpro PR: https://github.com/rundeckpro/rundeckpro/pull/4733

## Release Notes

Fix: Next UI Jobs page now correctly displays the project activity list instead of showing 0 executions.
