### PR TITLE
[RUN-4568] Make prepare-community-pr a reusable workflow

### DIFF
--- a/.github/workflows/prepare-community-pr.yml
+++ b/.github/workflows/prepare-community-pr.yml
@@ -15,6 +15,7 @@
 name: Prepare community PR
 
 on:
+  workflow_call: {}
   pull_request_target:
     types: [labeled]
 


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Enhancement. Adds `workflow_call: {}` to the `on:` trigger of `prepare-community-pr.yml`, making it a [reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows) that other Rundeck repositories can call without duplicating the full workflow logic.

Tracks: https://pagerduty.atlassian.net/browse/RUN-4568

**Describe the solution you've implemented**

A single line added to the `on:` block:

```yaml
on:
  workflow_call: {}    # <-- new: allows other repos to call this workflow
  pull_request_target:
    types: [labeled]
```

This is a non-breaking change — the workflow continues to function exactly as before in `rundeck/rundeck`. The `workflow_call` trigger only activates when another repo explicitly calls it via `uses: rundeck/rundeck/.github/workflows/prepare-community-pr.yml@main`.

Repos that want to adopt this workflow (e.g. `terraform-provider-rundeck`) only need to add a small caller file:

```yaml
name: Prepare community PR
on:
  pull_request_target:
    types: [labeled]
jobs:
  prepare:
    uses: rundeck/rundeck/.github/workflows/prepare-community-pr.yml@main
    permissions:
      contents: write
      pull-requests: write
```

**Describe alternatives you've considered**

Copying the full workflow file to each repo. This works but means security improvements or bug fixes must be replicated manually across all repos.

**Additional context**

- No behavior change for this repo.
- Future repos only need a 15-line caller file instead of copying the full 244-line workflow.
- Requires the target repos to have access to reusable workflows from `rundeck/rundeck` (Settings → Actions → General → Access).

## Release Notes

Internal CI improvement. No user-facing change.
