### PR TITLE
[RUN-4548] minor fix for mail service

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -134,3 +134,4 @@ mariadbVersion=2.7.13
 h2Version=2.2.220
 oracleDialectVersion=1.0.2
 hibernateValidatorVersion=8.0.3.Final
+grailsMailPluginVersion=5.0.3

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -203,7 +203,7 @@ dependencies {
     // Force CVE-patched mchange libraries (transitively brought by quartz:2.5.x)
     implementation "com.mchange:mchange-commons-java:${mchangeCommonsJavaVersion}"
     implementation "com.mchange:c3p0:${c3p0Version}"
-    implementation 'org.grails.plugins:mail:3.0.0'
+    implementation "org.grails.plugins:grails-mail:${grailsMailPluginVersion}"
 
     // Liquibase for compile-time exception classes (runtime provided by Spring Boot)
     compileOnly "org.liquibase:liquibase-core:${liquibaseVersion}"

--- a/rundeckapp/grails-app/conf/spring/resources.groovy
+++ b/rundeckapp/grails-app/conf/spring/resources.groovy
@@ -1000,5 +1000,7 @@ beans={
     //defines feature flag metadata for system configuration
     rundeckFeatureFlagConfigurable(FeatureFlagConfigurable)
 
-    rundeckDynamicMailSender(DynamicMailSender)
+    rundeckDynamicMailSender(DynamicMailSender) { bean ->
+        bean.primary = true
+    }
 }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/mail/DynamicMailSender.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/mail/DynamicMailSender.groovy
@@ -60,9 +60,10 @@ class DynamicMailSender implements JavaMailSender, ApplicationContextAware {
     }
 
     /**
-     * Resolves the {@code grails.mail} configuration map.
+     * Resolves the mail configuration map.
      * <p>
-     * Reads live from the Spring {@link Environment} via {@link Binder} so that mail settings
+     * Reads live from the Spring {@link Environment} via {@link Binder} (binding {@code rundeck.grails.mail}
+     * and falling back to {@code grails.mail}) so that mail settings
      * configured at runtime through System Configuration (database) are honored. Unlike the
      * Spring Environment, {@code grailsApplication.config} only exposes a snapshot built at
      * startup for prefix/Map lookups and does not reflect database values added later, which
@@ -85,7 +86,7 @@ class DynamicMailSender implements JavaMailSender, ApplicationContextAware {
                     return bound
                 }
             } catch (Exception e) {
-                log.warn("Failed to read grails.mail from Spring Environment, falling back to grailsApplication.config: {}", e.message)
+                log.warn("Failed to read rundeck.grails.mail from Spring Environment, falling back to grailsApplication.config: {}", e.message)
             }
         }
         return grailsApplication.config.getProperty('grails.mail', Map)
@@ -105,8 +106,8 @@ class DynamicMailSender implements JavaMailSender, ApplicationContextAware {
         if (!keys) {
             return
         }
-        if (keys.any { it.startsWith('rundeck.grails.mail') }) {
-            def mailKeys = keys.findAll { it.startsWith('rundeck.grails.mail') }
+        if (keys.any { it.startsWith('rundeck.grails.mail') || it.startsWith('grails.mail') }) {
+            def mailKeys = keys.findAll { it.startsWith('rundeck.grails.mail') || it.startsWith('grails.mail')}
             log.info("Mail configuration changed for keys: {} - updating mail sender", mailKeys)
             updateMailSender()
         }

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/mail/DynamicMailSender.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/mail/DynamicMailSender.groovy
@@ -8,8 +8,12 @@ import groovy.util.logging.Slf4j
 import org.rundeck.app.grails.events.AppEvents
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.bind.Bindable
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.context.properties.bind.handler.IgnoreErrorsBindHandler
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
+import org.springframework.core.env.Environment
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.JavaMailSenderImpl
 
@@ -48,11 +52,43 @@ class DynamicMailSender implements JavaMailSender, ApplicationContextAware {
         if (!original) {
             original = delegate
         }
-        def config = grailsApplication.config.getProperty('grails.mail', Map)
+        def config = resolveMailConfig()
         if (config == null) {
             config = [:]
         }
         delegate = constructMailSender(config)
+    }
+
+    /**
+     * Resolves the {@code grails.mail} configuration map.
+     * <p>
+     * Reads live from the Spring {@link Environment} via {@link Binder} so that mail settings
+     * configured at runtime through System Configuration (database) are honored. Unlike the
+     * Spring Environment, {@code grailsApplication.config} only exposes a snapshot built at
+     * startup for prefix/Map lookups and does not reflect database values added later, which
+     * previously made DB-configured mail settings invisible to the mail sender (RUN-4548).
+     * <p>
+     * Falls back to {@code grailsApplication.config} when the application context/environment
+     * is unavailable (e.g. in unit tests) or when nothing could be bound from the environment.
+     *
+     * @return the resolved {@code grails.mail} configuration map, or {@code null} if none is found
+     */
+    @CompileDynamic
+    Map resolveMailConfig() {
+        if (applicationContext) {
+            try {
+                Environment env = applicationContext.environment
+                Map bound = Binder.get(env)
+                        .bind('rundeck.grails.mail', Bindable.mapOf(String, Object), new IgnoreErrorsBindHandler())
+                        .orElse(null)
+                if (bound != null) {
+                    return bound
+                }
+            } catch (Exception e) {
+                log.warn("Failed to read grails.mail from Spring Environment, falling back to grailsApplication.config: {}", e.message)
+            }
+        }
+        return grailsApplication.config.getProperty('grails.mail', Map)
     }
 
     /**
@@ -69,8 +105,8 @@ class DynamicMailSender implements JavaMailSender, ApplicationContextAware {
         if (!keys) {
             return
         }
-        if (keys.any { it.startsWith('grails.mail') }) {
-            def mailKeys = keys.findAll { it.startsWith('grails.mail') }
+        if (keys.any { it.startsWith('rundeck.grails.mail') }) {
+            def mailKeys = keys.findAll { it.startsWith('rundeck.grails.mail') }
             log.info("Mail configuration changed for keys: {} - updating mail sender", mailKeys)
             updateMailSender()
         }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerConditionalSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ScheduledExecutionControllerConditionalSpec.groovy
@@ -28,7 +28,7 @@ import rundeck.services.PluginService
 import rundeck.services.ScheduledExecutionService
 import spock.lang.Specification
 
-import javax.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpServletResponse
 
 /**
  * Tests for ScheduledExecutionController conditional step export validation


### PR DESCRIPTION
Jira: [https://pagerduty.atlassian.net/browse/RUN-4548](url)

This pull request updates the mail plugin and improves how mail configuration is resolved at runtime, ensuring that dynamic mail settings from the database are honored. The most important changes are grouped below:

**Mail Plugin Upgrade:**
* Upgraded the mail plugin dependency from `org.grails.plugins:mail:3.0.0` to `org.grails.plugins:grails-mail:5.0.3`, with the version managed in `gradle.properties` as `grailsMailPluginVersion`. [[1]](diffhunk://#diff-6c34dc76098a70830b11453600ffa6e1d7450d6d58d092c85b8b5c36435d4a2cL206-R206) [[2]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R137)

**Dynamic Mail Configuration Resolution:**
* Enhanced `DynamicMailSender` to resolve mail configuration using Spring's `Environment` and `Binder`, allowing it to pick up mail settings changed at runtime (e.g., via the database). Falls back to the static config if the environment is unavailable. This addresses issues where database-configured mail settings were previously ignored.
* Updated the configuration change event handler in `DynamicMailSender` to listen for changes under the new prefix `rundeck.grails.mail` instead of `grails.mail`, ensuring correct detection of runtime mail config changes.

**Spring Bean Configuration:**
* Marked `rundeckDynamicMailSender` as the primary bean in `resources.groovy` to ensure it is preferred for mail sending.