### PR TITLE
[RUN-4668] Fix email notification content hidden on mobile clients

### DIFF
--- a/rundeckapp/grails-app/views/execution/mailNotification/_newStatus.gsp
+++ b/rundeckapp/grails-app/views/execution/mailNotification/_newStatus.gsp
@@ -226,17 +226,10 @@
         padding-left: 0 !important;
       }
 
-      .toggle-content {
-        max-height: 0;
-        overflow: auto;
-        transition: max-height .4s linear;
-        -webkit-transition: max-height .4s linear;
-      }
-
-      .toggle-trigger:hover+.toggle-content,
-      .toggle-content:hover {
-        max-height: 999px !important;
-      }
+      <%-- .toggle-content/.toggle-trigger were previously collapsed via max-height:0 and
+           only revealed on :hover, which never fires on touch devices (Android mail apps)
+           once this media query collapses them, permanently hiding the section. Removed
+           so Job Description/Nodes/Log Output stay visible everywhere. --%>
 
       .show-sm {
         display: inherit !important;

--- a/rundeckapp/grails-app/views/execution/mailNotification/_newStatus.gsp
+++ b/rundeckapp/grails-app/views/execution/mailNotification/_newStatus.gsp
@@ -474,7 +474,7 @@
                 </h3>
                 <h1 style="margin: 10px 0 15px 0;">
                   <g:link controller="execution" action="show" id="${execution.id}" class="job-link"
-                    absolute="${absolute ? 'true' : 'false'}"
+                    absolute="true"
                     params="${(followparams?.findAll { it.value }?:[:]) + [project: execution.project]}">
                     <g:if test="${scheduledExecution}">
                       <g:message code="scheduledExecution.identity"


### PR DESCRIPTION
## Release Notes

Fixed job notification emails so Job Description, Nodes, and Log Output stay visible on mobile and touch-based mail clients, where hover-based expand/collapse previously hid that content permanently. Also fixed the job title link in notification emails to use a full URL so it opens correctly when clicked from an email client.

## PR Details

## Summary
- The notification email's "Job Description", "Nodes", and "Log Output" sections were collapsed via CSS (`max-height: 0`) at mobile widths and only revealed on `:hover`.
- Touch devices (e.g. Android mail apps) have no hover state, so once the mobile media query collapsed these sections, their content became permanently invisible — not just a styling quirk, but missing information.
- Removed the hover-based collapse so these sections render visible by default in all clients.

Related: [RUN-4668](https://pagerduty.atlassian.net/browse/RUN-4668)

## Test plan
- [x] `./gradlew build -x check` passes locally
- [ ] Manual check: trigger a job notification email and confirm Job Description/Nodes/Log Output are visible in Outlook and an Android mail client (no automated test renders this GSP)

[RUN-4668]: https://pagerduty.atlassian.net/browse/RUN-4668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
