### PR TITLE
[RUN-4525] SCM: Restore plugin resilience when Git server is temporarily unreachable

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginInputsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/scm/ScmPluginInputsSpec.groovy
@@ -11,7 +11,7 @@ import org.rundeck.util.container.BaseContainer
 @ExcludePro
 class ScmPluginInputsSpec extends ScmBaseContainer {
 
-    static List<String> COMMON_INPUT_FIELD_NAMES = ['pathTemplate','dir','url','branch','strictHostKeyChecking','sshPrivateKeyPath','gitPasswordPath','format','fetchAutomatically','pullAutomatically']
+    static List<String> COMMON_INPUT_FIELD_NAMES = ['pathTemplate','dir','url','branch','strictHostKeyChecking','sshPrivateKeyPath','gitPasswordPath','format','fetchAutomatically','fetchTimeout','pullAutomatically']
     static List<String> EXPORT_INPUT_FIELD_NAMES = ['committerName','committerEmail','exportUuidBehavior','createBranch','baseBranch'] + COMMON_INPUT_FIELD_NAMES
     static List<String> IMPORT_INPUT_FIELD_NAMES = ['importUuidBehavior','useFilePattern','filePattern'] + COMMON_INPUT_FIELD_NAMES
 

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/BaseGitPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/BaseGitPlugin.groovy
@@ -263,6 +263,7 @@ class BaseGitPlugin {
         def agit = git1 ?: git
         def fetchCommand = agit.fetch()
         fetchCommand.setRemote(REMOTE_NAME)
+        fetchCommand.setTimeout(commonConfig.getFetchTimeoutSeconds())
         setupTransportAuthentication(sshConfig, context, fetchCommand)
         def fetchResult = fetchCommand.call()
 
@@ -308,6 +309,7 @@ class BaseGitPlugin {
 
     PullResult gitPull(ScmOperationContext context, Git git1 = null) {
         def pullCommand = (git1 ?: git).pull().setRemote(REMOTE_NAME).setRemoteBranchName(branch)
+        pullCommand.setTimeout(commonConfig.getFetchTimeoutSeconds())
         setupTransportAuthentication(sshConfig, context, pullCommand)
         pullCommand.call()
     }

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitExportPlugin.groovy
@@ -353,10 +353,12 @@ class GitExportPlugin extends BaseGitPlugin implements ScmExportPlugin {
                 }
             }
         }
-        synchState.message=msgs? msgs.join(', ') : null
-        if (fetchError && synchState.state == SynchState.CLEAN) {
-            synchState.state = SynchState.REFRESH_NEEDED
+        // A fetch error means the remote is unreachable. Throw so callers can show a clear
+        // "Git server unavailable" message rather than a misleading local-state status.
+        if (fetchError) {
+            throw new ScmPluginException(msgs.join(', '))
         }
+        synchState.message=msgs? msgs.join(', ') : null
 
         return synchState
     }

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
@@ -211,6 +211,7 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
         }
 
         def msgs = []
+        boolean fetchError = false
         if (performFetch) {
             try {
                 fetchFromRemote(context)
@@ -218,6 +219,7 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
                     actions[ACTION_PULL].performAction(context,this,null,null,null)
                 }
             } catch (Exception e) {
+                fetchError = true
                 msgs<<"Fetch from the repository failed: ${e.message}"
                 logger.error("Failed fetch from the repository: ${e.message}")
                 logger.debug("Failed fetch from the repository: ${e.message}", e)
@@ -331,6 +333,11 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
         }
         if (deleted) {
             msgs << "${deleted} tracked file(s) were deleted"
+        }
+        // A fetch error means the remote is unreachable. Throw so callers can show a clear
+        // "Git server unavailable" message rather than a misleading local-state status.
+        if (fetchError) {
+            throw new ScmPluginException(msgs.join(', '))
         }
         state.message = msgs.join(', ')
         return state

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/GitImportPlugin.groovy
@@ -211,7 +211,6 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
         }
 
         def msgs = []
-        boolean fetchError = false
         if (performFetch) {
             try {
                 fetchFromRemote(context)
@@ -219,10 +218,11 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
                     actions[ACTION_PULL].performAction(context,this,null,null,null)
                 }
             } catch (Exception e) {
-                fetchError = true
-                msgs<<"Fetch from the repository failed: ${e.message}"
+                msgs << "Fetch from the repository failed: ${e.message}"
                 logger.error("Failed fetch from the repository: ${e.message}")
                 logger.debug("Failed fetch from the repository: ${e.message}", e)
+                // Short-circuit: skip expensive tree walk when the remote is unreachable.
+                throw new ScmPluginException(msgs.join(', '))
             }
         }
 
@@ -333,11 +333,6 @@ class GitImportPlugin extends BaseGitPlugin implements ScmImportPlugin {
         }
         if (deleted) {
             msgs << "${deleted} tracked file(s) were deleted"
-        }
-        // A fetch error means the remote is unreachable. Throw so callers can show a clear
-        // "Git server unavailable" message rather than a misleading local-state status.
-        if (fetchError) {
-            throw new ScmPluginException(msgs.join(', '))
         }
         state.message = msgs.join(', ')
         return state

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/config/Common.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/config/Common.groovy
@@ -240,6 +240,30 @@ Path can include variable references
         return fetchAutomatically in [null,'true']
     }
 
+    @PluginProperty(
+            title = "Fetch Timeout",
+            description = "Timeout in seconds for git fetch/pull network operations. Prevents an " +
+                    "unreachable or slow Git server from blocking indefinitely.",
+            defaultValue = '30',
+            required = false
+    )
+    @RenderingOption(
+            key = StringRenderingConstants.GROUP_NAME,
+            value = "Git Repository"
+    )
+    String fetchTimeout
+
+    /**
+     * @return the configured fetch/pull timeout in seconds, or 30 if unset or not a valid number
+     */
+    int getFetchTimeoutSeconds() {
+        try {
+            fetchTimeout ? Integer.parseInt(fetchTimeout) : 30
+        } catch (NumberFormatException ignored) {
+            30
+        }
+    }
+
 
     static List<Property> addDirDefaultValue(List<Property> properties, File basedir, String finalDir) {
         if (null == basedir) {

--- a/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/config/Common.groovy
+++ b/plugins/git-plugin/src/main/groovy/org/rundeck/plugin/scm/git/config/Common.groovy
@@ -240,28 +240,39 @@ Path can include variable references
         return fetchAutomatically in [null,'true']
     }
 
+    static class FetchTimeoutValidator implements PropertyValidator {
+        @Override
+        boolean isValid(final String value) throws ValidationException {
+            try {
+                if (Integer.parseInt(value) <= 0) {
+                    throw new ValidationException("Fetch Timeout must be a positive number of seconds.")
+                }
+            } catch (NumberFormatException e) {
+                throw new ValidationException("Fetch Timeout must be a valid number.")
+            }
+            true
+        }
+    }
+
     @PluginProperty(
             title = "Fetch Timeout",
             description = "Timeout in seconds for git fetch/pull network operations. Prevents an " +
-                    "unreachable or slow Git server from blocking indefinitely.",
+                    "unreachable or slow Git server from blocking indefinitely. Must be a positive number.",
             defaultValue = '30',
-            required = false
+            required = false,
+            validatorClass = FetchTimeoutValidator
     )
     @RenderingOption(
             key = StringRenderingConstants.GROUP_NAME,
             value = "Git Repository"
     )
-    String fetchTimeout
+    Integer fetchTimeout
 
     /**
-     * @return the configured fetch/pull timeout in seconds, or 30 if unset or not a valid number
+     * @return the configured fetch/pull timeout in seconds, or 30 if unset
      */
     int getFetchTimeoutSeconds() {
-        try {
-            fetchTimeout ? Integer.parseInt(fetchTimeout) : 30
-        } catch (NumberFormatException ignored) {
-            30
-        }
+        fetchTimeout ?: 30
     }
 
 

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginFactorySpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginFactorySpec.groovy
@@ -48,7 +48,7 @@ class GitExportPluginFactorySpec extends Specification {
         expect:
         desc.title == 'Git Export'
         desc.name == 'git-export'
-        desc.properties.size() == 15
+        desc.properties.size() == 16
     }
 
     def "base description properties"() {
@@ -67,6 +67,7 @@ class GitExportPluginFactorySpec extends Specification {
                 'gitPasswordPath',
                 'format',
                 'fetchAutomatically',
+                'fetchTimeout',
                 'committerName',
                 'committerEmail',
                 'exportUuidBehavior',
@@ -92,6 +93,7 @@ class GitExportPluginFactorySpec extends Specification {
                 'gitPasswordPath',
                 'format',
                 'fetchAutomatically',
+                'fetchTimeout',
                 'committerName',
                 'committerEmail',
                 'exportUuidBehavior',
@@ -123,6 +125,7 @@ class GitExportPluginFactorySpec extends Specification {
                 'gitPasswordPath',
                 'format',
                 'fetchAutomatically',
+                'fetchTimeout',
                 'committerName',
                 'committerEmail',
                 'exportUuidBehavior',

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
@@ -535,7 +535,7 @@ class GitExportPluginSpec extends Specification {
         status.message==null
 
     }
-    def "get status fetch fails"() {
+    def "get status fetch fails throws ScmPluginException"() {
         given:
 
         def gitdir = new File(tempdir, 'scm')
@@ -552,12 +552,13 @@ class GitExportPluginSpec extends Specification {
         FileUtils.delete(origindir, FileUtils.RECURSIVE | FileUtils.IGNORE_ERRORS)
 
         when:
-        def status = plugin.getStatus(Mock(ScmOperationContext))
+        plugin.getStatus(Mock(ScmOperationContext))
 
         then:
-        status!=null
-        status.state==SynchState.REFRESH_NEEDED
-        status.message=='Fetch from the repository failed: Invalid remote: origin'
+        // A fetch failure signals the remote is unreachable — throw so the caller can surface a
+        // clear "Git server unavailable" message instead of a misleading local-state status.
+        ScmPluginException e = thrown()
+        e.message == 'Fetch from the repository failed: Invalid remote: origin'
     }
 
     static RevCommit addCommitFile(final File gitdir, final Git git, final String path, final String content) {

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitExportPluginSpec.groovy
@@ -535,6 +535,31 @@ class GitExportPluginSpec extends Specification {
         status.message==null
 
     }
+
+    def "get status clean with a configured fetch timeout"() {
+        // A custom fetchTimeout must be plumbed through to the JGit fetch/pull commands
+        // (BaseGitPlugin#fetchFromRemote/gitPull, RUN-4525) without breaking a normal,
+        // fast local fetch against a reachable remote.
+        given:
+
+        def gitdir = new File(tempdir, 'scm')
+        def origindir = new File(tempdir, 'origin')
+        Export config = createTestConfig(gitdir, origindir, [fetchTimeout: '5'])
+
+        //create a git dir
+        def git = createGit(origindir)
+        git.close()
+        def plugin = new GitExportPlugin(config)
+        plugin.initialize(Mock(ScmOperationContext))
+
+        when:
+        def status = plugin.getStatus(Mock(ScmOperationContext))
+
+        then:
+        status!=null
+        status.state==SynchState.CLEAN
+        status.message==null
+    }
     def "get status fetch fails throws ScmPluginException"() {
         given:
 

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitImportPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitImportPluginSpec.groovy
@@ -674,4 +674,32 @@ class GitImportPluginSpec extends Specification {
         status.content !=null
     }
 
+    def "get status fetch fails throws ScmPluginException"() {
+        given:
+        def gitdir = new File(tempdir, 'scm')
+        def origindir = new File(tempdir, 'origin')
+        Import config = createTestConfig(gitdir, origindir, [fetchAutomatically: 'true'])
+
+        Git git = GitExportPluginSpec.createGit(origindir)
+        GitExportPluginSpec.addCommitFile(origindir, git, 'job1-123.xml', 'blah')
+        git.close()
+
+        def plugin = new GitImportPlugin(config, [])
+        plugin.initialize(Mock(ScmOperationContext) {
+            getFrameworkProject() >> 'test'
+        })
+
+        // Delete origin to make fetch fail
+        FileUtils.delete(origindir, FileUtils.RECURSIVE | FileUtils.IGNORE_ERRORS)
+
+        when:
+        plugin.getStatus(Mock(ScmOperationContext))
+
+        then:
+        // A fetch failure signals the remote is unreachable — throw so the caller can surface a
+        // clear "Git server unavailable" message instead of a misleading local-state status.
+        ScmPluginException e = thrown()
+        e.message.contains('Fetch from the repository failed')
+    }
+
 }

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitImportPluginSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/GitImportPluginSpec.groovy
@@ -702,4 +702,29 @@ class GitImportPluginSpec extends Specification {
         e.message.contains('Fetch from the repository failed')
     }
 
+    def "get status succeeds with a configured fetch timeout"() {
+        // A custom fetchTimeout must be plumbed through to the JGit fetch command
+        // (BaseGitPlugin#fetchFromRemote, RUN-4525) without breaking a normal,
+        // fast local fetch against a reachable remote.
+        given:
+        def gitdir = new File(tempdir, 'scm')
+        def origindir = new File(tempdir, 'origin')
+        Import config = createTestConfig(gitdir, origindir, [fetchAutomatically: 'true', fetchTimeout: '5'])
+
+        Git git = GitExportPluginSpec.createGit(origindir)
+        GitExportPluginSpec.addCommitFile(origindir, git, 'job1-123.xml', 'blah')
+        git.close()
+
+        def plugin = new GitImportPlugin(config, [])
+        plugin.initialize(Mock(ScmOperationContext) {
+            getFrameworkProject() >> 'test'
+        })
+
+        when:
+        def status = plugin.getStatus(Mock(ScmOperationContext))
+
+        then:
+        status != null
+    }
+
 }

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/config/CommonSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/config/CommonSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 SimplifyOps, Inc. (http://simplifyops.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rundeck.plugin.scm.git.config
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class CommonSpec extends Specification {
+
+    @Unroll
+    def "getFetchTimeoutSeconds - configured: #configured -> #expected"() {
+        given:
+        def common = new Common()
+        common.fetchTimeout = configured
+
+        expect:
+        common.getFetchTimeoutSeconds() == expected
+
+        where:
+        configured | expected
+        null       | 30
+        ''         | 30
+        '30'       | 30
+        '10'       | 10
+        '90'       | 90
+        'notanumber' | 30
+    }
+}

--- a/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/config/CommonSpec.groovy
+++ b/plugins/git-plugin/src/test/groovy/org/rundeck/plugin/scm/git/config/CommonSpec.groovy
@@ -16,6 +16,7 @@
 
 package org.rundeck.plugin.scm.git.config
 
+import com.dtolabs.rundeck.core.plugins.configuration.ValidationException
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -33,10 +34,35 @@ class CommonSpec extends Specification {
         where:
         configured | expected
         null       | 30
-        ''         | 30
-        '30'       | 30
-        '10'       | 10
-        '90'       | 90
-        'notanumber' | 30
+        30         | 30
+        10         | 10
+        90         | 90
+    }
+
+    @Unroll
+    def "FetchTimeoutValidator accepts positive numbers - value: #value"() {
+        given:
+        def validator = new Common.FetchTimeoutValidator()
+
+        expect:
+        validator.isValid(value)
+
+        where:
+        value << ['1', '30', '3600']
+    }
+
+    @Unroll
+    def "FetchTimeoutValidator rejects non-positive or non-numeric values - value: #value"() {
+        given:
+        def validator = new Common.FetchTimeoutValidator()
+
+        when:
+        validator.isValid(value)
+
+        then:
+        thrown(ValidationException)
+
+        where:
+        value << ['0', '-1', '-30', 'notanumber', '']
     }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -223,19 +223,18 @@ class ScmService {
     }
 
     def projectHasConfiguredExportPlugin(String project) {
-        def loaded = initProject(project, EXPORT)
-        if(!loaded){
-            unregisterPlugin(project, EXPORT)
-        }
-        return loaded
+        // Check persisted config only — do not trigger initProject() here.
+        // initProject() calls the git plugin which requires network access; a transient
+        // connectivity failure would cause unregisterPlugin() to discard an otherwise valid
+        // configuration, forcing users to manually re-activate the plugin after recovery.
+        def pluginConfig = loadScmConfig(project, EXPORT)
+        return pluginConfig?.enabled ?: false
     }
 
     def projectHasConfiguredImportPlugin(String project) {
-        def loaded = initProject(project, IMPORT)
-        if(!loaded){
-            unregisterPlugin(project, IMPORT)
-        }
-        return loaded
+        // Check persisted config only — same reasoning as projectHasConfiguredExportPlugin.
+        def pluginConfig = loadScmConfig(project, IMPORT)
+        return pluginConfig?.enabled ?: false
     }
 
     BasicInputView getInputView(UserAndRolesAuthContext auth, String integration, String project, String actionId) {
@@ -1105,9 +1104,21 @@ class ScmService {
         if (plugin) {
             try{
                 return plugin.getStatus(scmOperationContext(auth, project))
+            }catch (ScmPluginException e){
+                // Propagate — includes git connectivity errors reported by the plugin
+                throw e
             }catch (Throwable t){
-                log.error("Failed to get status for SCM export plugin in project ${project}: $t",t);
+                log.error("Failed to get status for SCM export plugin in project ${project}: $t",t)
+                return null
             }
+        }
+        // Plugin is configured on disk but not loaded in memory — git server is likely unreachable.
+        // Signal callers explicitly rather than returning null (which would silently show stale status).
+        if (loadScmConfig(project, EXPORT)?.enabled) {
+            throw new ScmPluginException(
+                "SCM export plugin for project ${project} is configured but currently unavailable. " +
+                "The Git server may be unreachable. The plugin will recover automatically when connectivity is restored."
+            )
         }
         null
     }
@@ -1120,6 +1131,13 @@ class ScmService {
         def plugin = getLoadedImportPluginFor project
         if (plugin) {
             return plugin.getStatus(scmOperationContext(auth, project))
+        }
+        // Plugin is configured on disk but not loaded — git server is likely unreachable.
+        if (loadScmConfig(project, IMPORT)?.enabled) {
+            throw new ScmPluginException(
+                "SCM import plugin for project ${project} is configured but currently unavailable. " +
+                "The Git server may be unreachable. The plugin will recover automatically when connectivity is restored."
+            )
         }
         null
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -1112,12 +1112,12 @@ class ScmService {
                 return null
             }
         }
-        // Plugin is configured on disk but not loaded in memory — git server is likely unreachable.
+        // Plugin is configured on disk but not loaded in memory.
         // Signal callers explicitly rather than returning null (which would silently show stale status).
         if (loadScmConfig(project, EXPORT)?.enabled) {
             throw new ScmPluginException(
                 "SCM export plugin for project ${project} is configured but currently unavailable. " +
-                "The Git server may be unreachable. The plugin will recover automatically when connectivity is restored."
+                "Check Git server connectivity and credentials, or reconfigure the plugin."
             )
         }
         null
@@ -1132,11 +1132,11 @@ class ScmService {
         if (plugin) {
             return plugin.getStatus(scmOperationContext(auth, project))
         }
-        // Plugin is configured on disk but not loaded — git server is likely unreachable.
+        // Plugin is configured on disk but not loaded in memory.
         if (loadScmConfig(project, IMPORT)?.enabled) {
             throw new ScmPluginException(
                 "SCM import plugin for project ${project} is configured but currently unavailable. " +
-                "The Git server may be unreachable. The plugin will recover automatically when connectivity is restored."
+                "Check Git server connectivity and credentials, or reconfigure the plugin."
             )
         }
         null

--- a/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScmService.groovy
@@ -104,6 +104,13 @@ class ScmService {
     RundeckJobDefinitionManager rundeckJobDefinitionManager
     UserDataProvider userDataProvider
     final Set<String> initedProjects = Collections.synchronizedSet(new HashSet())
+    /**
+     * Tracks projects/integrations that recently failed to connect to their SCM remote, keyed by
+     * "project-integration", mapped to the epoch millis timestamp of the next allowed retry attempt.
+     * Consulted by {@link #initProject} to short-circuit repeated network calls while the remote
+     * is unreachable, without requiring the plugin to be permanently disabled (RUN-4525).
+     */
+    final Map<String, Long> scmRetryState = Collections.synchronizedMap([:])
     Map<String, CloseableProvider<ScmExportPlugin>> loadedExportPlugins = Collections.synchronizedMap([:])
     Map<String, CloseableProvider<ScmImportPlugin>> loadedImportPlugins = Collections.synchronizedMap([:])
     Map<String, JobChangeListener> loadedExportListeners = Collections.synchronizedMap([:])
@@ -137,6 +144,9 @@ class ScmService {
             initedProjects.remove(integration + '/' + project)
             return false
         }
+        if (isInRetryCooldown(project, integration)) {
+            return false
+        }
         synchronized (initedProjects) {
             if (initedProjects.contains(integration + '/' + project)) {
                 return true
@@ -164,6 +174,7 @@ class ScmService {
                 return false
             }
             initedProjects.add(integration + '/' + project)
+            clearRetryState(project, integration)
             return true
         } catch (Throwable e) {
             log.error(
@@ -172,6 +183,41 @@ class ScmService {
             )
         }
     }
+
+    /**
+     * @return true if project/integration recently failed to connect and is still within its
+     * slow-poll cooldown window (RUN-4525)
+     */
+    boolean isInRetryCooldown(String project, String integration) {
+        Long nextRetryAt = scmRetryState.get(project + '-' + integration)
+        nextRetryAt != null && System.currentTimeMillis() < nextRetryAt
+    }
+
+    /**
+     * @return true if project/integration has a recorded slow-poll retry-state entry (whether or not
+     * its cooldown window has elapsed) — i.e. it previously failed and has not yet succeeded or had
+     * its config change. Used to tell a fresh fast-retry attempt apart from a slow-poll retry attempt
+     * (which should be a single try, not another full fast-retry burst) (RUN-4525).
+     */
+    boolean hasRetryState(String project, String integration) {
+        scmRetryState.containsKey(project + '-' + integration)
+    }
+
+    /**
+     * Record that project/integration failed to connect, and should not be retried again until nextRetryAt.
+     */
+    void markRetryFailure(String project, String integration, long nextRetryAt) {
+        scmRetryState.put(project + '-' + integration, nextRetryAt)
+    }
+
+    /**
+     * Clear any recorded retry/cooldown state for project/integration, e.g. after a successful
+     * connection or a plugin config change.
+     */
+    void clearRetryState(String project, String integration) {
+        scmRetryState.remove(project + '-' + integration)
+    }
+
     ScmExportPlugin getLoadedExportPluginFor(String project){
         initProject(project, EXPORT)
         loadedExportPlugins[project]?.provider

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
@@ -159,7 +159,14 @@ class ScmLoaderService implements EventBusAware {
                         if(retryCount>= retryTimes){
                             service.scmFailedProjectInit.put(projectIntegration, pluginConfigData)
                             process = true
-                            service.scmToFalse(pluginConfigData, project, integration)
+                            // Do not persist enabled=false to disk — the failure may be a transient
+                            // connectivity issue (e.g. Git server temporarily unreachable). Writing
+                            // enabled=false would require manual re-activation by the user even after
+                            // connectivity is restored. The next loader cycle will retry automatically.
+                            log.warn(
+                                "SCM ${integration} for ${project} unavailable after ${retryTimes} retries: ${t.message}. " +
+                                "Plugin remains enabled and will be retried on the next loader cycle."
+                            )
                             service.removingLoaderProcess(
                                 project,
                                 integration,

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
@@ -157,13 +157,13 @@ class ScmLoaderService implements EventBusAware {
 
                     } catch (Throwable t) {
                         if(retryCount>= retryTimes){
-                            service.scmFailedProjectInit.put(projectIntegration, pluginConfigData)
                             process = true
-                            // Do not persist enabled=false to disk — the failure may be a transient
-                            // connectivity issue (e.g. Git server temporarily unreachable). Writing
-                            // enabled=false would require manual re-activation by the user even after
-                            // connectivity is restored. The current loader task is cancelled; a new
-                            // loader task will be started on the next project activity or server restart.
+                            // Do not put into scmFailedProjectInit and do not persist enabled=false —
+                            // the failure may be a transient connectivity issue. scmFailedProjectInit
+                            // would block beginScmLoader() from restarting this loader (it only clears
+                            // on config change), preventing automatic recovery when Git comes back.
+                            // removingLoaderProcess() cancels the current task; beginScmLoader() will
+                            // start a fresh loader on the next periodic cycle when config is still enabled.
                             log.warn(
                                 "SCM ${integration} for ${project} failed to initialize after ${retryTimes} retries: ${t.message}. " +
                                 "Plugin remains enabled in configuration. Check connectivity and credentials."

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
@@ -162,10 +162,11 @@ class ScmLoaderService implements EventBusAware {
                             // Do not persist enabled=false to disk — the failure may be a transient
                             // connectivity issue (e.g. Git server temporarily unreachable). Writing
                             // enabled=false would require manual re-activation by the user even after
-                            // connectivity is restored. The next loader cycle will retry automatically.
+                            // connectivity is restored. The current loader task is cancelled; a new
+                            // loader task will be started on the next project activity or server restart.
                             log.warn(
-                                "SCM ${integration} for ${project} unavailable after ${retryTimes} retries: ${t.message}. " +
-                                "Plugin remains enabled and will be retried on the next loader cycle."
+                                "SCM ${integration} for ${project} failed to initialize after ${retryTimes} retries: ${t.message}. " +
+                                "Plugin remains enabled in configuration. Check connectivity and credentials."
                             )
                             service.removingLoaderProcess(
                                 project,

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
@@ -37,6 +37,7 @@ class ScmLoaderService implements EventBusAware {
     public static final long DEFAULT_LOADER_INTERVAL_SEC = 20
     public static final long INIT_RETRY_TIMES = 5
     public static final long INIT_RETRY_TIMES_DELAY = 1000
+    public static final long DEFAULT_SLOWPOLL_INTERVAL = 60_000
 
     /**
      * scheduledExecutor to load job SCM cache
@@ -45,7 +46,6 @@ class ScmLoaderService implements EventBusAware {
     final Map<String, ScheduledFuture> scmProjectLoaderProcess = Collections.synchronizedMap([:])
     final Map<String, Boolean> scmProjectInitLoaded = Collections.synchronizedMap([:])
     final Map<String, ScmPluginConfigData> scmPluginMeta = Collections.synchronizedMap([:])
-    final Map<String, ScmPluginConfigData> scmFailedProjectInit = Collections.synchronizedMap([:])
 
     @Subscriber("rundeck.bootstrap")
     @CompileDynamic
@@ -94,16 +94,9 @@ class ScmLoaderService implements EventBusAware {
 
     boolean projectIntegrationEnabled(String project, String integration,  ScmPluginConfigData pluginConfigData){
         String projectIntegration = getProjectIntegration(project, integration)
-        if(!scmProjectLoaderProcess.get(projectIntegration) && !scmFailedProjectInit.get(projectIntegration)){
+        if(!scmProjectLoaderProcess.get(projectIntegration)){
             if(pluginConfigData && pluginConfigData.enabled) {
                 return true
-            }
-        }else{
-            if(scmFailedProjectInit.get(projectIntegration)){
-                if(reloadPlugin(project, integration, pluginConfigData)){
-                    scmFailedProjectInit.remove(projectIntegration)
-                    return true
-                }
             }
         }
 
@@ -138,51 +131,85 @@ class ScmLoaderService implements EventBusAware {
                 service.scmPluginMeta.put(projectIntegration, pluginConfigData)
             }
             if(pluginConfigData && pluginConfigData.enabled){
-                boolean process = false
-                int retryCount = 0
+                // Currently in slow-poll cooldown after exhausting fast retries: this scheduled
+                // invocation is a cheap no-op until nextRetryAt elapses, avoiding a repeated
+                // connectivity attempt on every fixed-rate firing (RUN-4525).
+                if (service.scmService.isInRetryCooldown(project, integration)) {
+                    return
+                }
 
                 if (pluginConfigData.properties.get("flagToReturnProcess")) {
                     pluginConfigData.properties.remove("flagToReturnProcess")
                     service.scmService.storeConfig(pluginConfigData, project, integration)
                 }
 
-                while (!process){
-                    try {
-                        if (integration == service.scmService.EXPORT) {
-                            service.processScmExportLoader(project, pluginConfigData, state)
-                        }else{
-                            service.processScmImportLoader(project, pluginConfigData, state)
-                        }
-                        process = true
-
-                    } catch (Throwable t) {
-                        if(retryCount>= retryTimes){
-                            process = true
-                            // Do not put into scmFailedProjectInit and do not persist enabled=false —
-                            // the failure may be a transient connectivity issue. scmFailedProjectInit
-                            // would block beginScmLoader() from restarting this loader (it only clears
-                            // on config change), preventing automatic recovery when Git comes back.
-                            // removingLoaderProcess() cancels the current task; beginScmLoader() will
-                            // start a fresh loader on the next periodic cycle when config is still enabled.
-                            log.warn(
-                                "SCM ${integration} for ${project} failed to initialize after ${retryTimes} retries: ${t.message}. " +
-                                "Plugin remains enabled in configuration. Check connectivity and credentials."
-                            )
-                            service.removingLoaderProcess(
-                                project,
-                                integration,
-                                "Error initializing SCM: " + t.message
-                            )
-                        }else{
-                            retryCount++
-                            log.error("Error initializing SCM for: $project/$integration: ${t.message}. Retrying ${retryCount}/${retryTimes}")
-                            Thread.sleep(this.retryDelay)
-                        }
-                    }
+                if (service.scmService.hasRetryState(project, integration)) {
+                    // Already in slow-poll mode and the cooldown has just elapsed: make exactly ONE
+                    // real connectivity attempt, not another full fast-retry burst — the fast-retry
+                    // phase only ever runs once, on the first failure (RUN-4525).
+                    attemptOnce(pluginConfigData)
+                } else {
+                    fastRetryThenEnterSlowPoll(pluginConfigData)
                 }
 
             }else{
                 service.removingLoaderProcess(project, integration, "SCM disabled or project removed")
+            }
+        }
+
+        private void attemptOnce(ScmPluginConfigData pluginConfigData) {
+            try {
+                runLoader(pluginConfigData)
+                service.scmService.clearRetryState(project, integration)
+            } catch (Throwable t) {
+                long nextRetryAt = System.currentTimeMillis() + service.getScmLoaderSlowPollInterval()
+                service.scmService.markRetryFailure(project, integration, nextRetryAt)
+                log.warn(
+                    "SCM ${integration} for ${project} slow-poll attempt failed: ${t.message}. " +
+                    "Next attempt in ${service.getScmLoaderSlowPollInterval()}ms. Plugin remains enabled in configuration."
+                )
+            }
+        }
+
+        private void fastRetryThenEnterSlowPoll(ScmPluginConfigData pluginConfigData) {
+            boolean process = false
+            int retryCount = 0
+            while (!process){
+                try {
+                    runLoader(pluginConfigData)
+                    process = true
+                    service.scmService.clearRetryState(project, integration)
+
+                } catch (Throwable t) {
+                    if(retryCount>= retryTimes){
+                        process = true
+                        // Do not persist enabled=false — the failure may be a transient
+                        // connectivity issue. Instead, enter slow-poll mode: record when the
+                        // next single connectivity attempt is allowed, so the outer scheduled
+                        // task (already re-invoking run() every scmLoaderIntervalSeconds) keeps
+                        // retrying indefinitely without hammering the git server, and without
+                        // requiring manual re-activation (RUN-4525).
+                        long nextRetryAt = System.currentTimeMillis() + service.getScmLoaderSlowPollInterval()
+                        service.scmService.markRetryFailure(project, integration, nextRetryAt)
+                        log.warn(
+                            "SCM ${integration} for ${project} failed to initialize after ${retryTimes} retries: ${t.message}. " +
+                            "Entering slow-poll mode (retry interval=${service.getScmLoaderSlowPollInterval()}ms). " +
+                            "Plugin remains enabled in configuration."
+                        )
+                    }else{
+                        retryCount++
+                        log.error("Error initializing SCM for: $project/$integration: ${t.message}. Retrying ${retryCount}/${retryTimes}")
+                        Thread.sleep(this.retryDelay)
+                    }
+                }
+            }
+        }
+
+        private void runLoader(ScmPluginConfigData pluginConfigData) {
+            if (integration == service.scmService.EXPORT) {
+                service.processScmExportLoader(project, pluginConfigData, state)
+            }else{
+                service.processScmImportLoader(project, pluginConfigData, state)
             }
         }
     }
@@ -214,12 +241,6 @@ class ScmLoaderService implements EventBusAware {
 
     ProjectScmLoader createProjectLoader(String project, String integration) {
         new ProjectScmLoader(project, integration, this, this.getScmLoaderInitialRetryDelay(), this.getScmLoaderInitialRetryTimes())
-    }
-
-    def scmToFalse(ScmPluginConfigData scmPluginConfig, String project, String integration) {
-        log.debug("SCM disabled")
-        scmPluginConfig.enabled = false
-        scmService.storeConfig(scmPluginConfig, project, integration)
     }
 
     static class CancelTaskException extends Exception {
@@ -259,6 +280,17 @@ class ScmLoaderService implements EventBusAware {
                 DEFAULT_LOADER_INTERVAL_SEC
         ) ?:
                 DEFAULT_LOADER_INTERVAL_SEC
+    }
+
+    /**
+     * Interval, in milliseconds, between single connectivity retry attempts once a project/integration
+     * has exhausted its fast retries and entered slow-poll mode. Enforces a hard floor of
+     * {@link #DEFAULT_SLOWPOLL_INTERVAL} (60s) regardless of configured value, to prevent an overly
+     * aggressive interval from re-introducing the repeated-network-call problem this replaces (RUN-4525).
+     */
+    long getScmLoaderSlowPollInterval() {
+        def configured = configurationService?.getLong('scmLoader.slowPoll.interval', DEFAULT_SLOWPOLL_INTERVAL)
+        Math.max(configured != null ? configured : DEFAULT_SLOWPOLL_INTERVAL, DEFAULT_SLOWPOLL_INTERVAL)
     }
 
     @CompileDynamic
@@ -512,6 +544,9 @@ class ScmLoaderService implements EventBusAware {
             def pluginConfigCache = scmPluginMeta.get(key)
             if(pluginConfigCache && pluginConfig.getProperties() != pluginConfigCache.getProperties()){
                 scmService.unregisterPlugin(integration, project)
+                // Config changed — clear any slow-poll cooldown so the fresh initProject() attempt
+                // below isn't short-circuited by a stale retry-state entry (RUN-4525).
+                scmService.clearRetryState(project, integration)
                 scmService.initProject(project, integration)
                 scmPluginMeta.remove(key)
                 return true

--- a/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/scm/ScmLoaderService.groovy
@@ -157,6 +157,12 @@ class ScmLoaderService implements EventBusAware {
             }
         }
 
+        /**
+         * Make a single connectivity attempt for a project/integration that is already in slow-poll
+         * mode (i.e. has previously failed and has retry state recorded). On success, clears the
+         * retry state; on failure, records a new cooldown window via {@link ScmService#markRetryFailure}
+         * (RUN-4525).
+         */
         private void attemptOnce(ScmPluginConfigData pluginConfigData) {
             try {
                 runLoader(pluginConfigData)
@@ -171,6 +177,12 @@ class ScmLoaderService implements EventBusAware {
             }
         }
 
+        /**
+         * First-ever (or post-config-change) load attempt for a project/integration: retries up to
+         * {@code retryTimes} times, {@code retryDelay}ms apart. On success, clears any retry state;
+         * once retries are exhausted, enters slow-poll mode by recording a cooldown via
+         * {@link ScmService#markRetryFailure} instead of disabling the plugin (RUN-4525).
+         */
         private void fastRetryThenEnterSlowPoll(ScmPluginConfigData pluginConfigData) {
             boolean process = false
             int retryCount = 0
@@ -205,6 +217,10 @@ class ScmLoaderService implements EventBusAware {
             }
         }
 
+        /**
+         * Delegates to the export or import loader implementation for this project, based on
+         * {@link #integration}.
+         */
         private void runLoader(ScmPluginConfigData pluginConfigData) {
             if (integration == service.scmService.EXPORT) {
                 service.processScmExportLoader(project, pluginConfigData, state)

--- a/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
@@ -1333,4 +1333,136 @@ class ScmServiceSpec extends Specification implements ServiceUnitTest<ScmService
 
     }
 
+    @Unroll
+    def "projectHasConfiguredPlugin reads persisted config without triggering initProject - integration: #integration"() {
+        given:
+        service.frameworkService = Mock(FrameworkService) { isClusterModeEnabled() >> true }
+        service.pluginConfigService = Mock(PluginConfigService)
+        ScmPluginConfigData config = Mock(ScmPluginConfigData) {
+            getEnabled() >> enabled
+        }
+
+        when:
+        def result = integration == ScmService.EXPORT
+            ? service.projectHasConfiguredExportPlugin('test')
+            : service.projectHasConfiguredImportPlugin('test')
+
+        then:
+        1 * service.pluginConfigService.loadScmConfig(
+            'test',
+            "etc/scm-${integration}.properties",
+            "scm.${integration}"
+        ) >> config
+        result == enabled
+        // initProject is not triggered so no write to disk should occur
+        0 * service.pluginConfigService.storeConfig(*_)
+
+        where:
+        integration       | enabled
+        ScmService.EXPORT | true
+        ScmService.EXPORT | false
+        ScmService.IMPORT | true
+        ScmService.IMPORT | false
+    }
+
+    @Unroll
+    def "projectHasConfiguredPlugin does not unregister in-memory plugin when config is disabled - integration: #integration"() {
+        given:
+        service.frameworkService = Mock(FrameworkService) { isClusterModeEnabled() >> true }
+        service.pluginConfigService = Mock(PluginConfigService)
+        service.jobEventsService = Mock(JobEventsService)
+        ScmPluginConfigData config = Mock(ScmPluginConfigData) {
+            getEnabled() >> false
+        }
+        // Simulate a plugin already loaded in memory
+        def loadedPlugin = Mock(CloseableProvider)
+        if (integration == ScmService.EXPORT) {
+            service.loadedExportPlugins['test'] = loadedPlugin
+        } else {
+            service.loadedImportPlugins['test'] = loadedPlugin
+        }
+
+        when:
+        def result = integration == ScmService.EXPORT
+            ? service.projectHasConfiguredExportPlugin('test')
+            : service.projectHasConfiguredImportPlugin('test')
+
+        then:
+        1 * service.pluginConfigService.loadScmConfig(*_) >> config
+        result == false
+        // In-memory plugin must remain — connectivity issues must not evict a live plugin
+        0 * service.jobEventsService.removeListener(_)
+        if (integration == ScmService.EXPORT) {
+            service.loadedExportPlugins['test'] != null
+        } else {
+            service.loadedImportPlugins['test'] != null
+        }
+
+        where:
+        integration       | _
+        ScmService.EXPORT | _
+        ScmService.IMPORT | _
+    }
+
+    def "projectHasConfiguredPlugin returns false when no config exists on disk"() {
+        given:
+        service.frameworkService = Mock(FrameworkService) { isClusterModeEnabled() >> true }
+        service.pluginConfigService = Mock(PluginConfigService)
+
+        when:
+        def exportResult = service.projectHasConfiguredExportPlugin('test')
+        def importResult = service.projectHasConfiguredImportPlugin('test')
+
+        then:
+        2 * service.pluginConfigService.loadScmConfig(*_) >> null
+        !exportResult
+        !importResult
+    }
+
+    @Unroll
+    def "exportPluginStatus throws ScmPluginException when plugin configured but not loaded - simulates git unavailable"() {
+        given:
+        service.frameworkService = Mock(FrameworkService) { isClusterModeEnabled() >> true }
+        service.pluginConfigService = Mock(PluginConfigService)
+        // No plugin loaded in memory (git server down)
+        ScmPluginConfigData config = Mock(ScmPluginConfigData) { getEnabled() >> true }
+
+        when:
+        service.exportPluginStatus(Mock(UserAndRolesAuthContext), 'test')
+
+        then:
+        // loadScmConfig called twice: once by getLoadedExportPluginFor->initProject, once by the availability check
+        _ * service.pluginConfigService.loadScmConfig(*_) >> config
+        thrown(ScmPluginException)
+    }
+
+    @Unroll
+    def "importPluginStatus throws ScmPluginException when plugin configured but not loaded - simulates git unavailable"() {
+        given:
+        service.frameworkService = Mock(FrameworkService) { isClusterModeEnabled() >> true }
+        service.pluginConfigService = Mock(PluginConfigService)
+        ScmPluginConfigData config = Mock(ScmPluginConfigData) { getEnabled() >> true }
+
+        when:
+        service.importPluginStatus(Mock(UserAndRolesAuthContext), 'test')
+
+        then:
+        _ * service.pluginConfigService.loadScmConfig(*_) >> config
+        thrown(ScmPluginException)
+    }
+
+    def "exportPluginStatus returns null when plugin not configured on disk"() {
+        given:
+        service.frameworkService = Mock(FrameworkService) { isClusterModeEnabled() >> true }
+        service.pluginConfigService = Mock(PluginConfigService)
+
+        when:
+        def result = service.exportPluginStatus(Mock(UserAndRolesAuthContext), 'test')
+
+        then:
+        _ * service.pluginConfigService.loadScmConfig(*_) >> null
+        result == null
+        noExceptionThrown()
+    }
+
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScmServiceSpec.groovy
@@ -1465,4 +1465,87 @@ class ScmServiceSpec extends Specification implements ServiceUnitTest<ScmService
         noExceptionThrown()
     }
 
+    def "initProject does not re-invoke plugin validation while in retry cooldown"() {
+        given:
+        service.frameworkService = Mock(FrameworkService) { isClusterModeEnabled() >> true }
+        service.pluginConfigService = Mock(PluginConfigService)
+        ScmPluginConfigData config = Mock(ScmPluginConfigData) { getEnabled() >> true }
+        service.pluginConfigService.loadScmConfig(*_) >> config
+        // Simulate a project/integration currently within its slow-poll cooldown window
+        service.scmRetryState['test-export'] = System.currentTimeMillis() + 60000
+
+        when:
+        def result1 = service.initProject('test', 'export')
+        def result2 = service.initProject('test', 'export')
+
+        then:
+        !result1
+        !result2
+        // Reaching the username/roles check (and beyond, to plugin validation/loading) would mean
+        // the cooldown short-circuit did not fire and the real connectivity attempt was repeated.
+        0 * config.getSetting("username")
+        0 * config.getSettingList("roles")
+    }
+
+    def "isInRetryCooldown returns false once nextRetryAt has elapsed"() {
+        given:
+        service.scmRetryState['test-export'] = System.currentTimeMillis() - 1000
+
+        expect:
+        !service.isInRetryCooldown('test', 'export')
+    }
+
+    def "clearRetryState removes a recorded cooldown entry"() {
+        given:
+        service.markRetryFailure('test', 'export', System.currentTimeMillis() + 60000)
+
+        expect:
+        service.isInRetryCooldown('test', 'export')
+
+        when:
+        service.clearRetryState('test', 'export')
+
+        then:
+        !service.isInRetryCooldown('test', 'export')
+    }
+
+    def "initProject clears retry state after a successful init"() {
+        given:
+        service.frameworkService = Mock(FrameworkService) { isClusterModeEnabled() >> true }
+        service.pluginConfigService = Mock(PluginConfigService)
+        service.storageService = Mock(StorageService)
+        service.pluginService = Mock(PluginService)
+        service.jobEventsService = Mock(JobEventsService)
+        service.rundeckAuthContextProvider = Mock(AuthContextProvider) {
+            getAuthContextForUserAndRolesAndProject(_, _, _) >> Mock(UserAndRolesAuthContext) {
+                getUsername() >> 'admin'
+            }
+        }
+        service.scmExportPluginProviderService = Mock(ScmExportPluginProviderService)
+        ScmPluginConfigData config = Mock(ScmPluginConfigData) {
+            getEnabled() >> true
+            getSetting("username") >> "admin"
+            getSettingList("roles") >> ["admin"]
+            getType() >> "git-export"
+            getConfig() >> [:]
+        }
+        service.pluginConfigService.loadScmConfig(*_) >> config
+        ScmExportPlugin plugin = Mock(ScmExportPlugin)
+        ScmExportPluginFactory exportFactory = Mock(ScmExportPluginFactory) {
+            createPlugin(_, _, true) >> plugin
+        }
+        service.pluginService.validatePlugin(*_) >> Mock(ValidatedPlugin) { isValid() >> true }
+        service.pluginService.retainPlugin('git-export', _) >> Closeables.closeableProvider(exportFactory)
+        // A prior failure whose cooldown window has already elapsed — initProject should proceed
+        // (not short-circuit) and clear this stale entry entirely once it succeeds.
+        service.markRetryFailure('test', 'export', System.currentTimeMillis() - 60000)
+
+        when:
+        def result = service.initProject('test', 'export')
+
+        then:
+        result
+        !service.scmRetryState.containsKey('test-export')
+    }
+
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/scm/ScmLoaderServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/scm/ScmLoaderServiceSpec.groovy
@@ -741,4 +741,51 @@ class  ScmLoaderServiceSpec extends Specification implements ServiceUnitTest<Scm
         0 * service.scmService.initProject(project, "import")
 
     }
+
+    @Unroll
+    def "SCM project loader does not persist enabled=false to disk when initialization fails after retries exhausted - integration: #integration"() {
+        given:
+        def project = "test"
+        def username = "admin"
+        def roles = ["admin"]
+
+        service.frameworkService = Mock(FrameworkService) {
+            isClusterModeEnabled() >> false
+        }
+        service.scheduledExecutionService = Mock(ScheduledExecutionService) {
+            listWorkflows(_) >> ["schedlist": []]
+        }
+        def scmPluginConfigData = Mock(ScmPluginConfigData) {
+            getSetting("username") >> username
+            getSettingList("roles") >> roles
+            getEnabled() >> true
+            getProperties() >> [:]
+        }
+        service.scmService = Mock(ScmService) {
+            _* projectHasConfiguredExportPlugin(project) >> true
+            _* projectHasConfiguredImportPlugin(project) >> true
+            _* scmOperationContext(username, roles, project) >> Mock(ScmOperationContext)
+            // Every attempt to load the plugin throws — simulates git server unreachable
+            _* loadPluginWithConfig(_, _, _, _) >> { throw new RuntimeException("Connection refused: git server unreachable") }
+            1 * loadScmConfig(project, integration) >> scmPluginConfigData
+        }
+        service.configurationService = Mock(ConfigService) {
+            _* getLong('scmLoader.init.retry', _) >> 0L
+            _* getLong('scmLoader.init.delay', _) >> 0L
+        }
+
+        when:
+        service.createProjectLoader(project, integration).run()
+
+        then:
+        thrown(ScmLoaderService.CancelTaskException)
+        // Must NOT write enabled=false to disk — connectivity errors are transient.
+        // Writing enabled=false would require manual re-activation after recovery (RUN-4525).
+        0 * service.scmService.storeConfig(*_)
+
+        where:
+        integration       | _
+        ScmService.EXPORT | _
+        ScmService.IMPORT | _
+    }
 }

--- a/rundeckapp/src/test/groovy/rundeck/services/scm/ScmLoaderServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/scm/ScmLoaderServiceSpec.groovy
@@ -697,7 +697,8 @@ class  ScmLoaderServiceSpec extends Specification implements ServiceUnitTest<Scm
             service.createProjectLoader(project, 'export').run()
 
         then:
-            thrown(ScmLoaderService.CancelTaskException)
+            noExceptionThrown()
+            1 * service.scmService.markRetryFailure(project, integration, _)
 
             0 * plugin.initJobsStatus(_)
             0 * plugin.refreshJobsStatus(_)
@@ -772,20 +773,139 @@ class  ScmLoaderServiceSpec extends Specification implements ServiceUnitTest<Scm
         service.configurationService = Mock(ConfigService) {
             _* getLong('scmLoader.init.retry', _) >> 0L
             _* getLong('scmLoader.init.delay', _) >> 0L
+            _* getLong('scmLoader.slowPoll.interval', _) >> ScmLoaderService.DEFAULT_SLOWPOLL_INTERVAL
         }
 
         when:
         service.createProjectLoader(project, integration).run()
 
         then:
-        thrown(ScmLoaderService.CancelTaskException)
+        noExceptionThrown()
         // Must NOT write enabled=false to disk — connectivity errors are transient.
         // Writing enabled=false would require manual re-activation after recovery (RUN-4525).
         0 * service.scmService.storeConfig(*_)
+        // Instead, the loader enters slow-poll mode: it records a cooldown and keeps the plugin enabled.
+        1 * service.scmService.markRetryFailure(project, integration, _)
 
         where:
         integration       | _
         ScmService.EXPORT | _
         ScmService.IMPORT | _
+    }
+
+    @Unroll
+    def "getScmLoaderSlowPollInterval enforces a 60 second floor - configured: #configured"() {
+        given:
+        // getLong(String, Long) returns a primitive long — a real ConfigService already applies
+        // ScmLoaderService.DEFAULT_SLOWPOLL_INTERVAL internally when the key is unset, so the
+        // "unset" case is simulated the same way here rather than stubbing a null return.
+        service.configurationService = Mock(ConfigService) {
+            getLong('scmLoader.slowPoll.interval', _) >> configured
+        }
+
+        expect:
+        service.getScmLoaderSlowPollInterval() == expected
+
+        where:
+        configured                                  | expected
+        ScmLoaderService.DEFAULT_SLOWPOLL_INTERVAL   | ScmLoaderService.DEFAULT_SLOWPOLL_INTERVAL
+        10_000L                                      | ScmLoaderService.DEFAULT_SLOWPOLL_INTERVAL
+        60_000L                                       | 60_000L
+        120_000L                                     | 120_000L
+    }
+
+    def "ProjectScmLoader run() no-ops during retry cooldown without attempting to load the plugin"() {
+        given:
+        def project = "test"
+        def integration = 'export'
+
+        service.scmService = Mock(ScmService) {
+            loadScmConfig(project, integration) >> Mock(ScmPluginConfigData) { getEnabled() >> true }
+            isInRetryCooldown(project, integration) >> true
+        }
+        service.configurationService = Mock(ConfigService) {
+            _* getLong(*_) >> 0L
+        }
+
+        when:
+        service.createProjectLoader(project, integration).run()
+
+        then:
+        noExceptionThrown()
+        0 * service.scmService.loadPluginWithConfig(*_)
+        0 * service.scmService.markRetryFailure(*_)
+    }
+
+    def "ProjectScmLoader run() makes exactly one attempt (no fast-retry burst) once already in slow-poll mode"() {
+        // Once a project/integration has already failed and entered slow-poll mode, a re-invocation
+        // after the cooldown has elapsed must try exactly once — not repeat the full fast-retry burst
+        // (5 attempts) every time the cooldown expires (RUN-4525).
+        given:
+        def project = "test"
+        def integration = 'export'
+        def username = "admin"
+        def roles = ["admin"]
+
+        service.frameworkService = Mock(FrameworkService) {
+            isClusterModeEnabled() >> false
+        }
+        service.scheduledExecutionService = Mock(ScheduledExecutionService) {
+            listWorkflows(_) >> ["schedlist": []]
+        }
+        def scmPluginConfigData = Mock(ScmPluginConfigData) {
+            getSetting("username") >> username
+            getSettingList("roles") >> roles
+            getEnabled() >> true
+            getProperties() >> [:]
+        }
+        service.scmService = Mock(ScmService) {
+            _* projectHasConfiguredExportPlugin(project) >> true
+            _* projectHasConfiguredImportPlugin(project) >> true
+            _* scmOperationContext(username, roles, project) >> Mock(ScmOperationContext)
+            // Every attempt to load the plugin throws — simulates git server unreachable.
+            // Exact cardinality (not "_*"): proves attemptOnce() tries exactly once, not a full
+            // fast-retry burst — this is verified automatically at the end of the test, so it
+            // must NOT also be re-declared (bare, without a response) in the "then:" block below,
+            // which would register a competing, response-less interaction for the same method and
+            // shadow this one's throw behavior.
+            1 * loadPluginWithConfig(_, _, _, _) >> { throw new RuntimeException("Connection refused: git server unreachable") }
+            1 * loadScmConfig(project, integration) >> scmPluginConfigData
+            isInRetryCooldown(project, integration) >> false
+            hasRetryState(project, integration) >> true
+        }
+        service.configurationService = Mock(ConfigService) {
+            _* getLong('scmLoader.init.retry', _) >> 5L
+            _* getLong('scmLoader.init.delay', _) >> 0L
+            _* getLong('scmLoader.slowPoll.interval', _) >> ScmLoaderService.DEFAULT_SLOWPOLL_INTERVAL
+        }
+
+        when:
+        service.createProjectLoader(project, integration).run()
+
+        then:
+        noExceptionThrown()
+        1 * service.scmService.markRetryFailure(project, integration, _)
+    }
+
+    def "reloadPlugin clears retry state when a config change is detected"() {
+        given:
+        def project = "test"
+        def integration = ScmService.EXPORT
+        def key = service.getProjectIntegration(project, integration)
+        // reloadPlugin() compares pluginConfig.getProperties() under @CompileStatic, which resolves
+        // to Groovy's reflective bean-properties map (built from the real getPrefix/getConfig/
+        // getEnabled/getType getters), not a stubbable "getProperties()" interaction — so the two
+        // configs must differ via one of those real getters (getConfig() here) to be detected as changed.
+        def cachedConfig = Mock(ScmPluginConfigData) { getConfig() >> [original: '1'] }
+        def newConfig = Mock(ScmPluginConfigData) { getConfig() >> [changed: '2'] }
+        service.scmPluginMeta.put(key, cachedConfig)
+        service.scmService = Mock(ScmService)
+
+        when:
+        def result = service.reloadPlugin(project, integration, newConfig)
+
+        then:
+        result
+        1 * service.scmService.clearRetryState(project, integration)
     }
 }


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix for RUN-4525. LSEG reported that the SCM plugin requires manual re-activation every time the connection to Git is temporarily lost. After investigating and reproducing the issue locally with a Gitea Docker environment (and live-verifying with a TCP connection listener against the running app), the fix went through two iterations — the first removed the permanent-disable behavior but reintroduced unbounded network retries; the second replaces it with a proper slow-poll circuit breaker.

**Describe the solution you've implemented**

Four related changes across two services and the git plugin:

**1. `ScmService.projectHasConfiguredPlugin` — separate "is configured" from "is initialized"**
The method called `initProject()` which requires network access, and on failure called `unregisterPlugin()` — evicting a valid in-memory plugin from memory on every status check while Git was unreachable. The method now only reads the persisted config from disk.

**2. `ScmService.exportPluginStatus` / `importPluginStatus` + git plugin — surface unavailability clearly**
When Git is unreachable, the status methods previously returned `null` or a stale local state silently. Now:
- `GitExportPlugin` and `GitImportPlugin` throw `ScmPluginException` when `fetchFromRemote()` fails
- `exportPluginStatus`/`importPluginStatus` propagate `ScmPluginException` to callers
- Controllers already catch `ScmPluginException` and surface it as a visible warning in the UI

**3. `ScmService` / `ScmLoaderService` — replace unbounded retry with a slow-poll circuit breaker**
An earlier version of this fix simply stopped persisting `enabled=false` on failure, without replacing the old disable-on-exhaustion logic. Live-testing against a stopped Gitea container (using a raw TCP listener on the git port to observe actual connection attempts) showed this reintroduced the exact problem the original design prevented: every request-path caller (job status checks, `apiProjectStatus` in cluster mode) re-hammered the git server on every single call while it was down, and the background loader repeated its full 5-attempt fast-retry burst every time its cooldown elapsed, instead of trying once.

The fix:
- `ScmService` now tracks per-project/integration retry state (`scmRetryState`: `isInRetryCooldown`, `markRetryFailure`, `clearRetryState`, `hasRetryState`).
- `initProject()` short-circuits immediately while a project/integration is in its cooldown window — no network call.
- `ScmLoaderService.ProjectScmLoader` keeps the existing fast-retry phase unchanged (5 attempts, 1s apart). Once exhausted, it enters slow-poll mode: exactly **one** real connectivity attempt per `scmLoader.slowPoll.interval` (default 60s, hard floor of 60s regardless of configured value), not a repeat of the fast-retry burst.
- The plugin config stays `enabled=true` throughout — no manual re-activation is ever required, and `reloadPlugin()` clears any stale retry state on a config change.

**4. `BaseGitPlugin` / `Common` — explicit JGit fetch/pull timeout**
No timeout existed on `fetchFromRemote()`/`gitPull()`, so a hung or slow remote could block a git operation indefinitely. Added a new "Fetch Timeout" plugin property (default 30s, configurable) applied via JGit's `TransportCommand.setTimeout()`.

**Describe alternatives you've considered**

- Exponential backoff for the slow-poll interval (5min → 7.5min → ... → 30min cap) — considered and discussed, but a fixed interval was chosen instead: simpler to implement/test/reason about, and it already bounds the retry rate adequately (one attempt per interval, not a burst).
- Marking the plugin as "degraded" with a new state rather than throwing an exception — rejected because it would require adding a new `SynchState` enum value and updating all consumers.
- Retrying indefinitely inside a single loader invocation (blocking `Thread.sleep` for the full slow-poll interval) — rejected because the loader's `scheduledExecutor` only has 2 threads shared across all projects/integrations; a long sleep per project would starve the pool.

**Additional context**

Reproduced and verified locally using Gitea in Docker, plus a raw TCP listener on the Gitea port to directly observe connection-attempt cadence (independent of any app-level logging):

1. `docker stop gitea` → fast-retry burst (5 attempts, ~1s apart), then **silence** for ~60s, then exactly one isolated connection attempt per cycle — no repeated bursts.
2. Config stayed `enabled=true` throughout the outage (checked via `GET .../scm/{integration}/config`).
3. `docker start gitea` → the next slow-poll cycle picks it up automatically; status returns to `CLEAN` with no `enable` call.
4. Verified the same independent behavior with **two projects configured simultaneously** (one export, one import) — each project/integration tracks its own retry state (keyed by `project-integration`), with no cross-contamination.
5. Full round-trip also verified: created jobs → exported/committed/pushed to Gitea → imported into a separate project from a different branch.

Fixes: https://pagerduty.atlassian.net/browse/RUN-4525

## Release Notes

Fixed SCM plugin (git-export/git-import) incorrectly disabling itself when the Git server is temporarily unreachable. The plugin now recovers automatically when connectivity is restored, without requiring manual re-activation, and without repeatedly hammering the Git server during an outage — after fast retries are exhausted it polls once per `scmLoader.slowPoll.interval` (default 60s) instead of giving up. Users will see a clear "Git server unavailable" warning in the UI during outages instead of a stale or missing status. Also adds a configurable fetch/pull timeout for the git plugin (default 30s) to prevent a hung remote from blocking indefinitely.
