### PR TITLE
[RUN-4570] Remove WAR publication and restrict Maven Central to GA releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -785,6 +785,12 @@ filters:
       branches: {ignore: /.*/}
       tags: {only: '/^v.*/'}
 
+  # GA-only tags: matches v1.2.3 but NOT v1.2.3-rc1, v1.2.3-alpha1, etc. (RUN-4570)
+  ga-tags: &filter-ga-tags
+    filters:
+      branches: {ignore: /.*/}
+      tags: {only: '/^v\d+\.\d+\.\d+$/'}
+
 workflows:
 
   build_and_publish:
@@ -807,7 +813,7 @@ workflows:
           requires:
             - Build Release
           <<: *cloudsmith-slack-defaults
-          <<: *filter-tags
+          <<: *filter-ga-tags
       - docker-publish:
           name: Docker Publish
           requires:

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -914,60 +914,13 @@ tasks.withType(GenerateMavenPom).all {
     }
 }
 
-publishing {
-    publications {
-        "rundeck"(MavenPublication) {
-            artifactId = "rundeck"
-            groupId = project.group
-            artifact bootWar
-            version = version
-            pom {
-                 name = "Rundeck library Rundeck"
-                 description = project.description?:'Rundeck'
-                 url = 'http://rundeck.org'
-                 licenses {
-                     license {
-                         name = 'The Apache Software License, Version 2.0'
-                         url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                         distribution = 'repo'
-                     }
-                 }
-                 developers {
-                     developer {
-                         id = 'gschueler'
-                         name = 'Greg Schueler'
-                         email = 'greg@rundeck.com'
-                     }
-                 }
-                 scm {
-                     connection = 'scm:git:git@github.com/rundeck/rundeck.git'
-                     developerConnection = 'scm:git:git@github.com:rundeck/rundeck.git'
-                     url = 'https://github.com/rundeck/rundeck'
-                 }
-             }
-        }
-    }
-    repositories {
-         maven {
-             // change URLs to point to your repos, e.g. http://my.org/repo
-             def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/'
-             def snapshotsRepoUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
-             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-             credentials {
-                 username findProperty('sonatypeUsername')
-                 password findProperty('sonatypePassword')
-             }
-         }
-     }
-}
+// WAR publication to Maven Central removed (RUN-4570).
+// The WAR (~240 MB) had zero dependents on Maven Central.
+// Distribution channels: Docker Hub, PackageCloud, GitHub Releases.
 
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "../gradle/java-version.gradle"
 
 
-if (project.hasProperty('signing.keyId') && project.hasProperty('signing.password')) {
-    signing {
-        sign(publishing.publications)
-    }
-}
+// Signing block removed along with WAR publication (RUN-4570).
 

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -914,9 +914,7 @@ tasks.withType(GenerateMavenPom).all {
     }
 }
 
-// WAR publication to Maven Central removed (RUN-4570).
-// The WAR (~240 MB) had zero dependents on Maven Central.
-// Distribution channels: Docker Hub, PackageCloud, GitHub Releases.
+// WAR publication to Sonatype/Maven Central removed (RUN-4570); the WAR is still built for distribution via Docker Hub, PackageCloud, and GitHub Releases.
 
 apply from: "${rootDir}/gradle/java.gradle"
 apply from: "../gradle/java-version.gradle"


### PR DESCRIPTION
## Jira Ticket
[RUN-4637](https://pagerduty.atlassian.net/browse/RUN-4637) (subtask of [RUN-4570](https://pagerduty.atlassian.net/browse/RUN-4570))

## Summary

1. **Remove WAR publication** — eliminates ~240 MB per release. The WAR (`org.rundeck:rundeck`) has [zero dependents on Maven Central](https://central.sonatype.com/artifact/org.rundeck/rundeck/dependents) and is distributed via Docker Hub, PackageCloud, and GitHub Releases.

2. **Restrict Maven Central to GA releases only** — adds a `ga-tags` filter (`/^v\d+\.\d+\.\d+$/`) to the `maven-publish` CircleCI job. RC, alpha, and beta tags still trigger build, packaging, and Docker jobs — only Maven Central publication is skipped.

## Changes

- `rundeckapp/build.gradle`: Removed the `publishing { }` block that published `bootWar` as `org.rundeck:rundeck` and the associated `signing` block. The `bootWar` task and `artifacts` configuration remain untouched (needed for Docker/PackageCloud builds).

- `.circleci/config.yml`: Added new `ga-tags` filter anchor. Changed `maven-publish` job from `*filter-tags` (all `v*` tags) to `*filter-ga-tags` (only `v1.2.3` without suffix).

## What is NOT affected

- The 9 library JARs (rundeck-core, authz-*, storage-*, data-models) continue to publish to Maven Central on GA releases
- All other CI jobs (Build Release, Package and Release, Docker Publish) continue to run for all tags including RCs
- The `bootWar` task still builds the WAR for Docker/PackageCloud distribution
- `exported-project.gradle` and the `nexusPublishing` plugin configuration are untouched

## Test Plan

- [ ] Verify library JARs still publish correctly on a GA tag (e.g., `v6.1.0`)
- [ ] Verify RC tags (e.g., `v6.1.0-rc1`) trigger build/package/Docker but skip `maven-publish`
- [ ] Verify the WAR is no longer in the Sonatype staging repository
- [ ] Verify `./gradlew build -x check` succeeds locally


Made with [Cursor](https://cursor.com)

[RUN-4637]: https://pagerduty.atlassian.net/browse/RUN-4637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RUN-4570]: https://pagerduty.atlassian.net/browse/RUN-4570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ