### PR TITLE
[RUN-4521] Fix node sources randomly getting deleted — Vue 3.5 null vnode crashes and JSON body parse data loss

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/FrameworkController.groovy
@@ -34,6 +34,7 @@ import com.dtolabs.rundeck.core.resources.format.ResourceFormatParserException
 import com.dtolabs.rundeck.core.resources.format.ResourceFormatParserService
 import com.dtolabs.rundeck.core.config.Features
 import com.dtolabs.rundeck.plugins.ServiceNameConstants
+import com.dtolabs.rundeck.util.JsonUtil
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Delete
 import io.micronaut.http.annotation.Get
@@ -1728,7 +1729,15 @@ Since: v55""",
         }
 
         // Grails 7: Parse body using Jackson instead of request.JSON
-        def body = com.dtolabs.rundeck.util.JsonUtil.parseRequestBody(request)
+        def body = JsonUtil.parseRequestBody(request)
+        if (body == null) {
+            render(
+                contentType: 'application/json',
+                status: HttpStatus.BAD_REQUEST.value(),
+                text: ([errors: ['Request body is missing or empty.']] as grails.converters.JSON) as String
+            )
+            return
+        }
         List plugins = (body?.plugins ?: []) as List
         List removedPlugins = (body?.removedPlugins ?: []) as List
 

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-nodes-config/ProjectPluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-nodes-config/ProjectPluginConfig.vue
@@ -56,12 +56,7 @@
 
             <div v-if="additionalProps && additionalProps.props.length > 0">
               <plugin-config
-                :key="
-                  'additional_config_' +
-                  index +
-                  '/' +
-                  (editFocus === index ? 'true' : 'false')
-                "
+                :key="'additional_config_' + index"
                 v-model="plugin.extra"
                 :mode="
                   editFocus === index
@@ -131,7 +126,7 @@
                         >{{ $t("Edit") }}</a
                       >
                     </span>
-                    <span v-if="editFocus === index">
+                    <span v-else-if="editFocus === index">
                       <a
                         :key="'save'"
                         class="btn btn-cta btn-xs"
@@ -450,13 +445,14 @@ export default defineComponent({
     },
     addPlugin(provider: string) {
       this.modalAddOpen = false;
-      this.pluginConfigs.push({
-        entry: { type: provider, config: {} },
-        extra: { config: {} },
-        create: true,
-      } as ProjectPluginConfigEntry);
-
-      this.setFocus(this.pluginConfigs.length - 1);
+      this.$nextTick(() => {
+        this.pluginConfigs.push({
+          entry: { type: provider, config: {} },
+          extra: { config: {} },
+          create: true,
+        } as ProjectPluginConfigEntry);
+        this.setFocus(this.pluginConfigs.length - 1);
+      });
     },
     setFocus(focus: number) {
       this.editFocus = focus;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginConfig.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginConfig.vue
@@ -71,18 +71,22 @@
         <span v-if="validation && !validation.valid" class="text-warning">
           <i class="fas fa-exclamation-circle"></i> {{ validationWarningText }}
         </span>
-        <span v-for="prop in props" :key="prop.name" class="configprop">
-          <plugin-prop-view
+        <template v-for="prop in props" :key="prop.name">
+          <span
             v-if="
               (prop.type === 'Boolean' || config[prop.name]) &&
               isPropInScope(prop) &&
               !isPropHidden(prop)
             "
-            :prop="prop"
-            :value="config[prop.name]"
-            :allow-copy="allowCopy"
-          />
-        </span>
+            class="configprop"
+          >
+            <plugin-prop-view
+              :prop="prop"
+              :value="config[prop.name]"
+              :allow-copy="allowCopy"
+            />
+          </span>
+        </template>
         <div class="col-sm-12">
           <slot name="extraProperties"></slot>
         </div>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropVal.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropVal.vue
@@ -8,7 +8,7 @@
             : $t("yes")
         }}
       </template>
-      <template v-if="value === 'false' || value === false">
+      <template v-else-if="value === 'false' || value === false">
         {{
           prop.options && prop.options["booleanFalseDisplayValue"]
             ? prop.options["booleanFalseDisplayValue"]

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropView.vue
@@ -19,7 +19,7 @@
           @click="copyText(innerValue)"
         >
           <plugin-prop-val :prop="prop" :value="innerValue" />
-          <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
+          <i v-show="allowCopy" class="pi pi-copy copy-icon" data-testid="copy-icon"></i>
         </span>
         <span
           v-else-if="innerValue === 'false'"
@@ -32,7 +32,7 @@
           @click="copyText(innerValue)"
         >
           <plugin-prop-val :prop="prop" :value="innerValue" />
-          <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
+          <i v-show="allowCopy" class="pi pi-copy copy-icon" data-testid="copy-icon"></i>
         </span>
       </template>
       <template v-else></template>
@@ -57,7 +57,7 @@
         <template v-if="prop.type !== 'Options'">
           <span class="text-success copiable-text" @click="copyText(innerValue)">
             <plugin-prop-val :prop="prop" :value="innerValue" />
-            <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
+            <i v-show="allowCopy" class="pi pi-copy copy-icon" data-testid="copy-icon"></i>
           </span>
         </template>
         <template v-else>
@@ -74,7 +74,7 @@
                   class="glyphicon glyphicon-ok-circle"
               ></i>
               <plugin-prop-val :prop="prop" :value="optval" />
-              <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
+              <i v-show="allowCopy" class="pi pi-copy copy-icon" data-testid="copy-icon"></i>
             </span>
           </span>
           <span v-else-if="typeof value !== 'string' && innerValue.length > 0">
@@ -89,7 +89,7 @@
                   class="glyphicon glyphicon-ok-circle"
               ></i>
               <plugin-prop-val :prop="prop" :value="optval" />
-              <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
+              <i v-show="allowCopy" class="pi pi-copy copy-icon" data-testid="copy-icon"></i>
             </span>
           </span>
           <template v-else></template>
@@ -151,7 +151,7 @@
             @click="copyText(custom.value)"
           >
             {{ custom.value }}
-            <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
+            <i v-show="allowCopy" class="pi pi-copy copy-icon" data-testid="copy-icon"></i>
           </span>
         </span>
       </template>
@@ -165,7 +165,7 @@
           :title="allowCopy ? 'Click to copy password' : ''"
         >
           &bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;
-          <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
+          <i v-show="allowCopy" class="pi pi-copy copy-icon" data-testid="copy-icon"></i>
         </span>
         <span
           v-else
@@ -174,7 +174,7 @@
           @click="copyText(innerValue)"
         >
           {{ innerValue }}
-          <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
+          <i v-show="allowCopy" class="pi pi-copy copy-icon" data-testid="copy-icon"></i>
         </span>
       </span>
     </span>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropView.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/pluginPropView.vue
@@ -7,7 +7,7 @@
           (prop.defaultValue === 'true' && innerValue === 'false')
         "
       >
-        <span data-testid="boolean-prop-title" :title="$t(prop.desc)">{{ $t(prop.title) }}: </span>
+        <span data-testid="boolean-prop-title" :title="prop.desc ? $t(prop.desc) : ''">{{ $t(prop.title) }}: </span>
         <span
           v-if="innerValue === 'true'"
           data-testid="boolean-true-value"
@@ -19,7 +19,7 @@
           @click="copyText(innerValue)"
         >
           <plugin-prop-val :prop="prop" :value="innerValue" />
-          <i v-if="allowCopy" class="pi pi-copy copy-icon"></i>
+          <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
         </span>
         <span
           v-else-if="innerValue === 'false'"
@@ -32,12 +32,13 @@
           @click="copyText(innerValue)"
         >
           <plugin-prop-val :prop="prop" :value="innerValue" />
-          <i v-if="allowCopy" class="pi pi-copy copy-icon"></i>
+          <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
         </span>
       </template>
+      <template v-else></template>
     </span>
     <span v-else-if="prop.type === 'Integer'" class="configpair">
-      <span :title="$t(prop.desc)" data-testid="integer-prop-title">
+      <span :title="prop.desc ? $t(prop.desc) : ''" data-testid="integer-prop-title">
         {{ $t(prop.title) }}:
       </span>
       <span
@@ -52,11 +53,11 @@
       class="configpair"
     >
       <span>
-        <span data-testid="options-prop-title" :title="$t(prop.desc)">{{ $t(prop.title) }}:</span>
+        <span data-testid="options-prop-title" :title="prop.desc ? $t(prop.desc) : ''">{{ $t(prop.title) }}:</span>
         <template v-if="prop.type !== 'Options'">
           <span class="text-success copiable-text" @click="copyText(innerValue)">
             <plugin-prop-val :prop="prop" :value="innerValue" />
-            <i v-if="allowCopy" class="pi pi-copy copy-icon"></i>
+            <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
           </span>
         </template>
         <template v-else>
@@ -69,11 +70,11 @@
                 @click="copyText(optval)"
             >
               <i
-                  v-if="!(prop.options && prop.options['valueDisplayType'])"
+                  v-show="!(prop.options && prop.options['valueDisplayType'])"
                   class="glyphicon glyphicon-ok-circle"
               ></i>
               <plugin-prop-val :prop="prop" :value="optval" />
-              <i v-if="allowCopy" class="pi pi-copy copy-icon"></i>
+              <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
             </span>
           </span>
           <span v-else-if="typeof value !== 'string' && innerValue.length > 0">
@@ -84,13 +85,14 @@
                 @click="copyText(optval)"
             >
               <i
-                  v-if="!(prop.options && prop.options['valueDisplayType'])"
+                  v-show="!(prop.options && prop.options['valueDisplayType'])"
                   class="glyphicon glyphicon-ok-circle"
               ></i>
               <plugin-prop-val :prop="prop" :value="optval" />
-              <i v-if="allowCopy" class="pi pi-copy copy-icon"></i>
+              <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
             </span>
           </span>
+          <template v-else></template>
         </template>
       </span>
     </span>
@@ -98,7 +100,7 @@
       <template v-if="prop.options && prop.options['displayType'] === 'CODE'">
         <expandable>
           <template #label>
-            <span data-testid="code-prop-title" :title="$t(prop.desc)">{{ $t(prop.title) }}:</span>
+            <span data-testid="code-prop-title" :title="prop.desc ? $t(prop.desc) : ''">{{ $t(prop.title) }}:</span>
             <span data-testid="code-line-count" class="text-info">
               {{ innerValue.split(/\r?\n/).length }} lines
             </span>
@@ -117,7 +119,7 @@
       >
         <expandable>
           <template #label
-            ><span data-testid="multiline-prop-title" :title="$t(prop.desc)">{{ $t(prop.title) }}:</span>
+            ><span data-testid="multiline-prop-title" :title="prop.desc ? $t(prop.desc) : ''">{{ $t(prop.title) }}:</span>
             <span data-testid="multiline-line-count" class="text-info"
               >{{ `${innerValue}`.split(/\r?\n/).length }} lines</span
             ></template
@@ -149,12 +151,12 @@
             @click="copyText(custom.value)"
           >
             {{ custom.value }}
-            <i v-if="allowCopy" class="pi pi-copy copy-icon"></i>
+            <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
           </span>
         </span>
       </template>
       <span class="" v-else>
-        <span data-testid="string-prop-title" :title="$t(prop.desc)">{{ $t(prop.title) }}:</span>
+        <span data-testid="string-prop-title" :title="prop.desc ? $t(prop.desc) : ''">{{ $t(prop.title) }}:</span>
         <span
           v-if="prop.options && prop.options['displayType'] === 'PASSWORD'"
           data-testid="password-prop-value"
@@ -163,7 +165,7 @@
           :title="allowCopy ? 'Click to copy password' : ''"
         >
           &bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;
-          <i v-if="allowCopy" class="pi pi-copy copy-icon"></i>
+          <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
         </span>
         <span
           v-else
@@ -172,7 +174,7 @@
           @click="copyText(innerValue)"
         >
           {{ innerValue }}
-          <i v-if="allowCopy" class="pi pi-copy copy-icon"></i>
+          <i v-show="allowCopy" class="pi pi-copy copy-icon"></i>
         </span>
       </span>
     </span>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginPropView.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginPropView.spec.ts
@@ -5,21 +5,39 @@ import * as Clipboard from "../../../utilities/Clipboard";
 jest.mock("../../../utilities/Clipboard");
 const mockedClipboard = Clipboard as jest.Mocked<typeof Clipboard>;
 
+interface MountOptions {
+  props?: Record<string, any>;
+  stubs?: Record<string, boolean | object>;
+}
+
 let originalMutationObserver: typeof MutationObserver;
 
-const createWrapper = async (options: { props?: Record<string, any> } = {}) => {
+const createWrapper = async (options: MountOptions = {}) => {
   const wrapper = mount(PluginPropView, {
     props: {
       prop: { type: "String", title: "My Prop", desc: "Prop description" },
       value: "hello",
+      allowCopy: false,
       ...options.props,
+    },
+    global: {
+      stubs: {
+        "ace-editor": true,
+        expandable: {
+          template: '<div><slot name="label"></slot><slot></slot></div>',
+        },
+        ...options.stubs,
+      },
     },
   });
   await wrapper.vm.$nextTick();
   return wrapper;
 };
 
-describe("pluginPropView", () => {
+const findByTestId = (wrapper: ReturnType<typeof mount>, testId: string) =>
+  wrapper.find(`[data-testid="${testId}"]`);
+
+describe("PluginPropView", () => {
   beforeEach(() => {
     originalMutationObserver = global.MutationObserver;
     global.MutationObserver = jest
@@ -46,12 +64,10 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(
-        wrapper.find('[data-testid="boolean-prop-title"]').exists(),
-      ).toBe(true);
-      expect(
-        wrapper.find('[data-testid="boolean-prop-title"]').text(),
-      ).toContain("Enable Feature");
+      expect(findByTestId(wrapper, "boolean-prop-title").exists()).toBe(true);
+      expect(findByTestId(wrapper, "boolean-prop-title").text()).toContain(
+        "Enable Feature",
+      );
     });
 
     it("shows 'yes' text when value is true", async () => {
@@ -62,9 +78,9 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(
-        wrapper.find('[data-testid="boolean-true-value"]').text(),
-      ).toContain("yes");
+      expect(findByTestId(wrapper, "boolean-true-value").text()).toContain(
+        "yes",
+      );
     });
 
     it("applies custom booleanTrueDisplayValueClass to true value", async () => {
@@ -81,7 +97,7 @@ describe("pluginPropView", () => {
       });
 
       expect(
-        wrapper.find('[data-testid="boolean-true-value"]').classes(),
+        findByTestId(wrapper, "boolean-true-value").classes(),
       ).toContain("text-primary");
     });
 
@@ -94,7 +110,7 @@ describe("pluginPropView", () => {
       });
 
       expect(
-        wrapper.find('[data-testid="boolean-true-value"]').classes(),
+        findByTestId(wrapper, "boolean-true-value").classes(),
       ).toContain("text-success");
     });
 
@@ -111,12 +127,10 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(
-        wrapper.find('[data-testid="boolean-false-value"]').exists(),
-      ).toBe(true);
-      expect(
-        wrapper.find('[data-testid="boolean-false-value"]').text(),
-      ).toContain("no");
+      expect(findByTestId(wrapper, "boolean-false-value").exists()).toBe(true);
+      expect(findByTestId(wrapper, "boolean-false-value").text()).toContain(
+        "no",
+      );
     });
 
     it("hides boolean content when value is false and no defaultValue is true", async () => {
@@ -127,9 +141,7 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(
-        wrapper.find('[data-testid="boolean-prop-title"]').exists(),
-      ).toBe(false);
+      expect(findByTestId(wrapper, "boolean-prop-title").exists()).toBe(false);
     });
 
     it("applies custom booleanFalseDisplayValueClass to false value", async () => {
@@ -147,7 +159,7 @@ describe("pluginPropView", () => {
       });
 
       expect(
-        wrapper.find('[data-testid="boolean-false-value"]').classes(),
+        findByTestId(wrapper, "boolean-false-value").classes(),
       ).toContain("text-danger");
     });
   });
@@ -161,9 +173,9 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(
-        wrapper.find('[data-testid="integer-prop-title"]').text(),
-      ).toContain("Max Count");
+      expect(findByTestId(wrapper, "integer-prop-title").text()).toContain(
+        "Max Count",
+      );
     });
 
     it("shows integer value", async () => {
@@ -174,9 +186,7 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(wrapper.find('[data-testid="integer-prop-value"]').text()).toBe(
-        "42",
-      );
+      expect(findByTestId(wrapper, "integer-prop-value").text()).toBe("42");
     });
   });
 
@@ -189,9 +199,9 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(
-        wrapper.find('[data-testid="options-prop-title"]').text(),
-      ).toContain("Colors");
+      expect(findByTestId(wrapper, "options-prop-title").text()).toContain(
+        "Colors",
+      );
     });
 
     it("renders each comma-separated option as a separate value element", async () => {
@@ -202,8 +212,7 @@ describe("pluginPropView", () => {
         },
       });
 
-      const options = wrapper.findAll('[data-testid="option-value"]');
-      expect(options).toHaveLength(3);
+      expect(wrapper.findAll('[data-testid="option-value"]')).toHaveLength(3);
     });
 
     it("shows the text of each option value", async () => {
@@ -242,7 +251,7 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(wrapper.find('[data-testid="string-prop-title"]').text()).toContain(
+      expect(findByTestId(wrapper, "string-prop-title").text()).toContain(
         "My String",
       );
     });
@@ -255,7 +264,7 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(wrapper.find('[data-testid="string-prop-value"]').text()).toContain(
+      expect(findByTestId(wrapper, "string-prop-value").text()).toContain(
         "hello world",
       );
     });
@@ -275,15 +284,13 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(
-        wrapper.find('[data-testid="password-prop-value"]').exists(),
-      ).toBe(true);
-      expect(
-        wrapper.find('[data-testid="password-prop-value"]').text(),
-      ).not.toContain("mysecretpassword");
-      expect(
-        wrapper.find('[data-testid="password-prop-value"]').text(),
-      ).toContain("••••••••••••");
+      expect(findByTestId(wrapper, "password-prop-value").exists()).toBe(true);
+      expect(findByTestId(wrapper, "password-prop-value").text()).not.toContain(
+        "mysecretpassword",
+      );
+      expect(findByTestId(wrapper, "password-prop-value").text()).toContain(
+        "••••••••••••",
+      );
     });
 
     it("does not show the string-prop-value element for PASSWORD type", async () => {
@@ -299,9 +306,7 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(
-        wrapper.find('[data-testid="string-prop-value"]').exists(),
-      ).toBe(false);
+      expect(findByTestId(wrapper, "string-prop-value").exists()).toBe(false);
     });
   });
 
@@ -319,9 +324,9 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(
-        wrapper.find('[data-testid="code-prop-title"]').text(),
-      ).toContain("Script");
+      expect(findByTestId(wrapper, "code-prop-title").text()).toContain(
+        "Script",
+      );
     });
 
     it("shows the computed line count", async () => {
@@ -337,9 +342,9 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(
-        wrapper.find('[data-testid="code-line-count"]').text(),
-      ).toContain("3 lines");
+      expect(findByTestId(wrapper, "code-line-count").text()).toContain(
+        "3 lines",
+      );
     });
 
     it("shows 1 line for a single-line value", async () => {
@@ -355,9 +360,9 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(
-        wrapper.find('[data-testid="code-line-count"]').text(),
-      ).toContain("1 lines");
+      expect(findByTestId(wrapper, "code-line-count").text()).toContain(
+        "1 lines",
+      );
     });
   });
 
@@ -375,9 +380,9 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(
-        wrapper.find('[data-testid="multiline-prop-title"]').text(),
-      ).toContain("Description");
+      expect(findByTestId(wrapper, "multiline-prop-title").text()).toContain(
+        "Description",
+      );
     });
 
     it("shows the computed line count", async () => {
@@ -393,9 +398,9 @@ describe("pluginPropView", () => {
         },
       });
 
-      expect(
-        wrapper.find('[data-testid="multiline-line-count"]').text(),
-      ).toContain("4 lines");
+      expect(findByTestId(wrapper, "multiline-line-count").text()).toContain(
+        "4 lines",
+      );
     });
   });
 
@@ -416,8 +421,7 @@ describe("pluginPropView", () => {
         },
       });
 
-      const pairs = wrapper.findAll('[data-testid="configpair"]');
-      expect(pairs).toHaveLength(2);
+      expect(wrapper.findAll('[data-testid="configpair"]')).toHaveLength(2);
     });
 
     it("shows each attribute label and value", async () => {
@@ -479,9 +483,10 @@ describe("pluginPropView", () => {
           value: "LOCAL",
         },
       });
-      const titleEl = wrapper.find('[data-testid="string-prop-title"]');
-      expect(titleEl.exists()).toBe(true);
-      expect(titleEl.attributes("title")).toBe("");
+
+      expect(findByTestId(wrapper, "string-prop-title").attributes("title")).toBe(
+        "",
+      );
     });
 
     it("mounts without throwing when desc is undefined for Boolean type", async () => {
@@ -497,7 +502,7 @@ describe("pluginPropView", () => {
   });
 
   describe("copy to clipboard (allowCopy)", () => {
-    it("shows copy icon on string value when allowCopy is true", async () => {
+    it("shows copy icon when allowCopy is true", async () => {
       const wrapper = await createWrapper({
         props: {
           prop: { type: "String", title: "Field", desc: "desc" },
@@ -506,10 +511,21 @@ describe("pluginPropView", () => {
         },
       });
 
-      const copyIcon = wrapper
-        .find('[data-testid="string-prop-value"]')
-        .find(".pi-copy");
-      expect(copyIcon.exists()).toBe(true);
+      const icon = findByTestId(wrapper, "copy-icon").element as HTMLElement;
+      expect(icon.style.display).not.toBe("none");
+    });
+
+    it("hides copy icon when allowCopy is false", async () => {
+      const wrapper = await createWrapper({
+        props: {
+          prop: { type: "String", title: "Field", desc: "desc" },
+          value: "copyable text",
+          allowCopy: false,
+        },
+      });
+
+      const icon = findByTestId(wrapper, "copy-icon").element as HTMLElement;
+      expect(icon.style.display).toBe("none");
     });
 
     it("copies the value to clipboard when clicking string prop value", async () => {
@@ -521,7 +537,7 @@ describe("pluginPropView", () => {
         },
       });
 
-      await wrapper.find('[data-testid="string-prop-value"]').trigger("click");
+      await findByTestId(wrapper, "string-prop-value").trigger("click");
       await flushPromises();
 
       expect(mockedClipboard.CopyToClipboard).toHaveBeenCalledWith(
@@ -538,7 +554,7 @@ describe("pluginPropView", () => {
         },
       });
 
-      await wrapper.find('[data-testid="boolean-true-value"]').trigger("click");
+      await findByTestId(wrapper, "boolean-true-value").trigger("click");
       await flushPromises();
 
       expect(mockedClipboard.CopyToClipboard).toHaveBeenCalledWith("true");

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginPropView.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/pluginPropView.spec.ts
@@ -460,6 +460,42 @@ describe("pluginPropView", () => {
     });
   });
 
+  describe("prop.desc undefined — regression for RUN-4521", () => {
+    it("mounts without throwing when desc is undefined", async () => {
+      await expect(
+        createWrapper({
+          props: {
+            prop: { type: "String", title: "Runner Filter", desc: undefined },
+            value: "LOCAL",
+          },
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it("renders empty title attribute when desc is undefined", async () => {
+      const wrapper = await createWrapper({
+        props: {
+          prop: { type: "String", title: "Runner Filter", desc: undefined },
+          value: "LOCAL",
+        },
+      });
+      const titleEl = wrapper.find('[data-testid="string-prop-title"]');
+      expect(titleEl.exists()).toBe(true);
+      expect(titleEl.attributes("title")).toBe("");
+    });
+
+    it("mounts without throwing when desc is undefined for Boolean type", async () => {
+      await expect(
+        createWrapper({
+          props: {
+            prop: { type: "Boolean", title: "Enable", desc: undefined },
+            value: "true",
+          },
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
+
   describe("copy to clipboard (allowCopy)", () => {
     it("shows copy icon on string value when allowCopy is true", async () => {
       const wrapper = await createWrapper({

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/util/JsonUtil.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/util/JsonUtil.groovy
@@ -16,14 +16,16 @@
 
 package com.dtolabs.rundeck.util
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
+import groovy.util.logging.Slf4j
 import jakarta.servlet.http.HttpServletRequest
-import org.grails.web.json.JSONObject
 
 
 /**
  * JSON request handling utilities
  */
+@Slf4j
 class JsonUtil {
 
     // Grails 7: Shared ObjectMapper instance for parsing JSON request bodies
@@ -38,46 +40,46 @@ class JsonUtil {
      * @throws IOException if JSON parsing fails (but not if body is unavailable)
      */
     static Map parseRequestBody(HttpServletRequest request) throws IOException {
-        // Grails 7: Check if this is actually a JSON request
         def contentType = request.contentType
-        if (contentType) {
-            // Skip non-JSON content types (multipart/form-data, etc.)
-            if (!contentType.toLowerCase().contains('json')) {
-                return null
-            }
+        if (contentType && !contentType.toLowerCase().contains('json')) {
+            return null
         }
-        
-        // Spring Boot 3: Try multiple approaches to read the request body
-        
-        // Attempt 1: Read from input stream
+
+        // Use getReader() FIRST — never call getInputStream() before getReader().
+        // Calling getInputStream() first locks the stream and causes getReader() to throw
+        // IllegalStateException (Servlet spec), which combined with available()==0 (common on
+        // real networks/ALB) was the root cause of the silent data-loss bug (RUN-4521).
+        String content = null
         try {
-            def inputStream = request.getInputStream()
-            if (inputStream && inputStream.available() > 0) {
-                return objectMapper.readValue(inputStream, Map.class)
-            }
-        } catch (Exception e) {
-            // Stream might be already consumed or unavailable
-            // Continue to next attempt
-        }
-        
-        // Attempt 2: Read from reader  
-        try {
-            def reader = request.getReader()
-            if (reader) {
-                def content = reader.text
-                if (content && !content.trim().empty) {
-                    return objectMapper.readValue(content, Map.class)
+            content = request.getReader()?.text
+        } catch (Exception readerEx) {
+            // Reader unavailable (stream closed, IllegalStateException from prior getInputStream
+            // call, etc.) — fall back to reading raw bytes without the available() check.
+            // Do NOT use available(): it returns only buffered bytes and silently truncates
+            // data not yet in the local buffer on proxied/slow connections.
+            log.error("parseRequestBody: getReader() failed [${readerEx.class.simpleName}: ${readerEx.message}], falling back to getInputStream()")
+            try {
+                def bytes = request.getInputStream()?.readAllBytes()
+                if (bytes?.length > 0) {
+                    content = new String(bytes, 'UTF-8')
                 }
+            } catch (Exception streamEx) {
+                // Both reader and stream unavailable — body cannot be read
+                log.error("parseRequestBody: getInputStream() also failed [${streamEx.class.simpleName}: ${streamEx.message}] — body is unreadable")
             }
-        } catch (Exception e) {
-            // Reader might be unavailable
-            // Continue to next attempt
         }
-        
-        // NOTE: No fallback needed for Grails 7 controllers using @RequestBody
-        // Spring automatically handles JSON deserialization for @RequestBody parameters
-        
-        return null
+
+        if (!content?.trim()) {
+            return null
+        }
+
+        try {
+            return objectMapper.readValue(content, Map.class)
+        } catch (JsonProcessingException parseEx) {
+            // Body readable but not a JSON object (array, primitive, malformed) — return null
+            log.error("parseRequestBody: JSON parsing failed [${parseEx.class.simpleName}: ${parseEx.originalMessage}] — body was readable but not a JSON object")
+            return null
+        }
     }
 
     /**

--- a/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/FrameworkControllerSpec.groovy
@@ -2182,6 +2182,224 @@ project.label=A Label
                 errors : ['Project does not exist']
         ]
     }
+
+    /**
+     * RUN-4521 regression: reproduces the exact production payload where removing a node source
+     * with runner extra config (docker) while keeping only local caused all sources to be deleted.
+     *
+     * Run in debug mode and set a breakpoint in JsonUtil.parseRequestBody and
+     * FrameworkController.saveProjectPlugins to inspect the parsed body and configs list.
+     */
+    def "save project plugins — production payload RUN-4521: keep local remove docker with runner extra"() {
+        given:
+        def utilTagLib = mockTagLib(UtilityTagLib)
+        def project = "BadNodeSources"
+        def serviceName = "ResourceModelSource"
+        def configPrefix = "resources.source"
+
+        controller.frameworkService = Mock(FrameworkService) {
+            _ * getGrailsEventBus() >> Mock(grails.events.bus.EventBus) {
+                _ * notify(_, _)
+            }
+        }
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor)
+        controller.pluginService = Mock(PluginService)
+        controller.obscurePasswordFieldsService = Mock(PasswordFieldsService)
+        controller.featureService = Mock(FeatureService)
+
+        controller.apiService = Mock(ApiService) {
+            1 * requireApi(_, _, _) >> true
+            1 * requireParameters(_, _, ['serviceName', 'configPrefix']) >> true
+            1 * requireExists(_, _, ['project', project]) >> true
+            1 * requireAuthorized(_, _, ['configure', 'Project', project]) >> true
+        }
+
+        // Exact payload observed in production — 5 plugins, removedPlugins empty
+        def runnerExtra = { String providerType -> [runner: [
+            runnerFilterType     : 'LOCAL_RUNNER',
+            runnerFilterMode     : 'LOCAL',
+            checkProviders       : true,
+            providers            : [[provider: providerType, serviceName: 'ResourceModelSource', checkProvider: true]],
+            serviceProvidersFilter: ['ResourceModelSource']
+        ]]}
+        def inputData = [
+            plugins: [
+                [extra: [:],                            type: 'local',                      config: [description: 'Rundeck server node'], origIndex: 0],
+                [extra: runnerExtra('yaml-text-model-source'),  type: 'yaml-text-model-source',     config: ['yaml-text': '# hypothetical node, somenode2\nsomenode2:\n  tags: "pool,service"\n'], origIndex: 1],
+                [extra: runnerExtra('docker-container-model-source'), type: 'docker-container-model-source', config: [:],                            origIndex: 2],
+                [extra: runnerExtra('gcp-gke-clusters'), type: 'gcp-gke-clusters',          config: [usePodServiceAccount: 'false'],        origIndex: 3],
+                [extra: runnerExtra('file'),             type: 'file',                       config: [format: 'dsad', file: 'dsa', generateFileAutomatically: 'false', includeServerNode: 'false', requireFileExists: 'false', writeable: 'false']]
+                // note: last plugin has no origIndex — intentional to match production payload
+            ],
+            removedPlugins: []
+        ]
+        request.json = inputData
+        request.method = 'POST'
+        setupFormTokens(params)
+
+        when:
+        controller.saveProjectPlugins(project, serviceName, configPrefix)
+
+        then:
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
+        1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_, project) >> true
+        1 * controller.obscurePasswordFieldsService.untrack(_, _, _)
+        1 * controller.obscurePasswordFieldsService.resetTrack(_, _, _)
+
+        // All 5 plugin types must be found and valid for save to succeed
+        1 * controller.pluginService.getPluginDescriptor('local', _) >>
+                new DescribedPlugin(null, null, 'local', null, null)
+        1 * controller.pluginService.validatePluginConfig(serviceName, 'local', [description: 'Rundeck server node']) >>
+                new ValidatedPlugin(valid: true)
+        1 * controller.pluginService.getPluginDescriptor('yaml-text-model-source', _) >>
+                new DescribedPlugin(null, null, 'yaml-text-model-source', null, null)
+        1 * controller.pluginService.validatePluginConfig(serviceName, 'yaml-text-model-source', _) >>
+                new ValidatedPlugin(valid: true)
+        1 * controller.pluginService.getPluginDescriptor('docker-container-model-source', _) >>
+                new DescribedPlugin(null, null, 'docker-container-model-source', null, null)
+        1 * controller.pluginService.validatePluginConfig(serviceName, 'docker-container-model-source', [:]) >>
+                new ValidatedPlugin(valid: true)
+        1 * controller.pluginService.getPluginDescriptor('gcp-gke-clusters', _) >>
+                new DescribedPlugin(null, null, 'gcp-gke-clusters', null, null)
+        1 * controller.pluginService.validatePluginConfig(serviceName, 'gcp-gke-clusters', [usePodServiceAccount: 'false']) >>
+                new ValidatedPlugin(valid: true)
+        1 * controller.pluginService.getPluginDescriptor('file', _) >>
+                new DescribedPlugin(null, null, 'file', null, null)
+        1 * controller.pluginService.validatePluginConfig(serviceName, 'file', _) >>
+                new ValidatedPlugin(valid: true)
+
+        // project config saved with 5 plugins — NOT empty
+        1 * controller.frameworkService.updateFrameworkProjectConfig(project, _, ["${configPrefix}."].toSet()) >>
+                [success: true]
+        response.status == 200
+        response.json.plugins.size() == 5
+    }
+
+    /**
+     * RUN-4521 fix: malformed/truncated JSON body causes ObjectMapper to throw JsonParseException
+     * (an IOException). saveProjectPlugins must catch it and return 400 with the exact error
+     * message instead of silently wiping all sources.
+     */
+    def "save project plugins — malformed JSON body returns 400 and does not delete sources RUN-4521"() {
+        given:
+        def utilTagLib = mockTagLib(UtilityTagLib)
+        def project = "BadNodeSources"
+        def serviceName = "ResourceModelSource"
+        def configPrefix = "resources.source"
+
+        controller.frameworkService = Mock(FrameworkService)
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor)
+        controller.pluginService = Mock(PluginService)
+        controller.obscurePasswordFieldsService = Mock(PasswordFieldsService)
+        controller.featureService = Mock(FeatureService)
+
+        controller.apiService = Mock(ApiService) {
+            1 * requireApi(_, _, _) >> true
+            1 * requireParameters(_, _, ['serviceName', 'configPrefix']) >> true
+            1 * requireExists(_, _, ['project', project]) >> true
+            1 * requireAuthorized(_, _, ['configure', 'Project', project]) >> true
+        }
+
+        // Truncated JSON — Jackson throws JsonParseException (IOException subclass)
+        def truncatedJson = '{"plugins":[{"extra":{},"type":"local","config":{"description":"Rundeck server node"},"origIndex":0},{"extra":{"runner":{"runnerFilterType":"LOCAL_RUNNER"'
+        request.contentType = 'application/json'
+        request.content = truncatedJson.bytes
+        request.method = 'POST'
+        setupFormTokens(params)
+
+        when:
+        controller.saveProjectPlugins(project, serviceName, configPrefix)
+
+        then:
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
+        1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_, project) >> true
+        // Fix: project config is NOT touched — sources are preserved
+        0 * controller.frameworkService.updateFrameworkProjectConfig(_, _, _)
+        // Malformed JSON → parseRequestBody returns null → 400 "body is missing or empty"
+        response.status == 400
+        response.json.errors == ['Request body is missing or empty.']
+    }
+
+    /**
+     * RUN-4521 fix: when parseRequestBody returns null (empty/absent body),
+     * saveProjectPlugins must return 400 instead of silently wiping all sources.
+     */
+    def "save project plugins — null request body returns 400 and does not delete sources RUN-4521"() {
+        given:
+        def utilTagLib = mockTagLib(UtilityTagLib)
+        def project = "BadNodeSources"
+        def serviceName = "ResourceModelSource"
+        def configPrefix = "resources.source"
+
+        controller.frameworkService = Mock(FrameworkService)
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor)
+        controller.pluginService = Mock(PluginService)
+        controller.obscurePasswordFieldsService = Mock(PasswordFieldsService)
+        controller.featureService = Mock(FeatureService)
+
+        controller.apiService = Mock(ApiService) {
+            1 * requireApi(_, _, _) >> true
+            1 * requireParameters(_, _, ['serviceName', 'configPrefix']) >> true
+            1 * requireExists(_, _, ['project', project]) >> true
+            1 * requireAuthorized(_, _, ['configure', 'Project', project]) >> true
+        }
+
+        // No body → parseRequestBody returns null
+        request.method = 'POST'
+        setupFormTokens(params)
+
+        when:
+        controller.saveProjectPlugins(project, serviceName, configPrefix)
+
+        then:
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
+        1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_, project) >> true
+        // Fix: project config is NOT touched — sources are preserved
+        0 * controller.frameworkService.updateFrameworkProjectConfig(_, _, _)
+        // Fix: returns 400 with meaningful message
+        response.status == 400
+        response.json.errors == ['Request body is missing or empty.']
+    }
+
+    /**
+     * RUN-4521 fix: when stream is consumed upstream (both getReader and getInputStream fail),
+     * parseRequestBody returns null and saveProjectPlugins returns 400 instead of wiping sources.
+     */
+    def "save project plugins — stream consumed upstream returns 400 and does not delete sources RUN-4521"() {
+        given:
+        def utilTagLib = mockTagLib(UtilityTagLib)
+        def project = "BadNodeSources"
+        def serviceName = "ResourceModelSource"
+        def configPrefix = "resources.source"
+
+        controller.frameworkService = Mock(FrameworkService)
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor)
+        controller.pluginService = Mock(PluginService)
+        controller.obscurePasswordFieldsService = Mock(PasswordFieldsService)
+        controller.featureService = Mock(FeatureService)
+
+        controller.apiService = Mock(ApiService) {
+            1 * requireApi(_, _, _) >> true
+            1 * requireParameters(_, _, ['serviceName', 'configPrefix']) >> true
+            1 * requireExists(_, _, ['project', project]) >> true
+            1 * requireAuthorized(_, _, ['configure', 'Project', project]) >> true
+        }
+
+        // No body — both getReader() and getInputStream() return empty/null → parseRequestBody returns null
+        request.method = 'POST'
+        setupFormTokens(params)
+
+        when:
+        controller.saveProjectPlugins(project, serviceName, configPrefix)
+
+        then:
+        1 * controller.rundeckAuthContextProcessor.getAuthContextForSubject(_)
+        1 * controller.rundeckAuthContextProcessor.authorizeProjectConfigure(_, project) >> true
+        0 * controller.frameworkService.updateFrameworkProjectConfig(_, _, _)
+        response.status == 400
+        response.json.errors == ['Request body is missing or empty.']
+    }
+
     def "save node source file, catch IOException"() {
 
         setup:


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bug fix for [RUN-4521](https://pagerduty.atlassian.net/browse/RUN-4521): Node sources randomly getting deleted — two independent root causes identified and fixed.

**Describe the solution you've implemented**

### Root Cause 1: Vue 3.5 null vnode crashes corrupt component state

Four related Vue 3.5 rendering bugs were identified and fixed in the node sources configuration components:

**`ProjectPluginConfig.vue`**
- Removed `editFocus` from `:key` of the `additional_config` plugin-config component, which was causing forced destroy/recreate on every `editFocus` change — leaving null entries in Vue 3.5 block tracking `dynamicChildren`
- Changed two adjacent `v-if` spans (Edit/Save buttons) to `v-if`/`v-else-if` since they are mutually exclusive — prevents simultaneous null vnodes in the same block
- Wrapped `addPlugin` state changes in `$nextTick` to separate modal unmount from v-for array push, avoiding `Cannot set properties of null (setting '__vnode')` during concurrent DOM reconciliation

**`pluginConfig.vue`**
- Changed `<span v-for> + <plugin-prop-view v-if>` to `<template v-for> + <span v-if>` pattern — in Vue 3.5, a `v-if` without `v-else` inside a non-block `<span>` produces literal `null` in the children array, which causes `unmountChildren` to crash

**`pluginPropVal.vue`**
- Fixed two separate `v-if` blocks for Boolean `true`/`false` display to use `v-if`/`v-else-if` — eliminates null entries in the Boolean template's Fragment children array

**`pluginPropView.vue`**
- Replaced `v-if="allowCopy"` with `v-show="allowCopy"` on all copy icon `<i>` elements — since `allowCopy` defaults to `false`, `v-if` was producing null in children arrays for every `PluginPropView` instance in show mode
- Added guard `prop.desc ? $t(prop.desc) : ''` to prevent `SyntaxError: 17` in vue-i18n when `prop.desc` is `undefined`
- Added `<template v-else></template>` for Boolean template `v-if` and Options `v-else-if` cases

---

### Root Cause 2: `JsonUtil.parseRequestBody` silently drops request body — causes destructive save

**`JsonUtil.groovy`** — `parseRequestBody` had a Servlet spec violation that caused intermittent silent data loss:

The old code called `getInputStream()` first (Attempt 1). When `available() == 0` (common on proxied/ALB network connections due to TCP buffering timing), it fell through without reading anything. Attempt 2 then called `getReader()`, which throws `IllegalStateException` because `getInputStream()` was already called. That exception was caught silently, returning `null`.

With `body == null`, `saveProjectPlugins` proceeded with `plugins = []`, then `updateFrameworkProjectConfig` deleted **all** `resources.source.*` project properties and wrote nothing back. This is the random deletion in production.

**Fix:**
- `JsonUtil.parseRequestBody`: call `getReader()` first (never `getInputStream()` before `getReader()`). Fall back to `getInputStream().readAllBytes()` only if `getReader()` throws. Added `log.error` at each failure point for diagnosability.
- `FrameworkController.saveProjectPlugins`: added null body guard — returns HTTP 400 with a clear error message instead of silently proceeding with an empty plugin list.

**`ResourceModelRunnerFilter.vue`** (rundeckpro)
- Added `desc: ""` to `propsData` entries to prevent `$t(undefined)` → `SyntaxError: 17` in vue-i18n, which left `subTree = null` and triggered the null vnode crash cascade.

---

**Describe alternatives you've considered**

- Upgrading Vue to a patch version that handles null children in `unmountChildren` more gracefully — not viable as it would require full regression testing
- Using `v-memo` on v-for items to prevent unnecessary re-renders — partially effective but doesn't address the null vnode root cause
- Using `@RequestBody` annotation on `saveProjectPlugins` to let Spring/Micronaut handle body parsing — valid long-term fix, but requires broader controller refactoring

**Additional context**

The root cause of null vnodes in Vue 3.5 is that `v-if` without `v-else` inside non-block elements (compiled with `createElementVNode` rather than `createElementBlock`) generates `null` as the false branch in the children array. When `unmountChildren` iterates these arrays, it calls `unmount(null)` which crashes with `TypeError: Cannot destructure property 'type' of 'vnode' as it is null`.

The `JsonUtil` bug is intermittent because `available()` on a `ByteArrayInputStream` (unit tests) always returns > 0, but on Tomcat's real network stream with an AWS ALB, it can return 0 before all TCP segments arrive.

## Release Notes

Fixed intermittent node sources deletion in the project nodes configuration page. Two independent bugs were addressed: Vue 3.5 null vnode crashes that could corrupt component state during Add/Delete operations, and a request body parsing bug in `JsonUtil.parseRequestBody` that caused `saveProjectPlugins` to silently proceed with an empty plugin list — deleting all node sources — when the HTTP input stream was not immediately available.

[RUN-4521]: https://pagerduty.atlassian.net/browse/RUN-4521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ