### PR TITLE
[RUN-4445] Fix label not being saved

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobCreatePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/jobs/JobCreatePage.groovy
@@ -89,7 +89,7 @@ class JobCreatePage extends BasePage {
         static By adhocRemoteStringBy = By.xpath('//*[@data-prop-name="adhocRemoteString"]//input[@type="text"]')
         static By workFlowStrategyBy = By.xpath('//select[contains(@name, \'workflow.strategy\')]')
         static By strategyPluginParallelMsgBy = By.xpath('//*[@id="strategyPluginparallel"]/span')
-        static By numberOfStepsBy = By.cssSelector("[data-test='edit-step-item']")
+        static By numberOfStepsBy = By.cssSelector("[data-testid='edit-step-item']")
         static By deleteStepBy = By.cssSelector('button[data-test="remove-step"]')
         static By stepEditModalCancelBy = By.cssSelector('.modal.in [data-testid="cancel-button"]')
         static By stepEditModalSaveBy = By.cssSelector('.modal.in [data-testid="save-button"]')

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/WorkflowSteps.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/WorkflowSteps.vue
@@ -17,7 +17,7 @@
               <div
                   :id="`wfitem_${index}`"
                   class="step-item-config"
-                  data-test="edit-step-item"
+                  data-testid="edit-step-item"
                   :title="$t('Workflow.clickToEdit')"
                   @click="editStepByIndex(index)"
               >
@@ -42,7 +42,7 @@
                 </plugin-config>
                 <job-ref-step v-else-if="element.jobref" :step="element"></job-ref-step>
 
-                <div v-if="element.description" class="wfstep-description">
+                <div v-if="element.description" :data-testid="`wfstep-description-${index}`" class="wfstep-description">
                   {{ element.description }}
                 </div>
               </div>
@@ -547,9 +547,6 @@ export default defineComponent({
         const result = await validateStepForSave(stepForValidation as EditStepData, this.editService);
 
         if (result.valid) {
-          if (stepForValidation.jobref) {
-            saveData.description = this.editModel.description;
-          }
           if (!stepForValidation.jobref && !this.isErrorHandler) {
             mergePreservedLogFiltersIntoSaveData(saveData, this.editExtra?.filters);
           }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/WorkflowSteps.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/workflow/tests/WorkflowSteps.spec.ts
@@ -201,7 +201,7 @@ describe("WorkflowSteps", () => {
 
     it("emits update:modelValue when a step is updated", async () => {
       const mockEventBus = getRundeckContext().eventBus;
-      const editStep = wrapper.find('[data-test="edit-step-item"]');
+      const editStep = wrapper.find('[data-testid="edit-step-item"]');
       await editStep.trigger("click");
       await wrapper.vm.$nextTick();
       const editModal = wrapper.findAllComponents(EditPluginModal)[1];
@@ -265,7 +265,7 @@ describe("WorkflowSteps", () => {
       };
       const localWrapper = await createWrapper({ commands: [commandWithFilters] });
 
-      const editStep = localWrapper.find('[data-test="edit-step-item"]');
+      const editStep = localWrapper.find('[data-testid="edit-step-item"]');
       await editStep.trigger("click");
       await localWrapper.vm.$nextTick();
 
@@ -420,6 +420,69 @@ describe("WorkflowSteps", () => {
         "workflow-editor-workflowsteps-request",
         expect.any(Function),
       );
+    });
+  });
+
+  describe("job reference step label (RUN-4445)", () => {
+    it("preserves label when JobRefForm update:modelValue clears editModel description on existing step", async () => {
+      const jobRefCommand: PersistedWorkflowCommand = {
+        description: "existing label",
+        jobref: { name: "some-job", group: "", uuid: "abc-123" },
+        nodeStep: false,
+      };
+      const localWrapper = await createWrapper({ commands: [jobRefCommand] });
+
+      await localWrapper.find('[data-testid="edit-step-item"]').trigger("click");
+      await localWrapper.vm.$nextTick();
+
+      const jobRefForm = localWrapper.findComponent({ name: "JobRefForm" });
+      // In production JobRefForm emits update:modelValue with jobref data but without the
+      // description field, overwriting editModel and clearing editModel.description
+      jobRefForm.vm.$emit("update:modelValue", {
+        jobref: { name: "some-job", group: "", uuid: "abc-123" },
+        nodeStep: false,
+      });
+      await localWrapper.vm.$nextTick();
+
+      jobRefForm.vm.$emit("save");
+      await flushPromises();
+
+      expect(localWrapper.find('[data-testid="wfstep-description-0"]').exists()).toBe(true);
+      expect(localWrapper.find('[data-testid="wfstep-description-0"]').text().trim()).toBe("existing label");
+    });
+
+    it("renders the typed label after adding a new job reference step", async () => {
+      const localWrapper = await createWrapper({ commands: [] }, {
+        JobRefForm: {
+          name: "JobRefForm",
+          template: '<div><slot name="extra"/></div>',
+        },
+      });
+
+      await localWrapper.find('[data-testid="add-button"]').trigger("click");
+      const chooseModal = localWrapper.findComponent(ChoosePluginModal);
+      chooseModal.vm.$emit("selected", {
+        service: "WorkflowStep",
+        provider: "job.reference",
+      });
+      await localWrapper.vm.$nextTick();
+
+      await localWrapper.find('[data-testid="step-description"]').setValue("new label");
+
+      const jobRefForm = localWrapper.findComponent({ name: "JobRefForm" });
+      // Simulate JobRefForm emitting update:modelValue without description,
+      // which would overwrite editModel and lose any description on it
+      jobRefForm.vm.$emit("update:modelValue", {
+        jobref: { name: "chosen-job", group: "", uuid: "def-456" },
+        nodeStep: false,
+      });
+      await localWrapper.vm.$nextTick();
+
+      jobRefForm.vm.$emit("save");
+      await flushPromises();
+
+      expect(localWrapper.find('[data-testid="wfstep-description-0"]').exists()).toBe(true);
+      expect(localWrapper.find('[data-testid="wfstep-description-0"]').text().trim()).toBe("new label");
     });
   });
 


### PR DESCRIPTION
## Release Notes

Fixed an issue where the label (description) on a Job Reference step was not saved—both when adding a new job reference step and when editing an existing one—causing the label to disappear or revert after saving. Job Reference step labels are now preserved correctly.

## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. When adding or editing a Job Reference step, the label (description) the user typed was lost on save.

**Describe the solution you've implemented**

In `WorkflowSteps.vue`, `saveEditStep` explicitly overwrote `saveData.description` with `editModel.description` for job reference steps. Because `JobRefForm` emits `update:modelValue` (without a `description` field) before save runs, `editModel.description` had already been cleared—so the overwrite wiped the user's label. The fix removes that overwrite so the label captured in the step editor flows through to `saveData` unchanged. Also standardized the step-item test selector from `data-test` to `data-testid` and added a stable `data-testid` on the step description element.

**Describe alternatives you've considered**

N/A

**Additional context**

Adds Jest regression tests covering both scenarios: preserving the label on an existing job reference step, and rendering the typed label after adding a new one.