### PR TITLE
[RUN-4654] Fix Remote URL option Auth Type lost after saving and reopening job

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionEdit.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/OptionEdit.vue
@@ -896,6 +896,9 @@ export default defineComponent({
               ? "secureExposed"
               : "secure"
             : "plain",
+        remoteUrlAuthenticationType:
+          this.modelValue.remoteUrlAuthenticationType ||
+          this.modelValue.configRemoteUrl?.authenticationType,
       }) as JobOptionEdit,
       regexChoice: false,
       validationErrors: {} as Record<string, string[]>,

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/tests/OptionEdit.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/components/job/options/tests/OptionEdit.spec.ts
@@ -368,6 +368,24 @@ describe("OptionEdit", () => {
       );
     },
   );
+  it.each([["BASIC"], ["API_KEY"], ["BEARER_TOKEN"]])(
+    "restores remoteUrlAuthenticationType %p from configRemoteUrl on reload",
+    async (authenticationType: string) => {
+      const wrapper = await mountOptionEdit({
+        modelValue: {
+          name: "test",
+          type: "text",
+          valuesUrl: "https://example.com",
+          configRemoteUrl: { authenticationType },
+        },
+        editable: true,
+      });
+
+      expect(wrapper.vm.option.remoteUrlAuthenticationType).toBe(
+        authenticationType,
+      );
+    },
+  );
   it("doSave does not emit value if validation fails", async () => {
     mockedValidateJobOption.mockResolvedValueOnce({
       valid: false,


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
Bugfix. When a Job Option's Remote URL Auth Type (Bearer Token / Basic / API Key) is set and the job is saved, reopening the job for editing shows the Auth Type field blank, and the option loses its authentication headers on subsequent remote value fetches. See RUN-4654.

**Describe the solution you've implemented**
Root cause: `Option.toMap()` only serializes the persisted auth type nested under `option.configRemoteUrl.authenticationType`; it never emits the top-level `remoteUrlAuthenticationType` field. `OptionEdit.vue` initialized its `option` state from `modelValue` but never backfilled `remoteUrlAuthenticationType` from `configRemoteUrl.authenticationType`. Since `OptionRemoteUrlConfig.vue` gates the Basic/API Key/Bearer Token credential sections on that top-level field, the UI rendered no Auth Type selection on reopen — even though the credentials (token/password storage paths, etc.) were still intact in `configRemoteUrl`.

Fixed by deriving `remoteUrlAuthenticationType` from `configRemoteUrl.authenticationType` at `option` init time in `OptionEdit.vue`, mirroring the existing `valuesType`/`inputType` derivation pattern already used in that same block.

Note: this complements the earlier save-side fix in #10152 (RUN-4436), which ensured `authenticationType` is correctly persisted into `configRemoteUrl` on save. This PR fixes the read-back/reload side of the same field.

**Describe alternatives you've considered**
Could have added the same backfill logic inside `OptionRemoteUrlConfig.vue` instead, but doing it in `OptionEdit.vue`'s `option` init keeps the derivation consistent with how other derived fields (`valuesType`, `inputType`) are already computed for the same object, and keeps `OptionRemoteUrlConfig.vue` a plain controlled child component.

**Additional context**
Customer-reported: LSEG (SFDC case 00838871), Broome-Tioga Boces.

## Release Notes
Fixed: Remote URL job option's Auth Type (Bearer Token / Basic / API Key) is now correctly restored when reopening a saved job for editing.