### PR TITLE
[RUN-4670] Guard buildscript Maven Central declaration with mavenCentralUrl check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,17 +24,20 @@
 
 buildscript {
     repositories {
-        maven {
-            name 'mavenCentralProxy'
-            url mavenCentralUrl
-            if (project.hasProperty('mavenUser') && project.hasProperty('mavenPassword')) {
-                credentials {
-                    username mavenUser
-                    password mavenPassword
+        if (project.findProperty('mavenCentralUrl')) {
+            maven {
+                name 'mavenCentralProxy'
+                url mavenCentralUrl
+                if (project.hasProperty('mavenUser') && project.hasProperty('mavenPassword')) {
+                    credentials {
+                        username mavenUser
+                        password mavenPassword
+                    }
                 }
             }
+        } else {
+            mavenCentral()
         }
-        mavenCentral()
     }
     dependencies {
         classpath 'com.adaptc.gradle:nexus-workflow:0.8'


### PR DESCRIPTION
## Summary

The root `buildscript { repositories {} }` block declared both a `mavenCentralUrl`-based alias (`repo1.maven.org`) and a bare `mavenCentral()` (`repo.maven.apache.org`) unconditionally. Both resolve the same underlying Maven Central content, so every buildscript classpath dependency lookup (in real Gradle builds and in Renovate dependency scans) was checking Maven Central twice under two different hostnames.

## Root cause

This is a regression of intentional either/or logic introduced in `edbfb438` ("Use mavenCentral by default unless mavenCentralUrl is overridden", 2022-04-18), which added this exact guard to `gradle/java.gradle`:

```groovy
if (project.findProperty('mavenCentralUrl')) {
    maven { name 'mavenCentralProxy'; url mavenCentralUrl }
} else {
    mavenCentral()
}
```

`mavenCentralUrl` is meant as an opt-in override for pointing builds at an internal mirror; by default it should fall back to plain `mavenCentral()`. The root `build.gradle`'s own `buildscript` block never adopted this guard -- both branches were unconditionally active.

## Fix

Apply the same conditional guard to the `buildscript` repositories block.

## Verified not a duplicate elsewhere

Swept the whole repo for `mavenCentralUrl` + `mavenCentral()` co-occurring in the same file:
- `gradle/java.gradle` -- only declares the `mavenCentralUrl` alias, no `mavenCentral()`, not affected.
- `build.gradle:347` -- a separate, unrelated top-level `repositories {}` block for the root project's own dependencies (not buildscript), only has `mavenCentral()` with no nearby `mavenCentralUrl` alias -- not a duplicate.

This was the only instance of the bug.

Jira: RUN-4670

## Test plan

- [ ] `./gradlew build -x check` succeeds
- [ ] Confirm buildscript classpath dependencies (`nexus-workflow`, `osdetector-gradle-plugin`, `snakeyaml`, `dependency-check-gradle`) still resolve correctly