### PR TITLE
[RUN-4520] Bump bundled remco to v0.12.6 (fix CVE-2026-34986 go-jose)

### DIFF
--- a/docker/ubuntu-base/Dockerfile
+++ b/docker/ubuntu-base/Dockerfile
@@ -2,11 +2,11 @@
 ###################################################
 FROM golang:1.24.6 AS remco
 
-# Pinned to rundeck/remco HEAD (2026-01-27).
-# Forked from HeavyHorst/remco; includes CVE fixes from upstream
-# PR #115 (https://github.com/HeavyHorst/remco/pull/115) for
-# CVE-2025-47914, CVE-2025-61727, CVE-2026-33186 (grpc v1.79.3).
-ENV REMCO_COMMIT=dd15086e958dd83f334fb857ecd29bb1615fa179
+# Pinned to rundeck/remco @ v0.12.6 (synced to upstream HeavyHorst/remco).
+# Includes CVE fixes through v0.12.6: go-jose/go-jose/v4 4.1.4 for
+# CVE-2026-34986 (GHSA-78h2-9frx-2jm8), plus CVE-2025-47914,
+# CVE-2025-61727, CVE-2026-33186 (grpc v1.79.3).
+ENV REMCO_COMMIT=777d12eaff303faa220f7686cdfa583a84f9bda4
 
 RUN git clone https://github.com/rundeck/remco.git /tmp/remco && \
     cd /tmp/remco && \


### PR DESCRIPTION
## Security Fix

**CVE:** CVE-2026-34986 ([GHSA-78h2-9frx-2jm8](https://github.com/advisories/GHSA-78h2-9frx-2jm8))
**Severity:** HIGH (DoS panic)
**Component:** `remco` (bundled in the Rundeck Docker images), via transitive `go-jose/go-jose/v4`
**Fix:** Bundle remco **v0.12.6**, which ships `go-jose/v4` **4.1.4**

## Summary

The Docker base image builds `remco` from `rundeck/remco` pinned by `REMCO_COMMIT`. The previous pin (`dd15086`) carried `go-jose/v4 4.1.3`, which panics when decrypting a JWE whose `alg` is a key-wrapping algorithm and `encrypted_key` is empty (DoS).

`rundeck/remco` master has been synced to upstream `HeavyHorst/remco` **v0.12.6** (commit `777d12e`), which upgrades `go-jose/v4` to **4.1.4**. This bumps `REMCO_COMMIT` to that commit. v0.12.6 also includes the prior remco CVE fixes (grpc v1.79.3, etc.).

## Changes
- `docker/ubuntu-base/Dockerfile`: `REMCO_COMMIT` `dd15086` → `777d12e` (v0.12.6) + comment update

## References
- Advisory: https://github.com/advisories/GHSA-78h2-9frx-2jm8