### PR TITLE
[RUN-4587] Fix Windows argument quoting to use double quotes instead of single quotes

### DIFF
--- a/core/src/main/java/com/dtolabs/rundeck/core/cli/CLIUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/cli/CLIUtils.java
@@ -143,6 +143,16 @@ public class CLIUtils {
         return stringBuilder.toString();
     }
 
+    /**
+     * Quote a Windows argument using double quotes. Single quotes have no quoting
+     * semantics in cmd.exe and are passed literally, breaking arguments and providing
+     * no injection protection. Double quotes correctly handle spaces and prevent
+     * interpretation of most shell metacharacters ({@code |}, {@code &}, {@code >},
+     * {@code <}, {@code ;}).
+     *
+     * <p>Internal double-quote characters are escaped as {@code \"} and percent signs
+     * are doubled ({@code %%}) to prevent cmd.exe environment-variable expansion.</p>
+     */
     private static void quoteWindowsCMDArg(StringBuilder sb, String arg) {
         if (StringUtils.containsNone(arg, WINDOWS_CMD_CHARS) &&
                 StringUtils.containsNone(arg, WINDOWS_WS_CHARS) &&
@@ -152,9 +162,18 @@ public class CLIUtils {
             }
             return;
         }
-        sb.append("'");
-        sb.append(arg.replace("'", "'\"'\"'"));
-        sb.append("'");
+        sb.append('"');
+        for (int i = 0; i < arg.length(); i++) {
+            char c = arg.charAt(i);
+            if (c == '"') {
+                sb.append("\\\"");
+            } else if (c == '%') {
+                sb.append("%%");
+            } else {
+                sb.append(c);
+            }
+        }
+        sb.append('"');
     }
 
     private static void quoteUnixShellArg(StringBuilder sb, String arg) {

--- a/core/src/main/java/com/dtolabs/rundeck/core/cli/CLIUtils.java
+++ b/core/src/main/java/com/dtolabs/rundeck/core/cli/CLIUtils.java
@@ -144,14 +144,25 @@ public class CLIUtils {
     }
 
     /**
-     * Quote a Windows argument using double quotes. Single quotes have no quoting
+     * Quote a Windows argument using double quotes following the
+     * {@code CommandLineToArgvW} escaping rules. Single quotes have no quoting
      * semantics in cmd.exe and are passed literally, breaking arguments and providing
      * no injection protection. Double quotes correctly handle spaces and prevent
      * interpretation of most shell metacharacters ({@code |}, {@code &}, {@code >},
      * {@code <}, {@code ;}).
      *
-     * <p>Internal double-quote characters are escaped as {@code \"} and percent signs
-     * are doubled ({@code %%}) to prevent cmd.exe environment-variable expansion.</p>
+     * <p>Backslash handling follows the MSVC C-runtime convention used by
+     * {@code CommandLineToArgvW}:</p>
+     * <ul>
+     *   <li>{@code 2n} backslashes before {@code "} produce {@code n} literal
+     *       backslashes and the {@code "} acts as a delimiter/escape.</li>
+     *   <li>{@code 2n+1} backslashes before {@code "} produce {@code n} literal
+     *       backslashes plus a literal {@code "}.</li>
+     *   <li>Backslashes not followed by {@code "} are literal.</li>
+     * </ul>
+     *
+     * <p>Percent signs are doubled ({@code %%}) to prevent cmd.exe
+     * environment-variable expansion.</p>
      */
     private static void quoteWindowsCMDArg(StringBuilder sb, String arg) {
         if (StringUtils.containsNone(arg, WINDOWS_CMD_CHARS) &&
@@ -163,14 +174,38 @@ public class CLIUtils {
             return;
         }
         sb.append('"');
-        for (int i = 0; i < arg.length(); i++) {
-            char c = arg.charAt(i);
-            if (c == '"') {
+        int i = 0;
+        while (i < arg.length()) {
+            int numBackslashes = 0;
+            while (i < arg.length() && arg.charAt(i) == '\\') {
+                numBackslashes++;
+                i++;
+            }
+            if (i == arg.length()) {
+                // Trailing backslashes: double them so the closing " is not escaped
+                for (int j = 0; j < numBackslashes * 2; j++) {
+                    sb.append('\\');
+                }
+                break;
+            } else if (arg.charAt(i) == '"') {
+                // Backslashes before ": double them, then emit \"
+                for (int j = 0; j < numBackslashes * 2; j++) {
+                    sb.append('\\');
+                }
                 sb.append("\\\"");
-            } else if (c == '%') {
-                sb.append("%%");
+                i++;
             } else {
-                sb.append(c);
+                // Backslashes not before ": emit literally
+                for (int j = 0; j < numBackslashes; j++) {
+                    sb.append('\\');
+                }
+                char c = arg.charAt(i);
+                if (c == '%') {
+                    sb.append("%%");
+                } else {
+                    sb.append(c);
+                }
+                i++;
             }
         }
         sb.append('"');

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/cli/CLIUtilsSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/cli/CLIUtilsSpec.groovy
@@ -55,11 +55,51 @@ class CLIUtilsSpec extends Specification {
         windowsCmdConverter.convert("foo&bar") == "foo^&bar"
         windowsCmdConverter.convert("`foobar`") == "^`foobar^`"
 
-        when: "Windows PowerShell case"
-        Converter<String, String> windowsPsConverter = CLIUtils.argumentQuoteForOperatingSystem("windows", "powershell")
+        when: "Windows default case (no interpreter)"
+        Converter<String, String> windowsDefaultConverter = CLIUtils.argumentQuoteForOperatingSystem("windows", null)
         then:
-        windowsPsConverter.convert("foo bar") == "'foo bar'"
-        windowsPsConverter.convert("foo&bar") == "'foo&bar'"
-        windowsPsConverter.convert("`foobar`") == "'`foobar`'"
+        windowsDefaultConverter.convert("foo bar") == '"foo bar"'
+        windowsDefaultConverter.convert("foo&bar") == '"foo&bar"'
+        windowsDefaultConverter.convert("`foobar`") == '"`foobar`"'
+    }
+
+    def "quoteWindowsCMDArg escapes internal double quotes"() {
+        expect:
+        CLIUtils.quoteWindowsCMDArg('"hello world"') == '"\\"hello world\\""'
+    }
+
+    def "quoteWindowsCMDArg escapes percent for env var protection"() {
+        expect:
+        CLIUtils.quoteWindowsCMDArg('%PATH%') == '"%%PATH%%"'
+    }
+
+    def "quoteWindowsCMDArg returns simple args unchanged"() {
+        expect:
+        CLIUtils.quoteWindowsCMDArg('simple') == 'simple'
+    }
+
+    def "quoteWindowsCMDArg handles UNC paths with spaces"() {
+        expect:
+        CLIUtils.quoteWindowsCMDArg('\\\\server\\share\\path with spaces\\script.ps1') == '"\\\\server\\share\\path with spaces\\script.ps1"'
+    }
+
+    def "quoteWindowsCMDArg blocks pipe injection"() {
+        expect:
+        CLIUtils.quoteWindowsCMDArg('80 | whoami') == '"80 | whoami"'
+    }
+
+    def "quoteWindowsCMDArg blocks redirect injection"() {
+        expect:
+        CLIUtils.quoteWindowsCMDArg('data > C:\\tmp\\file') == '"data > C:\\tmp\\file"'
+    }
+
+    def "quoteWindowsCMDArg blocks AND operator injection"() {
+        expect:
+        CLIUtils.quoteWindowsCMDArg('test && del /q C:\\') == '"test && del /q C:\\"'
+    }
+
+    def "quoteWindowsCMDArg blocks semicolon injection"() {
+        expect:
+        CLIUtils.quoteWindowsCMDArg('test; whoami') == '"test; whoami"'
     }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/cli/CLIUtilsSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/cli/CLIUtilsSpec.groovy
@@ -95,11 +95,22 @@ class CLIUtilsSpec extends Specification {
 
     def "quoteWindowsCMDArg blocks AND operator injection"() {
         expect:
-        CLIUtils.quoteWindowsCMDArg('test && del /q C:\\') == '"test && del /q C:\\"'
+        CLIUtils.quoteWindowsCMDArg('test && del /q C:\\') == '"test && del /q C:\\\\"'
     }
 
     def "quoteWindowsCMDArg blocks semicolon injection"() {
         expect:
         CLIUtils.quoteWindowsCMDArg('test; whoami') == '"test; whoami"'
+    }
+
+    def "quoteWindowsCMDArg doubles trailing backslashes before closing quote"() {
+        expect:
+        CLIUtils.quoteWindowsCMDArg('path\\') == '"path\\\\"'
+        CLIUtils.quoteWindowsCMDArg('path\\\\') == '"path\\\\\\\\"'
+    }
+
+    def "quoteWindowsCMDArg doubles backslashes before internal quote"() {
+        expect:
+        CLIUtils.quoteWindowsCMDArg('say\\"hi\\"') == '"say\\\\\\"hi\\\\\\""'
     }
 }

--- a/core/src/test/groovy/com/dtolabs/rundeck/core/cli/CLIUtilsSpec.groovy
+++ b/core/src/test/groovy/com/dtolabs/rundeck/core/cli/CLIUtilsSpec.groovy
@@ -55,6 +55,13 @@ class CLIUtilsSpec extends Specification {
         windowsCmdConverter.convert("foo&bar") == "foo^&bar"
         windowsCmdConverter.convert("`foobar`") == "^`foobar^`"
 
+        when: "Windows PowerShell case"
+        Converter<String, String> windowsPsConverter = CLIUtils.argumentQuoteForOperatingSystem("windows", "powershell")
+        then:
+        windowsPsConverter.convert("foo bar") == '"foo bar"'
+        windowsPsConverter.convert("foo&bar") == '"foo&bar"'
+        windowsPsConverter.convert("`foobar`") == '"`foobar`"'
+
         when: "Windows default case (no interpreter)"
         Converter<String, String> windowsDefaultConverter = CLIUtils.argumentQuoteForOperatingSystem("windows", null)
         then:

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/ExecArgListTest.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/ExecArgListTest.java
@@ -201,7 +201,15 @@ public class ExecArgListTest {
     @Test
     public void buildWindowsEscaping() {
         ExecArgList list = ExecArgList.fromStrings(false, true, "echo", "a&b");
-        List<String> expected = Arrays.asList("echo", "'a&b'");
+        List<String> expected = Arrays.asList("echo", "\"a&b\"");
+        ArrayList<String> result = list.buildCommandForNode(null, "windows");
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void buildWindowsEscapingUncPath() {
+        ExecArgList list = ExecArgList.fromStrings(false, true, "powershell", "-file", "\\\\server\\share\\test.ps1");
+        List<String> expected = Arrays.asList("powershell", "-file", "\"\\\\server\\share\\test.ps1\"");
         ArrayList<String> result = list.buildCommandForNode(null, "windows");
         Assert.assertEquals(expected, result);
     }

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/ExecCommandInjectionTest.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/ExecCommandInjectionTest.java
@@ -239,7 +239,7 @@ public class ExecCommandInjectionTest {
 
         Assert.assertEquals(2, result.size());
         Assert.assertEquals("echo", result.get(0));
-        Assert.assertEquals("\"test && del /q C:\\\"", result.get(1));
+        Assert.assertEquals("\"test && del /q C:\\\\\"", result.get(1));
     }
 
     @Test

--- a/core/src/test/java/com/dtolabs/rundeck/core/execution/ExecCommandInjectionTest.java
+++ b/core/src/test/java/com/dtolabs/rundeck/core/execution/ExecCommandInjectionTest.java
@@ -211,4 +211,111 @@ public class ExecCommandInjectionTest {
         Assert.assertEquals("echo", result.get(0));
         Assert.assertEquals("literal text", result.get(1));
     }
+
+    @Test
+    public void testWindowsCommandInjectionPipeBlocked() {
+        ExecArgList.Builder builder = ExecArgList.builder();
+        builder.arg("echo", false, false);
+        builder.arg("Scanning port: 80 | whoami", true, false);
+        ExecArgList execArgList = builder.build();
+
+        Map<String, Map<String, String>> dataContext = new HashMap<>();
+        ArrayList<String> result = execArgList.buildCommandForNode(dataContext, "windows");
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals("echo", result.get(0));
+        Assert.assertEquals("\"Scanning port: 80 | whoami\"", result.get(1));
+    }
+
+    @Test
+    public void testWindowsCommandInjectionAndOperatorBlocked() {
+        ExecArgList.Builder builder = ExecArgList.builder();
+        builder.arg("echo", false, false);
+        builder.arg("test && del /q C:\\", true, false);
+        ExecArgList execArgList = builder.build();
+
+        Map<String, Map<String, String>> dataContext = new HashMap<>();
+        ArrayList<String> result = execArgList.buildCommandForNode(dataContext, "windows");
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals("echo", result.get(0));
+        Assert.assertEquals("\"test && del /q C:\\\"", result.get(1));
+    }
+
+    @Test
+    public void testWindowsCommandInjectionRedirectionBlocked() {
+        ExecArgList.Builder builder = ExecArgList.builder();
+        builder.arg("echo", false, false);
+        builder.arg("data > C:\\tmp\\file", true, false);
+        ExecArgList execArgList = builder.build();
+
+        Map<String, Map<String, String>> dataContext = new HashMap<>();
+        ArrayList<String> result = execArgList.buildCommandForNode(dataContext, "windows");
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals("echo", result.get(0));
+        Assert.assertEquals("\"data > C:\\tmp\\file\"", result.get(1));
+    }
+
+    @Test
+    public void testWindowsPathWithSpacesQuoted() {
+        ExecArgList.Builder builder = ExecArgList.builder();
+        builder.arg("pwsh", false, false);
+        builder.arg("-File", false, false);
+        builder.arg("\\\\server\\share\\path with spaces\\script.ps1", true, false);
+        ExecArgList execArgList = builder.build();
+
+        Map<String, Map<String, String>> dataContext = new HashMap<>();
+        ArrayList<String> result = execArgList.buildCommandForNode(dataContext, "windows");
+
+        Assert.assertEquals(3, result.size());
+        Assert.assertEquals("pwsh", result.get(0));
+        Assert.assertEquals("-File", result.get(1));
+        Assert.assertEquals("\"\\\\server\\share\\path with spaces\\script.ps1\"", result.get(2));
+    }
+
+    @Test
+    public void testWindowsEnvVarExpansionBlocked() {
+        ExecArgList.Builder builder = ExecArgList.builder();
+        builder.arg("echo", false, false);
+        builder.arg("%PATH%", true, false);
+        ExecArgList execArgList = builder.build();
+
+        Map<String, Map<String, String>> dataContext = new HashMap<>();
+        ArrayList<String> result = execArgList.buildCommandForNode(dataContext, "windows");
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals("echo", result.get(0));
+        Assert.assertEquals("\"%%PATH%%\"", result.get(1));
+    }
+
+    @Test
+    public void testWindowsInternalDoubleQuotesEscaped() {
+        ExecArgList.Builder builder = ExecArgList.builder();
+        builder.arg("echo", false, false);
+        builder.arg("say \"hello\"", true, false);
+        ExecArgList execArgList = builder.build();
+
+        Map<String, Map<String, String>> dataContext = new HashMap<>();
+        ArrayList<String> result = execArgList.buildCommandForNode(dataContext, "windows");
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals("echo", result.get(0));
+        Assert.assertEquals("\"say \\\"hello\\\"\"", result.get(1));
+    }
+
+    @Test
+    public void testWindowsSimpleValueNotQuoted() {
+        ExecArgList.Builder builder = ExecArgList.builder();
+        builder.arg("echo", false, false);
+        builder.arg("80", true, false);
+        ExecArgList execArgList = builder.build();
+
+        Map<String, Map<String, String>> dataContext = new HashMap<>();
+        ArrayList<String> result = execArgList.buildCommandForNode(dataContext, "windows");
+
+        Assert.assertEquals(2, result.size());
+        Assert.assertEquals("echo", result.get(0));
+        Assert.assertEquals("80", result.get(1));
+    }
 }


### PR DESCRIPTION
## Summary

Changes `CLIUtils.quoteWindowsCMDArg()` from single quotes to double quotes following `CommandLineToArgvW` escaping rules, fixing command execution failures on Windows nodes when the remote shell is **cmd.exe** (WinRM cmd shell, or SSH/OpenSSH default shell).

Quoting applies when an exec argument contains an expanded Rundeck property reference (`${option.*}`, `${globals.*}`, `${data.*}`) and `shouldQuote=true`.

## Root Cause

The security fix RUN-4175 (Rundeck 6.0) added argument quoting for those property references via `CommandNodeStepPlugin`. On Windows nodes (`osFamily=windows`), quoting goes through `quoteWindowsCMDArg()`.

The problem: `quoteWindowsCMDArg()` used **single quotes** (`'path'`), which have **no quoting semantics in cmd.exe**:

- **cmd.exe**: `'` is a literal character → `powershell -File 'C:\Users\Administrator\test file.ps1'` is parsed as multiple tokens / literal quotes → PowerShell sees a broken `-File` path (e.g. `''C:\Users\Administrator\test'`) → *path format not supported* / *does not have a '.ps1' extension*
- **PowerShell as WinRM shell**: single quotes work as string delimiters → hid the bug for the default py-winrm PowerShell shell

Customers on **cmd** (WinRM cmd shell, or SSH to Windows) hit the failure after upgrading to 6.x (quoting on by default). The same commands often worked on Runner 5.x (no quoting).

## What “correct quoting” means for expanded variables

When Rundeck expands `${option.x}` / `${globals.x}` into an argv element and marks it for quoting, Windows quoting must produce a form that:

1. **cmd.exe** treats as **one argument** (so spaces and `|` `>` `&&` `;` do not split or inject), and
2. **`CommandLineToArgvW`** (used by `powershell.exe`, most Win32 programs) recovers the **original string** as a single `$args` / argv entry.

That is double-quote wrapping with MSVC/`CommandLineToArgvW` escapes (`\"`, doubled trailing `\`, etc.) — the same convention as Python `list2cmdline`, .NET `ProcessStartInfo`, Rust `Command` on Windows.


## What this PR covers

| Area | Covered? | Notes |
|---|---|---|
| Paths with spaces via `${option.*}` / `${globals.*}` + `powershell -File` | Yes | Primary customer / RUN-4587 case |
| SSH → Windows (OpenSSH → cmd) | Yes | Manually verified |
| WinRM + cmd shell | Yes | Same quoting path; originally reproduced on staging |
| WinRM + PowerShell shell | Yes | Remains working (PowerShell accepts `"`) |
| Injection via option values: `\|`, `>`, `&&`, `;` | Yes | Kept as **one** literal argv; no second command |
| Internal `"` in values | Yes | Escaped for ArgvW → process sees `say "hello"` |
| Trailing `\` | Yes | Doubled before closing `"` so argv is `path\` |
| UNC paths with spaces | Yes | Single argv with spaces preserved |
| Simple values (no special chars) | Yes | Fast path, unquoted (e.g. `80`) |
| Unix / missing `osFamily` | Unchanged | Still Unix single-quote quoting |
| `exec.quoting.enabled=false` | Unchanged | No quoting |
| `commandInterpreter=cmd` (caret escape path) | Unchanged | Still `WINDOWS_CMD_ESCAPE` |

### Manual SSH verification (with / without fix)

Same job, Windows node over SSH, argv checked with `print-args.ps1`:

**With fix**

- Paths: `hello from windows` ×3
- `ARG=[80]`
- `ARG=[Scanning port: 80 | echo INJECTION_PIPE]` (no `INJECTION_PIPE` side command)
- Redirect payload literal + file not created
- `ARG=[test && echo INJECTION_AND]` / `ARG=[test; echo INJECTION_SEMI]`
- `ARG=[say "hello"]`, `ARG=[path\]`, UNC as one arg

**Without fix (regression baseline)**

- `${option}` / `${globals}` paths: **fail** (`-File ''C:\Users\Administrator\test'`)
- Pipe / AND: **injection runs** (`INJECTION_PIPE` / `INJECTION_AND`)
- Values with spaces / quotes: **split** into multiple `ARG=[…]` entries (literal `'` characters attached)

## What this PR does **not** fully cover

| Area | Not covered / limited | Why |
|---|---|---|
| Stopping **cmd interactive** `%VAR%` expansion of option values like `%PATH%` | Limited | On SSH/`cmd`, `%VAR%` expands **before** CreateProcess, including inside `"…"`. `%%` doubling matches batch-oriented / unit-test expectations and helps some paths, but does **not** guarantee a literal `%PATH%` argv over interactive cmd. |
| Same `%PATH%` behavior **before this PR** | Also expanded | Pre-fix runs also expanded PATH; worse, single quotes caused the expanded value to **split** on spaces (`Program Files` → multiple `ARG=`). Post-fix: still may expand, but stays **one** argv. |
| Changing Unix quoting or disabling quoting globally | Out of scope | |

## Why change core `quoteWindowsCMDArg` (not only the plugin)

1. A “quote Windows CMD arg” helper must use quoting cmd actually understands (`"`), not `'`.
2. All Windows executors share this path (WinRM, SSH, etc.).
3. Plugin workarounds (e.g. py-winrm `cleanescaping` stripping `'`) are fragile and should not paper over broken core quoting.

## Scope and backward compatibility

| Scenario | Before (main) | After (fix) |
|---|---|---|
| WinRM + cmd shell | `'path'` → **fails** | `"path"` → works |
| WinRM + PowerShell shell | `'path'` → works | `"path"` → works |
| SSH to Windows (cmd default) | `'path'` → fails | `"path"` → works |

**Upgrade impact:** `osFamily=windows` with property-ref quoting moves from `'` to `"`. Broken paths with spaces start working. Intentional multi-command injection via option values is blocked (aligned with RUN-4175). Escape hatch: `exec.quoting.enabled=false`.

## Changes

### `CLIUtils.java`
- `quoteWindowsCMDArg()`: double-quote escaping per `CommandLineToArgvW` rules

### `CLIUtilsSpec.groovy`
- Windows quoting expectations updated; coverage for UNC, injection metacharacters, `%`, internal `"`, trailing `\`

### `ExecCommandInjectionTest.java`
- Windows-specific injection / quoting cases (pipe, redirect, AND, env form, internal quotes, UNC, simple values)

### `ExecArgListTest.java`
- Related quoting assertions updated as needed

## Test plan

- [x] Unit tests: Unix quoting unchanged
- [x] Unit tests: Windows double-quote / ArgvW behavior
- [x] Unit tests: Windows injection forms (pipe, redirect, AND, semicolon, `%`, quotes, UNC)
- [x] Staging reproduction: WinRM + cmd + `${globals.*}` path with spaces
- [x] Manual SSH regression: same verification job **without** fix (paths fail, injection/split)
- [x] Manual SSH verification: same job **with** fix (`print-args.ps1` argv checks)
- [x] Optional: re-check WinRM cmd shell on staging with the same argv-style job