### PR TITLE
[RUN-0000] Bump required npm engine version to 11.16.0

### DIFF
--- a/rundeckapp/grails-app/assets/javascripts/_package-manager/package-lock.json
+++ b/rundeckapp/grails-app/assets/javascripts/_package-manager/package-lock.json
@@ -33,7 +33,7 @@
         "vue-loader": "^16.4.1"
       },
       "engines": {
-        "npm": "10.9.4"
+        "npm": "11.16.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/rundeckapp/grails-app/assets/javascripts/_package-manager/package.json
+++ b/rundeckapp/grails-app/assets/javascripts/_package-manager/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "engines": {
-    "npm": "10.9.4"
+    "npm": "11.16.0"
   },
   "main": "",
   "scripts": {

--- a/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
@@ -121,7 +121,7 @@
         "webpack-cli": "^5.1.4"
       },
       "engines": {
-        "npm": "10.9.4"
+        "npm": "11.16.0"
       },
       "peerDependencies": {
         "@rundeck/client": "^0.2.5",

--- a/rundeckapp/grails-spa/packages/ui-trellis/package.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package.json
@@ -3,7 +3,7 @@
   "version": "3.3.8",
   "description": "A collection of utilities used across various javascript applications and components.",
   "engines": {
-    "npm": "10.9.4"
+    "npm": "11.16.0"
   },
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
Pins the _package-manager and ui-trellis package.json engines field to npm 11.16.0 to address a webpack-cli build failure caused by a yargs CJS/ESM resolution mismatch under the currently supported Node toolchain.

<!--
IMPORTANT: Before submitting your Pull Request, please review the following instructions:

1. Please follow the [Developer Guidelines](https://github.com/rundeck/rundeck/wiki/Developer-Guidelines) document.
2. Are you implementing a feature or enhancement? Please search the existing Issues and look 
   at the [Rundeck Roadmap Trello Board](https://trello.com/b/sn3g9nOr/rundeck-development) for your idea before posting.
   If your enhancement is not listed, it is better to 
   [post a new enhancement request](https://github.com/rundeck/rundeck/issues/new?template=feature_request.md)
   and get feedback from maintainers and the community *before* submitting an Pull request to implement it.
3. Please be sure the issue you are addressing is referenced in a commit, or the body of your PR,
   using [github keywords](https://help.github.com/articles/closing-issues-using-keywords/), e.g. "fixes #123".
-->
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
<!-- Include a clear and concise description of the bug you are fixing (reference issue number), or enhancement you are implementing. -->

**Describe the solution you've implemented**
<!-- A clear and concise description of what you want to happen. -->

**Describe alternatives you've considered**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

**Additional context**
<!-- Add any other context or screenshots about the change here. -->

## Release Notes

<!-- If you have suggested content that would describe this PR to other Rundeck community users, please enter it here.-->