### PR TITLE
[RUN-4512] Fix AES-GCM plugin: recover inconsistent encryption metadata via legacy flag precedence

### DIFF
--- a/plugins/aes-gcm-encryption-plugin/src/main/java/org/rundeck/plugin/encryption/ModernEncryptionConverterPlugin.java
+++ b/plugins/aes-gcm-encryption-plugin/src/main/java/org/rundeck/plugin/encryption/ModernEncryptionConverterPlugin.java
@@ -130,7 +130,7 @@ public class ModernEncryptionConverterPlugin implements StorageConverterPlugin {
                                        HasInputStream hasInputStream) {
         if ("true".equals(resourceMetaBuilder.getResourceMeta().get(META_ENCRYPTED))) {
             logger.debug("readResource (aes-gcm-encrypted) {}", path);
-            return decrypt(hasInputStream);
+            return decryptWithFallback(hasInputStream, path);
         }
         if ("true".equals(resourceMetaBuilder.getResourceMeta().get(JASYPT_META_ENCRYPTED))) {
             logger.debug("readResource (jasypt-encrypted, legacy fallback) {}", path);
@@ -171,18 +171,36 @@ public class ModernEncryptionConverterPlugin implements StorageConverterPlugin {
         }
     }
 
-    private HasInputStream decrypt(HasInputStream input) {
-        try {
-            return new TransformStream(input) {
-                @Override
-                protected byte[] transform(byte[] data) {
+    /**
+     * Decrypts data tagged as AES-GCM in metadata, but falls back to legacy Jasypt decryption
+     * when the actual content bytes do not match the AES-GCM wire format.
+     *
+     * <p>This handles inconsistent storage state that can arise from two causes:
+     * <ul>
+     *   <li>Partial write failure during migration: metadata was updated to AES-GCM flags
+     *       but the content bytes were never re-encrypted (still Jasypt format).</li>
+     *   <li>Legacy migration records where both {@code aes-gcm-encryption:encrypted} and
+     *       {@code jasypt-encryption:encrypted} are {@code "true"} simultaneously.</li>
+     * </ul>
+     *
+     * @see <a href="https://pagerduty.atlassian.net/browse/RUN-4512">RUN-4512</a>
+     */
+    private HasInputStream decryptWithFallback(HasInputStream input, Path path) {
+        return new TransformStream(input) {
+            @Override
+            protected byte[] transform(byte[] data) {
+                if (AesEncryptor.isAesFormat(data)) {
                     return getAesEncryptor().decrypt(getResolvedPassword(), data);
                 }
-            };
-        } catch (Exception e) {
-            logger.error("AES-256-GCM decryption failed. Wrong password or tampered data.", e);
-            throw new RuntimeException("AES-256-GCM decryption failed", e);
-        }
+                logger.warn(
+                        "readResource: metadata indicates AES-GCM encryption but content at '{}' "
+                        + "is not AES-GCM format (first byte: 0x{})."
+                        + " Falling back to legacy Jasypt decryption."
+                        + " This record has inconsistent metadata/content state (see RUN-4512).",
+                        path, String.format("%02X", data[0] & 0xFF));
+                return getLegacyDecryptor().decrypt(getResolvedPassword(), data);
+            }
+        };
     }
 
     private HasInputStream decryptLegacy(HasInputStream input) {

--- a/plugins/aes-gcm-encryption-plugin/src/main/java/org/rundeck/plugin/encryption/ModernEncryptionConverterPlugin.java
+++ b/plugins/aes-gcm-encryption-plugin/src/main/java/org/rundeck/plugin/encryption/ModernEncryptionConverterPlugin.java
@@ -128,13 +128,29 @@ public class ModernEncryptionConverterPlugin implements StorageConverterPlugin {
     @Override
     public HasInputStream readResource(Path path, ResourceMetaBuilder resourceMetaBuilder,
                                        HasInputStream hasInputStream) {
-        if ("true".equals(resourceMetaBuilder.getResourceMeta().get(META_ENCRYPTED))) {
-            logger.debug("readResource (aes-gcm-encrypted) {}", path);
-            return decryptWithFallback(hasInputStream, path);
-        }
-        if ("true".equals(resourceMetaBuilder.getResourceMeta().get(JASYPT_META_ENCRYPTED))) {
-            logger.debug("readResource (jasypt-encrypted, legacy fallback) {}", path);
+        boolean jasyptEncrypted = "true".equals(resourceMetaBuilder.getResourceMeta().get(JASYPT_META_ENCRYPTED));
+        boolean aesEncrypted = "true".equals(resourceMetaBuilder.getResourceMeta().get(META_ENCRYPTED));
+
+        // The two flags are mutually exclusive by construction: every AES-GCM write clears the
+        // legacy Jasypt flag (see createResource/updateResource), and content + metadata are
+        // persisted atomically by the storage layer (single row write). Therefore any record
+        // that still carries jasypt-encryption:encrypted=true holds Jasypt-encrypted content —
+        // even when the aes-gcm-encryption:encrypted flag is also true. The legacy flag wins so
+        // that inconsistent records (e.g. production row id=130, where both flags were true) are
+        // decrypted with the correct algorithm instead of crashing. See RUN-4512.
+        if (jasyptEncrypted) {
+            if (aesEncrypted) {
+                logger.warn("readResource: record at '{}' has both encryption flags set; decrypting as "
+                        + "legacy Jasypt (content predates the AES-GCM migration, see RUN-4512). It will be "
+                        + "re-encrypted to AES-GCM on its next update.", path);
+            } else {
+                logger.debug("readResource (jasypt-encrypted, legacy) {}", path);
+            }
             return decryptLegacy(hasInputStream);
+        }
+        if (aesEncrypted) {
+            logger.debug("readResource (aes-gcm-encrypted) {}", path);
+            return decryptModern(hasInputStream);
         }
         logger.debug("readResource (unencrypted) {}", path);
         return null;
@@ -172,39 +188,18 @@ public class ModernEncryptionConverterPlugin implements StorageConverterPlugin {
         }
     }
 
-    /**
-     * Decrypts data tagged as AES-GCM in metadata, but falls back to legacy Jasypt decryption
-     * when the actual content bytes do not match the AES-GCM wire format.
-     *
-     * <p>This handles inconsistent storage state that can arise from two causes:
-     * <ul>
-     *   <li>Partial write failure during migration: metadata was updated to AES-GCM flags
-     *       but the content bytes were never re-encrypted (still Jasypt format).</li>
-     *   <li>Legacy migration records where both {@code aes-gcm-encryption:encrypted} and
-     *       {@code jasypt-encryption:encrypted} are {@code "true"} simultaneously.</li>
-     * </ul>
-     *
-     * @see <a href="https://pagerduty.atlassian.net/browse/RUN-4512">RUN-4512</a>
-     */
-    private HasInputStream decryptWithFallback(HasInputStream input, Path path) {
-        return new TransformStream(input) {
-            @Override
-            protected byte[] transform(byte[] data) {
-                if (AesEncryptor.isAesFormat(data)) {
+    private HasInputStream decryptModern(HasInputStream input) {
+        try {
+            return new TransformStream(input) {
+                @Override
+                protected byte[] transform(byte[] data) {
                     return getAesEncryptor().decrypt(getResolvedPassword(), data);
                 }
-                String firstByteHex = data.length > 0
-                        ? String.format("%02X", data[0] & 0xFF)
-                        : "empty";
-                logger.warn(
-                        "readResource: metadata indicates AES-GCM encryption but content at '{}' "
-                        + "is not AES-GCM format (first byte: 0x{})."
-                        + " Falling back to legacy Jasypt decryption."
-                        + " This record has inconsistent metadata/content state (see RUN-4512).",
-                        path, firstByteHex);
-                return getLegacyDecryptor().decrypt(getResolvedPassword(), data);
-            }
-        };
+            };
+        } catch (Exception e) {
+            logger.error("AES-256-GCM decryption failed. Wrong password or corrupted data.", e);
+            throw new RuntimeException("AES-256-GCM decryption failed", e);
+        }
     }
 
     private HasInputStream decryptLegacy(HasInputStream input) {

--- a/plugins/aes-gcm-encryption-plugin/src/main/java/org/rundeck/plugin/encryption/ModernEncryptionConverterPlugin.java
+++ b/plugins/aes-gcm-encryption-plugin/src/main/java/org/rundeck/plugin/encryption/ModernEncryptionConverterPlugin.java
@@ -144,6 +144,7 @@ public class ModernEncryptionConverterPlugin implements StorageConverterPlugin {
     public HasInputStream createResource(Path path, ResourceMetaBuilder resourceMetaBuilder,
                                          HasInputStream hasInputStream) {
         resourceMetaBuilder.getResourceMeta().put(META_ENCRYPTED, "true");
+        resourceMetaBuilder.getResourceMeta().put(JASYPT_META_ENCRYPTED, "false");
         logger.debug("createResource {}", path);
         return encrypt(hasInputStream);
     }

--- a/plugins/aes-gcm-encryption-plugin/src/main/java/org/rundeck/plugin/encryption/ModernEncryptionConverterPlugin.java
+++ b/plugins/aes-gcm-encryption-plugin/src/main/java/org/rundeck/plugin/encryption/ModernEncryptionConverterPlugin.java
@@ -193,12 +193,15 @@ public class ModernEncryptionConverterPlugin implements StorageConverterPlugin {
                 if (AesEncryptor.isAesFormat(data)) {
                     return getAesEncryptor().decrypt(getResolvedPassword(), data);
                 }
+                String firstByteHex = data.length > 0
+                        ? String.format("%02X", data[0] & 0xFF)
+                        : "empty";
                 logger.warn(
                         "readResource: metadata indicates AES-GCM encryption but content at '{}' "
                         + "is not AES-GCM format (first byte: 0x{})."
                         + " Falling back to legacy Jasypt decryption."
                         + " This record has inconsistent metadata/content state (see RUN-4512).",
-                        path, String.format("%02X", data[0] & 0xFF));
+                        path, firstByteHex);
                 return getLegacyDecryptor().decrypt(getResolvedPassword(), data);
             }
         };

--- a/plugins/aes-gcm-encryption-plugin/src/test/groovy/org/rundeck/plugin/encryption/BackwardCompatibilityIntegrationSpec.groovy
+++ b/plugins/aes-gcm-encryption-plugin/src/test/groovy/org/rundeck/plugin/encryption/BackwardCompatibilityIntegrationSpec.groovy
@@ -227,8 +227,95 @@ class BackwardCompatibilityIntegrationSpec extends Specification {
     }
 
     // ========================================================================
-    // SCENARIO 6: Full lifecycle proving no data loss during upgrade
+    // SCENARIO 6: RUN-4512 — inconsistent metadata recovery via legacy flag precedence
+    //
+    // Reproduces the production incident where a storage record had BOTH
+    // aes-gcm-encryption:encrypted=true AND jasypt-encryption:encrypted=true
+    // while the content bytes were still Jasypt-encrypted (e.g. row id=130).
+    // The legacy Jasypt flag now takes precedence in readResource(), so the record
+    // is decrypted with the correct algorithm instead of crashing.
     // ========================================================================
+
+    @Unroll
+    def "RUN-4512 recovery: '#name' is readable when both flags are true but content is Jasypt"() {
+        given: "Jasypt-encrypted content (simulates production row id=130)"
+        def plugin = createModernPlugin()
+        def path = Mock(Path)
+
+        and: "metadata has BOTH flags true — the inconsistent state from production"
+        def meta = metaWith([
+            "aes-gcm-encryption:encrypted": "true",
+            "jasypt-encryption:encrypted" : "true"
+        ])
+
+        when: "readResource is called — legacy flag wins, Jasypt decryptor is used"
+        def result = plugin.readResource(path, meta, mockStream(jasyptFixtures[name]))
+
+        then: "plaintext is recovered without throwing"
+        readAllBytes(result) == plaintexts[name]
+
+        where:
+        name << ["simple-password", "ssh-private-key", "api-token",
+                 "unicode-password", "large-certificate"]
+    }
+
+    def "RUN-4512 self-healing: record with both flags true is re-encrypted to AES-GCM on next update"() {
+        given: "a resource in the inconsistent RUN-4512 state (both flags true, Jasypt content)"
+        def plugin = createModernPlugin()
+        def path = Mock(Path)
+        def plaintext = plaintexts["simple-password"]
+        def readMeta = metaWith([
+            "aes-gcm-encryption:encrypted": "true",
+            "jasypt-encryption:encrypted" : "true"
+        ])
+
+        when: "read is called — legacy flag wins, Jasypt decryptor is used"
+        def decrypted = plugin.readResource(path, readMeta, mockStream(jasyptFixtures["simple-password"]))
+        def decryptedBytes = readAllBytes(decrypted)
+
+        then: "original plaintext is recovered without throwing"
+        decryptedBytes == plaintext
+
+        when: "the resource is written back (simulates any project config save)"
+        def updateMeta = metaWith([
+            "aes-gcm-encryption:encrypted": "true",
+            "jasypt-encryption:encrypted" : "true"
+        ])
+        def reEncrypted = plugin.updateResource(path, updateMeta, mockStream(decryptedBytes))
+        def reEncryptedBytes = readAllBytes(reEncrypted)
+
+        then: "the ambiguous state is resolved: jasypt flag is cleared"
+        updateMeta.getResourceMeta()["aes-gcm-encryption:encrypted"] == "true"
+        updateMeta.getResourceMeta()["jasypt-encryption:encrypted"] == "false"
+
+        and: "content is now AES-GCM format"
+        reEncryptedBytes[0] == AesEncryptor.FORMAT_VERSION
+
+        when: "subsequent reads use the now-clean metadata"
+        def readMeta2 = metaWith(updateMeta.getResourceMeta())
+        def finalResult = plugin.readResource(path, readMeta2, mockStream(reEncryptedBytes))
+
+        then: "plaintext is still recovered correctly"
+        readAllBytes(finalResult) == plaintext
+    }
+
+    def "RUN-4512 alias: JasyptEncryptionAliasPlugin also recovers inconsistent records"() {
+        given: "the legacy alias plugin in use (existing rundeck-config.properties not updated)"
+        def plugin = createAliasPlugin()
+        def path = Mock(Path)
+
+        and: "both flags true, Jasypt content"
+        def meta = metaWith([
+            "aes-gcm-encryption:encrypted": "true",
+            "jasypt-encryption:encrypted" : "true"
+        ])
+
+        when:
+        def result = plugin.readResource(path, meta, mockStream(jasyptFixtures["api-token"]))
+
+        then:
+        readAllBytes(result) == plaintexts["api-token"]
+    }
 
     def "full upgrade lifecycle: multiple keys survive jasypt → aes-gcm migration"() {
         given: "simulate a storage tree with multiple Jasypt-encrypted keys"

--- a/plugins/aes-gcm-encryption-plugin/src/test/groovy/org/rundeck/plugin/encryption/ModernEncryptionConverterPluginSpec.groovy
+++ b/plugins/aes-gcm-encryption-plugin/src/test/groovy/org/rundeck/plugin/encryption/ModernEncryptionConverterPluginSpec.groovy
@@ -64,25 +64,6 @@ class ModernEncryptionConverterPluginSpec extends Specification {
         return encryptor.encrypt(password, plaintext)
     }
 
-    /**
-     * Encrypts with Jasypt and guarantees the result does NOT start with the AES-GCM
-     * version byte (0x01). Jasypt prepends random salt so the first byte is non-deterministic
-     * (~1/256 chance of colliding with FORMAT_VERSION). This helper retries up to 20 times,
-     * making a collision astronomically unlikely in practice while keeping the test deterministic.
-     */
-    private byte[] jasyptEncryptNotAesFormat(byte[] plaintext, String password, String algorithm, String provider) {
-        def encryptor = new LegacyJasyptEncryptor(algorithm, provider, 1000)
-        for (int attempt = 0; attempt < 20; attempt++) {
-            def result = encryptor.encrypt(password, plaintext)
-            if (result[0] != AesEncryptor.FORMAT_VERSION) {
-                return result
-            }
-        }
-        throw new IllegalStateException(
-            "Could not generate a Jasypt payload whose first byte differs from FORMAT_VERSION (0x01) " +
-            "after 20 attempts. This is extremely unlikely (~(1/256)^20) and indicates a bug.")
-    }
-
     // --- createResource tests ---
 
     def "createResource encrypts data and sets modern metadata"() {
@@ -422,58 +403,36 @@ class ModernEncryptionConverterPluginSpec extends Specification {
         meta.getResourceMeta()["jasypt-encryption:encrypted"] == "false"
     }
 
-    // --- RUN-4512: Inconsistent metadata/content state (partial migration failure) ---
+    // --- RUN-4512: Inconsistent metadata recovery via flag precedence ---
     //
-    // These tests document the bug reported in RUN-4512:
-    // readResource() trusts metadata flags blindly. If the storage record has
-    // aes-gcm-encryption:encrypted=true but the actual bytes are Jasypt-encrypted
-    // (first byte != 0x01, e.g. random salt prepended by Jasypt), the AES-GCM
-    // decryptor throws:
+    // Root cause: readResource() checked the aes-gcm flag first and trusted it blindly. A record
+    // whose metadata had aes-gcm-encryption:encrypted=true but whose content was still Jasypt
+    // (e.g. production row id=130, where BOTH flags were true after a legacy migration) was sent
+    // to the AES-GCM decryptor, which threw:
     //   EncryptionException: Unsupported encryption format version: -126
     //
-    // The fix uses AesEncryptor.isAesFormat() to detect the real content format and
-    // falls back to legacy decryption when the metadata is inconsistent.
+    // Fix: the legacy Jasypt flag takes precedence. Because every AES-GCM write clears the Jasypt
+    // flag and content+metadata are persisted atomically, any record still carrying
+    // jasypt-encryption:encrypted=true holds Jasypt content and must be decrypted as legacy —
+    // even if the aes-gcm flag is also set.
 
-    def "RUN-4512: readResource recovers data when both flags are true but content is Jasypt-encrypted"() {
-        given: "Jasypt-encrypted content (simulates storage row 130: both flags = true)"
+    def "RUN-4512: readResource decrypts as legacy Jasypt when both flags are true (content is Jasypt)"() {
+        given: "Jasypt-encrypted content (simulates production row id=130: both flags = true)"
         def plugin = createPlugin()
         def plaintext = "project.properties content".bytes
         def path = Mock(Path)
 
-        and: "content encrypted with Jasypt — first byte is random salt (not the 0x01 AES-GCM version marker)"
-        def jasyptEncrypted = jasyptEncryptNotAesFormat(plaintext, TEST_PASSWORD,
+        and:
+        def jasyptEncrypted = jasyptEncrypt(plaintext, TEST_PASSWORD,
                 "PBEWITHSHA256AND128BITAES-CBC-BC", "BC")
 
-        and: "metadata has BOTH flags true (the exact state found in production on row id=130)"
+        and: "metadata has BOTH flags true (the exact inconsistent state found in production)"
         def meta = metaWith([
             "aes-gcm-encryption:encrypted": "true",
             "jasypt-encryption:encrypted" : "true"
         ])
 
-        when: "readResource is called — should detect Jasypt content and use legacy decryptor"
-        def result = plugin.readResource(path, meta, mockHasInputStream(jasyptEncrypted))
-
-        then: "plaintext is recovered correctly without throwing"
-        readAllBytes(result) == plaintext
-    }
-
-    def "RUN-4512: readResource recovers data when aes flag is true but content is Jasypt-encrypted (partial write failure)"() {
-        given: "Jasypt-encrypted content (simulates partial write failure: metadata updated, content not re-encrypted)"
-        def plugin = createPlugin()
-        def plaintext = "project.properties content after partial write".bytes
-        def path = Mock(Path)
-
-        and: "content encrypted with Jasypt — first byte is random salt (not the 0x01 AES-GCM version marker)"
-        def jasyptEncrypted = jasyptEncryptNotAesFormat(plaintext, TEST_PASSWORD,
-                "PBEWITHSHA256AND128BITAES-CBC-BC", "BC")
-
-        and: "metadata says AES-GCM only (updateResource committed metadata but content write failed)"
-        def meta = metaWith([
-            "aes-gcm-encryption:encrypted": "true",
-            "jasypt-encryption:encrypted" : "false"
-        ])
-
-        when: "readResource is called — should fall back to Jasypt decryptor"
+        when: "readResource is called — legacy flag wins, so the Jasypt decryptor is used"
         def result = plugin.readResource(path, meta, mockHasInputStream(jasyptEncrypted))
 
         then: "plaintext is recovered correctly without throwing"

--- a/plugins/aes-gcm-encryption-plugin/src/test/groovy/org/rundeck/plugin/encryption/ModernEncryptionConverterPluginSpec.groovy
+++ b/plugins/aes-gcm-encryption-plugin/src/test/groovy/org/rundeck/plugin/encryption/ModernEncryptionConverterPluginSpec.groovy
@@ -64,6 +64,25 @@ class ModernEncryptionConverterPluginSpec extends Specification {
         return encryptor.encrypt(password, plaintext)
     }
 
+    /**
+     * Encrypts with Jasypt and guarantees the result does NOT start with the AES-GCM
+     * version byte (0x01). Jasypt prepends random salt so the first byte is non-deterministic
+     * (~1/256 chance of colliding with FORMAT_VERSION). This helper retries up to 20 times,
+     * making a collision astronomically unlikely in practice while keeping the test deterministic.
+     */
+    private byte[] jasyptEncryptNotAesFormat(byte[] plaintext, String password, String algorithm, String provider) {
+        def encryptor = new LegacyJasyptEncryptor(algorithm, provider, 1000)
+        for (int attempt = 0; attempt < 20; attempt++) {
+            def result = encryptor.encrypt(password, plaintext)
+            if (result[0] != AesEncryptor.FORMAT_VERSION) {
+                return result
+            }
+        }
+        throw new IllegalStateException(
+            "Could not generate a Jasypt payload whose first byte differs from FORMAT_VERSION (0x01) " +
+            "after 20 attempts. This is extremely unlikely (~(1/256)^20) and indicates a bug.")
+    }
+
     // --- createResource tests ---
 
     def "createResource encrypts data and sets modern metadata"() {
@@ -408,11 +427,11 @@ class ModernEncryptionConverterPluginSpec extends Specification {
     // These tests document the bug reported in RUN-4512:
     // readResource() trusts metadata flags blindly. If the storage record has
     // aes-gcm-encryption:encrypted=true but the actual bytes are Jasypt-encrypted
-    // (first byte 0x82 instead of 0x01), the AES-GCM decryptor throws:
+    // (first byte != 0x01, e.g. random salt prepended by Jasypt), the AES-GCM
+    // decryptor throws:
     //   EncryptionException: Unsupported encryption format version: -126
     //
-    // Both scenarios below FAIL with the current code and must PASS after the fix
-    // that uses AesEncryptor.isAesFormat() to detect the real content format and
+    // The fix uses AesEncryptor.isAesFormat() to detect the real content format and
     // falls back to legacy decryption when the metadata is inconsistent.
 
     def "RUN-4512: readResource recovers data when both flags are true but content is Jasypt-encrypted"() {
@@ -421,10 +440,9 @@ class ModernEncryptionConverterPluginSpec extends Specification {
         def plaintext = "project.properties content".bytes
         def path = Mock(Path)
 
-        and: "content was encrypted with Jasypt (first byte = 0x82, not 0x01)"
-        def jasyptEncrypted = jasyptEncrypt(plaintext, TEST_PASSWORD,
+        and: "content encrypted with Jasypt — first byte is random salt (not the 0x01 AES-GCM version marker)"
+        def jasyptEncrypted = jasyptEncryptNotAesFormat(plaintext, TEST_PASSWORD,
                 "PBEWITHSHA256AND128BITAES-CBC-BC", "BC")
-        assert jasyptEncrypted[0] != AesEncryptor.FORMAT_VERSION: "precondition: must be Jasypt format"
 
         and: "metadata has BOTH flags true (the exact state found in production on row id=130)"
         def meta = metaWith([
@@ -445,10 +463,9 @@ class ModernEncryptionConverterPluginSpec extends Specification {
         def plaintext = "project.properties content after partial write".bytes
         def path = Mock(Path)
 
-        and: "content is still Jasypt-encrypted"
-        def jasyptEncrypted = jasyptEncrypt(plaintext, TEST_PASSWORD,
+        and: "content encrypted with Jasypt — first byte is random salt (not the 0x01 AES-GCM version marker)"
+        def jasyptEncrypted = jasyptEncryptNotAesFormat(plaintext, TEST_PASSWORD,
                 "PBEWITHSHA256AND128BITAES-CBC-BC", "BC")
-        assert jasyptEncrypted[0] != AesEncryptor.FORMAT_VERSION: "precondition: must be Jasypt format"
 
         and: "metadata says AES-GCM only (updateResource committed metadata but content write failed)"
         def meta = metaWith([

--- a/plugins/aes-gcm-encryption-plugin/src/test/groovy/org/rundeck/plugin/encryption/ModernEncryptionConverterPluginSpec.groovy
+++ b/plugins/aes-gcm-encryption-plugin/src/test/groovy/org/rundeck/plugin/encryption/ModernEncryptionConverterPluginSpec.groovy
@@ -367,6 +367,66 @@ class ModernEncryptionConverterPluginSpec extends Specification {
         readAllBytes(result) == plaintext
     }
 
+    // --- RUN-4512: Inconsistent metadata/content state (partial migration failure) ---
+    //
+    // These tests document the bug reported in RUN-4512:
+    // readResource() trusts metadata flags blindly. If the storage record has
+    // aes-gcm-encryption:encrypted=true but the actual bytes are Jasypt-encrypted
+    // (first byte 0x82 instead of 0x01), the AES-GCM decryptor throws:
+    //   EncryptionException: Unsupported encryption format version: -126
+    //
+    // Both scenarios below FAIL with the current code and must PASS after the fix
+    // that uses AesEncryptor.isAesFormat() to detect the real content format and
+    // falls back to legacy decryption when the metadata is inconsistent.
+
+    def "RUN-4512: readResource recovers data when both flags are true but content is Jasypt-encrypted"() {
+        given: "Jasypt-encrypted content (simulates storage row 130: both flags = true)"
+        def plugin = createPlugin()
+        def plaintext = "project.properties content".bytes
+        def path = Mock(Path)
+
+        and: "content was encrypted with Jasypt (first byte = 0x82, not 0x01)"
+        def jasyptEncrypted = jasyptEncrypt(plaintext, TEST_PASSWORD,
+                "PBEWITHSHA256AND128BITAES-CBC-BC", "BC")
+        assert jasyptEncrypted[0] != AesEncryptor.FORMAT_VERSION: "precondition: must be Jasypt format"
+
+        and: "metadata has BOTH flags true (the exact state found in production on row id=130)"
+        def meta = metaWith([
+            "aes-gcm-encryption:encrypted": "true",
+            "jasypt-encryption:encrypted" : "true"
+        ])
+
+        when: "readResource is called — should detect Jasypt content and use legacy decryptor"
+        def result = plugin.readResource(path, meta, mockHasInputStream(jasyptEncrypted))
+
+        then: "plaintext is recovered correctly without throwing"
+        readAllBytes(result) == plaintext
+    }
+
+    def "RUN-4512: readResource recovers data when aes flag is true but content is Jasypt-encrypted (partial write failure)"() {
+        given: "Jasypt-encrypted content (simulates partial write failure: metadata updated, content not re-encrypted)"
+        def plugin = createPlugin()
+        def plaintext = "project.properties content after partial write".bytes
+        def path = Mock(Path)
+
+        and: "content is still Jasypt-encrypted"
+        def jasyptEncrypted = jasyptEncrypt(plaintext, TEST_PASSWORD,
+                "PBEWITHSHA256AND128BITAES-CBC-BC", "BC")
+        assert jasyptEncrypted[0] != AesEncryptor.FORMAT_VERSION: "precondition: must be Jasypt format"
+
+        and: "metadata says AES-GCM only (updateResource committed metadata but content write failed)"
+        def meta = metaWith([
+            "aes-gcm-encryption:encrypted": "true",
+            "jasypt-encryption:encrypted" : "false"
+        ])
+
+        when: "readResource is called — should fall back to Jasypt decryptor"
+        def result = plugin.readResource(path, meta, mockHasInputStream(jasyptEncrypted))
+
+        then: "plaintext is recovered correctly without throwing"
+        readAllBytes(result) == plaintext
+    }
+
     // --- Wrong password test ---
 
     def "readResource with wrong password throws exception"() {

--- a/plugins/aes-gcm-encryption-plugin/src/test/groovy/org/rundeck/plugin/encryption/ModernEncryptionConverterPluginSpec.groovy
+++ b/plugins/aes-gcm-encryption-plugin/src/test/groovy/org/rundeck/plugin/encryption/ModernEncryptionConverterPluginSpec.groovy
@@ -367,6 +367,42 @@ class ModernEncryptionConverterPluginSpec extends Specification {
         readAllBytes(result) == plaintext
     }
 
+    // --- RUN-4512: Prevention — metadata flags are always set consistently on write ---
+    //
+    // These tests verify that createResource() and updateResource() never leave the storage
+    // record in a state where both flags are true simultaneously, which was the root cause
+    // of the bug found in production (row id=130).
+
+    def "RUN-4512 prevention: createResource always sets jasypt flag to false"() {
+        given: "a resource that already has jasypt=true in its metadata (pre-existing Jasypt record)"
+        def plugin = createPlugin()
+        def plaintext = "new project config".bytes
+        def path = Mock(Path)
+        def meta = metaWith(["jasypt-encryption:encrypted": "true"])
+
+        when: "createResource is called (e.g. after a project re-creation)"
+        plugin.createResource(path, meta, mockHasInputStream(plaintext))
+
+        then: "aes-gcm flag is set and jasypt flag is explicitly cleared — never both true"
+        meta.getResourceMeta()["aes-gcm-encryption:encrypted"] == "true"
+        meta.getResourceMeta()["jasypt-encryption:encrypted"] == "false"
+    }
+
+    def "RUN-4512 prevention: updateResource always sets jasypt flag to false"() {
+        given: "a resource with jasypt=true (old Jasypt-encrypted record being updated)"
+        def plugin = createPlugin()
+        def plaintext = "updated project config".bytes
+        def path = Mock(Path)
+        def meta = metaWith(["jasypt-encryption:encrypted": "true"])
+
+        when: "updateResource is called (triggers lazy migration)"
+        plugin.updateResource(path, meta, mockHasInputStream(plaintext))
+
+        then: "aes-gcm flag is set and jasypt flag is explicitly cleared — never both true"
+        meta.getResourceMeta()["aes-gcm-encryption:encrypted"] == "true"
+        meta.getResourceMeta()["jasypt-encryption:encrypted"] == "false"
+    }
+
     // --- RUN-4512: Inconsistent metadata/content state (partial migration failure) ---
     //
     // These tests document the bug reported in RUN-4512:


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bug fix for RUN-4512.

The `aes-gcm-encryption` storage converter plugin throws `EncryptionException: Unsupported encryption format version: -126` when a storage record has `aes-gcm-encryption:encrypted = "true"` in its metadata but the actual binary content (`data` column) is still Jasypt-encrypted. This causes affected projects to fail loading entirely, with repeated cache refresh errors on the Rundeck home page.

The confirmed production state was storage row id=130, which had **both** `jasypt-encryption:encrypted = "true"` AND `aes-gcm-encryption:encrypted = "true"` simultaneously, while the content bytes were still in Jasypt format. `readResource()` checked the AES-GCM flag first and trusted it blindly, sending Jasypt bytes to the AES-GCM decryptor.

**Describe the solution you've implemented**

Two complementary changes, both relying on invariants that hold in the codebase:

1. **Prevention (write side):** `createResource()` and `updateResource()` always set the two flags consistently — `aes-gcm-encryption:encrypted = "true"` and `jasypt-encryption:encrypted = "false"` — so a record can never be left with both flags `true` after a write.

2. **Recovery (read side) via flag precedence:** the two flags are treated as mutually exclusive in `readResource()`, and the **legacy Jasypt flag takes precedence**:
   - if `jasypt-encryption:encrypted = "true"` → decrypt with the legacy Jasypt decryptor (logging a `WARN` when the AES-GCM flag is also set, i.e. the inconsistent state);
   - else if `aes-gcm-encryption:encrypted = "true"` → decrypt with AES-256-GCM;
   - else → unencrypted.

Because every AES-GCM write clears the Jasypt flag, any record still carrying `jasypt-encryption:encrypted = "true"` holds Jasypt content **by construction** — even when the AES-GCM flag is also `true`. So the precedence rule decrypts row id=130 correctly without crashing, and the record is transparently re-encrypted to AES-GCM on its next update.

This approach was chosen over inspecting the content's first byte because:
- It does not rely on a content heuristic. First-byte detection (`AesEncryptor.isAesFormat`) has a ~1/256 blind spot: a Jasypt payload begins with a random salt, so roughly one in 256 Jasypt records starts with the AES-GCM version marker (`0x01`) and would still be misclassified and crash.
- It does not use exceptions for control flow.
- Content (`data`) and metadata (`json_data`) are persisted **atomically** by `DbStorageService.saveStorage` (a single GORM save → one SQL row UPDATE/INSERT with optimistic locking), so a "partial write" where metadata and content disagree is not reachable on the storage backend. Metadata is therefore a reliable source of truth for plugin-written records; only pre-existing/legacy rows can be inconsistent, and those are exactly the ones the precedence rule recovers.

Regression coverage in `ModernEncryptionConverterPluginSpec`:
- `RUN-4512: readResource decrypts as legacy Jasypt when both flags are true (content is Jasypt)` — reproduces the production state of row id=130 and asserts recovery.
- Prevention tests asserting `createResource()`/`updateResource()` never leave both flags `true`.

**Describe alternatives you've considered**

- **Content first-byte detection + fallback** (previous iteration of this PR): decide AES vs Jasypt by inspecting the payload and fall back on mismatch. Rejected because of the ~1/256 first-byte collision blind spot and because it relied on attempting decryption and catching the failure (exceptions as control flow).
- **One-time data repair migration only** (SQL/Liquibase): fixes existing rows but is hard to make portable across all supported databases (it must inspect the binary first byte and edit JSON), and does not establish a self-consistent read rule. The precedence rule recovers existing rows in DB-agnostic Java instead.
- **Strict failure + alerting**: keep throwing but surface the error more clearly. Rejected because it leaves projects inaccessible and requires manual DB intervention.

**Additional context**

Optional immediate workaround for already-affected environments (MySQL) — not required with this fix, but useful for normalizing legacy rows:

```sql
-- Find affected records (metadata says AES-GCM but content is not AES-GCM format)
SELECT id, name, HEX(SUBSTR(data, 1, 1)) AS first_byte
FROM storage
WHERE JSON_UNQUOTE(JSON_EXTRACT(json_data, '$."aes-gcm-encryption:encrypted"')) = 'true'
  AND HEX(SUBSTR(data, 1, 1)) != '01';

-- Normalize metadata for an affected id so the legacy flag reflects the content
UPDATE storage
SET json_data = JSON_SET(
    JSON_REMOVE(json_data, '$."aes-gcm-encryption:encrypted"'),
    '$."jasypt-encryption:encrypted"', 'true'
)
WHERE id = <affected_id>;
```

## Release Notes

**Bug fix:** The `aes-gcm-encryption` storage converter plugin now correctly handles storage records whose encryption metadata is inconsistent with the stored content (e.g. after a legacy migration from Jasypt where both encryption flags ended up set). Such records are decrypted with the legacy Jasypt decryptor (legacy flag precedence), a warning is logged to identify them, and they are re-encrypted to AES-GCM on their next update — instead of failing project load with `Unsupported encryption format version: -126`.