### PR TITLE
[RUN-4583] Fix integer overflow in API token duration validation

### DIFF
--- a/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
+++ b/grails-webhooks/grails-app/services/webhooks/WebhookService.groovy
@@ -255,7 +255,7 @@ class WebhookService {
             //create token
             String checkUser = hookData.user ?: authContext.username
             try {
-                def at=apiService.generateUserToken(authContext, null, checkUser, roles, false,
+                def at=apiService.generateUserToken(authContext, 0L, checkUser, roles, false,
                                                             AuthTokenType.WEBHOOK)
                 saveWebhookRequest.setAuthToken(at.token)
             } catch (Exception e) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ApiController.groovy
@@ -830,7 +830,6 @@ Since: v11
         }
         AuthenticationToken token
 
-        Integer tokenDurationSeconds = tokenDuration ? Sizes.parseTimeDuration(tokenDuration) : 0
         if (tokenDuration && !Sizes.validTimeDuration(tokenDuration)) {
             return apiService.renderErrorFormat(response, [
                     status: HttpServletResponse.SC_BAD_REQUEST,
@@ -839,10 +838,21 @@ Since: v11
             ]
             )
         }
+        long tokenDurationSeconds
+        try {
+            tokenDurationSeconds = tokenDuration ? Sizes.parseTimeDuration(tokenDuration) : 0L
+        } catch (ArithmeticException e) {
+            return apiService.renderErrorFormat(response, [
+                    status: HttpServletResponse.SC_BAD_REQUEST,
+                    code  : 'api.error.parameter.invalid',
+                    args  : [tokenDuration, "duration", "Duration value is too large"]
+            ]
+            )
+        }
         try {
             token = apiService.generateUserToken(
                     authContext,
-                    tokenDurationSeconds ?: null,
+                    tokenDurationSeconds,
                     tokenuser,
                     rolesSet,
                     true,

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/MenuController.groovy
@@ -330,8 +330,11 @@ class MenuController extends ControllerBase implements ApplicationContextAware{
         if (query.daysAhead && query.daysAhead >= 0) {
             futureDate = new Date() + query.daysAhead
         } else if (params.future && Sizes.validTimeDuration(params.future)) {
-            def period = Sizes.parseTimeDuration(params.future, TimeUnit.MILLISECONDS)
-            futureDate = new Date(System.currentTimeMillis() + period)
+            try {
+                def period = Sizes.parseTimeDuration(params.future, TimeUnit.MILLISECONDS)
+                futureDate = new Date(System.currentTimeMillis() + period)
+            } catch (ArithmeticException ignored) {
+            }
         }
         def maxFutures = null
         if (params.maxFutures) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/UserController.groovy
@@ -874,9 +874,13 @@ For APIv53+, the results will also include:
             def result = [result: false, error: "Duration format was not valid"]
             return renderTokenGenerateResult(result, params.login)
         }
-        Integer tokenDurationSeconds = tokenTimeString ? Sizes.parseTimeDuration(tokenTimeString) : 0
-        //check auth to edit profile
-        //default to current user profile
+        long tokenDurationSeconds
+        try {
+            tokenDurationSeconds = tokenTimeString ? Sizes.parseTimeDuration(tokenTimeString) : 0L
+        } catch (ArithmeticException e) {
+            def result = [result: false, error: "Duration value is too large"]
+            return renderTokenGenerateResult(result, params.login)
+        }
         def result = [:]
         try {
             AuthenticationToken token = apiService.generateUserToken(

--- a/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
@@ -80,17 +80,26 @@ class ApiService implements WebUtilService{
      * if it exceeds the
      * maximum
      */
-    Map generateTokenExpirationDate(Integer tokenDuration, Integer maxDuration = null) {
-        int useTokenTime = maxDuration ?: 0
+    /**
+     * Generate the expiration date for a token given the duration in seconds and an optional maximum.
+     * @param tokenDuration requested duration in seconds (0 or negative means use max)
+     * @param maxDuration maximum allowed duration in seconds (0 means no maximum)
+     * @return map with [date: Date or null, max: boolean, error: String or null]
+     */
+    Map generateTokenExpirationDate(long tokenDuration, long maxDuration = 0L) {
+        if (tokenDuration < 0) {
+            return [date: null, max: false, error: "Invalid negative duration: ${tokenDuration}"]
+        }
+        long useTokenTime = maxDuration > 0 ? maxDuration : 0L
         boolean max = false
-        if (tokenDuration) {
-            if (tokenDuration <= useTokenTime || useTokenTime < 1) {
+        if (tokenDuration > 0) {
+            if (useTokenTime < 1 || tokenDuration <= useTokenTime) {
                 useTokenTime = tokenDuration
             } else {
                 max = true
             }
         }
-        def newDate = null;
+        def newDate = null
         if (useTokenTime > 0) {
             def currentDate = systemClock.instant()
             newDate = Date.from(currentDate.plusSeconds(useTokenTime))
@@ -185,7 +194,7 @@ class ApiService implements WebUtilService{
      */
     AuthenticationToken generateUserToken(
             UserAndRolesAuthContext authContext,
-            Integer tokenTimeSeconds,
+            long tokenTimeSeconds,
             String username,
             Set<String> roles,
             boolean forceExpiration = true,
@@ -206,7 +215,7 @@ class ApiService implements WebUtilService{
      */
     AuthenticationToken createUserToken(
             UserAndRolesAuthContext authContext,
-            Integer tokenTimeSeconds,
+            long tokenTimeSeconds,
             String token,
             String username,
             Set<String> roles,
@@ -214,8 +223,6 @@ class ApiService implements WebUtilService{
             AuthTokenType tokenType = null,
             String tokenName = null
     ) throws Exception {
-        //check auth to edit profile
-        //default to current user profile
         TokenRolesAuthCheck authed = checkTokenAuthorization(authContext, username, roles)
         if (!authed.authorized) {
             throw new Exception(authed.message)
@@ -225,8 +232,11 @@ class ApiService implements WebUtilService{
 
         Date newDate = null
         if (forceExpiration) {
-            Integer maxTokenDuration = maxTokenDurationConfig()
+            long maxTokenDuration = maxTokenDurationConfig()
             def generate = generateTokenExpirationDate(tokenTimeSeconds, maxTokenDuration)
+            if (generate.error) {
+                throw new Exception(generate.error as String)
+            }
             if (generate.max) {
                 throw new Exception("Duration exceeds maximum allowed: " + maxTokenDuration)
             }
@@ -351,13 +361,16 @@ class ApiService implements WebUtilService{
         )
     }
 
-    public int maxTokenDurationConfig() {
+    /**
+     * @return the configured max token duration in seconds, or 0 if unset
+     */
+    public long maxTokenDurationConfig() {
         def string = configurationService.getString("api.tokens.duration.max", null)
         if (!Sizes.validTimeDuration(string)) {
             log.warn("Invalid configuration for rundeck.api.tokens.duration.max: " + string + ", using 30d")
             string = "30d"
         }
-        string ? Sizes.parseTimeDuration(string) : 0
+        string ? Sizes.parseTimeDuration(string) : 0L
     }
 
 

--- a/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ApiService.groovy
@@ -72,17 +72,8 @@ class ApiService implements WebUtilService{
 
     Clock systemClock = Clock.systemUTC()
     /**
-     * Generate the expiration date for a token given the duration string, and
-     * duration max string
-     * @param tokenDuration duration string
-     * @param maxDuration optional maximum duration time, if null then no maximum
-     * @return [date:Date] date is UTC time, or [error:'format'] if the input duration is not valid or [error:'max']
-     * if it exceeds the
-     * maximum
-     */
-    /**
      * Generate the expiration date for a token given the duration in seconds and an optional maximum.
-     * @param tokenDuration requested duration in seconds (0 or negative means use max)
+     * @param tokenDuration requested duration in seconds (0 means use max, negative is rejected)
      * @param maxDuration maximum allowed duration in seconds (0 means no maximum)
      * @return map with [date: Date or null, max: boolean, error: String or null]
      */
@@ -104,7 +95,7 @@ class ApiService implements WebUtilService{
             def currentDate = systemClock.instant()
             newDate = Date.from(currentDate.plusSeconds(useTokenTime))
         }
-        [date: newDate, max: max]
+        [date: newDate, max: max, error: null]
     }
 
     /**
@@ -370,7 +361,12 @@ class ApiService implements WebUtilService{
             log.warn("Invalid configuration for rundeck.api.tokens.duration.max: " + string + ", using 30d")
             string = "30d"
         }
-        string ? Sizes.parseTimeDuration(string) : 0L
+        try {
+            return string ? Sizes.parseTimeDuration(string) : 0L
+        } catch (ArithmeticException e) {
+            log.warn("Overflow in rundeck.api.tokens.duration.max: " + string + ", using 30d")
+            return Sizes.parseTimeDuration("30d")
+        }
     }
 
 

--- a/rundeckapp/grails-app/services/rundeck/services/RundeckAuthTokenManagerService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/RundeckAuthTokenManagerService.groovy
@@ -95,7 +95,7 @@ class RundeckAuthTokenManagerService implements AuthTokenManager {
             return updateAuthRoles(authContext, token, roleSet)
         }
 
-        apiService.createUserToken(authContext, 0, token, user, roleSet, false, AuthTokenType.WEBHOOK)
+        apiService.createUserToken(authContext, 0L, token, user, roleSet, false, AuthTokenType.WEBHOOK)
 
         return true
     }

--- a/rundeckapp/src/main/groovy/org/rundeck/util/Sizes.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/util/Sizes.groovy
@@ -54,12 +54,6 @@ class Sizes {
 
     static final Map<String, Long> TIME_UNITS = [s: 1, m: 60, h: 60 * 60, d: 24 * 60 * 60,w: 7 * 24 * 60 * 60, y: 365 * 24 * 60 * 60]
     /**
-     * Return the timeout duration in seconds for a timeout string in the form "1d2h3m15s" etc
-     * @param time
-     * @param opts
-     * @return
-     */
-    /**
      * Return the timeout duration in seconds for a timeout string in the form "1d2h3m15s" etc.
      * @param time duration string
      * @param unit desired output time unit
@@ -84,11 +78,12 @@ class Sizes {
             }
         }
         return unit.convert(timeval, TimeUnit.SECONDS)
-    }/**
-     * Return the timeout duration in seconds for a timeout string in the form "1d2h3m15s" etc
-     * @param time
-     * @param opts
-     * @return
+    }
+
+    /**
+     * Validate the format of a timeout duration string (digits optionally followed by a unit letter).
+     * @param time duration string to validate
+     * @return true if the format is valid
      */
     public static boolean validTimeDuration(String time) {
         def matcher = (time =~ /(\d+)([smhdwy])?/)

--- a/rundeckapp/src/main/groovy/org/rundeck/util/Sizes.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/util/Sizes.groovy
@@ -59,6 +59,13 @@ class Sizes {
      * @param opts
      * @return
      */
+    /**
+     * Return the timeout duration in seconds for a timeout string in the form "1d2h3m15s" etc.
+     * @param time duration string
+     * @param unit desired output time unit
+     * @return duration converted to the requested unit
+     * @throws ArithmeticException if the parsed value overflows a long
+     */
     public static long parseTimeDuration(String time, TimeUnit unit = TimeUnit.SECONDS) {
         long timeval = 0
         def matcher = (time =~ /(\d+)(.)?/)
@@ -67,12 +74,13 @@ class Sizes {
             try {
                 val = Long.parseLong(m[1])
             } catch (NumberFormatException e) {
-                return
+                throw new ArithmeticException("Duration value too large: " + m[1])
             }
             if (m[2] && TIME_UNITS[m[2]]) {
-                timeval += (val * TIME_UNITS[m[2]])
+                long product = Math.multiplyExact(val, TIME_UNITS[m[2]])
+                timeval = Math.addExact(timeval, product)
             } else if (!m[2]) {
-                timeval += val
+                timeval = Math.addExact(timeval, val)
             }
         }
         return unit.convert(timeval, TimeUnit.SECONDS)

--- a/rundeckapp/src/test/groovy/org/rundeck/util/SizesTest.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/util/SizesTest.groovy
@@ -149,4 +149,26 @@ class SizesTest extends Specification {
         "asdf" | 0L
         "123z" | 0
     }
+
+    def "parseTimeDuration handles large values within long range"() {
+        expect:
+        Sizes.parseTimeDuration(value) == result
+
+        where:
+        value              | result
+        "999999999991d"    | 999999999991L * 86400L
+        "999999999999999s" | 999999999999999L
+    }
+
+    @Unroll("parseTimeDuration overflow #value should throw ArithmeticException")
+    def "parseTimeDuration detects overflow for values exceeding long range"() {
+        when:
+        Sizes.parseTimeDuration(value)
+
+        then:
+        thrown(ArithmeticException)
+
+        where:
+        value << ["99999999999999999999999999d", "999999999999999d", "9999999999999999999999s"]
+    }
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
@@ -298,7 +298,7 @@ class ApiControllerSpec extends Specification implements ControllerUnitTest<ApiC
 
         then:
         1 * controller.apiService.requireApi(_, _) >> true
-        1 * controller.apiService.generateUserToken(null, null, 'bob', roles, _, _, _) >> createdToken
+        1 * controller.apiService.generateUserToken(null, 0L, 'bob', roles, _, _, _) >> createdToken
         0 * controller.apiService._(*_)
 
         response.status == 201
@@ -350,7 +350,7 @@ class ApiControllerSpec extends Specification implements ControllerUnitTest<ApiC
             it[2].json(requestJson)
             true
         }
-        1 * controller.apiService.generateUserToken(_, null, 'bob', roles, _, _, _) >> createdToken
+        1 * controller.apiService.generateUserToken(_, 0L, 'bob', roles, _, _, _) >> createdToken
         0 * controller.apiService._(*_)
 
         response.status == 201
@@ -407,7 +407,7 @@ class ApiControllerSpec extends Specification implements ControllerUnitTest<ApiC
             it[2].json(requestJson)
             true
         }
-        1 * controller.apiService.generateUserToken(_, null, 'bob', null, _, _, _) >> createdToken
+        1 * controller.apiService.generateUserToken(_, 0L, 'bob', null, _, _, _) >> createdToken
         0 * controller.apiService._(*_)
 
         response.status == 201

--- a/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
@@ -229,16 +229,16 @@ class ApiServiceSpec extends Specification implements ServiceUnitTest<ApiService
         result == expected
         where:
         duration | max | expected
-        123      | 200 | [date: new Date(124000), max: false]
-        123      | 100 | [date: new Date(101000), max: true]
-        0        | 100 | [date: new Date(101000), max: false]
-        200      | 0   | [date: new Date(201000), max: false]
-        0        | 0   | [date: null, max: false]
+        123      | 200 | [date: new Date(124000), max: false, error: null]
+        123      | 100 | [date: new Date(101000), max: true, error: null]
+        0        | 100 | [date: new Date(101000), max: false, error: null]
+        200      | 0   | [date: new Date(201000), max: false, error: null]
+        0        | 0   | [date: null, max: false, error: null]
 
     }
 
     @Unroll
-    def "generateTokenExpirationDate rejects non-positive duration #duration"() {
+    def "generateTokenExpirationDate rejects negative duration #duration"() {
         given:
         service.systemClock = Clock.fixed(Instant.ofEpochMilli(1000), ZoneId.of("Z"))
 

--- a/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/ApiServiceSpec.groovy
@@ -237,6 +237,34 @@ class ApiServiceSpec extends Specification implements ServiceUnitTest<ApiService
 
     }
 
+    @Unroll
+    def "generateTokenExpirationDate rejects non-positive duration #duration"() {
+        given:
+        service.systemClock = Clock.fixed(Instant.ofEpochMilli(1000), ZoneId.of("Z"))
+
+        when:
+        def result = service.generateTokenExpirationDate(duration, 2592000L)
+
+        then:
+        result.error != null
+        result.date == null
+
+        where:
+        duration << [-1668537728L, -1L, Long.MIN_VALUE]
+    }
+
+    def "generateTokenExpirationDate handles large duration exceeding max"() {
+        given:
+        service.systemClock = Clock.fixed(Instant.ofEpochMilli(1000), ZoneId.of("Z"))
+        long hugeDuration = 86_399_999_999_222_400L
+
+        when:
+        def result = service.generateTokenExpirationDate(hugeDuration, 2592000L)
+
+        then:
+        result.max == true
+    }
+
     def "generate user token unauthorized"() {
         given:
         def auth = Mock(UserAndRolesAuthContext) {

--- a/rundeckapp/src/test/groovy/rundeck/services/WebhookServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/WebhookServiceSpec.groovy
@@ -944,7 +944,7 @@ class WebhookServiceSpec extends Specification implements ServiceUnitTest<Webhoo
     }
 
     interface MockApiService {
-        Map generateUserToken(UserAndRolesAuthContext ctx, Integer expiration, String user, Set<String> roles, boolean forceExpiration, AuthTokenType tokenType) throws Exception
+        Map generateUserToken(UserAndRolesAuthContext ctx, long expiration, String user, Set<String> roles, boolean forceExpiration, AuthTokenType tokenType) throws Exception
     }
 
     interface MockStorageService {


### PR DESCRIPTION
## Release Notes

Fixed a security issue in API token creation where certain invalid expiration durations could bypass maximum duration limits and result in tokens that never expire. Token expiration is now validated correctly when creating tokens through the API and user profile.

## PR Details

## Jira Ticket
[RUN-4583](https://pagerduty.atlassian.net/browse/RUN-4583)

## Summary
- Fix integer overflow vulnerability in API token duration parsing that allows creation of never-expiring tokens when huge duration values (e.g., `999999999991d`) overflow from `long` to `int`
- Widen types from `Integer`/`int` to `long` throughout the token duration pipeline
- Add overflow detection in `Sizes.parseTimeDuration()` using `Math.multiplyExact`/`Math.addExact`
- Add bounds validation in `generateTokenExpirationDate()` to reject negative durations

## Root Cause
`Sizes.parseTimeDuration()` returns `long`, but three call sites downcast to `Integer`/`int`:
- `ApiController.groovy:833`
- `UserController.groovy:877`
- `ApiService.maxTokenDurationConfig():354`

When a huge value like `999999999991d` is parsed, `86,399,999,999,222,400` seconds wraps to `-1,668,537,728` as an `int`. This negative value bypasses the max-duration check and produces `newDate = null` — a never-expiring token.

## Changes
| File | Change |
|------|--------|
| `Sizes.groovy` | Use `Math.multiplyExact`/`Math.addExact` for overflow detection; throw `ArithmeticException` on `NumberFormatException` |
| `ApiService.groovy` | Widen `Integer`/`int` → `long` in `generateTokenExpirationDate`, `generateUserToken`, `createUserToken`, `maxTokenDurationConfig`; reject negative durations |
| `ApiController.groovy` | Use `long` for `tokenDurationSeconds`; catch `ArithmeticException` |
| `UserController.groovy` | Use `long` for `tokenDurationSeconds`; catch `ArithmeticException` |
| `SizesTest.groovy` | Tests for large values within `long` range and overflow beyond `long` range |
| `ApiServiceSpec.groovy` | Tests for negative duration rejection and huge duration exceeding max |
| `ApiControllerSpec.groovy` | Update mock expectations from `null` to `0L` for `tokenTimeSeconds` |

## Test plan
- [x] SizesTest — all existing tests pass + new overflow tests
- [x] ApiServiceSpec — all existing tests pass + new negative/huge duration tests
- [x] ApiControllerSpec — all existing tests pass with updated mocks

Made with [Cursor](https://cursor.com)

[RUN-4583]: https://pagerduty.atlassian.net/browse/RUN-4583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
