### PR TITLE
[RUN-4667] Increase .col line-height in status email template

### DIFF
--- a/rundeckapp/grails-app/views/execution/mailNotification/_newStatus.gsp
+++ b/rundeckapp/grails-app/views/execution/mailNotification/_newStatus.gsp
@@ -88,7 +88,7 @@
 
     .col {
       font-size: 16px;
-      line-height: 26px;
+      line-height: 38px;
       vertical-align: top;
     }
 
@@ -115,7 +115,7 @@
       .col {
         box-sizing: border-box;
         display: inline-block !important;
-        line-height: 23px;
+        line-height: 34px;
         width: 100% !important;
       }
 


### PR DESCRIPTION
## Jira Ticket
[RUN-4667](https://pagerduty.atlassian.net/browse/RUN-4667) - Email notification: Job title overlaps when wrapped into multiple lines

## Summary
The status notification email template (`_newStatus.gsp`) uses a `.col` CSS class with a `line-height` of 26px (desktop) / 23px (mobile). When a job title wraps into multiple lines, this line-height is too tight and the wrapped lines visually overlap.

## Changes
- `.col` desktop line-height: `26px` → `38px`
- `.col` mobile line-height (`@media max-width: 699px`): `23px` → `34px`

Both values are scoped to this one email template's inline `<style>` block; no other views share this stylesheet.

## Testing
Rendered the status notification email preview locally and confirmed multi-line job titles no longer overlap, at both desktop and mobile widths.

[RUN-4667]: https://pagerduty.atlassian.net/browse/RUN-4667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ