### PR TITLE
[RUN-4695] Enforce job-run authorization for Quartz-triggered scheduled executions

### DIFF
--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -377,7 +377,6 @@ class ExecutionJob implements InterruptableJob {
             )
             if (!initMap.executionService.validateExecution(initMap.scheduledExecution, initMap.authContext)) {
                 initMap.jobShouldNotRun = "Job ${initMap.scheduledExecution.extid} triggered but user '${initMap.scheduledExecution.user}' is not authorized to run it (ACTION_RUN denied); skipping this execution."
-                log.warn(initMap.jobShouldNotRun)
                 return initMap
             }
             initMap.secureOptsExposed = initMap.executionService.selectSecureOptionInput(initMap.scheduledExecution,[:],true)

--- a/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
+++ b/rundeckapp/grails-app/jobs/rundeck/quartzjobs/ExecutionJob.groovy
@@ -375,6 +375,11 @@ class ExecutionJob implements InterruptableJob {
                     rolelist,
                     project
             )
+            if (!initMap.executionService.validateExecution(initMap.scheduledExecution, initMap.authContext)) {
+                initMap.jobShouldNotRun = "Job ${initMap.scheduledExecution.extid} triggered but user '${initMap.scheduledExecution.user}' is not authorized to run it (ACTION_RUN denied); skipping this execution."
+                log.warn(initMap.jobShouldNotRun)
+                return initMap
+            }
             initMap.secureOptsExposed = initMap.executionService.selectSecureOptionInput(initMap.scheduledExecution,[:],true)
             def inputMap=[executionType:'scheduled']
             def triggerData = context?.trigger?.jobDataMap?.get('scheduleArgs')

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2546,6 +2546,7 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
      * Used by the Quartz scheduled-trigger path (ExecutionJob), which builds its authContext
      * from the job's stored user/roles rather than an interactively-authenticated caller.
      */
+    @CompileStatic
     public boolean validateExecution(ScheduledExecution se, UserAndRolesAuthContext authContext) {
         return rundeckAuthContextProcessor.authorizeProjectJobAll(authContext, se, [AuthConstants.ACTION_RUN], se.project)
     }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -2542,6 +2542,15 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
     }
 
     /**
+     * Check whether the given authContext is authorized to run (ACTION_RUN) the given job.
+     * Used by the Quartz scheduled-trigger path (ExecutionJob), which builds its authContext
+     * from the job's stored user/roles rather than an interactively-authenticated caller.
+     */
+    public boolean validateExecution(ScheduledExecution se, UserAndRolesAuthContext authContext) {
+        return rundeckAuthContextProcessor.authorizeProjectJobAll(authContext, se, [AuthConstants.ACTION_RUN], se.project)
+    }
+
+    /**
      * Run a job at a later time.
      *
      * The runAtTime parameter must be specified as an ISO 8601 compliant timestamp.

--- a/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionJobIntegrationSpec.groovy
+++ b/rundeckapp/src/integration-test/groovy/rundeck/quartzjobs/ExecutionJobIntegrationSpec.groovy
@@ -568,6 +568,7 @@ class ExecutionJobIntegrationSpec extends Specification {
             def jobSchedulesServiceMock = Mock(JobSchedulesService)
             def jobSchedulerServiceMock = Mock(JobSchedulerService)
             1 * mockes.selectSecureOptionInput(se, _, true) >> [test: 'input']
+            1 * mockes.validateExecution(se, _) >> true
             1 * mockes.createExecution(se, { it.username == se.user }, _, { it.executionType == 'scheduled' }) >> e
 
             def proj = Mock(IRundeckProject) {
@@ -757,6 +758,7 @@ class ExecutionJobIntegrationSpec extends Specification {
             def jobSchedulesServiceMock = Mock(JobSchedulesService)
             def jobSchedulerServiceMock = Mock(JobSchedulerService)
             1 * mockes.selectSecureOptionInput(se, _, true) >> [test: 'input']
+            1 * mockes.validateExecution(se, _) >> true
             1 * mockes.createExecution(se, { it.username == se.user }, _, { it.executionType == 'scheduled' }) >> e
 
             def proj = Mock(IRundeckProject) {
@@ -824,6 +826,7 @@ class ExecutionJobIntegrationSpec extends Specification {
         def jobSchedulesServiceMock = Mock(JobSchedulesService)
         def jobSchedulerServiceMock = Mock(JobSchedulerService)
         1 * mockes.selectSecureOptionInput(se, _, true) >> [test: 'input']
+        1 * mockes.validateExecution(se, _) >> true
         1 * mockes.createExecution(se, { it.username == se.user }, _, { it.executionType == 'scheduled' }) >> e
 
         def proj = Mock(IRundeckProject) {
@@ -892,6 +895,7 @@ class ExecutionJobIntegrationSpec extends Specification {
             def jobSchedulesServiceMock = Mock(JobSchedulesService)
             def jobSchedulerServiceMock = Mock(JobSchedulerService)
             1 * mockes.selectSecureOptionInput(se, _, true) >> [test: 'input']
+            1 * mockes.validateExecution(se, _) >> true
             1 * mockes.createExecution(se, { it.username == se.user }, _, { it.executionType == 'scheduled' }) >> e
 
             def proj = Mock(IRundeckProject) {

--- a/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/ExecutionServiceSpec.groovy
@@ -1333,6 +1333,34 @@ class ExecutionServiceSpec extends Specification implements ServiceUnitTest<Exec
         'ISO-8859-1' | _
     }
 
+    def "validateExecution returns true when authorized"() {
+        given:
+        service.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor)
+        def authContext = Mock(UserAndRolesAuthContext)
+        def se = new ScheduledExecution(project: 'AProject')
+
+        when:
+        def result = service.validateExecution(se, authContext)
+
+        then:
+        1 * service.rundeckAuthContextProcessor.authorizeProjectJobAll(authContext, se, [AuthConstants.ACTION_RUN], se.project) >> true
+        result
+    }
+
+    def "validateExecution returns false when unauthorized"() {
+        given:
+        service.rundeckAuthContextProcessor = Mock(AppAuthContextProcessor)
+        def authContext = Mock(UserAndRolesAuthContext)
+        def se = new ScheduledExecution(project: 'AProject')
+
+        when:
+        def result = service.validateExecution(se, authContext)
+
+        then:
+        1 * service.rundeckAuthContextProcessor.authorizeProjectJobAll(authContext, se, [AuthConstants.ACTION_RUN], se.project) >> false
+        !result
+    }
+
     def "delete execution unauthorized"() {
         given:
 

--- a/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/quartzjobs/ExecutionJobSpec.groovy
@@ -406,7 +406,9 @@ class ExecutionJobSpec extends Specification implements DataTest {
 
         def serverUUID = UUID.randomUUID().toString()
         def jobUUID = UUID.randomUUID().toString()
-        def es = Mock(ExecutionService)
+        def es = Mock(ExecutionService) {
+            validateExecution(_, _) >> true
+        }
         def eus = Mock(ExecutionUtilService)
         def jobSchedulesService = Mock(JobSchedulesService)
         def jobSchedulerService = Mock(JobSchedulerService)
@@ -487,6 +489,82 @@ class ExecutionJobSpec extends Specification implements DataTest {
         then: "execution args are set"
         0 * quartzScheduler.deleteJob(ajobKey)
         1 * es.createExecution(_, _, null, { it.argString == '-opt1 test1' }) >> e
+    }
+
+    def "scheduled job trigger does not execute when ACTION_RUN authorization is denied"() {
+
+        def serverUUID = UUID.randomUUID().toString()
+        def jobUUID = UUID.randomUUID().toString()
+        def es = Mock(ExecutionService) {
+            validateExecution(_, _) >> false
+        }
+        def eus = Mock(ExecutionUtilService)
+        def jobSchedulesService = Mock(JobSchedulesService)
+        def jobSchedulerService = Mock(JobSchedulerService)
+        def fs = Mock(FrameworkService) {
+            getServerUUID() >> serverUUID
+            getProjectConfigReloaded('AProject') >> Mock(IRundeckProject) {
+                getProjectProperties() >> [:]
+            }
+        }
+        AuthContextProvider authContextProvider = Mock(AuthContextProvider) {
+            getAuthContextForUserAndRolesAndProject(_, _, _) >> Mock(UserAndRolesAuthContext)
+        }
+        ScheduledExecution se = new ScheduledExecution(
+                jobName: 'blue',
+                project: 'AProject',
+                groupPath: 'some/where',
+                description: 'a job',
+                argString: '-a b -c d',
+                serverNodeUUID: jobUUID,
+                user: 'devread',
+                workflow: new Workflow(
+                        keepgoing: true,
+                        commands: [new CommandExec(
+                                [adhocRemoteString: 'test buddy', argString: '-delay 12 -monkey cheese -particle']
+                        )]
+                ),
+                scheduled: true,
+                executionEnabled: true,
+                scheduleEnabled: true,
+                uuid: jobUUID
+        )
+        se.save(flush: true)
+        def datamap = new JobDataMap(
+                [
+                        project             : se.project,
+                        scheduledExecutionId: se.uuid,
+                        executionService    : es,
+                        executionUtilService: eus,
+                        frameworkService    : fs,
+                        bySchedule          : true,
+                        jobSchedulesService : jobSchedulesService,
+                        jobSchedulerService : jobSchedulerService,
+                        authContextProvider : authContextProvider,
+                ]
+        )
+        ExecutionJob job = new ExecutionJob()
+        def ajobKey = JobKey.jobKey('jobname', 'jobgroup')
+
+        def quartzScheduler = Mock(Scheduler)
+        def trigger = Mock(Trigger)
+        def context = Mock(JobExecutionContext) {
+            getJobDetail() >> Mock(JobDetail) {
+                getJobDataMap() >> datamap
+                getKey() >> ajobKey
+            }
+
+            getScheduler() >> quartzScheduler
+            getTrigger() >> trigger
+        }
+
+        when: "job with a denied ACTION_RUN authorization is triggered by its schedule"
+        job.execute(context)
+
+        then: "no execution is created, and the job is not unscheduled"
+        0 * es.createExecution(*_)
+        0 * es.executeAsyncBegin(*_)
+        0 * quartzScheduler.deleteJob(ajobKey)
     }
 
     def "average notification threshold from options"() {
@@ -788,7 +866,9 @@ class ExecutionJobSpec extends Specification implements DataTest {
     def "scheduled job quartz checking the same format of dates"() {
         def serverUUID = UUID.randomUUID().toString()
         def jobUUID = UUID.randomUUID().toString()
-        def es = Mock(ExecutionService)
+        def es = Mock(ExecutionService) {
+            validateExecution(_, _) >> true
+        }
         def eus = Mock(ExecutionUtilService)
         def jobSchedulesService = Mock(JobSchedulesService)
         def jobSchedulerService = Mock(JobSchedulerService)


### PR DESCRIPTION
## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**
This is a bugfix. Quartz-triggered scheduled job executions did not re-verify that the job's stored owner still holds run authorization for the project before creating an execution. Every interactive execution path (retry, ad-hoc immediate, ad-hoc scheduled-for-later) already performs this check consistently -- the scheduled-trigger path was the one exception.

**Describe the solution you've implemented**
Added `ExecutionService.validateExecution(ScheduledExecution, UserAndRolesAuthContext)`, which mirrors the existing `rundeckAuthContextProcessor.authorizeProjectJobAll(authContext, scheduledExecution, [AuthConstants.ACTION_RUN], project)` pattern already used by `retryExecuteJob`/`scheduleAdHocJob`. `ExecutionJob.initialize()`'s scheduled-trigger branch now calls this method before creating an execution. If authorization is denied, the trigger is skipped for that cycle (logged at `WARN`, using the existing `jobShouldNotRun` short-circuit already used elsewhere in this method) -- no execution is created, and the job is **not** unscheduled, so it will be correctly evaluated again on its next trigger.

**Describe alternatives you've considered**
- Injecting the authorization-decision bean directly into the Quartz `JobDataMap` and checking inside `ExecutionJob` -- rejected, since it would touch the shared Quartz job-listener wiring (`resources.groovy`) and require updating every unrelated test that constructs a `JobDataMap` for this job type.
- Adding the check inside the shared `createExecution`/`int_createExecution` methods -- rejected, since those methods are shared by multiple execution paths that each already perform their own (sometimes differently-scoped) authorization check upstream; changing the shared low-level method risked altering behavior across unrelated paths for a fix that only needed to close one specific gap.

**Additional context**
Covered by a new regression test plus updates to existing tests in `ExecutionServiceSpec`, `ExecutionJobSpec`, and `ExecutionJobIntegrationSpec`.

## Release Notes

Fixed an issue where a scheduled job's Quartz trigger could create an execution without re-verifying that the job's owner still holds run authorization for the project.
