### PR TITLE
[RUN-4604] Fix CVE-2026-54399 in httpcore5-h2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,6 +157,7 @@ allprojects {
     // Override Spring Boot BOM-managed versions (eachDependency/force can't move Boot-managed deps).
     ext["micrometer.version"] = micrometerVersion          // CVE-2026-40983, CVE-2026-40984
     ext["spring-retry.version"] = springRetryVersion       // CVE-2026-41710
+    ext["httpcore5.version"] = httpCore5Version             // CVE-2026-54399 (httpcore5-h2 HTTP/2 DoS)
     // CVE-2026-54512, CVE-2026-54513 (jackson-databind PolymorphicTypeValidator bypass). Grails/Spring
     // Boot dependency management pins jackson to 2.21.2 and downgrades transitive 2.21.4; a plain
     // platform import or resolutionStrategy.force does NOT override it. Overriding the Boot BOM property
@@ -238,6 +239,15 @@ allprojects {
                 if (details.requested.group == 'org.springframework.retry' && details.requested.name == 'spring-retry') {
                     details.useVersion springRetryVersion
                     details.because 'spring-retry 2.0.13 fixes CVE-2026-41710'
+                }
+                // CVE-2026-54399: httpcore5-h2 HTTP/2 DoS, fixed in 5.4.2. Pulled transitively via
+                // grails-data-hibernate5-dbmigration -> grails-shell-cli -> spring-boot-cli -> httpclient5.
+                // The Spring Boot BOM manages httpcore5.version and overrides resolutionStrategy.force,
+                // so use a useVersion rule (like spring/micrometer above). Covers httpcore5 and httpcore5-h2
+                // (released together) so the core5 family stays aligned.
+                if (details.requested.group == 'org.apache.httpcomponents.core5') {
+                    details.useVersion httpCore5Version
+                    details.because 'httpcore5 5.4.2 fixes CVE-2026-54399 (httpcore5-h2 HTTP/2 DoS)'
                 }
             }
             

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,6 +42,10 @@ snakeyamlVersion=2.6
 gsonVersion=2.14.0
 httpCoreVersion=4.4.16
 httpClientVersion=4.5.14
+# CVE-2026-54399 (SNYK-JAVA-ORGAPACHEHTTPCOMPONENTSCORE5-17817218): httpcore5-h2 HTTP/2 DoS,
+# fixed in 5.4.2. Pulled transitively via grails-data-hibernate5-dbmigration -> grails-shell-cli
+# -> spring-boot-cli -> httpclient5. Applies to both httpcore5 and httpcore5-h2 (released together).
+httpCore5Version=5.4.2
 bouncyCastleVersion=1.84
 grailsSpringSecurityVersion=7.0.0
 slf4jVersion=2.0.18


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Security bugfix. Resolves CVE-2026-54399 (SNYK-JAVA-ORGAPACHEHTTPCOMPONENTSCORE5-17817218), a high-severity (CVSS 7.1) HTTP/2 denial-of-service vulnerability in Apache HttpComponents Core `httpcore5-h2` 5.3.6.

**Describe the solution you've implemented**
Upgrade `httpcore5` and `httpcore5-h2` from 5.3.6 to the patched 5.4.2.

The vulnerable jar is pulled transitively:
`grails-data-hibernate5-dbmigration` -> `grails-shell-cli` -> `spring-boot-cli` -> `httpclient5:5.5.2` -> `httpcore5-h2:5.3.6`.

The Spring Boot 3.5.15 BOM manages `httpcore5.version` (governing `httpcore5`, `httpcore5-h2`, and `httpcore5-reactive` together) via the `io.spring.dependency-management` plugin, which overrides Gradle's `resolutionStrategy.force` and `eachDependency.useVersion`. The fix therefore:
- Adds `httpCore5Version=5.4.2` in `gradle.properties`.
- Overrides the Boot-managed `ext["httpcore5.version"]` in `allprojects` (the mechanism that actually moves the version), matching the existing micrometer/spring-retry/jackson pattern.
- Adds a defensive `eachDependency` `useVersion` rule for `org.apache.httpcomponents.core5` (covers configs where Spring dependency-management is not applied).

**Describe alternatives you've considered**
`resolutionStrategy.force` alone (matching the plexus-utils precedent) — verified it does NOT override the Spring Boot BOM-managed version. `httpcore5` and `httpcore5-h2` are released together, so both are aligned to 5.4.2 to avoid a split-version mismatch.

**Additional context**
- Fixed version confirmed on Maven Central (GA, backward-compatible within the 5.x line).
- Verified via `dependencyInsight` that `httpcore5`/`httpcore5-h2` now resolve `5.3.6 -> 5.4.2`.

## Release Notes

This release resolves a high-severity security vulnerability (CVE-2026-54399) by updating the bundled Apache HttpComponents Core HTTP/2 library to a patched version (5.4.2), protecting against a potential denial-of-service condition. No configuration changes or user action are required.