### PR TITLE
[RUN-4445] Fix job reference step label not being saved on edit

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/WorkflowSteps.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/WorkflowSteps.vue
@@ -548,7 +548,7 @@ export default defineComponent({
 
         if (result.valid) {
           if (stepForValidation.jobref) {
-            saveData.description = this.editModel.description;
+            saveData.description = this.editExtra.description;
           }
           if (!stepForValidation.jobref && !this.isErrorHandler) {
             mergePreservedLogFiltersIntoSaveData(saveData, this.editExtra?.filters);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/WorkflowSteps.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/WorkflowSteps.spec.ts
@@ -423,6 +423,68 @@ describe("WorkflowSteps", () => {
     });
   });
 
+  describe("job reference step label (RUN-4445)", () => {
+    it("preserves description when saving an edited job ref step", async () => {
+      const jobRefCommand: PersistedWorkflowCommand = {
+        description: "my job ref label",
+        jobref: {
+          name: "some-job",
+          group: "",
+          uuid: "abc-123",
+          useName: false,
+        },
+        nodeStep: false,
+      };
+      const localWrapper = await createWrapper({ commands: [jobRefCommand] });
+
+      const editStep = localWrapper.find('[data-test="edit-step-item"]');
+      await editStep.trigger("click");
+      await localWrapper.vm.$nextTick();
+
+      // Simulate the JobRefForm emitting save (description stays in editExtra)
+      const jobRefForm = localWrapper.findComponent({ name: "JobRefForm" });
+      jobRefForm.vm.$emit("save");
+      await flushPromises();
+
+      const emissions = localWrapper.emitted("update:modelValue");
+      expect(emissions).toBeDefined();
+      const lastPayload = emissions![emissions!.length - 1][0] as StepsData;
+      expect(lastPayload.commands[0].description).toBe("my job ref label");
+    });
+
+    it("saves updated description when user edits label on a job ref step", async () => {
+      const jobRefCommand: PersistedWorkflowCommand = {
+        description: "original label",
+        jobref: {
+          name: "some-job",
+          group: "",
+          uuid: "abc-123",
+          useName: false,
+        },
+        nodeStep: false,
+      };
+      const localWrapper = await createWrapper({ commands: [jobRefCommand] });
+
+      const editStep = localWrapper.find('[data-test="edit-step-item"]');
+      await editStep.trigger("click");
+      await localWrapper.vm.$nextTick();
+
+      // Simulate user typing a new label into the description input (bound to editExtra.description)
+      const vm = localWrapper.vm as any;
+      vm.editExtra.description = "updated label";
+      await localWrapper.vm.$nextTick();
+
+      const jobRefForm = localWrapper.findComponent({ name: "JobRefForm" });
+      jobRefForm.vm.$emit("save");
+      await flushPromises();
+
+      const emissions = localWrapper.emitted("update:modelValue");
+      expect(emissions).toBeDefined();
+      const lastPayload = emissions![emissions!.length - 1][0] as StepsData;
+      expect(lastPayload.commands[0].description).toBe("updated label");
+    });
+  });
+
   describe("editing state", () => {
     it("emits workflow-editing-state-changed with isEditing true when a step edit opens", async () => {
       const mockEventBus = getRundeckContext().eventBus;


### PR DESCRIPTION
## Is this a bugfix, or an enhancement?

Bugfix. Fixes #RUN-4445 — when editing a Job Reference step, the label (description) field was not being saved.

## Describe the solution you've implemented

`saveEditStep` was reading `editModel.description` for job reference steps, but `JobRefForm` overwrites `editModel` via its `update:modelValue` emit before `saveEditStep` runs, clearing the user's input. The label input is already bound to `editExtra.description`, so the fix reads from there instead (one-line change). Two unit tests added to cover the regression.

## Alternatives considered

Moving the v-model binding to a separate data property was considered, but editExtra.description was already the correct source of truth — only the read side needed fixing.

## Release Notes

Fixed an issue in the job editor where changing the label of a Job Reference step and saving would not take effect—the label reverted to its previous value. Job Reference step labels now save correctly.