### PR TITLE
[RUN-4626] Declare nextUiMode feature flag in RundeckConfigBase feature config

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/config/RundeckConfigBase.java
@@ -476,6 +476,7 @@ public class RundeckConfigBase {
         Enabled defaultExecutionCleanup = new Enabled();
         Enabled earlyAccessJobConditional = new Enabled();
         Enabled activityDefaultTimeFilter = new Enabled();
+        Enabled nextUiMode = new Enabled();
         Enabled vueKeyStorage = new Enabled(true);
         Enabled pluginGroups = new Enabled(true);
         int guiAceEditorMinLines = 12;


### PR DESCRIPTION
## Is this a bugfix, or an enhancement? Please describe.

Bugfix (one line).

The `nextUiMode` feature introduced in #9981 is gated via `featurePresent('nextUiMode')`, but the feature was never declared as a field in `RundeckConfigBase.RundeckFeatureConfig` — unlike every other feature flag.

## Describe the solution you've implemented

Declare the missing field with the standard disabled default:

```java
Enabled nextUiMode = new Enabled();
```

## Why this matters

- `GET /api/{v}/feature` (`featureQueryAll`) iterates the declared feature config map, so `nextUiMode` is currently omitted from the feature listing entirely, even when `rundeck.feature.nextUiMode.enabled=true` is set.
- Any consumer that binds the `rundeck` config subtree into the typed `RundeckConfigBase` class (Spring `@ConfigurationProperties`-style binding) silently drops `rundeck.feature.nextUiMode.*` values because undeclared keys don't survive typed binding. In such contexts the flag cannot be enabled by any configuration mechanism (properties file, system property, or environment), leaving `NextUiInterceptor` to fall back to per-user cookie opt-in only.
- Every other feature flag (37 of them) is declared here; this brings `nextUiMode` in line with the existing pattern.

Default behavior is unchanged: the feature remains disabled unless explicitly enabled.

## Verification

- `./gradlew :core:compileJava` passes.
- With the field declared, `rundeck.feature.nextUiMode.enabled=true` resolves through typed config binding and the feature appears in the `/api/{v}/feature` listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)