### PR TITLE
[RUN-4684] Fix long ACL policy summary text overflowing the row on the Access Control list page

### DIFF
--- a/rundeckapp/grails-app/views/menu/_aclValidationRowKO.gsp
+++ b/rundeckapp/grails-app/views/menu/_aclValidationRowKO.gsp
@@ -14,9 +14,8 @@
   - limitations under the License.
   --}%
 
-
 <div data-bind="css: {'flash_info':wasSaved}" style="border-top:1px solid #cfcfca; padding-top:1em;">
-    <div class=" hover-action-holder">
+    <div class="hover-action-holder acl-policy-row">
         <span class="h4" data-bind="template: { name: 'acl-policy-ident', data:$data }"></span>
           <span data-bind="if: loader.loading" class="text-muted">...</span>
           <span data-bind="if: loader.error" class="text-warning">
@@ -69,13 +68,13 @@
             </a>
         </g:if>
         <!-- ko if: meta() && meta().policies -->
-        <ul data-bind="foreach:  { data: meta().policies, as: 'policy' }">
+        <ul class="acl-policy-summary-list" data-bind="foreach:  { data: meta().policies, as: 'policy' }">
             <li>
-                <span class="text-strong" data-bind="text: policy.description()">
+                <span class="text-strong acl-policy-summary-text" data-bind="text: policy.description(), attr: {title: policy.description()}">
                 </span>
                 <ul>
                     <li>
-                        <span class="text-strong" data-bind="text: policy.by()">
+                        <span class="text-strong acl-policy-summary-text" data-bind="text: policy.by(), attr: {title: policy.by()}">
                         </span>
                     </li>
                 </ul>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/app.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/app.scss
@@ -145,6 +145,7 @@
 @import "custom/plugin-config";
 @import "custom/ace-editor";
 @import "custom/logo";
+@import "custom/acl-manager";
 
 // PAGES
 @import "pages/login";

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/acl-manager.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/acl-manager.scss
@@ -12,7 +12,6 @@
 
 .acl-policy-row {
     max-width: 100%;
-    overflow: hidden;
 }
 
 .acl-policy-summary-list {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/acl-manager.scss
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/acl-manager.scss
@@ -1,0 +1,28 @@
+// RUN-4684: the Access Control list page (/menu/acls, /project/$project/admin/acls)
+// renders each stored policy's description/by summary next to an Edit button
+// (see rundeckapp/grails-app/views/menu/_aclValidationRowKO.gsp). A long, unbreakable
+// value (e.g. a long "by" regex) must not push that row wider than its container.
+
+// Scoped to this page only (not the shared .hover-action-holder class, which is
+// used by unrelated views like node tables).
+#fsPolicies,
+#storedPolicies {
+    max-width: 97vw;
+}
+
+.acl-policy-row {
+    max-width: 100%;
+    overflow: hidden;
+}
+
+.acl-policy-summary-list {
+    max-width: 100%;
+}
+
+.acl-policy-summary-text {
+    display: inline-block;
+    max-width: 100%;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    vertical-align: bottom;
+}


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Bugfix. This is the `rundeck` (core/OSS) side of PagerDuty RUN-4684: a stored ACL policy's summary row on the Access Control list page (`/menu/acls`, and the project-scoped equivalent) has no width constraint on its description/"by" text. A long, unbroken value (e.g. a deny-all-except-list regex with no spaces or hyphens) forces the row wider than its container, pushing the Edit/dropdown action buttons off-screen with no way to scroll to reach them.

**Describe the solution you've implemented**
- `rundeckapp/grails-app/views/menu/_aclValidationRowKO.gsp`: added scoped classes (`acl-policy-row`, `acl-policy-summary-list`, `acl-policy-summary-text`) to the policy summary row instead of relying on the shared `.hover-action-holder` class (used by unrelated views like node tables).
- New `rundeckapp/grails-spa/packages/ui-trellis/src/library/theme/scss/custom/acl-manager.scss` (imported from `app.scss`, following the existing `custom/*.scss` convention instead of an inline `<style>` tag):
  - Hard-caps the ACL list containers (`#fsPolicies`, `#storedPolicies`) at `97vw` so the row can never grow wider than the viewport.
  - Long summary text wraps (`white-space: normal; overflow-wrap: anywhere`) instead of being truncated, so the full value stays readable without hovering.

**Describe alternatives you've considered**
- A fixed pixel `max-width` (e.g. `600px`) on the summary list — rejected because it doesn't scale with the actual available width and can still overflow on narrower viewports.
- Ellipsis truncation with a `title` tooltip — works, but hides part of the value behind a hover; wrapping keeps everything visible on the page.
- `max-width: 100%` alone without the `97vw` cap on the containers — insufficient on its own; percentage widths only help once an ancestor actually resolves to a real pixel width, which wasn't reliably the case here.

**Additional context**
This is the core-side companion to a `rundeckpro` fix for the same root issue in the PRO ACL rule editor's "Rules" tab table (`table-layout: fixed` there). Verified against a live local instance with a real-world example regex (33-entry deny-all-except-list) via both manual browser inspection (DOM bounding-rect measurements, not just visual) and an automated Selenium regression test in `pro-functional-test`.

## Release Notes

Fixed: a long "by" value in a stored ACL policy's summary (Access Control list page) could push the Edit button off-screen with no way to reach it.
