### PR TITLE
[RUN-4214] Audit failed login attempts when using rundeck.jaaslogin=true

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/events/UserActionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/events/UserActionService.groovy
@@ -57,11 +57,15 @@ class UserActionService implements LogoutHandler{
         }
     }
 
-    private String extractUsername(Authentication authentication) {
-        if (!authentication){
-            log.error("Null authentication on event")
-            return null
-        }
-        return authentication.name ?: authentication.principal.name ?: null
+    /**
+     * Extracts the username from an authentication object without side effects.
+     * Returns null if authentication is null or no username can be determined;
+     * callers are responsible for logging when null is returned.
+     */
+    private static String extractUsername(Authentication authentication) {
+        if (!authentication) return null
+        if (authentication.name) return authentication.name
+        if (authentication.principal instanceof String) return authentication.principal as String
+        return authentication.principal?.name ?: null
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/events/UserActionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/events/UserActionService.groovy
@@ -2,6 +2,7 @@ package rundeck.services.events
 
 import grails.gorm.transactions.Transactional
 import org.springframework.context.event.EventListener
+import org.springframework.security.authentication.event.AuthenticationFailureServiceExceptionEvent
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.logout.LogoutHandler
@@ -26,6 +27,24 @@ class UserActionService implements LogoutHandler{
             userService.registerLogin(extractUsername(event.authentication), sessionId)
         }else{
             log.error("Null user name on handleAuthenticationSuccessEvent")
+        }
+    }
+
+    /**
+     * Handles failed authentication events produced by JAAS login providers.
+     * When {@code rundeck.jaaslogin=true}, Spring Security publishes
+     * {@code AuthenticationFailureServiceExceptionEvent} for failed logins instead of
+     * {@code AuthenticationFailureBadCredentialsEvent}, leaving a gap in login-failure tracking.
+     *
+     * @param event the JAAS authentication failure event
+     */
+    @EventListener
+    void handleAuthenticationFailureServiceExceptionEvent(AuthenticationFailureServiceExceptionEvent event) {
+        def username = extractUsername(event?.authentication)
+        if (username != null) {
+            log.warn("Failed login attempt (JAAS) for user: ${username}")
+        } else {
+            log.error("Null user name on handleAuthenticationFailureServiceExceptionEvent")
         }
     }
 

--- a/rundeckapp/src/main/groovy/rundeck/services/audit/AuditEventsService.groovy
+++ b/rundeckapp/src/main/groovy/rundeck/services/audit/AuditEventsService.groovy
@@ -26,6 +26,7 @@ import org.springframework.context.event.EventListener
 import org.springframework.core.task.AsyncTaskExecutor
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent
+import org.springframework.security.authentication.event.AuthenticationFailureServiceExceptionEvent
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
@@ -209,6 +210,32 @@ class AuditEventsService
             return
         }
 
+        eventBuilder()
+                .setUsername(extractUsername(event.authentication))
+                .setUserRoles(extractAuthorities(event.authentication))
+                .setActionType(ActionTypes.LOGIN_FAILED)
+                .setResourceType(ResourceTypes.USER)
+                .setResourceName(extractUsername(event.authentication))
+                .publish()
+    }
+
+    /**
+     * Handles authentication failure events produced by JAAS login providers.
+     * When {@code rundeck.jaaslogin=true}, Spring Security wraps the JAAS {@code LoginException}
+     * as an {@code AuthenticationServiceException} and publishes
+     * {@code AuthenticationFailureServiceExceptionEvent} — a different type than the
+     * {@code AuthenticationFailureBadCredentialsEvent} used by the built-in realm provider.
+     * Without this listener, JAAS login failures are silently dropped from the audit log.
+     *
+     * @param event the JAAS authentication failure event
+     */
+    @EventListener
+    void handleAuthenticationServiceExceptionFailureEvent(AuthenticationFailureServiceExceptionEvent event) {
+        userLoginFailure.inc()
+        if (!event.authentication) {
+            LOG.error("Null authentication on JAAS login failure event. Cancelling event dispatch.")
+            return
+        }
 
         eventBuilder()
                 .setUsername(extractUsername(event.authentication))

--- a/rundeckapp/src/test/groovy/rundeck/services/audit/AuditEventsServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/audit/AuditEventsServiceSpec.groovy
@@ -11,6 +11,7 @@ import org.grails.plugins.metricsweb.MetricService
 import org.grails.spring.beans.factory.InstanceFactoryBean
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent
+import org.springframework.security.authentication.event.AuthenticationFailureServiceExceptionEvent
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent
 import org.springframework.security.core.Authentication
 import rundeck.services.FrameworkService
@@ -131,6 +132,76 @@ class AuditEventsServiceSpec extends Specification implements ServiceUnitTest<Au
         !receivedEvent.userInfo.userRoles.is(roleList)
         receivedEvent.userInfo.userRoles == roleList
         receivedEvent.requestInfo.serverUUID == uuid
+    }
+
+    def "JAAS login failure dispatches LOGIN_FAILED audit event"() {
+        given:
+        defineBeans {
+            frameworkService(InstanceFactoryBean, Mock(FrameworkService) {
+                getServerUUID() >> "serverUUID"
+                getServerHostname() >> "serverHostname"
+                pluginService >> Mock(PluginService) {
+                    listPluginDescriptions(_) >> []
+                }
+            })
+            metricService(InstanceFactoryBean, Mock(MetricService) {
+                counter("userLogin", "success") >> Mock(Counter)
+                counter("userLogin", "failure") >> Mock(Counter)
+                counter("userLogout", "success") >> Mock(Counter)
+            })
+        }
+        service.installedPlugins = new HashMap<>()
+        def receivedEvent = null
+        CountDownLatch latch = new CountDownLatch(1)
+        service.addListener(new AuditEventListener() {
+            @Override
+            void onEvent(AuditEvent event) {
+                receivedEvent = event
+                latch.countDown()
+            }
+        })
+
+        when:
+        service.handleAuthenticationServiceExceptionFailureEvent(
+            Stub(AuthenticationFailureServiceExceptionEvent) {
+                getAuthentication() >> new UsernamePasswordAuthenticationToken("baduser", "pw")
+            })
+        latch.await(3, TimeUnit.SECONDS)
+
+        then:
+        receivedEvent?.actionType == ActionTypes.LOGIN_FAILED
+        receivedEvent?.userInfo?.username == "baduser"
+    }
+
+    def "JAAS login failure increments userLogin.failure counter"() {
+        given:
+        def failureCounter = Mock(Counter) {
+            1 * inc()
+        }
+        defineBeans {
+            frameworkService(InstanceFactoryBean, Mock(FrameworkService) {
+                getServerUUID() >> "serverUUID"
+                getServerHostname() >> "serverHostname"
+                pluginService >> Mock(PluginService) {
+                    listPluginDescriptions(_) >> []
+                }
+            })
+            metricService(InstanceFactoryBean, Mock(MetricService) {
+                counter("userLogin", "success") >> Mock(Counter)
+                counter("userLogin", "failure") >> failureCounter
+                counter("userLogout", "success") >> Mock(Counter)
+            })
+        }
+        service.installedPlugins = new HashMap<>()
+
+        when:
+        service.handleAuthenticationServiceExceptionFailureEvent(
+            Stub(AuthenticationFailureServiceExceptionEvent) {
+                getAuthentication() >> new UsernamePasswordAuthenticationToken("baduser", "pw")
+            })
+
+        then:
+        noExceptionThrown()
     }
 
     def "test metric counters"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/events/UserActionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/events/UserActionServiceSpec.groovy
@@ -2,6 +2,11 @@ package rundeck.services.events
 
 import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.core.appender.WriterAppender
+import org.apache.logging.log4j.core.layout.PatternLayout
 import org.springframework.security.authentication.event.AuthenticationFailureServiceExceptionEvent
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent
 import org.springframework.security.core.Authentication
@@ -33,12 +38,29 @@ class UserActionServiceSpec extends Specification implements ServiceUnitTest<Use
         AuthenticationFailureServiceExceptionEvent event = Mock(AuthenticationFailureServiceExceptionEvent) {
             getAuthentication() >> Mock(Authentication) { getName() >> "baduser" }
         }
+        def logOutput = new StringWriter()
+        def ctx = (LoggerContext) LogManager.getContext(false)
+        def config = ctx.getConfiguration()
+        def appender = WriterAppender.newBuilder()
+            .setConfiguration(config)
+            .setName("UserActionServiceTestCapture")
+            .setTarget(logOutput)
+            .setLayout(PatternLayout.newBuilder().withPattern("[%level] %msg%n").withConfiguration(config).build())
+            .build()
+        appender.start()
+        config.getRootLogger().addAppender(appender, Level.WARN, null)
+        ctx.updateLoggers()
 
         when:
         service.handleAuthenticationFailureServiceExceptionEvent(event)
 
         then:
-        noExceptionThrown()
+        logOutput.toString().contains("baduser")
+
+        cleanup:
+        config.getRootLogger().removeAppender("UserActionServiceTestCapture")
+        appender.stop()
+        ctx.updateLoggers()
     }
 
     void "handleAuthenticationFailureServiceExceptionEvent handles null authentication gracefully"() {

--- a/rundeckapp/src/test/groovy/rundeck/services/events/UserActionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/events/UserActionServiceSpec.groovy
@@ -2,6 +2,7 @@ package rundeck.services.events
 
 import grails.testing.gorm.DataTest
 import grails.testing.services.ServiceUnitTest
+import org.springframework.security.authentication.event.AuthenticationFailureServiceExceptionEvent
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent
 import org.springframework.security.core.Authentication
 import rundeck.services.UserService
@@ -24,6 +25,34 @@ class UserActionServiceSpec extends Specification implements ServiceUnitTest<Use
         service.handleAuthenticationSuccessEvent(event)
         then:
         true
+    }
+
+    void "handleAuthenticationFailureServiceExceptionEvent logs warning for JAAS login failure"() {
+        setup:
+        service.userService = Mock(UserService)
+        AuthenticationFailureServiceExceptionEvent event = Mock(AuthenticationFailureServiceExceptionEvent) {
+            getAuthentication() >> Mock(Authentication) { getName() >> "baduser" }
+        }
+
+        when:
+        service.handleAuthenticationFailureServiceExceptionEvent(event)
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "handleAuthenticationFailureServiceExceptionEvent handles null authentication gracefully"() {
+        setup:
+        service.userService = Mock(UserService)
+        AuthenticationFailureServiceExceptionEvent event = Mock(AuthenticationFailureServiceExceptionEvent) {
+            getAuthentication() >> null
+        }
+
+        when:
+        service.handleAuthenticationFailureServiceExceptionEvent(event)
+
+        then:
+        noExceptionThrown()
     }
 
     void "logout"() {


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

This is a bug fix. When Rundeck is configured with `rundeck.jaaslogin=true`, failed login attempts are not captured in the audit log, leaving no security trail for failed authentication events. Successful logins are audited correctly.

Related Jira ticket: [RUN-4214](https://pagerduty.atlassian.net/browse/RUN-4214)

**Describe the solution you've implemented**

`AuditEventsService` only listened to `AuthenticationFailureBadCredentialsEvent`. However, when JAAS is enabled, Spring Security wraps the JAAS `LoginException` via `DefaultLoginExceptionResolver` into `AuthenticationServiceException`, which is published as `AuthenticationFailureServiceExceptionEvent` — a different event type.

Added `@EventListener` handlers for `AuthenticationFailureServiceExceptionEvent` in:

- **`AuditEventsService`**: new `handleAuthenticationServiceExceptionFailureEvent()` method that mirrors the existing `BadCredentials` handler — increments `userLogin.failure` metric counter and dispatches a `LOGIN_FAILED` audit event with username, roles, and action type.
- **`UserActionService`**: new `handleAuthenticationFailureServiceExceptionEvent()` method that logs a warning with the username of the failed JAAS login attempt.

Both changes are surgical and isolated — the existing `AuthenticationFailureBadCredentialsEvent` handlers are unchanged, so non-JAAS login auditing is unaffected.

**Describe alternatives you've considered**

- **Listen to `AbstractAuthenticationFailureEvent`** (parent class of all failure events): would cover all providers in one handler but risks catching unintended events from OAuth2 or X509 flows.
- **Override `RundeckJaasAuthenticationProvider`** to re-throw `BadCredentialsException`: changes provider behavior and could affect callers; more invasive than necessary.

**Additional context**

Root cause: `DefaultLoginExceptionResolver` maps `LoginException` → `AuthenticationServiceException`, so the published Spring Security event type differs from non-JAAS failures. Successful JAAS logins are audited correctly because `ProviderManager` always publishes `AuthenticationSuccessEvent` regardless of provider type.

## Release Notes

Fixed: Failed login attempts are now audited when Rundeck is configured with `rundeck.jaaslogin=true`. Previously, JAAS authentication failures were silently dropped from the audit log.


[RUN-4214]: https://pagerduty.atlassian.net/browse/RUN-4214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ