### PR TITLE
[RUN-4559] Fix Stored XSS in autoLink taglib via raw job name

### DIFF
--- a/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
@@ -661,7 +661,7 @@ class UtilityTagLib{
                     def lparams= [:]+opts.linkParams
                     lparams.id=it[2]
                     def text = opts.textValue?opts.textValue(it[2]):it[1]
-                    return g.link(lparams,text)
+                    return g.link(lparams, text?.encodeAsHTML())
                 }else if(opts.hrefParams){
                     def lparams= [:]+opts.hrefParams
                     return g.createLink(lparams)

--- a/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
+++ b/rundeckapp/grails-app/taglib/rundeck/UtilityTagLib.groovy
@@ -661,7 +661,7 @@ class UtilityTagLib{
                     def lparams= [:]+opts.linkParams
                     lparams.id=it[2]
                     def text = opts.textValue?opts.textValue(it[2]):it[1]
-                    return g.link(lparams, text?.encodeAsHTML())
+                    return g.link(lparams, text?.encodeAsHTML()) ?: ''
                 }else if(opts.hrefParams){
                     def lparams= [:]+opts.hrefParams
                     return g.createLink(lparams)

--- a/rundeckapp/src/test/groovy/rundeck/UtilityTagLibSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/UtilityTagLibSpec.groovy
@@ -219,28 +219,35 @@ class UtilityTagLibSpec extends Specification implements TagLibUnitTest<UtilityT
      * and passing the raw job name to g.link() as the anchor body text. Job names containing
      * HTML/JS payloads must be HTML-encoded via encodeAsHTML() before being placed inside the anchor.
      *
-     * This test verifies the encoding step that was added to the fix. Full end-to-end rendering
-     * of the autoLink tag (including g.link URL generation) requires an integration test.
+     * This test exercises the full autoLink tag rendering pipeline. Removing encodeAsHTML() from the
+     * taglib causes this test to fail, validating the fix regression is caught.
+     *
+     * configurationService must be mocked because autoLink eagerly calls helpLinkUrl() when building
+     * the linkopts map, which calls configurationService.getString("gui.helpLink").
      */
     @Unroll
-    def "autoLink job name textValue must be HTML-encoded to prevent XSS (PS-1691)"() {
-        given: "a job whose name contains an XSS payload, as resolved by autoLink's textValue closure"
+    def "autoLink HTML-encodes XSS payloads in job names before rendering anchor body (PS-1691)"() {
+        given: "dependencies required by autoLink's eager helpLinkUrl() call"
+        tagLib.configurationService = Mock(ConfigurationService) {
+            getString("gui.helpLink") >> 'https://docs.rundeck.com'
+        }
+
+        and: "a job whose name contains an XSS payload, wired via ScheduledExecution static lookup"
+        def jobUuid = '12345678-1234-1234-1234-1234567890ab'
         ScheduledExecution.metaClass.static.getByIdOrUUID = { String id ->
             [generateFullName: { maliciousName }]
         }
 
-        when: "the textValue closure resolves the job name and encodeAsHTML() is applied (the fix)"
-        def rawName = ScheduledExecution.getByIdOrUUID('12345678-1234-1234-1234-1234567890ab')?.generateFullName()
-        def encodedName = rawName?.encodeAsHTML()
+        when: "autoLink renders a flash message containing a {{Job UUID}} token"
+        def output = applyTemplate(
+            "<g:autoLink>Deleted job {{Job ${jobUuid}}}</g:autoLink>"
+        )
 
-        then: "the raw name contains the dangerous payload"
-        rawName == maliciousName
-
-        and: "after encoding, all HTML special chars are neutralized"
-        !encodedName.contains('<')
-        !encodedName.contains('>')
-        encodedName.contains('&lt;')
-        encodedName.contains('&gt;')
+        then: "no raw unencoded HTML tags appear — XSS payload is safely HTML-encoded in the anchor body"
+        !output.contains('<img ')      // &lt;img is safe; raw <img is exploitable
+        !output.contains('<script')    // &lt;script is safe; raw <script is exploitable
+        !output.contains('<svg ')      // &lt;svg is safe; raw <svg is exploitable
+        output.contains('&lt;')        // encoding occurred
 
         cleanup:
         ScheduledExecution.metaClass.static.getByIdOrUUID = null

--- a/rundeckapp/src/test/groovy/rundeck/UtilityTagLibSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/UtilityTagLibSpec.groovy
@@ -212,6 +212,47 @@ class UtilityTagLibSpec extends Specification implements TagLibUnitTest<UtilityT
         output.trim() == expected
     }    
     
+    /**
+     * Regression test for Stored XSS via job name in autoLink flash message (PS-1691 / RUN-4559).
+     *
+     * The autoLink taglib resolves {{Job UUID}} tokens by calling ScheduledExecution.getByIdOrUUID()
+     * and passing the raw job name to g.link() as the anchor body text. Job names containing
+     * HTML/JS payloads must be HTML-encoded via encodeAsHTML() before being placed inside the anchor.
+     *
+     * This test verifies the encoding step that was added to the fix. Full end-to-end rendering
+     * of the autoLink tag (including g.link URL generation) requires an integration test.
+     */
+    @Unroll
+    def "autoLink job name textValue must be HTML-encoded to prevent XSS (PS-1691)"() {
+        given: "a job whose name contains an XSS payload, as resolved by autoLink's textValue closure"
+        ScheduledExecution.metaClass.static.getByIdOrUUID = { String id ->
+            [generateFullName: { maliciousName }]
+        }
+
+        when: "the textValue closure resolves the job name and encodeAsHTML() is applied (the fix)"
+        def rawName = ScheduledExecution.getByIdOrUUID('12345678-1234-1234-1234-1234567890ab')?.generateFullName()
+        def encodedName = rawName?.encodeAsHTML()
+
+        then: "the raw name contains the dangerous payload"
+        rawName == maliciousName
+
+        and: "after encoding, all HTML special chars are neutralized"
+        !encodedName.contains('<')
+        !encodedName.contains('>')
+        encodedName.contains('&lt;')
+        encodedName.contains('&gt;')
+
+        cleanup:
+        ScheduledExecution.metaClass.static.getByIdOrUUID = null
+
+        where:
+        maliciousName << [
+            '<img src=x onerror=alert(document.cookie)>',
+            '<script>alert(1)</script>',
+            '"><svg onload=alert(1)>',
+        ]
+    }
+
     /** test html content sanitation on basicTable tagLib */
     def "basicTable should sanitize inner content."() {
         when:

--- a/rundeckapp/src/test/groovy/rundeck/UtilityTagLibSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/UtilityTagLibSpec.groovy
@@ -250,7 +250,11 @@ class UtilityTagLibSpec extends Specification implements TagLibUnitTest<UtilityT
         output.contains('&lt;')        // encoding occurred
 
         cleanup:
-        ScheduledExecution.metaClass.static.getByIdOrUUID = null
+        // Remove the EMC entry entirely to prevent metaclass pollution across test classes.
+        // Setting = null is insufficient; it leaves a null-closure entry in the ExpandoMetaClass
+        // that blocks normal Groovy dispatch and causes TooFewInvocationsError in other specs
+        // (e.g. EditOptsControllerSpec) that call getByIdOrUUID in the same JVM.
+        GroovySystem.metaClassRegistry.removeMetaClass(ScheduledExecution)
 
         where:
         maliciousName << [


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Security bugfix for a Stored XSS vulnerability in the `autoLink` taglib (`UtilityTagLib.groovy`). An authenticated user with `create_job` permission can craft a job name containing an HTML/JS payload (e.g. `<img src=x onerror=alert(document.cookie)>`). When a user with `delete_execution` permission deletes an execution of that job, the flash message renders the `{{Job UUID}}` token via `autoLink`, which calls `g.link()` with the raw, un-encoded job name as the anchor body — executing arbitrary JavaScript in the victim's browser context.

Reported via HackerOne (#3815645 / PS-1691). Jira: https://pagerduty.atlassian.net/browse/RUN-4559

**Describe the solution you've implemented**

Added `text?.encodeAsHTML()` before passing the job name to `g.link()` inside the `autoLink` taglib:

```groovy
// Before (vulnerable)
return g.link(lparams, text)

// After (fixed)
return g.link(lparams, text?.encodeAsHTML())
```

This single-line change covers all surfaces where `autoLink` resolves `{{Job UUID}}` tokens:
- Execution delete flash message (`ExecutionController`)
- Bulk job action result messages (`ScheduledExecutionController` / `menu/jobs.gsp`)
- Cluster heartbeat job/member views

A Spock regression test was added to `UtilityTagLibSpec` covering three XSS payload variants (`<img onerror>`, `<script>`, `<svg onload>`).

**Describe alternatives you've considered**

- Sanitizing at the job name validation level (only blocks `/`, too narrow).
- Encoding in the GSP templates (already attempted via `<g:enc>` wrapper but it runs before `autoLink` substitution, leaving the replacement unprotected).
- Encoding in the controller flash message (doesn't cover all `autoLink` surfaces).

The taglib fix is the correct single point of control.

**Additional context**

Reproduction steps (from HackerOne report):
1. Create a job with name `<img src=x onerror=alert(document.cookie)>`
2. Run the job once to create an execution
3. Navigate to `/execution/show/<id>` and delete the execution
4. Observe XSS alert on redirect to reports page (session cookie exposed)

## Release Notes

Fixed a Stored XSS vulnerability in the `autoLink` taglib where job names containing HTML/JS payloads were rendered unencoded in flash messages. Job names are now HTML-encoded before being placed inside anchor tags.

Made with [Cursor](https://cursor.com)