### PR TITLE
[RUN-0000] Stop duplicating the compiled assets inside the WAR

### DIFF
--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -493,6 +493,9 @@ bootRun {
     //    addResources = true
     // Full resources/main so classpath:/assets/ resolves; duplicateFileMode=WARN avoids Liquibase failure on duplicate migrations
     classpath += files("$buildDir/resources/main", "$buildDir/resources/main/META-INF")
+    // Compiled assets under classpath:/assets/. Only bootRun needs these; the packaged
+    // WAR serves the same files from its root instead (see copyCompiledAssets).
+    classpath += files("$buildDir/bootrun-assets")
     // Strip liquibase-commercial: it ships LicenseValidationChange (extends AbstractChange)
     // compiled against the 4.26 API, whose bytecode references liquibase.ChecksumVersion.
     // We pin liquibase-core to 4.19.0 for DB compatibility, so 4.26's commercial jar causes
@@ -850,16 +853,29 @@ task copyAssetManifest(type: Copy) {
     into "$buildDir/resources/main/META-INF/assets"
 }
 
-// Copy compiled assets to classpath:/assets/ (resources/main/assets/) for bootRun and WAR
+// Copy compiled assets to classpath:/assets/ for bootRun only.
+//
+// This deliberately does NOT go into resources/main: the packaged WAR already
+// carries the compiled assets at its root (assets/**), added by the
+// asset-pipeline Gradle plugin, and asset-pipeline resolves that copy first.
+// Both AssetPipelineFilter and AssetPipelineGrailsPlugin do:
+//
+//     resource = applicationContext.getResource("assets/${uri}")
+//     if (!resource.exists()) resource = applicationContext.getResource("classpath:assets/${uri}")
+//
+// In a WebApplicationContext the first lookup is a ServletContextResource, i.e.
+// the WAR root, which always hits. Staging the same files under
+// resources/main/assets therefore only duplicated ~32 MiB of the WAR without
+// ever being read. bootRun has no WAR root, so it needs the classpath copy.
 task copyCompiledAssets(type: Copy) {
     dependsOn assetCompile
     from "$buildDir/assets"
-    into "$buildDir/resources/main/assets"
+    into "$buildDir/bootrun-assets/assets"
     exclude 'manifest.properties'
 }
 
-processResources.dependsOn copyAssetManifest, copyCompiledAssets
-bootRun.dependsOn processResources
+processResources.dependsOn copyAssetManifest
+bootRun.dependsOn processResources, copyCompiledAssets
 
 archivesBaseName = 'rundeck'
 


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Bugfix — dead weight left behind by the Grails 7 upgrade (#9922).

`rundeck-6.1.0-20260803.war` carries two byte-identical copies of every compiled
asset:

| location | files | MiB | produced by |
| --- | --- | --- | --- |
| `assets/` | 728 | 32.32 | asset-pipeline Gradle plugin |
| `WEB-INF/classes/assets/` | 727 | 32.31 | `copyCompiledAssets` |

A CRC-32 comparison matches on all 727 shared entries; only
`manifest.properties` is unique to the WAR root.

The classpath copy is never read when running from a WAR. asset-pipeline resolves
assets in a fixed order, in both `AssetPipelineFilter` and
`AssetPipelineGrailsPlugin.doWithSpring`:

```groovy
resource = applicationContext.getResource("assets/${uri}")
if (!resource.exists())
    resource = applicationContext.getResource("classpath:assets/${uri}")
```

In a `WebApplicationContext` the first call resolves to a `ServletContextResource`,
that is the WAR root, which always exists.

`copyCompiledAssets` was introduced by #9922 alongside an
`AssetPipelineResourceConfigurer` that registered a Spring MVC handler for
`classpath:/assets/`. That configurer was deleted in `13c57ab1c3`, leaving 32 MiB
of staged files with no consumer. `rundeck-5.20.1-20260518.war` shipped no
classpath copy at all and served assets fine under the same `WarLauncher` setup.

**Describe the solution you've implemented**

Redirect `copyCompiledAssets` to `build/bootrun-assets/assets` and put that
directory on the `bootRun` classpath, since `bootRun` has no WAR root and does
need it. Nothing is staged into `resources/main` any more, so it no longer reaches
the WAR. `copyAssetManifest` is unchanged, so
`META-INF/assets/manifest.properties` still ships.

```groovy
 task copyCompiledAssets(type: Copy) {
     dependsOn assetCompile
     from "$buildDir/assets"
-    into "$buildDir/resources/main/assets"
+    into "$buildDir/bootrun-assets/assets"
     exclude 'manifest.properties'
 }

-processResources.dependsOn copyAssetManifest, copyCompiledAssets
-bootRun.dependsOn processResources
+processResources.dependsOn copyAssetManifest
+bootRun.dependsOn processResources, copyCompiledAssets
```

```groovy
 bootRun {
     classpath += files("$buildDir/resources/main", "$buildDir/resources/main/META-INF")
+    classpath += files("$buildDir/bootrun-assets")
```

Expected WAR size: 274.36 MiB -> 242.05 MiB (-11.8%).

**Describe alternatives you've considered**

- *Excluding `WEB-INF/classes/assets/**` in the `bootWar` task.* Rejected: the WAR
  task's include/exclude patterns are matched against source paths, and the WAR
  root copy arrives from a different source under the same `assets/` prefix, so a
  pattern narrow enough to be safe is hard to express and easy to break later.
  Changing where the files are staged is unambiguous.

- *Deleting `copyCompiledAssets` outright.* Its only remaining consumer is
  `bootRun`, and whether `bootRun` truly needs it is unclear: the manifest is
  excluded from the copy and `copyAssetManifest` writes to `META-INF/assets/`,
  while asset-pipeline's fallback looks for `classpath:assets/manifest.properties`,
  so `bootRun` likely never reaches the `warDeployed` branch at all. That is worth
  settling separately. Keeping the task on the `bootRun` classpath makes this
  change WAR-only.

- *Dropping the WAR root copy instead and keeping the classpath one.* Rejected:
  the WAR root copy is what asset-pipeline resolves first and what 5.20.1 shipped
  exclusively, and it is produced by the asset-pipeline Gradle plugin rather than
  by Rundeck's build.

**Additional context**

### Task graph

`--dry-run`, so nothing executes:

| task | base | this branch | difference |
| --- | --- | --- | --- |
| `:rundeckapp:bootWar` | 298 tasks | 297 | only `copyCompiledAssets` |
| `:rundeckapp:processResources` | 179 tasks | 178 | same single difference |
| `:rundeckapp:bootRun` | — | — | identical, `copyCompiledAssets` still present |

### Real WARs

`assetCompile` cannot run outside PagerDuty CI, because `vendorAssetDeps` and
`copySpa` resolve npm packages from `npm.artifacts.pd-internal.com`, which answers
401 without `CLOUDSMITH_NPM_TOKEN`. So `build/assets` was populated by hand with a
marker asset plus a matching `manifest.properties`, and the npm tasks were skipped.
Both WARs built successfully.

```
base        assets/ci-marker.js
            assets/manifest.properties
            WEB-INF/classes/assets/ci-marker.js
            WEB-INF/classes/META-INF/assets/manifest.properties

this        assets/ci-marker.js
            assets/manifest.properties
            WEB-INF/classes/META-INF/assets/manifest.properties
```

### Booting them

Installed and started the way the official Docker image does —
`java -jar rundeck.war --installonly --basedir`, then `java -jar rundeck.war`:

| | startup | `GET /assets/ci-marker.js` |
| --- | --- | --- |
| base | up after 40s | HTTP 200, body matches |
| this branch | up after 40s | HTTP 200, body matches |

Because `manifest.properties` is present at the WAR root,
`AssetPipelineConfigHolder.manifest` is populated and the filter takes its
`warDeployed` branch, so this exercises the production resolution path rather than
the development one.

### Nothing else depends on the classpath copy

- No Rundeck class references `classpath:assets/`. Scanning 6905 classes across the
  `rundeck-*` and `grails-*` jars in the WAR, only asset-pipeline's own
  `AssetPipelineFilter`, `AssetPipelineGrailsPlugin` and `AssetPipelineBootStrap`
  match, and all three try the WAR root first.
- `AssetPipelineBootStrap` returns immediately unless `grails.assets.storagePath`
  is set, which Rundeck never sets.
- No plugin supplies assets over the classpath. `grails-webhooks` is the only
  module with a `grails-app/assets` directory and it is empty, so its jar ships an
  empty `META-INF/assets/` and an empty `META-INF/assets.list`. None of the 22
  bundled plugin jars contains an `assets/` or `META-INF/assets` entry.
- Plugin assets would resolve through `META-INF/assets/` via
  `ClasspathAssetResolver`, not through `assets/`, so they are unaffected either
  way.

### Not verified

The 32 MiB figure itself, since the test WARs contain a single marker asset rather
than a real `assetCompile` output. `bootRun` was not executed either, because that
also needs `assetCompile`. The size numbers in this description come from measuring
the released `rundeck-6.1.0-20260803.war`.

Note for local verification: `build/resources/main/assets` left over from an
earlier build is not removed by this change, so start from a clean build.

## Release Notes

The Rundeck WAR no longer contains a second, unused copy of the compiled frontend
assets, reducing the artifact by roughly 32 MiB. There is no functional change.
