### PR TITLE
[RUN-4439] Fix OffsetPagination Watcher

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/OffsetPagination.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/OffsetPagination.vue
@@ -68,8 +68,10 @@ export default defineComponent({
     },
   },
   watch: {
-    "pagination.offset"(newVal) {
-      this.currentPage = this.pageNumberForOffset(newVal);
+    "pagination.offset"(newVal, oldVal) {
+      if (newVal !== oldVal) {
+        this.currentPage = this.pageNumberForOffset(newVal);
+      }
     },
   },
   mounted() {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/OffsetPagination.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/OffsetPagination.vue
@@ -68,12 +68,8 @@ export default defineComponent({
     },
   },
   watch: {
-    "pagination.offset": {
-      handler(newVal) {
-        if (this.pagination.offset !== newVal) {
-          this.currentPage = this.pageNumberForOffset(newVal);
-        }
-      },
+    "pagination.offset"(newVal) {
+      this.currentPage = this.pageNumberForOffset(newVal);
     },
   },
   mounted() {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/Pagination.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/Pagination.vue
@@ -48,12 +48,17 @@
             href="#"
             :class="navigationClass"
             :title="'Page ' + page.page"
+            :data-testid="`pagination-page-${page.page}`"
             @click.prevent="changePage(page.page)"
             >{{ page.page }}</a
           >
-          <span v-else :class="navigationClass" :title="'Page ' + page.page">{{
-            page.page
-          }}</span>
+          <span
+            v-else
+            :class="navigationClass"
+            :title="'Page ' + page.page"
+            data-testid="pagination-current-page"
+            >{{ page.page }}</span
+          >
         </li>
         <li :class="{ disabled: !hasNextButton || disabled }">
           <a

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/tests/OffsetPagination.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/utils/tests/OffsetPagination.spec.ts
@@ -1,0 +1,41 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import OffsetPagination from "../OffsetPagination.vue";
+
+const mountComponent = async (offset = 0, max = 10, total = 30) => {
+  const wrapper = mount(OffsetPagination, {
+    props: { pagination: { offset, max, total } },
+  });
+  await flushPromises();
+  return wrapper;
+};
+
+describe("OffsetPagination", () => {
+  it("shows correct active page on mount for different offsets", async () => {
+    const wrapper1 = await mountComponent(0, 10, 30);
+    expect(
+      wrapper1.find('[data-testid="pagination-current-page"]').text(),
+    ).toBe("1");
+
+    const wrapper2 = await mountComponent(10, 10, 30);
+    expect(
+      wrapper2.find('[data-testid="pagination-current-page"]').text(),
+    ).toBe("2");
+
+    const wrapper3 = await mountComponent(20, 10, 30);
+    expect(
+      wrapper3.find('[data-testid="pagination-current-page"]').text(),
+    ).toBe("3");
+  });
+
+  it("emits the correct offset when user clicks page links", async () => {
+    const wrapper = await mountComponent(0, 10, 30);
+
+    await wrapper.find('[data-testid="pagination-page-2"]').trigger("click");
+    const changes = wrapper.emitted("change");
+    expect(changes).toBeTruthy();
+    expect(changes?.[0]).toEqual([10]);
+
+    await wrapper.find('[data-testid="pagination-page-3"]').trigger("click");
+    expect(changes?.[1]).toEqual([20]);
+  });
+});


### PR DESCRIPTION
<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Bug fix

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
Fixed a broken watcher in OffsetPagination.vue where the condition this.pagination.offset !== newVal was always false (since newVal is pagination.offset in a Vue watcher). This meant currentPage never updated when the parent changed the offset programmatically — the list would reload on the correct page but the active page button would stay stuck on the old page.
**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

## Release Notes

<!-- If you have suggested content that would describe this PR to other Rundeck community users, please enter it here.-->