### PR TITLE
[RUN-4247] Enforce project-level authorization on execution metrics API

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -3751,10 +3751,13 @@ Note: This endpoint has the same query parameters and response as the `/executio
         if (params.project) {
             metricsProjects.add(params.project.toString())
         }
-        query.jobIdListFilter?.each { jobUuid ->
-            def job = ScheduledExecution.findByUuid(jobUuid.toString())
-            if (job?.project) {
-                metricsProjects.add(job.project)
+        List<String> jobUuids = query.jobIdListFilter?.collect { it.toString() }
+        if (jobUuids) {
+            //fetch the jobs' projects in a single query rather than one findByUuid per UUID
+            ScheduledExecution.findAllByUuidInList(jobUuids).each { job ->
+                if (job.project) {
+                    metricsProjects.add(job.project)
+                }
             }
         }
         if (metricsProjects) {

--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ExecutionController.groovy
@@ -3743,6 +3743,35 @@ Note: This endpoint has the same query parameters and response as the `/executio
             )
         }
 
+        // RUN-4247: Enforce project-level authorization before any metrics are computed, closing the
+        // cross-project information-disclosure (IDOR) hole. The in-scope projects are the explicit
+        // `project` param plus the owning project of each job in jobIdListFilter. When none are given
+        // the aggregate is restricted to the caller's authorized projects rather than the whole instance.
+        Set<String> metricsProjects = new LinkedHashSet<>()
+        if (params.project) {
+            metricsProjects.add(params.project.toString())
+        }
+        query.jobIdListFilter?.each { jobUuid ->
+            def job = ScheduledExecution.findByUuid(jobUuid.toString())
+            if (job?.project) {
+                metricsProjects.add(job.project)
+            }
+        }
+        if (metricsProjects) {
+            List<String> denied = partitionProjectsByEventReadAuth(metricsProjects).unauthorized
+            if (denied) {
+                return renderMetricsForbidden(denied.join(', '))
+            }
+        } else {
+            List<String> allowed = partitionProjectsByEventReadAuth(
+                frameworkService.projectNames(getSystemAuthContext())
+            ).authorized
+            if (!allowed) {
+                return renderMetricsForbidden('*')
+            }
+            query.projNameFilter = allowed
+        }
+
         // RUN-3768 Phase 5: Batch mode support
         if (useStats && groupByJob) {
             // Batch mode: Get metrics for all jobs in project
@@ -3877,6 +3906,46 @@ Note: This endpoint has the same query parameters and response as the `/executio
         }
 
 
+    }
+
+    /**
+     * Partition a collection of projects by whether the current subject may read events (execution
+     * history) for them. A reusable project-list authorization primitive — not tied to any single
+     * endpoint (RUN-4247).
+     *
+     * @param projects the project names to check
+     * @return a map with two entries, each a {@code List<String>} preserving iteration order:
+     *         {@code authorized} (event-level READ granted) and {@code unauthorized} (denied)
+     */
+    private Map<String, List<String>> partitionProjectsByEventReadAuth(Collection<String> projects) {
+        Map<String, List<String>> partitioned = [authorized: [], unauthorized: []]
+        projects.each { String project ->
+            AuthContext authContext = rundeckAuthContextProcessor.getAuthContextForSubjectAndProject(session.subject, project)
+            boolean allowed = rundeckAuthContextProcessor.authorizeProjectResource(
+                authContext,
+                AuthConstants.RESOURCE_TYPE_EVENT,
+                AuthConstants.ACTION_READ,
+                project
+            )
+            partitioned[allowed ? 'authorized' : 'unauthorized'] << project
+        }
+        partitioned
+    }
+
+    /**
+     * Render the standard API 403 response for an unauthorized metrics request (RUN-4247).
+     * @param project the project (or {@code '*'} for the instance-wide default) the caller may not read
+     */
+    private def renderMetricsForbidden(String project) {
+        apiService.renderErrorFormat(
+            response,
+            [
+                status: HttpServletResponse.SC_FORBIDDEN,
+                code  : 'api.error.item.unauthorized',
+                args  : [AuthConstants.ACTION_READ, 'Events in project', project],
+                format: response.format ?: 'json'
+            ]
+        )
     }
 
     /**

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ExecutionQuery.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ExecutionQuery.groovy
@@ -54,6 +54,12 @@ class ExecutionQuery extends ScheduledExecutionQuery implements Validateable{
     boolean doendbeforeFilter
     boolean includeJobRef
     List<String> execProjects
+    /**
+     * Restrict the query to this set of projects when no single {@link #projFilter} is set. Used to
+     * scope a metrics/execution aggregate to only the projects a caller is authorized to read,
+     * without spanning the whole instance (RUN-4247).
+     */
+    List<String> projNameFilter
     String recentFilter
     String olderFilter
     String userFilter
@@ -79,6 +85,7 @@ class ExecutionQuery extends ScheduledExecutionQuery implements Validateable{
         jobExactFilter(nullable:true)
         idlist(nullable:true)
         projFilter(nullable:true)
+        projNameFilter(nullable:true)
         userFilter(nullable:true)
         excludeGroupPath(nullable:true)
         excludeJobFilter(nullable:true)
@@ -408,6 +415,13 @@ class ExecutionQuery extends ScheduledExecutionQuery implements Validateable{
           if(excludeRunning){
               isNotNull('dateCompleted')
           }
+        } else if (query.projNameFilter) {
+          //restrict to an authorized set of projects when no single project is given (RUN-4247)
+          inList('project', query.projNameFilter)
+
+          if(excludeRunning){
+              isNotNull('dateCompleted')
+          }
         }
         if (query.userFilter) {
           eq('user', query.userFilter)
@@ -654,6 +668,10 @@ class ExecutionQuery extends ScheduledExecutionQuery implements Validateable{
         if (this.projFilter) {
             hqlParts << "AND e.project = :project"
             params.project = this.projFilter
+        } else if (this.projNameFilter) {
+            //restrict to an authorized set of projects when no single project is given (RUN-4247)
+            hqlParts << "AND e.project IN (:projNameList)"
+            params.projNameList = this.projNameFilter
         }
 
         // Job UUID filter - uses execution.job_uuid column directly (no JOIN needed)

--- a/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ExecutionQuery.groovy
+++ b/rundeckapp/src/main/groovy/com/dtolabs/rundeck/app/support/ExecutionQuery.groovy
@@ -85,7 +85,9 @@ class ExecutionQuery extends ScheduledExecutionQuery implements Validateable{
         jobExactFilter(nullable:true)
         idlist(nullable:true)
         projFilter(nullable:true)
-        projNameFilter(nullable:true)
+        //never bind projNameFilter from request params — it is set server-side only, after the
+        //caller has been authorized for those projects (RUN-4247)
+        projNameFilter(nullable:true, bindable:false)
         userFilter(nullable:true)
         excludeGroupPath(nullable:true)
         excludeJobFilter(nullable:true)

--- a/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/support/ExecutionQuerySpec.groovy
+++ b/rundeckapp/src/test/groovy/com/dtolabs/rundeck/app/support/ExecutionQuerySpec.groovy
@@ -124,4 +124,45 @@ class ExecutionQuerySpec extends Specification {
         ExecutionQuery.escapeLikePattern("user@example.com") == "user@example.com"
         ExecutionQuery.escapeLikePattern("") == ""
     }
+
+    // ==================== projNameFilter (RUN-4247) ====================
+
+    def "createCriteria restricts to projNameFilter via an IN list when no single projFilter is set (RUN-4247)"() {
+        given:
+            def query = new ExecutionQuery(projNameFilter: ['ProjectA', 'ProjectB'])
+            def recorder = new RecordingCriteria()
+            def clos = query.createCriteria(recorder)
+
+        when:
+            clos.call()
+
+        then:
+            recorder.calls.contains(['inList', ['project', ['ProjectA', 'ProjectB']]])
+            !recorder.calls.any { it[0] == 'eq' && it[1][0] == 'project' }
+    }
+
+    def "createCriteria ignores projNameFilter when a single projFilter is set (RUN-4247)"() {
+        given:
+            def query = new ExecutionQuery(projFilter: 'ProjectA', projNameFilter: ['ProjectA', 'ProjectB'])
+            def recorder = new RecordingCriteria()
+            def clos = query.createCriteria(recorder)
+
+        when:
+            clos.call()
+
+        then:
+            recorder.calls.contains(['eq', ['project', 'ProjectA']])
+            !recorder.calls.any { it[0] == 'inList' }
+    }
+}
+
+/**
+ * Records the criteria-builder method calls the createCriteria closure makes against its delegate,
+ * so the project-restriction branch can be asserted without a live GORM criteria (RUN-4247).
+ * Declared top-level because Groovy forbids methodMissing/propertyMissing on static inner classes.
+ */
+class RecordingCriteria {
+    List<List> calls = []
+    def methodMissing(String name, args) { calls << [name, (args as List)]; null }
+    def propertyMissing(String name) { null }
 }

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionController2Spec.groovy
@@ -20,6 +20,7 @@ import com.dtolabs.rundeck.app.api.ApiVersions
 import com.dtolabs.rundeck.app.internal.logging.FSStreamingLogReader
 import com.dtolabs.rundeck.core.logging.internal.RundeckLogFormat
 import com.dtolabs.rundeck.app.support.ExecutionQuery
+import com.dtolabs.rundeck.core.authorization.UserAndRolesAuthContext
 import com.dtolabs.rundeck.core.config.FeatureService
 import com.dtolabs.rundeck.core.execution.logstorage.ExecutionFileState
 import grails.testing.gorm.DataTest
@@ -60,6 +61,17 @@ class ExecutionController2Spec extends Specification implements ControllerUnitTe
 
     public static <T extends Annotation> T getMethodAnnotation(Object instance, String name, Class<T> clazz) {
         instance.getClass().getDeclaredMethods().find { it.name == name }.getAnnotation(clazz)
+    }
+
+    /**
+     * Stub the metrics authorization gate (RUN-4247) to grant event READ on every project, so
+     * tests exercising a successful apiExecutionMetrics path are not blocked by the 403 gate.
+     */
+    private void allowAllProjectAuth() {
+        controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+            getAuthContextForSubjectAndProject(_, _) >> Mock(UserAndRolesAuthContext)
+            authorizeProjectResource(_, _, _, _) >> true
+        }
     }
     def setup(){
         controller.rundeckWebDefaultParameterNamesMapper=Mock(WebDefaultParameterNamesMapper)
@@ -739,6 +751,7 @@ class ExecutionController2Spec extends Specification implements ControllerUnitTe
         // mock exec service
         controller.executionService = Mock(ExecutionService)
         response.format = "json"
+        allowAllProjectAuth()
 
 
         1 * controller.executionService.queryExecutionMetrics(_)>>[
@@ -851,6 +864,7 @@ class ExecutionController2Spec extends Specification implements ControllerUnitTe
             controller.apiService = apiMock
             controller.executionService = Mock(ExecutionService)
             response.format = "json"
+            allowAllProjectAuth()
 
         when:
             def query = new ExecutionQuery()
@@ -871,6 +885,170 @@ class ExecutionController2Spec extends Specification implements ControllerUnitTe
             response.status == 200
     }
 
+    def "apiExecutionMetrics single-job stats denies a cross-project job with 403 (RUN-4247)"() {
+        given: "a job that lives in ProjectB, which the caller is NOT authorized to read"
+            request.api_version = ApiVersions.V57
+            request.contentType = "application/json"
+            params.useStats = "true"
+            response.format = "json"
+
+            def jobUuid = UUID.randomUUID().toString()
+            new ScheduledExecution(uuid: jobUuid, jobName: "Secret Job", project: "ProjectB").save(flush: true)
+
+            def apiMock = Mock(ApiService)
+            controller.apiService = apiMock
+            controller.executionService = Mock(ExecutionService)
+            controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+                getAuthContextForSubjectAndProject(_, "ProjectB") >> Mock(UserAndRolesAuthContext)
+                authorizeProjectResource(_, _, _, "ProjectB") >> false
+            }
+
+        when: "requesting metrics for a job UUID belonging to the unauthorized project"
+            controller.apiExecutionMetrics(new ExecutionQuery(jobIdListFilter: [jobUuid]))
+
+        then: "the request is rejected with 403 naming ProjectB, rather than leaking its metrics"
+            1 * apiMock.requireApi(_, _, ApiVersions.V57) >> true
+            1 * apiMock.renderErrorFormat(_, { Map m -> m.status == 403 && m.args[2] == 'ProjectB' })
+    }
+
+    def "apiExecutionMetrics batch mode denies an unauthorized project with 403 (RUN-4247)"() {
+        given:
+            request.api_version = ApiVersions.V57
+            request.contentType = "application/json"
+            params.project = "TestProject"
+            params.useStats = "true"
+            params.groupByJob = "true"
+            response.format = "json"
+
+            def apiMock = Mock(ApiService)
+            controller.apiService = apiMock
+            controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+                getAuthContextForSubjectAndProject(_, "TestProject") >> Mock(UserAndRolesAuthContext)
+                authorizeProjectResource(_, _, _, "TestProject") >> false
+            }
+
+        when:
+            controller.apiExecutionMetrics(new ExecutionQuery())
+
+        then:
+            1 * apiMock.requireApi(_, _, ApiVersions.V57) >> true
+            1 * apiMock.renderErrorFormat(_, { Map m -> m.status == 403 })
+    }
+
+    def "apiExecutionMetrics default mode denies an unauthorized explicit project with 403 (RUN-4247)"() {
+        given:
+            request.api_version = 29
+            request.contentType = "application/json"
+            params.project = "TestProject"
+            response.format = "json"
+
+            def apiMock = Mock(ApiService)
+            controller.apiService = apiMock
+            controller.executionService = Mock(ExecutionService)
+            controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+                getAuthContextForSubjectAndProject(_, "TestProject") >> Mock(UserAndRolesAuthContext)
+                authorizeProjectResource(_, _, _, "TestProject") >> false
+            }
+
+        when:
+            controller.apiExecutionMetrics(new ExecutionQuery())
+
+        then:
+            1 * apiMock.requireApi(_, _, 29) >> true
+            1 * apiMock.renderErrorFormat(_, { Map m -> m.status == 403 })
+            0 * controller.executionService.queryExecutionMetrics(_)
+    }
+
+    def "apiExecutionMetrics default mode with no filters restricts the query to authorized projects (RUN-4247)"() {
+        given: "caller may read ProjectA but not ProjectB, and supplies no project/job filter"
+            request.api_version = 29
+            request.contentType = "application/json"
+            response.format = "json"
+
+            def apiMock = Mock(ApiService)
+            controller.apiService = apiMock
+            controller.executionService = Mock(ExecutionService)
+            controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+                getAuthContextForSubject(_) >> Mock(UserAndRolesAuthContext)
+                getAuthContextForSubjectAndProject(_, _) >> Mock(UserAndRolesAuthContext)
+                authorizeProjectResource(_, _, _, "ProjectA") >> true
+                authorizeProjectResource(_, _, _, "ProjectB") >> false
+            }
+            controller.frameworkService = Mock(FrameworkService) {
+                projectNames(_) >> ["ProjectA", "ProjectB"]
+            }
+            ExecutionQuery captured = null
+
+        when:
+            controller.apiExecutionMetrics(new ExecutionQuery())
+
+        then: "the aggregate is scoped to only the authorized project, never instance-wide"
+            1 * apiMock.requireApi(_, _, 29) >> true
+            1 * controller.executionService.queryExecutionMetrics(_) >> { args ->
+                captured = args[0]
+                [total: 0, duration: [average: 0, min: 0, max: 0]]
+            }
+            captured.projNameFilter == ["ProjectA"]
+            response.status == 200
+    }
+
+    def "apiExecutionMetrics default mode with no authorized projects returns 403 (RUN-4247)"() {
+        given:
+            request.api_version = 29
+            request.contentType = "application/json"
+            response.format = "json"
+
+            def apiMock = Mock(ApiService)
+            controller.apiService = apiMock
+            controller.executionService = Mock(ExecutionService)
+            controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+                getAuthContextForSubject(_) >> Mock(UserAndRolesAuthContext)
+                getAuthContextForSubjectAndProject(_, _) >> Mock(UserAndRolesAuthContext)
+                authorizeProjectResource(_, _, _, _) >> false
+            }
+            controller.frameworkService = Mock(FrameworkService) {
+                projectNames(_) >> ["ProjectA", "ProjectB"]
+            }
+
+        when:
+            controller.apiExecutionMetrics(new ExecutionQuery())
+
+        then:
+            1 * apiMock.requireApi(_, _, 29) >> true
+            1 * apiMock.renderErrorFormat(_, { Map m -> m.status == 403 })
+            0 * controller.executionService.queryExecutionMetrics(_)
+    }
+
+    def "apiExecutionMetrics denies when one of several in-scope projects is unauthorized (RUN-4247)"() {
+        given: "an authorized explicit project plus a job whose owning project is NOT authorized"
+            request.api_version = 29
+            request.contentType = "application/json"
+            params.project = "ProjectA"
+            response.format = "json"
+
+            def jobUuid = UUID.randomUUID().toString()
+            new ScheduledExecution(uuid: jobUuid, jobName: "Cross Job", project: "ProjectB").save(flush: true)
+
+            def apiMock = Mock(ApiService)
+            controller.apiService = apiMock
+            controller.executionService = Mock(ExecutionService)
+            controller.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor) {
+                getAuthContextForSubjectAndProject(_, _) >> Mock(UserAndRolesAuthContext)
+                authorizeProjectResource(_, _, _, "ProjectA") >> true
+                authorizeProjectResource(_, _, _, "ProjectB") >> false
+            }
+
+        when:
+            controller.apiExecutionMetrics(new ExecutionQuery(jobIdListFilter: [jobUuid]))
+
+        then: "the whole request is rejected and the 403 names only the denied project, not ProjectA"
+            1 * apiMock.requireApi(_, _, 29) >> true
+            1 * apiMock.renderErrorFormat(_, { Map m ->
+                m.status == 403 && m.args[2] == 'ProjectB'
+            })
+            0 * controller.executionService.queryExecutionMetrics(_)
+    }
+
     // RUN-3768 Phase 5: Batch endpoint tests
     // Note: Parameter validation (project required) is tested via integration tests
     // Unit testing this requires extensive mocking of the response chain
@@ -886,6 +1064,7 @@ class ExecutionController2Spec extends Specification implements ControllerUnitTe
             def apiMock = Mock(ApiService)
             controller.apiService = apiMock
             response.format = "json"
+            allowAllProjectAuth()
 
         when:
             def query = new ExecutionQuery()
@@ -965,6 +1144,7 @@ class ExecutionController2Spec extends Specification implements ControllerUnitTe
             def apiMock = Mock(ApiService)
             controller.apiService = apiMock
             response.format = "json"
+            allowAllProjectAuth()
 
         when:
             def query = new ExecutionQuery()
@@ -999,6 +1179,7 @@ class ExecutionController2Spec extends Specification implements ControllerUnitTe
             controller.apiService = apiMock
             controller.executionService = Mock(ExecutionService)
             response.format = "json"
+            allowAllProjectAuth()
 
         when:
             def query = new ExecutionQuery()
@@ -1403,6 +1584,7 @@ class ExecutionController2Spec extends Specification implements ControllerUnitTe
             def apiMock = Mock(ApiService)
             controller.apiService = apiMock
             response.format = "json"
+            allowAllProjectAuth()
 
         when:
             def query = new ExecutionQuery()
@@ -1412,7 +1594,7 @@ class ExecutionController2Spec extends Specification implements ControllerUnitTe
         then:
             1 * apiMock.requireApi(_, _, ApiVersions.V57) >> true
             response.status == 200
-            
+
             // Parse JSON response to verify filtering
             def jsonResponse = new JsonSlurper().parseText(response.text)
             jsonResponse.total == 35  // 20 + 15 (filtered)
@@ -1504,6 +1686,7 @@ class ExecutionController2Spec extends Specification implements ControllerUnitTe
             def apiMock = Mock(ApiService)
             controller.apiService = apiMock
             response.format = "json"
+            allowAllProjectAuth()
 
         when:
             def query = new ExecutionQuery()
@@ -1513,7 +1696,7 @@ class ExecutionController2Spec extends Specification implements ControllerUnitTe
         then:
             1 * apiMock.requireApi(_, _, ApiVersions.V57) >> true
             response.status == 200
-            
+
             // Verify response contains metrics from stats
             def jsonResponse = new JsonSlurper().parseText(response.text)
             jsonResponse.total == 20

--- a/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionController2Spec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/controllers/ExecutionController2Spec.groovy
@@ -1049,6 +1049,18 @@ class ExecutionController2Spec extends Specification implements ControllerUnitTe
             0 * controller.executionService.queryExecutionMetrics(_)
     }
 
+    def "ExecutionQuery.projNameFilter is not bindable from request params (RUN-4247)"() {
+        given: "a query bound from request data that tries to inject projNameFilter"
+            def query = new ExecutionQuery()
+
+        when:
+            controller.bindData(query, [projFilter: 'ProjectA', projNameFilter: ['InjectedProject']])
+
+        then: "normal fields bind, but the server-only projNameFilter is ignored"
+            query.projFilter == 'ProjectA'
+            query.projNameFilter == null
+    }
+
     // RUN-3768 Phase 5: Batch endpoint tests
     // Note: Parameter validation (project required) is tested via integration tests
     // Unit testing this requires extensive mocking of the response chain


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix for RUN-4247. The `/executions/metrics` API did not enforce project-level authorization on the projects in scope of a request, so execution metrics could be returned for projects the caller was not authorized to read. This adds the missing authorization check.

**Describe the solution you've implemented**

- `ExecutionController.apiExecutionMetrics` now authorizes the projects in scope **before** computing any metrics — the union of the `project` parameter and the projects that own the jobs listed in `jobIdListFilter`. Event-level READ (`RESOURCE_TYPE_EVENT` / `ACTION_READ`) is required on each; any unauthorized project returns `403`, naming only the denied project(s).
- When neither `project` nor `jobIdListFilter` is supplied, the aggregate is restricted to the projects the caller is authorized to read, instead of spanning every project on the instance.
- Added a reusable `partitionProjectsByEventReadAuth(projects)` helper that splits a project list into `authorized` / `unauthorized`.
- Added `ExecutionQuery.projNameFilter` to scope the query to a set of projects, applied in both the criteria and HQL paths and only when no single `projFilter` is set.

**Describe alternatives you've considered**

- Making `project` mandatory on the endpoint — rejected to preserve backward compatibility; scope is instead derived from whatever the caller supplies.
- Authorizing per individual job vs. per project set — chose the project-set approach (union of the `project` param and the job-owning projects) as it composes cleanly and keeps the check at the request-input boundary.

**Additional context**

Unit tests added/updated in `ExecutionController2Spec` (authorized and denied paths across single-job, batch, and default modes; the 403 names only the denied project) and `ExecutionQuerySpec` (project-set filter applied / ignored when a single `projFilter` is set). The touched specs pass locally (`ExecutionController2Spec` 55 tests, `ExecutionQuerySpec` 31 tests, 0 failures).

## Release Notes

The execution metrics API (`/executions/metrics`) now enforces project-level authorization: metrics are only returned for projects the requesting user is authorized to read.
