### PR TITLE
[RUN-4604] Apache HttpComponents httpcore5 library to version 5.4.3 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ httpClientVersion=4.5.14
 # CVE-2026-54399 (SNYK-JAVA-ORGAPACHEHTTPCOMPONENTSCORE5-17817218): httpcore5-h2 HTTP/2 DoS,
 # fixed in 5.4.2. Pulled transitively via grails-data-hibernate5-dbmigration -> grails-shell-cli
 # -> spring-boot-cli -> httpclient5. Applies to both httpcore5 and httpcore5-h2 (released together).
-httpCore5Version=5.4.2
+httpCore5Version=5.4.3
 bouncyCastleVersion=1.84
 grailsSpringSecurityVersion=7.0.0
 slf4jVersion=2.0.18


### PR DESCRIPTION
Release Notes
Updated the bundled Apache HttpComponents httpcore5 library to version 5.4.3 to remediate https://github.com/advisories/GHSA-hf6x-8p5f-cgmf, a denial-of-service vulnerability in HTTP/2 handling. The library is included transitively, and no configuration changes are required.

Summary
Bumps the bundled httpcore5 / httpcore5-h2 dependency from 5.4.2 to 5.4.3 to remediate https://github.com/advisories/GHSA-hf6x-8p5f-cgmf (SNYK-JAVA-ORGAPACHEHTTPCOMPONENTSCORE5-17817218), an HTTP/2 denial-of-service vulnerability.