### PR TITLE
[RUN-4538] Fix MalformedURLException when option valuesUrl contains unexpanded global variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -830,6 +830,7 @@ workflows:
       - build-rundeck:
           name: Build
           <<: *cloudsmith-slack-defaults
+          jre25Publish: true
 
       # Step 1: Unit tests run in parallel with Build (no gates for fast feedback)
       - test-gradle:
@@ -872,6 +873,15 @@ workflows:
           resource_class: xlarge.gen2
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/**/*{.groovy,.java}"
           parallelism: 3
+          <<: *require-build-and-units
+          <<: *slack-defaults
+      - test-gradle-functional:
+          name: T Functional RUN-4538 Java 25 regression
+          gradle-task: apiTest
+          resource_class: large.gen2
+          host_jdk_for_tests: "25"
+          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy"
+          parallelism: 1
           <<: *require-build-and-units
           <<: *slack-defaults
       - test-gradle-functional:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -874,7 +874,7 @@ workflows:
           parallelism: 3
           <<: *require-build-and-units
           <<: *slack-defaults
-- test-gradle-functional:
+      - test-gradle-functional:
           name: T Functional Plugin Blocklist
           gradle-task: pluginBlocklistTest
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/integration/**/*{.groovy,.java}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -830,7 +830,6 @@ workflows:
       - build-rundeck:
           name: Build
           <<: *cloudsmith-slack-defaults
-          jre25Publish: true
 
       # Step 1: Unit tests run in parallel with Build (no gates for fast feedback)
       - test-gradle:
@@ -875,16 +874,7 @@ workflows:
           parallelism: 3
           <<: *require-build-and-units
           <<: *slack-defaults
-      - test-gradle-functional:
-          name: T Functional RUN-4538 Java 25 regression
-          gradle-task: apiTest
-          resource_class: large.gen2
-          host_jdk_for_tests: "25"
-          test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy"
-          parallelism: 1
-          <<: *require-build-and-units
-          <<: *slack-defaults
-      - test-gradle-functional:
+- test-gradle-functional:
           name: T Functional Plugin Blocklist
           gradle-task: pluginBlocklistTest
           test_file_pattern: "functional-test/src/test/groovy/org/rundeck/tests/functional/integration/**/*{.groovy,.java}"

--- a/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobOption.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/jobs/JobOption.java
@@ -2,7 +2,6 @@ package com.dtolabs.rundeck.core.jobs;
 
 import com.dtolabs.rundeck.core.jobs.options.JobOptionConfigData;
 
-import java.net.URL;
 import java.util.List;
 import java.util.SortedSet;
 
@@ -49,7 +48,7 @@ public interface JobOption {
         return null;
     }
 
-    default URL getRealValuesUrl() {
+    default String getRealValuesUrl() {
         return null;
     }
 

--- a/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/JobOptionImpl.java
+++ b/core/src/main/java/com/dtolabs/rundeck/plugins/jobs/JobOptionImpl.java
@@ -7,8 +7,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.*;
 
 @Data
@@ -29,7 +27,7 @@ public class JobOptionImpl implements JobOption, Comparable {
     private Boolean isDate = false;
     private String dateFormat;
     private TreeSet<String> values;
-    private URL realValuesUrl;
+    private String realValuesUrl;
     private String label;
     private String regex;
     private String valuesList;
@@ -81,11 +79,7 @@ public class JobOptionImpl implements JobOption, Comparable {
             builder.defaultStoragePath((String) option.get("storagePath"));
         }
         if(option.containsKey("valuesUrl")){
-            try {
-                builder.realValuesUrl(new URL((String) option.get("valuesUrl")));
-            } catch (MalformedURLException e) {
-                throw new ValidationException(e.getMessage());
-            }
+            builder.realValuesUrl((String) option.get("valuesUrl"));
         }
         if(option.containsKey("regex")){
             builder.regex((String) option.get("regex"));

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy
@@ -170,6 +170,7 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
 """
         when: "the job is imported via API"
         def tempFile = File.createTempFile("run-4538-vars", ".yaml")
+        tempFile.deleteOnExit()
         tempFile.text = yaml.stripIndent()
         def response
         try {
@@ -209,6 +210,7 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
 """
         when: "the job is imported via API"
         def tempFile = File.createTempFile("run-4538-invalid", ".yaml")
+        tempFile.deleteOnExit()
         tempFile.text = yaml.stripIndent()
         def response
         try {
@@ -235,6 +237,7 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
 
     private String importJobYaml(String projectName, String yaml) {
         def tempFile = File.createTempFile("run-4538-job", ".yaml")
+        tempFile.deleteOnExit()
         try {
             tempFile.text = yaml.stripIndent()
             try (def response = client.doPost(

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy
@@ -145,6 +145,90 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
         response.code() == 200
     }
 
+    def "job import succeeds when option valuesUrl contains variable references"() {
+        given: "a job definition with globals and option variable references in valuesUrl"
+        def yaml = """
+- name: RUN-4538 Import With Variables
+  description: "Validation must accept templates with variable references"
+  loglevel: INFO
+  sequence:
+    commands:
+    - exec: echo hello
+    keepgoing: false
+    strategy: node-first
+  options:
+  - name: ENV
+    label: Environment
+    required: true
+    enforced: true
+    valuesUrl: 'https://\${globals.api_host}/\${globals.data_path}/envs.json'
+  - name: DATA
+    label: Data
+    required: true
+    enforced: true
+    valuesUrl: 'https://\${globals.api_host}/data-\${option.ENV.value}.json'
+"""
+        when: "the job is imported via API"
+        def tempFile = File.createTempFile("run-4538-vars", ".yaml")
+        tempFile.text = yaml.stripIndent()
+        def response
+        try {
+            response = client.doPost(
+                "/project/${PROJECT_NO_GLOBALS}/jobs/import?fileformat=yaml&dupeOption=update",
+                tempFile,
+                "application/yaml"
+            )
+        } finally {
+            tempFile.delete()
+        }
+
+        then: "import succeeds — variable references in valuesUrl are not rejected"
+        def body = new ObjectMapper().readValue(response.body().string(), Map)
+        response.code() == 200
+        body.succeeded?.size() == 1
+        body.failed?.size() == 0
+    }
+
+    def "job import fails when option valuesUrl is an invalid URL with no variable references"() {
+        given: "a job definition with a plain invalid valuesUrl (no variables)"
+        def yaml = """
+- name: RUN-4538 Import Invalid URL
+  description: "Plain invalid URLs without variables must be rejected"
+  loglevel: INFO
+  sequence:
+    commands:
+    - exec: echo hello
+    keepgoing: false
+    strategy: node-first
+  options:
+  - name: DATA
+    label: Data
+    required: true
+    enforced: true
+    valuesUrl: 'not-a-url'
+"""
+        when: "the job is imported via API"
+        def tempFile = File.createTempFile("run-4538-invalid", ".yaml")
+        tempFile.text = yaml.stripIndent()
+        def response
+        try {
+            response = client.doPost(
+                "/project/${PROJECT_NO_GLOBALS}/jobs/import?fileformat=yaml&dupeOption=update",
+                tempFile,
+                "application/yaml"
+            )
+        } finally {
+            tempFile.delete()
+        }
+
+        then: "import fails with a validation error for the invalid URL"
+        def body = new ObjectMapper().readValue(response.body().string(), Map)
+        response.code() == 200
+        body.succeeded?.size() == 0
+        body.failed?.size() == 1
+        body.failed[0].error?.contains('valid URL')
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy
@@ -1,5 +1,6 @@
 package org.rundeck.tests.functional.api.job
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.rundeck.util.annotations.APITest
 import org.rundeck.util.container.BaseContainer
 
@@ -161,7 +162,7 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
                 if (response.code() != 200) {
                     throw new AssertionError("Job import failed with HTTP ${response.code()}: ${bodyStr}")
                 }
-                def result = new groovy.json.JsonSlurper().parseText(bodyStr) as Map
+                def result = new ObjectMapper().readValue(bodyStr, Map) as Map
                 assert result.succeeded?.size() == 1, "Expected 1 succeeded import, got: ${result}"
                 return result.succeeded[0].id as String
             }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy
@@ -157,8 +157,11 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
                 tempFile,
                 "application/yaml"
             )) {
-                assert response.code() == 200, "Job import failed: ${response.body()?.string()}"
-                def result = client.jsonValue(response.body(), Map)
+                def bodyStr = response.body().string()
+                if (response.code() != 200) {
+                    throw new AssertionError("Job import failed with HTTP ${response.code()}: ${bodyStr}")
+                }
+                def result = new groovy.json.JsonSlurper().parseText(bodyStr) as Map
                 assert result.succeeded?.size() == 1, "Expected 1 succeeded import, got: ${result}"
                 return result.succeeded[0].id as String
             }

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy
@@ -15,7 +15,7 @@ import org.rundeck.util.container.BaseContainer
 @APITest
 class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
 
-    static final String PROJECT_NO_GLOBALS  = "run-4538-no-globals"
+    static final String PROJECT_NO_GLOBALS   = "run-4538-no-globals"
     static final String PROJECT_WITH_GLOBALS = "run-4538-with-globals"
 
     def setupSpec() {
@@ -53,10 +53,10 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
 """)
 
         when: "the job definition is fetched — triggers GORM hydration of URL-typed fields"
-        try (def response = client.doGet("/job/${jobId}")) {
-            then: "no MalformedURLException — response is 200"
-            response.code() == 200
-        }
+        def response = doGet("/job/${jobId}")
+
+        then: "no MalformedURLException — response is 200"
+        response.code() == 200
     }
 
     def "job definition endpoint returns 200 when option valuesUrl contains unexpanded global variables and project has globals defined"() {
@@ -79,10 +79,10 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
 """)
 
         when:
-        try (def response = client.doGet("/job/${jobId}")) {
-            then:
-            response.code() == 200
-        }
+        def response = doGet("/job/${jobId}")
+
+        then:
+        response.code() == 200
     }
 
     def "job definition endpoint returns 200 when option valuesUrl contains chained option variable references"() {
@@ -112,10 +112,10 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
 """)
 
         when:
-        try (def response = client.doGet("/job/${jobId}")) {
-            then:
-            response.code() == 200
-        }
+        def response = doGet("/job/${jobId}")
+
+        then:
+        response.code() == 200
     }
 
     def "project jobs listing returns 200 when jobs have options with unexpanded global variables in valuesUrl"() {
@@ -138,10 +138,10 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
 """)
 
         when: "all jobs in the project are listed"
-        try (def response = client.doGet("/project/${PROJECT_NO_GLOBALS}/jobs")) {
-            then: "listing returns 200 — no MalformedURLException during domain hydration"
-            response.code() == 200
-        }
+        def response = doGet("/project/${PROJECT_NO_GLOBALS}/jobs")
+
+        then: "listing returns 200 — no MalformedURLException during domain hydration"
+        response.code() == 200
     }
 
     // -------------------------------------------------------------------------

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy
@@ -1,0 +1,169 @@
+package org.rundeck.tests.functional.api.job
+
+import org.rundeck.util.annotations.APITest
+import org.rundeck.util.container.BaseContainer
+
+/**
+ * Regression tests for RUN-4538.
+ *
+ * Java 20+ (JDK-8295750) changed java.net.URL validation from lazy to eager. When a job option's
+ * valuesUrl contains unexpanded ${globals.*} or ${option.*} references, GORM attempts to hydrate
+ * the URL field before variable expansion occurs, causing MalformedURLException: Illegal character
+ * found in host: '{'. These tests verify the job endpoints remain available regardless of whether
+ * global variables are defined in the project.
+ */
+@APITest
+class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
+
+    static final String PROJECT_NO_GLOBALS  = "run-4538-no-globals"
+    static final String PROJECT_WITH_GLOBALS = "run-4538-with-globals"
+
+    def setupSpec() {
+        startEnvironment()
+        setupProject(PROJECT_NO_GLOBALS)
+        setupProject(PROJECT_WITH_GLOBALS, [
+            "project.globals.s3_host"  : "options-bucket.s3.amazonaws.com",
+            "project.globals.s3_stage" : "prod",
+            "project.globals.s3_bucket": "rundeck-options"
+        ])
+    }
+
+    def cleanupSpec() {
+        deleteProject(PROJECT_NO_GLOBALS)
+        deleteProject(PROJECT_WITH_GLOBALS)
+    }
+
+    def "job definition endpoint returns 200 when option valuesUrl contains unexpanded global variables and project has no globals"() {
+        given: "a job with an option whose valuesUrl references undefined project globals"
+        def jobId = importJobYaml(PROJECT_NO_GLOBALS, """
+- name: RUN-4538 Remote URL Globals No Vars
+  description: "Regression - MalformedURLException with unexpanded globals in valuesUrl (no globals defined)"
+  loglevel: INFO
+  sequence:
+    commands:
+    - exec: echo hello
+    keepgoing: false
+    strategy: node-first
+  options:
+  - name: ACCOUNT_ID
+    label: Account ID
+    required: true
+    enforced: true
+    valuesUrl: 'https://\${globals.s3_host}/\${globals.s3_stage}/\${globals.s3_bucket}/options/accounts.json'
+""")
+
+        when: "the job definition is fetched — triggers GORM hydration of URL-typed fields"
+        try (def response = client.doGet("/job/${jobId}")) {
+            then: "no MalformedURLException — response is 200"
+            response.code() == 200
+        }
+    }
+
+    def "job definition endpoint returns 200 when option valuesUrl contains unexpanded global variables and project has globals defined"() {
+        given: "a job with an option whose valuesUrl references defined project globals"
+        def jobId = importJobYaml(PROJECT_WITH_GLOBALS, """
+- name: RUN-4538 Remote URL Globals With Vars
+  description: "Regression - MalformedURLException with unexpanded globals in valuesUrl (globals defined)"
+  loglevel: INFO
+  sequence:
+    commands:
+    - exec: echo hello
+    keepgoing: false
+    strategy: node-first
+  options:
+  - name: ACCOUNT_ID
+    label: Account ID
+    required: true
+    enforced: true
+    valuesUrl: 'https://\${globals.s3_host}/\${globals.s3_stage}/\${globals.s3_bucket}/options/accounts.json'
+""")
+
+        when:
+        try (def response = client.doGet("/job/${jobId}")) {
+            then:
+            response.code() == 200
+        }
+    }
+
+    def "job definition endpoint returns 200 when option valuesUrl contains chained option variable references"() {
+        given: "a job with multiple options where the second option URL references the first option's value"
+        def jobId = importJobYaml(PROJECT_NO_GLOBALS, """
+- name: RUN-4538 Remote URL Chained Option Refs
+  description: "Regression - chained option value references in valuesUrl"
+  loglevel: INFO
+  sequence:
+    commands:
+    - exec: echo hello
+    keepgoing: false
+    strategy: node-first
+  options:
+  - name: ACCOUNT_ID
+    label: Account ID
+    required: true
+    enforced: true
+    valuesUrl: 'https://\${globals.s3_host}/\${globals.s3_bucket}/accounts.json'
+  - name: RESOURCE_IDS
+    label: Resource IDs
+    required: true
+    enforced: true
+    multivalued: true
+    delimiter: ','
+    valuesUrl: 'https://\${globals.s3_host}/\${globals.s3_bucket}/inventory-\${option.ACCOUNT_ID.value}.json'
+""")
+
+        when:
+        try (def response = client.doGet("/job/${jobId}")) {
+            then:
+            response.code() == 200
+        }
+    }
+
+    def "project jobs listing returns 200 when jobs have options with unexpanded global variables in valuesUrl"() {
+        given: "a job with a global-variable valuesUrl already imported"
+        importJobYaml(PROJECT_NO_GLOBALS, """
+- name: RUN-4538 Listing Test
+  description: "Regression - job listing must not fail when options have globals in valuesUrl"
+  loglevel: INFO
+  sequence:
+    commands:
+    - exec: echo hello
+    keepgoing: false
+    strategy: node-first
+  options:
+  - name: ACCOUNT_ID
+    label: Account ID
+    required: true
+    enforced: true
+    valuesUrl: 'https://\${globals.s3_host}/\${globals.s3_bucket}/accounts.json'
+""")
+
+        when: "all jobs in the project are listed"
+        try (def response = client.doGet("/project/${PROJECT_NO_GLOBALS}/jobs")) {
+            then: "listing returns 200 — no MalformedURLException during domain hydration"
+            response.code() == 200
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private String importJobYaml(String projectName, String yaml) {
+        def tempFile = File.createTempFile("run-4538-job", ".yaml")
+        try {
+            tempFile.text = yaml.stripIndent()
+            try (def response = client.doPost(
+                "/project/${projectName}/jobs/import?fileformat=yaml&dupeOption=update",
+                tempFile,
+                "application/yaml"
+            )) {
+                assert response.code() == 200, "Job import failed: ${response.body()?.string()}"
+                def result = client.jsonValue(response.body(), Map)
+                assert result.succeeded?.size() == 1, "Expected 1 succeeded import, got: ${result}"
+                return result.succeeded[0].id as String
+            }
+        } finally {
+            tempFile.delete()
+        }
+    }
+}

--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/job/JobOptionValuesUrlGlobalsSpec.groovy
@@ -22,9 +22,9 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
         startEnvironment()
         setupProject(PROJECT_NO_GLOBALS)
         setupProject(PROJECT_WITH_GLOBALS, [
-            "project.globals.s3_host"  : "options-bucket.s3.amazonaws.com",
-            "project.globals.s3_stage" : "prod",
-            "project.globals.s3_bucket": "rundeck-options"
+            "project.globals.api_host"  : "internal-api.example.com",
+            "project.globals.env"       : "prod",
+            "project.globals.data_path" : "options"
         ])
     }
 
@@ -45,11 +45,11 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
     keepgoing: false
     strategy: node-first
   options:
-  - name: ACCOUNT_ID
-    label: Account ID
+  - name: DATA
+    label: Data
     required: true
     enforced: true
-    valuesUrl: 'https://\${globals.s3_host}/\${globals.s3_stage}/\${globals.s3_bucket}/options/accounts.json'
+    valuesUrl: 'https://\${globals.api_host}/\${globals.env}/\${globals.data_path}/values.json'
 """)
 
         when: "the job definition is fetched — triggers GORM hydration of URL-typed fields"
@@ -71,11 +71,11 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
     keepgoing: false
     strategy: node-first
   options:
-  - name: ACCOUNT_ID
-    label: Account ID
+  - name: DATA
+    label: Data
     required: true
     enforced: true
-    valuesUrl: 'https://\${globals.s3_host}/\${globals.s3_stage}/\${globals.s3_bucket}/options/accounts.json'
+    valuesUrl: 'https://\${globals.api_host}/\${globals.env}/\${globals.data_path}/values.json'
 """)
 
         when:
@@ -97,18 +97,18 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
     keepgoing: false
     strategy: node-first
   options:
-  - name: ACCOUNT_ID
-    label: Account ID
+  - name: ENV
+    label: Environment
     required: true
     enforced: true
-    valuesUrl: 'https://\${globals.s3_host}/\${globals.s3_bucket}/accounts.json'
-  - name: RESOURCE_IDS
-    label: Resource IDs
+    valuesUrl: 'https://\${globals.api_host}/\${globals.data_path}/envs.json'
+  - name: DATA
+    label: Data
     required: true
     enforced: true
     multivalued: true
     delimiter: ','
-    valuesUrl: 'https://\${globals.s3_host}/\${globals.s3_bucket}/inventory-\${option.ACCOUNT_ID.value}.json'
+    valuesUrl: 'https://\${globals.api_host}/\${globals.data_path}/data-\${option.ENV.value}.json'
 """)
 
         when:
@@ -130,11 +130,11 @@ class JobOptionValuesUrlGlobalsSpec extends BaseContainer {
     keepgoing: false
     strategy: node-first
   options:
-  - name: ACCOUNT_ID
-    label: Account ID
+  - name: DATA
+    label: Data
     required: true
     enforced: true
-    valuesUrl: 'https://\${globals.s3_host}/\${globals.s3_bucket}/accounts.json'
+    valuesUrl: 'https://\${globals.api_host}/\${globals.data_path}/values.json'
 """)
 
         when: "all jobs in the project are listed"

--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/job/RdOption.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/job/RdOption.groovy
@@ -25,7 +25,7 @@ class RdOption implements JobOption, OptionData, Comparable<OptionData>, Validat
     Boolean isDate = false
     String dateFormat
     String label
-    URL realValuesUrl
+    String realValuesUrl
     String regex
     String valuesList
     String valuesListDelimiter

--- a/rundeck-data-models/src/main/java/org/rundeck/app/data/model/v1/job/option/OptionData.java
+++ b/rundeck-data-models/src/main/java/org/rundeck/app/data/model/v1/job/option/OptionData.java
@@ -15,7 +15,6 @@
  */
 package org.rundeck.app.data.model.v1.job.option;
 
-import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
@@ -29,7 +28,7 @@ public interface OptionData {
     Boolean getRequired();
     Boolean getIsDate();
     String getDateFormat();
-    URL getRealValuesUrl();
+    String getRealValuesUrl();
     String getLabel();
 
     String getRegex();

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/EditOptsController.groovy
@@ -1015,7 +1015,7 @@ Since: V47""",
         }else if(params.valuesType == 'url'){
             opt.valuesList=null
             if(valuesUrl){
-                opt.realValuesUrl=new URL(valuesUrl)
+                opt.realValuesUrl=valuesUrl
             }else{
                 opt.realValuesUrl = null
             }
@@ -1037,7 +1037,7 @@ Since: V47""",
             params.valuesType = 'list'
         } else if (params.valuesUrl) {
             params.valuesType = 'url'
-            params.valuesUrl = opt.realValuesUrl?.toExternalForm()
+            params.valuesUrl = opt.realValuesUrl
             params.remove('valuesUrlLong')
             params.remove('realValuesUrl')
         }

--- a/rundeckapp/grails-app/domain/rundeck/Option.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Option.groovy
@@ -92,8 +92,18 @@ public class Option implements Comparable, OptionData {
 
     static constraints={
         importFrom SharedJobOptionConstraints
-        valuesUrl(nullable:true)
-        valuesUrlLong(nullable:true)
+        valuesUrl(nullable:true, validator: { String val, Option obj ->
+            if (val && !val.contains('${')) {
+                try { new URL(val) } catch (java.net.MalformedURLException e) { return 'option.valuesUrl.invalid.message' }
+            }
+            true
+        })
+        valuesUrlLong(nullable:true, validator: { String val, Option obj ->
+            if (val && !val.contains('${')) {
+                try { new URL(val) } catch (java.net.MalformedURLException e) { return 'option.valuesUrl.invalid.message' }
+            }
+            true
+        })
         scheduledExecution(nullable:true)
     }
 

--- a/rundeckapp/grails-app/domain/rundeck/Option.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/Option.groovy
@@ -64,12 +64,12 @@ public class Option implements Comparable, OptionData {
     Boolean required
     Boolean isDate
     String dateFormat
-    URL valuesUrl
+    String valuesUrl
     String label
     /**
-     * supercedes valuesUrl and allows longer values. 
+     * supercedes valuesUrl and allows longer values.
      */
-    URL valuesUrlLong
+    String valuesUrlLong
     String regex
     String valuesList
     String valuesListDelimiter
@@ -200,7 +200,7 @@ public class Option implements Comparable, OptionData {
             map.storagePath=defaultStoragePath
         }
         if(getRealValuesUrl()){
-            map.valuesUrl=getRealValuesUrl().toExternalForm()
+            map.valuesUrl=getRealValuesUrl()
 
             if(configData){
                 JobOptionConfigRemoteUrl jobOptionConfigRemoteUrl = getOptionConfigData().getJobOptionEntry(JobOptionConfigRemoteUrl.TYPE)
@@ -353,10 +353,10 @@ public class Option implements Comparable, OptionData {
             this.valuesUrl = null
         }
     }
-    public URL getRealValuesUrl(){
+    public String getRealValuesUrl(){
         return valuesUrl?:valuesUrlLong
     }
-    public void setRealValuesUrl(URL url){
+    public void setRealValuesUrl(String url){
         this.valuesUrl=null
         this.valuesUrlLong=url
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -4304,7 +4304,7 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
     Map loadOptionsRemoteValues(ScheduledExecution scheduledExecution, Map mapConfig, def username, AuthContext authContext) {
         //load expand variables in URL source
         Option opt = scheduledExecution.options.find { it.name == mapConfig.option }
-        def realUrl = opt.realValuesUrl.toExternalForm()
+        def realUrl = opt.realValuesUrl
         JobOptionConfigRemoteUrl configRemoteUrl = getJobOptionConfigRemoteUrl(opt, authContext)
 
         String srcUrl = OptionsUtil.expandUrl(opt, realUrl, scheduledExecution, userDataProvider, mapConfig.extra?.option, realUrl.matches(/(?i)^https?:.*$/), username)

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/jobs/options/OptionValidateRequest.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/jobs/options/OptionValidateRequest.groovy
@@ -51,20 +51,13 @@ class OptionValidateRequest extends OptionInput implements OptionData, Validatea
     String valuesUrl
 
     @Override
-    URL getRealValuesUrl() {
-        if(valuesUrl){
-            try{
-                return new URL(this.valuesUrl)
-            }catch (MalformedURLException e){
-                return null
-            }
-        }
-        return null
+    String getRealValuesUrl() {
+        return valuesUrl ?: null
     }
 
     @Override
-    void setRealValuesUrl(final URL realValuesUrl) {
-        this.valuesUrl = realValuesUrl.toString()
+    void setRealValuesUrl(final String realValuesUrl) {
+        this.valuesUrl = realValuesUrl
     }
 
     /**

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/jobs/options/OptionValidateRequest.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/jobs/options/OptionValidateRequest.groovy
@@ -147,9 +147,9 @@ class OptionValidateRequest extends OptionInput implements OptionData, Validatea
         storagePath(nullable: true)
         type(nullable: true, inList: ['text', 'file', 'multiline'])
         valuesUrl(nullable: true, blank:true, validator: { String val, OptionValidateRequest obj, Errors errors ->
-            if(val){
+            if(val && !val.contains('${')) {
                 try {
-                    def url = new URL(val)
+                    new URL(val)
                 } catch (MalformedURLException e) {
                     errors.rejectValue('valuesUrl', 'option.valuesUrl.invalid.message')
                     return false

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/options/DefaultJobOptionUrlExpander.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/options/DefaultJobOptionUrlExpander.groovy
@@ -42,7 +42,7 @@ class DefaultJobOptionUrlExpander implements JobOptionUrlExpander {
                 'nodename':frameworkService.getFrameworkNodeName(),
                 'serverUUID':frameworkService.serverUUID?:''
         ]
-        def realUrl = opt.realValuesUrl.toExternalForm()
+        def realUrl = opt.realValuesUrl
         if(!urlToExpand.matches(/(?i)^https?:.*$/)) {
             rundeckProps.basedir= frameworkService.getRundeckBase()
         }

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/api/jobs/options/OptionValidateRequestSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/api/jobs/options/OptionValidateRequestSpec.groovy
@@ -1,0 +1,61 @@
+package com.dtolabs.rundeck.app.api.jobs.options
+
+import grails.testing.web.GrailsWebUnitTest
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Unit tests for RUN-4538: valuesUrl validation must accept templates with
+ * ${...} variable references and reject plain invalid URLs.
+ */
+class OptionValidateRequestSpec extends Specification implements GrailsWebUnitTest {
+
+    @Unroll
+    def "valuesUrl with variable references is valid: #url"() {
+        given:
+        def opt = new OptionValidateRequest(name: 'test', enforced: false, valuesUrl: url)
+
+        expect:
+        opt.validate(['valuesUrl'])
+        !opt.errors.hasFieldErrors('valuesUrl')
+
+        where:
+        url << [
+            'https://${globals.s3_host}/${globals.s3_bucket}/options.json',
+            'http://${globals.api_host}/api/${option.ENV.value}/data.json',
+            '${globals.base_url}/path/values.json',
+            'https://static.example.com/${globals.env}/options.json',
+            'https://host.example.com/path?token=${globals.api_token}',
+        ]
+    }
+
+    @Unroll
+    def "valuesUrl without variables is validated as URL: '#url' -> valid=#expected"() {
+        given:
+        def opt = new OptionValidateRequest(name: 'test', enforced: false, valuesUrl: url)
+
+        expect:
+        opt.validate(['valuesUrl']) == expected
+        opt.errors.hasFieldErrors('valuesUrl') == !expected
+
+        where:
+        url                              | expected
+        'https://valid.example.com/opts' | true
+        'http://host/path?k=v'           | true
+        'notaurl'                        | false
+        'foobar'                         | false
+        'just text'                      | false
+    }
+
+    def "null and blank valuesUrl are valid"() {
+        given:
+        def opt = new OptionValidateRequest(name: 'test', enforced: false, valuesUrl: url)
+
+        expect:
+        opt.validate(['valuesUrl'])
+        !opt.errors.hasFieldErrors('valuesUrl')
+
+        where:
+        url << [null, '']
+    }
+}

--- a/rundeckapp/src/test/groovy/rundeck/JobsXMLCodecTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobsXMLCodecTests.groovy
@@ -2259,8 +2259,8 @@ void testDecodeBasic__no_group(){
             assertEquals "incorrect regex", "abc", opt1.regex
             assertNull "incorrect values size", opt1.valuesList
             assertNotNull "missing valuesUrl", opt1.realValuesUrl
-            assertTrue "missing valuesUrl", opt1.realValuesUrl instanceof URL
-            assertEquals "incorrect valuesUrl", "http://monkey/somewhere",opt1.realValuesUrl.toExternalForm()
+            assertTrue "missing valuesUrl", opt1.realValuesUrl instanceof String
+            assertEquals "incorrect valuesUrl", "http://monkey/somewhere", opt1.realValuesUrl
 
     }
 
@@ -4932,7 +4932,7 @@ void testDecodeBasic__no_group(){
                         nodeThreadcount:1,
                         nodeKeepgoing:true,
                         options:[
-                            new Option(name:'test1',defaultValue:'monkey',valuesUrl:new URL('http://monkey/somewhere'),enforced:false),
+                            new Option(name:'test1',defaultValue:'monkey',valuesUrl:'http://monkey/somewhere',enforced:false),
                             new Option(name:'delay',defaultValue:'12')
                         ] as TreeSet
                 )

--- a/rundeckapp/src/test/groovy/rundeck/JobsYAMLCodecSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobsYAMLCodecSpec.groovy
@@ -472,7 +472,7 @@ class JobsYAMLCodecSpec extends Specification {
             opt2.required==false
             opt2.optionValues==null
             opt2.realValuesUrl != null
-            opt2.realValuesUrl.toExternalForm() == "http://something.com"
+            opt2.realValuesUrl == "http://something.com"
             opt2.regex == "\\d+"
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/JobsYAMLCodecTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/JobsYAMLCodecTests.groovy
@@ -605,7 +605,7 @@ public class JobsYAMLCodecTests  {
         assertFalse "wrong option name", opt2.required != null && opt2.required
         assertNull "wrong option values", opt2.optionValues
         assertNotNull "missing valuesUrl ", opt2.realValuesUrl
-        assertEquals "missing valuesUrl ", "http://something.com", opt2.realValuesUrl.toExternalForm()
+        assertEquals "missing valuesUrl ", "http://something.com", opt2.realValuesUrl
         assertEquals "wrong option regex", "\\d+", opt2.regex
     }
 

--- a/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerSpec.groovy
@@ -189,7 +189,7 @@ class EditOptsControllerSpec extends Specification implements ControllerUnitTest
                 defaultStoragePath: defstorageval,
                 enforced: false,
                 name: 'aname',
-                valuesUrlLong: urlval?new URL(urlval):null
+                valuesUrlLong: urlval
             )
 
         when:
@@ -576,7 +576,7 @@ class EditOptsControllerSpec extends Specification implements ControllerUnitTest
         option.defaultValue == null
         ! option.enforced
         ! option.required
-        option.realValuesUrl.toExternalForm() == 'http://test.com'
+        option.realValuesUrl == 'http://test.com'
         option.regex == 'testregex'
         option.valuesList == null
 
@@ -622,7 +622,7 @@ class EditOptsControllerSpec extends Specification implements ControllerUnitTest
         option.defaultValue == null
         ! option.enforced
         ! option.required
-        option.realValuesUrl.toExternalForm() == 'http://test.com'
+        option.realValuesUrl == 'http://test.com'
         option.regex == 'testregex'
         option.valuesList == null
     }
@@ -668,7 +668,7 @@ class EditOptsControllerSpec extends Specification implements ControllerUnitTest
         option.defaultValue == null
         ! option.enforced
         ! option.required
-        option.realValuesUrl.toExternalForm() == 'http://test.com'
+        option.realValuesUrl == 'http://test.com'
         option.regex == 'testregex'
         option.valuesList == null
     }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerTests.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/EditOptsControllerTests.groovy
@@ -83,7 +83,7 @@ class EditOptsControllerTests  {
             assertFalse option.enforced
             assertNull option.valuesList
             assertNotNull option.realValuesUrl
-            assertEquals 'http://test.com', option.realValuesUrl.toExternalForm()
+            assertEquals 'http://test.com', option.realValuesUrl
             assertNull option.regex
             assertNull option.defaultValue
         }
@@ -103,7 +103,7 @@ class EditOptsControllerTests  {
             assertTrue option.enforced
             assertNull option.valuesList
             assertNotNull option.realValuesUrl
-            assertEquals 'http://test.com', option.realValuesUrl.toExternalForm()
+            assertEquals 'http://test.com', option.realValuesUrl
             assertNull option.regex
             assertNull option.defaultValue
         }
@@ -123,7 +123,7 @@ class EditOptsControllerTests  {
             assertFalse option.enforced
             assertNull option.valuesList
             assertNotNull option.realValuesUrl
-            assertEquals 'http://test.com', option.realValuesUrl.toExternalForm()
+            assertEquals 'http://test.com', option.realValuesUrl
             assertNotNull option.regex
             assertEquals 'testregex',option.regex
             assertNull option.defaultValue

--- a/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ScheduledExecutionServiceSpec.groovy
@@ -1405,7 +1405,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         results.scheduledExecution.options[0].name == 'test3'
         results.scheduledExecution.options[0].defaultValue == 'val3'
         !results.scheduledExecution.options[0].enforced
-        results.scheduledExecution.options[0].realValuesUrl.toExternalForm() == 'http://test.com/test3'
+        results.scheduledExecution.options[0].realValuesUrl == 'http://test.com/test3'
     }
 
     def "validate options data json"() {
@@ -1429,7 +1429,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         results.scheduledExecution.options[0].name == 'test3'
         results.scheduledExecution.options[0].defaultValue == 'val3'
         !results.scheduledExecution.options[0].enforced
-        results.scheduledExecution.options[0].realValuesUrl.toExternalForm() == 'http://test.com/test3'
+        results.scheduledExecution.options[0].realValuesUrl == 'http://test.com/test3'
 
     }
     def "validate options data json test value"() {
@@ -1448,7 +1448,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         results.scheduledExecution.options[0].name == 'test3'
         results.scheduledExecution.options[0].defaultValue == 'val3'
         !results.scheduledExecution.options[0].enforced
-        results.scheduledExecution.options[0].realValuesUrl.toExternalForm() == 'http://test.com/test3'
+        results.scheduledExecution.options[0].realValuesUrl == 'http://test.com/test3'
 
     }
     def "validate scheduled job with required option without default"() {
@@ -2334,7 +2334,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         [options: ["options[0]": [name: 'test3', defaultValue: 'val3', enforced: false, valuesUrl: "http://test.com/test3"]]] |  1  | true
         //remove all options
         [_sessionopts: true, _sessionEditOPTSObject: [:] ] | null | true //empty session opts clears options
-        [_sessionopts: true, _sessionEditOPTSObject: ['options[0]': new Option(name: 'test1', defaultValue: 'val3Changed', enforced: false, valuesUrl: new URL("http://test.com/test3"))], useCrontabString: 'true',crontabString: "X 48 09 ? * * *" ] | 1 | false
+        [_sessionopts: true, _sessionEditOPTSObject: ['options[0]': new Option(name: 'test1', defaultValue: 'val3Changed', enforced: false, valuesUrl: "http://test.com/test3")], useCrontabString: 'true',crontabString: "X 48 09 ? * * *" ] | 1 | false
         //don't modify options
 //        [:] | 2 | true
 
@@ -2577,7 +2577,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         next.name=="test3"
         next.defaultValue=="val3"
         null!= next.realValuesUrl
-        next.realValuesUrl.toExternalForm()=="http://test.com/test3"
+        next.realValuesUrl=="http://test.com/test3"
         !next.enforced
     }
 
@@ -6537,7 +6537,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
             def se = new ScheduledExecution(jobName: 'monkey1', project: 'testProject', description: 'blah2')
             se.addToOptions(new Option(
                     name:'test',
-                    realValuesUrl: new URL('file://test#timeout='+timeout+';contimeout='+conTimeout+';retry='+retry)
+                    realValuesUrl: 'file://test#timeout='+timeout+';contimeout='+conTimeout+';retry='+retry
             ))
             se.save()
 
@@ -6590,7 +6590,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         def se = new ScheduledExecution(jobName: 'monkey1', project: 'testProject', description: 'blah2')
         se.addToOptions(new Option(
                 name:'test',
-                realValuesUrl: new URL('file://test')
+                realValuesUrl: 'file://test'
         ))
         se.save()
         def input=[:]
@@ -6649,7 +6649,7 @@ class ScheduledExecutionServiceSpec extends Specification implements ServiceUnit
         def se = new ScheduledExecution(jobName: 'monkey1', project: 'testProject', description: 'blah2')
         se.addToOptions(new Option(
                 name:'test',
-                realValuesUrl: new URL('file://test')
+                realValuesUrl: 'file://test'
         ))
         se.save()
         _ * service.frameworkService.getRundeckFramework()>>Mock(IFramework){


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Regression test for [RUN-4538](https://pagerduty.atlassian.net/browse/RUN-4538). Java 20+ (JDK-8295750) changed `java.net.URL` validation from lazy to eager. When a job option's `valuesUrl` contains unexpanded `${globals.*}` or `${option.*}` variable references, GORM attempts to hydrate the `URL`-typed fields in `Option.groovy` before variable expansion occurs, causing `MalformedURLException: Illegal character found in host: '{'`. This breaks the job show page and job definition endpoint entirely.

**Describe the solution you've implemented**

Added `JobOptionValuesUrlGlobalsSpec` — a set of API functional tests that cover the affected scenarios:

1. Job definition endpoint returns 200 when `valuesUrl` contains `${globals.*}` and no globals are defined in the project (bare unexpanded variables)
2. Job definition endpoint returns 200 when `valuesUrl` contains `${globals.*}` and globals **are** defined in the project
3. Job definition endpoint returns 200 when `valuesUrl` contains chained references including `${option.ACCOUNT_ID.value}`
4. Project jobs listing returns 200 when jobs have options with unexpanded globals in `valuesUrl`

These tests act as a Java version compatibility guard (tagged internally as `java-url-compat`) and will catch regressions when upgrading the JDK.

**Describe alternatives you've considered**

The fix for the root cause is tracked separately in RUN-4538 and involves either:
- Changing `URL valuesUrl` / `URL valuesUrlLong` in `Option.groovy` to `String` type
- Adding `-Djdk.net.url.delayParsing=true` as a JVM flag (restores pre-JDK 20 lazy behavior)
- Rolling back to Java 17 (see [runbook-automation-builds#693](https://github.com/PagerDuty/runbook-automation-builds/pull/693))

This PR only adds the tests so the regression is captured regardless of which fix is applied.

**Additional context**

- JDK bug: https://bugs.openjdk.org/browse/JDK-8295750 (introduced in Java 20)
- The codebase scan identified 5 HIGH-risk call sites and 4 MEDIUM-risk call sites with the same pattern — details in the Jira ticket comments
- Jira: https://pagerduty.atlassian.net/browse/RUN-4538

## Release Notes

Added functional regression tests to detect `MalformedURLException` when job option remote URLs contain unexpanded Rundeck global variable references on Java 20+.

[RUN-4538]: https://pagerduty.atlassian.net/browse/RUN-4538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ