### PR TITLE
[RUN-0000] Align okhttp-urlconnection with okhttpVersion

### DIFF
--- a/functional-test/build.gradle
+++ b/functional-test/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     testImplementation "org.slf4j:slf4j-simple:${slf4jVersion}"
     testImplementation "org.slf4j:jul-to-slf4j:${slf4jVersion}"
     testImplementation "org.seleniumhq.selenium:selenium-java:${seleniumJavaVersion}"
-    testImplementation "com.squareup.okhttp3:okhttp-urlconnection:${okhttpUrlConnectionVersion}"
+    testImplementation "com.squareup.okhttp3:okhttp-urlconnection:${okhttpVersion}"
     testImplementation group: 'com.jcraft', name: 'jsch', version: "${jschVersion}"
 
     implementation "org.apache.commons:commons-compress:${commonsCompressVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -74,7 +74,6 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx4096M -XX:MaxMetaspaceSize=1024M -X
 rundeckProBuild=false
 lombokVersion=1.18.46
 okhttpVersion=4.12.0
-okhttpUrlConnectionVersion=5.4.0
 nimbusJoseVersion=9.37.4
 commonsCodecVersion=1.22.0
 commonsIoVersion=2.22.0


### PR DESCRIPTION
## Summary
- `functional-test` pinned `okhttp-urlconnection` to a separate `okhttpUrlConnectionVersion` (5.4.0) while `okhttp` itself remained at `okhttpVersion` (4.12.0).
- Mixing okhttp 4.x and 5.x on the same test classpath causes conflicting transitive resolution (Gradle silently upgrades okhttp to 5.x via the urlconnection artifact).
- This consolidates `okhttp-urlconnection` onto `${okhttpVersion}` and removes the now-redundant `okhttpUrlConnectionVersion` property, matching the pattern used elsewhere in the build.

## Test plan
- [ ] `functional-test` resolves a single, consistent okhttp version (4.12.0) with no version conflict.
- [ ] Functional test build/compile succeeds.