### PR TITLE
[RUN-4716] Hide adhoc inline endpoints from public OpenAPI spec

### DIFF
--- a/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
+++ b/rundeckapp/grails-app/controllers/rundeck/controllers/ScheduledExecutionController.groovy
@@ -2700,7 +2700,10 @@ Authorization required: `delete` on project resource type `job`, and `delete` on
     /**
      * execute the job defined via input parameters, but do not store it.
      * REST API endpoint: /api/{api_version}/project/{project}/run/command/inline
+     * Internal-only: backs the adhoc Vue SPA's session/CSRF-authenticated ajax call, not a
+     * documented public API surface. See RUN-4716.
      */
+    @Hidden
     @Post(uri='/project/{project}/run/command/inline', produces = MediaType.APPLICATION_JSON)
     @Operation(
         method='POST',
@@ -2822,7 +2825,10 @@ Since: v56''',
      * execute the job defined via input parameters, but do not store it.
      * REST API endpoint: /api/{api_version}/project/{project}/run/command/inline/api
      * This endpoint uses API authentication (for v56+)
+     * Internal-only: supports the adhoc Vue SPA, not a documented public API surface.
+     * See RUN-4716.
      */
+    @Hidden
     @Post(uri='/project/{project}/run/command/inline/api', produces = MediaType.APPLICATION_JSON)
     @Operation(
         method='POST',


### PR DESCRIPTION
## Jira Ticket
[RUN-4716](https://pagerduty.atlassian.net/browse/RUN-4716)

## Summary

`runAdhocInline` and `runAdhocInlineApi` (added in #10138 / RUN-4197 for the adhoc Vue SPA) ended up surfaced in the public 6.1.0 `rundeck-api.yml` OpenAPI spec, but were never documented in `docs/api/index.md` and weren't called out in the 6.1.0 release notes.

Investigation found that the ajax endpoint these replace (`runAdhocInline`, pre-#10138) was never part of the public API surface: it was invoked only via a plain `createLink(controller:'scheduledExecution', action:'runAdhocInline', ...)` from the old GSP page (not under `/api/{version}/...`), carried no OpenAPI annotations, and authenticates via CSRF token + session (`withForm{}.invalidToken{}`) rather than an API key.

#10138 added a new `/api/{version}/project/{project}/run/command/inline` URL mapping and full `@Operation`/`@ApiResponse` annotations to that same session/CSRF-authenticated action — which doesn't fit the public API auth model used elsewhere (e.g. `apiRunCommandv14` behind the already-documented `POST /project/[PROJECT]/run/command`, which uses `apiService.requireApi`). `runAdhocInlineApi` does use proper API-key auth, but its own description states it's "intended for use by the new Vue.js UI" — a UI-support endpoint, not general customer integration surface.

## Changes

- Add `@Hidden` to both `runAdhocInline` and `runAdhocInlineApi` in `ScheduledExecutionController.groovy` so they're excluded from generated OpenAPI spec / API Explorer, while remaining fully functional for the adhoc Vue SPA.

## Testing

- Endpoints are unchanged functionally — only the OpenAPI annotation processing changes. Verified via existing adhoc Selenium/functional coverage (no behavior change expected).

[RUN-4716]: https://pagerduty.atlassian.net/browse/RUN-4716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ