### PR TITLE
[RUN-4569] Align Jackson to patched 2.21.4 (CVE-2026-54512, CVE-2026-54513)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,6 +157,11 @@ allprojects {
     // Override Spring Boot BOM-managed versions (eachDependency/force can't move Boot-managed deps).
     ext["micrometer.version"] = micrometerVersion          // CVE-2026-40983, CVE-2026-40984
     ext["spring-retry.version"] = springRetryVersion       // CVE-2026-41710
+    // CVE-2026-54512, CVE-2026-54513 (jackson-databind PolymorphicTypeValidator bypass). Grails/Spring
+    // Boot dependency management pins jackson to 2.21.2 and downgrades transitive 2.21.4; a plain
+    // platform import or resolutionStrategy.force does NOT override it. Overriding the Boot BOM property
+    // moves jackson onto the patched 2.21.4 across grails-* plugin modules and rundeckapp.
+    ext["jackson-bom.version"] = jacksonDatabindVersion
     ext.isReleaseBuild = false
     ext.isSnapshotBuild = false
     ext.isDevBuild = false


### PR DESCRIPTION
## Jira Ticket
[RUN-4569](https://pagerduty.atlassian.net/browse/RUN-4569)

## Security Fix
- **CVEs:** CVE-2026-54512, CVE-2026-54513 (jackson-databind `PolymorphicTypeValidator` allowlist bypass)
- **Severity:** High (CVSS 8.1)
- **Affected:** jackson-databind `>= 2.19.0, < 2.21.4`
- **Fix:** resolve jackson onto the patched **2.21.4**

## Root Cause
Grails 7 / Spring Boot dependency management pins jackson-databind to **2.21.2** and downgrades the transitive 2.21.4 from `:core`. Neither the global `resolutionStrategy.force` nor a `platform()` import overrides a Boot-managed version, so the following modules compiled/resolved against the vulnerable 2.21.2: `grails-webhooks`, `grails-metricsweb`, `grails-repository`, `grails-job-kill-handler`, `grails-execution-mode-timer`, `grails-rundeck-data-shared`, and `rundeckapp`.

## Change
Override the Spring Boot BOM property `jackson-bom.version` in the `allprojects` block, matching the existing pattern already used for `spring-framework.version`, `micrometer.version`, and `spring-retry.version`. No version is hardcoded (`jacksonDatabindVersion`).

## Verification
- Dependency tree: the BOM constraint now reads `jackson-databind:2.21.2 -> 2.21.4 (c)`; no node resolves below 2.21.4.
- Scan across all modules: every module/configuration resolves `jackson-databind=2.21.4`.
- Affected grails-* modules compile cleanly (including webhooks OpenAPI generation).

[RUN-4569]: https://pagerduty.atlassian.net/browse/RUN-4569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ