### PR TITLE
[RUN-2869] Bump py-winrm-plugin to 3.2.0

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ rundeck:
   plugins: # Extra plugins to bundle
   - "org.rundeck.plugins:ansible-plugin:5.0.1"
   - "org.rundeck.plugins:aws-s3-model-source:2.0.0"
-  - "org.rundeck.plugins:py-winrm-plugin:3.1.0"
+  - "org.rundeck.plugins:py-winrm-plugin:3.2.0"
   - "org.rundeck.plugins:openssh-node-execution:3.0.0"
   - "org.rundeck.plugins:multiline-regex-datacapture-filter:2.0.0"
   - "org.rundeck.plugins:attribute-match-node-enhancer:1.0.0"


### PR DESCRIPTION
## Release Notes

Resolved intermittent failures of Windows (WinRM) jobs using Kerberos authentication when many executions run concurrently. Previously, running large numbers of Kerberos WinRM jobs at the same time could fail with `GSSError: Credential cache is empty` because all executions shared a single Kerberos credential cache. Each execution now uses its own isolated credential cache, so high-concurrency WinRM workloads run reliably.

## Jira Ticket
[RUN-2869](https://pagerduty.atlassian.net/browse/RUN-2869)

## Summary
Bumps `py-winrm-plugin` from `3.1.0` to `3.2.0` which fixes a Kerberos concurrent credential cache race condition.

## Root Cause (fixed in 3.2.0)
When 40+ jobs execute concurrently with Kerberos WinRM auth, all `winrm-exec.py` processes shared the same default Kerberos cache file (`/tmp/krb5cc_<uid>`) because `kinit` was called without setting `KRB5CCNAME`. Concurrent writes corrupted the cache, causing intermittent `GSSError: Credential cache is empty`.

## Fix (in py-winrm-plugin 3.2.0)
Each execution now derives a unique `KRB5CCNAME` from `RD_JOB_EXECID`, isolating credential caches across concurrent executions.

## Related PRs
- py-winrm-plugin fix: https://github.com/rundeck-plugins/py-winrm-plugin/pull/118

## Note
This PR depends on py-winrm-plugin 3.2.0 being published to Maven. Merge after the plugin PR is merged and 3.2.0 is released.

Made with [Cursor](https://cursor.com)

[RUN-2869]: https://pagerduty.atlassian.net/browse/RUN-2869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ