### PR TITLE
[RUN-4561] Fix node-keepgoing ignored when workflow has job reference steps

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/NodeFirstWorkflowExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/NodeFirstWorkflowExecutor.java
@@ -28,6 +28,8 @@ import com.dtolabs.rundeck.core.NodesetEmptyException;
 import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.common.IFramework;
 import com.dtolabs.rundeck.core.common.INodeEntry;
+import com.dtolabs.rundeck.core.common.INodeSet;
+import com.dtolabs.rundeck.core.common.NodeSetImpl;
 import com.dtolabs.rundeck.core.common.NodesSelector;
 import com.dtolabs.rundeck.core.execution.ExecutionContext;
 import com.dtolabs.rundeck.core.execution.ExecutionContextImpl;
@@ -108,6 +110,10 @@ public class NodeFirstWorkflowExecutor extends BaseWorkflowExecutor {
                 WorkflowStatusResult sectionSuccess;
                 WorkflowDataResult sectionData;
 
+                // When node-keepgoing is active, exclude nodes that already failed in previous
+                // sections so that subsequent steps do not execute on them.
+                StepExecutionContext sectionContext = buildSectionContext(executionContext, failures.keySet());
+
                 StepExecutor
                         stepExecutor =
                         getFramework().getStepExecutorForItem(flowsection.getCommands().get(0),
@@ -115,7 +121,7 @@ public class NodeFirstWorkflowExecutor extends BaseWorkflowExecutor {
 
                 if (stepExecutor.isNodeDispatchStep(flowsection.getCommands().get(0))) {
                     WorkflowStatusDataResult workflowStatusDataResult = executeWFSectionNodeDispatch(
-                            executionContext,
+                            sectionContext,
                             stepCount,
                             results,
                             failures,
@@ -135,7 +141,7 @@ public class NodeFirstWorkflowExecutor extends BaseWorkflowExecutor {
                     WFSharedContext currentData = new WFSharedContext(wfCurrentContext);
 
                     StepExecutionContext newContext =
-                            ExecutionContextImpl.builder(executionContext)
+                            ExecutionContextImpl.builder(sectionContext)
                                                 .sharedDataContext(currentData)
                                                 .stepNumber(stepCount)
                                                 .build();
@@ -166,8 +172,20 @@ public class NodeFirstWorkflowExecutor extends BaseWorkflowExecutor {
                 if(sectionSuccess.getStatusString() !=null) {
                     statusString = sectionSuccess.getStatusString();
                 }
-                if (!workflowsuccess && !item.getWorkflow().isKeepgoing() || controlBehavior == ControlBehavior.Halt) {
+                if (controlBehavior == ControlBehavior.Halt) {
                     break;
+                }
+                if (!workflowsuccess && !item.getWorkflow().isKeepgoing()) {
+                    // With node-keepgoing enabled, continue subsequent sections for nodes that have
+                    // not yet failed — mirroring the behavior when all steps are in a single dispatch
+                    // section. Only halt when node-keepgoing is off or every node has already failed.
+                    INodeSet allNodes = executionContext.getNodes();
+                    boolean hasSurvivingNodes = executionContext.isKeepgoing()
+                            && allNodes != null
+                            && !failures.keySet().containsAll(allNodes.getNodeNames());
+                    if (!hasSurvivingNodes) {
+                        break;
+                    }
                 }
                 stepCount += flowsection.getCommands().size();
             }
@@ -357,6 +375,51 @@ public class NodeFirstWorkflowExecutor extends BaseWorkflowExecutor {
             stepFailures.put(integer, NodeDispatchStepExecutor.wrapDispatcherResult(r));
         }
         return wfSharedContext;
+    }
+
+    /**
+     * Builds a section execution context for the given section of the workflow.
+     * When node-keepgoing is active ({@link StepExecutionContext#isKeepgoing()} is {@code true}),
+     * nodes present in {@code failedNodes} are excluded from the returned context so that
+     * subsequent sections do not execute on nodes that already failed in a previous section.
+     * If node-keepgoing is off, or there are no failed nodes, the original context is returned
+     * unchanged.
+     *
+     * @param context    original execution context
+     * @param failedNodes set of node names that have failed in preceding sections
+     * @return a context with failed nodes filtered out, or the original context if no filtering is needed
+     */
+    private StepExecutionContext buildSectionContext(
+            StepExecutionContext context,
+            Set<String> failedNodes
+    ) {
+        if (!context.isKeepgoing() || failedNodes.isEmpty() || context.getNodes() == null) {
+            return context;
+        }
+
+        Collection<String> allNodeNames = context.getNodes().getNodeNames();
+        Set<String> survivingNodeNames = new HashSet<>(allNodeNames);
+        survivingNodeNames.removeAll(failedNodes);
+
+        if (survivingNodeNames.size() == allNodeNames.size() || survivingNodeNames.isEmpty()) {
+            // No actual change needed (nothing to filter, or all failed — let caller decide)
+            return context;
+        }
+
+        NodeSetImpl filteredNodes = new NodeSetImpl();
+        for (String nodeName : survivingNodeNames) {
+            INodeEntry node = context.getNodes().getNode(nodeName);
+            if (node != null) {
+                filteredNodes.putNode(node);
+            }
+        }
+
+        // Only update the node set; the existing node selector (if any) will apply correctly
+        // against the already-filtered node set. Setting a new AND-selector would fail when the
+        // original selector is null (no-op / accept-all), so we leave the selector unchanged.
+        return ExecutionContextImpl.builder(context)
+                                   .nodes(filteredNodes)
+                                   .build();
     }
 
     private void mergeFailure(Map<String, Collection<StepExecutionResult>> destination, Map<String, Collection<StepExecutionResult>> source) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/NodeFirstWorkflowExecutor.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/execution/workflow/NodeFirstWorkflowExecutor.java
@@ -112,7 +112,7 @@ public class NodeFirstWorkflowExecutor extends BaseWorkflowExecutor {
 
                 // When node-keepgoing is active, exclude nodes that already failed in previous
                 // sections so that subsequent steps do not execute on them.
-                StepExecutionContext sectionContext = buildSectionContext(executionContext, failures.keySet());
+                StepExecutionContext sectionContext = buildSectionContext(executionContext, trulyFailedNodes(failures));
 
                 StepExecutor
                         stepExecutor =
@@ -178,11 +178,30 @@ public class NodeFirstWorkflowExecutor extends BaseWorkflowExecutor {
                 if (!workflowsuccess && !item.getWorkflow().isKeepgoing()) {
                     // With node-keepgoing enabled, continue subsequent sections for nodes that have
                     // not yet failed — mirroring the behavior when all steps are in a single dispatch
-                    // section. Only halt when node-keepgoing is off or every node has already failed.
+                    // section. The bypass only applies when:
+                    //   (a) the current section failed due to a node-dispatch failure (not a
+                    //       workflow-step failure), OR the current section succeeded but an earlier
+                    //       node-dispatch section failed, AND
+                    //   (b) node-keepgoing is active, AND
+                    //   (c) at least one node has not yet failed.
+                    boolean isSectionNodeDispatch =
+                            stepExecutor.isNodeDispatchStep(flowsection.getCommands().get(0));
+                    Set<String> failedNodes = trulyFailedNodes(failures);
                     INodeSet allNodes = executionContext.getNodes();
-                    boolean hasSurvivingNodes = executionContext.isKeepgoing()
-                            && allNodes != null
-                            && !failures.keySet().containsAll(allNodes.getNodeNames());
+                    boolean hasSurvivingNodes;
+                    if (!sectionSuccess.isSuccess()) {
+                        // Current section failed: only bypass for node-dispatch section failures
+                        hasSurvivingNodes = isSectionNodeDispatch
+                                && executionContext.isKeepgoing()
+                                && allNodes != null
+                                && !failedNodes.containsAll(allNodes.getNodeNames());
+                    } else {
+                        // Current section succeeded, but an earlier section failed:
+                        // continue as long as there are surviving nodes
+                        hasSurvivingNodes = executionContext.isKeepgoing()
+                                && allNodes != null
+                                && !failedNodes.containsAll(allNodes.getNodeNames());
+                    }
                     if (!hasSurvivingNodes) {
                         break;
                     }
@@ -375,6 +394,24 @@ public class NodeFirstWorkflowExecutor extends BaseWorkflowExecutor {
             stepFailures.put(integer, NodeDispatchStepExecutor.wrapDispatcherResult(r));
         }
         return wfSharedContext;
+    }
+
+    /**
+     * Returns the set of node names that have at least one recorded failure in the given map.
+     * Entries created via {@code computeIfAbsent} with empty collections (e.g. for successfully
+     * dispatched nodes) are excluded so that only genuinely-failed nodes are returned.
+     *
+     * @param failures accumulated node-failure map from the section loop
+     * @return set of node names with at least one failure
+     */
+    private static Set<String> trulyFailedNodes(Map<String, Collection<StepExecutionResult>> failures) {
+        Set<String> failed = new HashSet<>();
+        for (Map.Entry<String, Collection<StepExecutionResult>> entry : failures.entrySet()) {
+            if (!entry.getValue().isEmpty()) {
+                failed.add(entry.getKey());
+            }
+        }
+        return failed;
     }
 
     /**

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/NodeFirstWorkflowStrategySpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/NodeFirstWorkflowStrategySpec.groovy
@@ -28,7 +28,6 @@ import com.dtolabs.rundeck.core.execution.ExecutionListener
 import com.dtolabs.rundeck.core.execution.ExecutionServiceImpl
 import com.dtolabs.rundeck.core.execution.StepExecutionItem
 import com.dtolabs.rundeck.core.execution.dispatch.DispatcherException
-import com.dtolabs.rundeck.core.execution.dispatch.DispatcherResult
 import com.dtolabs.rundeck.core.execution.dispatch.DispatcherResultImpl
 import com.dtolabs.rundeck.core.execution.dispatch.NodeDispatcher
 import com.dtolabs.rundeck.core.execution.dispatch.SequentialNodeDispatcher

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/NodeFirstWorkflowStrategySpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/execution/workflow/NodeFirstWorkflowStrategySpec.groovy
@@ -28,6 +28,8 @@ import com.dtolabs.rundeck.core.execution.ExecutionListener
 import com.dtolabs.rundeck.core.execution.ExecutionServiceImpl
 import com.dtolabs.rundeck.core.execution.StepExecutionItem
 import com.dtolabs.rundeck.core.execution.dispatch.DispatcherException
+import com.dtolabs.rundeck.core.execution.dispatch.DispatcherResult
+import com.dtolabs.rundeck.core.execution.dispatch.DispatcherResultImpl
 import com.dtolabs.rundeck.core.execution.dispatch.NodeDispatcher
 import com.dtolabs.rundeck.core.execution.dispatch.SequentialNodeDispatcher
 import com.dtolabs.rundeck.core.execution.service.FileCopier
@@ -40,6 +42,7 @@ import com.dtolabs.rundeck.core.execution.workflow.steps.StepExecutor
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepException
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepExecutor
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepFailureReason
+import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepResultImpl
 import com.dtolabs.rundeck.core.tools.AbstractBaseTest
 import spock.lang.Specification
 
@@ -172,6 +175,129 @@ class NodeFirstWorkflowStrategySpec extends Specification {
         result.getNodeFailures()['node1']
         NodeStepFailureReason.NonZeroResultCode == result.nodeFailures['node1'][0].failureReason
 
+    }
+
+    /**
+     * Regression test for RUN-4561:
+     * When node-keepgoing is true and a workflow-step (e.g. Job Reference) splits the section list,
+     * surviving nodes must continue executing subsequent sections instead of being halted by the
+     * outer section-loop break that fires when workflow-keepgoing is false.
+     */
+    def "node-keepgoing with workflow step between node steps: surviving nodes complete all sections"() {
+        given: "a two-node workflow: [node-step(fails on nodeA), workflow-step, node-step]"
+        def strategy = new NodeFirstWorkflowExecutor(framework)
+
+        def nodeA = new NodeEntryImpl('nodeA')
+        def nodeB = new NodeEntryImpl('nodeB')
+        def nodeSet = new NodeSetImpl()
+        nodeSet.putNode(nodeA)
+        nodeSet.putNode(nodeB)
+
+        def wfStepNodes   = []  // tracks nodes visible to the workflow step (step 2)
+        def finalStepNodes = [] // tracks nodes the final node step (step 3) ran on
+
+        def dataContext = new BaseDataContext()
+        def context = Mock(StepExecutionContext) {
+            getExecutionListener() >> Mock(ExecutionListener) {
+                log(*_)         >> { args -> System.err.println(args[1]) }
+                ignoreErrors(_) >> {}
+                getFailedNodesListener() >> null
+            }
+            getNodes()          >> nodeSet
+            isKeepgoing()       >> true   // node-keepgoing: continue on other nodes after one fails
+            getFrameworkProject() >> TEST_PROJ
+            getDataContext()      >> dataContext
+            getDataContextObject() >> dataContext
+            getFramework()        >> framework
+            componentForType(_)   >> Optional.empty()
+            componentsForType(_)  >> []
+            getComponentList()    >> []
+            getStepContext()      >> []
+        }
+
+        // Step 1: node-dispatch step — fails on nodeA, succeeds on nodeB
+        def step1Executor = new StepExecutor() {
+            boolean isNodeDispatchStep(StepExecutionItem item) { true }
+            StepExecutionResult executeWorkflowStep(StepExecutionContext ctx, StepExecutionItem item) {
+                def nodeNames = ctx.getNodes()?.getNodeNames() ?: []
+                if (nodeNames.contains('nodeA')) {
+                    return NodeDispatchStepExecutor.wrapDispatcherException(new DispatcherException(
+                        "nodeA failed",
+                        new NodeStepException("bad", NodeStepFailureReason.NonZeroResultCode, "nodeA"),
+                        nodeA
+                    ))
+                }
+                return NodeDispatchStepExecutor.wrapDispatcherResult(
+                    new DispatcherResultImpl(['nodeB': new NodeStepResultImpl(nodeB)], true)
+                )
+            }
+        }
+
+        // Step 2: workflow step (like a Job Reference) — NOT a node-dispatch step
+        def step2Executor = new StepExecutor() {
+            boolean isNodeDispatchStep(StepExecutionItem item) { false }
+            StepExecutionResult executeWorkflowStep(StepExecutionContext ctx, StepExecutionItem item) {
+                wfStepNodes.addAll(ctx.getNodes()?.getNodeNames() ?: [])
+                return new StepExecutionResultImpl()
+            }
+        }
+
+        // Step 3: node-dispatch step — always succeeds, records which nodes it ran on
+        def step3Executor = new StepExecutor() {
+            boolean isNodeDispatchStep(StepExecutionItem item) { true }
+            StepExecutionResult executeWorkflowStep(StepExecutionContext ctx, StepExecutionItem item) {
+                def nodeNames = ctx.getNodes()?.getNodeNames() ?: []
+                def nodeName = nodeNames.isEmpty() ? null : nodeNames.first()
+                if (nodeName) {
+                    finalStepNodes.add(nodeName)
+                    def node = nodeName == 'nodeA' ? nodeA : nodeB
+                    return NodeDispatchStepExecutor.wrapDispatcherResult(
+                        new DispatcherResultImpl([(nodeName): new NodeStepResultImpl(node)], true)
+                    )
+                }
+                return new StepExecutionResultImpl()
+            }
+        }
+
+        def execPluginsMock = Mock(IExecutionProviders) {
+            _ * getStepExecutorForItem({ it.type == 'step1' }, _) >> step1Executor
+            _ * getStepExecutorForItem({ it.type == 'step2' }, _) >> step2Executor
+            _ * getStepExecutorForItem({ it.type == 'step3' }, _) >> step3Executor
+            _ * getNodeDispatcherForContext(_) >> new SequentialNodeDispatcher(framework)
+        }
+        serviceSupport.setExecutionProviders(execPluginsMock)
+        executionServiceImpl.setExecutionProviders(execPluginsMock)
+
+        def item = Mock(WorkflowExecutionItem) {
+            getWorkflow() >> Mock(IWorkflow) {
+                isKeepgoing()   >> false  // stop at failed step (workflow-level)
+                getThreadcount() >> 1
+                getStrategy()    >> 'node-first'
+                getPluginConfig() >> [:]
+                getCommands() >> [
+                    Mock(StepExecutionItem) { getType() >> 'step1' },
+                    Mock(StepExecutionItem) { getType() >> 'step2' },
+                    Mock(StepExecutionItem) { getType() >> 'step3' }
+                ]
+            }
+        }
+
+        when:
+        def result = strategy.executeWorkflowImpl(context, item)
+
+        then: "overall workflow failed because nodeA failed step 1"
+        !result.isSuccess()
+
+        and: "nodeA failure is recorded"
+        result.getNodeFailures().containsKey('nodeA')
+
+        and: "the workflow step (step 2) ran only on surviving nodeB, not on failed nodeA"
+        wfStepNodes.contains('nodeB')
+        !wfStepNodes.contains('nodeA')
+
+        and: "the final node step (step 3) ran on nodeB but not on nodeA"
+        finalStepNodes.contains('nodeB')
+        !finalStepNodes.contains('nodeA')
     }
 
     def "node step fails on empty node list"() {


### PR DESCRIPTION
## Jira Ticket
[RUN-4561](https://pagerduty.atlassian.net/browse/RUN-4561)

## Summary
- Fix `NodeFirstWorkflowExecutor` to respect node-keepgoing when workflow steps (e.g. Job References) split the execution into multiple sections
- Add regression test reproducing the exact scenario from the bug report

## Problem

When a job uses **Node-First** strategy with:
- **Node failure**: "Continue running on any remaining nodes before failing the step" (`node-keepgoing=true`)
- **Step failure**: "Stop at the failed step" (`workflow-keepgoing=false`)
- A **Job Reference** (workflow step) between two node steps

The workflow was incorrectly halted after the first dispatch section failed. Nodes that had **not** failed were left with "Not Started" on all subsequent steps.

**Root cause**: `NodeFirstWorkflowExecutor` splits the workflow into sections at every workflow step boundary. The outer section loop used only `workflow.isKeepgoing()` in its break condition, ignoring `context.isKeepgoing()` (node-level keepgoing). When a Job Reference split the workflow into sections:
- Section A: [cmd1] — node dispatch
- Section B: [job-ref] — workflow step  ← causes the split
- Section C: [cmd3] — node dispatch

After Section A failed (one node failed), the loop broke unconditionally — sections B and C never executed for surviving nodes.

Without the Job Reference, all steps are in a single dispatch section and each node's per-node mini-workflow handles them independently, which is why the bug only appears with job references.

## Fix

**`NodeFirstWorkflowExecutor.java`**:

1. **`buildSectionContext()`** — new helper that filters already-failed nodes from the execution context before each section starts, ensuring subsequent sections do not dispatch to nodes that already failed in a prior section.

2. **Changed break condition** — the outer section loop now continues when `context.isKeepgoing()=true` and there are surviving nodes, halting only when all nodes have failed or node-keepgoing is disabled.

## Test

Added `"node-keepgoing with workflow step between node steps: surviving nodes complete all sections"` to `NodeFirstWorkflowStrategySpec` that reproduces the exact scenario: 3 steps `[node-step, workflow-step, node-step]`, two nodes where one fails step 1, verifying that the surviving node completes all 3 steps.

## Verification

Manually verified before/after in a local Rundeck instance:

**Before fix** — localhost and node2 (which succeeded step 1) had steps 2 and 3 as "Not Started"  
**After fix** — localhost and node2 complete all 3 steps; node1 (failed step 1) has steps 2-3 as "Not Started"

Made with [Cursor](https://cursor.com)

[RUN-4561]: https://pagerduty.atlassian.net/browse/RUN-4561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ