### PR TITLE
[RUN-4523] Upgrade Spring Framework to 6.2.19 for CVE-2026-41850 and CVE-2026-41840

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,6 +151,9 @@ logger.lifecycle("Building version {}", project.resolvedVersion)
 allprojects {
     version = project.resolvedVersion
     ext["spring.version"] = springVersion
+    // Spring Boot's dependency-management BOM overrides Spring Framework via this property name
+    // (ext["spring.version"] alone does NOT move the BOM-managed spring-framework version).
+    ext["spring-framework.version"] = springVersion
     ext.isReleaseBuild = false
     ext.isSnapshotBuild = false
     ext.isDevBuild = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ grailsVersion=7.1.1
 # Core framework versions - prefer BOM-managed versions where possible
 # Required for plugin declaration in build.gradle
 springBootVersion=3.5.14
-springVersion=6.2.18
+springVersion=6.2.19
 micronautPlatformVersion=4.9.4
 micronautOpenapiVersion=6.20.0
 springCloudContextVersion=4.3.2


### PR DESCRIPTION
## Security Fix

**CVEs:** CVE-2026-41850, CVE-2026-41840
**Component:** Spring Framework
**Fix:** `springVersion` `6.2.18` → `6.2.19`

## Changes
- `gradle.properties`: `springVersion=6.2.19`