### PR TITLE
[RUN-0000] Restore three dependency exclusions broken by renamed coor…

### DIFF
--- a/grails-repository/build.gradle
+++ b/grails-repository/build.gradle
@@ -81,7 +81,9 @@ dependencies {
         exclude(group:"org.rundeck", module:"rundeck-storage-filesys")
         exclude(group:"com.squareup.okhttp3", module:"okhttp")
         exclude(group:"javax.mail", module:"mailapi")
-        exclude(group:"org.codehaus.groovy", module:"groovy-all")
+        // Groovy 4 renamed the group, so this exclusion stopped matching and the whole
+        // groovy-all aggregate started leaking in again.
+        exclude(group:"org.apache.groovy", module:"groovy-all")
         exclude(group: 'ch.qos.logback', module: 'logback-classic')
     }
 

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -124,8 +124,12 @@ configurations {
         exclude group: 'org.junit.platform'
         exclude group: 'org.apache.groovy', module: 'groovy-test-junit5'
         exclude group: 'org.apache.ant', module: 'ant-junit'
-        exclude group: 'org.codehaus.groovy', module: 'groovy-ant'
-        exclude group: 'org.grails', module: 'grails-shell'
+        // Grails 7 / Groovy 4 renamed both of these coordinates
+        // (org.grails:grails-shell -> org.apache.grails:grails-shell-cli,
+        // org.codehaus.groovy -> org.apache.groovy), so the exclusions stopped matching
+        // and the `grails` CLI toolchain reappeared on the runtime classpath.
+        exclude group: 'org.apache.groovy', module: 'groovy-ant'
+        exclude group: 'org.apache.grails', module: 'grails-shell-cli'
     }
 
     implementation.exclude module: "spring-boot-starter-tomcat"


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix.

Grails 7 / Groovy 4 renamed several group ids. Three dependency exclusions still
reference the old coordinates and therefore silently stopped matching anything:

| file | exclusion | current coordinate |
| --- | --- | --- |
| `rundeckapp/build.gradle` | `org.grails:grails-shell` | `org.apache.grails:grails-shell-cli` |
| `rundeckapp/build.gradle` | `org.codehaus.groovy:groovy-ant` | `org.apache.groovy:groovy-ant` |
| `grails-repository/build.gradle` | `org.codehaus.groovy:groovy-all` | `org.apache.groovy:groovy-all` |

Two things came back into the packaged WAR as a result.

**The `grails` CLI.** `grails-data-hibernate5-dbmigration` depends on
`grails-shell-cli` at compile scope because its `dbm-*` commands implement CLI
interfaces. That drags in `gradle-tooling-api`, the Maven model and resolver,
`plexus-*` and `sisu-inject`.

**The `groovy-all` aggregate.** `:rundeck-repository:rundeck-repository-client`
declares it with `implementation` scope, and `grails-repository` is the only
consumer that excluded it, so its 21 optional Groovy modules started resolving
again.

`rundeck-5.20.1-20260518.war` contains none of these artifacts, which confirms
both are regressions rather than long-standing behaviour.

**Describe the solution you've implemented**

Restore all three exclusions with their current coordinates. The diff is three
lines.

```groovy
// rundeckapp/build.gradle
runtimeClasspath {
    ...
-   exclude group: 'org.codehaus.groovy', module: 'groovy-ant'
-   exclude group: 'org.grails',          module: 'grails-shell'
+   exclude group: 'org.apache.groovy',  module: 'groovy-ant'
+   exclude group: 'org.apache.grails',  module: 'grails-shell-cli'
}
```

```groovy
// grails-repository/build.gradle
api (project(":rundeck-repository:rundeck-repository-client")) {
    ...
-   exclude(group:"org.codehaus.groovy", module:"groovy-all")
+   exclude(group:"org.apache.groovy",  module:"groovy-all")
}
```

**Describe alternatives you've considered**

- *Only repairing the two exclusions in `rundeckapp/build.gradle`, and blocking
  the `groovy-all` fallout locally* by additionally excluding `groovy-groovydoc`,
  `groovy-docgenerator`, `groovy-test` and `org.apache.grails.gradle` on
  `runtimeClasspath`. Rejected: that is a second workaround layered on top of the
  broken one, it needs three separate justifications instead of one, and it
  removes 343,553 bytes less.

- *Also repairing the four remaining stale exclusions* (`org.grails:grails-core`
  in `rundeckapp/build.gradle` and `grails-securityheaders/build.gradle`,
  `javax.mail:mailapi` in `grails-repository/build.gradle`,
  `javax.xml.bind:jaxb-api` in `core/build.gradle`). Rejected: none of them
  resolves to an artifact, so reviving them would change version selection for no
  benefit. Left alone.

- *Fixing `groovy-all` at its source.*
  `:rundeck-repository:rundeck-repository-client` should not depend on the Groovy
  aggregate with `implementation` scope at all — every other module in the repo
  uses `testImplementation` for it, and `rundeck-repository-client` is published,
  so the aggregate leaks into downstream POMs too. That is the correct end state
  and would let the `grails-repository` exclusion be deleted rather than repaired,
  but it changes a published artifact's POM and needs its own compile
  verification. Worth a separate PR.

**Additional context**

### Classpath delta

Resolved `:rundeckapp:runtimeClasspath`, which is exactly the WAR's `WEB-INF/lib`.

|  | files | bytes | MiB |
| --- | --- | --- | --- |
| base (`f2f142bc66`) | 357 | 148,189,262 | 141.32 |
| restored | 318 | 140,527,954 | 134.02 |
| **delta** | **-39** | **-7,661,308** | **-7.31** |

```
gradle-tooling-api            3,385,363
maven-*   (16 jars)           1,567,366
grails-shell-cli                769,220
org.eclipse.sisu.inject         433,639
plexus-*  (5 jars)              409,900
groovy-macro                    250,245
qdox                            179,818
groovy-groovydoc                148,204
groovy-docgenerator             115,243
groovy-jmx                      113,399
groovy-ant                       72,052
groovy-test                      70,515
groovy-cli-picocli               53,052
groovy-servlet                   23,339
groovy-jsr223                    16,832
groovy-nio                       16,244
groovy-datetime                  15,813
ant-antlr                        12,273
groovy-yaml                       6,294
javax.inject                      2,497
```

Nothing was added and no version changed: the two resolved file lists differ only
by those 39 removals. `picocli` stays, because `grails-bom` supplies it
independently of `groovy-cli-picocli`.

### Tests

The `groovy-all` exclusion sits on a dependency declaration rather than on a
configuration, so it also applies to `testRuntimeClasspath`, which loses the ten
Groovy modules that only `groovy-all` provided: 423 -> 413 files, -790,279 bytes.

`./gradlew :rundeckapp:test` passes: **6113 tests, 0 failures, 0 errors, 5
skipped**, `BUILD SUCCESSFUL`.

That is worth noting explicitly. Four of the removed modules — `groovy-nio`,
`groovy-datetime`, `groovy-macro` and `groovy-jsr223` — register Groovy extension
modules through `META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule`,
and `groovy-jsr223` also registers a `javax.script.ScriptEngineFactory`. A missing
extension module does not fail at startup; it fails at the point of use with
`MissingMethodException`, which a static analysis cannot detect. Because the test
run no longer has these modules on its classpath either, the passing suite is
direct evidence that they are unused. `ScriptEngineManager`, `javax.script` and
`getEngineByName` do not appear anywhere in the codebase, and 5.20.1 shipped
without all ten modules.

### Dangling reference analysis

Removing the 39 jars makes 335 packages unavailable that no surviving jar
provides. Scanning every remaining jar on `runtimeClasspath` for references into
those packages yields four, and none is reached at server startup:

| jar | referencing class | missing package |
| --- | --- | --- |
| `grails-bootstrap` | `org.grails.build.logging.GrailsConsoleAntBuilder` | `groovy.ant` |
| `grails-gradle-model` | Gradle tooling model | `org.grails.cli` |
| `grails-data-hibernate5-dbmigration` | `Dbm*Command` | `org.grails.cli.profile` |
| `micronaut-inject` | `JavaxProviderBeanDefinition` | `javax.inject` |

- The first two are build-time code paths. 5.20.1 shipped `grails-bootstrap`
  without `groovy-ant` on the classpath and ran in production.
- The `dbm-*` command classes are only loaded when the Grails CLI dispatches one.
  The plugin's `META-INF/grails-plugin.xml` lists no command class, and
  `DatabaseMigrationGrailsPlugin`'s `doWithSpring` and `doWithApplicationContext`
  do not reference the `command` package.
- `JavaxProviderBeanDefinition` is Micronaut's optional `javax.inject.Provider`
  support. `micronaut-inject` declares a dependency on `jakarta.inject-api`, which
  stays on the classpath, and
  `AbstractInitializableBeanDefinitionReference.isPresent()` handles
  `NoClassDefFoundError` so the definition is skipped when `javax.inject` is
  absent.

### Not verified

A full `bootWar` and the functional test suite were not run: both need
`CLOUDSMITH_NPM_TOKEN` to resolve npm packages from
`npm.artifacts.pd-internal.com`, which is unavailable outside PagerDuty CI.

### Suggested follow-up

Nothing in Gradle flags an exclusion that matches no module, which is why all
three of these rotted unnoticed through the Grails 7 upgrade. A verification task
that fails the build when a declared exclusion resolves to nothing would have
caught them together.

## Release Notes

The Rundeck WAR no longer bundles the Gradle and Maven build tooling and the
optional Groovy modules that the Grails 7 upgrade pulled in, removing 39 jars /
7.31 MiB from the runtime classpath. There is no functional change.
