### PR TITLE
[RUN-4558] Fix i18n fallback for dynamically registered plugin messages

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/jest.config.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/jest.config.js
@@ -22,6 +22,7 @@ module.exports = {
     "^@/(.*)$": "<rootDir>/src/$1",
     "^primevue/(.*)": "<rootDir>/node_modules/primevue/$1",
     "^@primevue/(.*)": "<rootDir>/node_modules/@primevue/$1",
+    "^vue-i18n$": "<rootDir>/node_modules/vue-i18n/dist/vue-i18n.cjs",
   },
   modulePathIgnorePatterns: ["<rootDir>/public"],
   testMatch: ["**/*.test.ts", "**/*.spec.ts"],

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/navbar/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/navbar/main.ts
@@ -10,7 +10,11 @@ import SettingsModal from "../../../library/components/widgets/settings-bar/Sett
 import { UtilityBarItem } from "../../../library/stores/UtilityBar";
 import { UiMessage } from "../../../library/stores/UIStore";
 import { getRundeckContext, getAppLinks } from "../../../library";
-import { commonAddUiMessages, initI18n } from "../../utilities/i18n";
+import {
+  commonAddUiMessages,
+  initI18n,
+  type LocalizedMessages,
+} from "../../utilities/i18n";
 import * as uiv from "uiv";
 import VueCookies from "vue-cookies";
 
@@ -128,8 +132,10 @@ function initUtil() {
   vue.use(VueCookies);
   vue.use(i18n);
   vue.use(uiv);
-  vue.provide("addUiMessages", async (messages: UiMessage[]) => {
-    await commonAddUiMessages(i18n, messages);
-  });
+  vue.provide(
+    "addUiMessages",
+    async (messages: UiMessage[] | LocalizedMessages) =>
+      commonAddUiMessages(i18n, messages),
+  );
   vue.mount(elm);
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/readme-motd/main.ts
@@ -1,23 +1,9 @@
 import { defineComponent, markRaw } from "vue";
 import { getRundeckContext } from "../../../library";
-import { UiMessage } from "../../../library/stores/UIStore";
+import type { LocalizedMessages } from "../../utilities/i18n";
 import EditProjectFile from "./EditProjectFile.vue";
 
 import messages from "./i18n";
-
-const _i18n = messages as any;
-
-// Create VueI18n instance with options
-const locale = getRundeckContext().locale || "en_US";
-const lang = getRundeckContext().language || "en";
-
-// include any i18n injected in the page by the app
-const i18nMessages = {
-  [locale]: Object.assign(
-    {},
-    _i18n[locale] || _i18n[lang] || _i18n["en_US"] || {},
-  ),
-};
 
 const rundeckContext = getRundeckContext();
 
@@ -48,9 +34,9 @@ rundeckContext.rootStore.ui.addItems([
           };
         },
         created() {
-          (this.addUiMessages as (messages: UiMessage[]) => Promise<void>)([
-            i18nMessages[locale],
-          ]);
+          (this.addUiMessages as (messages: LocalizedMessages) => Promise<void>)(
+            messages as LocalizedMessages,
+          );
 
           this.filename = this.itemData.filename;
           // code to handle displayConfig

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/ui/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/ui/main.ts
@@ -5,7 +5,11 @@ import VueCookies from "vue-cookies";
 import { getRundeckContext } from "../../../library";
 import { UiMessage } from "../../../library/stores/UIStore";
 import UiSocket from "../../../library/components/utils/UiSocket.vue";
-import { initI18n, updateLocaleMessages } from "../../utilities/i18n";
+import {
+  initI18n,
+  commonAddUiMessages,
+  type LocalizedMessages,
+} from "../../utilities/i18n";
 import {configurePrimeVue} from "../../../library/utilities/primeVueConfig";
 
 const rootStore = getRundeckContext().rootStore;
@@ -72,16 +76,11 @@ function initUiComponents(elmElement: any) {
   vue.provide("registerComponent", (name: string, comp: Component) => {
     vue.component(name, comp);
   });
-  vue.provide("addUiMessages", async (messages: UiMessage[]) => {
-    const newMessages = messages.reduce(
-      (acc: Record<string, any>, message: UiMessage) =>
-        message ? { ...acc, ...message } : acc,
-      {},
-    );
-    const locale = window._rundeck.locale || "en_US";
-    const lang = window._rundeck.language || "en";
-    return updateLocaleMessages(i18n, locale, lang, newMessages);
-  });
+  vue.provide(
+    "addUiMessages",
+    async (messages: UiMessage[] | LocalizedMessages) =>
+      commonAddUiMessages(i18n, messages),
+  );
   try {
     vue.mount(elmElement);
   } catch (e) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/command/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/command/main.ts
@@ -2,7 +2,11 @@ import { createApp } from "vue";
 
 import LogViewer from "../../../library/components/execution-log/logViewer.vue";
 import { RootStore } from "../../../library/stores/RootStore";
-import { initI18n, commonAddUiMessages } from "../../utilities/i18n";
+import {
+  initI18n,
+  commonAddUiMessages,
+  type LocalizedMessages,
+} from "../../utilities/i18n";
 import { UiMessage } from "../../../library/stores/UIStore";
 
 const eventBus = window._rundeck.eventBus;
@@ -62,8 +66,10 @@ eventBus.on("ko-adhoc-running", (data: any) => {
     },
   );
   vue.use(i18n);
-  vue.provide("addUiMessages", async (messages: UiMessage[]) =>
-    commonAddUiMessages(i18n, messages),
+  vue.provide(
+    "addUiMessages",
+    async (messages: UiMessage[] | LocalizedMessages) =>
+      commonAddUiMessages(i18n, messages),
   );
   vue.mount(elm);
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/nodeView.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/execution-show/nodeView.ts
@@ -5,7 +5,11 @@ import { autorun } from "mobx";
 import LogViewer from "../../../library/components/execution-log/logViewer.vue";
 import { getRundeckContext } from "../../../library";
 import * as uiv from "uiv";
-import { initI18n, commonAddUiMessages } from "../../utilities/i18n";
+import {
+  initI18n,
+  commonAddUiMessages,
+  type LocalizedMessages,
+} from "../../utilities/i18n";
 import { UiMessage } from "../../../library/stores/UIStore";
 
 const rootStore = getRundeckContext().rootStore;
@@ -78,8 +82,10 @@ window._rundeck.eventBus.on("ko-exec-show-output", (nodeStep: any) => {
   });
   vue.use(uiv);
   vue.use(i18n);
-  vue.provide("addUiMessages", async (messages: UiMessage[]) =>
-    commonAddUiMessages(i18n, messages),
+  vue.provide(
+    "addUiMessages",
+    async (messages: UiMessage[] | LocalizedMessages) =>
+      commonAddUiMessages(i18n, messages),
   );
   // Mount on elm directly (preserving its CSS height/overflow for the virtual scroller)
   vue.mount(elm);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/main.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/job/editor/main.js
@@ -10,7 +10,7 @@ import NotificationsEditorSection from "./NotificationsEditorSection.vue";
 import ResourcesEditorSection from "./ResourcesEditorSection.vue";
 import SchedulesEditorSection from "./SchedulesEditorSection.vue";
 import OtherEditorSection from "./OtherEditorSection.vue";
-import { initI18n, updateLocaleMessages } from "../../../utilities/i18n";
+import { initI18n, commonAddUiMessages } from "../../../utilities/i18n";
 import { observer } from "../../../utilities/uiSocketObserver";
 import OptionsEditorSection from "./OptionsEditorSection.vue";
 import { getRundeckContext } from "@/library";
@@ -109,15 +109,9 @@ const mountSection = (section) => {
       app.use(uiv);
       app.use(i18n);
       if (section.addUiMessages) {
-        app.provide("addUiMessages", async (messages) => {
-          const newMessages = messages.reduce(
-            (acc, message) => (message ? { ...acc, ...message } : acc),
-            {},
-          );
-          const locale = window._rundeck.locale || "en_US";
-          const lang = window._rundeck.language || "en";
-          return updateLocaleMessages(i18n, locale, lang, newMessages);
-        });
+        app.provide("addUiMessages", async (messages) =>
+          commonAddUiMessages(i18n, messages),
+        );
       }
       if (section.addCookies) {
         app.use(VueCookies);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-nodes-config/main.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-nodes-config/main.js
@@ -12,7 +12,7 @@ import PageConfirm from "../../../library/components/utils/PageConfirm.vue";
 import ProjectConfigurableForm from "./ProjectConfigurableForm.vue";
 import ProjectNodePage from "./ProjectNodePage.vue";
 import { getRundeckContext } from "../../../library";
-import { initI18n, updateLocaleMessages } from "../../utilities/i18n";
+import { initI18n, commonAddUiMessages } from "../../utilities/i18n";
 import PrimeVue from "primevue/config";
 import Lara from "@primeuix/themes/lara";
 
@@ -57,14 +57,8 @@ for (let i = 0; i < els.length; i++) {
       },
     },
   });
-  app.provide("addUiMessages", async (messages) => {
-    const newMessages = messages.reduce(
-      (acc, message) => (message ? { ...acc, ...message } : acc),
-      {},
-    );
-    const locale = window._rundeck.locale || "en_US";
-    const lang = window._rundeck.language || "en";
-    return updateLocaleMessages(i18n, locale, lang, newMessages);
-  });
+  app.provide("addUiMessages", async (messages) =>
+    commonAddUiMessages(i18n, messages),
+  );
   app.mount(e);
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/storage/main.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/storage/main.ts
@@ -4,7 +4,11 @@ import * as uiv from "uiv";
 import KeyStoragePage from "../../../library/components/storage/KeyStoragePage.vue";
 import KeyStorageView from "../../../library/components/storage/KeyStorageView.vue";
 import KeyStorageEdit from "../../../library/components/storage/KeyStorageEdit.vue";
-import { initI18n, updateLocaleMessages } from "../../utilities/i18n";
+import {
+  initI18n,
+  commonAddUiMessages,
+  type LocalizedMessages,
+} from "../../utilities/i18n";
 import { UiMessage } from "../../../library/stores/UIStore";
 
 const i18n = initI18n();
@@ -17,15 +21,11 @@ const vue = createApp({
 });
 vue.use(uiv);
 vue.use(i18n);
-vue.provide("addUiMessages", async (messages: UiMessage[]) => {
-  const newMessages = messages.reduce(
-    (acc: Record<string, any>, message: UiMessage) => (message ? { ...acc, ...message } : acc),
-    {},
-  );
-  const locale = window._rundeck.locale || "en_US";
-  const lang = window._rundeck.language || "en";
-  return updateLocaleMessages(i18n, locale, lang, newMessages);
-});
+vue.provide(
+  "addUiMessages",
+  async (messages: UiMessage[] | LocalizedMessages) =>
+    commonAddUiMessages(i18n, messages),
+);
 if (elm) {
   vue.mount(elm);
 }

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/i18n.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/i18n.ts
@@ -54,7 +54,7 @@ const initI18n = (options = {}) => {
 const updateLocaleMessages = async (
   i18n: I18n,
   locale: string,
-  lang: string,
+  _lang: string,
   messages: Record<string, any>,
 ) => {
   i18n.global.mergeLocaleMessage(locale, messages);
@@ -69,7 +69,9 @@ const isLocalizedMessages = (
  * update locale messages for the i18n instance
  * @param i18n vue-i18n instance
  * @param messages new messages data — pass a LocalizedMessages object to register
- *   both the active locale and en_US (fallback); pass UiMessage[] for legacy behavior
+ *   the active locale and, when an `en_US` bundle is present and the active locale
+ *   is not already `en_US`, also register `en_US` so vue-i18n's built-in fallback
+ *   chain resolves to English instead of raw keys; pass UiMessage[] for legacy behavior
  */
 const commonAddUiMessages = async (
   i18n: I18n,

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/i18n.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/i18n.ts
@@ -10,7 +10,8 @@ import pt_BR from "./locales/pt_BR";
 import zh_CN from "./locales/zh_CN";
 import { createI18n, type I18n } from "vue-i18n";
 
-export type LocalizedMessages = Record<string, Record<string, string>>;
+export type LocaleMessageValue = string | { [key: string]: LocaleMessageValue };
+export type LocalizedMessages = Record<string, Record<string, LocaleMessageValue>>;
 
 const internationalization: Record<string, any> = {
   en_US: en_US,

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/i18n.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/i18n.ts
@@ -9,7 +9,8 @@ import nl_NL from "./locales/nl_NL";
 import pt_BR from "./locales/pt_BR";
 import zh_CN from "./locales/zh_CN";
 import { createI18n, type I18n } from "vue-i18n";
-import { mergeDeep } from "./objectUtils";
+
+export type LocalizedMessages = Record<string, Record<string, string>>;
 
 const internationalization: Record<string, any> = {
   en_US: en_US,
@@ -46,25 +47,47 @@ const initI18n = (options = {}) => {
   });
 };
 
-const updateLocaleMessages = async (i18n: I18n, locale: string, lang: string, messages: Record<string, any>) => {
-  //include previously loaded messages
-  const merged = mergeDeep((i18n.global.getLocaleMessage(locale) as Record<string, any>) || {}, messages);
-  i18n.global.setLocaleMessage(locale, merged);
+const updateLocaleMessages = async (
+  i18n: I18n,
+  locale: string,
+  lang: string,
+  messages: Record<string, any>,
+) => {
+  i18n.global.mergeLocaleMessage(locale, messages);
   return nextTick();
 };
+
+const isLocalizedMessages = (
+  m: UiMessage[] | LocalizedMessages,
+): m is LocalizedMessages => !Array.isArray(m);
+
 /**
  * update locale messages for the i18n instance
  * @param i18n vue-i18n instance
- * @param messages new messages data
+ * @param messages new messages data — pass a LocalizedMessages object to register
+ *   both the active locale and en_US (fallback); pass UiMessage[] for legacy behavior
  */
-const commonAddUiMessages = async (i18n: I18n, messages: UiMessage[]) => {
-  const newMessages = messages.reduce(
-    (acc: any, message: UiMessage) => (message ? { ...acc, ...message } : acc),
-    {},
-  );
+const commonAddUiMessages = async (
+  i18n: I18n,
+  messages: UiMessage[] | LocalizedMessages,
+) => {
   const locale = window._rundeck.locale || "en_US";
   const lang = window._rundeck.language || "en";
-  return updateLocaleMessages(i18n, locale, lang, newMessages);
+
+  if (isLocalizedMessages(messages)) {
+    const localeMessages =
+      messages[locale] || messages[lang] || messages["en_US"] || {};
+    await updateLocaleMessages(i18n, locale, lang, localeMessages);
+    if (locale !== "en_US" && messages["en_US"]) {
+      await updateLocaleMessages(i18n, "en_US", "en", messages["en_US"]);
+    }
+  } else {
+    const flat = messages.reduce(
+      (acc: any, m: UiMessage) => (m ? { ...acc, ...m } : acc),
+      {},
+    );
+    await updateLocaleMessages(i18n, locale, lang, flat);
+  }
 };
 
 export { initI18n, updateLocaleMessages, commonAddUiMessages };

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/i18n.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/i18n.ts
@@ -1,5 +1,9 @@
 import { nextTick } from "vue";
-import { UiMessage } from "../../library/stores/UIStore";
+import {
+  UiMessage,
+  type LocaleMessageValue,
+  type LocalizedMessages,
+} from "../../library/stores/UIStore";
 import en_US from "./locales/en_US";
 import de_DE from "./locales/de_DE";
 import es_419 from "./locales/es_419";
@@ -10,8 +14,7 @@ import pt_BR from "./locales/pt_BR";
 import zh_CN from "./locales/zh_CN";
 import { createI18n, type I18n } from "vue-i18n";
 
-export type LocaleMessageValue = string | { [key: string]: LocaleMessageValue };
-export type LocalizedMessages = Record<string, Record<string, LocaleMessageValue>>;
+export type { LocaleMessageValue, LocalizedMessages };
 
 const internationalization: Record<string, any> = {
   en_US: en_US,

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/tests/i18n.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/tests/i18n.spec.ts
@@ -1,0 +1,116 @@
+jest.mock("vue-i18n", () => ({ createI18n: jest.fn() }));
+
+import { commonAddUiMessages, updateLocaleMessages } from "../i18n";
+import type { UiMessage } from "../../../library/stores/UIStore";
+
+const createMockI18n = () => {
+  const store: Record<string, Record<string, any>> = {};
+  return {
+    global: {
+      mergeLocaleMessage: jest.fn(
+        (locale: string, messages: Record<string, any>) => {
+          store[locale] = { ...(store[locale] || {}), ...messages };
+        },
+      ),
+      getLocaleMessage: jest.fn((locale: string) => store[locale] || {}),
+      setLocaleMessage: jest.fn(
+        (locale: string, messages: Record<string, any>) => {
+          store[locale] = messages;
+        },
+      ),
+    },
+  };
+};
+
+const setWindowLocale = (locale: string, language: string) => {
+  (window as any)._rundeck = { locale, language };
+};
+
+describe("updateLocaleMessages", () => {
+  it("calls mergeLocaleMessage on the i18n instance", async () => {
+    const i18n = createMockI18n();
+    const messages = { "key.one": "One" };
+
+    await updateLocaleMessages(i18n as any, "en_US", "en", messages);
+
+    expect(i18n.global.mergeLocaleMessage).toHaveBeenCalledWith(
+      "en_US",
+      messages,
+    );
+  });
+});
+
+describe("commonAddUiMessages", () => {
+  beforeEach(() => {
+    setWindowLocale("ja_JP", "ja");
+  });
+
+  it("registers en_US when passed a LocalizedMessages object and locale is non-English", async () => {
+    const i18n = createMockI18n();
+    const messages = {
+      ja_JP: { "button.save": "保存" },
+      en_US: { "button.save": "Save" },
+    };
+
+    await commonAddUiMessages(i18n as any, messages as any);
+
+    expect(i18n.global.getLocaleMessage("en_US")["button.save"]).toBe("Save");
+  });
+
+  it("registers the active locale when passed a LocalizedMessages object", async () => {
+    const i18n = createMockI18n();
+    const messages = {
+      ja_JP: { "button.save": "保存" },
+      en_US: { "button.save": "Save" },
+    };
+
+    await commonAddUiMessages(i18n as any, messages as any);
+
+    expect(i18n.global.getLocaleMessage("ja_JP")["button.save"]).toBe("保存");
+  });
+
+  it("does not register en_US twice when locale is already en_US", async () => {
+    setWindowLocale("en_US", "en");
+    const i18n = createMockI18n();
+    const messages = {
+      en_US: { "button.save": "Save" },
+    };
+
+    await commonAddUiMessages(i18n as any, messages as any);
+
+    const en_US_calls = i18n.global.mergeLocaleMessage.mock.calls.filter(
+      ([locale]) => locale === "en_US",
+    );
+    expect(en_US_calls.length).toBe(1);
+  });
+
+  it("does not blow up when LocalizedMessages has no en_US key", async () => {
+    const i18n = createMockI18n();
+    const messages = {
+      ja_JP: { "button.save": "保存" },
+    };
+
+    await expect(
+      commonAddUiMessages(i18n as any, messages as any),
+    ).resolves.not.toThrow();
+
+    expect(i18n.global.getLocaleMessage("ja_JP")["button.save"]).toBe("保存");
+    expect(Object.keys(i18n.global.getLocaleMessage("en_US")).length).toBe(0);
+  });
+
+  it("handles legacy UiMessage[] flat array — only registers active locale", async () => {
+    const i18n = createMockI18n();
+    const messages: UiMessage[] = [
+      { "button.save": "Save" },
+      { "button.cancel": "Cancel" },
+    ];
+
+    await commonAddUiMessages(i18n as any, messages);
+
+    expect(i18n.global.getLocaleMessage("ja_JP")["button.save"]).toBe("Save");
+    expect(i18n.global.getLocaleMessage("ja_JP")["button.cancel"]).toBe(
+      "Cancel",
+    );
+    expect(Object.keys(i18n.global.getLocaleMessage("en_US")).length).toBe(0);
+  });
+});

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/uiSocketObserver.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/uiSocketObserver.ts
@@ -3,7 +3,7 @@ import * as uiv from "uiv";
 import { getRundeckContext } from "../../library";
 import { UiMessage } from "../../library/stores/UIStore";
 import UiSocket from "../../library/components/utils/UiSocket.vue";
-import { initI18n, updateLocaleMessages } from "./i18n";
+import { initI18n, commonAddUiMessages, type LocalizedMessages } from "./i18n";
 import { createApp } from "vue";
 import { configurePrimeVue } from "../../library/utilities/primeVueConfig";
 
@@ -37,15 +37,11 @@ export const observer = new MutationObserver(function (mutations_list) {
             },
           );
 
-          vue.provide("addUiMessages", async (messages: UiMessage[]) => {
-            const newMessages = messages.reduce(
-              (acc: Record<string, any>, message: UiMessage) => (message ? { ...acc, ...message } : acc),
-              {},
-            );
-            const locale = getRundeckContext().locale || "en_US";
-            const lang = getRundeckContext().language || "en";
-            return updateLocaleMessages(i18n, locale, lang, newMessages);
-          });
+          vue.provide(
+            "addUiMessages",
+            async (messages: UiMessage[] | LocalizedMessages) =>
+              commonAddUiMessages(i18n, messages),
+          );
 
           vue.use(i18n);
           vue.use(uiv);

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/job/workflow-designer/RulesetStrategyEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/job/workflow-designer/RulesetStrategyEditor.vue
@@ -33,14 +33,7 @@ import { getRundeckContext } from "../../../";
 import { defineComponent } from "vue";
 import WorkflowGraph from "./WorkflowGraph.vue";
 import messages from "./i18n";
-const localeData = getRundeckContext()?.locale || "en_US";
-const lang = getRundeckContext()?.language || "en";
-const i18nmessages = {
-  [localeData]: Object.assign(
-    {},
-    messages[localeData] || messages[lang] || messages["en_US"] || {},
-  ),
-};
+import type { LocalizedMessages } from "../../../app/utilities/i18n";
 
 interface GraphNode {
   identifier: string;
@@ -90,7 +83,9 @@ export default defineComponent({
     },
   },
   created() {
-    this.addUiMessages([i18nmessages[localeData]]);
+    (this.addUiMessages as (messages: LocalizedMessages) => Promise<void>)(
+      messages as LocalizedMessages,
+    );
     this.rulesInput = this.modelValue;
 
     eventBus.on("workflow-editor-workflowsteps-updated", async (data: any) => {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/job/workflow-designer/RulesetStrategyEditor.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/job/workflow-designer/RulesetStrategyEditor.vue
@@ -33,7 +33,7 @@ import { getRundeckContext } from "../../../";
 import { defineComponent } from "vue";
 import WorkflowGraph from "./WorkflowGraph.vue";
 import messages from "./i18n";
-import type { LocalizedMessages } from "../../../app/utilities/i18n";
+import type { LocalizedMessages } from "../../../";
 
 interface GraphNode {
   identifier: string;

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/job/workflow-designer/i18n.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/job/workflow-designer/i18n.ts
@@ -1,5 +1,5 @@
 const messages: any = {
-  en: {
+  en_US: {
     graph: {
       stepLabel: {
         scriptFile: "Script File",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/i18n.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/i18n.ts
@@ -1,6 +1,6 @@
 // Ready translated locale messages
 export default {
-  en: {
+  en_US: {
     message: {
       delete: "Delete this field",
       duplicated: "Field already exists",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/index.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/index.ts
@@ -7,6 +7,7 @@ export { RundeckBrowser } from "@rundeck/client";
 export type { RundeckContext } from "./interfaces/rundeckWindow";
 export type { AppLinks } from "./interfaces/AppLinks";
 export { EventBus } from "./utilities/vueEventBus";
+export type { LocaleMessageValue, LocalizedMessages } from "./stores/UIStore";
 
 export default {
   FilterPrefs,

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/UIStore.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/stores/UIStore.ts
@@ -64,3 +64,8 @@ export interface UIItem {
 export interface UiMessage {
   [key: string]: string;
 }
+
+export type LocaleMessageValue =
+  | string
+  | { [key: string]: LocaleMessageValue };
+export type LocalizedMessages = Record<string, Record<string, LocaleMessageValue>>;


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bug fix. When plugins registered i18n messages via `addUiMessages`, only the active locale was registered into the vue-i18n instance. When vue-i18n fell back to `en_US` (e.g. for a Japanese user with a missing translation key), the fallback lookup failed because `en_US` was never registered — causing the raw key string to render instead of the English text.

Jira: RUN-4558

**Describe the solution you've implemented**

- Changed `updateLocaleMessages` to use `i18n.global.mergeLocaleMessage` instead of the previous `setLocaleMessage`/`mergeDeep` approach, ensuring messages are merged rather than overwriting existing locale state.
- Widened `commonAddUiMessages` to accept either `UiMessage[]` (legacy flat array) or the new `LocalizedMessages = Record<string, Record<string, LocaleMessageValue>>` type.
- When given a `LocalizedMessages` object, `commonAddUiMessages` now registers both the active locale AND `en_US` (when locale is not already `en_US`), so vue-i18n's built-in fallback chain always resolves to English text instead of raw keys.
- Exported the new `LocalizedMessages` and `LocaleMessageValue` types from `library/index.ts` so rundeckpro plugins can import and use them directly.
- Updated all inline `addUiMessages` provider implementations in the rundeck submodule (`ui/main.ts`, `uiSocketObserver.ts`, `storage/main.ts`, `project-nodes-config/main.js`, `job/editor/main.js`) to delegate to `commonAddUiMessages`.
- Migrated existing call sites (`readme-motd/main.ts`, `RulesetStrategyEditor.vue`) to pass the full `LocalizedMessages` object instead of a locale-sliced flat array.

**Describe alternatives you've considered**

Alternative: register all locale keys at build time (static imports). Rejected — plugins are dynamically loaded and their locales are not known at build time.

Alternative: use `setLocaleMessage` with a pre-merged object. Rejected — this overwrites any previously registered messages for the locale rather than merging.

**Additional context**

- Backward compatible: the legacy `UiMessage[]` code path is preserved unchanged.
- rundeckpro plugin migration is in a companion PR against the rundeckpro repo.

## Release Notes

Fixed an issue where plugin-provided i18n messages would show raw translation keys instead of English text for users whose locale was not `en_US` and a specific key was missing in their locale's message catalogue.