### PR TITLE
[RUN-4440] Restore job reference name autocomplete lost in Vue migration

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/JobRefFormFields.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/JobRefFormFields.vue
@@ -91,16 +91,19 @@
       >
         <label class="col-sm-2 control-label"></label>
         <div class="col-sm-5">
-          <input
+          <PtAutoComplete
             :id="`jobNameField${rkey}`"
-            v-model="modelValue.name"
-            type="text"
+            v-model="jobNameInputText"
+            :suggestions="(jobNameSuggestions as any)"
+            option-label="name"
             name="jobName"
             data-testid="jobNameField"
             :placeholder="$t('scheduledExecution.jobName.label')"
-            class="form-control"
-            size="100"
-            :readonly="!isUseName"
+            class="form-control w-100"
+            :read-only="!isUseName"
+            :replace-on-select="true"
+            @update:model-value="onJobNameInput"
+            @onComplete="onSearchJobNames"
           />
         </div>
         <div class="col-sm-5">
@@ -716,6 +719,13 @@ export default defineComponent({
       rkey:
         "r_" + Math.floor(Math.random() * Math.floor(1024)).toString(16) + "_",
       eventBus: eventBus,
+      jobNameInputText: "",
+      jobNameSuggestions: [] as Array<{
+        name: string;
+        group: string;
+        id: string;
+        project: string;
+      }>,
     };
   },
   computed: {
@@ -737,6 +747,14 @@ export default defineComponent({
     ]),
   },
   watch: {
+    "modelValue.name": {
+      immediate: true,
+      handler(val: string) {
+        if (typeof val === "string" && val !== this.jobNameInputText) {
+          this.jobNameInputText = val;
+        }
+      },
+    },
     "nodeFilterStore.filter": {
       async handler(val) {
         if (val !== this.modelValue.nodefilters.filter) {
@@ -810,6 +828,35 @@ export default defineComponent({
 
     handleFavoritesButton() {
       this.showFavoritesButton = false;
+    },
+
+    async onSearchJobNames(event: { query: string }) {
+      const project = this.modelValue.project || this.currentProject;
+      try {
+        const url = new URL(
+          rundeckContext.appLinks.menuJobSearchJson,
+          window.location.origin,
+        );
+        url.searchParams.set("jobFilter", event.query);
+        url.searchParams.set("project", project);
+        url.searchParams.set("runAuthRequired", "true");
+        const resp = await fetch(url.toString(), { credentials: "include" });
+        this.jobNameSuggestions = await resp.json();
+      } catch {
+        this.jobNameSuggestions = [];
+      }
+    },
+
+    onJobNameInput(val: string | { name: string; group: string; id: string }) {
+      if (typeof val === "string") {
+        this.jobNameInputText = val;
+        this.modelValue.name = val;
+      } else if (val && typeof val === "object") {
+        this.jobNameInputText = val.name;
+        this.modelValue.name = val.name;
+        this.modelValue.group = val.group || "";
+        this.modelValue.uuid = val.id;
+      }
     },
 
     updatedValue(val: string) {


### PR DESCRIPTION
Bugfix. Fixes RUN-4440 — job reference name autocomplete stopped working after upgrade to 5.20.

## Describe the solution

The jQuery-based _initJobPickerAutocomplete function was not ported when the workflow editor was migrated to Vue 3, leaving the job name field as a plain static input with no suggestions. Replaced it with PrimeVue's AutoComplete component calling /menu/jobsSearchJson on keypress (300ms debounce). On selection, name, group and UUID are all populated automatically — matching the original behavior.

## Alternatives considered

Re-implementing with vanilla JS was considered but rejected in favor of the existing PrimeVue AutoComplete already used elsewhere in the component.

## Release Notes

Restored job name autocomplete in the Job Reference step form, which was lost during the Vue 3 UI migration in 5.20. Customers with many jobs can now search by name instead of browsing manually.