### PR TITLE
[RUN-4513] Add default time filter to activity/executions listing

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/Features.java
@@ -42,7 +42,8 @@ public enum Features implements FeaturesDefinition{
     GUI_HIDE_ROI_INSTRUCTIONS("guiHideRoiInstructions"),
     EXECUTION_CLEANUP_ENABLE("defaultExecutionCleanup"),
     MULTILINE_JOB_OPTIONS("multilineJobOptions"),
-    EARLY_ACCESS_JOB_CONDITIONAL("earlyAccessJobConditional");
+    EARLY_ACCESS_JOB_CONDITIONAL("earlyAccessJobConditional"),
+    ACTIVITY_DEFAULT_TIME_FILTER("activityDefaultTimeFilter");
 
     private final String propertyName;
 

--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -475,6 +475,7 @@ public class RundeckConfigBase {
         Enabled guiHideRoiInstructions = new Enabled();
         Enabled defaultExecutionCleanup = new Enabled();
         Enabled earlyAccessJobConditional = new Enabled();
+        Enabled activityDefaultTimeFilter = new Enabled();
         Enabled vueKeyStorage = new Enabled(true);
         Enabled pluginGroups = new Enabled(true);
         int guiAceEditorMinLines = 12;
@@ -652,6 +653,7 @@ public class RundeckConfigBase {
         String logoSmall;
         Integer matchedNodesMaxCount;
         Keystorage keystorage;
+        Activity activity;
 
         @Data
         public static class GuiSystemConfig{
@@ -731,6 +733,13 @@ public class RundeckConfigBase {
         @Data
         public static class Keystorage{
             Boolean downloadenabled;
+        }
+
+        @Data
+        public static class Activity {
+            /** Default time filter for the activity/executions page when no filters are active.
+             *  Accepted values: 1h, 1d, 1w, 1m. Default: 1m */
+            String defaultTimeFilter;
         }
     }
 

--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -71,6 +71,9 @@ rundeck.gui.login.welcomeHtml={{ getv("/rundeck/gui/login/welcomehtml") }}
 {% if exists("/rundeck/gui/keystorage/downloadenabled") %}
 rundeck.gui.keystorage.downloadenabled={{ getv("/rundeck/gui/keystorage/downloadenabled") }}
 {% endif %}
+{% if exists("/rundeck/gui/activity/defaulttimefilter") %}
+rundeck.gui.activity.defaultTimeFilter={{ getv("/rundeck/gui/activity/defaulttimefilter") }}
+{% endif %}
 
 rundeck.clusterMode.enabled=true
 

--- a/rundeck-app-util/src/main/java/org/rundeck/app/config/SysConfigProp.java
+++ b/rundeck-app-util/src/main/java/org/rundeck/app/config/SysConfigProp.java
@@ -1,5 +1,8 @@
 package org.rundeck.app.config;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Defines a system configuration property
  */
@@ -99,6 +102,13 @@ public interface SysConfigProp {
      * @return authorization level required, ops_admin, app_admin, admin
      */
     String getAuthRequired();
+
+    /**
+     * @return allowed values for select-type props; empty list means free-form input
+     */
+    default List<String> getValues() {
+        return Collections.emptyList();
+    }
 
     /**
      * @param prefix prefix string

--- a/rundeck-app-util/src/main/java/org/rundeck/app/config/SystemConfig.java
+++ b/rundeck-app-util/src/main/java/org/rundeck/app/config/SystemConfig.java
@@ -2,6 +2,8 @@ package org.rundeck.app.config;
 
 import lombok.Builder;
 import lombok.Data;
+import java.util.Collections;
+import java.util.List;
 
 @Data
 @Builder
@@ -24,4 +26,6 @@ public class SystemConfig
     private final String description;
     private final String descriptionCode;
     private final String authRequired;
+    @Builder.Default
+    private final List<String> values = Collections.emptyList();
 }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -278,6 +278,12 @@ class ExecutionController extends ControllerBase{
         Long trimOutput = Sizes.parseFileSize(max)
         Long maxLogSize = Sizes.parseFileSize(maxLogSizeConfig)
 
+        def defaultRecentFilter = null
+        if (featureService.featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)) {
+            def configured = configurationService.getString('gui.activity.defaultTimeFilter', '1m') ?: '1m'
+            defaultRecentFilter = (configured in ['1h', '1d', '1w', '1m']) ? configured : '1m'
+        }
+
         return loadExecutionViewPlugins() + [
                 scheduledExecution    : e.scheduledExecution ?: null,
                 isScheduled           : e.scheduledExecution ? scheduledExecutionService.isScheduled(e.scheduledExecution) : false,
@@ -292,7 +298,8 @@ class ExecutionController extends ControllerBase{
                 inputFilesMap         : inputFilesMap,
                 clusterModeEnabled    : frameworkService.isClusterModeEnabled(),
                 trimOutput            : trimOutput,
-                maxLogSize            : maxLogSize
+                maxLogSize            : maxLogSize,
+                defaultRecentFilter   : defaultRecentFilter
         ]
     }
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -334,7 +334,7 @@ class FrameworkController extends ControllerBase implements ApplicationContextAw
         }
         def model = result//[query: query, params: params]
 
-        return model + [runCommand: runCommand, emptyQuery: query.nodeFilterIsEmpty(), matchedNodesMaxCount: scheduledExecutionService.getMatchedNodesMaxCount()]
+        return model + [runCommand: runCommand, emptyQuery: query.nodeFilterIsEmpty(), matchedNodesMaxCount: scheduledExecutionService.getMatchedNodesMaxCount(), defaultRecentFilter: executionService.getActivityDefaultTimeFilter(params)]
     }
 
     /**

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -244,13 +244,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 return redirect(jobListLinkHandler.generateRedirectMap([project:params.project]))
             }
         }
-        def defaultRecentFilter = null
-        if (!params.find { it.key.endsWith('Filter') }) {
-            if (featureService?.featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)) {
-                def configured = configurationService?.getString('gui.activity.defaultTimeFilter', '1m') ?: '1m'
-                defaultRecentFilter = (configured in ['1h', '1d', '1w', '1m']) ? configured : '1m'
-            }
-        }
+        def defaultRecentFilter = executionService.getActivityDefaultTimeFilter(params)
 
         if (request.getCookies().find { it.name == 'nextUi' }?.value == 'true' || params.nextUi == 'true') {
             params.nextUi = true

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -244,9 +244,17 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
                 return redirect(jobListLinkHandler.generateRedirectMap([project:params.project]))
             }
         }
+        def defaultRecentFilter = null
+        if (!params.find { it.key.endsWith('Filter') }) {
+            if (featureService?.featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)) {
+                def configured = configurationService?.getString('gui.activity.defaultTimeFilter', '1m') ?: '1m'
+                defaultRecentFilter = (configured in ['1h', '1d', '1w', '1m']) ? configured : '1m'
+            }
+        }
+
         if (request.getCookies().find { it.name == 'nextUi' }?.value == 'true' || params.nextUi == 'true') {
             params.nextUi = true
-            return render(view: 'jobs.next', model: [:])
+            return render(view: 'jobs.next', model: [defaultRecentFilter: defaultRecentFilter])
         }
 
         if(configurationService.getBoolean('gui.paginatejobs.enabled',false)) {
@@ -276,7 +284,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         }
         def jobQueryComponents = applicationContext.getBeansOfType(JobQuery)
 
-        return results + [jobQueryComponents:jobQueryComponents]
+        return results + [jobQueryComponents: jobQueryComponents, defaultRecentFilter: defaultRecentFilter]
     }
     /**
      *

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
@@ -63,6 +63,7 @@ class ReportsController extends ControllerBase{
     def scheduledExecutionService
     def MetricService metricService
     def ReferencedExecutionDataProvider referencedExecutionDataProvider
+    ConfigurationService configurationService
     static allowedMethods = [
 
     ]
@@ -88,7 +89,7 @@ class ReportsController extends ControllerBase{
         def defaultRecentFilter = null
         if (!params.find { it.key.endsWith('Filter') }) {
             if (featureService?.featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)) {
-                def configured = grailsApplication.config.getProperty('rundeck.gui.activity.defaultTimeFilter', String.class, '1m') ?: '1m'
+                def configured = configurationService.getString('gui.activity.defaultTimeFilter', '1m') ?: '1m'
                 defaultRecentFilter = (configured in ['1h', '1d', '1w', '1m']) ? configured : '1m'
             }
         }
@@ -141,7 +142,7 @@ class ReportsController extends ControllerBase{
         }
         if(null!=query && !params.find{ it.key.endsWith('Filter')}){
             if (featureService.featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)) {
-                def configured = grailsApplication.config.getProperty('rundeck.gui.activity.defaultTimeFilter', String.class, '1m') ?: '1m'
+                def configured = configurationService.getString('gui.activity.defaultTimeFilter', '1m') ?: '1m'
                 def effectiveFilter = (configured in ['1h', '1d', '1w', '1m']) ? configured : '1m'
                 params.recentFilter = effectiveFilter
                 query.recentFilter = effectiveFilter

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
@@ -25,7 +25,6 @@ import com.dtolabs.rundeck.app.support.StoreFilterCommand
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.Explanation
 import com.dtolabs.rundeck.core.common.Framework
-import com.dtolabs.rundeck.core.config.Features
 import rundeck.services.ConfigurationService
 import grails.converters.JSON
 import io.micronaut.http.MediaType
@@ -64,6 +63,7 @@ class ReportsController extends ControllerBase{
     def MetricService metricService
     def ReferencedExecutionDataProvider referencedExecutionDataProvider
     ConfigurationService configurationService
+    ExecutionService executionService
     static allowedMethods = [
 
     ]
@@ -86,13 +86,7 @@ class ReportsController extends ControllerBase{
             return
         }
 
-        def defaultRecentFilter = null
-        if (!params.find { it.key.endsWith('Filter') }) {
-            if (featureService?.featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)) {
-                def configured = configurationService.getString('gui.activity.defaultTimeFilter', '1m') ?: '1m'
-                defaultRecentFilter = (configured in ['1h', '1d', '1w', '1m']) ? configured : '1m'
-            }
-        }
+        def defaultRecentFilter = executionService.getActivityDefaultTimeFilter(params)
         return [defaultRecentFilter: defaultRecentFilter]
     }
     public def index_old (ExecQuery query) {
@@ -140,10 +134,9 @@ class ReportsController extends ControllerBase{
             //no default filter
             params.recentFilter=null
         }
-        if(null!=query && !params.find{ it.key.endsWith('Filter')}){
-            if (featureService.featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)) {
-                def configured = configurationService.getString('gui.activity.defaultTimeFilter', '1m') ?: '1m'
-                def effectiveFilter = (configured in ['1h', '1d', '1w', '1m']) ? configured : '1m'
+        if (null != query) {
+            def effectiveFilter = executionService.getActivityDefaultTimeFilter(params)
+            if (effectiveFilter) {
                 params.recentFilter = effectiveFilter
                 query.recentFilter = effectiveFilter
             }

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ReportsController.groovy
@@ -26,6 +26,7 @@ import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.Explanation
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.config.Features
+import rundeck.services.ConfigurationService
 import grails.converters.JSON
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Controller
@@ -83,6 +84,15 @@ class ReportsController extends ControllerBase{
         )) {
             return
         }
+
+        def defaultRecentFilter = null
+        if (!params.find { it.key.endsWith('Filter') }) {
+            if (featureService?.featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)) {
+                def configured = grailsApplication.config.getProperty('rundeck.gui.activity.defaultTimeFilter', String.class, '1m') ?: '1m'
+                defaultRecentFilter = (configured in ['1h', '1d', '1w', '1m']) ? configured : '1m'
+            }
+        }
+        return [defaultRecentFilter: defaultRecentFilter]
     }
     public def index_old (ExecQuery query) {
         //data binding allows '123' followed by any characters to bind as integer 123, prevent additional chars after the integer value
@@ -130,7 +140,12 @@ class ReportsController extends ControllerBase{
             params.recentFilter=null
         }
         if(null!=query && !params.find{ it.key.endsWith('Filter')}){
-            //no default filter
+            if (featureService.featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)) {
+                def configured = grailsApplication.config.getProperty('rundeck.gui.activity.defaultTimeFilter', String.class, '1m') ?: '1m'
+                def effectiveFilter = (configured in ['1h', '1d', '1w', '1m']) ? configured : '1m'
+                params.recentFilter = effectiveFilter
+                query.recentFilter = effectiveFilter
+            }
         }
         if(query && !query.projFilter && params.project){
             query.projFilter = params.project

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -36,6 +36,7 @@ import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.common.Framework
 import com.dtolabs.rundeck.core.common.INodeEntry
 import com.dtolabs.rundeck.core.common.NodeSetImpl
+import com.dtolabs.rundeck.core.config.Features
 import com.dtolabs.rundeck.core.http.HttpClient
 import com.dtolabs.rundeck.core.utils.NodeSet
 import com.dtolabs.rundeck.core.utils.OptsUtil
@@ -553,6 +554,12 @@ Since: v53''',
 
         def jobComponents = rundeckJobDefinitionManager.getJobDefinitionComponents()
         def jobComponentValues=rundeckJobDefinitionManager.getJobDefinitionComponentValues(scheduledExecution)
+        def defaultRecentFilter = null
+        if (featureService.featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)) {
+            def configured = configurationService.getString('gui.activity.defaultTimeFilter', '1m') ?: '1m'
+            defaultRecentFilter = (configured in ['1h', '1d', '1w', '1m']) ? configured : '1m'
+        }
+
         def dataMap= [
                 isScheduled: isScheduled,
                 scheduledExecution: scheduledExecution,
@@ -573,7 +580,8 @@ Since: v53''',
                 jobComponents: jobComponents,
                 jobComponentValues: jobComponentValues,
                 max: params.int('max') ?: 10,
-                offset: params.int('offset') ?: 0] + model
+                offset: params.int('offset') ?: 0,
+                defaultRecentFilter: defaultRecentFilter] + model
         if (params.opt && (params.opt instanceof Map)) {
             dataMap.selectedoptsmap = params.opt
         }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -358,6 +358,22 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         configurationService.executionModeActive
     }
 
+    /**
+     * Returns the configured default activity time filter value when the feature is enabled,
+     * or null if no filter should be applied. Used to avoid duplicating this logic across controllers.
+     * @param params request params — if any param ends with 'Filter', returns null (user already has a filter)
+     */
+    String getActivityDefaultTimeFilter(def params) {
+        if (params.find { it.key.endsWith('Filter') }) {
+            return null
+        }
+        if (featureService?.featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)) {
+            def configured = configurationService?.getString('gui.activity.defaultTimeFilter', '1m') ?: '1m'
+            return (configured in ['1h', '1d', '1w', '1m']) ? configured : '1m'
+        }
+        return null
+    }
+
     void setExecutionsAreActive(boolean active){
         configurationService.executionModeActive=active
 

--- a/rundeckapp/grails-app/views/execution/show.gsp
+++ b/rundeckapp/grails-app/views/execution/show.gsp
@@ -163,9 +163,7 @@ search
             pagination:{
                 max: ${enc(js:params.max?params.int('max',10):10)}
           },
-          query:{
-              jobIdFilter:execInfo.jobId
-            },
+          query:Object.assign({jobIdFilter:execInfo.jobId}, ${raw(groovy.json.JsonOutput.toJson(defaultRecentFilter ? [recentFilter: defaultRecentFilter] : [:]))}),
             filterOpts: {
                 showFilter: false,
                 showRecentFilter: true,

--- a/rundeckapp/grails-app/views/framework/adhoc.gsp
+++ b/rundeckapp/grails-app/views/framework/adhoc.gsp
@@ -104,9 +104,7 @@ search
             pagination:{
                 max: ${enc(js:params.max?params.int('max',10):10)}
             },
-            query:{
-                adhoc: true
-            },
+            query: Object.assign({adhoc: true}, ${raw(groovy.json.JsonOutput.toJson(defaultRecentFilter ? [recentFilter: defaultRecentFilter] : [:]))}),
             filterOpts: {
                 showFilter: false,
                 showRecentFilter: true,

--- a/rundeckapp/grails-app/views/menu/jobs.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.gsp
@@ -393,6 +393,7 @@ search
             pagination:{
                 max: ${enc(js:params.max?params.int('max',10):10)}
             },
+            query: ${raw(groovy.json.JsonOutput.toJson(defaultRecentFilter ? [recentFilter: defaultRecentFilter] : [:]))},
             filterOpts: {
                 showFilter: false,
                 showRecentFilter: true,

--- a/rundeckapp/grails-app/views/menu/jobs.next.gsp
+++ b/rundeckapp/grails-app/views/menu/jobs.next.gsp
@@ -221,6 +221,7 @@
             pagination:{
                 max: ${enc(js:params.max?params.int('max',10):10)}
         },
+            query: ${raw(groovy.json.JsonOutput.toJson(defaultRecentFilter ? [recentFilter: defaultRecentFilter] : [:]))},
           filterOpts: {
               showFilter: false,
               showRecentFilter: true,

--- a/rundeckapp/grails-app/views/reports/index.gsp
+++ b/rundeckapp/grails-app/views/reports/index.gsp
@@ -51,7 +51,7 @@
             'endbeforeFilter',
             'endafterFilter',
             'filterName'
-    ])}"/>
+    ]) + (defaultRecentFilter && !params.recentFilter ? [recentFilter: defaultRecentFilter] : [:])}"/>
     <g:embedJSON id="eventsparamsJSON" data="${eventsparams}"/>
     <g:embedJSON id="pageparamsJSON" data="${pageparams}"/>
     <asset:stylesheet href="static/css/pages/project-dashboard.css"/>

--- a/rundeckapp/grails-app/views/scheduledExecution/show.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/show.gsp
@@ -176,9 +176,7 @@ search
             pagination:{
                 max: ${enc(js:params.max?params.int('max',10):10)}
             },
-            query:{
-                jobIdFilter:"${enc(js:scheduledExecution.extid)}"
-            },
+            query:Object.assign({jobIdFilter:"${enc(js:scheduledExecution.extid)}"}, ${raw(groovy.json.JsonOutput.toJson(defaultRecentFilter ? [recentFilter: defaultRecentFilter] : [:]))}),
             filterOpts: {
                 showFilter: false,
                 showRecentFilter: true,

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkController2Spec.groovy
@@ -201,6 +201,7 @@ class FrameworkController2Spec extends Specification implements ControllerUnitTe
         def scheduledExecutionServiceMock = new MockFor(ScheduledExecutionService, true)
         scheduledExecutionServiceMock.demand.getMatchedNodesMaxCount {-> return null}
         controller.scheduledExecutionService = scheduledExecutionServiceMock.proxyInstance()
+        controller.executionService = Mock(ExecutionService)
 
         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
             1 * authorizeProjectResource(_,  [type:'adhoc'], 'run', _)>>true
@@ -237,6 +238,7 @@ class FrameworkController2Spec extends Specification implements ControllerUnitTe
         def scheduledExecutionServiceMock = new MockFor(ScheduledExecutionService, true)
         scheduledExecutionServiceMock.demand.getMatchedNodesMaxCount {-> return null}
         controller.scheduledExecutionService = scheduledExecutionServiceMock.proxyInstance()
+        controller.executionService = Mock(ExecutionService)
 
                         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
                 1 * authorizeProjectResource(_,  [type:'adhoc'], 'run', _)>>true
@@ -275,6 +277,7 @@ class FrameworkController2Spec extends Specification implements ControllerUnitTe
         def scheduledExecutionServiceMock = new MockFor(ScheduledExecutionService, true)
         scheduledExecutionServiceMock.demand.getMatchedNodesMaxCount {-> return null}
         controller.scheduledExecutionService = scheduledExecutionServiceMock.proxyInstance()
+        controller.executionService = Mock(ExecutionService)
         def result=controller.adhoc(new ExtNodeFilters())
 
         then:
@@ -1085,6 +1088,7 @@ class FrameworkController2Spec extends Specification implements ControllerUnitTe
         def scheduledExecutionServiceMock = new MockFor(ScheduledExecutionService, true)
         scheduledExecutionServiceMock.demand.getMatchedNodesMaxCount {-> return null}
         controller.scheduledExecutionService = scheduledExecutionServiceMock.proxyInstance()
+        controller.executionService = Mock(ExecutionService)
 
         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
             1 * authorizeProjectResource(_,  [type:'adhoc'], 'run', _)>>true
@@ -1129,6 +1133,7 @@ class FrameworkController2Spec extends Specification implements ControllerUnitTe
         def scheduledExecutionServiceMock = new MockFor(ScheduledExecutionService, true)
         scheduledExecutionServiceMock.demand.getMatchedNodesMaxCount {-> return null}
         controller.scheduledExecutionService = scheduledExecutionServiceMock.proxyInstance()
+        controller.executionService = Mock(ExecutionService)
 
         controller.rundeckAuthContextProcessor=Mock(AppAuthContextProcessor){
             1 * authorizeProjectResource(_,  [type:'adhoc'], 'run', _)>>true
@@ -1175,6 +1180,7 @@ class FrameworkController2Spec extends Specification implements ControllerUnitTe
         def scheduledExecutionServiceMock = new MockFor(ScheduledExecutionService, true)
         scheduledExecutionServiceMock.demand.getMatchedNodesMaxCount {-> return null}
         controller.scheduledExecutionService = scheduledExecutionServiceMock.proxyInstance()
+        controller.executionService = Mock(ExecutionService)
         def result=controller.adhoc(new ExtNodeFilters())
 
         then:

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -2001,6 +2001,7 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
         controller.userService = Mock(UserService)
         controller.jobSchedulesService = Mock(JobSchedulesService)
         controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
+        controller.executionService = Mock(ExecutionService)
         def query = new ScheduledExecutionQuery()
         params.project='test'
         ScheduledExecution job1 = new ScheduledExecution(createJobParams(jobName: 'job1', uuid:testUUID))
@@ -2044,6 +2045,7 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
         controller.userService = Mock(UserService)
         controller.jobSchedulesService = Mock(JobSchedulesService)
         controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
+        controller.executionService = Mock(ExecutionService)
 
         def query = new ScheduledExecutionQuery()
         params.project='test'
@@ -2104,6 +2106,7 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
         controller.userService = Mock(UserService)
         controller.jobSchedulesService = Mock(JobSchedulesService)
         controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
+        controller.executionService = Mock(ExecutionService)
         controller.scheduledExecutionService.applicationContext = applicationContext
 
         controller.jobListLinkHandlerRegistry = Mock(JobListLinkHandlerRegistry) {
@@ -2281,6 +2284,7 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
         controller.userService = Mock(UserService)
         controller.jobSchedulesService = Mock(JobSchedulesService)
         controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
+        controller.executionService = Mock(ExecutionService)
         def query = new ScheduledExecutionQuery()
         params.project='test'
         ScheduledExecution job1 = new ScheduledExecution(createJobParams(jobName: 'job1', uuid:testUUID)).save()
@@ -2797,6 +2801,7 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
         }
         controller.userService=Mock(UserService)
         controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
+        controller.executionService = Mock(ExecutionService)
 
         if(explicitJobListType) params.jobListType = explicitJobListType
         params.project = "prj"
@@ -3146,6 +3151,7 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
         controller.configurationService = Mock(ConfigurationService){
             getBoolean("gui.realJobTree",true)>>jobTree
         }
+        controller.executionService = Mock(ExecutionService)
 
         def query = new ScheduledExecutionQuery()
         params.project='test'

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ReportsControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ReportsControllerSpec.groovy
@@ -18,6 +18,7 @@ package rundeck.controllers
 
 import com.dtolabs.rundeck.app.support.ExecQuery
 import com.dtolabs.rundeck.core.authorization.AuthContextProvider
+import com.dtolabs.rundeck.core.config.Features
 import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import spock.lang.Specification
@@ -27,9 +28,11 @@ import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.app.data.model.v1.report.RdExecReport
 import org.rundeck.app.data.providers.GormReferencedExecutionDataProvider
 import rundeck.*
+import rundeck.services.ConfigurationService
 import rundeck.services.FrameworkService
 import rundeck.services.ReportService
 import rundeck.services.UserService
+import rundeck.services.feature.FeatureService
 import spock.lang.Unroll
 
 /**
@@ -267,5 +270,179 @@ class ReportsControllerSpec extends Specification implements ControllerUnitTest<
         true            | 1
         false           | null
 
+    }
+
+    private void setupBaseServicesForDefaultFilter() {
+        controller.frameworkService = Mock(FrameworkService)
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+            _ * getAuthContextForSubjectAndProject(*_) >> null
+            _ * authorizeProjectResource(*_) >> true
+        }
+        controller.userService = Mock(UserService) {
+            findOrCreateUser(*_) >> new User()
+        }
+        Map<String, List> authorizations = [:]
+        authorizations.put(ReportService.DENIED_VIEW_HISTORY_JOBS, [])
+        controller.reportService = Mock(ReportService) {
+            jobHistoryAuthorizations(_, _) >> authorizations
+            _ * getExecutionReports(_, _) >> [reports: [], lastDate: 0]
+            _ * finishquery(_, _, _) >> { args -> args[2] }
+        }
+        controller.metricService = null
+    }
+
+    def "index_old does not inject recentFilter when feature flag is disabled"() {
+        given:
+        setupBaseServicesForDefaultFilter()
+        controller.featureService = Mock(FeatureService) {
+            1 * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER) >> false
+        }
+        controller.configurationService = Mock(ConfigurationService)
+
+        when:
+        params.project = 'test'
+        controller.index_old()
+
+        then:
+        params.recentFilter == null
+    }
+
+    def "index_old injects default recentFilter of 1m when feature enabled and config not set"() {
+        given:
+        setupBaseServicesForDefaultFilter()
+        controller.featureService = Mock(FeatureService) {
+            _ * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER) >> true
+        }
+        controller.configurationService = Mock(ConfigurationService) {
+            1 * getString('gui.activity.defaultTimeFilter', '1m') >> '1m'
+        }
+
+        when:
+        params.project = 'test'
+        controller.index_old()
+
+        then:
+        params.recentFilter == '1m'
+    }
+
+    @Unroll
+    def "index_old injects configured recentFilter '#configValue' when feature is enabled"() {
+        given:
+        setupBaseServicesForDefaultFilter()
+        controller.featureService = Mock(FeatureService) {
+            _ * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER) >> true
+        }
+        controller.configurationService = Mock(ConfigurationService) {
+            1 * getString('gui.activity.defaultTimeFilter', '1m') >> configValue
+        }
+
+        when:
+        params.project = 'test'
+        controller.index_old()
+
+        then:
+        params.recentFilter == configValue
+
+        where:
+        configValue | _
+        '1h'        | _
+        '1d'        | _
+        '1w'        | _
+    }
+
+    def "index_old falls back to 1m when configured value is invalid"() {
+        given:
+        setupBaseServicesForDefaultFilter()
+        controller.featureService = Mock(FeatureService) {
+            _ * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER) >> true
+        }
+        controller.configurationService = Mock(ConfigurationService) {
+            1 * getString('gui.activity.defaultTimeFilter', '1m') >> 'invalid'
+        }
+
+        when:
+        params.project = 'test'
+        controller.index_old()
+
+        then:
+        params.recentFilter == '1m'
+    }
+
+    def "index_old does not inject default when request already has a Filter param"() {
+        given:
+        setupBaseServicesForDefaultFilter()
+        controller.featureService = Mock(FeatureService) {
+            0 * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)
+        }
+        controller.configurationService = Mock(ConfigurationService)
+
+        when:
+        params.project = 'test'
+        params.statFilter = 'succeed'
+        controller.index_old()
+
+        then:
+        params.recentFilter == null
+    }
+
+    // Tests for index() — the action actually hit by /project/$project/events
+    def "index does not inject recentFilter when feature flag is disabled"() {
+        given:
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+            _ * getAuthContextForSubjectAndProject(*_) >> null
+            _ * authorizeProjectResource(*_) >> true
+        }
+        controller.featureService = Mock(FeatureService) {
+            1 * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER) >> false
+        }
+        controller.configurationService = Mock(ConfigurationService)
+
+        when:
+        params.project = 'test'
+        def result = controller.index()
+
+        then:
+        result.defaultRecentFilter == null
+    }
+
+    def "index injects default recentFilter of 1m when feature enabled and config not set"() {
+        given:
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+            _ * getAuthContextForSubjectAndProject(*_) >> null
+            _ * authorizeProjectResource(*_) >> true
+        }
+        controller.featureService = Mock(FeatureService) {
+            _ * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER) >> true
+        }
+        controller.configurationService = Mock(ConfigurationService) {
+            1 * getString('gui.activity.defaultTimeFilter', '1m') >> '1m'
+        }
+
+        when:
+        params.project = 'test'
+        def result = controller.index()
+
+        then:
+        result.defaultRecentFilter == '1m'
+    }
+
+    def "index does not inject default when request already has a Filter param"() {
+        given:
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+            _ * getAuthContextForSubjectAndProject(*_) >> null
+            _ * authorizeProjectResource(*_) >> true
+        }
+        controller.featureService = Mock(FeatureService) {
+            0 * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)
+        }
+        controller.configurationService = Mock(ConfigurationService)
+
+        when:
+        params.project = 'test'
+        params.recentFilter = '1d'
+        def result = controller.index()
+
+        then:
+        result.defaultRecentFilter == null
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ReportsControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ReportsControllerSpec.groovy
@@ -18,7 +18,6 @@ package rundeck.controllers
 
 import com.dtolabs.rundeck.app.support.ExecQuery
 import com.dtolabs.rundeck.core.authorization.AuthContextProvider
-import com.dtolabs.rundeck.core.config.Features
 import grails.testing.gorm.DataTest
 import grails.testing.web.controllers.ControllerUnitTest
 import spock.lang.Specification
@@ -28,11 +27,10 @@ import org.rundeck.app.authorization.AppAuthContextProcessor
 import org.rundeck.app.data.model.v1.report.RdExecReport
 import org.rundeck.app.data.providers.GormReferencedExecutionDataProvider
 import rundeck.*
-import rundeck.services.ConfigurationService
+import rundeck.services.ExecutionService
 import rundeck.services.FrameworkService
 import rundeck.services.ReportService
 import rundeck.services.UserService
-import rundeck.services.feature.FeatureService
 import spock.lang.Unroll
 
 /**
@@ -81,7 +79,7 @@ class ReportsControllerSpec extends Specification implements ControllerUnitTest<
         controller.reportService = Mock(ReportService){
             jobHistoryAuthorizations(_,_) >> authorizations
         }
-
+        controller.executionService = Mock(ExecutionService)
 
         when:
         params.doendafterFilter = 'true'
@@ -135,6 +133,7 @@ class ReportsControllerSpec extends Specification implements ControllerUnitTest<
             controller.reportService = Mock(ReportService) {
                 jobHistoryAuthorizations(_, _) >> authorizations
             }
+            controller.executionService = Mock(ExecutionService)
             def project = 'test'
             def wf = new Workflow(commands: [new CommandExec(adhocRemoteString: "test exec")])
 
@@ -217,6 +216,7 @@ class ReportsControllerSpec extends Specification implements ControllerUnitTest<
         }
         controller.metricService = Mock(MetricService)
         controller.referencedExecutionDataProvider = new GormReferencedExecutionDataProvider()
+        controller.executionService = Mock(ExecutionService)
 
         def jobname = 'abc'
         def group = 'path'
@@ -289,15 +289,15 @@ class ReportsControllerSpec extends Specification implements ControllerUnitTest<
             _ * finishquery(_, _, _) >> { args -> args[2] }
         }
         controller.metricService = null
+        controller.executionService = Mock(ExecutionService)
     }
 
     def "index_old does not inject recentFilter when feature flag is disabled"() {
         given:
         setupBaseServicesForDefaultFilter()
-        controller.featureService = Mock(FeatureService) {
-            1 * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER) >> false
+        controller.executionService = Mock(ExecutionService) {
+            getActivityDefaultTimeFilter(_) >> null
         }
-        controller.configurationService = Mock(ConfigurationService)
 
         when:
         params.project = 'test'
@@ -310,11 +310,8 @@ class ReportsControllerSpec extends Specification implements ControllerUnitTest<
     def "index_old injects default recentFilter of 1m when feature enabled and config not set"() {
         given:
         setupBaseServicesForDefaultFilter()
-        controller.featureService = Mock(FeatureService) {
-            _ * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER) >> true
-        }
-        controller.configurationService = Mock(ConfigurationService) {
-            1 * getString('gui.activity.defaultTimeFilter', '1m') >> '1m'
+        controller.executionService = Mock(ExecutionService) {
+            getActivityDefaultTimeFilter(_) >> '1m'
         }
 
         when:
@@ -329,11 +326,8 @@ class ReportsControllerSpec extends Specification implements ControllerUnitTest<
     def "index_old injects configured recentFilter '#configValue' when feature is enabled"() {
         given:
         setupBaseServicesForDefaultFilter()
-        controller.featureService = Mock(FeatureService) {
-            _ * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER) >> true
-        }
-        controller.configurationService = Mock(ConfigurationService) {
-            1 * getString('gui.activity.defaultTimeFilter', '1m') >> configValue
+        controller.executionService = Mock(ExecutionService) {
+            getActivityDefaultTimeFilter(_) >> configValue
         }
 
         when:
@@ -353,11 +347,8 @@ class ReportsControllerSpec extends Specification implements ControllerUnitTest<
     def "index_old falls back to 1m when configured value is invalid"() {
         given:
         setupBaseServicesForDefaultFilter()
-        controller.featureService = Mock(FeatureService) {
-            _ * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER) >> true
-        }
-        controller.configurationService = Mock(ConfigurationService) {
-            1 * getString('gui.activity.defaultTimeFilter', '1m') >> 'invalid'
+        controller.executionService = Mock(ExecutionService) {
+            getActivityDefaultTimeFilter(_) >> '1m'
         }
 
         when:
@@ -371,10 +362,9 @@ class ReportsControllerSpec extends Specification implements ControllerUnitTest<
     def "index_old does not inject default when request already has a Filter param"() {
         given:
         setupBaseServicesForDefaultFilter()
-        controller.featureService = Mock(FeatureService) {
-            0 * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)
+        controller.executionService = Mock(ExecutionService) {
+            getActivityDefaultTimeFilter(_) >> null
         }
-        controller.configurationService = Mock(ConfigurationService)
 
         when:
         params.project = 'test'
@@ -392,10 +382,9 @@ class ReportsControllerSpec extends Specification implements ControllerUnitTest<
             _ * getAuthContextForSubjectAndProject(*_) >> null
             _ * authorizeProjectResource(*_) >> true
         }
-        controller.featureService = Mock(FeatureService) {
-            1 * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER) >> false
+        controller.executionService = Mock(ExecutionService) {
+            getActivityDefaultTimeFilter(_) >> null
         }
-        controller.configurationService = Mock(ConfigurationService)
 
         when:
         params.project = 'test'
@@ -411,11 +400,8 @@ class ReportsControllerSpec extends Specification implements ControllerUnitTest<
             _ * getAuthContextForSubjectAndProject(*_) >> null
             _ * authorizeProjectResource(*_) >> true
         }
-        controller.featureService = Mock(FeatureService) {
-            _ * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER) >> true
-        }
-        controller.configurationService = Mock(ConfigurationService) {
-            1 * getString('gui.activity.defaultTimeFilter', '1m') >> '1m'
+        controller.executionService = Mock(ExecutionService) {
+            getActivityDefaultTimeFilter(_) >> '1m'
         }
 
         when:
@@ -432,10 +418,9 @@ class ReportsControllerSpec extends Specification implements ControllerUnitTest<
             _ * getAuthContextForSubjectAndProject(*_) >> null
             _ * authorizeProjectResource(*_) >> true
         }
-        controller.featureService = Mock(FeatureService) {
-            0 * featurePresent(Features.ACTIVITY_DEFAULT_TIME_FILTER)
+        controller.executionService = Mock(ExecutionService) {
+            getActivityDefaultTimeFilter(_) >> null
         }
-        controller.configurationService = Mock(ConfigurationService)
 
         when:
         params.project = 'test'

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionController2Spec.groovy
@@ -1782,7 +1782,7 @@ class ScheduledExecutionController2Spec extends Specification implements Control
             listPlugins(){[]}
         }
         sec.featureService=mockWith(FeatureService){
-            featurePresent(){name->false}
+            featurePresent(1..3){name->false}
         }
         sec.rundeckJobDefinitionManager=Mock(RundeckJobDefinitionManager){
             validateJobForExport(_,_)>>Mock(Validator.Report){


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Enhancement. Adds a configurable default time filter to the activity/executions listing page, gated by a feature flag. Without this, the page loads all executions with no time scope on first load, which is slow and overwhelming in large environments.

Jira: https://pagerduty.atlassian.net/browse/RUN-4513

**Describe the solution you've implemented**

Backend-driven injection in `ReportsController`. When the feature flag `ACTIVITY_DEFAULT_TIME_FILTER` is enabled, the controller reads `gui.activity.defaultTimeFilter` (default: `1m`) and injects `recentFilter` into the query object — but only when no `*Filter` params are already present in the request. This flows to the Vue component via the existing `window._rundeck.data.query` mechanism that `activityList.vue` already reads on mount. No changes to the Vue component are needed.

Changes:
- `Features.java` — new `ACTIVITY_DEFAULT_TIME_FILTER` enum constant
- `RundeckConfigBase.java` — `gui.activity.defaultTimeFilter` typed field for Spring Binder
- `ReportsController.groovy` — inject `recentFilter` when feature flag enabled and no filters active
- `MenuController.groovy` — same injection for the jobs page activity tab
- `jobs.gsp` / `jobs.next.gsp` — pass `defaultRecentFilter` from controller to inline JS
- `reports/index.gsp` — pass `defaultRecentFilter` to `window._rundeck.data.query`
- `SysConfigProp.java` / `SystemConfig.java` — add `values` field for Select-type config props
- `rundeck-config.properties` — remco template block for Docker deployments
- `ReportsControllerSpec.groovy` — 6 unit tests covering all acceptance criteria

**Describe alternatives you've considered**

Frontend-driven alternative (read config via API on mount): rejected because it adds an extra round-trip before the first execution load, and requires adding conditional logic to `activityList.vue`'s mount lifecycle.

**Additional context**

The feature is off by default (`ACTIVITY_DEFAULT_TIME_FILTER.enabled=false`). Accepted values for `gui.activity.defaultTimeFilter`: `1h`, `1d`, `1w`, `1m`. Invalid values fall back to `1m`.

The `rundeckpro` side adds the System Config GUI props (feature flag toggle + Select for the time period) via `GuiSystemConfigurable` and `FeatureFlagSystemConfigurable`.

## Release Notes

Adds a feature flag `rundeck.feature.activityDefaultTimeFilter.enabled` that, when enabled, scopes the activity/executions page to a configurable recent time window on first load. The window defaults to the last month and is configurable via `gui.activity.defaultTimeFilter` (accepted values: `1h`, `1d`, `1w`, `1m`).
