### PR TITLE
[RUN-3955] Exclude mysql-connector-java from classpath to fix spuriou…

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -71,6 +71,11 @@ configurations.all {
         }
     }
     exclude group: 'io.micronaut', module: 'micronaut-bom'
+    // mysql-connector-java registers com.mysql.jdbc.Driver via JDBC SPI, causing spurious HikariCP
+    // ERROR logs at startup even when org.mariadb.jdbc.Driver is configured. Rundeck ships
+    // mariadb-java-client for MySQL/MariaDB connectivity; mysql-connector-java is not needed.
+    exclude group: 'mysql', module: 'mysql-connector-java'
+    exclude group: 'com.mysql', module: 'mysql-connector-j'
 }
 
 //list of grails plugins to depend on in various ways


### PR DESCRIPTION

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->
Bugfix.

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->
mysql-connector-java was being pulled into the WAR as a transitive dependency and registering com.mysql.jdbc.Driver via Java's JDBC ServiceLoader SPI (META-INF/services/java.sql.Driver). At startup, HikariCP validates all SPI-registered drivers and tries to load com.mysql.jdbc.Driver — which fails because the class is not loadable from Spring Boot's LaunchedURLClassLoader, producing a spurious ERROR log even when org.mariadb.jdbc.Driver is correctly configured.

The fix excludes both MySQL Connector/J artifact IDs from the Gradle configurations.all block in rundeckapp/build.gradle:

mysql:mysql-connector-java (Connector/J 5.x and early 8.x)
com.mysql:mysql-connector-j (Connector/J 8.0.31+ renamed artifact)
Rundeck ships mariadb-java-client for MySQL/MariaDB connectivity and does not need mysql-connector-java. The enterprise WAR build already excluded this JAR at the packaging step — this fix applies the exclusion upstream at the Gradle configuration level so it never enters the resolved classpath at all.

Verified by inspecting all 358 JARs in WEB-INF/lib/ of the built WAR: com.mysql.jdbc.Driver is not registered by any JAR via JDBC SPI.
**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

## Release Notes

<!-- If you have suggested content that would describe this PR to other Rundeck community users, please enter it here.-->