### PR TITLE
[RUN-4435] Update workflow strategy validation to allow node-first and step-first with conditionals

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -3059,14 +3059,21 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 }
             }
             
-            // If conditional steps exist, strategy must be sequential or parallel
-            if (hasConditionalSteps && strategy != null && strategy != "sequential" && strategy != "parallel") {
+            // If conditional steps exist, strategy must be sequential, parallel, node-first, or step-first
+            final Set<String> supportedConditionalStrategies = [
+                    'sequential',
+                    'parallel',
+                    'node-first',
+                    'step-first'
+            ] as Set<String>
+
+            if (hasConditionalSteps && strategy != null && !supportedConditionalStrategies.contains(strategy)) {
                 failed = true
                 scheduledExecution.errors.rejectValue(
-                    'workflow',
-                    'scheduledExecution.workflow.conditional.strategy.invalid.message',
-                    [strategy] as Object[],
-                    "Conditional steps can only be used with 'sequential' or 'parallel' workflow strategy. Current strategy: {0}"
+                        'workflow',
+                        'scheduledExecution.workflow.conditional.strategy.invalid.message',
+                        [strategy] as Object[],
+                        "Conditional steps can only be used with 'sequential', 'parallel', 'node-first', or 'step-first' workflow strategy. Current strategy: {0}"
                 )
             }
         }


### PR DESCRIPTION
## Jira Ticket

[RUN-4435](https://rundeckpro.atlassian.net/browse/RUN-4435)

## Summary

Update ScheduledExecutionService workflow strategy validation to allow conditional steps with node-first and step-first execution strategies in addition to sequential and parallel.

## Changes

- Updated validation in `ScheduledExecutionService.groovy` to allow `node-first` and `step-first` strategies when conditional steps are present
- Updated error message to reflect all supported strategies: sequential, parallel, node-first, and step-first

## Context

This change enables conditional logic support for all workflow execution strategies. Previously, conditional steps were only allowed with sequential and parallel strategies, which prevented their use in node-first workflows.

Node-first execution runs all workflow steps on each node before moving to the next node, making it useful for minimizing context switching overhead when executing across multiple nodes.

## Related Changes

This change is required for the corresponding rundeckpro PR that implements ConditionalNodeFirstStrategy: https://github.com/rundeckpro/rundeckpro/pull/4758

## Testing

- Validation logic updated to include new strategies
- Error message updated to reflect supported strategies
- Existing validation behavior preserved for unsupported strategies

[RUN-4435]: https://pagerduty.atlassian.net/browse/RUN-4435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ