### PR TITLE
[RUN-4661] Fix incorrect groupId for failureaccess (errorprone -> guava)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -291,7 +291,7 @@ allprojects {
             // sync with rundeckpro's enterprise packaging so core and pro resolve identically and
             // don't end up with duplicate jars when pro bundles rundeck's artifacts into its WAR.
             force "com.google.guava:guava:${guavaVersion}"
-            force "com.google.errorprone:failureaccess:${failureAccessVersion}"
+            force "com.google.guava:failureaccess:${failureAccessVersion}"
             force "org.ow2.asm:asm:${asmVersion}"
             force "org.ow2.asm:asm-tree:${asmVersion}"
             force "org.ow2.asm:asm-commons:${asmVersion}"

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -419,7 +419,7 @@ dependencies {
             }
             because "guava 33.4.8 from micronaut-guice-bom causes variant resolution conflicts with exportedLibs; aligned to guavaVersion so this doesn't fight the global force"
         }
-        implementation('com.google.errorprone:failureaccess') {
+        implementation('com.google.guava:failureaccess') {
             version {
                 strictly failureAccessVersion
             }


### PR DESCRIPTION
## Summary

`failureaccess` is published under Maven groupId `com.google.guava`, not `com.google.errorprone` (an unrelated Google project). Several build files here pinned/forced it under the wrong groupId:

- `build.gradle:294` — `force "com.google.errorprone:failureaccess:${failureAccessVersion}"`
- `rundeckapp/build.gradle:422` — `constraints { implementation('com.google.errorprone:failureaccess') { ... } }`

Because the coordinate was wrong, these rules were silent no-ops: nothing in the dependency graph ever resolves a module under `com.google.errorprone:failureaccess`, so the intended alignment of `failureaccess`'s version with `guavaVersion` (to prevent duplicate jars) wasn't actually happening.

This surfaced via a Renovate warning (`Failed to look up maven package com.google.errorprone:failureaccess: no-result`) — Renovate was correctly unable to find an artifact that doesn't exist under that coordinate.

The corresponding rundeckpro-side files (`build.gradle`, `enterprise/build.gradle`) have the same fix applied separately.

Jira: RUN-4661

## Test plan

- [x] `./gradlew build -x check` succeeds
- [x] Confirm `com.google.guava:failureaccess` now actually resolves to `${failureAccessVersion}` in the dependency graph (e.g. via `./gradlew dependencyInsight --dependency failureaccess`)