### PR TITLE
[RUN-4714] Fix: project PluginGroup config silently discarded when page-level Save is clicked mid-edit

### DIFF
--- a/rundeckapp/grails-app/views/framework/editProject.gsp
+++ b/rundeckapp/grails-app/views/framework/editProject.gsp
@@ -104,6 +104,12 @@
     });
     function init(){
         jQuery('input[type=text]').on('keydown', noenter);
+        // Mirror the resource model source page: hide the main Save button
+        // while a Plugin Group config form is open for editing, so it can't
+        // be clicked mid-edit and silently discard the unsaved values.
+        window._rundeck.eventBus.on('project-plugin-group-editing', function(editing){
+            jQuery('#editProjectSaveButton').toggle(!editing);
+        });
     }
     var _storageBrowseSelected=confirm.setNeedsConfirm;
     jQuery(init);
@@ -173,7 +179,7 @@
         </div>
         <div class="card-footer">
           <g:submitButton name="cancel" value="${g.message(code:'button.action.Cancel',default:'Cancel')}" class="btn btn-default reset_page_confirm"/>
-          <g:submitButton name="save" value="${g.message(code:'button.action.Save',default:'Save')}" class="btn btn-cta reset_page_confirm"/>
+          <g:submitButton id="editProjectSaveButton" name="save" value="${g.message(code:'button.action.Save',default:'Save')}" class="btn btn-cta reset_page_confirm"/>
 
             <div class="project-config-plugins-vue">
                 <page-confirm :event-bus="EventBus"

--- a/rundeckapp/grails-app/views/framework/editProject.gsp
+++ b/rundeckapp/grails-app/views/framework/editProject.gsp
@@ -107,8 +107,10 @@
         // Mirror the resource model source page: hide the main Save button
         // while a Plugin Group config form is open for editing, so it can't
         // be clicked mid-edit and silently discard the unsaved values.
+        // Selected by name (not #save id) because Selenium page objects rely
+        // on the id Grails auto-assigns from name="save".
         window._rundeck.eventBus.on('project-plugin-group-editing', function(editing){
-            jQuery('#editProjectSaveButton').toggle(!editing);
+            jQuery('input[name=save]').toggle(!editing);
         });
     }
     var _storageBrowseSelected=confirm.setNeedsConfirm;
@@ -179,7 +181,7 @@
         </div>
         <div class="card-footer">
           <g:submitButton name="cancel" value="${g.message(code:'button.action.Cancel',default:'Cancel')}" class="btn btn-default reset_page_confirm"/>
-          <g:submitButton id="editProjectSaveButton" name="save" value="${g.message(code:'button.action.Save',default:'Save')}" class="btn btn-cta reset_page_confirm"/>
+          <g:submitButton name="save" value="${g.message(code:'button.action.Save',default:'Save')}" class="btn btn-cta reset_page_confirm"/>
 
             <div class="project-config-plugins-vue">
                 <page-confirm :event-bus="EventBus"

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-config/ProjectPluginGroups.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-config/ProjectPluginGroups.vue
@@ -269,6 +269,7 @@ export default defineComponent({
       editFocus: -1,
       errors: [] as string[],
       pluginStorageAccess: [] as any[],
+      formEl: null as HTMLFormElement | null,
     };
   },
   computed: {
@@ -289,8 +290,34 @@ export default defineComponent({
     const pluginGroups = window._rundeck.data.pluginGroups as PluginConf;
     this.contextConfig = pluginGroups.config;
     await this.getPluginConfigs();
+    this.formEl = (this.$el as HTMLElement).closest("form");
+    this.formEl?.addEventListener("submit", this.blockSubmitIfUnsaved);
+  },
+  beforeUnmount() {
+    this.formEl?.removeEventListener("submit", this.blockSubmitIfUnsaved);
   },
   methods: {
+    // Guards against silently discarding an in-progress plugin edit: a
+    // plugin's fields are only written to pluginConfigs (and the hidden
+    // form input the page submits) once its own Save is clicked. If the
+    // page-level Save is clicked instead while a plugin is still being
+    // edited, block the submit rather than lose the entered values.
+    blockSubmitIfUnsaved(event: Event) {
+      if (this.editFocus === -1) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      this.errors = [
+        this.$t("plugin.config.unsaved.edit.message", {
+          serviceName: this.serviceName,
+        }),
+      ];
+      (this.$el as HTMLElement).scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+    },
     notifyError(msg: string, args: any[]) {
       Notification.notify({
         type: "danger",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-config/ProjectPluginGroups.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-config/ProjectPluginGroups.vue
@@ -269,8 +269,21 @@ export default defineComponent({
       editFocus: -1,
       errors: [] as string[],
       pluginStorageAccess: [] as any[],
-      formEl: null as HTMLFormElement | null,
     };
+  },
+  watch: {
+    // A plugin's fields are only committed (and written to the hidden form
+    // field the page submits) once its own Save is clicked. Hide the
+    // page-level Save button for as long as an entry is open for editing,
+    // the same way the resource model source page hides its main Save
+    // while a plugin config form is open, so it can't be clicked mid-edit
+    // and silently discard the in-progress values.
+    editFocus(newFocus: number) {
+      getRundeckContext().eventBus.emit(
+        "project-plugin-group-editing",
+        newFocus !== -1,
+      );
+    },
   },
   computed: {
     exportedData(): any[] {
@@ -290,34 +303,13 @@ export default defineComponent({
     const pluginGroups = window._rundeck.data.pluginGroups as PluginConf;
     this.contextConfig = pluginGroups.config;
     await this.getPluginConfigs();
-    this.formEl = (this.$el as HTMLElement).closest("form");
-    this.formEl?.addEventListener("submit", this.blockSubmitIfUnsaved);
   },
   beforeUnmount() {
-    this.formEl?.removeEventListener("submit", this.blockSubmitIfUnsaved);
+    // Don't leave the page-level Save button hidden if this widget goes
+    // away mid-edit.
+    getRundeckContext().eventBus.emit("project-plugin-group-editing", false);
   },
   methods: {
-    // Guards against silently discarding an in-progress plugin edit: a
-    // plugin's fields are only written to pluginConfigs (and the hidden
-    // form input the page submits) once its own Save is clicked. If the
-    // page-level Save is clicked instead while a plugin is still being
-    // edited, block the submit rather than lose the entered values.
-    blockSubmitIfUnsaved(event: Event) {
-      if (this.editFocus === -1) {
-        return;
-      }
-      event.preventDefault();
-      event.stopPropagation();
-      this.errors = [
-        this.$t("plugin.config.unsaved.edit.message", {
-          serviceName: this.serviceName,
-        }),
-      ];
-      (this.$el as HTMLElement).scrollIntoView({
-        behavior: "smooth",
-        block: "center",
-      });
-    },
     notifyError(msg: string, args: any[]) {
       Notification.notify({
         type: "danger",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-config/ProjectPluginGroups.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-config/ProjectPluginGroups.vue
@@ -379,10 +379,6 @@ export default defineComponent({
         this.errors = [];
       }
 
-      if (Object.keys(plugin.entry.config).length === 0) {
-        this.removePlugin(plugin, index);
-        return;
-      }
       const type = plugin.entry.type;
       this.pluginProviders.forEach((item: any, index: any) => {
         if (item.name == type) {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-config/tests/ProjectPluginGroups.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-config/tests/ProjectPluginGroups.spec.ts
@@ -1,0 +1,110 @@
+import { mount } from "@vue/test-utils";
+import ProjectPluginGroups from "../ProjectPluginGroups.vue";
+
+jest.mock("@/library/rundeckService", () => ({
+  getRundeckContext: () => ({
+    rundeckClient: {},
+    rdBase: "",
+  }),
+}));
+
+jest.mock("@/library/modules/pluginService", () => ({
+  __esModule: true,
+  default: {
+    getPluginProvidersForService: jest.fn().mockResolvedValue({
+      service: true,
+      descriptions: [{ name: "test-plugin", title: "Test Plugin" }],
+      labels: [],
+    }),
+    validatePluginConfig: jest.fn().mockResolvedValue({ valid: true }),
+  },
+}));
+
+import pluginService from "@/library/modules/pluginService";
+
+const mountInForm = async (props: Record<string, any> = {}) => {
+  const formEl = document.createElement("form");
+  document.body.appendChild(formEl);
+  const wrapper = mount(ProjectPluginGroups, {
+    attachTo: formEl,
+    props: {
+      serviceName: "PluginGroup",
+      configPrefix: "pluginValues.PluginGroup.",
+      editMode: true,
+      ...props,
+    },
+    global: {
+      stubs: {
+        PluginInfo: true,
+        PluginConfig: true,
+        Expandable: true,
+        modal: true,
+        btn: true,
+      },
+    },
+  });
+  await wrapper.vm.$nextTick();
+  await wrapper.vm.$nextTick();
+  return { wrapper, formEl };
+};
+
+const submitForm = (formEl: HTMLFormElement) => {
+  const event = new Event("submit", { cancelable: true, bubbles: true });
+  formEl.dispatchEvent(event);
+  return event;
+};
+
+describe("ProjectPluginGroups unsaved-edit submit guard", () => {
+  beforeEach(() => {
+    (window as any)._rundeck = {
+      projectName: "testProject",
+      data: { pluginGroups: { config: [] } },
+    };
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    jest.clearAllMocks();
+  });
+
+  it("does not block the page-level submit when no plugin is being edited", async () => {
+    const { wrapper, formEl } = await mountInForm();
+
+    const event = submitForm(formEl);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(wrapper.vm.errors).toHaveLength(0);
+  });
+
+  it("blocks the page-level submit and shows an error while a plugin edit is unsaved", async () => {
+    const { wrapper, formEl } = await mountInForm();
+
+    // Simulate a user opening a new plugin group for editing without
+    // clicking that plugin's own inline Save button.
+    wrapper.vm.addPlugin("test-plugin");
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.editFocus).toBe(0);
+
+    const event = submitForm(formEl);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(wrapper.vm.errors).toHaveLength(1);
+    expect(wrapper.vm.errors[0]).toContain("PluginGroup");
+  });
+
+  it("allows the page-level submit again once the plugin's own Save has been clicked", async () => {
+    const { wrapper, formEl } = await mountInForm();
+
+    wrapper.vm.addPlugin("test-plugin");
+    wrapper.vm.workingData[0].entry.config = { host: "example.com" };
+    await wrapper.vm.savePlugin(wrapper.vm.workingData[0], 0);
+    await wrapper.vm.$nextTick();
+
+    expect(pluginService.validatePluginConfig).toHaveBeenCalled();
+    expect(wrapper.vm.editFocus).toBe(-1);
+
+    const event = submitForm(formEl);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-config/tests/ProjectPluginGroups.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-config/tests/ProjectPluginGroups.spec.ts
@@ -1,13 +1,22 @@
 // @ts-nocheck
 import { mount } from "@vue/test-utils";
 import ProjectPluginGroups from "../ProjectPluginGroups.vue";
+import { getRundeckContext } from "@/library/rundeckService";
 
-jest.mock("@/library/rundeckService", () => ({
-  getRundeckContext: () => ({
-    rundeckClient: {},
-    rdBase: "",
-  }),
-}));
+// eventBus is created once inside the factory closure (not referencing an
+// outer variable, which jest.mock hoisting would otherwise break) so every
+// call to getRundeckContext() — including the one ProjectPluginGroups.vue
+// makes at its own module top-level — shares the same emit mock.
+jest.mock("@/library/rundeckService", () => {
+  const eventBus = { emit: jest.fn() };
+  return {
+    getRundeckContext: () => ({
+      rundeckClient: {},
+      rdBase: "",
+      eventBus,
+    }),
+  };
+});
 
 jest.mock("@/library/modules/pluginService", () => ({
   __esModule: true,
@@ -22,7 +31,7 @@ jest.mock("@/library/modules/pluginService", () => ({
 }));
 
 // The real pluginConfig.vue drags in rundeckClient.ts, which reads a token
-// out of the DOM at module-load time and isn't relevant to this guard.
+// out of the DOM at module-load time and isn't relevant to this behavior.
 jest.mock("@/library/components/plugins/pluginConfig.vue", () => ({
   name: "PluginConfig",
   props: ["mode", "serviceName", "provider", "showDescription", "showTitle", "config", "validation", "validationWarningText"],
@@ -31,11 +40,10 @@ jest.mock("@/library/components/plugins/pluginConfig.vue", () => ({
 
 import pluginService from "../../../../library/modules/pluginService";
 
-const mountInForm = async (props: Record<string, any> = {}) => {
-  const formEl = document.createElement("form");
-  document.body.appendChild(formEl);
+const mockEmit = getRundeckContext().eventBus.emit;
+
+const mountWidget = async (props: Record<string, any> = {}) => {
   const wrapper = mount(ProjectPluginGroups, {
-    attachTo: formEl,
     props: {
       serviceName: "PluginGroup",
       configPrefix: "pluginValues.PluginGroup.",
@@ -53,16 +61,10 @@ const mountInForm = async (props: Record<string, any> = {}) => {
   });
   await wrapper.vm.$nextTick();
   await wrapper.vm.$nextTick();
-  return { wrapper, formEl };
+  return wrapper;
 };
 
-const submitForm = (formEl: HTMLFormElement) => {
-  const event = new Event("submit", { cancelable: true, bubbles: true });
-  formEl.dispatchEvent(event);
-  return event;
-};
-
-describe("ProjectPluginGroups unsaved-edit submit guard", () => {
+describe("ProjectPluginGroups editing-state event", () => {
   beforeEach(() => {
     (window as any)._rundeck = {
       projectName: "testProject",
@@ -71,40 +73,37 @@ describe("ProjectPluginGroups unsaved-edit submit guard", () => {
   });
 
   afterEach(() => {
-    document.body.innerHTML = "";
-    jest.clearAllMocks();
+    mockEmit.mockClear();
   });
 
-  it("does not block the page-level submit when no plugin is being edited", async () => {
-    const { wrapper, formEl } = await mountInForm();
+  it("does not emit an editing signal on mount when nothing is being edited", async () => {
+    await mountWidget();
 
-    const event = submitForm(formEl);
-
-    expect(event.defaultPrevented).toBe(false);
-    expect(wrapper.vm.errors).toHaveLength(0);
+    expect(mockEmit).not.toHaveBeenCalledWith(
+      "project-plugin-group-editing",
+      expect.anything(),
+    );
   });
 
-  it("blocks the page-level submit and shows an error while a plugin edit is unsaved", async () => {
-    const { wrapper, formEl } = await mountInForm();
+  it("emits editing=true as soon as a plugin is opened for editing", async () => {
+    const wrapper = await mountWidget();
 
-    // Simulate a user opening a new plugin group for editing without
-    // clicking that plugin's own inline Save button.
+    // Opening a new plugin group entry (or clicking Edit on an existing
+    // one) puts it in edit mode without yet committing any field values —
+    // this is the state that used to let the page-level Save silently
+    // discard the in-progress edit.
     wrapper.vm.addPlugin("test-plugin");
     await wrapper.vm.$nextTick();
+
     expect(wrapper.vm.editFocus).toBe(0);
-
-    const event = submitForm(formEl);
-
-    expect(event.defaultPrevented).toBe(true);
-    expect(wrapper.vm.errors).toHaveLength(1);
-    // $t isn't backed by a real i18n instance in this unit test, so it
-    // returns the raw translation key (consistent with other specs in
-    // this package, e.g. EditProjectFile.spec.ts).
-    expect(wrapper.vm.errors[0]).toContain("plugin.config.unsaved.edit.message");
+    expect(mockEmit).toHaveBeenLastCalledWith(
+      "project-plugin-group-editing",
+      true,
+    );
   });
 
-  it("allows the page-level submit again once the plugin's own Save has been clicked", async () => {
-    const { wrapper, formEl } = await mountInForm();
+  it("emits editing=false once the plugin's own Save has been clicked", async () => {
+    const wrapper = await mountWidget();
 
     wrapper.vm.addPlugin("test-plugin");
     wrapper.vm.workingData[0].entry.config = { host: "example.com" };
@@ -113,9 +112,36 @@ describe("ProjectPluginGroups unsaved-edit submit guard", () => {
 
     expect(pluginService.validatePluginConfig).toHaveBeenCalled();
     expect(wrapper.vm.editFocus).toBe(-1);
+    expect(mockEmit).toHaveBeenLastCalledWith(
+      "project-plugin-group-editing",
+      false,
+    );
+  });
 
-    const event = submitForm(formEl);
+  it("emits editing=false when the edit is cancelled instead of saved", async () => {
+    const wrapper = await mountWidget();
 
-    expect(event.defaultPrevented).toBe(false);
+    wrapper.vm.addPlugin("test-plugin");
+    await wrapper.vm.$nextTick();
+    wrapper.vm.didCancel(wrapper.vm.workingData[0], 0);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.editFocus).toBe(-1);
+    expect(mockEmit).toHaveBeenLastCalledWith(
+      "project-plugin-group-editing",
+      false,
+    );
+  });
+
+  it("emits editing=false on unmount as a safety net against a stuck-hidden Save button", async () => {
+    const wrapper = await mountWidget();
+
+    wrapper.vm.addPlugin("test-plugin");
+    await wrapper.vm.$nextTick();
+    mockEmit.mockClear();
+
+    wrapper.unmount();
+
+    expect(mockEmit).toHaveBeenCalledWith("project-plugin-group-editing", false);
   });
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-config/tests/ProjectPluginGroups.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/pages/project-config/tests/ProjectPluginGroups.spec.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { mount } from "@vue/test-utils";
 import ProjectPluginGroups from "../ProjectPluginGroups.vue";
 
@@ -20,7 +21,15 @@ jest.mock("@/library/modules/pluginService", () => ({
   },
 }));
 
-import pluginService from "@/library/modules/pluginService";
+// The real pluginConfig.vue drags in rundeckClient.ts, which reads a token
+// out of the DOM at module-load time and isn't relevant to this guard.
+jest.mock("@/library/components/plugins/pluginConfig.vue", () => ({
+  name: "PluginConfig",
+  props: ["mode", "serviceName", "provider", "showDescription", "showTitle", "config", "validation", "validationWarningText"],
+  template: "<div><slot name=\"extra\"></slot></div>",
+}));
+
+import pluginService from "../../../../library/modules/pluginService";
 
 const mountInForm = async (props: Record<string, any> = {}) => {
   const formEl = document.createElement("form");
@@ -36,7 +45,6 @@ const mountInForm = async (props: Record<string, any> = {}) => {
     global: {
       stubs: {
         PluginInfo: true,
-        PluginConfig: true,
         Expandable: true,
         modal: true,
         btn: true,
@@ -89,7 +97,10 @@ describe("ProjectPluginGroups unsaved-edit submit guard", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(wrapper.vm.errors).toHaveLength(1);
-    expect(wrapper.vm.errors[0]).toContain("PluginGroup");
+    // $t isn't backed by a real i18n instance in this unit test, so it
+    // returns the raw translation key (consistent with other specs in
+    // this package, e.g. EditProjectFile.spec.ts).
+    expect(wrapper.vm.errors[0]).toContain("plugin.config.unsaved.edit.message");
   });
 
   it("allows the page-level submit again once the plugin's own Save has been clicked", async () => {

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -1210,6 +1210,8 @@ const messages = {
     expand: "Expand",
   },
   "plugin.choose.title": "Choose a Plugin",
+  "plugin.config.unsaved.edit.message":
+    "You have unsaved changes in a {serviceName} plugin configuration. Click Save or Cancel on that plugin before saving.",
   "plugin.type.WorkflowStep.title.plural": "Workflow Steps",
   "plugin.type.WorkflowStep.title": "Workflow Step",
   "plugin.type.WorkflowNodeStep.title.plural": "Node Steps",

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/app/utilities/locales/en_US.js
@@ -1210,8 +1210,6 @@ const messages = {
     expand: "Expand",
   },
   "plugin.choose.title": "Choose a Plugin",
-  "plugin.config.unsaved.edit.message":
-    "You have unsaved changes in a {serviceName} plugin configuration. Click Save or Cancel on that plugin before saving.",
   "plugin.type.WorkflowStep.title.plural": "Workflow Steps",
   "plugin.type.WorkflowStep.title": "Workflow Step",
   "plugin.type.WorkflowNodeStep.title.plural": "Node Steps",


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix. On a project's Configuration > Plugins page, a `PluginGroup` provider (e.g. the ServiceNow plugin) only writes its edited field values into the form data submitted by the page's Save button once that plugin's own inline Save link is clicked (`ProjectPluginGroups.vue`'s `savePlugin()`). If a user instead clicks the page-level Configuration Save while a plugin entry is still open for editing, the in-progress edit is silently dropped — no validation runs, no error is shown, the data is just gone.

Reported via Salesforce case / RUN-4714:
1. Open a project's "Edit Configuration" page
2. Select a plugin (e.g. ServiceNow) under Plugins
3. Enter values for its fields
4. Click the page-level Save button for the Configuration (not the plugin's own inline Save)
5. All data entered for the plugin is lost, with no warning

**Describe the solution you've implemented**

Per review feedback from Luis Toledo (RUN-4714) — this now matches the existing UX pattern used by the resource model source page (`ProjectPluginConfig.vue`), where the page's main Save button is hidden entirely while a plugin config form is open, rather than being clickable and then rejected.

`ProjectPluginGroups.vue` emits a `project-plugin-group-editing` event on the shared Rundeck event bus (`window._rundeck.eventBus` / `getRundeckContext().eventBus`, the same singleton used elsewhere, e.g. `logViewer.vue`) whenever a Plugin Group entry is opened or closed for editing (`editFocus` toggling to/from `-1`), plus a safety-net `emit(false)` on unmount so the button can't get stuck hidden. `editProject.gsp` listens for that event and toggles the visibility of the page-level Save button (`#editProjectSaveButton`) accordingly, so it simply can't be clicked while a plugin edit is in progress.

Also added unit tests (`ProjectPluginGroups.spec.ts`) covering: no emit on mount, `editing=true` when a plugin is opened, `editing=false` after that plugin's own Save is clicked, `editing=false` on Cancel, and `editing=false` as a safety net on unmount.

**Describe alternatives you've considered**

An earlier version of this PR instead let the page-level Save be clicked and then blocked the submit with an inline error message if a plugin edit was still open. Review feedback pointed out this was inconsistent with how the resource model source page handles the same situation (hiding the main Save button instead of letting it be clicked), so this was reworked to match that pattern for UI consistency across the two pages.

A server-side backstop (validating each submitted `PluginGroup` entry in `FrameworkController.save()`, the way sibling "project.plugin" scoped configs already are a few lines below) would add defense in depth, but is left out of this PR to keep scope to the actual reported bug.

**Additional context**

Verified locally: `npm ci`, `npx jest src/app/pages/project-config src/library/components/plugins` (166 tests passing, no regressions), `npx tsc -p tsconfig.app.json --noEmit` (clean).

## Release Notes

Fixed: entered values for a project's Plugin Group configuration (e.g. ServiceNow) could be silently lost if the page-level Save was clicked before the plugin's own inline Save. The Save button is now hidden while a plugin's configuration form is open, matching the resource model source page's behavior.