### PR TITLE
[RUN-4523] Batch CVE fixes: Spring Framework/Security, Micrometer, spring-retry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,9 @@ allprojects {
     // Spring Boot's dependency-management BOM overrides Spring Framework via this property name
     // (ext["spring.version"] alone does NOT move the BOM-managed spring-framework version).
     ext["spring-framework.version"] = springVersion
+    // Override Spring Boot BOM-managed versions (eachDependency/force can't move Boot-managed deps).
+    ext["micrometer.version"] = micrometerVersion          // CVE-2026-40983, CVE-2026-40984
+    ext["spring-retry.version"] = springRetryVersion       // CVE-2026-41710
     ext.isReleaseBuild = false
     ext.isSnapshotBuild = false
     ext.isDevBuild = false
@@ -201,6 +204,35 @@ allprojects {
                                     name: details.requested.name,
                                     version: groovyVersion)
                     details.because 'Grails 7 uses Apache Groovy 4.x; skip Groovy 3.x for Gradle plugins'
+                }
+                // Align Spring Framework across all configs (grails-bom pins older); plugin subprojects
+                // don't apply spring-boot dependency-management so ext["spring-framework.version"] alone
+                // doesn't reach them. CVE-2026-41839/41840/41845/41848/41850/41851/41852/41853/41854.
+                if (details.requested.group == 'org.springframework') {
+                    details.useVersion springVersion
+                    details.because 'Align Spring Framework to managed version across all configs'
+                }
+                // Align Spring Security (CVE-2026-41706, CVE-2026-47838). Exclude spring-security-rsa (1.x line).
+                if (details.requested.group == 'org.springframework.security' && details.requested.name != 'spring-security-rsa') {
+                    details.useVersion project.findProperty('spring-security.version')
+                    details.because 'Align Spring Security to managed version across all configs'
+                }
+                // Align Micrometer metrics modules (CVE-2026-40983, CVE-2026-40984). Exclude tracing/BOM.
+                if (details.requested.group == 'io.micrometer'
+                        && details.requested.name.startsWith('micrometer-')
+                        && !details.requested.name.contains('-bom')
+                        && !details.requested.name.startsWith('micrometer-tracing')) {
+                    details.useVersion micrometerVersion
+                    details.because 'Align Micrometer metrics modules to managed version'
+                }
+                // spring-integration 6.5.9 pulls spring-retry 2.0.13 (CVE-2026-41710)
+                if (details.requested.group == 'org.springframework.integration') {
+                    details.useVersion springIntegrationVersion
+                    details.because 'spring-integration 6.5.9 (spring-retry 2.0.13)'
+                }
+                if (details.requested.group == 'org.springframework.retry' && details.requested.name == 'spring-retry') {
+                    details.useVersion springRetryVersion
+                    details.because 'spring-retry 2.0.13 fixes CVE-2026-41710'
                 }
             }
             

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ springVersion=6.2.19
 micronautPlatformVersion=4.9.4
 micronautOpenapiVersion=6.20.0
 springCloudContextVersion=4.3.2
-springIntegrationVersion=6.5.5
+springIntegrationVersion=6.5.9
 swaggerVersion=2.2.49
 # hibernateVersion managed by Grails BOM (GORM 9.x uses Hibernate 6.x for Jakarta support)
 hibernateVersion=5.6.15.Final
@@ -44,14 +44,16 @@ httpClientVersion=4.5.14
 bouncyCastleVersion=1.84
 grailsSpringSecurityVersion=7.0.0
 slf4jVersion=2.0.17
-seleniumJavaVersion=4.36.0
+seleniumJavaVersion=4.44.0
 spockVersion=2.3-groovy-4.0
 testContainersVersion=1.21.4
 # For verifyBuild script only - actual runtime versions managed by Spring Boot BOM
 # CVE-2026-2332 (CWE-444 HTTP request smuggling) - jetty-http fixed in 12.0.33+
 jetty.version=12.0.33
 # Updated from 6.2.7 - fixes CVE-2025-22228 (SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-9486467) - Authentication Bypass in BCrypt. No breaking changes, API-compatible with 6.2.7
-spring-security.version=6.5.9
+spring-security.version=6.5.11
+# CVE-2026-41710: spring-retry cache-exhaustion DoS, fixed in 2.0.13 (pulled via spring-integration)
+springRetryVersion=2.0.13
 log4j2.version=2.25.4
 assetPluginVersion=5.0.34
 dbMigrationPluginVersion=5.0.0
@@ -98,7 +100,7 @@ kotlinVersion=1.9.25
 antVersion=1.10.15
 guavaVersion=33.4.8-jre
 asmVersion=9.9
-micrometerVersion=1.15.11
+micrometerVersion=1.15.12
 jaxenVersion=2.0.1
 failureAccessVersion=1.0.3
 # CVE-specific dependency versions - will re-enable constraints after Grails 7 baseline is stable


### PR DESCRIPTION
## Release Notes
This update remediates several recently disclosed High-severity security findings by upgrading the bundled Spring Framework, Spring Security, Micrometer, and spring-retry libraries to their patched releases, keeping Rundeck protected against the corresponding CVEs with no functional changes.

## PR Details
Aligns framework versions across **all** configurations to clear High-severity Snyk findings. `grails-bom` pins older transitive versions in plugin subprojects that don't apply spring-boot dependency-management, so this adds `ext[]` Boot-managed version overrides plus `eachDependency` alignment rules.

### Fixes
- **Spring Framework 6.2.19** — CVE-2026-41840, CVE-2026-41850 (and related)
- **Spring Security 6.5.11** — CVE-2026-41706, CVE-2026-47838 (`spring-security-web`)
- **Micrometer 1.15.12** — CVE-2026-40983, CVE-2026-40984 (`micrometer-core`)
- **spring-retry 2.0.13** via **spring-integration 6.5.9** — CVE-2026-41710

### Other
- Bumps `selenium` to 4.44.0 (test scope).

### Verification
- Confirmed via `gradle dependencyInsight` that each module resolves to the patched version across runtime and test classpaths.
- Snyk scan (from the rundeckpro consolidated branch) shows none of the above categories remain as High findings.

### Notes / out of scope
- `opentelemetry-api@1.55.0` (CVE-2026-45292, test scope via selenium) is **not** addressed here — it's pinned by the Grails 7.1.1 / `selenium-bom` platform and will resolve once Grails aligns those BOMs.
- `jackson-core@2.19.2` (via `groovy-yaml`) is handled in a separate PR.