### PR TITLE
[RUN-4390] Fix CVE-2025-67030 in plexus-utils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,6 +204,8 @@ allprojects {
             // CVE and compatibility fixes
             force "commons-fileupload:commons-fileupload:${commonsFileuploadVersion}"
             force "com.google.protobuf:protobuf-java:${protobufVersion}" // CVE-2024-7254 fix
+            // CVE-2025-67030 - plexus-utils Directory Traversal (Expand.extractFile); pulled via grails-shell-cli
+            force "org.codehaus.plexus:plexus-utils:${plexusUtilsVersion}"
             
             // Force centralized versions to prevent duplicates in WAR
             force "org.apache.ant:ant:${antVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -111,6 +111,10 @@ grailsQuartzVersion=4.0.1
 mchangeCommonsJavaVersion=0.4.0
 c3p0Version=0.13.0
 protobufVersion=3.25.5
+# CVE-2025-67030 (GHSA-6fmv-xxpf-w3cw): plexus-utils Directory Traversal in Expand.extractFile.
+# Pulled transitively into the rundeckapp WAR via grails-shell-cli -> maven-model/settings-builder.
+# 4.0.3 is the first patched release.
+plexusUtilsVersion=4.0.3
 commonsLang3Version=3.20.0
 # Third-party plugin versions (org.rundeck.plugins bundled in Core)
 ansiblePluginVersion=5.0.1


### PR DESCRIPTION
## Security Fix

**CVE:** CVE-2025-67030 ([GHSA-6fmv-xxpf-w3cw](https://github.com/advisories/GHSA-6fmv-xxpf-w3cw))
**Severity:** HIGH — Directory Traversal in `org.codehaus.plexus.util.Expand.extractFile`
**Affected:** `org.codehaus.plexus:plexus-utils` `[,4.0.3)` — we shipped `3.5.1`
**Fix:** Force to `4.0.3` (first patched release; adds canonical-path validation)

## Summary

`plexus-utils:3.5.1` is bundled into the `rundeckapp` WAR **transitively** via:

```
grails-shell-cli:7.1.1
  -> maven-model-builder:3.9.9 / maven-settings-builder:3.9.9 (Maven 3.9.9)
       -> plexus-utils:3.5.1
```

The fix forces `plexus-utils` to `4.0.3` via the existing `allprojects` `resolutionStrategy` force block (same pattern as the protobuf / kotlin CVE pins), with the version centralized as `plexusUtilsVersion` in `gradle.properties`.

## Impact Assessment

- Transitive dependency (not declared directly)
- Present in the production artifact (WAR) — which is why scanners flag it
- Exploitable at runtime: **unlikely** — the vulnerable `Expand.extractFile` lives in Grails shell/bootstrap Maven tooling that the running server does not exercise. Remediated regardless to clear the HIGH finding and remove the vulnerable class from the artifact.

## Testing

- `:rundeckapp:dependencyInsight --configuration runtimeClasspath --dependency plexus-utils` → `plexus-utils:4.0.3 (forced)` (all transitive entry points resolve to 4.0.3)

## References
- Advisory: https://github.com/advisories/GHSA-6fmv-xxpf-w3cw
- OSV: https://osv.dev/vulnerability/CVE-2025-67030