### PR TITLE
[RUN-4628] Remove stray zero-width spaces from Dutch i18n strings

### DIFF
--- a/rundeckapp/grails-app/i18n/messages_nl.properties
+++ b/rundeckapp/grails-app/i18n/messages_nl.properties
@@ -693,7 +693,7 @@ if.a.node.fails=Als een node faalt
 sort.nodes.by=Sorteer nodes op
 ascending=oplopend
 descending=aflopend
-page.SystemConfiguration.description=Deze pagina toont de belangrijkste configuratie-instellingen. Wijzig het bijbehorende configuratiebestand om een ​​configuratie-instelling te wijzigen.
+page.SystemConfiguration.description=Deze pagina toont de belangrijkste configuratie-instellingen. Wijzig het bijbehorende configuratiebestand om een configuratie-instelling te wijzigen.
 page.SecurityConfiguration.description=Systeembeveiliging wordt beheerd via configuratiebestanden. Deze pagina beschrijft de huidige instellingen van de bestanden om ze te wijzigen.
 gui.menu.SystemInfo=Systeemrapport
 gui.menu.Security=Beveiliging
@@ -1022,7 +1022,7 @@ archive.request.please.wait.pagetitle.wait=[WACHT] Archief exporteren
 archive.request.please.wait.pagetitle.ready=[KLAAR] Archief exporteren
 upload.job.page.title=Upload taakdefinitie
 ScheduledExecution.page.delete.title=Taak verwijderen
-project.config.editor.help.markdown=Wachtwoordwaarden zijn verborgen. U kunt een nieuwe waarde invoeren of u kunt de hele regel laten staan ​​met `key\=*****` om de oorspronkelijke waarde te behouden bij het opslaan.  **Opmerking**\: Als u de *sleutelnaam* van een verborgen eigenschap wijzigt, blijft de waarde *niet behouden* en moet u een nieuwe waarde invoeren.
+project.config.editor.help.markdown=Wachtwoordwaarden zijn verborgen. U kunt een nieuwe waarde invoeren of u kunt de hele regel laten staan met `key\=*****` om de oorspronkelijke waarde te behouden bij het opslaan.  **Opmerking**\: Als u de *sleutelnaam* van een verborgen eigenschap wijzigt, blijft de waarde *niet behouden* en moet u een nieuwe waarde invoeren.
 button.action.Cancel=Annuleren
 page.unsaved.changes=U heeft niet-opgeslagen wijzigingen
 configuration=Configuratie


### PR DESCRIPTION
## Summary
- Two strings in `messages_nl.properties` (`page.SystemConfiguration.description` and `project.config.editor.help.markdown`) contained a double zero-width space (U+200B U+200B) — a known artifact left by copy-pasting text out of Google Translate's web UI.
- These invisible characters are flagged by Renovate's hidden-unicode-character check on the [Dependency Dashboard](https://github.com/rundeck/rundeck/issues/7759).
- No visible text or meaning changes — this is purely stripping the stray invisible characters.

## Test plan
- [x] Diff reviewed to confirm no other characters/content changed
- [x] Confirmed no `U+200B` characters remain in the file
- [ ] Confirm the Renovate Dependency Dashboard warning clears after this merges