### PR TITLE
[RUN-4663] Handle Node version mismatch and enforce build to use the expected Node version

### DIFF
--- a/gradle/node-version.gradle
+++ b/gradle/node-version.gradle
@@ -1,0 +1,45 @@
+def nvmrcVersion = new File(rootDir, '.nvmrc').text.trim().replace('v', '')
+def nvmDir = System.getenv('NVM_DIR') ?: "${System.getProperty('user.home')}/.nvm"
+def nvmNodeBin = new File(nvmDir, "versions/node/v${nvmrcVersion}/bin")
+// If nvm has the pinned version installed, use it explicitly. Otherwise fall back to
+// whatever Node is already on PATH, and only fail if there's no Node at all, or an older one.
+ext.pinnedNodeBin = nvmNodeBin.directory ? nvmNodeBin : null
+
+task verifyNodeVersion {
+    doFirst {
+        if (project.ext.pinnedNodeBin == null) {
+            def actualVersion = null
+            try {
+                actualVersion = ['node', '--version'].execute().text.trim().replace('v', '')
+            } catch (IOException ignored) {
+                actualVersion = null
+            }
+            if (!actualVersion) {
+                throw new GradleException(
+                    "No Node.js installation found. Install Node ${nvmrcVersion} (pinned in " +
+                    "${rootDir}/.nvmrc) — via nvm (nvm install ${nvmrcVersion}) or by " +
+                    "downloading it from https://nodejs.org/en/download."
+                )
+            }
+            def actualParts = actualVersion.split('\\.').collect { it.toInteger() }
+            def pinnedParts = nvmrcVersion.split('\\.').collect { it.toInteger() }
+            def isOlder = false
+            for (int i = 0; i < Math.max(actualParts.size(), pinnedParts.size()); i++) {
+                def a = i < actualParts.size() ? actualParts[i] : 0
+                def p = i < pinnedParts.size() ? pinnedParts[i] : 0
+                if (a != p) {
+                    isOlder = a < p
+                    break
+                }
+            }
+            if (isOlder) {
+                throw new GradleException(
+                    "Node ${actualVersion} on PATH is older than the pinned ${nvmrcVersion} (from " +
+                    "${rootDir}/.nvmrc). Upgrade via nvm (nvm install ${nvmrcVersion}) or " +
+                    "by downloading it from https://nodejs.org/en/download."
+                )
+            }
+        }
+    }
+}
+tasks.withType(NpmTask).configureEach { dependsOn verifyNodeVersion }

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -803,6 +803,35 @@ task copySpa(type: Copy) {
 assetPluginPackage.dependsOn copySpa
 assetCompile.dependsOn copySpa
 
+def nvmrcVersion = new File(rootProject.rootDir, '.nvmrc').text.trim().replace('v', '')
+def nvmDir = System.getenv('NVM_DIR') ?: "${System.getProperty('user.home')}/.nvm"
+def nvmNodeBin = new File(nvmDir, "versions/node/v${nvmrcVersion}/bin")
+// If nvm has the pinned version installed, use it explicitly. Otherwise fall back to
+// whatever Node is already on PATH, and only fail if there's no Node at all.
+def pinnedNodeBin = nvmNodeBin.directory ? nvmNodeBin : null
+
+task verifyNodeVersion {
+    doFirst {
+        if (pinnedNodeBin == null) {
+            def nodeAvailable
+            try {
+                def proc = ['node', '--version'].execute()
+                proc.waitFor()
+                nodeAvailable = proc.exitValue() == 0
+            } catch (IOException ignored) {
+                nodeAvailable = false
+            }
+            if (!nodeAvailable) {
+                throw new GradleException(
+                    "No Node.js installation found. Install Node ${nvmrcVersion} (pinned in " +
+                    "${rootProject.rootDir}/.nvmrc) — via nvm (nvm install ${nvmrcVersion}) or any other method."
+                )
+            }
+        }
+    }
+}
+tasks.withType(NpmTask).configureEach { dependsOn verifyNodeVersion }
+
 task vendorAssetDeps(type: NpmTask) { it ->
     dependsOn copySpa
     def baseDir = "${projectDir}/grails-app/assets/javascripts"
@@ -821,6 +850,9 @@ task vendorAssetDeps(type: NpmTask) { it ->
 
     execOverrides {
         it.workingDir = "${baseDir}/_package-manager"
+        if (pinnedNodeBin != null) {
+            it.environment('PATH', "${pinnedNodeBin}${File.pathSeparator}${System.getenv('PATH')}")
+        }
         def token = project.findProperty('CLOUDSMITH_NPM_TOKEN') ?: System.getenv('CLOUDSMITH_NPM_TOKEN')
         if (token) {
             it.environment('CLOUDSMITH_NPM_TOKEN', token)

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -803,34 +803,8 @@ task copySpa(type: Copy) {
 assetPluginPackage.dependsOn copySpa
 assetCompile.dependsOn copySpa
 
-def nvmrcVersion = new File(rootProject.rootDir, '.nvmrc').text.trim().replace('v', '')
-def nvmDir = System.getenv('NVM_DIR') ?: "${System.getProperty('user.home')}/.nvm"
-def nvmNodeBin = new File(nvmDir, "versions/node/v${nvmrcVersion}/bin")
-// If nvm has the pinned version installed, use it explicitly. Otherwise fall back to
-// whatever Node is already on PATH, and only fail if there's no Node at all.
-def pinnedNodeBin = nvmNodeBin.directory ? nvmNodeBin : null
-
-task verifyNodeVersion {
-    doFirst {
-        if (pinnedNodeBin == null) {
-            def nodeAvailable
-            try {
-                def proc = ['node', '--version'].execute()
-                proc.waitFor()
-                nodeAvailable = proc.exitValue() == 0
-            } catch (IOException ignored) {
-                nodeAvailable = false
-            }
-            if (!nodeAvailable) {
-                throw new GradleException(
-                    "No Node.js installation found. Install Node ${nvmrcVersion} (pinned in " +
-                    "${rootProject.rootDir}/.nvmrc) — via nvm (nvm install ${nvmrcVersion}) or any other method."
-                )
-            }
-        }
-    }
-}
-tasks.withType(NpmTask).configureEach { dependsOn verifyNodeVersion }
+apply from: "../gradle/node-version.gradle"
+def pinnedNodeBin = project.ext.pinnedNodeBin
 
 task vendorAssetDeps(type: NpmTask) { it ->
     dependsOn copySpa

--- a/rundeckapp/grails-app/assets/javascripts/_package-manager/.npmrc
+++ b/rundeckapp/grails-app/assets/javascripts/_package-manager/.npmrc
@@ -1,5 +1,4 @@
 registry=https://npm.artifacts.pd-internal.com/npm/
 //npm.artifacts.pd-internal.com/npm/:_authToken=${CLOUDSMITH_NPM_TOKEN}
 @pagerduty:registry=https://npm.artifacts.pd-internal.com/npm/
-always-auth=true
 legacy-peer-deps=true

--- a/rundeckapp/grails-spa/build.gradle
+++ b/rundeckapp/grails-spa/build.gradle
@@ -24,34 +24,8 @@ node{
     download = false
 }
 
-def nvmrcVersion = new File(rootProject.rootDir, '.nvmrc').text.trim().replace('v', '')
-def nvmDir = System.getenv('NVM_DIR') ?: "${System.getProperty('user.home')}/.nvm"
-def nvmNodeBin = new File(nvmDir, "versions/node/v${nvmrcVersion}/bin")
-// If nvm has the pinned version installed, use it explicitly. Otherwise fall back to
-// whatever Node is already on PATH, and only fail if there's no Node at all.
-def pinnedNodeBin = nvmNodeBin.directory ? nvmNodeBin : null
-
-task verifyNodeVersion {
-    doFirst {
-        if (pinnedNodeBin == null) {
-            def nodeAvailable
-            try {
-                def proc = ['node', '--version'].execute()
-                proc.waitFor()
-                nodeAvailable = proc.exitValue() == 0
-            } catch (IOException ignored) {
-                nodeAvailable = false
-            }
-            if (!nodeAvailable) {
-                throw new GradleException(
-                    "No Node.js installation found. Install Node ${nvmrcVersion} (pinned in " +
-                    "${rootProject.rootDir}/.nvmrc) — via nvm (nvm install ${nvmrcVersion}) or any other method."
-                )
-            }
-        }
-    }
-}
-tasks.withType(NpmTask).configureEach { dependsOn verifyNodeVersion }
+apply from: "../../gradle/node-version.gradle"
+def pinnedNodeBin = project.ext.pinnedNodeBin
 
 
 task noop() {

--- a/rundeckapp/grails-spa/build.gradle
+++ b/rundeckapp/grails-spa/build.gradle
@@ -24,6 +24,35 @@ node{
     download = false
 }
 
+def nvmrcVersion = new File(rootProject.rootDir, '.nvmrc').text.trim().replace('v', '')
+def nvmDir = System.getenv('NVM_DIR') ?: "${System.getProperty('user.home')}/.nvm"
+def nvmNodeBin = new File(nvmDir, "versions/node/v${nvmrcVersion}/bin")
+// If nvm has the pinned version installed, use it explicitly. Otherwise fall back to
+// whatever Node is already on PATH, and only fail if there's no Node at all.
+def pinnedNodeBin = nvmNodeBin.directory ? nvmNodeBin : null
+
+task verifyNodeVersion {
+    doFirst {
+        if (pinnedNodeBin == null) {
+            def nodeAvailable
+            try {
+                def proc = ['node', '--version'].execute()
+                proc.waitFor()
+                nodeAvailable = proc.exitValue() == 0
+            } catch (IOException ignored) {
+                nodeAvailable = false
+            }
+            if (!nodeAvailable) {
+                throw new GradleException(
+                    "No Node.js installation found. Install Node ${nvmrcVersion} (pinned in " +
+                    "${rootProject.rootDir}/.nvmrc) — via nvm (nvm install ${nvmrcVersion}) or any other method."
+                )
+            }
+        }
+    }
+}
+tasks.withType(NpmTask).configureEach { dependsOn verifyNodeVersion }
+
 
 task noop() {
   doLast {
@@ -58,6 +87,9 @@ tasks.register("runNpmBuild", NpmTask) {
 
     execOverrides {
       it.workingDir = './packages/ui-trellis/src/app'
+      if (pinnedNodeBin != null) {
+          it.environment('PATH', "${pinnedNodeBin}${File.pathSeparator}${System.getenv('PATH')}")
+      }
       def token = project.findProperty('CLOUDSMITH_NPM_TOKEN') ?: System.getenv('CLOUDSMITH_NPM_TOKEN')
       if (token) {
           it.environment('CLOUDSMITH_NPM_TOKEN', token)

--- a/rundeckapp/grails-spa/packages/ui-trellis/build.gradle
+++ b/rundeckapp/grails-spa/packages/ui-trellis/build.gradle
@@ -26,6 +26,35 @@ node{
     download = false
 }
 
+def nvmrcVersion = new File(rootProject.rootDir, '.nvmrc').text.trim().replace('v', '')
+def nvmDir = System.getenv('NVM_DIR') ?: "${System.getProperty('user.home')}/.nvm"
+def nvmNodeBin = new File(nvmDir, "versions/node/v${nvmrcVersion}/bin")
+// If nvm has the pinned version installed, use it explicitly. Otherwise fall back to
+// whatever Node is already on PATH, and only fail if there's no Node at all.
+def pinnedNodeBin = nvmNodeBin.directory ? nvmNodeBin : null
+
+task verifyNodeVersion {
+    doFirst {
+        if (pinnedNodeBin == null) {
+            def nodeAvailable
+            try {
+                def proc = ['node', '--version'].execute()
+                proc.waitFor()
+                nodeAvailable = proc.exitValue() == 0
+            } catch (IOException ignored) {
+                nodeAvailable = false
+            }
+            if (!nodeAvailable) {
+                throw new GradleException(
+                    "No Node.js installation found. Install Node ${nvmrcVersion} (pinned in " +
+                    "${rootProject.rootDir}/.nvmrc) — via nvm (nvm install ${nvmrcVersion}) or any other method."
+                )
+            }
+        }
+    }
+}
+tasks.withType(NpmTask).configureEach { dependsOn verifyNodeVersion }
+
 def sourceDirs = [
         '.storybook',
         'lib',
@@ -52,6 +81,9 @@ def runNpmBuild = tasks.register('runNpmBuild', NpmTask) {
     args = ['run', npmCommand]
 
     execOverrides {
+        if (pinnedNodeBin != null) {
+            it.environment('PATH', "${pinnedNodeBin}${File.pathSeparator}${System.getenv('PATH')}")
+        }
         def token = project.findProperty('CLOUDSMITH_NPM_TOKEN') ?: System.getenv('CLOUDSMITH_NPM_TOKEN')
         if (token) {
             it.environment('CLOUDSMITH_NPM_TOKEN', token)
@@ -103,6 +135,9 @@ def runNpmVersion = tasks.register('runNpmVersion', NpmTask) {t ->
 
     t.execOverrides {
         it.workingDir = 'build/pack-version'
+        if (pinnedNodeBin != null) {
+            it.environment('PATH', "${pinnedNodeBin}${File.pathSeparator}${System.getenv('PATH')}")
+        }
     }
 }
 
@@ -153,6 +188,9 @@ def runNpmPack = tasks.register('runNpmPack', NpmTask) {
 
     it.execOverrides {
         it.workingDir = 'build/pack'
+        if (pinnedNodeBin != null) {
+            it.environment('PATH', "${pinnedNodeBin}${File.pathSeparator}${System.getenv('PATH')}")
+        }
     }
 
     it.doFirst {
@@ -190,6 +228,9 @@ tasks.register('runNpmPublish', NpmTask) {t ->
 
     t.execOverrides {
         it.workingDir = 'build/pack'
+        if (pinnedNodeBin != null) {
+            it.environment('PATH', "${pinnedNodeBin}${File.pathSeparator}${System.getenv('PATH')}")
+        }
     }
 }
 
@@ -210,6 +251,9 @@ tasks.register('runNpmTest', NpmTask) {
     args = ['run', npmCommand]
 
     execOverrides {
+        if (pinnedNodeBin != null) {
+            it.environment('PATH', "${pinnedNodeBin}${File.pathSeparator}${System.getenv('PATH')}")
+        }
         def token = project.findProperty('CLOUDSMITH_NPM_TOKEN') ?: System.getenv('CLOUDSMITH_NPM_TOKEN')
         if (token) {
             it.environment('CLOUDSMITH_NPM_TOKEN', token)

--- a/rundeckapp/grails-spa/packages/ui-trellis/build.gradle
+++ b/rundeckapp/grails-spa/packages/ui-trellis/build.gradle
@@ -26,34 +26,8 @@ node{
     download = false
 }
 
-def nvmrcVersion = new File(rootProject.rootDir, '.nvmrc').text.trim().replace('v', '')
-def nvmDir = System.getenv('NVM_DIR') ?: "${System.getProperty('user.home')}/.nvm"
-def nvmNodeBin = new File(nvmDir, "versions/node/v${nvmrcVersion}/bin")
-// If nvm has the pinned version installed, use it explicitly. Otherwise fall back to
-// whatever Node is already on PATH, and only fail if there's no Node at all.
-def pinnedNodeBin = nvmNodeBin.directory ? nvmNodeBin : null
-
-task verifyNodeVersion {
-    doFirst {
-        if (pinnedNodeBin == null) {
-            def nodeAvailable
-            try {
-                def proc = ['node', '--version'].execute()
-                proc.waitFor()
-                nodeAvailable = proc.exitValue() == 0
-            } catch (IOException ignored) {
-                nodeAvailable = false
-            }
-            if (!nodeAvailable) {
-                throw new GradleException(
-                    "No Node.js installation found. Install Node ${nvmrcVersion} (pinned in " +
-                    "${rootProject.rootDir}/.nvmrc) — via nvm (nvm install ${nvmrcVersion}) or any other method."
-                )
-            }
-        }
-    }
-}
-tasks.withType(NpmTask).configureEach { dependsOn verifyNodeVersion }
+apply from: "../../../../gradle/node-version.gradle"
+def pinnedNodeBin = project.ext.pinnedNodeBin
 
 def sourceDirs = [
         '.storybook',


### PR DESCRIPTION
## Summary
- CI and local Gradle builds were silently using whatever Node was active in the invoking shell/orb, completely disconnected from `.nvmrc`. A newer ambient Node (e.g. v26) would let `npm install` proceed with only a warning, then fail cryptically deep inside webpack/yargs instead of at the actual point of mismatch.
- Adds a `verifyNodeVersion` Gradle task, extracted into a single shared `gradle/node-version.gradle` script (mirroring the existing `gradle/java-version.gradle` convention) and applied via `apply from:` in `rundeckapp/build.gradle`, `rundeckapp/grails-spa/build.gradle`, and `rundeckapp/grails-spa/packages/ui-trellis/build.gradle` — every `NpmTask` in those files depends on it:
  - If `nvm` has the `.nvmrc`-pinned version installed, forces that Node onto the npm subprocess's `PATH`, regardless of what's active in the shell.
  - If no matching `nvm` install is found, falls back to whatever Node is already on `PATH`.
  - **Updated from the original description**: the fallback path now does enforce a minimum version — it fails if the Node found on `PATH` is *older* than the `.nvmrc`-pinned version (a newer Node is still allowed through). Only fails outright if there's no Node installation at all. Both failure messages point to installing via `nvm` or downloading directly from nodejs.org.
- Removes `always-auth=true` from `rundeckapp/grails-app/assets/javascripts/_package-manager/.npmrc`: `always-auth` is a deprecated npm config option (npm already warns on it — visible in the original bug report's log output), unrelated to the Node-version fix but cleaned up alongside it since it was flagged.

## Testing
- Verified `verifyNodeVersion` passes with the correct Node active (via `nvm`).
- Verified it fails immediately with a clear message when no Node is available at all.
- Verified the fallback path works when no matching `nvm` install exists but a correct (or newer) Node is still on `PATH`.
- Verified the fallback path now fails with a clear message when no matching `nvm` install exists and the Node on `PATH` is older than `.nvmrc`.
- Reproduced the original bug with a decoy Node v26 shadowing the real one at the front of `PATH` (with `nvm` present), and confirmed `vendorAssetDeps` still built cleanly since the task forces the pinned Node regardless of shell state.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>