### PR TITLE
[RUN-4536] Parse blankIfUnexpandable from script plugin YAML config

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPlugin.java
@@ -59,6 +59,7 @@ import java.util.*;
  *     config.X.default = default string of the property
  *     config.X.values = comma-separated values list for Select or FreeSelect properties
  *     config.X.scope = scope of the property, from {@link PropertyScope}
+ *     config.X.blankIfUnexpandable = true/false, if unresolvable ${...} references should be blanked (default: true)
  * </pre>
  *
  * @author Greg Schueler <a href="mailto:greg@dtosolutions.com">greg@dtosolutions.com</a>
@@ -80,6 +81,7 @@ public abstract class AbstractDescribableScriptPlugin implements Describable {
     public static final String SETTING_MERGE_ENVIRONMENT = "mergeEnvironment";
 
     public static final String CONFIG_BLANK_IF_UNEXPANDED = "blankIfUnexpanded";
+    public static final String CONFIG_BLANK_IF_UNEXPANDABLE = "blankIfUnexpandable";
 
     private final ScriptPluginProvider provider;
     private final Framework framework;
@@ -223,7 +225,7 @@ public abstract class AbstractDescribableScriptPlugin implements Describable {
 
                         dbuilder.frameworkMapping(propName, frameworkPropertyPrefix + propName);
                     }
-                    final Object blankIfUnexpandableValue = itemmeta.get("blankIfUnexpandable");
+                    final Object blankIfUnexpandableValue = itemmeta.get(CONFIG_BLANK_IF_UNEXPANDABLE);
                     if (blankIfUnexpandableValue instanceof Boolean) {
                         pbuild.blankIfUnexpandable((Boolean) blankIfUnexpandableValue);
                     } else if (blankIfUnexpandableValue instanceof String) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPlugin.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPlugin.java
@@ -223,6 +223,13 @@ public abstract class AbstractDescribableScriptPlugin implements Describable {
 
                         dbuilder.frameworkMapping(propName, frameworkPropertyPrefix + propName);
                     }
+                    final Object blankIfUnexpandableValue = itemmeta.get("blankIfUnexpandable");
+                    if (blankIfUnexpandableValue instanceof Boolean) {
+                        pbuild.blankIfUnexpandable((Boolean) blankIfUnexpandableValue);
+                    } else if (blankIfUnexpandableValue instanceof String) {
+                        pbuild.blankIfUnexpandable(Boolean.parseBoolean((String) blankIfUnexpandableValue));
+                    }
+
                     //rendering options
                     final Object renderingOpts = itemmeta.get(CONFIG_RENDERING_OPTIONS);
                     if(null != renderingOpts && renderingOpts instanceof Map){

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPluginSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/plugins/AbstractDescribableScriptPluginSpec.groovy
@@ -217,4 +217,118 @@ class AbstractDescribableScriptPluginSpec extends Specification{
         result.properties.get(0).hasProperty("blankIfUnexpandable")
 
     }
+
+    def "blankIfUnexpandable parsed as false from plugin metadata"() {
+        given:
+        File basedir = File.createTempFile("test", "dir")
+        basedir.deleteOnExit()
+
+        def metaWithBlankIfUnexpandable = [
+                config: [
+                        [
+                                type               : 'String',
+                                name               : 'script',
+                                title              : 'Script',
+                                required           : true,
+                                blankIfUnexpandable: false,
+                                scope              : PropertyScope.Instance
+                        ],
+                        [
+                                type               : 'String',
+                                name               : 'arguments',
+                                title              : 'Arguments',
+                                required           : false,
+                                scope              : PropertyScope.Instance
+                        ]
+                ]
+        ]
+
+        def pluginMeta = Mock(PluginMeta) {
+            getRundeckPluginVersion() >> "1.2"
+        }
+        ScriptPluginProvider provider = Mock(ScriptPluginProvider) {
+            getName() >> 'testBlankIfUnexpandable'
+            getMetadata() >> metaWithBlankIfUnexpandable
+            getPluginMeta() >> pluginMeta
+            getContentsBasedir() >> basedir
+            getService() >> ServiceNameConstants.WorkflowNodeStep
+        }
+
+        when:
+        TestScriptPlugin plugin = new TestScriptPlugin(provider, framework)
+        def description = plugin.getPluginProperties(null, [:], [:], ServiceNameConstants.WorkflowNodeStep)
+
+        then:
+        description != null
+        description.properties.size() == 2
+        description.properties[0].name == 'script'
+        description.properties[0].isBlankIfUnexpandable() == false
+        description.properties[1].name == 'arguments'
+        description.properties[1].isBlankIfUnexpandable() == true
+    }
+
+    def "blankIfUnexpandable parsed as string false from plugin metadata"() {
+        given:
+        File basedir = File.createTempFile("test", "dir")
+        basedir.deleteOnExit()
+
+        def metaWithBlankIfUnexpandable = [
+                config: [
+                        [
+                                type               : 'String',
+                                name               : 'script',
+                                title              : 'Script',
+                                required           : true,
+                                blankIfUnexpandable: 'false',
+                                scope              : PropertyScope.Instance
+                        ]
+                ]
+        ]
+
+        def pluginMeta = Mock(PluginMeta) {
+            getRundeckPluginVersion() >> "1.2"
+        }
+        ScriptPluginProvider provider = Mock(ScriptPluginProvider) {
+            getName() >> 'testBlankIfUnexpandableString'
+            getMetadata() >> metaWithBlankIfUnexpandable
+            getPluginMeta() >> pluginMeta
+            getContentsBasedir() >> basedir
+            getService() >> ServiceNameConstants.WorkflowNodeStep
+        }
+
+        when:
+        TestScriptPlugin plugin = new TestScriptPlugin(provider, framework)
+        def description = plugin.getPluginProperties(null, [:], [:], ServiceNameConstants.WorkflowNodeStep)
+
+        then:
+        description != null
+        description.properties.size() == 1
+        description.properties[0].name == 'script'
+        description.properties[0].isBlankIfUnexpandable() == false
+    }
+
+    def "blankIfUnexpandable defaults to true when not specified"() {
+        given:
+        File basedir = File.createTempFile("test", "dir")
+        basedir.deleteOnExit()
+
+        def pluginMeta = Mock(PluginMeta) {
+            getRundeckPluginVersion() >> "1.2"
+        }
+        ScriptPluginProvider provider = Mock(ScriptPluginProvider) {
+            getName() >> 'testBlankIfUnexpandableDefault'
+            getMetadata() >> pluginMetaData
+            getPluginMeta() >> pluginMeta
+            getContentsBasedir() >> basedir
+            getService() >> ServiceNameConstants.WorkflowNodeStep
+        }
+
+        when:
+        TestScriptPlugin plugin = new TestScriptPlugin(provider, framework)
+        def description = plugin.getPluginProperties(null, [:], [:], ServiceNameConstants.WorkflowNodeStep)
+
+        then:
+        description != null
+        description.properties.every { it.isBlankIfUnexpandable() == true }
+    }
 }


### PR DESCRIPTION
## Release Notes

Fixed an issue where shell variable references such as `${VAR}` and `${VAR:-default}` in scripts run by script-based step plugins could be stripped out before the shell had a chance to evaluate them, causing those variables to resolve to empty values. Script plugins can now preserve these expressions so they expand correctly at runtime.

## Summary

- Fixes the script plugin property loader to parse `blankIfUnexpandable` from `plugin.yaml` config sections.
- Without this fix, script plugins could not opt out of having unresolved `${...}` patterns blanked during data-context expansion, breaking shell variable references like `${VAR}` and `${VAR:-default}`.

## Problem

`AbstractDescribableScriptPlugin.createDescription()` reads property attributes from plugin.yaml (`type`, `name`, `title`, `description`, `required`, `default`, `values`, `labels`, `scope`, `renderingOptions`) but never read `blankIfUnexpandable`. The `PropertyBuilder` defaults this to `true`, so **all** script plugin string properties had unresolvable `${...}` patterns replaced with empty string.

This caused the [nixy-step-plugins issue #20](https://github.com/rundeck-plugins/nixy-step-plugins/issues/20) where `${VAR}` and `${VAR:-default}` in user scripts were blanked before bash could expand them.

## Fix

Added parsing of `blankIfUnexpandable` (both Boolean and String forms) from the plugin.yaml config map, calling `pbuild.blankIfUnexpandable(value)` before building the property. This allows script plugins to declare:

```yaml
config:
  - type: String
    name: script
    blankIfUnexpandable: false
```

## Test plan

- [x] Verified locally: rebuilt Rundeck core + nixy plugin with `blankIfUnexpandable: false` → `${VAR}` and `${VAR:-default}` now expand correctly in the *nixy / local-script step
- [x] Unit test for `AbstractDescribableScriptPlugin` parsing `blankIfUnexpandable`

## Related

- Plugin fix: https://github.com/rundeck-plugins/nixy-step-plugins/pull/37
- Upstream issue: https://github.com/rundeck-plugins/nixy-step-plugins/issues/20
- Jira: https://pagerduty.atlassian.net/browse/RUN-4536


Made with [Cursor](https://cursor.com)