### PR TITLE
[RUN-4664] Fix project home executions stat links missing last-day filter

### DIFF
--- a/rundeckapp/grails-app/views/menu/home.gsp
+++ b/rundeckapp/grails-app/views/menu/home.gsp
@@ -316,7 +316,7 @@
 										<div class="col-sm-6 col-md-2 text-center">
 											<div data-bind="if: $root.projectForName(project)">
 												<a data-bind="css: { 'text-secondary': $root.projectForName(project).execCount()<1 }, urlPathParam: project,  bootstrapPopover: true, bootstrapPopoverContentRef: '#exec_detail_'+project "
-												   href="${g.createLink(controller: "reports", action: "index", params: [project: '<$>'])}"
+												   href="${g.createLink(controller: "reports", action: "index", params: [project: '<$>', recentFilter: '1d'])}"
 												   class="as-block link-hover link-block-padded text-inverse "
 												   data-toggle="popover"
 												   data-placement="bottom"
@@ -363,7 +363,7 @@
 													   href="${g.createLink(
 															   controller: "reports",
 															   action: "index",
-															   params: [project: '<$>', statFilter: 'fail']
+															   params: [project: '<$>', statFilter: 'fail', recentFilter: '1d']
 													   )}">
 														<span data-bind="messageTemplate: $root.projectForName(project).failedCount()">
 															<g:message

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/HomeBrowserItem.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/HomeBrowserItem.vue
@@ -63,7 +63,7 @@
       <!--      TODO: ADJUST THIS SECTION ONCE ACTIVITY IS REFACTORED -->
       <div class="col-sm-6 col-md-2 text-center">
         <a
-          :href="createLink(`project/${project.name}/activity`)"
+          :href="createLink(`project/${project.name}/activity?recentFilter=1d`)"
           class="as-block link-hover link-block-padded text-inverse"
           :class="{ 'text-secondary': project.execCount < 1 }"
           data-toggle="popover"
@@ -116,7 +116,11 @@
         <a
           v-if="project.failedCount > 0"
           class="text-warning"
-          :href="createLink(`project/${project.name}/activity?statFilter=fail`)"
+          :href="
+            createLink(
+              `project/${project.name}/activity?statFilter=fail&recentFilter=1d`,
+            )
+          "
         >
           <span>
             {{ project.failedCount

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/tests/HomeBrowserItem.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/home/tests/HomeBrowserItem.spec.ts
@@ -129,6 +129,17 @@ describe("HomeBrowserItem", () => {
     );
   });
 
+  it("links execution count and failed count to activity filtered to the last day", async () => {
+    const wrapper = await mountHomeBrowserItem();
+
+    expect(wrapper.find(".as-block").attributes("href")).toBe(
+      "http://localhost:4440/project/example/activity?recentFilter=1d",
+    );
+    expect(wrapper.find("a.text-warning").attributes("href")).toBe(
+      "http://localhost:4440/project/example/activity?statFilter=fail&recentFilter=1d",
+    );
+  });
+
   it("renders loading state when loaded is false", async () => {
     const wrapper = await mountHomeBrowserItem({
       loaded: false,

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-dashboard/components/activitySummary.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-dashboard/components/activitySummary.spec.ts
@@ -37,7 +37,7 @@ describe("EditProjectFile", () => {
       rdBase: "http://localhost:9999",
     });
     expect(wrapper.find(".card-content a.h4").attributes()["href"]).toBe(
-      "http://localhost:9999/project/test/activity",
+      "http://localhost:9999/project/test/activity?recentFilter=1d",
     );
   });
 
@@ -64,7 +64,9 @@ describe("EditProjectFile", () => {
       wrapper
         .find(`.card-content [data-test-id="failed-count"] a`)
         .attributes()["href"],
-    ).toBe("http://localhost:9999/project/test/activity?statFilter=fail");
+    ).toBe(
+      "http://localhost:9999/project/test/activity?statFilter=fail&recentFilter=1d",
+    );
   });
   it("does not failed count 0", async () => {
     const wrapper = await mountActivitySummary({

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-dashboard/components/activitySummary.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-dashboard/components/activitySummary.spec.ts
@@ -26,7 +26,7 @@ const mountActivitySummary = async (props = {}) => {
   });
 };
 
-describe("EditProjectFile", () => {
+describe("ActivitySummary", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -68,7 +68,7 @@ describe("EditProjectFile", () => {
       "http://localhost:9999/project/test/activity?statFilter=fail&recentFilter=1d",
     );
   });
-  it("does not failed count 0", async () => {
+  it("does not render failed count link when count is 0", async () => {
     const wrapper = await mountActivitySummary({
       project: { failedCount: 0, name: "test" },
       rdBase: "http://localhost:9999",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-dashboard/components/activitySummary.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-dashboard/components/activitySummary.vue
@@ -3,7 +3,10 @@
     <div class="col-xs-12">
       <div class="card">
         <div class="card-content">
-          <a class="h4" :href="`${rdBase}/project/${project.name}/activity`">
+          <a
+            class="h4"
+            :href="`${rdBase}/project/${project.name}/activity?recentFilter=1d`"
+          >
             <span
               class="summary-count"
               :class="{ 'text-strong': count < 1, 'text-info': count > 0 }"
@@ -21,7 +24,7 @@
                 'text-warning': project.failedCount > 0,
                 'text-muted': project.failedCount < 1,
               }"
-              :href="`${rdBase}/project/${project.name}/activity?statFilter=fail`"
+              :href="`${rdBase}/project/${project.name}/activity?statFilter=fail&recentFilter=1d`"
             >
               {{
                 $t("project.activitySummary.failedCount", [project.failedCount])


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. Fixes [RUN-4664](https://pagerduty.atlassian.net/browse/RUN-4664).

On the project home page and the project list page, the execution summary stat reads
**"N Executions In the last Day (M Failed)"**, but clicking the total execution count or the
"Failed" count navigated to the project's Activity page with no date range filter applied,
showing all-time executions/failures instead of just the last day's.

**Describe the solution you've implemented**

Appended `recentFilter=1d` to the Activity links so they match the "last day" label the stat
displays:

- `activitySummary.vue` (project dashboard widget) — total link now uses
  `?recentFilter=1d`, failed-count link now uses `?statFilter=fail&recentFilter=1d`.
- `home.gsp` (legacy project list page, `/menu/home`) — same fix applied to the
  server-rendered Knockout.js links (`g.createLink(controller: "reports", action: "index", ...)`).
- Updated `HomeBrowserItem.vue` (Vue project-list row, used under the `nextUi` flag) with the
  same fix for consistency, since it renders the equivalent stat/links when that UI mode is
  active.

No backend changes were needed — the Activity page (`ExecutionQuery.recentFilter`) already
supports the `1d` shorthand end-to-end.

**Describe alternatives you've considered**

N/A — this is a minimal, targeted link fix; no alternative approaches were considered.

**Additional context**

Updated existing Jest specs (`activitySummary.spec.ts`, `HomeBrowserItem.spec.ts`) to assert
the corrected hrefs.

## Release Notes

Fixed: the "Executions in the last Day" stat on the project home/list pages now links to the
Activity page pre-filtered to the last day, instead of showing all-time executions.


[RUN-4664]: https://pagerduty.atlassian.net/browse/RUN-4664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ