### PR TITLE
[RUN-4644] fix(user-management): use substring match for User Management search filters

### DIFF
--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
@@ -178,7 +178,7 @@ class GormUserDataProvider implements UserDataProvider, SystemConfigurable{
             }
             if (filters) {
                 filters.each { k, v ->
-                    eq(k, v)
+                    ilike(k, "%${v}%")
                 }
             }
 
@@ -205,7 +205,7 @@ class GormUserDataProvider implements UserDataProvider, SystemConfigurable{
 
                 if (filters) {
                     filters.each { k, v ->
-                        eq(k, v)
+                        ilike(k, "%${v}%")
                     }
                 }
                 order("login", "asc")

--- a/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
@@ -281,10 +281,11 @@ class GormUserDataProviderSpec extends Specification implements DataTest {
         showLoginStatus | loggedInOnly | filters                | expect
         true            | true         | [login: "admin_other"] | 0
         true            | true         | [:]                    | 1
-        false           | true         | [login: "admin"]       | 1
+        false           | true         | [login: "admin"]       | 2
         false           | true         | [:]                    | 2
         false           | false        | [:]                    | 2
-        true            | false        | [login: "admin"]       | 1
+        true            | false        | [login: "admin"]       | 2
+        false           | false        | [login: "_other"]      | 1
     }
 
     @Unroll

--- a/rundeckapp/src/test/groovy/rundeck/services/UserServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/UserServiceSpec.groovy
@@ -218,7 +218,7 @@ class UserServiceSpec extends Specification implements ServiceUnitTest<UserServi
 
         then:
             result.users
-            result.users.size() == 1
+            result.users.size() == 2
             result.users.find { it.login == userToSearch }
             result.users.find { it.login == userToSearch }.id == u.id
 


### PR DESCRIPTION
## Release Notes

Fixed User Management search so login, session ID, and hostname filters match partial text (case-insensitive) instead of requiring the exact full string. Users can now find accounts by typing part of a login — for example, searching by first name when the login is stored as "First Last" — consistent with search behavior elsewhere in Rundeck.

## PR Details

## Summary

The User Management > Summary page search box (login, session ID, and hostname filters) used GORM's `eq()` for **exact-match** comparison instead of a substring/contains match. As a result, searching for a partial login (e.g. a user's first name, when the login is stored as `First Last`) returned no results — only the full, exact string matched.

Reported by a customer running 6.0.1: a user provisioned via SSO with a login like `Alejo Bozas` could not be found by searching `Alejo`, only by typing the full `Alejo Bozas`.

## Root cause

`GormUserDataProvider.findWithFilters()` applied every filter with:
```groovy
filters.each { k, v -> eq(k, v) }
```
in both the count query and the list query.

## Fix

Switch to a substring/case-insensitive match:
```groovy
filters.each { k, v -> ilike(k, "%${v}%") }
```
This matches the pattern already used for every other search filter in the app (jobs, executions, reports), e.g. `ScheduledExecutionService.groovy`, `ReportService.groovy`, `ExecutionService.groovy` all use `ilike(val, '%' + query["${key}Filter"] + '%')`. The three fields this filters on (`login`, `lastSessionId`, `lastLoggedHostName`) are all `String`-typed on the `User` domain class, so `ilike` is safe here.

## Tests

Updated `GormUserDataProviderSpec` ("Should findWithFilters"):
- Two existing rows asserted that filtering by `login: "admin"` returned exactly 1 record (only the exact match). With substring matching, that filter now also matches a second seeded user `admin_other`, so those rows' expected count is bumped from 1 to 2.
- Added a new row asserting a genuine substring filter (`_other`) returns only the user whose login contains it — this is the scenario the customer hit.

**Verified locally:** ran `./gradlew :rundeckapp:test --tests "org.rundeck.app.providers.GormUserDataProviderSpec"` — 46 tests, 0 failures, 0 errors, including all 7 rows of `Should findWithFilters` (both `login:admin` rows now correctly return 2, and the new `login:_other` partial-match row correctly returns 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
