### PR TITLE
[RUN-2580] Fix H2 dialect detection and debug logging in isSqlCompatible

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -4707,8 +4707,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
         boolean isCompatible = false
         try {
             def sessionFactory = applicationContext.getBean("sessionFactory")
-            def dialectName = sessionFactory.configurationProperties?.getProperty("hibernate.dialect") ?: ""
-            boolean isH2 = dialectName.contains("H2Dialect")
+            def dialectName = (sessionFactory?.properties?.get('hibernate.dialect') ?: '') as String
+            def dataSourceUrl = grailsApplication?.config?.getProperty('dataSource.url', String, '') ?: ''
+            boolean isH2 = dialectName.contains('H2Dialect') || dataSourceUrl.startsWith('jdbc:h2:')
 
             Execution.createCriteria().list(max:1) {
                 projections {
@@ -4720,7 +4721,8 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 }
             }
             isCompatible = true
-        } catch(Exception ex) {
+        } catch (Exception ex) {
+            log.debug("Execution metrics SQL compatibility check failed, falling back to in-memory metrics calculation", ex)
             isCompatible = false
         }
         return isCompatible

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -4705,18 +4705,24 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
     private boolean isSqlCompatible() {
         boolean isCompatible = false
-        try{
+        try {
+            def sessionFactory = applicationContext.getBean("sessionFactory")
+            def dialectName = sessionFactory.configurationProperties?.getProperty("hibernate.dialect") ?: ""
+            boolean isH2 = dialectName.contains("H2Dialect")
+
             Execution.createCriteria().list(max:1) {
-                projections{
-                    sqlProjection '(date_completed - date_started) as durationSum', 'durationSum', StandardBasicTypes.TIME
+                projections {
+                    if (isH2) {
+                        sqlProjection 'DATEDIFF(\'SECOND\', date_started, date_completed) as durationSum', 'durationSum', StandardBasicTypes.LONG
+                    } else {
+                        sqlProjection '(date_completed - date_started) as durationSum', 'durationSum', StandardBasicTypes.TIME
+                    }
                 }
             }
-
             isCompatible = true
-        } catch(JDBCException ex){
+        } catch(Exception ex) {
             isCompatible = false
         }
-
         return isCompatible
     }
 


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Bugfix. Addresses two issues found in code review of the H2 SQL compatibility probe in `ExecutionService.isSqlCompatible()`.

1. `sessionFactory.configurationProperties` is not a standard Hibernate 5.6 API — calling it throws `MissingPropertyException` at runtime, causing the method to silently fall back to in-memory metrics even when H2 is in use.
2. Silent `catch (Exception)` block made it impossible to diagnose why metrics were consistently falling back to the in-memory path.

Fixes https://pagerduty.atlassian.net/browse/RUN-2580

**Describe the solution you've implemented**
- Replaced `sessionFactory.configurationProperties?.getProperty('hibernate.dialect')` with `sessionFactory?.properties?.get('hibernate.dialect')` (standard Hibernate API).
- Added `dataSource.url` fallback: H2 is also detected when `dataSource.url` starts with `jdbc:h2:`, so detection works even when `hibernate.dialect` is not explicitly configured.
- Added `log.debug(...)` in the catch block to surface unexpected failures without polluting logs in normal operation.

**Describe alternatives you've considered**
Could have only fixed the API call without the `dataSource.url` fallback, but that would still miss unconfigured-dialect H2 setups (common in test environments).

**Additional context**
These changes were identified via Copilot code review on the original PR that introduced H2 dialect branching.

## Release Notes

Fix H2 dialect detection in execution metrics SQL compatibility probe to prevent silent fallback to in-memory metrics calculation.