### PR TITLE
[RUN-3651] Preserve shared data context when resolving dynamic secure…

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionServiceImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/ExecutionServiceImpl.java
@@ -182,9 +182,11 @@ public class ExecutionServiceImpl implements ExecutionService {
         try {
             final ExecutionContextImpl nodeContext;
             if(secureOptionReplaced){
+                WFSharedContext updatedSharedContext = new WFSharedContext(context.getSharedDataContext());
+                updatedSharedContext.merge(ContextView.global(), context.getDataContextObject());
                 nodeContext = new ExecutionContextImpl.Builder(context)
                         .singleNodeContext(node, true)
-                        .sharedDataContext(WFSharedContext.with(ContextView.global(), context.getDataContextObject()))
+                        .sharedDataContext(updatedSharedContext)
                         .build();
             }else{
                 nodeContext = new ExecutionContextImpl.Builder(context)


### PR DESCRIPTION
## Release Notes

Fixed an edge case where data.* variables set by log filter plugins (e.g. key-value-data) were lost in subsequent workflow steps when a secure option's storage path contained a node context variable such as ${node.name}.
Bug fix for [RUN-3651](https://pagerduty.atlassian.net/browse/RUN-3651).

## Ticket Details
When a secure option's storagePath contains a node context variable (e.g. keys/project/foo/${node.name}), data variables captured by log filter plugins (e.g. key-value-data) in earlier workflow steps are lost and unavailable in subsequent steps. With a hardcoded storage path the bug does not occur.

Describe the solution you've implemented

In ExecutionServiceImpl.executeNodeStep(), when secureOptionReplaced=true (i.e. the storage path contained ${node.*} and was resolved per-node), the code previously constructed a brand-new WFSharedContext containing only the global view of the current data context:

// Before — discards accumulated data.* vars from log filters
.sharedDataContext(WFSharedContext.with(ContextView.global(), context.getDataContextObject()))
WFSharedContext.with(ContextView, DataContext) creates an empty context and merges only that single view, losing every other view (including data.* variables set by key-value-data in previous steps).

The fix copies the existing sharedDataContext first, then merges the updated global data (which contains the resolved secure option value) on top:

WFSharedContext updatedSharedContext = new WFSharedContext(context.getSharedDataContext());
updatedSharedContext.merge(ContextView.global(), context.getDataContextObject());
nodeContext = new ExecutionContextImpl.Builder(context)
        .singleNodeContext(node, true)
        .sharedDataContext(updatedSharedContext)
        .build();
This preserves all accumulated data variables while still propagating the resolved secure option value into the node context.

Describe alternatives you've considered

Since context.getDataContext().get("option") is mutated in-place before building nodeContext, simply dropping the explicit .sharedDataContext(...) call (matching the secureOptionReplaced=false branch) might also work. However, copying the shared context and explicitly merging the global data is safer and more intentional — it avoids relying on whether the shared context holds a reference or a copy of the flat data context.

## Additional context

Reported by customer LSEG Business Services Limited. Reproduces on Rundeck 5.13.0 with a job that:

Configures a secure option with storagePath: keys/project/<name>/${node.name}
Runs a local command with a key-value-data log filter writing to data.variable
Runs a subsequent step that tries to echo ${data.variable} — value is blank
With a hardcoded path (no ${node.name}) the data variable prints correctly.

[RUN-3651]: https://pagerduty.atlassian.net/browse/RUN-3651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ