### PR TITLE
[RUN-4678] Remove unused net.i2p.crypto:eddsa dependency (CVE-2020-36843)

### DIFF
--- a/plugins/git-plugin/build.gradle
+++ b/plugins/git-plugin/build.gradle
@@ -52,11 +52,9 @@ dependencies {
     implementation "org.apache.groovy:groovy:${groovyVersion}"
     implementation group: 'com.hierynomus', name: 'sshj', version: '0.40.0'
     implementation group: 'com.hierynomus', name: 'asn-one', version: '0.6.0'
-    implementation 'net.i2p.crypto:eddsa:0.3.0'
 
     pluginLibs group: 'com.hierynomus', name: 'sshj', version: '0.40.0', ext: 'jar'
     pluginLibs group: 'com.hierynomus', name: 'asn-one', version: '0.6.0', ext: 'jar'
-    pluginLibs 'net.i2p.crypto:eddsa:0.3.0'
 
     implementation ("org.bouncycastle:bcprov-jdk18on:${bouncyCastleVersion}")
     implementation ("org.bouncycastle:bcpg-jdk18on:${bouncyCastleVersion}")


### PR DESCRIPTION
## Summary

Removes the direct `net.i2p.crypto:eddsa:0.3.0` dependency from `git-plugin`, resolving [RUN-4678](https://pagerduty.atlassian.net/browse/RUN-4678) / [CVE-2020-36843](https://nvd.nist.gov/vuln/detail/CVE-2020-36843) (Snyk `SNYK-JAVA-NETI2PCRYPTO-9402849`, signature malleability in EdDSA-Java). The project is unmaintained and has no fixed release, so this removes the dependency entirely rather than patching it.

## Why this is safe

- `net.i2p.crypto:eddsa` was a standalone, direct dependency in `plugins/git-plugin/build.gradle` — it was **not** required transitively by `org.eclipse.jgit`, `org.eclipse.jgit.ssh.jsch`, `sshj`, or `asn-one` (confirmed via the resolved `pluginLibs` dependency tree).
- `sshj` 0.40.0's Ed25519 support (`SignatureEdDSA`, `Ed25519KeyFactory`) goes through the standard JCA `"Ed25519"` algorithm name (`KeyFactory`/`Signature.getInstance("Ed25519")`), not through `net.i2p.crypto.eddsa` classes directly.
- Ed25519 is natively supported by the JDK since Java 15 (JEP 339); this module targets Java 17. BouncyCastle (`bcprov-jdk18on`, already on the classpath via `bcpkix-jdk18on`) also implements Ed25519 natively.
- No source in `git-plugin` references `net.i2p.crypto.eddsa`/`EdDSA`/`Ed25519` directly.

## Test plan

- [x] `./gradlew :plugins:git-plugin:dependencies --configuration pluginLibs` — confirmed `net.i2p.crypto:eddsa` no longer appears in the resolved graph
- [x] `./gradlew :plugins:git-plugin:clean :plugins:git-plugin:test :plugins:git-plugin:build -x check` — passes
- [x] Standalone smoke test exercising `sshj`'s `SignatureEdDSA` class directly (Ed25519 keygen, sign, verify) against the plugin's actual runtime classpath with the eddsa jar absent — signing and verification succeed via the JDK's native JCA provider

[RUN-4678]: https://pagerduty.atlassian.net/browse/RUN-4678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ