### PR TITLE
[RUN-4562] Set HikariCP transactionIsolation to READ_COMMITTED in production

### DIFF
--- a/rundeckapp/grails-app/conf/application.groovy
+++ b/rundeckapp/grails-app/conf/application.groovy
@@ -93,7 +93,13 @@ environments {
                 testWhileIdle= true
                 testOnReturn= false
                 jdbcInterceptors= "ConnectionState"
-                defaultTransactionIsolation= 2 // TRANSACTION_READ_COMMITTED
+                defaultTransactionIsolation= 2 // TRANSACTION_READ_COMMITTED (Tomcat JDBC pool property)
+                // HikariCP property name (Grails 7 default pool is HikariCP).
+                // The Tomcat-style `defaultTransactionIsolation` above is ignored by HikariCP,
+                // so set the isolation level using HikariCP's own property name.
+                // READ_COMMITTED disables gap/next-key locking on MySQL/InnoDB, reducing
+                // deadlocks on unique-index INSERTs. No-op on PostgreSQL/Oracle (already their default).
+                transactionIsolation= "TRANSACTION_READ_COMMITTED"
             }
         }
     }


### PR DESCRIPTION

## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix.

Grails 7 uses HikariCP as the default connection pool. However, the `production` `dataSource.properties` block in `application.groovy` still uses Tomcat JDBC pool property names (`maxActive`, `testOnBorrow`, `jdbcInterceptors`, `defaultTransactionIsolation`, ...). HikariCP binds properties by setter name, so these Tomcat-named properties are silently ignored and the pool falls back to HikariCP / database defaults.

The practical consequence relevant to this PR: the intended `defaultTransactionIsolation = READ_COMMITTED` never takes effect. On MySQL/MariaDB (InnoDB) the connection therefore runs at the engine default of `REPEATABLE READ`, whose gap / next-key locking causes deadlocks on concurrent INSERTs into unique indexes. A concrete hot spot is the unique `execution` index on `LogFileStorageRequest`, written on every execution completion: under load these INSERTs deadlock (`SQLState 40001`, "Deadlock found when trying to get lock").

This is the same class of MySQL deadlock reported historically (e.g. #4255), and is distinct from the pool-sizing regression in #9148.

**Describe the solution you've implemented**

Set the HikariCP-native `transactionIsolation` property (string form, `"TRANSACTION_READ_COMMITTED"`) in the production `dataSource.properties` block. This is the property name HikariCP actually binds, so the isolation level now takes effect.

- On MySQL/MariaDB this disables gap/next-key locking and removes the deadlock source.
- On PostgreSQL/Oracle it is a no-op, since `READ_COMMITTED` is already their default isolation level.

The pre-existing Tomcat-style `defaultTransactionIsolation` line is kept and annotated with a comment explaining why a HikariCP-named property is also required, to avoid future confusion.

**Describe alternatives you've considered**

- `spring.datasource.hikari.transaction-isolation` in `application.yml`: equivalent effect, but the existing pool configuration already lives in `application.groovy`, so keeping it there is less surprising.
- Per-transaction `@Transactional(isolation = READ_COMMITTED)` on the hot-path services (execution completion / log-storage request): more targeted but easy to miss call sites; a pool-level default is broader and simpler.

**Additional context**

The mismatch is easy to miss because the Grails reference documentation still shows a `type = HikariDataSource` example whose `properties` block uses Tomcat JDBC pool names. HikariCP ignores those names, which is why the isolation setting silently had no effect.


## Release Notes

Fixes intermittent MySQL/MariaDB deadlocks under concurrent job execution by ensuring the connection pool runs at the `READ_COMMITTED` transaction isolation level. Previously the isolation setting was configured using Tomcat JDBC pool property names that HikariCP (the Grails 7 default pool) ignores, leaving MySQL at its `REPEATABLE READ` default. No effect on PostgreSQL/Oracle, which already default to `READ_COMMITTED`.