### PR TITLE
chore: remove unused gson dependency from rundeckapp

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,6 @@ jacksonDatabindVersion=2.22.0
 jacksonDataformatCBORVersion=2.22.0
 jacksonAnnotationsVersion=2.22
 snakeyamlVersion=2.6
-gsonVersion=2.14.0
 httpCoreVersion=4.4.16
 httpClientVersion=4.5.14
 bouncyCastleVersion=1.84

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -306,7 +306,6 @@ dependencies {
     implementation "org.apache.grails:grails-codecs"
     implementation "org.apache.grails:grails-cache"
     compileOnly "io.micronaut:micronaut-inject-groovy:${micronautVersion}"
-    implementation "com.google.code.gson:gson:${gsonVersion}"
     // Jackson versions managed by Spring Boot BOM
     implementation "com.fasterxml.jackson.core:jackson-databind"
     implementation "com.fasterxml.jackson.core:jackson-core"


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Neither — this is a dependency cleanup (removal of an unused runtime dependency).

**Describe the solution you've implemented**

`gson` was added in 2018 to parse LDAP role strings as JSON (`ScheduledExecution.groovy`), but that implementation was replaced by Jackson in 2021 (`d2da3c46db`). Since then `gson` has had no import or usage anywhere in `rundeckapp`.

Verified via `dependencyInsight` in a CI-matching container (`cimg/openjdk:17.0.19`) that `gson` has no transitive requesters: only `rundeckapp`'s own `implementation` declaration and a Spring Boot BOM version constraint (no library actually pulling it in). Removing the declaration makes `gson` disappear entirely from `:rundeckapp:runtimeClasspath` (confirmed with a temporary revert-and-rerun test), and `:rundeckapp:compileGroovy` / `:compileJava` still build successfully.

Also removes the now-unused `gsonVersion` property from `gradle.properties`.

**Describe alternatives you've considered**

- Leaving the declaration in place "just in case" — rejected, since the dependency graph confirms nothing (rundeckapp code, bundled plugins, or transitive libraries) requires it.
- Downgrading to a `compileOnly`/`testImplementation` scope instead of full removal — unnecessary, since there is zero usage.

**Additional context**

Found while auditing JVM dependencies across the Gradle multi-module build for unused/leftover declarations.

## Release Notes

N/A — internal dependency cleanup, no user-facing change.
