### PR TITLE
[RUN-4160] Fixes bulk edit when using NextUI

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/browse/JobBulkEditControls.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/browse/JobBulkEditControls.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="flex col justify-between">
-    <div class="flex col flex-justify-start">
+  <div class="flex justify-between items-center bulk_edit_header">
+    <div class="flex flex-justify-start">
       <ui-socket section="job-list-page" location="card-header" />
     </div>
-    <div class="flex col flex-justify-end">
+    <div class="flex flex-justify-end">
       <div v-if="showControls" class="bulk_edit_controls">
         <ui-socket section="job-list-page" location="status-item" />
 
@@ -51,138 +51,135 @@
         </ui-socket>
       </div>
     </div>
-    <div v-if="jobPageStore.bulkEditMode">
-      <div class="panel panel-warning bulk_edit_panel">
-        <div class="panel-heading">
-          <btn
-            class="close"
-            aria-hidden="true"
-            @click="jobPageStore.bulkEditMode = false"
-            >&times;
-          </btn>
-          <h3 class="panel-title">
-            {{ $t("job.bulk.panel.select.title") }}
-          </h3>
-        </div>
-        <div class="panel-body">
-          <btn
-            id="bulk_select_all_button"
-            size="xs"
-            type="simple"
-            class="btn-hover"
-            @click="selectAll"
-          >
-            <b class="glyphicon glyphicon-check"></b>
-            {{ $t("select.all") }}
-          </btn>
-          <btn
-            id="bulk_select_none_button"
-            size="xs"
-            type="simple"
-            class="btn-hover"
-            @click="selectNone"
-          >
-            <b class="glyphicon glyphicon-unchecked"></b>
-            {{ $t("select.none") }}
-          </btn>
-          {{
-            $t(
-              "job.bulk.panel.select.message",
-              jobPageStore.selectedJobs.length,
-            )
-          }}
-        </div>
-
-        <div class="panel-footer">
-          <dropdown>
-            <btn
-              id="bulk_perform_action_button"
-              size="sm"
-              class="dropdown-toggle"
-              :disabled="jobPageStore.selectedJobs.length < 1"
-            >
-              {{ $t("job.bulk.perform.action.menu.label") }}
-              <span class="caret"></span>
-            </btn>
-            <template #dropdown>
-              <li v-if="projAuthz('delete')">
-                <a
-                  id="bulk_delete_jobs_action"
-                  role="button"
-                  @click="bulkAction('delete')"
-                >
-                  <b class="glyphicon glyphicon-remove-circle"></b>
-                  {{ $t("delete.selected.jobs") }}
-                </a>
-              </li>
-              <li class="divider"></li>
-              <li v-for="action in ['enable', 'disable']">
-                <a
-                  :id="`bulk_${action}_schedules_action`"
-                  role="button"
-                  @click="bulkAction(`${action}_schedule`)"
-                >
-                  <b
-                    class="glyphicon"
-                    :class="
-                      action === 'enable'
-                        ? 'glyphicon-check'
-                        : 'glyphicon-unchecked'
-                    "
-                  ></b>
-                  {{ $t(`job.bulk.${action}_schedule.button`) }}
-                </a>
-              </li>
-              <li class="divider"></li>
-              <li v-for="action in ['enable', 'disable']">
-                <a
-                  :id="`bulk_${action}_execution_action`"
-                  role="button"
-                  @click="bulkAction(`${action}_execution`)"
-                >
-                  <b
-                    class="glyphicon"
-                    :class="
-                      action === 'enable'
-                        ? 'glyphicon-check'
-                        : 'glyphicon-unchecked'
-                    "
-                  ></b>
-                  {{ $t(`job.bulk.${action}_execution.button`) }}
-                </a>
-              </li>
-            </template>
-          </dropdown>
-        </div>
+  </div>
+  <div v-if="jobPageStore.bulkEditMode">
+    <div class="panel panel-warning bulk_edit_panel">
+      <div class="panel-heading">
+        <btn
+          class="close"
+          aria-hidden="true"
+          @click="jobPageStore.bulkEditMode = false"
+          >&times;
+        </btn>
+        <h3 class="panel-title">
+          {{ $t("job.bulk.panel.select.title") }}
+        </h3>
       </div>
-    </div>
-    <modal
-      id="bulk_confirm_modal"
-      ref="bulk_confirm_modal"
-      v-model="bulkConfirm"
-      :title="$t('job.bulk.modify.confirm.panel.title')"
-    >
-      <p>{{ $t(`job.bulk.${bulkConfirmAction}.confirm.message`) }}</p>
-      <p>
+      <div class="panel-body">
+        <btn
+          id="bulk_select_all_button"
+          size="xs"
+          type="simple"
+          class="btn-hover"
+          @click="selectAll"
+        >
+          <b class="glyphicon glyphicon-check"></b>
+          {{ $t("select.all") }}
+        </btn>
+        <btn
+          id="bulk_select_none_button"
+          size="xs"
+          type="simple"
+          class="btn-hover"
+          @click="selectNone"
+        >
+          <b class="glyphicon glyphicon-unchecked"></b>
+          {{ $t("select.none") }}
+        </btn>
         {{
           $t("job.bulk.panel.select.message", jobPageStore.selectedJobs.length)
         }}
-      </p>
-      <template #footer>
-        <btn id="bulk_confirm_action_no_button" @click="bulkConfirm = false">{{
-          $t("no")
-        }}</btn>
-        <btn
-          id="bulk_confirm_action_yes_button"
-          type="danger"
-          :disabled="jobPageStore.selectedJobs.length < 1"
-          @click="performBulkAction"
-        >
-          {{ $t(`job.bulk.${bulkConfirmAction}.button`) }}
-        </btn>
-      </template>
-    </modal>
+      </div>
+
+      <div class="panel-footer">
+        <dropdown>
+          <btn
+            id="bulk_perform_action_button"
+            size="sm"
+            class="dropdown-toggle"
+            :disabled="jobPageStore.selectedJobs.length < 1"
+          >
+            {{ $t("job.bulk.perform.action.menu.label") }}
+            <span class="caret"></span>
+          </btn>
+          <template #dropdown>
+            <li v-if="projAuthz('delete')">
+              <a
+                id="bulk_delete_jobs_action"
+                role="button"
+                @click="bulkAction('delete')"
+              >
+                <b class="glyphicon glyphicon-remove-circle"></b>
+                {{ $t("delete.selected.jobs") }}
+              </a>
+            </li>
+            <li class="divider"></li>
+            <li v-for="action in ['enable', 'disable']">
+              <a
+                :id="`bulk_${action}_schedules_action`"
+                role="button"
+                @click="bulkAction(`${action}_schedule`)"
+              >
+                <b
+                  class="glyphicon"
+                  :class="
+                    action === 'enable'
+                      ? 'glyphicon-check'
+                      : 'glyphicon-unchecked'
+                  "
+                ></b>
+                {{ $t(`job.bulk.${action}_schedule.button`) }}
+              </a>
+            </li>
+            <li class="divider"></li>
+            <li v-for="action in ['enable', 'disable']">
+              <a
+                :id="`bulk_${action}_execution_action`"
+                role="button"
+                @click="bulkAction(`${action}_execution`)"
+              >
+                <b
+                  class="glyphicon"
+                  :class="
+                    action === 'enable'
+                      ? 'glyphicon-check'
+                      : 'glyphicon-unchecked'
+                  "
+                ></b>
+                {{ $t(`job.bulk.${action}_execution.button`) }}
+              </a>
+            </li>
+          </template>
+        </dropdown>
+      </div>
+    </div>
   </div>
+  <modal
+    id="bulk_confirm_modal"
+    ref="bulk_confirm_modal"
+    v-model="bulkConfirm"
+    :title="$t('job.bulk.modify.confirm.panel.title')"
+  >
+    <p>{{ $t(`job.bulk.${bulkConfirmAction}.confirm.message`) }}</p>
+    <p>
+      {{
+        $t("job.bulk.panel.select.message", jobPageStore.selectedJobs.length)
+      }}
+    </p>
+    <template #footer>
+      <btn id="bulk_confirm_action_no_button" @click="bulkConfirm = false">{{
+        $t("no")
+      }}</btn>
+      <btn
+        id="bulk_confirm_action_yes_button"
+        type="danger"
+        :disabled="jobPageStore.selectedJobs.length < 1"
+        @click="performBulkAction"
+      >
+        {{ $t(`job.bulk.${bulkConfirmAction}.button`) }}
+      </btn>
+    </template>
+  </modal>
 </template>
 
 <script lang="ts">

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/browse/JobBulkEditControls.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/browse/JobBulkEditControls.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="flex justify-between items-center bulk_edit_header">
-    <div class="flex flex-justify-start">
+    <div class="flex">
       <ui-socket section="job-list-page" location="card-header" />
     </div>
-    <div class="flex flex-justify-end">
+    <div class="flex">
       <div v-if="showControls" class="bulk_edit_controls">
         <ui-socket section="job-list-page" location="status-item" />
 


### PR DESCRIPTION
## Release Notes
Fixed the layout of the bulk edit controls on the Jobs page when using the next-generation UI, correcting the alignment and structure of the header so bulk actions display properly.

## PR Details
This pull request makes adjustments to the layout and structure of the `JobBulkEditControls.vue` component to improve the alignment and organization of its elements. The changes focus on updating the flexbox classes, simplifying the template structure, and making minor formatting improvements.

**Layout and structure updates:**

* Updated the main container and child divs to use improved flexbox classes (`flex`, `justify-between`, `items-center`, and removed unnecessary `col` classes) for better alignment of the bulk edit controls header.
* Closed the main flex container div earlier in the template to separate the header from the bulk edit panel, clarifying the component structure.
* Removed an unnecessary closing div at the end of the template, fixing the template structure.

**Minor formatting improvements:**

* Simplified the translation call for the bulk panel select message by removing unnecessary line breaks and parentheses.