### PR TITLE
[RUN-4518] Implement NodeFilter in job execution URL

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -577,6 +577,9 @@ Since: v53''',
         if (params.opt && (params.opt instanceof Map)) {
             dataMap.selectedoptsmap = params.opt
         }
+        if (params.nodeFilter) {
+            dataMap.nodeFilterParam = params.nodeFilter
+        }
 
         withFormat{
             html{

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -44,7 +44,7 @@
 
 </g:if>
     <g:set var="project" value="${scheduledExecution?.project ?: params.project?:request.project?: projects?.size() == 1 ? projects[0].name : ''}"/>
-    <g:embedJSON id="filterParamsJSON" data="${[filter: query?.filter, filterAll: params.showall in ['true', true]]}"/>
+    <g:embedJSON id="filterParamsJSON" data="${[filter: nodeFilterParam ?: nodefilter ?: query?.filter, filterAll: params.showall in ['true', true]]}"/>
 
 
 
@@ -300,7 +300,7 @@
                 <div class="subfields nodeFilterFields ">
                     %{-- filter text --}%
                     <div class="">
-                        <g:set var="filtvalue" value="${nodefilter}"/>
+                        <g:set var="filtvalue" value="${nodeFilterParam ?: nodefilter}"/>
 
                         <div id="nodefilterViewArea" data-ko-bind="nodeFilter" data-bind="visible: nodeFiltersVisible">
                         <div class="${emptyQuery ? 'active' : ''}" id="nodeFilterInline">
@@ -511,7 +511,7 @@
 
         var tmpfilt = {};
         jQuery.data( tmpfilt, "node-filter-name", "" );
-        jQuery.data( tmpfilt, "node-filter", "${nodefilter}" );
+        jQuery.data( tmpfilt, "node-filter", "${nodeFilterParam ?: nodefilter}" );
         nodeFilter.selectNodeFilterLink(tmpfilt);
 
         kocontrollers.nodeFilter = nodeFilter
@@ -522,9 +522,9 @@
         let selectedNodes=hasSelectedNodes?loadJsonData('selectedNodesJson'):hasSelectedByDefault?loadJsonData('allNodesJson'):[];
         kocontrollers.runformoptions = new JobRunFormOptions({
             debug:${enc(js:scheduledExecution?.loglevel=='DEBUG')},
-            changeTargetNodes:hasSelectedNodes||!hasSelectedByDefault,
+            changeTargetNodes:${enc(js:!!nodeFilterParam)} || hasSelectedNodes||!hasSelectedByDefault,
             canOverrideFilter:${enc(js:scheduledExecution.nodeFilterEditable|| nodefilter == '')},
-            nodeOverride: "${enc(js:!nodesetvariables && nodes?'cherrypick':'filter')}",
+            nodeOverride: "${enc(js: nodeFilterParam ? 'filter' : (!nodesetvariables && nodes?'cherrypick':'filter'))}",
             selectedNodes: selectedNodes,
             hasDynamicFilter: ${enc(js:!!nodesetvariables)},
             allNodes:loadJsonData('allNodesJson'),

--- a/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
+++ b/rundeckapp/grails-app/views/scheduledExecution/_execOptionsForm.gsp
@@ -511,7 +511,7 @@
 
         var tmpfilt = {};
         jQuery.data( tmpfilt, "node-filter-name", "" );
-        jQuery.data( tmpfilt, "node-filter", "${nodeFilterParam ?: nodefilter}" );
+        jQuery.data( tmpfilt, "node-filter", "${enc(js: nodeFilterParam ?: nodefilter)}" );
         nodeFilter.selectNodeFilterLink(tmpfilt);
 
         kocontrollers.nodeFilter = nodeFilter
@@ -522,9 +522,9 @@
         let selectedNodes=hasSelectedNodes?loadJsonData('selectedNodesJson'):hasSelectedByDefault?loadJsonData('allNodesJson'):[];
         kocontrollers.runformoptions = new JobRunFormOptions({
             debug:${enc(js:scheduledExecution?.loglevel=='DEBUG')},
-            changeTargetNodes:${enc(js:!!nodeFilterParam)} || hasSelectedNodes||!hasSelectedByDefault,
+            changeTargetNodes:${enc(js:!!(nodeFilterParam && (scheduledExecution.nodeFilterEditable || nodefilter == '')))} || hasSelectedNodes||!hasSelectedByDefault,
             canOverrideFilter:${enc(js:scheduledExecution.nodeFilterEditable|| nodefilter == '')},
-            nodeOverride: "${enc(js: nodeFilterParam ? 'filter' : (!nodesetvariables && nodes?'cherrypick':'filter'))}",
+            nodeOverride: "${enc(js: (nodeFilterParam && (scheduledExecution.nodeFilterEditable || nodefilter == '')) ? 'filter' : (!nodesetvariables && nodes?'cherrypick':'filter'))}",
             selectedNodes: selectedNodes,
             hasDynamicFilter: ${enc(js:!!nodesetvariables)},
             allNodes:loadJsonData('allNodesJson'),

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.spec.ts
@@ -1,0 +1,102 @@
+import { mount, flushPromises } from "@vue/test-utils";
+
+jest.mock("@/library", () => ({
+  getRundeckContext: jest.fn(() => ({
+    projectName: "testProject",
+    rootStore: {
+      ui: { addItems: jest.fn() },
+    },
+  })),
+}));
+
+jest.mock("@/library/stores/NodeFilterLocalstore", () => ({
+  NodeFilterStore: jest.fn().mockImplementation(() => ({
+    selectedFilter: "",
+    setSelectedFilter: jest.fn(),
+  })),
+}));
+
+jest.mock("@/app/utilities/uiSocketObserver", () => ({
+  observer: { observe: jest.fn() },
+}));
+
+jest.mock("@/app/components/job/resources/NodeFilterInput.vue", () => ({
+  default: { name: "NodeFilterInput", template: "<div />" },
+}));
+
+jest.mock("@/app/components/job/resources/NodeCard.vue", () => ({
+  default: { name: "NodeCard", template: "<div />" },
+}));
+
+import { FilterInputComp } from "./main";
+
+function makeKoFilter(filterVal = "") {
+  const filterObservable = jest.fn().mockReturnValue(filterVal) as any;
+  filterObservable.subscribe = jest
+    .fn()
+    .mockReturnValue({ dispose: jest.fn() });
+  return {
+    filter: filterObservable,
+    selectNodeFilter: jest.fn(),
+  };
+}
+
+const mountComp = (filter: string) =>
+  mount(FilterInputComp, {
+    props: {
+      itemData: { filter },
+      extraAttrs: {},
+    },
+    global: {
+      stubs: { NodeFilterInput: { template: "<div />" } },
+    },
+  });
+
+describe("FilterInputComp attachKnockout", () => {
+  afterEach(() => {
+    delete (window as any).nodeFilter;
+  });
+
+  it("pushes preset filterValue into KO when filterValue is initialized from itemData", async () => {
+    const koFilter = makeKoFilter("ko-default");
+    (window as any).nodeFilter = koFilter;
+
+    const wrapper = mountComp("name: preset-node");
+    await flushPromises();
+
+    expect(koFilter.selectNodeFilter).toHaveBeenCalledWith(
+      { filter: "name: preset-node" },
+      false,
+    );
+    expect(wrapper.vm.filterValue).toBe("name: preset-node");
+  });
+
+  it("reads filterValue from KO when itemData has no filter", async () => {
+    const koFilter = makeKoFilter("name: from-ko");
+    (window as any).nodeFilter = koFilter;
+
+    const wrapper = mountComp("");
+    await flushPromises();
+
+    expect(koFilter.selectNodeFilter).not.toHaveBeenCalled();
+    expect(wrapper.vm.filterValue).toBe("name: from-ko");
+  });
+
+  it("retries attachKnockout when KO is not yet available", async () => {
+    jest.useFakeTimers();
+    const koFilter = makeKoFilter("retry-filter");
+
+    const wrapper = mountComp("");
+
+    expect(wrapper.vm.filterValue).toBe("");
+    expect(koFilter.selectNodeFilter).not.toHaveBeenCalled();
+
+    (window as any).nodeFilter = koFilter;
+    jest.advanceTimersByTime(1000);
+    await flushPromises();
+
+    expect(wrapper.vm.filterValue).toBe("retry-filter");
+
+    jest.useRealTimers();
+  });
+});

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.ts
@@ -6,7 +6,7 @@ import NodeCard from "../../components/job/resources/NodeCard.vue";
 import { observer } from "../../utilities/uiSocketObserver";
 
 const rundeckContext = getRundeckContext();
-const FilterInputComp = defineComponent({
+export const FilterInputComp = defineComponent({
   name: "NodeFilter",
   components: { NodeFilterInput },
   props: ["itemData", "extraAttrs"],

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/nodes/main.ts
@@ -87,7 +87,12 @@ const FilterInputComp = defineComponent({
             (val: string) => (this.filterValue = val),
           ),
         );
-        this.filterValue = this.nodeFilterKo().filter();
+        const koVal = this.nodeFilterKo().filter();
+        if (this.filterValue) {
+          this.nodeFilterKo().selectNodeFilter({ filter: this.filterValue }, false);
+        } else {
+          this.filterValue = koVal;
+        }
       } else if (retry > 0) {
         setTimeout(() => this.attachKnockout(retry - 1), 1000);
       } else {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -5576,4 +5576,100 @@ class ScheduledExecutionControllerSpec extends Specification implements Controll
         // If someone reverts to old pattern, tests checking 'instanceof WorkflowDataImpl' will FAIL
     }
 
+    def "show action includes nodeFilterParam in model when nodeFilter param is provided"() {
+        given:
+        ScheduledExecution.metaClass.static.withNewSession = { Closure c -> c.call() }
+        def se = new ScheduledExecution(
+                uuid: 'testUUID',
+                jobName: 'test1',
+                project: 'project1',
+                groupPath: 'testgroup',
+                doNodedispatch: true,
+                filter: '.*',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec([adhocRemoteString: 'test buddy'])]
+                )
+        ).save()
+
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+            _*authorizeProjectJobAny(_, _, _, _) >> true
+            _*filterAuthorizedNodes(_, _, _, _) >> { args -> args[2] }
+        }
+        controller.frameworkService = Mock(FrameworkService) {
+            filterNodeSet(_, _) >> new NodeSetImpl()
+            getRundeckFramework() >> Mock(Framework) {
+                getFrameworkNodeName() >> 'fwnode'
+            }
+        }
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService) {
+            getByIDorUUID(_) >> se
+            _*calculateJobStats(_) >> Mock(JobStatsProvider.JobStats)
+        }
+        controller.rundeckJobDefinitionManager = Mock(RundeckJobDefinitionManager) {
+            validateJobForExport(_, _) >> Mock(Validator.Report) { isValid() >> true }
+        }
+        controller.notificationService = Mock(NotificationService)
+        controller.orchestratorPluginService = Mock(OrchestratorPluginService)
+        controller.pluginService = Mock(PluginService)
+        controller.featureService = Mock(FeatureService)
+        controller.referencedExecutionDataProvider = new GormReferencedExecutionDataProvider()
+
+        when:
+        request.parameters = [id: se.id.toString(), project: 'project1', nodeFilter: 'name: nodea']
+        def model = controller.show()
+
+        then:
+        model != null
+        model.nodeFilterParam == 'name: nodea'
+    }
+
+    def "show action omits nodeFilterParam from model when nodeFilter param is absent"() {
+        given:
+        ScheduledExecution.metaClass.static.withNewSession = { Closure c -> c.call() }
+        def se = new ScheduledExecution(
+                uuid: 'testUUID',
+                jobName: 'test1',
+                project: 'project1',
+                groupPath: 'testgroup',
+                doNodedispatch: true,
+                filter: '.*',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec([adhocRemoteString: 'test buddy'])]
+                )
+        ).save()
+
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+            _*authorizeProjectJobAny(_, _, _, _) >> true
+            _*filterAuthorizedNodes(_, _, _, _) >> { args -> args[2] }
+        }
+        controller.frameworkService = Mock(FrameworkService) {
+            filterNodeSet(_, _) >> new NodeSetImpl()
+            getRundeckFramework() >> Mock(Framework) {
+                getFrameworkNodeName() >> 'fwnode'
+            }
+        }
+        controller.scheduledExecutionService = Mock(ScheduledExecutionService) {
+            getByIDorUUID(_) >> se
+            _*calculateJobStats(_) >> Mock(JobStatsProvider.JobStats)
+        }
+        controller.rundeckJobDefinitionManager = Mock(RundeckJobDefinitionManager) {
+            validateJobForExport(_, _) >> Mock(Validator.Report) { isValid() >> true }
+        }
+        controller.notificationService = Mock(NotificationService)
+        controller.orchestratorPluginService = Mock(OrchestratorPluginService)
+        controller.pluginService = Mock(PluginService)
+        controller.featureService = Mock(FeatureService)
+        controller.referencedExecutionDataProvider = new GormReferencedExecutionDataProvider()
+
+        when:
+        request.parameters = [id: se.id.toString(), project: 'project1']
+        def model = controller.show()
+
+        then:
+        model != null
+        model.nodeFilterParam == null
+    }
+
 }


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Enhancement:  Currently, the job show URL accepts parameters for job options (?opt.who=), and previous execution IDs (?retryExecId=):

Example: http://localhost:4440/project/martin/job/show/f151ec00-ef90-48c6-8c4b-0aa947932e91?opt.who=martin
Example: http://localhost:4440/project/martin/job/show/f151ec00-ef90-48c6-8c4b-0aa947932e91?retryExecId=10

This enhancement enables a node filter to be passed as well:
Example:  http://localhost:4440/project/martin/job/show/f151ec00-ef90-48c6-8c4b-0aa947932e91?opt.who=martin&**nodeFilter=node1**


**Describe the solution you've implemented**
This enhancement implements parsing the URL encoded ?nodefilter=<filter pattern> to optionally default the node filter before starting the Rundeck job.  NOTE: This is ONLY done when the node filter is specified as "editable" on the job.

**Describe alternatives you've considered**
None.

**Additional context**
Syntax is using ServiceNow for Incident Management.  When they have an incident (disk is full, CPU is high), they have Rundeck diagnostic jobs to handle those cases.  The incident includes the hostname/IP address (node filter info).  Syntax would like to make an active URL clickable link that an L1 responder can click on that will open Rundeck and pre-populate the job with both job options AND THE NODE FILTER.  This enhancement enables that capability.

## Release Notes

None.