### PR TITLE
[RUN-4565] Fix ${DATE:FORMAT} colon parsing and add per-token timezone support

### DIFF
--- a/grails-rundeck-data-shared/src/main/groovy/rundeck/data/validation/validators/jobargs/JobArgStringValidator.groovy
+++ b/grails-rundeck-data-shared/src/main/groovy/rundeck/data/validation/validators/jobargs/JobArgStringValidator.groovy
@@ -5,6 +5,8 @@ import org.springframework.validation.Errors
 import org.springframework.validation.Validator
 
 import java.text.SimpleDateFormat
+import java.time.DateTimeException
+import java.time.ZoneId
 
 class JobArgStringValidator implements Validator {
     @Override
@@ -20,7 +22,18 @@ class JobArgStringValidator implements Validator {
                 jobData.argString.replaceAll(
                         /\$\{DATE:(.*)\}/,
                         { all, String tstamp ->
-                            new SimpleDateFormat(tstamp).format(new Date())
+                            // Extract optional timezone from last colon-segment
+                            String fdate = tstamp
+                            final lastColon = tstamp.lastIndexOf(":")
+                            if (lastColon >= 0) {
+                                try {
+                                    ZoneId.of(tstamp.substring(lastColon + 1))
+                                    fdate = tstamp.substring(0, lastColon)
+                                } catch (DateTimeException ignored) {
+                                    // last segment is not a valid ZoneId; treat whole tstamp as FORMAT
+                                }
+                            }
+                            new SimpleDateFormat(fdate).format(new Date())
                         }
                 )
             } catch (IllegalArgumentException e) {

--- a/grails-rundeck-data-shared/src/test/groovy/rundeck/data/validation/validators/jobargs/JobArgStringValidatorSpec.groovy
+++ b/grails-rundeck-data-shared/src/test/groovy/rundeck/data/validation/validators/jobargs/JobArgStringValidatorSpec.groovy
@@ -16,4 +16,36 @@ class JobArgStringValidatorSpec extends Specification {
         fieldError.field == "argString"
         fieldError.code == "scheduledExecution.argString.datestamp.invalid"
     }
+
+    def "Validate accepts format with colons"() {
+        when:
+        def validator = new JobArgStringValidator()
+        def rdJob = new RdJob(argString: '${DATE:HH:mm:ss}')
+        validator.validate(rdJob, rdJob.errors)
+
+        then:
+        rdJob.errors.fieldErrors.isEmpty()
+    }
+
+    def "Validate accepts format with valid timezone"() {
+        when:
+        def validator = new JobArgStringValidator()
+        def rdJob = new RdJob(argString: '${DATE:HH:mm:ss:Asia/Tokyo}')
+        validator.validate(rdJob, rdJob.errors)
+
+        then:
+        rdJob.errors.fieldErrors.isEmpty()
+    }
+
+    def "Validate rejects format with invalid timezone"() {
+        when:
+        def validator = new JobArgStringValidator()
+        def rdJob = new RdJob(argString: '${DATE:HH:mm:ss:NotAZone}')
+        validator.validate(rdJob, rdJob.errors)
+        def fieldError = rdJob.errors.fieldErrors[0]
+
+        then:
+        fieldError.field == "argString"
+        fieldError.code == "scheduledExecution.argString.datestamp.invalid"
+    }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2408,11 +2408,11 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 }
 
             } catch (IllegalArgumentException e) {
-                log.warn(e.getMessage())
+                log.warn("expandDateStrings: ${e.getMessage()}", e)
             } catch (NumberFormatException e) {
-                log.warn(e.getMessage())
+                log.warn("expandDateStrings: ${e.getMessage()}", e)
             } catch (DateTimeException e) {
-                log.warn(e.getMessage())
+                log.warn("expandDateStrings: ${e.getMessage()}", e)
             }
 
 

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -142,6 +142,8 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 import java.util.regex.Pattern
+import java.time.DateTimeException
+import java.time.ZoneId
 import java.util.stream.Collectors
 
 /**
@@ -2372,12 +2374,30 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
 
             try {
                 newstr = input.replaceAll(/\$\{DATE((?:[-+]\d+)?:.*?)\}/) { all, tstamp ->
-                    if (tstamp.lastIndexOf(":") == -1) {
+                    final firstColon = tstamp.indexOf(":")
+                    if (firstColon == -1) {
                         return all
                     }
-                    final operator = tstamp.substring(0, tstamp.lastIndexOf(":"))
-                    final fdate = tstamp.substring(tstamp.lastIndexOf(":") + 1)
+                    final operator = tstamp.substring(0, firstColon)
+                    final rest = tstamp.substring(firstColon + 1)
+
+                    // Try to extract optional TIMEZONE from the last colon-segment
+                    String fdate = rest
+                    TimeZone tz = null
+                    final lastColon = rest.lastIndexOf(":")
+                    if (lastColon >= 0) {
+                        try {
+                            tz = TimeZone.getTimeZone(ZoneId.of(rest.substring(lastColon + 1)))
+                            fdate = rest.substring(0, lastColon)
+                        } catch (DateTimeException ignored) {
+                            // last segment is part of FORMAT, not a timezone — use whole rest
+                        }
+                    }
+
                     def formatter = new SimpleDateFormat(fdate)
+                    if (tz != null) {
+                        formatter.setTimeZone(tz)
+                    }
                     if (operator == '') {
                         formatter.format(dateStarted)
                     } else {
@@ -2388,9 +2408,11 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
                 }
 
             } catch (IllegalArgumentException e) {
-                log.warn(e)
+                log.warn(e.getMessage())
             } catch (NumberFormatException e) {
-                log.warn(e)
+                log.warn(e.getMessage())
+            } catch (DateTimeException e) {
+                log.warn(e.getMessage())
             }
 
 

--- a/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ScheduledExecutionService.groovy
@@ -151,7 +151,9 @@ import java.sql.ResultSet
 import java.sql.SQLException
 import java.text.MessageFormat
 import java.text.SimpleDateFormat
+import java.time.DateTimeException
 import java.time.Duration
+import java.time.ZoneId
 import com.google.common.collect.Lists
 import java.util.concurrent.TimeUnit
 import java.util.function.Supplier
@@ -3410,7 +3412,18 @@ class ScheduledExecutionService implements ApplicationContextAware, Initializing
                 scheduledExecution.argString.replaceAll(
                         /\$\{DATE:(.*)\}/,
                         { all, String tstamp ->
-                            new SimpleDateFormat(tstamp).format(new Date())
+                            // Extract optional timezone from last colon-segment
+                            String fdate = tstamp
+                            final lastColon = tstamp.lastIndexOf(":")
+                            if (lastColon >= 0) {
+                                try {
+                                    ZoneId.of(tstamp.substring(lastColon + 1))
+                                    fdate = tstamp.substring(0, lastColon)
+                                } catch (DateTimeException ignored) {
+                                    // last segment is not a valid ZoneId; treat whole tstamp as FORMAT
+                                }
+                            }
+                            new SimpleDateFormat(fdate).format(new Date())
                         }
                 )
             } catch (IllegalArgumentException e) {

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -186,7 +186,7 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         '${DATE:HH:mm:ss:Asia/Tokyo}'                  | '17:20:30'
         // 1970-01-15 08:20:30 UTC = 1970-01-15 03:20:30 EST (UTC-5 in January)
         '${DATE+1:HH:mm:ss:America/New_York}'          | '03:20:30'
-        // Unknown TZ segment — silently falls back, IllegalArgumentException caught, token returned unexpanded
+        // Unknown TZ segment — falls back to treating full string as FORMAT; SimpleDateFormat rejects it, token left unexpanded
         '${DATE:HH:mm:ss:NotAZone}'                    | '${DATE:HH:mm:ss:NotAZone}'
     }
     void "retry execution otherwise running"() {

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -156,6 +156,9 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
     @Unroll
     def "expand date strings"() {
         given:
+        // Fix JVM timezone to UTC so expected values are portable across test environments
+        def originalTz = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
         def cal = new GregorianCalendar(1970, 0, 14, 8, 20, 30)
         Date thedate = cal.time
 
@@ -164,6 +167,10 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
 
         then:
         result == expected
+
+        cleanup:
+        TimeZone.setDefault(originalTz)
+
         where:
         input                                          | expected
         ''                                             | ''
@@ -173,6 +180,14 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         '${DATE:yyyy-MM-dd} blah ${DATE+3:yyyy-MM-dd}' | '1970-01-14 blah 1970-01-17'
         '${DATE-7:yyyy-MM-dd}'                         | '1970-01-07'
         'invalid ${DATE-asdf7:yyyy-MM-dd}'             | 'invalid ${DATE-asdf7:yyyy-MM-dd}'
+        '${DATE:HH:mm:ss}'                             | '08:20:30'
+        '${DATE:yyyy-MM-dd HH:mm:ss}'                  | '1970-01-14 08:20:30'
+        // TZ-aware: Asia/Tokyo is UTC+9, so 08:20:30 UTC = 17:20:30 JST
+        '${DATE:HH:mm:ss:Asia/Tokyo}'                  | '17:20:30'
+        // 1970-01-15 08:20:30 UTC = 1970-01-15 03:20:30 EST (UTC-5 in January)
+        '${DATE+1:HH:mm:ss:America/New_York}'          | '03:20:30'
+        // Unknown TZ segment — silently falls back, IllegalArgumentException caught, token returned unexpanded
+        '${DATE:HH:mm:ss:NotAZone}'                    | '${DATE:HH:mm:ss:NotAZone}'
     }
     void "retry execution otherwise running"() {
 


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix for `${DATE:FORMAT}` tokens in job arg strings. When FORMAT contains colons (e.g. `HH:mm:ss`), `expandDateStrings()` used `lastIndexOf(":")` to split the operator from the format, which landed on a colon inside the format string itself. This corrupted the parse, causing a `NumberFormatException` that was silently swallowed and left the token unexpanded. Fixes RUN-4565.

**Describe the solution you've implemented**

- Replaced `lastIndexOf(":")` with `indexOf(":")` (first colon) to correctly extract the operator, which is always colon-free by definition.
- Added optional per-token timezone support via `${DATE:FORMAT:TIMEZONE}` syntax. After extracting the operator, a `ZoneId.of()` trial is applied to the last colon-segment of the remainder — if it resolves to a valid zone ID, that segment is used as the timezone; otherwise the whole remainder is treated as FORMAT (backward-compatible fallback).
- Updated `JobArgStringValidator` and `ScheduledExecutionService.validateDefinitionArgStringDatestamp()` to apply the same TZ disambiguation when validating job-save time arg strings.

**Describe alternatives you've considered**

A named-group regex approach was considered but rejected — the regex alone cannot distinguish FORMAT colons from the TZ delimiter, so it would still require the same `ZoneId.of()` trial, adding complexity without benefit.

**Additional context**

Fixed-offset zone strings like `+09:00` (which contain colons) are intentionally out of scope for this syntax — they would be ambiguous with FORMAT colons.

## Release Notes

Fixed a bug where `${DATE:HH:mm:ss}` and other time-of-day format patterns in job argument strings were silently left unexpanded at runtime. Added support for an optional per-token timezone: `${DATE:HH:mm:ss:Asia/Tokyo}`.