### PR TITLE
[RUN-4653] Wire up countPerformance execution flag in remco config template

### DIFF
--- a/docker/official/remco/templates/rundeck-config.properties
+++ b/docker/official/remco/templates/rundeck-config.properties
@@ -59,6 +59,10 @@ rundeck.security.syncLdapUser={{ getv("/rundeck/security/syncldapuser") }}
 
 rundeck.api.tokens.duration.max={{ getv("/rundeck/api/tokens/duration/max", "30d") }}
 
+{% if exists("/rundeck/api/execution/countperformance/enabled") %}
+rundeck.api.executionQueryConfig.countPerformance.enabled={{ getv("/rundeck/api/execution/countperformance/enabled") }}
+{% endif %}
+
 rundeck.log4j.config.file={{ rundeckHome }}/server/config/log4j.properties
 
 rundeck.gui.startpage={{ getv("/rundeck/gui/startpage", "projectHome") }}


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Enhancement. [RUN-4653](https://pagerduty.atlassian.net/browse/RUN-4653)

The `rundeck.api.executionQueryConfig.countPerformance.enabled` flag (`ExecutionService.groovy`) enables an optimized execution-count path that avoids an `INNER JOIN` against `scheduled_execution` when counting executions filtered by job UUID. It currently has no way to be set via the official Docker image, because `docker/official/remco/templates/rundeck-config.properties` has no line for it — there's no generic passthrough for `rundeck.api.*` properties (only `rundeck.feature.*` has one).

This was discovered while investigating a production `SQLNonTransientConnectionException` / read timeout on a JOIN-based execution count query — exactly the slow path this flag exists to avoid.

**Describe the solution you've implemented**
Added a conditional line to `docker/official/remco/templates/rundeck-config.properties` that maps the remco path `/rundeck/api/execution/countperformance/enabled` to `rundeck.api.executionQueryConfig.countPerformance.enabled`, following the same `exists`/`getv` pattern already used for other optional properties in this template (e.g. `rundeck.api.tokens.duration.max`).

This can now be set via the `RUNDECK_API_EXECUTION_COUNTPERFORMANCE_ENABLED` environment variable on the container.

**Describe alternatives you've considered**
Setting the env var directly on the deployment without a remco template change — doesn't work, since `docker/official/lib/entry.sh` unsets all `RUNDECK_*` env vars after remco runs and before the JVM starts, so the value never reaches the properties file without an explicit template line.

**Additional context**
This flag's optimized path depends on indexes (`EXEC_IDX_JOB_PROJ_DATE`, `execution_job_uuid_idx`) added in RUN-4043, which is why the flag defaults to `false` and was never enabled — this PR only wires up the config plumbing; enabling the flag itself is a deployment-level decision.

## Release Notes

Adds Docker/remco support for setting `rundeck.api.executionQueryConfig.countPerformance.enabled` via the `RUNDECK_API_EXECUTION_COUNTPERFORMANCE_ENABLED` environment variable.


[RUN-4653]: https://pagerduty.atlassian.net/browse/RUN-4653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ