### PR TITLE
[RUN-4629] Fix flaky NodeWizardSpec by waiting for node search to complete

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/BasePage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/BasePage.groovy
@@ -217,6 +217,22 @@ abstract class BasePage {
                 .until(ExpectedConditions.numberOfElementsToBeMoreThan(locator, number))
     }
 
+    /**
+     * Best-effort wait for more than the given number of elements matching locator.
+     * Returns quietly (false) if the condition is not met within duration, rather than throwing.
+     * Useful for observing a transient state (e.g. a loading indicator) that may appear and
+     * disappear faster than the caller can otherwise reliably catch, before waiting for it to clear.
+     */
+    boolean waitForNumberOfElementsToBeMoreThanIgnoringTimeout(By locator, Integer number, Duration duration = Duration.ofSeconds(3)) {
+        try {
+            new WebDriverWait(context.driver, duration)
+                    .until(ExpectedConditions.numberOfElementsToBeMoreThan(locator, number))
+            return true
+        } catch (org.openqa.selenium.TimeoutException ignored) {
+            return false
+        }
+    }
+
     WebElement waitIgnoringForElementVisible(WebElement locator) {
         new WebDriverWait(context.driver, Duration.ofSeconds(30))
                 .ignoring(StaleElementReferenceException.class)

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/nodes/NodesPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/nodes/NodesPage.groovy
@@ -14,6 +14,7 @@ class NodesPage extends BasePage {
     By nodeFilterInputDropdownSaveFilterBy = By.partialLinkText("Save Filter")
     By saveNodeFilterModalNameFieldBy = By.id("newFilterName")
     By saveNodeFilterModalSaveButtonBy = By.cssSelector("[data-testid='sfm-button-save']")
+    By nodesLoadingIndicatorBy = By.xpath("//span[contains(.,'Loading matched nodes')]")
 
     By actionsDropdownToggleBy = By.cssSelector("[data-testid='nc-actions-dropdown-toggle']")
     By actionsDropdownRunCommandBy = By.cssSelector("[data-testid='nc-run-command']")
@@ -41,6 +42,7 @@ class NodesPage extends BasePage {
         (el searchNodeInputBy).clear()
         (el searchNodeInputBy).sendKeys(".*")
         clickSearchNodes()
+        waitForNumberOfElementsToBe(nodesLoadingIndicatorBy, 0)
         return (els nodeListTrBy).size()
     }
 
@@ -52,6 +54,7 @@ class NodesPage extends BasePage {
         (el searchNodeInputBy).clear()
         (el searchNodeInputBy).sendKeys(nodeName)
         clickSearchNodes()
+        waitForNumberOfElementsToBe(nodesLoadingIndicatorBy, 0)
         return (els nodeListTrBy).size() > 0
     }
 

--- a/functional-test/src/test/groovy/org/rundeck/util/gui/pages/nodes/NodesPage.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/util/gui/pages/nodes/NodesPage.groovy
@@ -14,7 +14,7 @@ class NodesPage extends BasePage {
     By nodeFilterInputDropdownSaveFilterBy = By.partialLinkText("Save Filter")
     By saveNodeFilterModalNameFieldBy = By.id("newFilterName")
     By saveNodeFilterModalSaveButtonBy = By.cssSelector("[data-testid='sfm-button-save']")
-    By nodesLoadingIndicatorBy = By.xpath("//span[contains(.,'Loading matched nodes')]")
+    By nodesLoadingIndicatorBy = By.cssSelector("span.text-info > i.glyphicon-time")
 
     By actionsDropdownToggleBy = By.cssSelector("[data-testid='nc-actions-dropdown-toggle']")
     By actionsDropdownRunCommandBy = By.cssSelector("[data-testid='nc-run-command']")
@@ -42,6 +42,7 @@ class NodesPage extends BasePage {
         (el searchNodeInputBy).clear()
         (el searchNodeInputBy).sendKeys(".*")
         clickSearchNodes()
+        waitForNumberOfElementsToBeMoreThanIgnoringTimeout(nodesLoadingIndicatorBy, 0)
         waitForNumberOfElementsToBe(nodesLoadingIndicatorBy, 0)
         return (els nodeListTrBy).size()
     }
@@ -54,6 +55,7 @@ class NodesPage extends BasePage {
         (el searchNodeInputBy).clear()
         (el searchNodeInputBy).sendKeys(nodeName)
         clickSearchNodes()
+        waitForNumberOfElementsToBeMoreThanIgnoringTimeout(nodesLoadingIndicatorBy, 0)
         waitForNumberOfElementsToBe(nodesLoadingIndicatorBy, 0)
         return (els nodeListTrBy).size() > 0
     }


### PR DESCRIPTION
## Summary
- `NodeWizardSpec` ("add edit delete node using wizard") intermittently fails at `nodesPage.getTotalNodes() == 1`, expecting 1 but getting 0.
- Root cause: `NodesPage.getTotalNodes()` / `findNodeByName()` click the search button and immediately read the node row count, with no wait for the search's async fetch (`NodeCard.vue` `fetchNodes()`, triggered via a deep-watched store update) to complete. Under CI load the row count can be read before the table refreshes.
- Fix: wait for the "Loading matched nodes..." indicator (`v-if="loading"` in `NodeTable.vue`) to disappear before reading rows — it's only cleared *after* the row data is assigned in `fetchNodes()`, so it's a reliable completion signal rather than an arbitrary sleep.

## Test plan
- [x] `./gradlew :functional-test:compileTestGroovy` passes
- [ ] Verify in rundeckpro via the linked draft test PR that `NodeWizardSpec` no longer flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)