### PR TITLE
[RUN-4539] Fix StorageTreeFactory stopping at first gap in provider index sequence

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/storage/StorageTreeFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/storage/StorageTreeFactory.java
@@ -29,8 +29,11 @@ import org.rundeck.storage.conf.TreeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -57,6 +60,40 @@ public class StorageTreeFactory {
     private PluggableProviderService<StoragePlugin> storagePluginProviderService;
     private PluggableProviderService<StorageConverterPlugin> storageConverterPluginProviderService;
 
+
+    /**
+     * Scans the given config map for keys of the form {@code prefix.N.type} and returns a
+     * sorted list of all distinct integer indices {@code N} found.
+     * <p>
+     * Replaces the sequential {@code while (config.containsKey(prefix.N.type))} pattern,
+     * which stopped at the first gap in the index sequence and silently skipped all providers
+     * configured at higher indices (e.g. if index 3 was absent, index 4 and beyond were never
+     * loaded even if they were explicitly defined).
+     *
+     * @param config config property map
+     * @param prefix key prefix (e.g. {@code storage.provider} or {@code storage.converter})
+     * @return sorted list of integer indices N for which {@code prefix.N.type} exists
+     */
+    static List<Integer> extractConfiguredIndices(Map<String, String> config, String prefix) {
+        String indexedPrefix = prefix + SEP;
+        String typeSuffix    = SEP + TYPE;
+        List<Integer> indices = new ArrayList<>();
+        for (String key : config.keySet()) {
+            if (key.startsWith(indexedPrefix) && key.endsWith(typeSuffix)) {
+                // Extract the middle segment — must be a plain integer with no extra dots
+                String middle = key.substring(indexedPrefix.length(), key.length() - typeSuffix.length());
+                if (!middle.contains(SEP)) {
+                    try {
+                        indices.add(Integer.parseInt(middle));
+                    } catch (NumberFormatException ignored) {
+                        // non-numeric segment — not a valid index key, skip
+                    }
+                }
+            }
+        }
+        Collections.sort(indices);
+        return indices;
+    }
 
     public StorageTree createTree() throws Exception {
         if ( null == frameworkPropertyLookup) {
@@ -100,26 +137,26 @@ public class StorageTreeFactory {
         //base layer of storage
         TreeBuilder<ResourceMeta> builder = baseStorage(TreeBuilder.<ResourceMeta>builder());
 
-        int storeIndex = 1;
-
-        while (config.containsKey(getStorageConfigPrefix() + SEP + storeIndex + SEP + TYPE)) {
+        // Scan all keys to find configured storage provider indices, then sort and apply them.
+        // The previous sequential while-loop stopped at the first missing index, silently
+        // skipping all providers at higher indices whenever there was a gap in the sequence.
+        List<Integer> storeIndices = extractConfiguredIndices(config, getStorageConfigPrefix());
+        for (int storeIndex : storeIndices) {
             configureStoragePlugin(builder, storeIndex, config);
-            storeIndex++;
         }
-        if (1 == storeIndex) {
+        if (storeIndices.isEmpty()) {
             logger.debug("No storage plugins configured with prefix " + getStorageConfigPrefix());
         }
-        builder = addLogger(builder,config);
+        builder = addLogger(builder, config);
         //apply default converters on top of storage
         builder = baseConverter(builder);
 
         //add plugin converters
-        int converterIndex = 1;
-        while (config.containsKey(getConverterConfigPrefix() + SEP + converterIndex + SEP + TYPE)) {
+        List<Integer> converterIndices = extractConfiguredIndices(config, getConverterConfigPrefix());
+        for (int converterIndex : converterIndices) {
             builder = configureConverterPlugin(builder, converterIndex, config);
-            converterIndex++;
         }
-        if (1 == converterIndex) {
+        if (converterIndices.isEmpty()) {
             logger.debug("No converter plugins configured with prefix " + getConverterConfigPrefix());
         }
         return builder.build();

--- a/core/src/main/java/com/dtolabs/rundeck/core/storage/StorageTreeFactory.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/storage/StorageTreeFactory.java
@@ -77,20 +77,28 @@ public class StorageTreeFactory {
     static List<Integer> extractConfiguredIndices(Map<String, String> config, String prefix) {
         String indexedPrefix = prefix + SEP;
         String typeSuffix    = SEP + TYPE;
-        List<Integer> indices = new ArrayList<>();
+        // Use a Set to deduplicate: keys like "provider.4.type" and "provider.04.type"
+        // both parse to integer 4 and must not configure the same provider twice.
+        Set<Integer> indexSet = new HashSet<>();
         for (String key : config.keySet()) {
             if (key.startsWith(indexedPrefix) && key.endsWith(typeSuffix)) {
                 // Extract the middle segment — must be a plain integer with no extra dots
                 String middle = key.substring(indexedPrefix.length(), key.length() - typeSuffix.length());
                 if (!middle.contains(SEP)) {
                     try {
-                        indices.add(Integer.parseInt(middle));
+                        int index = Integer.parseInt(middle);
+                        // Only accept positive indices, consistent with the previous 1-based
+                        // sequential scan which never visited index 0 or below.
+                        if (index > 0) {
+                            indexSet.add(index);
+                        }
                     } catch (NumberFormatException ignored) {
                         // non-numeric segment — not a valid index key, skip
                     }
                 }
             }
         }
+        List<Integer> indices = new ArrayList<>(indexSet);
         Collections.sort(indices);
         return indices;
     }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/storage/StorageTreeFactorySpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/storage/StorageTreeFactorySpec.groovy
@@ -136,9 +136,9 @@ class StorageTreeFactorySpec extends Specification {
     def "extractConfiguredIndices ignores non-integer and nested index segments"() {
         given:
         def config = [
-            'provider.abc.type'   : 'bad', // non-numeric
+            'provider.abc.type'     : 'bad', // non-numeric
             'provider.1.config.type': 'bad', // nested — middle contains a dot
-            'provider.2.type'     : 'good',
+            'provider.2.type'       : 'good',
         ]
 
         when:
@@ -148,19 +148,34 @@ class StorageTreeFactorySpec extends Specification {
         result == [2]
     }
 
-    def "extractConfiguredIndices does not double-count an index with multiple keys"() {
-        given:
+    def "extractConfiguredIndices ignores non-positive indices"() {
+        given: "keys with index 0 and a negative index, which were never visited by the old 1-based while-loop"
         def config = [
-            'provider.4.type': 'vault',
-            'provider.4.path': 'keys/vault',
-            'provider.4.config.token': 'secret',
+            'provider.0.type' : 'zero',
+            'provider.-1.type': 'negative',
+            'provider.3.type' : 'valid',
         ]
 
         when:
         def result = StorageTreeFactory.extractConfiguredIndices(config, 'provider')
 
-        then:
-        result == [4]
+        then: "only index 3 is returned; 0 and negative values are excluded"
+        result == [3]
+    }
+
+    def "extractConfiguredIndices deduplicates indices that differ only in leading zeros"() {
+        given: "provider.4.type and provider.04.type both parse to integer 4"
+        def config = [
+            'provider.4.type' : 'vault',
+            'provider.04.type': 'vault-duplicate',
+            'provider.2.type' : 'db',
+        ]
+
+        when:
+        def result = StorageTreeFactory.extractConfiguredIndices(config, 'provider')
+
+        then: "index 4 appears exactly once despite two keys mapping to it"
+        result == [2, 4]
     }
 
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/storage/StorageTreeFactorySpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/storage/StorageTreeFactorySpec.groovy
@@ -97,4 +97,70 @@ class StorageTreeFactorySpec extends Specification {
         !result
 
     }
+
+    def "extractConfiguredIndices returns sorted indices skipping gaps"() {
+        given: "config with provider indices 1, 3, 5 (gaps at 2 and 4)"
+        def config = [
+            'provider.1.type': 'db',
+            'provider.1.path': 'keys',
+            'provider.3.type': 'vault',
+            'provider.5.type': 'aws',
+        ]
+
+        when:
+        def result = StorageTreeFactory.extractConfiguredIndices(config, 'provider')
+
+        then: "all three indices are returned even though 2 and 4 are absent"
+        result == [1, 3, 5]
+    }
+
+    def "extractConfiguredIndices returns empty list when no providers configured"() {
+        expect:
+        StorageTreeFactory.extractConfiguredIndices([:], 'provider') == []
+    }
+
+    def "extractConfiguredIndices ignores keys for a different prefix"() {
+        given:
+        def config = [
+            'provider.1.type'  : 'db',
+            'converter.1.type' : 'enc',  // different prefix — must not appear
+        ]
+
+        when:
+        def result = StorageTreeFactory.extractConfiguredIndices(config, 'provider')
+
+        then:
+        result == [1]
+    }
+
+    def "extractConfiguredIndices ignores non-integer and nested index segments"() {
+        given:
+        def config = [
+            'provider.abc.type'   : 'bad', // non-numeric
+            'provider.1.config.type': 'bad', // nested — middle contains a dot
+            'provider.2.type'     : 'good',
+        ]
+
+        when:
+        def result = StorageTreeFactory.extractConfiguredIndices(config, 'provider')
+
+        then:
+        result == [2]
+    }
+
+    def "extractConfiguredIndices does not double-count an index with multiple keys"() {
+        given:
+        def config = [
+            'provider.4.type': 'vault',
+            'provider.4.path': 'keys/vault',
+            'provider.4.config.token': 'secret',
+        ]
+
+        when:
+        def result = StorageTreeFactory.extractConfiguredIndices(config, 'provider')
+
+        then:
+        result == [4]
+    }
+
 }


### PR DESCRIPTION
## Release Notes

Fixed an issue where key storage providers and converters configured with non-contiguous index numbers were silently skipped, making any keys stored under the skipped providers inaccessible. Rundeck now loads every configured storage provider regardless of gaps in the index sequence, so administrators no longer need to keep provider indexes perfectly consecutive when configuring key storage outside the UI (for example, via `rundeck-config.properties` or automated/API-driven setups).

## About this change

**Jira Ticket:** [RUN-4539](https://pagerduty.atlassian.net/browse/RUN-4539)

**Companion rundeckpro PR:** [rundeckpro/rundeckpro#4770](https://github.com/rundeckpro/rundeckpro/pull/4770)

---

### Root Cause

\`StorageTreeFactory.buildTree()\` iterated storage and converter provider indices with a sequential \`while\` loop that stopped at the **first missing index**:

\`\`\`java
int storeIndex = 1;
while (config.containsKey(prefix + "." + storeIndex + ".type")) {
    configureStoragePlugin(builder, storeIndex, config);
    storeIndex++;   // stops here if storeIndex+1 is absent
}
\`\`\`

Any providers configured at indices **beyond the first gap** were silently never loaded — making all keys stored under those providers inaccessible.

**Example:** \`rundeck-config.properties\` with:
\`\`\`properties
rundeck.storage.provider.1.type=db
rundeck.storage.provider.1.path=keys
rundeck.storage.provider.4.type=vault
rundeck.storage.provider.4.path=keys/vault
\`\`\`
Provider at index 4 is never loaded because index 2 is absent. The loop stops when it checks for \`provider.2.type\` and finds nothing.

The same issue affected converter plugins (\`storage.converter.N\`).

This is a pre-existing bug surfaced during work on RUN-4539, where the companion rundeckpro PR introduces per-provider index reservation that can produce non-contiguous index sequences.

---

### Fix

Replace both \`while\` loops with **\`extractConfiguredIndices()\`**:

1. Scans the full config map for all keys matching \`prefix.N.type\`
2. Collects all distinct integer indices \`N\` (ignoring non-numeric and nested keys)
3. Returns them sorted — iterates the **complete set regardless of gaps**

\`extractConfiguredIndices()\` is package-visible static for direct unit testing.

---

### Testing

**New unit tests in \`StorageTreeFactorySpec\`:**

| Test | Covers |
|------|--------|
| Gap-skipping | Indices 1, 3, 5 all returned even when 2 and 4 are absent |
| Empty config | Returns empty list |
| Prefix isolation | Keys for a different prefix are ignored |
| Non-integer / nested key rejection | \`provider.abc.type\` and \`provider.1.config.type\` are skipped |
| Duplicate deduplication | Multiple keys for same index (type, path, config.*) counted once |

- [x] All new specs pass
- [x] Existing \`StorageTreeFactorySpec\` test passes

**Kind of Change**

- [x] Bug Fix

**Development Checklist**

- [x] Unit Tests added (5 new Spock specs)
- [x] Documentation Not needed

[RUN-4539]: https://pagerduty.atlassian.net/browse/RUN-4539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ