### PR TITLE
[RUN-3911] Fix compacted execution output API returning mixed-type entries array

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/container/RdClient.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/container/RdClient.groovy
@@ -33,7 +33,7 @@ class RdClient {
     /**
      *  The current (latest) released version of the Rundeck API
      */
-    public static final int API_CURRENT_VERSION = 58
+    public static final int API_CURRENT_VERSION = 59
 
     final ObjectMapper mapper = new ObjectMapper()
     String baseUrl

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -1065,7 +1065,9 @@ the result data.
 In this mode, Log Entries are compacted by only including the changed values from the
 previous Log Entry in the list.  The first Log Entry in the results will always have complete information.  Subsequent entries may include only changed values.
 
-In JSON format, if the `compactedAttr` value is `log` in the response data, and only the `log` value changed relative to a previous Log Entry, the Log Entry may consist only of the log message string. That is, the array entry will be a string, not an object.
+In JSON format (API v21-v58), if the `compactedAttr` value is `log` in the response data, and only the `log` value changed relative to a previous Log Entry, the Log Entry may consist only of the log message string. That is, the array entry will be a string, not an object.
+
+As of API v59, compacted entries are always objects even when only the `log` value changed. This avoids mixed-type arrays and eliminates JSON escape sequences (such as `\"`) in log entries that contain special characters.
 
 When no values changed from the previous Log Entry, the Log Entry will be an empty object.
 
@@ -1373,7 +1375,7 @@ this Log Entry.""",
         }
     }
     //Create a map that will be converted to JSON by the grails converter at the render phase
-    private def renderOutputFormatJson(Map data, List outputData, stateoutput = false) {
+    private def renderOutputFormatJson(Map data, List outputData, stateoutput = false, int apiVersion = 0) {
         def keys = [
                 'id', 'offset', 'completed', 'empty', 'unmodified', 'error', 'message', 'pending', 'execCompleted',
                 'hasFailedNodes', 'execState', 'lastModified', 'execDuration', 'percentLoaded', 'totalSize',
@@ -1434,8 +1436,9 @@ this Log Entry.""",
                     }
                 }
                 prev = origmap
-                if (compactedAttr && datamap.size() == 1 && datamap[compactedAttr] != null) {
-                    //compact the single attribute into just the string
+                if (compactedAttr && datamap.size() == 1 && datamap[compactedAttr] != null
+                        && apiVersion < ApiVersions.V59) {
+                    //compact the single attribute into just the string (V58 and below)
                     datamap = datamap[compactedAttr]
                 }
             }
@@ -1934,7 +1937,7 @@ JSON response requires API v14.
 
         withFormat {
             '*' {
-                render renderOutputFormatJson(resultData,entry,stateoutput) as JSON
+                render renderOutputFormatJson(resultData,entry,stateoutput,(int)request.api_version) as JSON
             }
             text{
                 response.addHeader('X-Rundeck-ExecOutput-Offset', storeoffset.toString())

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -1067,7 +1067,7 @@ previous Log Entry in the list.  The first Log Entry in the results will always 
 
 In JSON format (API v21-v58), if the `compactedAttr` value is `log` in the response data, and only the `log` value changed relative to a previous Log Entry, the Log Entry may consist only of the log message string. That is, the array entry will be a string, not an object.
 
-As of API v59, compacted entries are always objects even when only the `log` value changed. This avoids mixed-type arrays and eliminates JSON escape sequences (such as `\"`) in log entries that contain special characters.
+As of API v59, compacted entries are always objects even when only the `log` value changed. This avoids mixed-type arrays and ensures clients can always treat each entry as an object.
 
 When no values changed from the previous Log Entry, the Log Entry will be an empty object.
 
@@ -1937,7 +1937,7 @@ JSON response requires API v14.
 
         withFormat {
             '*' {
-                render renderOutputFormatJson(resultData,entry,stateoutput,(int)request.api_version) as JSON
+                render renderOutputFormatJson(resultData,entry,stateoutput,apiVersion) as JSON
             }
             text{
                 response.addHeader('X-Rundeck-ExecOutput-Offset', storeoffset.toString())

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiVersions.groovy
@@ -46,6 +46,7 @@ class ApiVersions {
     public static final int V56 = 56
     public static final int V57 = 57
     public static final int V58 = 58
+    public static final int V59 = 59
 
     // ^^^ New version is to be added above this line. ^^^
     // Ensure the constant name follows the API_VERSION_VARIABLE_NAME_PATTERN pattern.
@@ -55,9 +56,9 @@ class ApiVersions {
      * Current API version Configuration
      */
     // References the current API version
-    public final static int API_CURRENT_VERSION = V58
+    public final static int API_CURRENT_VERSION = V59
     // Hardcoded inline string constant for the current version used in API doc generation
-    public final static String API_CURRENT_VERSION_STR = "58"
+    public final static String API_CURRENT_VERSION_STR = "59"
 
 
     /**

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -680,6 +680,95 @@ class ExecutionControllerSpec extends Specification implements ControllerUnitTes
 
     }
 
+    def "api execution output compacted json v59 entries always objects"() {
+        given:
+
+        def assetTaglib = mockTagLib(UtilityTagLib)
+        Execution e1 = new Execution(
+                project: 'test1',
+                user: 'bob',
+                dateStarted: new Date(),
+                dateEnded: new Date(),
+                status: 'successful'
+
+        )
+        e1.save() != null
+        controller.loggingService = Mock(LoggingService)
+        controller.configurationService = Mock(ConfigurationService)
+        controller.frameworkService = Mock(FrameworkService) {
+            1 * isClusterModeEnabled()
+            1 * isFrameworkProjectDisabled(_) >> false
+            _ * getServerUUID()
+            0 * _(*_)
+        }
+
+        controller.apiService = Mock(ApiService) {
+            requireApi(*_) >> true
+            0 * _(*_)
+        }
+        session.subject = new Subject()
+        controller.rundeckAppAuthorizer=Mock(AppAuthorizer){
+            1 * execution(_,_)>>Mock(AuthorizingExecution){
+                1 * access(RundeckAccess.Execution.APP_READ_OR_VIEW) >>  e1
+
+            }
+        }
+        def reader = new ExecutionLogReader(state: ExecutionFileState.AVAILABLE)
+        def date1 = new Date(90000000)
+        def sdf=new SimpleDateFormat('yyyy-MM-dd\'T\'HH:mm:ssXXX')
+        sdf.timeZone=TimeZone.getTimeZone('GMT')
+        def abstime=sdf.format(date1)
+        def sdf2=new SimpleDateFormat('HH:mm:ss')
+        def timestr=sdf2.format(date1)
+        reader.reader = new TestReader(logs:
+                                               [
+                                                       new DefaultLogEvent(
+                                                               eventType: LogUtil.EVENT_TYPE_LOG,
+                                                               datetime: date1,
+                                                               message: 'message1',
+                                                               metadata: [:],
+                                                               loglevel: LogLevel.NORMAL
+                                                       ),
+                                                       new DefaultLogEvent(
+                                                               eventType: LogUtil.EVENT_TYPE_LOG,
+                                                               datetime: date1,
+                                                               message: '"quoted" message',
+                                                               metadata: [:],
+                                                               loglevel: LogLevel.NORMAL
+                                                       ),
+                                                       new DefaultLogEvent(
+                                                               eventType: LogUtil.EVENT_TYPE_LOG,
+                                                               datetime: date1,
+                                                               message: '"quoted" message',
+                                                               metadata: [:],
+                                                               loglevel: LogLevel.NORMAL
+                                                       ),
+                                               ]
+        )
+        when:
+        params.id = e1.id.toString()
+        params.compacted = 'true'
+        request.api_version = 59
+        response.format = 'json'
+        controller.apiExecutionOutput()
+        def json = response.json
+        then:
+        1 * controller.loggingService.getLogReader(e1) >> reader
+        json.compacted == true
+        json.compactedAttr == 'log'
+        json.entries.size() == 3
+        json.entries[0].log == 'message1'
+        json.entries[0].level == 'NORMAL'
+        json.entries[0].time == timestr
+        json.entries[0].absolute_time == abstime
+        // V59: log-only change returns object, not bare string
+        json.entries[1] instanceof Map
+        json.entries[1].log == '"quoted" message'
+        // identical to previous: empty object
+        json.entries[2] == [:]
+
+    }
+
     def "api execution log reader not found"() {
         given:
         messageSource.addMessage("execution.log.storage.state.NOT_FOUND",Locale.ENGLISH,"The Execution Log could not be found.")

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -683,7 +683,7 @@ class ExecutionControllerSpec extends Specification implements ControllerUnitTes
     def "api execution output compacted json v59 entries always objects"() {
         given:
 
-        def assetTaglib = mockTagLib(UtilityTagLib)
+        mockTagLib(UtilityTagLib)
         Execution e1 = new Execution(
                 project: 'test1',
                 user: 'bob',


### PR DESCRIPTION
## Release Notes

Fixed the compacted execution output API (`GET /api/*/execution/{id}/output?compacted=true&format=json`), which previously returned a mix of full objects and bare strings in its `entries` array—causing errors in clients that expected every entry to be an object with a `log` field. As of API v59, all compacted log entries are returned as consistent objects (omitting only unchanged fields), while API v58 and earlier keep their existing behavior for backward compatibility.

## Summary

- **Bug**: `GET /api/*/execution/{id}/output?compacted=true&format=json` returned a mixed-type `entries` array — first entry as a full object, subsequent log-only entries as bare strings (e.g. `"   \"blockdevices\": ["`).
- **Impact**: Most JSON clients (Python, JS, Java) iterate entries and call `.log` on each element; bare string entries lack `.log`, causing runtime errors. Log content with `"` characters (e.g. output from `lsblk --json`) also produced confusing `\"` escape sequences.
- **Fix**: Introduced **API v59**. In v59+, compacted entries are always objects with only changed fields omitted — never bare strings. API v58 and below retain existing behavior (backward compatible).

## Changes

| File | Change |
|------|--------|
| `ApiVersions.groovy` | Added `V59 = 59`, bumped `API_CURRENT_VERSION` to V59 |
| `ExecutionController.groovy` | `renderOutputFormatJson` accepts `apiVersion` param; bare-string collapse gated to `apiVersion < V59`; call site passes `request.api_version`; updated inline API docs |
| `ExecutionControllerSpec.groovy` | New test: V59 compacted entries are always `Map` instances, never bare strings |

## Before / After (API v59+)

**Before (`compacted=true`, v58):**
```json
"entries": [
  {"time": "16:54:06", "log": "{", "level": "NORMAL", ...},
  "   \"blockdevices\": [",
  "      {"
]
```

**After (`compacted=true`, v59+):**
```json
"entries": [
  {"time": "16:54:06", "log": "{", "level": "NORMAL", ...},
  {"log": "   \"blockdevices\": ["},
  {"log": "      {"}
]
```

## Test plan

- [x] Existing `api execution output compacted json` test still passes (v21 behavior unchanged)
- [x] New `api execution output compacted json v59 entries always objects` test passes
- [x] Manual: run job with `lsblk --json` step, call output API with `?compacted=true`, verify entries are all objects in v59