### PR TITLE
[RUN-4723] Fix NPE in NotificationService.triggerPlugin when execution context is null

### DIFF
--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -797,7 +797,7 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
             }
         }
         Map<Class, Object> servicesMap = [:]
-        servicesMap.put(KeyStorageTree, content.context.storageTree)
+        servicesMap.put(KeyStorageTree, content.context?.storageTree)
 
         def services = new RundeckSpiBaseServicesProvider(
                 services: servicesMap

--- a/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/services/NotificationServiceSpec.groovy
@@ -1180,6 +1180,48 @@ class NotificationServiceSpec extends Specification implements ServiceUnitTest<N
 
     }
 
+    def "plugin notification still sends when execution context is null"() {
+        given: 'a plugin-type notification dispatched without an execution context'
+        def (job, execution) = createTestJob()
+
+        def content = [
+                execution: execution,
+                context  : null
+        ]
+
+        job.notifications = [
+                new Notification(
+                        eventTrigger: 'onstart',
+                        type: 'SimpleNotificationPlugin'
+                )
+        ]
+        job.save()
+        service.frameworkService = Mock(FrameworkService) {
+            _ * getRundeckFramework() >> Mock(Framework) {
+                _ * getWorkflowStrategyService()
+            }
+            _ * getPluginControlService(_) >> Mock(PluginControlService)
+        }
+
+        service.grailsLinkGenerator = Mock(LinkGenerator) {
+            _ * link(*_) >> 'alink'
+        }
+        service.pluginService = Mock(PluginService)
+        service.executionService = Mock(ExecutionService) {
+            getEffectiveSuccessNodeList(_) >> []
+        }
+
+        def pluginInst = Mock(NotificationPlugin)
+
+        when: 'trigger notification'
+        def result = service.triggerJobNotification('start', job, content)
+
+        then: 'the plugin still runs and the notification is sent'
+        1 * service.pluginService.configurePlugin('SimpleNotificationPlugin', _, _, _, _) >> new ConfiguredPlugin(pluginInst, [:])
+        1 * pluginInst.postNotification(_, _, _) >> true
+        result
+    }
+
     def "export variables replace values in webhook url"() {
         given:
         def (job, execution) = createTestJob()


### PR DESCRIPTION
## Jira Ticket
[RUN-4723](https://pagerduty.atlassian.net/browse/RUN-4723)

## Related Issue
Fixes #10415

## Summary
Plugin-type job notifications (Slack, PagerDuty, MS Teams, and any non-`email`/`url` notification plugin) were silently failing to send on `onfailure`/`onsuccess` triggers whenever the notification's execution context (`content.context`) was null. `NotificationService.triggerPlugin()` read `content.context.storageTree` with no null-guard; the resulting `NullPointerException` was swallowed by `triggerJobNotification`'s per-notification `catch(Throwable)` block, so the notification silently dropped with only an `ERROR` log line and no visible failure to the user.

Built-in `email` and `url` (webhook) notification types are handled in separate branches that don't call `triggerPlugin`, so they were unaffected.

## Root Cause
`content.context` can be null when the caller derives it via an unguarded `execRun?.thread?.context` chain (e.g. `ExecutionService.groovy`) rather than a guaranteed-non-null `ExecutionContextImpl.builder()...build()`. The same file already defends against a null `content.context` a few lines up (line 673), so this was simply an inconsistency rather than a new bug pattern.

## Fix
```diff
-        servicesMap.put(KeyStorageTree, content.context.storageTree)
+        servicesMap.put(KeyStorageTree, content.context?.storageTree)
```

## Testing
- Added a regression test (`"plugin notification still sends when execution context is null"` in `NotificationServiceSpec.groovy`) that fails on the old code (`TooFewInvocationsError` — the plugin's `postNotification` never gets invoked because the NPE aborts the call first) and passes with the fix.
- Ran the full `NotificationServiceSpec` suite locally — all 41 tests pass.

## Test plan
- [x] `./gradlew :rundeckapp:test --tests "rundeck.services.NotificationServiceSpec"` passes
- [x] New test fails against the pre-fix code, passes against the fix (verified both ways locally)

[RUN-4723]: https://pagerduty.atlassian.net/browse/RUN-4723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ