### PR TITLE
[RUN-4530] Improve the recursive pattern of menu building.

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -527,7 +527,7 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
 
         def finishq=scheduledExecutionService.finishquery(query,params,qres)
 
-        def allScheduled = schedlist.findAll { jobSchedulesService.isScheduled(it.uuid) }
+        def allScheduled = schedlist.findAll { it.scheduled }
         def nextExecutions=scheduledExecutionService.nextExecutionTimes(allScheduled)
         def nextOneTimeScheduledExecutions = query.runJobLaterFilter ? scheduledExecutionService.nextOneTimeScheduledExecutions(schedlist) : null
 

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2959,7 +2959,7 @@ Authorization required: `delete` on project resource type `job`, and `delete` on
                             jobs          : jobs,
                             errjobs       : errjobs,
                             skipjobs      : skipjobs,
-                            nextExecutions: scheduledExecutionService.nextExecutionTimes(jobs.grep { scheduledExecutionService.isScheduled(it) }),
+                            nextExecutions: scheduledExecutionService.nextExecutionTimes(jobs.grep { it.scheduled }),
                             messages      : msgs,
                             didupload     : true
                     ]

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -2047,8 +2047,8 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
 
         def query = new ScheduledExecutionQuery()
         params.project='test'
-        ScheduledExecution job1 = new ScheduledExecution(createJobParams(jobName: 'job1', uuid:testUUID))
-        ScheduledExecution job2 = new ScheduledExecution(createJobParams(jobName: 'job2', uuid:testUUID2,scheduled:false))
+        ScheduledExecution job1 = new ScheduledExecution(createJobParams(jobName: 'job1', uuid:testUUID, scheduled:aScheduled))
+        ScheduledExecution job2 = new ScheduledExecution(createJobParams(jobName: 'job2', uuid:testUUID2, scheduled:bScheduled))
 
         when:
         def model = controller.jobs(query)
@@ -2067,8 +2067,6 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
                                                                           offset        : 0,
                                                                           paginateParams: [:],
                                                                           displayParams : [:]]
-        1 * controller.jobSchedulesService.isScheduled(testUUID) >> aScheduled
-        1 * controller.jobSchedulesService.isScheduled(testUUID2) >> bScheduled
         model.jobListIds.size() == 2
         model.jobListIds.size() == model.nextScheduled.size()
         model.jobListIds == model.nextScheduled*.extid
@@ -2103,6 +2101,7 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
         controller.scmService = Mock(ScmService)
         controller.userService = Mock(UserService)
         controller.jobSchedulesService = Mock(JobSchedulesService)
+        controller.scheduledExecutionService.jobSchedulesService = controller.jobSchedulesService
         controller.authContextEvaluatorCacheManager = new AuthContextEvaluatorCacheManager()
         controller.scheduledExecutionService.applicationContext = applicationContext
 
@@ -2191,6 +2190,7 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
         }
         controller.scheduledExecutionService = new ScheduledExecutionService()
         controller.jobSchedulesService = Mock(JobSchedulesService)
+        controller.scheduledExecutionService.jobSchedulesService = controller.jobSchedulesService
         controller.scheduledExecutionService.applicationContext = applicationContext
 
         controller.jobListLinkHandlerRegistry = Mock(JobListLinkHandlerRegistry) {
@@ -2299,7 +2299,6 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
                                                                           offset        : 0,
                                                                           paginateParams: [:],
                                                                           displayParams : [:]]
-        1 * controller.jobSchedulesService.isScheduled(testUUID) >> true
         1 * controller.scheduledExecutionService.nextExecutionTimes([job1]) >> [(job1.id):new Date()]
         model.nextExecutions!=null
         model.nextExecutions[job1.id]!=null

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerSpec.groovy
@@ -2802,7 +2802,6 @@ class ScheduledExecutionControllerSpec extends Specification implements Controll
                         jobs:[job]
                 ]
                 1 * issueJobChangeEvents(_)
-                1 * isScheduled(job)>>true
                 1 * nextExecutionTimes([job])>>[(job.id):new Date()]
                 _*calculateJobStats(_)>>Mock(JobStatsProvider.JobStats)
                 0 * _(*_)


### PR DESCRIPTION
This rest on the following assumption:

JobSchedulesService.isScheduled(uuid) is ScheduledExecution.findByUuid(jobUUID)?.scheduled
 it just reloads the row to read the same column. The objects in schedlist are fully hydrated ScheduledExecutions from
  listWorkflows, so it.scheduled returns the same value without the round-trip.

The behaviour should therefore not change, but the query count should be reduced.

Process fllowed
1. Followed the guidelines, however some part of the test suite requires a token. I ran focused tests for this change.
2. See https://github.com/rundeck/rundeck/issues/10208


**Is this a bugfix, or an enhancement? Please describe.**
bugfix to speed up menu loading

**Describe the solution you've implemented**
There is no functional change but database queries are avoided -> equivalent solution to what was already there.

**Describe alternatives you've considered**
More optimizations were considered, but this is the core change. Let's keep it simple and just do this.

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

## Release Notes

Job menu loading could be slow for large environments. This is now faster as one query per job is avoided.