### PR TITLE
[RUN-4642] Update plugin publishing docs to PackageCloud

### DIFF
--- a/.claude/docs/plugin-development.md
+++ b/.claude/docs/plugin-development.md
@@ -74,7 +74,7 @@ Easiest integration with GitHub
 
 **Triggers**: On tags `v*`
 
-**Example**: [rundeck-ec2-nodes-plugin release.yml](https://github.com/rundeck-plugins/rundeck-ec2-nodes-plugin/blob/main/.github/workflows/release.yml)
+**Example**: [sshj-plugin release.yml](https://github.com/rundeck-plugins/sshj-plugin/blob/main/.github/workflows/release.yml)
 
 **Steps**:
 - Same build steps as build.yml
@@ -137,45 +137,74 @@ git push v1.2.3
 
 ### Open Source Plugins
 
-#### Maven Central (Preferred)
+#### PackageCloud (Preferred)
 
-**Example**: [rundeck-ec2-nodes-plugin](https://github.com/rundeck-plugins/rundeck-ec2-nodes-plugin)
+> **Maven Central is no longer used for `rundeck-plugins` publishing.** `org.rundeck` exceeded Maven Central's
+> free publishing limits (see RUN-4570), so plugin publishing moved to PagerDuty's PackageCloud Maven repository
+> (`packagecloud.io/pagerduty/rundeck-plugins/maven2`). Do not add `nexusPublish`/`nexusPublishing`/Sonatype
+> config to new or existing plugins.
+
+**Example**: [sshj-plugin](https://github.com/rundeck-plugins/sshj-plugin) (pilot migration)
 
 **Setup Steps**:
 
-1. **Add release process to CI (GitHub Actions)**:
-   ```bash
-   ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
-   ```
-   Requires signing and sonatype secrets
-
-2. **Update build.gradle**:
-   - Add `nexusPublish` gradle plugin
-   - Add `nexusPublishing` configuration:
+1. **Update build.gradle** — remove any `nexusPublish`/`nexusPublishing` block and configure the PackageCloud
+   Maven repository instead:
    ```groovy
-   nexusPublishing {
+   def pkgcldRepoUrl = (System.getenv("PKGCLD_REPO_URL") ?: "https://packagecloud.io/pagerduty/rundeck-plugins/maven2").trim()
+   publishing {
        repositories {
-           sonatype {
-               nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-               snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+           maven {
+               name = "PackageCloud"
+               url = uri(pkgcldRepoUrl)
+               authentication { header(HttpHeaderAuthentication) }
+               credentials(HttpHeaderCredentials) {
+                   name = "Authorization"
+                   value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
+               }
            }
        }
    }
    ```
+   The `PKGCLD_REPO_URL` fallback default keeps unrelated CI jobs (e.g. `gradlew build` in `gradle.yml`) working
+   even when the env var isn't set — the URL is evaluated eagerly at configuration time, so it can't be null.
 
-3. **Apply publishing.gradle**:
+2. **Add release process to CI (GitHub Actions)**:
+   ```bash
+   ./gradlew publishAllPublicationsToPackageCloudRepository
+   ```
+   (Task name is derived from the `name = "PackageCloud"` repository above — verify the actual task name with
+   `./gradlew tasks --all | grep -i packagecloud` for each repo, since it can differ for zip-based plugins using
+   a `mavenZip(MavenPublication)` publication.)
+
+3. **Sign artifacts with real `gpg`, not Gradle's `signing` plugin**: PackageCloud rejects the checksum file
+   Gradle generates for the `.asc` signature (`*.jar.asc.sha1` → HTTP 422). Sign with the `gpg` CLI and upload
+   only the resulting `.asc` via `curl`, bypassing Gradle's checksum machinery for that artifact. See the
+   `migrate-plugin-to-packagecloud` skill (or an already-migrated repo's `release.yml`) for the exact step.
+
+4. **Apply publishing.gradle**:
    - Define project extension properties
    - Specify: `group = 'org.rundeck.plugins'`
    - Update `java` configuration:
      - Add `withJavadocJar()`
-     - Add `withSourcesJar()` (required by Maven Central)
+     - Add `withSourcesJar()`
 
-4. **Fix javadoc issues**:
+5. **Fix javadoc issues**:
    - Required before publishing (javadoc step will fail otherwise)
 
-5. **Configure GitHub Org Secrets**:
+6. **Configure GitHub Org Secrets**:
    - [rundeck-plugins secrets](https://github.com/organizations/rundeck-plugins/settings/secrets/actions)
-   - Required: `SIGNING_KEY_B64`, `SIGNING_PASSWORD`, `SONATYPE_PASSWORD`, `SONATYPE_USERNAME`
+   - Required: `PKGCLD_WRITE_TOKEN`, `SIGNING_KEY_B64`, `SIGNING_PASSWORD`
+   - `PKGCLD_REPO_URL` is set as a GitHub Actions **variable** (not secret) at the org level
+
+7. **Verify the GPG signing key hasn't expired**: `gpg --show-keys --with-colons <key>` — Gradle's
+   `useInMemoryPgpKeys` (Bouncy Castle) does not enforce key expiration, but real `gpg` does, so an expired key
+   fails only when the manual signing step runs.
+
+**Maven Central (deprecated for `rundeck-plugins`)**: still applicable to other orgs/repos that haven't hit the
+publishing limit. If reintroducing it elsewhere, it required the `nexusPublish` gradle plugin, a `nexusPublishing`
+block pointing at `https://ossrh-staging-api.central.sonatype.com/service/local/`, and
+`SIGNING_KEY_B64`/`SIGNING_PASSWORD`/`SONATYPE_USERNAME`/`SONATYPE_PASSWORD` secrets.
 
 #### JitPack (DEPRECATED - DO NOT USE)
 

--- a/.claude/docs/plugin-development.md
+++ b/.claude/docs/plugin-development.md
@@ -139,11 +139,6 @@ git push v1.2.3
 
 #### PackageCloud (Preferred)
 
-> **Maven Central is no longer used for `rundeck-plugins` publishing.** `org.rundeck` exceeded Maven Central's
-> free publishing limits (see RUN-4570), so plugin publishing moved to PagerDuty's PackageCloud Maven repository
-> (`packagecloud.io/pagerduty/rundeck-plugins/maven2`). Do not add `nexusPublish`/`nexusPublishing`/Sonatype
-> config to new or existing plugins.
-
 **Example**: [sshj-plugin](https://github.com/rundeck-plugins/sshj-plugin) (pilot migration)
 
 **Setup Steps**:

--- a/.claude/skills/create-plugin/SKILL.md
+++ b/.claude/skills/create-plugin/SKILL.md
@@ -343,16 +343,21 @@ jobs:
 
 ### Phase 8: Publishing (Optional, for open source)
 
-**Maven Central** (Preferred over JitPack):
+**PackageCloud** (Preferred over JitPack; replaces Maven Central for `rundeck-plugins` — see RUN-4570):
 
 **Requirements**:
-1. Apply `nexusPublish` gradle plugin
-2. Configure `nexusPublishing` block
-3. Add `withJavadocJar()` and `withSourcesJar()`
-4. Fix javadoc issues
-5. Configure Github secrets (SIGNING_KEY_B64, SIGNING_PASSWORD, SONATYPE_USERNAME, SONATYPE_PASSWORD)
+1. Configure a `maven` publishing repository pointing at
+   `https://packagecloud.io/pagerduty/rundeck-plugins/maven2` (Bearer token auth via `PKGCLD_WRITE_TOKEN`) —
+   do **not** apply `nexusPublish`/`nexusPublishing`
+2. Add `withJavadocJar()` and `withSourcesJar()`
+3. Fix javadoc issues
+4. Sign artifacts with the real `gpg` CLI (not Gradle's `signing` plugin) and upload the `.asc` via `curl` —
+   PackageCloud rejects Gradle's auto-generated checksum-of-signature file
+5. Configure Github secrets (`PKGCLD_WRITE_TOKEN`, `SIGNING_KEY_B64`, `SIGNING_PASSWORD`) and the
+   `PKGCLD_REPO_URL` org variable
 
-**See**: `.claude/docs/plugin-development.md` for complete publishing setup
+**See**: `.claude/docs/plugin-development.md` and the `migrate-plugin-to-packagecloud` skill for complete
+publishing setup
 
 ---
 
@@ -404,10 +409,11 @@ Before considering plugin complete:
 - [ ] Howto documentation in README
 
 **Publishing (if standalone, open source):**
-- [ ] GitHub secrets configured (SIGNING_KEY_B64, SIGNING_PASSWORD, SONATYPE_USERNAME, SONATYPE_PASSWORD)
+- [ ] GitHub secrets configured (PKGCLD_WRITE_TOKEN, SIGNING_KEY_B64, SIGNING_PASSWORD)
+- [ ] PKGCLD_REPO_URL org variable set
 - [ ] Javadoc fixed (no errors)
 - [ ] Release workflow tested
-- [ ] Maven Central publishing verified
+- [ ] PackageCloud publishing verified
 
 ---
 


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Documentation fix. [RUN-4642](https://pagerduty.atlassian.net/browse/RUN-4642) tracks reviewing all docs that reference Maven Central as the plugin publishing target, now that `org.rundeck` plugin publishing has moved to PagerDuty's PackageCloud (RUN-4570/RUN-4638). `.claude/docs/plugin-development.md` and `.claude/skills/create-plugin/SKILL.md` still instructed contributors to set up `nexusPublish`/Sonatype publishing and configure `SONATYPE_*` secrets, which is no longer how `rundeck-plugins` repos publish.

**Describe the solution you've implemented**
- Replaced the "Maven Central (Preferred)" section in both files with a "PackageCloud (Preferred)" section describing the actual validated flow: the `publishing { repositories { maven { ... } } }` block pointing at `packagecloud.io/pagerduty/rundeck-plugins/maven2`, the `PKGCLD_WRITE_TOKEN`/`PKGCLD_REPO_URL` secrets/variable, and the manual `gpg`+`curl` signing step required because PackageCloud rejects Gradle's auto-generated checksum-of-signature file.
- Updated the `release.yml` example link and the publishing checklist items in `create-plugin/SKILL.md` to match.
- Left a short note pointing out Maven Central/Sonatype config is still valid for other repos that haven't hit the publishing limit, in case it's needed elsewhere.

**Describe alternatives you've considered**
Could have deleted the Maven Central instructions outright, but kept a brief deprecated-but-documented note since the underlying Sonatype setup is still technically correct for repos outside `rundeck-plugins`.

**Additional context**
No code changes — `.claude/docs/` and `.claude/skills/` only. Part of the broader RUN-4642 documentation review; other doc areas (docs.rundeck.com, individual plugin repo READMEs, internal wiki) are tracked separately.

## Release Notes

N/A — internal contributor documentation only, no user-facing change.


[RUN-4642]: https://pagerduty.atlassian.net/browse/RUN-4642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ