### PR TITLE
[RUN-4526] Fix ExecutionsCleanUp slow query: ORDER BY e.id desc instead of dateCompleted asc

### DIFF
--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
@@ -157,8 +157,7 @@ class ExecutionsCleanUp implements InterruptableJob {
         List<Long> jobList = Execution.executeQuery(
             """select e.id from Execution e 
                where e.project = :project 
-               and e.dateCompleted <= :endDate 
-               order by e.id desc""",
+               and e.dateCompleted <= :endDate""",
             [
                 project: project,
                 endDate: endDate

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionsCleanUp.groovy
@@ -158,7 +158,7 @@ class ExecutionsCleanUp implements InterruptableJob {
             """select e.id from Execution e 
                where e.project = :project 
                and e.dateCompleted <= :endDate 
-               order by e.dateCompleted asc""",
+               order by e.id desc""",
             [
                 project: project,
                 endDate: endDate


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bug fix. The `searchExecutions` method in `ExecutionsCleanUp.groovy` has a slow query that exceeds the 28-second Aurora MySQL connection timeout under two distinct scenarios, triggering `FailoverSuccessSQLException` events in production.

Fixes [RUN-4526](https://pagerduty.atlassian.net/browse/RUN-4526)

**Describe the solution you've implemented**

Changed `ORDER BY e.dateCompleted ASC` to `ORDER BY e.id DESC` in the `searchExecutions` JPQL query. This addresses Root Cause 1. Root Cause 2 (cold buffer pool for old thresholds) is still under investigation — see findings below.

---

### Root Cause 1 — Wrong index traversal for recent thresholds

`EXEC_IDX_3` is defined as `(project, dateCompleted)`. The optimizer was traversing it using **only the `date_completed` column** (skipping `project`) to avoid a filesort, forcing a full range scan of all rows with `date_completed <= endDate` across all projects, then post-filtering by project.

`ORDER BY e.id DESC` uses a backward scan of the clustered PRIMARY KEY index with early LIMIT termination. For recent thresholds, most recent IDs have already completed, so 500 matches are found quickly.

| Query | `rows_examined` | Time |
|---|---|---|
| `ORDER BY date_completed ASC` | 8,336,077 | 7.47s |
| `ORDER BY id DESC` | 2,945 | **0.46s** |

---

### Root Cause 2 — Cold buffer pool for old thresholds (open)

When `maxDaysToKeep = 60` (the default), `endDate` is ~60 days in the past. With `ORDER BY id DESC`, MySQL scans backward from the highest IDs (most recent executions), but these rows do **not** satisfy `dateCompleted <= 60-days-ago` — early termination never kicks in, and the query must traverse all recent rows before reaching old ones.

On a cold Aurora buffer pool, this generates massive storage I/O:

| Run | Buffer pool state | Time |
|---|---|---|
| 1st | Cold — pages read from Aurora Storage | **74s → exceeds 28s timeout, connection lost** |
| 2nd | Warm — pages already in buffer pool | 1.61s |

The cleanup job always fails on first run after a cold start or buffer pool eviction.

**Next steps for Root Cause 2:**
- Confirm EXPLAIN plan for no-ORDER-BY variant — should use `EXEC_IDX_3` with `project` as leading key (correct bounded range scan)
- Run `ANALYZE TABLE execution` to update optimizer statistics
- If full table scan confirmed: force index via `USE INDEX (EXEC_IDX_3)` in native SQL

**Describe alternatives you've considered**

- `ORDER BY e.id ASC` — also uses PK forward scan with early termination, preserves oldest-first semantic needed by `minimumExecutionToKeep` trimming logic (see inline comment discussion)
- Remove `ORDER BY` entirely — would let optimizer use `EXEC_IDX_3 (project, dateCompleted)` with correct column order for all threshold dates; results come back in `dateCompleted ASC` order naturally via index traversal

**Additional context**

Datadog APM trace showing the failover triggered during this query:
https://app.datadoghq.com/apm/trace/6a297bf000000000137e45a7b08bd8c5?spanID=4913068879845778572&timeHint=1781103628073

## Release Notes

Performance fix for the `ExecutionsCleanUp` job: changed query ordering to use primary key index scan, reducing Aurora MySQL query time from ~7.5s to ~0.5s for recent thresholds. Cold buffer pool behaviour for older thresholds (60+ days) still under investigation.


[RUN-4526]: https://pagerduty.atlassian.net/browse/RUN-4526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ