### PR TITLE
[RUN-4537] Fix flaky JobsSpec "Error handlers" dropdown assertions

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/JobsSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/selenium/jobs/JobsSpec.groovy
@@ -947,15 +947,15 @@ class JobsSpec extends SeleniumBase {
         jobCreatePage.fillBasicJob 'job with error handlers'
         then: "Add error handler and check that its not possible to add more error handlers to same step"
         jobCreatePage.addErrorHandler( 'exec-command',  StepType.NODE)
-        assert jobCreatePage.doesntHasDropdownOption(0, "add-error-handler")
+        assert jobCreatePage.waitForDropdownOptionAbsent(0, "add-error-handler")
         then: "Duplicate step and remove duplicated error handler"
         jobCreatePage.scrollToElement(jobCreatePage.duplicateWfStepButton)
         jobCreatePage.duplicateWfStepButton.click()
         jobCreatePage.expectNumberOfStepsToBe(2)
-        assert jobCreatePage.doesntHasDropdownOption(1, "add-error-handler")
+        assert jobCreatePage.waitForDropdownOptionAbsent(1, "add-error-handler")
         jobCreatePage.scrollToElement(jobCreatePage.workflowAlphaUiButton)
         jobCreatePage.removeErrorHandlerButton(1).click()
-        assert !jobCreatePage.doesntHasDropdownOption(1, "add-error-handler")
+        assert jobCreatePage.waitForDropdownOptionPresent(1, "add-error-handler")
         expect: "Save the job successfully"
         jobCreatePage.scrollToElement(jobCreatePage.createJobButton);
         jobCreatePage.waitForElementToBeClickable jobCreatePage.createJobButton

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobCreatePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobCreatePage.groovy
@@ -1162,6 +1162,36 @@ class JobCreatePage extends BasePage {
     }
 
     /**
+     * Waits until the given step dropdown option is absent.
+     *
+     * {@link #doesntHasDropdownOption} is a point-in-time DOM query, so asserting it directly
+     * right after an async mutation (e.g. saving an error handler, which triggers a Vue re-render
+     * that removes the "add error handler" option) is racy. This polls until the option is actually
+     * gone instead of checking once.
+     *
+     * @return true once the option is absent; throws TimeoutException if it never disappears
+     */
+    boolean waitForDropdownOptionAbsent(int index, String dataTest, int timeoutSeconds = 30) {
+        new WebDriverWait(driver, Duration.ofSeconds(timeoutSeconds))
+                .until { doesntHasDropdownOption(index, dataTest) }
+        return true
+    }
+
+    /**
+     * Waits until the given step dropdown option is present.
+     *
+     * Counterpart to {@link #waitForDropdownOptionAbsent} for the cases where an async mutation
+     * (e.g. removing an error handler) is expected to re-add the option.
+     *
+     * @return true once the option is present; throws TimeoutException if it never appears
+     */
+    boolean waitForDropdownOptionPresent(int index, String dataTest, int timeoutSeconds = 30) {
+        new WebDriverWait(driver, Duration.ofSeconds(timeoutSeconds))
+                .until { !doesntHasDropdownOption(index, dataTest) }
+        return true
+    }
+
+    /**
      * Clicks the step at index to open edit modal (nextUi mode only).
      * The step item with id wfitem_${index} is clickable and opens EditPluginModal.
      */


### PR DESCRIPTION
## Summary
- Fixes intermittent failures in `JobsSpec` "Error handlers" (`legacyUi: false`), where `doesntHasDropdownOption(...)` was asserted immediately after async UI mutations.
- `doesntHasDropdownOption()` is a point-in-time DOM query with no wait. After saving an error handler (or duplicating a step / removing a handler), Vue re-renders to add or remove the "add error handler" option. If the assertion ran before that re-render propagated, it read stale DOM and failed — hence the flakiness.
- Adds `waitForDropdownOptionAbsent()` / `waitForDropdownOptionPresent()` to `JobCreatePage`, which poll the existing query until the expected state is reached, and uses them at the three racy assertion sites. `doesntHasDropdownOption()` is kept intact (still useful as a point-in-time query and one of the new helpers builds on it).

## Root cause
```
jobCreatePage.doesntHasDropdownOption(0, "add-error-handler")  // false — option still in DOM
    at JobsSpec.groovy:950
```
The `els(...).isEmpty()` check fired before the reactive update removed the option, so the assertion saw the option still present.

## Test plan
- [x] `./gradlew :functional-test:compileTestGroovy` succeeds
- [ ] CI Selenium run: `JobsSpec` "Error handlers" passes across repeated runs without `StaleElementReferenceException`/stale-DOM flakes

## Notes
This is part of a batch of flaky Selenium fixes tracked under RUN-4537. No production code changes — test harness only.