### PR TITLE
[RUN-4550] Add date formatter for api/** endpoints

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/RdExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/RdExecutionController.groovy
@@ -1,9 +1,12 @@
 package rundeck.controllers
 
+import com.dtolabs.rundeck.app.api.FormattedDate
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.rundeck.app.authorization.AppAuthContextProcessor
+
+import java.text.SimpleDateFormat
 import org.rundeck.core.auth.AuthConstants
 import org.rundeck.core.auth.access.UnauthorizedAccess
 import org.rundeck.core.auth.app.RundeckAccess
@@ -18,6 +21,11 @@ class RdExecutionController extends ControllerBase {
     static ObjectMapper mapper = new ObjectMapper()
     static {
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        // RUN-4550: serialize dates as second-precision W3C/ISO-8601 in UTC (e.g. 2026-03-25T21:16:50Z),
+        // matching the Grails API converters instead of Jackson's default epoch-millis timestamps.
+        SimpleDateFormat df = new SimpleDateFormat(FormattedDate.DEFAULT_DATE_FORMAT)
+        df.setTimeZone(TimeZone.getTimeZone("GMT"))
+        mapper.setDateFormat(df)
     }
 
     AppAuthContextProcessor rundeckAuthContextProcessor

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/RdExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/RdExecutionController.groovy
@@ -21,6 +21,7 @@ class RdExecutionController extends ControllerBase {
     static ObjectMapper mapper = new ObjectMapper()
     static {
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        mapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         // RUN-4550: serialize dates as second-precision W3C/ISO-8601 in UTC (e.g. 2026-03-25T21:16:50Z),
         // matching the Grails API converters instead of Jackson's default epoch-millis timestamps.
         SimpleDateFormat df = new SimpleDateFormat(FormattedDate.DEFAULT_DATE_FORMAT)

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiMarshallerRegistrar.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/api/ApiMarshallerRegistrar.groovy
@@ -21,6 +21,8 @@ import com.dtolabs.rundeck.app.api.marshall.CustomJsonMarshaller
 import com.dtolabs.rundeck.app.api.marshall.CustomXmlMarshaller
 import grails.converters.JSON
 import grails.converters.XML
+import org.apache.commons.lang3.time.FastDateFormat
+import org.grails.web.converters.marshaller.ClosureObjectMarshaller
 
 import jakarta.annotation.PostConstruct
 
@@ -28,6 +30,26 @@ import jakarta.annotation.PostConstruct
  * Created by greg on 10/28/15.
  */
 class ApiMarshallerRegistrar {
+
+    /**
+     * Second-precision W3C/ISO-8601 date format (UTC) used for every {@link Date} value serialized
+     * in API JSON/XML responses, e.g. {@code 2026-03-25T21:16:50Z}.
+     *
+     * Grails 7 / Spring Boot 3 delegate {@code Date} serialization to Jackson, whose default ISO-8601
+     * output includes milliseconds (e.g. {@code 2026-03-25T21:16:50.022Z}). That is an undocumented
+     * breaking change for API consumers (RUN-4550). Registering an explicit marshaller for {@code Date}
+     * on each versioned converter config restores the previous, backward-compatible format for all
+     * API endpoints and versions at once.
+     */
+    static final FastDateFormat API_DATE_FORMAT = FastDateFormat.getInstance(
+            FormattedDate.DEFAULT_DATE_FORMAT,
+            TimeZone.getTimeZone("GMT"),
+            Locale.US
+    )
+
+    static String formatApiDate(Date date) {
+        date != null ? API_DATE_FORMAT.format(date) : null
+    }
     @PostConstruct
     void registerMarshallers() {
         XML.registerObjectMarshaller(CDataString) { data,XML xml->
@@ -67,9 +89,11 @@ class ApiMarshallerRegistrar {
         (1..ApiVersions.API_CURRENT_VERSION).each { apivers ->
             XML.createNamedConfig("v${apivers}") { cfg ->
                 cfg.registerObjectMarshaller(new CustomXmlMarshaller(api, apivers))
+                cfg.registerObjectMarshaller(new ClosureObjectMarshaller<XML>(Date, { Date d -> formatApiDate(d) }))
             }
             JSON.createNamedConfig("v${apivers}") { cfg ->
                 cfg.registerObjectMarshaller(new CustomJsonMarshaller(api, apivers))
+                cfg.registerObjectMarshaller(new ClosureObjectMarshaller<JSON>(Date, { Date d -> formatApiDate(d) }))
             }
         }
 

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/api/ApiDateMarshallerSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/api/ApiDateMarshallerSpec.groovy
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 Rundeck, Inc. (http://rundeck.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtolabs.rundeck.app.api
+
+import com.dtolabs.rundeck.app.api.jobs.info.JobInfo
+import com.dtolabs.rundeck.app.api.jobs.upload.JobFileInfo
+import com.dtolabs.rundeck.app.api.scm.ScmCommit
+import com.dtolabs.rundeck.app.api.scm.ScmJobStatus
+import com.dtolabs.rundeck.app.api.tokens.Token
+import grails.converters.JSON
+import grails.converters.XML
+import grails.testing.web.GrailsWebUnitTest
+import org.rundeck.app.data.model.v1.authtoken.AuthenticationToken
+import org.rundeck.app.data.model.v1.authtoken.AuthTokenMode
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.Instant
+
+/**
+ * RUN-4550: every {@link Date} value exposed by the API (JSON and XML) must be serialized with
+ * second-precision W3C/ISO-8601 in UTC (e.g. {@code 2026-03-25T21:16:50Z}), NOT the millisecond
+ * precision that Grails 7 / Jackson emits by default (e.g. {@code 2026-03-25T21:16:50.022Z}).
+ *
+ * These tests cover the DTOs behind every affected endpoint: token list/get/create ({@link Token}),
+ * job file info ({@link JobFileInfo}), job scheduling info ({@link JobInfo}, including the
+ * {@code List<Date>} field), and SCM commit dates ({@link ScmCommit}, a plain POGO nested in the
+ * SCM status/diff responses).
+ */
+class ApiDateMarshallerSpec extends Specification implements GrailsWebUnitTest {
+
+    /** A Date that carries millisecond precision (…50.022Z) so we can prove the ms are dropped. */
+    @Shared
+    Date dateWithMillis = Date.from(Instant.parse('2026-03-25T21:16:50.022Z'))
+    static final String EXPECTED = '2026-03-25T21:16:50Z'
+    static final String UNEXPECTED_MS = '2026-03-25T21:16:50.022Z'
+
+    def setup() {
+        def registrar = new ApiMarshallerRegistrar()
+        registrar.registerMarshallers()
+        registrar.registerApiMarshallers()
+    }
+
+    /**
+     * Guardrail: the custom Date marshaller must be registered on EVERY versioned converter config,
+     * so no API version (present or future) can regress to millisecond precision. Uses a
+     * version-agnostic carrier ({@link JobFileInfo} has no {@code @ApiVersion} gating) so it is valid
+     * across the whole 1..CURRENT range.
+     */
+    @Unroll
+    def "Date is second-precision for every API version (v#version, #fmt)"() {
+        given:
+        def info = new JobFileInfo(id: 'f', dateCreated: dateWithMillis, expirationDate: dateWithMillis)
+
+        when:
+        def out = fmt == 'json' ? toJson(info, version) : toXml(info, version)
+
+        then:
+        out.contains(EXPECTED)
+        !out.contains(UNEXPECTED_MS)
+
+        where:
+        [version, fmt] << [(1..ApiVersions.API_CURRENT_VERSION).toList(), ['json', 'xml']].combinations()
+    }
+
+    private String toJson(Object obj, int version) {
+        JSON.use('v' + version)
+        (obj as JSON).toString()
+    }
+
+    private String toXml(Object obj, int version) {
+        XML.use('v' + version)
+        (obj as XML).toString()
+    }
+
+    private Token sampleToken() {
+        AuthenticationToken authToken = Stub(AuthenticationToken) {
+            getName() >> 'mytoken'
+            getUuid() >> '123uuid'
+            getToken() >> 'abc'
+            getClearToken() >> 'abc'
+            getTokenMode() >> AuthTokenMode.LEGACY
+            getCreator() >> 'elf'
+            getOwnerName() >> 'bob'
+            getAuthRolesSet() >> (['a', 'b'] as Set)
+            getExpiration() >> dateWithMillis
+        }
+        new Token(authToken, true, false)
+    }
+
+    @Unroll
+    def "Token.expiration is second-precision in #fmt"() {
+        given:
+        def token = sampleToken()
+
+        when:
+        def out = fmt == 'json' ? toJson(token, version) : toXml(token, version)
+
+        then:
+        out.contains(EXPECTED)
+        !out.contains(UNEXPECTED_MS)
+
+        where:
+        fmt    | version
+        'json' | ApiVersions.API_CURRENT_VERSION
+        'xml'  | ApiVersions.API_CURRENT_VERSION
+    }
+
+    @Unroll
+    def "JobFileInfo date fields are second-precision in #fmt"() {
+        given:
+        def info = new JobFileInfo(
+                id: 'file-id',
+                jobId: 'job-id',
+                execId: 1L,
+                fileName: 'f.txt',
+                dateCreated: dateWithMillis,
+                expirationDate: dateWithMillis,
+                user: 'bob',
+                fileState: 'ok'
+        )
+
+        when:
+        def out = fmt == 'json' ? toJson(info, version) : toXml(info, version)
+
+        then:
+        out.contains(EXPECTED)
+        !out.contains(UNEXPECTED_MS)
+
+        where:
+        fmt    | version
+        'json' | ApiVersions.API_CURRENT_VERSION
+        'xml'  | ApiVersions.API_CURRENT_VERSION
+    }
+
+    @Unroll
+    def "JobInfo nextScheduledExecution and futureScheduledExecutions are second-precision in #fmt"() {
+        given:
+        def info = new JobInfo(
+                id: 'job-id',
+                name: 'a job',
+                project: 'test',
+                nextScheduledExecution: dateWithMillis,
+                futureScheduledExecutions: [dateWithMillis, dateWithMillis]
+        )
+
+        when:
+        def out = fmt == 'json' ? toJson(info, version) : toXml(info, version)
+
+        then:
+        out.contains(EXPECTED)
+        !out.contains(UNEXPECTED_MS)
+
+        where:
+        fmt    | version
+        'json' | ApiVersions.API_CURRENT_VERSION
+        'xml'  | ApiVersions.API_CURRENT_VERSION
+    }
+
+    @Unroll
+    def "ScmCommit.date nested in ScmJobStatus is second-precision in #fmt"() {
+        given:
+        def status = new ScmJobStatus(
+                id: 'job-id',
+                project: 'test',
+                integration: 'import',
+                synchState: 'CLEAN',
+                commit: new ScmCommit(
+                        commitId: 'abc123',
+                        message: 'a commit',
+                        author: 'bob',
+                        date: dateWithMillis
+                )
+        )
+
+        when:
+        def out = fmt == 'json' ? toJson(status, version) : toXml(status, version)
+
+        then:
+        out.contains(EXPECTED)
+        !out.contains(UNEXPECTED_MS)
+
+        where:
+        fmt    | version
+        'json' | ApiVersions.API_CURRENT_VERSION
+        'xml'  | ApiVersions.API_CURRENT_VERSION
+    }
+}

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/api/ApiDateMarshallerSpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/api/ApiDateMarshallerSpec.groovy
@@ -50,7 +50,7 @@ class ApiDateMarshallerSpec extends Specification implements GrailsWebUnitTest {
     static final String EXPECTED = '2026-03-25T21:16:50Z'
     static final String UNEXPECTED_MS = '2026-03-25T21:16:50.022Z'
 
-    def setup() {
+    def setupSpec() {
         def registrar = new ApiMarshallerRegistrar()
         registrar.registerMarshallers()
         registrar.registerApiMarshallers()

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ApiControllerSpec.groovy
@@ -133,6 +133,81 @@ class ApiControllerSpec extends Specification implements ControllerUnitTest<ApiC
         response.json[1].id == "456uuid"
 
     }
+
+    def "api token list serializes expiration without milliseconds (RUN-4550)"() {
+        given:
+        User bob = new User(login: 'bob')
+        bob.save()
+        // Date carries millisecond precision (…50.022Z); API must expose second precision (…50Z)
+        Date expiration = Date.from(java.time.Instant.parse('2026-03-25T21:16:50.022Z'))
+        AuthToken createdToken = new AuthToken(
+                user: bob,
+                type: AuthTokenType.USER,
+                token: 'abc',
+                authRoles: 'a,b',
+                uuid: '123uuid',
+                creator: 'elf',
+                expiration: expiration
+        )
+        createdToken.save()
+
+        controller.apiService = Mock(ApiService) {
+            hasTokenAdminAuth(_) >> { true }
+            listTokens() >> { AuthToken.list() }
+        }
+        controller.frameworkService = Mock(FrameworkService)
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor)
+        request.api_version = 33
+        request.addHeader('accept', 'application/json')
+        JSON.use('v' + request.api_version)
+        when:
+        controller.apiTokenList()
+
+        then:
+        1 * controller.apiService.requireApi(_, _) >> true
+        1 * controller.apiService.requireVersion(_, _, _) >> true
+        response.json[0].expiration == '2026-03-25T21:16:50Z'
+    }
+
+    def "api token get serializes expiration without milliseconds (RUN-4550)"() {
+        given:
+        User bob = new User(login: 'bob')
+        bob.save()
+        Date expiration = Date.from(java.time.Instant.parse('2026-03-25T21:16:50.022Z'))
+        AuthToken createdToken = new AuthToken(
+                user: bob,
+                type: AuthTokenType.USER,
+                token: 'abc',
+                authRoles: 'a,b',
+                uuid: 'tok-uuid',
+                creator: 'elf',
+                expiration: expiration
+        )
+        createdToken.save(flush: true)
+
+        controller.apiService = Mock(ApiService) {
+            hasTokenAdminAuth(_) >> { true }
+            findTokenId('tok-uuid') >> createdToken
+            requireExistsFormat(_, _, _) >> true
+        }
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+            getAuthContextForSubject(_) >> Mock(UserAndRolesAuthContext) {
+                getUsername() >> 'bob'
+            }
+        }
+        request.api_version = 19
+        params.tokenid = 'tok-uuid'
+        request.addHeader('accept', 'application/json')
+        JSON.use('v' + request.api_version)
+        when:
+        controller.apiTokenGet('tok-uuid')
+
+        then:
+        1 * controller.apiService.requireApi(_, _) >> true
+        1 * controller.apiService.requireVersion(_, _, _) >> true
+        response.json.expiration == '2026-03-25T21:16:50Z'
+    }
+
     def "api token list unauthorized self param #inputUser"() {
         given:
         User bob = new User(login: 'bob')
@@ -358,8 +433,8 @@ class ApiControllerSpec extends Specification implements ControllerUnitTest<ApiC
                 creator   : 'elf',
                 expired   : true,
                 roles     : ['a', 'b'],
-                // Grails 7/Spring Boot 3: Jackson now includes milliseconds in ISO-8601 format
-                expiration: '1970-01-01T00:00:00.123Z',
+                // RUN-4550: Date values are serialized with second-precision W3C/ISO-8601 (no milliseconds)
+                expiration: '1970-01-01T00:00:00Z',
                 id        : '123uuid',
                 user      : 'bob',
                 token     : 'abc'
@@ -415,8 +490,8 @@ class ApiControllerSpec extends Specification implements ControllerUnitTest<ApiC
                 creator   : 'elf',
                 expired   : true,
                 roles     : ['a', 'b'],
-                // Grails 7/Spring Boot 3: Jackson now includes milliseconds in ISO-8601 format
-                expiration: '1970-01-01T00:00:00.123Z',
+                // RUN-4550: Date values are serialized with second-precision W3C/ISO-8601 (no milliseconds)
+                expiration: '1970-01-01T00:00:00Z',
                 id        : '123uuid',
                 user      : 'bob',
                 token     : 'abc'

--- a/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/MenuControllerSpec.groovy
@@ -16,7 +16,9 @@
 
 package rundeck.controllers
 
+import com.dtolabs.rundeck.app.api.ApiMarshallerRegistrar
 import com.dtolabs.rundeck.app.api.ApiVersions
+import grails.converters.JSON
 import com.dtolabs.rundeck.app.gui.GroupedJobListLinkHandler
 import com.dtolabs.rundeck.app.gui.JobListLinkHandlerRegistry
 import com.dtolabs.rundeck.app.internal.framework.RundeckFramework
@@ -2423,10 +2425,17 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
         controller.executionService = new ExecutionService()
         controller.executionService.jobStatsDataProvider = new GormJobStatsDataProvider()
 
+        // Register API marshallers and select the versioned converter config, as the
+        // ApiVersionInterceptor does for real /api requests (RUN-4550)
+        def registrar = new ApiMarshallerRegistrar()
+        registrar.registerMarshallers()
+        registrar.registerApiMarshallers()
+
         when:
         request.api_version = 48
         params.id=testUUID
         response.format='json'
+        JSON.use('v' + request.api_version)
         def result = controller.apiJobForecast()
 
         then:
@@ -2436,7 +2445,7 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
         1 * controller.apiService.requireExists(_, job1, _) >> true
         1 * controller.apiService.apiHrefForJob(job1) >> 'api/href'
         1 * controller.apiService.guiHrefForJob(job1) >> 'gui/href'
-        1 * controller.scheduledExecutionService.nextExecutions(_,_,false) >> [new Date()]
+        1 * controller.scheduledExecutionService.nextExecutions(_,_,false) >> [Date.from(java.time.Instant.parse('2026-03-25T21:16:50.022Z'))]
 
         response.json != null
         response.json.id  == testUUID
@@ -2448,6 +2457,8 @@ class MenuControllerSpec extends Specification implements ControllerUnitTest<Men
         response.json.averageDuration  == 2000
         response.json.futureScheduledExecutions != null
         response.json.futureScheduledExecutions.size() == 1
+        // RUN-4550: date serialized with second-precision W3C/ISO-8601 (no milliseconds)
+        response.json.futureScheduledExecutions[0] == '2026-03-25T21:16:50Z'
         response.json.projectDisableExecutions == false
         response.json.projectDisableSchedule == false
     }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/RdExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/RdExecutionControllerSpec.groovy
@@ -29,6 +29,22 @@ class RdExecutionControllerSpec extends Specification implements ControllerUnitT
         response.status == 200
     }
 
+    def "get serializes execution dates without milliseconds (RUN-4550)"() {
+        given:
+        // Date carries millisecond precision (…50.022Z); response must expose second precision (…50Z)
+        Date d = Date.from(java.time.Instant.parse('2026-03-25T21:16:50.022Z'))
+        params.id = 'abc'
+
+        when:
+        controller.get()
+
+        then:
+        1 * controller.rdExecutionService.getExecutionByUuid('abc') >> new RdExecution(dateStarted: d, dateCompleted: d)
+        response.status == 200
+        response.text.contains('2026-03-25T21:16:50Z')
+        !response.text.contains('2026-03-25T21:16:50.022Z')
+    }
+
     def "test delete method"() {
         given:
         def executionId = "123"


### PR DESCRIPTION
## Release Notes

Fixed a change in API date formatting introduced by the Grails 7 / Spring Boot 3 upgrade, where date/time fields in API responses began including milliseconds (e.g. `2026-03-25T21:16:50.123Z`). API date values are once again returned in second-precision UTC ISO-8601 format (e.g. `2026-03-25T21:16:50Z`) across both JSON and XML and for all API versions, restoring compatibility for existing API integrations.


## Ticket Details

Jira: [https://pagerduty.atlassian.net/browse/RUN-4550](url)

This pull request standardizes the serialization of all `Date` values in Rundeck API responses to use second-precision W3C/ISO-8601 format in UTC (e.g., `2026-03-25T21:16:50Z`), removing milliseconds. This change restores backward compatibility for API consumers after an upgrade to Grails 7 / Spring Boot 3, which began including milliseconds by default. The update is enforced for all API versions and is covered by comprehensive tests across affected endpoints.

**API Date Serialization Standardization:**

* Introduced a custom marshaller in `ApiMarshallerRegistrar` to serialize all `Date` values in API JSON and XML responses with second-precision W3C/ISO-8601 format (no milliseconds), and registered it for every API version. [[1]](diffhunk://#diff-6afb34835773788e379a495581b6dd0cb550244b8808fb69458313141c32ccaaR24-R52) [[2]](diffhunk://#diff-6afb34835773788e379a495581b6dd0cb550244b8808fb69458313141c32ccaaR92-R96)
* Updated `RdExecutionController` to configure Jackson's `ObjectMapper` to use the same date format for consistency in controller responses. [[1]](diffhunk://#diff-2b3ad1e0a2a304a03bfb4120c23f81bb53bba12166209a5629a2157ada3dadbbR3-R9) [[2]](diffhunk://#diff-2b3ad1e0a2a304a03bfb4120c23f81bb53bba12166209a5629a2157ada3dadbbR24-R28)

**Test Coverage and Verification:**

* Added `ApiDateMarshallerSpec` to verify that all relevant DTOs and endpoints serialize dates without milliseconds, for both JSON and XML, across all API versions.
* Updated and extended tests in `ApiControllerSpec`, `MenuControllerSpec`, and `RdExecutionControllerSpec` to assert that API responses do not include milliseconds in date fields. [[1]](diffhunk://#diff-62006b966c57c204ead5071093e47ac70df5e0ff3888cab22a7737666a1ccfd9R136-R210) [[2]](diffhunk://#diff-62006b966c57c204ead5071093e47ac70df5e0ff3888cab22a7737666a1ccfd9L361-R437) [[3]](diffhunk://#diff-62006b966c57c204ead5071093e47ac70df5e0ff3888cab22a7737666a1ccfd9L418-R494) [[4]](diffhunk://#diff-6e07be9b49269a1459df118da029d8635ccddda6dd5d6d8cb12c714ed0e5b9cdR19-R21) [[5]](diffhunk://#diff-6e07be9b49269a1459df118da029d8635ccddda6dd5d6d8cb12c714ed0e5b9cdR2428-R2438) [[6]](diffhunk://#diff-6e07be9b49269a1459df118da029d8635ccddda6dd5d6d8cb12c714ed0e5b9cdL2439-R2448) [[7]](diffhunk://#diff-6e07be9b49269a1459df118da029d8635ccddda6dd5d6d8cb12c714ed0e5b9cdR2460-R2461) [[8]](diffhunk://#diff-e5d266ba462bf481bc5e162a7a36e8da4b428538f671aed204a8d38c4d36a60aR32-R47)

This ensures consistent, backward-compatible date formatting for all API consumers, preventing regressions and aligning with previous API behavior.