### PR TITLE
[RUN-4665] Allow view_history to authorize job execution listing

### DIFF
--- a/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionsQueryViewHistoryAuthSpec.groovy
+++ b/functional-test/src/test/groovy/org/rundeck/tests/functional/api/execution/ExecutionsQueryViewHistoryAuthSpec.groovy
@@ -1,0 +1,86 @@
+package org.rundeck.tests.functional.api.execution
+
+import org.rundeck.util.annotations.APITest
+import org.rundeck.util.common.jobs.JobUtils
+import org.rundeck.util.container.BaseContainer
+import spock.lang.Shared
+
+/**
+ * RUN-4665: a user granted only the job {@code view_history} ACL action (without {@code read})
+ * must still see the execution list from {@code GET /project/{project}/executions}, not just the
+ * total count. Regression coverage for the fix in
+ * {@code ExecutionController.apiExecutionsQueryv14} (filterAuthorizedProjectExecutionsAny).
+ */
+@APITest
+class ExecutionsQueryViewHistoryAuthSpec extends BaseContainer {
+    static final String TEST_PROJECT = "ExecutionsQueryViewHistoryAuth"
+    static final String ACLPOLICY_FILE = "ExecutionsQueryViewHistoryAuthSpec.aclpolicy"
+    static final String VIEW_HISTORY_GROUP = "Run4665ViewHistory"
+    static final String NO_ACCESS_GROUP = "Run4665NoAccess"
+    static final int EXECUTION_COUNT = 3
+
+    @Shared
+    String jobId
+    @Shared
+    String viewHistoryToken
+    @Shared
+    String noAccessToken
+
+    def setupSpec() {
+        setupProject(TEST_PROJECT)
+        importSystemAcls("/${ACLPOLICY_FILE}", ACLPOLICY_FILE)
+
+        def jobXml = JobUtils.generateScheduledExecutionXml("run4665-history-job")
+        jobId = JobUtils.createJob(TEST_PROJECT, jobXml, client).succeeded[0].id
+
+        EXECUTION_COUNT.times {
+            def execution = JobUtils.runExecuteJob(jobId, client)
+            JobUtils.waitForSuccess(execution.id as String, client)
+        }
+
+        viewHistoryToken = client.post(
+            "/tokens/run4665-view-history-user",
+            [roles: [VIEW_HISTORY_GROUP]],
+            Map
+        ).token
+        noAccessToken = client.post(
+            "/tokens/run4665-no-access-user",
+            [roles: [NO_ACCESS_GROUP]],
+            Map
+        ).token
+    }
+
+    def cleanupSpec() {
+        deleteProject(TEST_PROJECT)
+        deleteSystemAcl(ACLPOLICY_FILE)
+    }
+
+    def "user with only view_history sees the execution list, not just the count"() {
+        given: "a client authenticated as a user with only the view_history job ACL action"
+            def viewHistoryClient = clientWithToken(viewHistoryToken)
+
+        when: "querying the executions API for the job"
+            def result = viewHistoryClient.get(
+                "/project/${TEST_PROJECT}/executions?jobIdListFilter=${jobId}",
+                Map
+            )
+
+        then: "the full execution list is returned, matching the total count"
+            result.paging.total == EXECUTION_COUNT
+            result.executions.size() == EXECUTION_COUNT
+    }
+
+    def "user with neither read nor view_history sees an empty execution list"() {
+        given: "a client authenticated as a user with project access but no job-level authorization"
+            def noAccessClient = clientWithToken(noAccessToken)
+
+        when: "querying the executions API for the job"
+            def result = noAccessClient.get(
+                "/project/${TEST_PROJECT}/executions?jobIdListFilter=${jobId}",
+                Map
+            )
+
+        then: "no executions are visible, regardless of the reported total"
+            result.executions.size() == 0
+    }
+}

--- a/functional-test/src/test/resources/ExecutionsQueryViewHistoryAuthSpec.aclpolicy
+++ b/functional-test/src/test/resources/ExecutionsQueryViewHistoryAuthSpec.aclpolicy
@@ -1,0 +1,29 @@
+description: RUN-4665 functional test - project access for view_history repro
+context:
+  application: rundeck
+for:
+  project:
+  - allow:
+    - read
+    equals:
+      name: ExecutionsQueryViewHistoryAuth
+by:
+  group:
+  - Run4665ViewHistory
+  - Run4665NoAccess
+---
+description: RUN-4665 functional test - view_history only, no job read
+context:
+  project: ExecutionsQueryViewHistoryAuth
+for:
+  job:
+  - allow:
+    - view_history
+  resource:
+  - allow:
+    - read
+    equals:
+      kind: event
+by:
+  group:
+  - Run4665ViewHistory

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -3223,8 +3223,12 @@ if executed in cluster mode.""",
 
         def result = results.result
         def total = results.total
-        //filter query results to READ authorized executions
-        def filtered = rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAll(authContext, result, [AuthConstants.ACTION_READ])
+        //filter query results to executions the user can view via READ or VIEW_HISTORY
+        def filtered = rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAny(
+            authContext,
+            result,
+            [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]
+        )
 
         def controller = this
         withFormat {

--- a/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/JobStateService.groovy
@@ -174,7 +174,11 @@ class JobStateService implements AuthorizingJobService {
             }
 
         }
-        executions = rundeckAuthContextEvaluator.filterAuthorizedProjectExecutionsAll(auth,executions,[AuthConstants.ACTION_READ])
+        executions = rundeckAuthContextEvaluator.filterAuthorizedProjectExecutionsAny(
+            auth,
+            executions,
+            [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]
+        )
 
         IFramework framework = frameworkService.getRundeckFramework()
         def frameworkProject = framework.getFrameworkProjectMgr().getFrameworkProject(project)
@@ -419,8 +423,12 @@ class JobStateService implements AuthorizingJobService {
         def results = frameworkService.queryExecutions(query, offset, max)
         def result=results.result
         def total=results.total
-        //filter query results to READ authorized executions
-        def filtered = rundeckAuthContextEvaluator.filterAuthorizedProjectExecutionsAll(auth,result,[AuthConstants.ACTION_READ])
+        //filter query results to executions the user can view via READ or VIEW_HISTORY
+        def filtered = rundeckAuthContextEvaluator.filterAuthorizedProjectExecutionsAny(
+            auth,
+            result,
+            [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]
+        )
         def reflist = filtered.collect { it.asReference() }
         return [result:reflist, total:reflist.size()]
     }

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/AppAuthContextEvaluator.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/AppAuthContextEvaluator.groovy
@@ -57,6 +57,20 @@ interface AppAuthContextEvaluator extends AuthContextEvaluator {
     )
 
     /**
+     * Filter a list of Executions and return only the ones that the user has authorization for any action in the
+     * project context
+     * @param framework
+     * @param execs list of executions
+     * @param actions
+     * @return List of authorized executions
+     */
+    List<Execution> filterAuthorizedProjectExecutionsAny(
+        AuthContext authContext,
+        List<Execution> execs,
+        Collection<String> actions
+    )
+
+    /**
      * Return true if the user is authorized for all actions for the job in the project context
      * @param framework
      * @param job

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/AppAuthContextEvaluator.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/AppAuthContextEvaluator.groovy
@@ -57,11 +57,11 @@ interface AppAuthContextEvaluator extends AuthContextEvaluator {
     )
 
     /**
-     * Filter a list of Executions and return only the ones that the user has authorization for any action in the
-     * project context
-     * @param framework
+     * Filter a list of Executions and return only the ones that the user has authorization for any one of the
+     * given actions in the project context
+     * @param authContext
      * @param execs list of executions
-     * @param actions
+     * @param actions actions to check, any one of which is sufficient for authorization
      * @return List of authorized executions
      */
     List<Execution> filterAuthorizedProjectExecutionsAny(

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/BaseAuthContextEvaluator.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/BaseAuthContextEvaluator.groovy
@@ -299,11 +299,11 @@ class BaseAuthContextEvaluator implements AppAuthContextEvaluator {
         return results
     }
     /**
-     * Filter a list of Executions and return only the ones that the user has authorization for any action in the
-     * project context
-     * @param framework
+     * Filter a list of Executions and return only the ones that the user has authorization for any one of the
+     * given actions in the project context
+     * @param authContext
      * @param execs list of executions
-     * @param actions
+     * @param actions actions to check, any one of which is sufficient for authorization
      * @return List of authorized executions
      */
     @Override

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/BaseAuthContextEvaluator.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/BaseAuthContextEvaluator.groovy
@@ -299,6 +299,39 @@ class BaseAuthContextEvaluator implements AppAuthContextEvaluator {
         return results
     }
     /**
+     * Filter a list of Executions and return only the ones that the user has authorization for any action in the
+     * project context
+     * @param framework
+     * @param execs list of executions
+     * @param actions
+     * @return List of authorized executions
+     */
+    @Override
+    List<Execution> filterAuthorizedProjectExecutionsAny(
+        AuthContext authContext,
+        List<Execution> execs,
+        Collection<String> actions
+    ) {
+        def semap = [:]
+        def adhocauth = null
+        List<Execution> results = []
+        execs.each { Execution exec ->
+            def ScheduledExecution se = exec.scheduledExecution
+            if (se && null == semap[se.id]) {
+                semap[se.id] = authorizeProjectJobAny(authContext, se, actions, se.project)
+            } else if (!se && null == adhocauth) {
+                adhocauth = authorizeProjectResourceAny(
+                    authContext, AuthConstants.RESOURCE_ADHOC, actions,
+                    exec.project
+                )
+            }
+            if (se ? semap[se.id] : adhocauth) {
+                results << exec
+            }
+        }
+        return results
+    }
+    /**
      * Return true if the user is authorized for all actions for the job in the project context
      * @param framework
      * @param job

--- a/rundeckapp/src/main/groovy/org/rundeck/app/authorization/TimedAuthContextEvaluator.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/authorization/TimedAuthContextEvaluator.groovy
@@ -186,6 +186,19 @@ class TimedAuthContextEvaluator implements AppAuthContextEvaluator {
     }
 
     @Override
+    List<Execution> filterAuthorizedProjectExecutionsAny(
+        final AuthContext authContext,
+        final List<Execution> execs,
+        final Collection<String> actions
+    ) {
+        List<Execution> result = null
+        metricService.withTimer(this.class.name, 'filterAuthorizedProjectExecutionsAny') {
+            result = rundeckAuthContextEvaluator.filterAuthorizedProjectExecutionsAny(authContext, execs, actions)
+        }
+        return result
+    }
+
+    @Override
     boolean authorizeProjectJobAny(
         final AuthContext authContext,
         final ScheduledExecution job,

--- a/rundeckapp/src/test/groovy/org/rundeck/app/authorization/BaseAuthContextEvaluatorSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/authorization/BaseAuthContextEvaluatorSpec.groovy
@@ -20,6 +20,8 @@ import com.dtolabs.rundeck.core.authorization.Attribute
 import com.dtolabs.rundeck.core.authorization.AuthContext
 import com.dtolabs.rundeck.core.authorization.Decision
 import com.dtolabs.rundeck.server.AuthContextEvaluatorCacheManager
+import org.rundeck.core.auth.AuthConstants
+import rundeck.Execution
 import rundeck.ScheduledExecution
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -330,6 +332,53 @@ class BaseAuthContextEvaluatorSpec extends Specification {
             [true, false]  | false
             [false, false] | false
             [true, true]   | true
+    }
+
+    @Unroll
+    def "filterAuthorizedProjectExecutionsAny allows read or view_history"() {
+        given:
+            def test = new BaseAuthContextEvaluator()
+            def auth = Mock(AuthContext)
+            def resources = [
+                ['name': 'name1', 'type': 'job', 'uuid': '8b411ae8-8931-4db9-b12e-8d29a6fec43b', 'group': 'blah/blee']
+            ].toSet()
+            test.authContextEvaluatorCacheManager = Mock(AuthCache) {
+                _ * evaluate(
+                    auth,
+                    resources,
+                    [AuthConstants.ACTION_READ].toSet(),
+                    'testProject'
+                ) >> makeDecisions([readAuthorized])
+                _ * evaluate(
+                    auth,
+                    resources,
+                    [AuthConstants.VIEW_HISTORY].toSet(),
+                    'testProject'
+                ) >> makeDecisions([viewHistoryAuthorized])
+            }
+
+            ScheduledExecution job = new ScheduledExecution(
+                jobName: 'name1',
+                groupPath: 'blah/blee',
+                uuid: '8b411ae8-8931-4db9-b12e-8d29a6fec43b',
+                project: 'testProject'
+            )
+            Execution exec = new Execution(scheduledExecution: job, project: 'testProject')
+        when:
+            def result = test.filterAuthorizedProjectExecutionsAny(
+                auth,
+                [exec],
+                [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]
+            )
+        then:
+            (result.size() == 1) == expectIncluded
+
+        where:
+            readAuthorized | viewHistoryAuthorized | expectIncluded
+            true           | false                 | true
+            false          | true                  | true
+            true           | true                  | true
+            false          | false                 | false
     }
 
     public HashSet<Decision> makeDecisions(List<Boolean> decisions) {

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionController2Spec.groovy
@@ -367,7 +367,7 @@ class ExecutionController2Spec extends Specification implements ControllerUnitTe
             controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
                 1 * getAuthContextForSubjectAndProject(_, _)
 
-                1 * filterAuthorizedProjectExecutionsAll(*_) >> []
+                1 * filterAuthorizedProjectExecutionsAny(*_) >> []
             }
         controller.frameworkService=fwkControl
         def execControl = Mock(ExecutionService)
@@ -490,7 +490,7 @@ class ExecutionController2Spec extends Specification implements ControllerUnitTe
             controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
                 1 * getAuthContextForSubjectAndProject(_, _)
 
-                1 * filterAuthorizedProjectExecutionsAll(_,[],_) >> []
+                1 * filterAuthorizedProjectExecutionsAny(_,[],_) >> []
             }
         controller.frameworkService = fwkControl
         controller.request.api_version = 11

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionControllerSpec.groovy
@@ -167,7 +167,7 @@ class ExecutionControllerSpec extends Specification implements ControllerUnitTes
         1 * controller.rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(_, 'test')
 
         1 * controller.executionService.queryExecutions(query, 0, 20) >> [result: [], total: 1]
-        1 * controller.rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAll(_, [], [AuthConstants.ACTION_READ]) >> []
+        1 * controller.rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAny(_, [], [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]) >> []
         respondJson * controller.executionService.respondExecutionsJson(_, _, [], [total: 1, offset: 0, max: 20],_)
         respondXml * controller.executionService.respondExecutionsXml(_, _, [], [total: 1, offset: 0, max: 20])
 
@@ -207,7 +207,7 @@ class ExecutionControllerSpec extends Specification implements ControllerUnitTes
         1 * controller.apiService.requireApi(_, _) >> true
 
         1 * controller.executionService.queryExecutions(query, 0, 20) >> [result: [], total: 1]
-        1 * controller.rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAll(_, [], [AuthConstants.ACTION_READ]) >> []
+        1 * controller.rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAny(_, [], [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]) >> []
         1 * controller.frameworkService.existsFrameworkProject('test') >> true
         1 * controller.apiService.requireExists(_,true,['Project','test']) >> true
     }
@@ -239,7 +239,7 @@ class ExecutionControllerSpec extends Specification implements ControllerUnitTes
         1 * controller.apiService.requireApi(_, _) >> true
 
         1 * controller.executionService.queryExecutions(query, 0, 20) >> [result: [], total: 1]
-        1 * controller.rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAll(_, [], [AuthConstants.ACTION_READ]) >> []
+        1 * controller.rundeckAuthContextProcessor.filterAuthorizedProjectExecutionsAny(_, [], [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]) >> []
 
         1 * controller.frameworkService.existsFrameworkProject('test') >> true
         1 * controller.apiService.requireExists(_,true,['Project','test']) >> true

--- a/rundeckapp/src/test/groovy/rundeck/services/JobStateServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/JobStateServiceSpec.groovy
@@ -54,6 +54,9 @@ class JobStateServiceSpec extends Specification implements ServiceUnitTest<JobSt
             filterAuthorizedProjectExecutionsAll(null, !null, !null) >> { auth, exec, actions ->
                 return exec
             }
+            filterAuthorizedProjectExecutionsAny(null, !null, !null) >> { auth, exec, actions ->
+                return exec
+            }
         }
         service.frameworkService=Mock(FrameworkService){
             kickJob(!null, !null, null,!null)>>{
@@ -549,7 +552,7 @@ class JobStateServiceSpec extends Specification implements ServiceUnitTest<JobSt
             }
             [result: [], total: 0]
         }
-        1 * service.rundeckAuthContextEvaluator.filterAuthorizedProjectExecutionsAll(_, _, [AuthConstants.ACTION_READ]) >>
+        1 * service.rundeckAuthContextEvaluator.filterAuthorizedProjectExecutionsAny(_, _, [AuthConstants.ACTION_READ, AuthConstants.VIEW_HISTORY]) >>
                 {authcontext, inputArr, actions ->
             return inputArr
         }


### PR DESCRIPTION
## Release Notes

Fixed a regression in 6.0 where users granted only the `view_history` job ACL permission could not see job execution history through the executions API or `rd executions query`—the total count was returned but the execution list was always empty. Users with `view_history` (without full job `read` access) can now view execution history again, matching the behavior already supported on the History page.

## Jira Ticket
[RUN-4665](https://pagerduty.atlassian.net/browse/RUN-4665)

## Summary
Users granted only the `view_history` job ACL action (without `read`) could no longer see job execution history via `rd executions query` / the `/api/*/project/{project}/executions` endpoint on 6.0.x. The execution count came back correct but the returned list was always empty, because the result filter only ever checked `ACTION_READ`. Granting full `read` worked around it, but that exposes far more (e.g. job definition export) than customers want.

`ReportService`'s `/history` endpoint already treats `read`, `view`, and `view_history` as any-of sufficient for visibility (see `authorizeViewHistoryJob`), but `ExecutionController`/`JobStateService` never adopted that pattern for the executions query path.

## Changes
- Added `filterAuthorizedProjectExecutionsAny` (any-of semantics) to `AppAuthContextEvaluator`, `BaseAuthContextEvaluator`, and the `TimedAuthContextEvaluator` metrics decorator, mirroring the existing all-of `filterAuthorizedProjectExecutionsAll` but built on `authorizeProjectJobAny`.
- Switched `ExecutionController.apiExecutionsQueryv14` and both execution-listing call sites in `JobStateService` to use `filterAuthorizedProjectExecutionsAny(..., [ACTION_READ, VIEW_HISTORY])` instead of `filterAuthorizedProjectExecutionsAll(..., [ACTION_READ])`.
- Added a new `BaseAuthContextEvaluatorSpec` test proving the any-of semantics (authorized via `view_history` alone, or `read` alone, or both; denied when neither).
- Updated existing mocks/expectations in `ExecutionControllerSpec`, `ExecutionController2Spec`, and `JobStateServiceSpec` to match.

## Testing
- `./gradlew :rundeckapp:test --tests "org.rundeck.app.authorization.BaseAuthContextEvaluatorSpec" --tests "rundeck.services.JobStateServiceSpec" --tests "rundeck.controllers.ExecutionControllerSpec" --tests "rundeck.controllers.ExecutionController2Spec"` — pass
- Full `./gradlew :rundeckapp:test` — pass, no regressions

[RUN-4665]: https://pagerduty.atlassian.net/browse/RUN-4665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


fixes: #10336 