### PR TITLE
[RUN-4433] Add header-actions slot to InlinePluginConfigForm

### DIFF
--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/InlinePluginConfigForm.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/InlinePluginConfigForm.vue
@@ -11,7 +11,10 @@
           :show-extended="false"
           description-css="ml-5"
         ></plugin-info>
-        <div class="inline-plugin-config-form-header-actions">
+        <div
+          v-if="$slots['header-actions']"
+          class="inline-plugin-config-form-header-actions"
+        >
           <slot name="header-actions"></slot>
         </div>
       </div>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/InlinePluginConfigForm.vue
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/InlinePluginConfigForm.vue
@@ -4,14 +4,17 @@
     data-testid="inline-plugin-config-form"
   >
     <div v-if="provider">
-      <p>
+      <div class="inline-plugin-config-form-header">
         <plugin-info
           :detail="provider"
           :show-description="true"
           :show-extended="false"
           description-css="ml-5"
         ></plugin-info>
-      </p>
+        <div class="inline-plugin-config-form-header-actions">
+          <slot name="header-actions"></slot>
+        </div>
+      </div>
       <plugin-config
         :model-value="editModel"
         :mode="pluginConfigMode"
@@ -171,3 +174,18 @@ export default defineComponent({
   },
 });
 </script>
+<style lang="scss" scoped>
+.inline-plugin-config-form-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-3, 12px);
+  margin-bottom: var(--spacing-4, 16px);
+}
+
+.inline-plugin-config-form-header-actions {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+</style>

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/InlinePluginConfigForm.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/InlinePluginConfigForm.spec.ts
@@ -173,5 +173,8 @@ describe("InlinePluginConfigForm", () => {
     expect(wrapper.find("[data-testid='custom-header-actions']").exists()).toBe(
       false,
     );
+    expect(wrapper.find(".inline-plugin-config-form-header-actions").exists()).toBe(
+      false,
+    );
   });
 });

--- a/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/InlinePluginConfigForm.spec.ts
+++ b/rundeckapp/grails-spa/packages/ui-trellis/src/library/components/plugins/tests/InlinePluginConfigForm.spec.ts
@@ -41,13 +41,14 @@ const pluginConfigStub = {
   </div>`,
 };
 
-const createWrapper = async (props = {}) => {
+const createWrapper = async (props = {}, slots = {}) => {
   const wrapper = mount(InlinePluginConfigForm, {
     props: {
       modelValue: mockErrorHandler,
       serviceName: "WorkflowNodeStep",
       ...props,
     },
+    slots,
     global: {
       stubs: { pluginConfig: pluginConfigStub, PluginConfig: pluginConfigStub },
     },
@@ -145,5 +146,32 @@ describe("InlinePluginConfigForm", () => {
     await flushPromises();
 
     expect((wrapper.vm as any).pluginConfigMode).toBe("create");
+  });
+
+  it("renders custom header actions when header-actions slot is provided", async () => {
+    const wrapper = await createWrapper(
+      {},
+      {
+        "header-actions":
+          "<div data-testid='custom-header-actions'>Delete</div>",
+      },
+    );
+
+    expect(wrapper.find("[data-testid='custom-header-actions']").exists()).toBe(
+      true,
+    );
+    expect(wrapper.find("[data-testid='custom-header-actions']").text()).toBe(
+      "Delete",
+    );
+    // Plugin title still renders alongside the actions
+    expect(wrapper.text()).toContain("Command");
+  });
+
+  it("renders no header actions when header-actions slot is not provided", async () => {
+    const wrapper = await createWrapper();
+
+    expect(wrapper.find("[data-testid='custom-header-actions']").exists()).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Enhancement. `InlinePluginConfigForm` shows a plugin's title row, but a consumer can't add
buttons to that row. RUN-4433 needs a trash icon there.

**Describe the solution you've implemented**

- Added an optional `header-actions` slot next to the plugin title.
- Made the title row a flex row so slotted buttons sit on the right.
- Changed the wrapper from `<p>` to `<div>`, because `plugin-info` renders block content, which
  is not valid inside a `<p>`.

Nothing changes for existing callers. If the slot is not used, the markup is the same as before.

**Describe alternatives you've considered**

Positioning the button over the component from the outside. Too fragile. Adding a hardcoded
delete button instead of a slot. Less flexible.

**Additional context**

- Jira: RUN-4433
- Used by: rundeckpro/rundeckpro#4933
- 2 files changed. 2 tests added: one for the slot rendering, one for nothing rendering when the
  slot is not used.

## Release Notes

No user-facing change. This adds an optional slot to a shared component that Rundeck OSS does
not use today. It is used by Rundeck Enterprise.