### PR TITLE
[RUN-4270] Fix NPE and SQL logic bugs for MSSQL case-sensitive collation

### DIFF
--- a/rundeckapp/grails-app/migrations/core/WorkflowStepNVARCHAR.groovy
+++ b/rundeckapp/grails-app/migrations/core/WorkflowStepNVARCHAR.groovy
@@ -4,7 +4,7 @@ databaseChangeLog = {
         preConditions(onFail: 'MARK_RAN') {
             grailsPrecondition {
                 check {
-                    def ran = sql.firstRow("SELECT count(*) as num FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'workflow_step' AND (COLUMN_NAME = 'description' AND DATA_TYPE = 'varchar') OR (COLUMN_NAME = 'adhoc_remote_string' AND DATA_TYPE = 'varchar')").num
+                    def ran = sql.firstRow("SELECT count(*) as num FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME COLLATE Latin1_General_CI_AS = 'workflow_step' AND ((COLUMN_NAME COLLATE Latin1_General_CI_AS = 'description' AND DATA_TYPE COLLATE Latin1_General_CI_AS = 'varchar') OR (COLUMN_NAME COLLATE Latin1_General_CI_AS = 'adhoc_remote_string' AND DATA_TYPE COLLATE Latin1_General_CI_AS = 'varchar'))").num
                     if (ran == 0) fail('precondition is not satisfied')
                 }
             }

--- a/rundeckapp/grails-app/migrations/core/WorkflowStepVARCHARtoNVARCHAR.groovy
+++ b/rundeckapp/grails-app/migrations/core/WorkflowStepVARCHARtoNVARCHAR.groovy
@@ -4,7 +4,7 @@ databaseChangeLog = {
         preConditions(onFail: 'MARK_RAN') {
             grailsPrecondition {
                 check {
-                    def ran = sql.firstRow("SELECT count(*) as num FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'workflow_step' AND COLUMN_NAME = 'adhoc_local_string' AND DATA_TYPE = 'varchar'").num
+                    def ran = sql.firstRow("SELECT count(*) as num FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME COLLATE Latin1_General_CI_AS = 'workflow_step' AND COLUMN_NAME COLLATE Latin1_General_CI_AS = 'adhoc_local_string' AND DATA_TYPE COLLATE Latin1_General_CI_AS = 'varchar'").num
                     if (ran == 0) fail('precondition is not satisfied')
                 }
             }

--- a/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ProjectManagerService.groovy
@@ -768,6 +768,10 @@ class ProjectManagerService implements ProjectManager, ApplicationContextAware, 
         long start=System.currentTimeMillis()
         log.info("Loading project definition for ${project}...")
         def projectData = projectDataProvider.findByName(project)
+        if (projectData == null) {
+            log.warn("Project '${project}' not found in database during loadProject despite existsFrameworkProject returning true")
+            return null
+        }
         def description = projectData.description
         def rdproject = new RundeckProject(projectData,null, this)
         //preload cached readme/motd


### PR DESCRIPTION
## Summary

Fixes startup `NullPointerException` when running Rundeck on MSSQL 2022 with `SQL_Latin1_General_CP1_CS_AS` (case-sensitive) collation. Reported by customer Allianz Technology of America running Docker + Azure Managed Instance MSSQL 2022 version 5.7; reproducible on 5.14 and 5.20.

## What changed

### 1. `WorkflowStepNVARCHAR.groovy` — SQL logic bug + CS collation fix
**Bug**: The `OR` condition in the `grailsPrecondition` SQL lacked proper parenthesization. Because `AND` binds tighter than `OR`, the second OR branch had no `TABLE_NAME` filter, meaning it could match columns from unrelated tables and produce a false-positive count.

**Before:**
```sql
WHERE TABLE_NAME = 'workflow_step' AND (COLUMN_NAME = 'description' AND DATA_TYPE = 'varchar')
OR (COLUMN_NAME = 'adhoc_remote_string' AND DATA_TYPE = 'varchar')
```
**After:** Wrapped the full OR in outer parens and added `COLLATE Latin1_General_CI_AS` to each string comparison so the precondition is collation-agnostic.

### 2. `WorkflowStepVARCHARtoNVARCHAR.groovy` — CS collation fix
Added `COLLATE Latin1_General_CI_AS` to the `INFORMATION_SCHEMA` string comparisons in the sister migration's precondition for the same reason.

### 3. `ProjectManagerService.loadProject` — NPE guard
`findByName(project)` can return `null` under a race condition (project deleted between `existsFrameworkProject` and `findByName`) or a CS collation case-mismatch between project names stored in different tables. Previously this caused an NPE at `projectData.description`. Now logs a warning and returns `null` cleanly (Guava raises `InvalidCacheLoadException` instead, which is surfaced with a meaningful message).

## Why `COLLATE Latin1_General_CI_AS`?
With CS collation, `INFORMATION_SCHEMA.COLUMNS` string comparisons are case-sensitive. While the values involved (`'workflow_step'`, `'varchar'`, etc.) are consistently lowercase and should match, making the COLLATE explicit removes any ambiguity and future-proofs the migrations against schema or collation changes.

## Reviewer notes
- These migrations are `dbms: "mssql"` only — no impact on H2/PostgreSQL/MySQL.
- `COLLATE Latin1_General_CI_AS` is a standard T-SQL collation available on all SQL Server versions (2008+) and Azure SQL/Managed Instance.
- The `loadProject` null return triggers `InvalidCacheLoadException` from Guava, which propagates up through `getFrameworkProject` — same failure mode as when `existsFrameworkProject` returns false, just with a log warning first.