### PR TITLE
[RUN-4662] Force ant via dependency-management, not just resolutionStrategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -303,10 +303,11 @@ allprojects {
     }
 
     // resolutionStrategy.force cannot override versions managed by the Spring Boot dependency
-    // management plugin (which applies grails-bom entries as strict constraints, e.g. asm:9.10 and
-    // kotlin-stdlib:1.9.25). Must use the plugin's own API to pin these above the BOM version;
-    // otherwise rundeckapp's own runtimeClasspath (bundled by bootWar) still carries the un-forced
-    // BOM version, which causes duplicate jars when rundeckpro's enterprise packaging merges it in.
+    // management plugin (which applies grails-bom entries as strict constraints, e.g. asm:9.10,
+    // kotlin-stdlib:1.9.25, and ant:1.10.15). Must use the plugin's own API to pin these above the
+    // BOM version; otherwise rundeckapp's own runtimeClasspath (bundled by bootWar) still carries
+    // the un-forced BOM version, which causes duplicate jars when rundeckpro's enterprise packaging
+    // merges it in.
     plugins.withId('io.spring.dependency-management') {
         dependencyManagement {
             dependencies {
@@ -316,6 +317,8 @@ allprojects {
                 dependency "org.ow2.asm:asm-analysis:${asmVersion}"
                 dependency "org.ow2.asm:asm-util:${asmVersion}"
                 dependency "org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}"
+                dependency "org.apache.ant:ant:${antVersion}"
+                dependency "org.apache.ant:ant-launcher:${antVersion}"
             }
         }
     }


### PR DESCRIPTION
## Summary

PR #10340 bumped `antVersion` to `1.10.17` and added `resolutionStrategy.force` entries for `org.apache.ant:ant` / `ant-launcher`, but `grails-bom` pins those two artifacts as **strict** version constraints (`1.10.15`). `resolutionStrategy.force` cannot override a strict BOM constraint — only Spring's dependency-management plugin API can (this codebase already has this exact workaround in place for `asm` and `kotlin-stdlib`, for the same reason).

As a result, `rundeckapp`'s `runtimeClasspath` still carries `ant`/`ant-launcher` at `1.10.15` alongside the forced `1.10.17`, which causes duplicate jars when downstream packaging (rundeckpro's enterprise WAR) merges rundeckapp's `bootWar` output with other modules built against the forced version:

```
FAIL: [rundeckpro-enterprise-*.war] stem "WEB-INF/lib/(ant:jar)" MUST be unique: false: [ant-1.10.15.jar, ant-1.10.17.jar]
```

## Fix

Add `org.apache.ant:ant` and `org.apache.ant:ant-launcher` to the existing `dependencyManagement` override block, alongside `asm` and `kotlin-stdlib`.

## Testing
- `./gradlew :rundeckapp:dependencies --configuration runtimeClasspath` — confirmed every `org.apache.ant:ant`/`ant-launcher` reference now resolves to `1.10.17` (previously several resolved to `1.10.15`).