### PR TITLE
[RUN-4680] Fix CVE-2026-41907 nested uuid dependency

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package-lock.json
@@ -113,7 +113,7 @@
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.1",
         "typescript": "^5.4.5",
-        "uuid": "^11.0.0",
+        "uuid": "^11.1.1",
         "vue-eslint-parser": "^9.4.0",
         "vue-loader": "^17.4.2",
         "walk": "^2.3.15",
@@ -151,6 +151,68 @@
       "integrity": "sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://npm.artifacts.pd-internal.com/npm/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.11.0",
+      "resolved": "https://npm.artifacts.pd-internal.com/npm/@azure/core-auth/-/core-auth-1.11.0.tgz",
+      "integrity": "sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.14.0",
+      "resolved": "https://npm.artifacts.pd-internal.com/npm/@azure/core-util/-/core-util-1.14.0.tgz",
+      "integrity": "sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/ms-rest-js": {
+      "version": "2.7.0",
+      "resolved": "https://npm.artifacts.pd-internal.com/npm/@azure/ms-rest-js/-/ms-rest-js-2.7.0.tgz",
+      "integrity": "sha512-ngbzWbqF+NmztDOpLBVDxYM+XLcUj7nKhxGbSU9WtIsXfRB//cf2ZbAG5HkOrhU9/wd/ORRB6lM/d69RKVjiyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.1.4",
+        "abort-controller": "^3.0.0",
+        "form-data": "^2.5.0",
+        "node-fetch": "^2.6.7",
+        "tslib": "^1.10.0",
+        "tunnel": "0.0.6",
+        "uuid": "^8.3.2",
+        "xml2js": "^0.5.0"
+      }
+    },
+    "node_modules/@azure/ms-rest-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://npm.artifacts.pd-internal.com/npm/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -4012,39 +4074,6 @@
         "promise-queue": "^2.2.5"
       }
     },
-    "node_modules/@rundeck/client/node_modules/@azure/ms-rest-js": {
-      "version": "2.0.7",
-      "resolved": "https://npm.artifacts.pd-internal.com/npm/@azure/ms-rest-js/-/ms-rest-js-2.0.7.tgz",
-      "integrity": "sha512-rQpNxDhyOIyS4E+4sUCBMvjrtbNwB32wH06cC2SFoQM4TR29bIKaTlIC1tMe0K07w9c5tNk/2uUHs6/ld/Z3+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node-fetch": "^2.3.7",
-        "@types/tunnel": "0.0.1",
-        "abort-controller": "^3.0.0",
-        "form-data": "^2.5.0",
-        "node-fetch": "^2.6.0",
-        "tough-cookie": "^3.0.1",
-        "tslib": "^1.10.0",
-        "tunnel": "0.0.6",
-        "uuid": "^3.3.2",
-        "xml2js": "^0.4.19"
-      }
-    },
-    "node_modules/@rundeck/client/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://npm.artifacts.pd-internal.com/npm/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
-    "node_modules/@rundeck/client/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://npm.artifacts.pd-internal.com/npm/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/@sideway/address/-/address-4.1.5.tgz",
@@ -4208,20 +4237,6 @@
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@storybook/addon-actions/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://npm.artifacts.pd-internal.com/npm/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/@storybook/addon-backgrounds": {
       "version": "8.4.5",
@@ -6077,17 +6092,8 @@
     "node_modules/@types/node": {
       "version": "14.18.63",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://npm.artifacts.pd-internal.com/npm/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
-      }
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.11",
@@ -6201,15 +6207,6 @@
       "resolved": "https://npm.artifacts.pd-internal.com/npm/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "optional": true
-    },
-    "node_modules/@types/tunnel": {
-      "version": "0.0.1",
-      "resolved": "https://npm.artifacts.pd-internal.com/npm/@types/tunnel/-/tunnel-0.0.1.tgz",
-      "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/unist": {
       "version": "3.0.2",
@@ -6490,6 +6487,55 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.7",
+      "resolved": "https://npm.artifacts.pd-internal.com/npm/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.7.tgz",
+      "integrity": "sha512-JVUD8X2tfDMWjcjLs4yVxxVrS8yR5vnh386GAXT9Qj79nBxxXSaHFQZg5FweLmT8HlPQ3kii6noUB+Z9RN7DvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://npm.artifacts.pd-internal.com/npm/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://npm.artifacts.pd-internal.com/npm/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://npm.artifacts.pd-internal.com/npm/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -16151,16 +16197,6 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/jest-junit/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://npm.artifacts.pd-internal.com/npm/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
@@ -21228,7 +21264,8 @@
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "dev": true
     },
     "node_modules/pug": {
       "version": "3.0.3",
@@ -21380,6 +21417,7 @@
       "version": "2.3.1",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -21429,7 +21467,8 @@
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -21901,7 +21940,8 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -22823,16 +22863,6 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
-      }
-    },
-    "node_modules/sockjs/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://npm.artifacts.pd-internal.com/npm/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/sortablejs": {
@@ -23962,6 +23992,7 @@
       "version": "4.1.4",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/tough-cookie/-/tough-cookie-4.1.4.tgz",
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "psl": "^1.1.33",
@@ -23977,6 +24008,7 @@
       "version": "0.2.0",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -24788,6 +24820,7 @@
       "version": "1.5.10",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -24849,7 +24882,6 @@
       "version": "11.1.1",
       "resolved": "https://npm.artifacts.pd-internal.com/npm/uuid/-/uuid-11.1.1.tgz",
       "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/rundeckapp/grails-spa/packages/ui-trellis/package.json
+++ b/rundeckapp/grails-spa/packages/ui-trellis/package.json
@@ -146,7 +146,7 @@
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.1",
     "typescript": "^5.4.5",
-    "uuid": "^11.0.0",
+    "uuid": "^11.1.1",
     "vue-eslint-parser": "^9.4.0",
     "vue-loader": "^17.4.2",
     "walk": "^2.3.15",
@@ -173,7 +173,9 @@
     "xml2js": "^0.5.0",
     "lodash": "4.18.1",
     "@babel/runtime": "^7.26.10",
-    "tough-cookie": "^4.1.3"
+    "tough-cookie": "^4.1.3",
+    "@azure/ms-rest-js": "2.7.0",
+    "uuid": "$uuid"
   },
   "jest-junit": {
     "outputDirectory": "./build/test-results",


### PR DESCRIPTION
## Tell us about your PR

**Is this a bug fix, or an enhancement? Please describe.**
Security fix for CVE-2026-41907 / SNYK-JS-UUID-16133035. Direct `uuid` was already at 11.x, but scanners still reported vulnerable nested `uuid@3.4.0` via `@rundeck/client` → `@azure/ms-rest-js@2.0.7`.

**Describe the solution you've implemented**
- Pin `uuid` to `^11.1.1` (patched version)
- Add npm overrides for `uuid: $uuid` so nested copies cannot remain on 3.x/8.x/9.x
- Override `@azure/ms-rest-js` to `2.7.0`, which uses `uuid.v4()` and is compatible with uuid 11 (2.0.7 used the removed `require('uuid/v4')` deep import)

**Describe alternatives you've considered**
- Overriding only `uuid` to 11 without upgrading `ms-rest-js` — breaks `@azure/ms-rest-js@2.0.7` because it requires `uuid/v4`
- Waiting for a new `@rundeck/client` release — longer path; override clears the finding now

**Additional context**
- Jira: [RUN-4680](https://pagerduty.atlassian.net/browse/RUN-4680)
- Path previously flagged: `@rundeck/ui-trellis` → `@rundeck/client@0.2.5` → `@azure/ms-rest-js@2.0.7` → `uuid@3.4.0`
- Verified with `npm list uuid` that all paths resolve to `uuid@11.1.1`

## Release Notes

[RUN-4680]: https://pagerduty.atlassian.net/browse/RUN-4680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ