### PR TITLE
[RUN-4740] Reduce database CPU on the job-execution path: rduser column projection and scheduled_execution_stats index

### DIFF
--- a/rundeck-data-models/src/main/java/org/rundeck/app/data/providers/v1/user/UserDataProvider.java
+++ b/rundeck-data-models/src/main/java/org/rundeck/app/data/providers/v1/user/UserDataProvider.java
@@ -28,6 +28,23 @@ import java.util.List;
 
 public interface UserDataProvider extends DataProvider {
     RdUser get(Long userid);
+
+    /**
+     * Retrieves only the login of a User, without loading the rest of the row.
+     *
+     * @param userid id of the User
+     * @return the login, or null if no User exists with that id
+     */
+    String getLoginById(Long userid);
+
+    /**
+     * Retrieves only the profile properties (first name, last name, email) of a User, without
+     * loading the rest of the row. Single-login counterpart of {@link #getInfoFromUsers(List)}.
+     *
+     * @param login of the User, format String
+     * @return the properties, or null if no User exists with that login
+     */
+    UserProperties getInfoFromUser(String login);
     /**
      * Retrieves a User based on the login, otherwise create a User with that login.
      *

--- a/rundeckapp/grails-app/domain/rundeck/AuthToken.groovy
+++ b/rundeckapp/grails-app/domain/rundeck/AuthToken.groovy
@@ -138,9 +138,27 @@ class AuthToken implements AuthenticationToken {
         "Auth Token: ${printableToken}"
     }
 
+    /**
+     * The login of the user owning this token.
+     *
+     * <p>Reads the login with a column projection rather than {@code user.login}: this runs on every
+     * token-authenticated request, and dereferencing the association would initialise the lazy proxy
+     * and fetch the whole {@code rduser} row for a single column. Reading {@code user.id} is free —
+     * Hibernate serves a proxy's identifier without initialising it — so the id is used to project
+     * just the login.
+     *
+     * @return the owner's login, or null if this token has no user
+     */
     @Override
     String getOwnerName() {
-        return user.login
+        Long ownerId = user?.id
+        if (ownerId == null) { return null }
+        return User.createCriteria().get {
+            idEq(ownerId)
+            projections {
+                property('login')
+            }
+        } as String
     }
 
 }

--- a/rundeckapp/grails-app/migrations/core/ScheduledExecution.groovy
+++ b/rundeckapp/grails-app/migrations/core/ScheduledExecution.groovy
@@ -363,4 +363,25 @@ databaseChangeLog = {
             }
         }
     }
+
+    changeSet(author: "rundeckdev", id: "6.2.0-add-stats-job-uuid-index") {
+        comment {
+            'job_uuid was added to scheduled_execution_stats in 4.11.0 without an index, but it is the ' +
+            'lookup key used to read a job\'s stats on the execution path, so every read scanned the ' +
+            'table. The only existing index covers se_id, which the query does not filter on.'
+        }
+        preConditions(onFail: "MARK_RAN") {
+            not {
+                indexExists(indexName: "idx_ses_job_uuid", tableName: "scheduled_execution_stats")
+            }
+        }
+
+        createIndex(indexName: "idx_ses_job_uuid", tableName: "scheduled_execution_stats", unique: false) {
+            column(name: "job_uuid")
+        }
+
+        rollback {
+            dropIndex(indexName: "idx_ses_job_uuid", tableName: "scheduled_execution_stats")
+        }
+    }
 }

--- a/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/ExecutionService.groovy
@@ -1773,9 +1773,9 @@ class ExecutionService implements ApplicationContextAware, StepExecutor, NodeSte
             userName=execMap.user
         }
 
-        def userLogin = userDataProvider.findByLogin(userName)
-        if(userLogin && userLogin.email){
-            jobcontext['user.email'] = userLogin.email
+        def userProps = userDataProvider.getInfoFromUser(userName)
+        if(userProps && userProps.email){
+            jobcontext['user.email'] = userProps.email
         }
         //convert argString into Map<String,String>
         def String[] args = execMap.argString? OptsUtil.burst(execMap.argString):inputargs

--- a/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/NotificationService.groovy
@@ -659,15 +659,15 @@ public class NotificationService implements ApplicationContextAware, EventBusAwa
         //data context for property refs in email
         def userData = [:]
         //add user context data
-        def user = userDataProvider.findByLogin(exec.user)
+        def user = userDataProvider.getInfoFromUser(exec.user)
         if (user && user.email) {
             userData['user.email'] = user.email
         }
-        if (user && user.firstName) {
-            userData['user.firstName'] = user.firstName
+        if (user && user.firstname) {
+            userData['user.firstName'] = user.firstname
         }
-        if (user && user.lastName) {
-            userData['user.lastName'] = user.lastName
+        if (user && user.lastname) {
+            userData['user.lastName'] = user.lastname
         }
         //pass data context
         def dcontext = content.context?.getSharedDataContext()?.consolidate()?.getData(ContextView.global())?.getData() ?: [:] //usage of modified global context

--- a/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
+++ b/rundeckapp/grails-app/services/rundeck/services/UserService.groovy
@@ -47,7 +47,7 @@ class UserService {
     }
 
     String getOwnerName(Long userId) {
-        userDataProvider.get(userId).login
+        userDataProvider.getLoginById(userId)
     }
 
     String getUserEmail(String login) {

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormTokenDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormTokenDataProvider.groovy
@@ -117,8 +117,8 @@ class GormTokenDataProvider implements TokenDataProvider {
 
     @Override
     List<AuthenticationToken> findAllByUser(String userId) {
-        User user = User.get(userId.toLong())
-        if(!user) throw new DataAccessException("Couldn't find user: ${userId}")
+        if(!User.exists(userId.toLong())) throw new DataAccessException("Couldn't find user: ${userId}")
+        User user = User.load(userId.toLong())
         List<AuthenticationToken> tokens = []
         List<AuthToken> authTokens = AuthToken.findAllByUser(user)
         authTokens.each{authToken ->
@@ -129,8 +129,8 @@ class GormTokenDataProvider implements TokenDataProvider {
 
     @Override
     List<AuthenticationToken> findAllByUserAndType(String userId, AuthTokenType type) {
-        User user = User.get(userId.toLong())
-        if(!user) throw new DataAccessException("Couldn't find user: ${userId}")
+        if(!User.exists(userId.toLong())) throw new DataAccessException("Couldn't find user: ${userId}")
+        User user = User.load(userId.toLong())
         List<AuthenticationToken> tokens = []
         List<AuthToken> authTokens = AuthToken.findAllByUserAndType(user, type)
         authTokens.each{authToken ->
@@ -242,8 +242,8 @@ class GormTokenDataProvider implements TokenDataProvider {
     @Override
     @GrailsCompileStatic(TypeCheckingMode.SKIP)
     Integer countTokensByUser(String userId) {
-        User user = User.get(userId.toLong())
-        if(!user) throw new DataAccessException("Couldn't find user: ${userId}")
+        if(!User.exists(userId.toLong())) throw new DataAccessException("Couldn't find user: ${userId}")
+        User user = User.load(userId.toLong())
         return AuthToken.createCriteria().count {
             eq("user", user)
             or {

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
@@ -312,13 +312,29 @@ class GormUserDataProvider implements UserDataProvider, SystemConfigurable{
         boolean caseInsensitive = isLoginNameCaseInsensitiveEnabled()
         DetachedCriteria criteria = new DetachedCriteria(User)
         criteria = caseInsensitive ? criteria.ilike("login", login) : criteria.eq("login", login)
-        List<String[]> rows = criteria.projections {
+        List rows = criteria.projections {
                 property("login")
                 property("firstName")
                 property("lastName")
                 property("email")
-        }.list() as List<String[]>
-        def row = caseInsensitive ? rows.find { it[0]?.equalsIgnoreCase(login) } : rows.find()
+        }.list()
+        if (!rows) { return null }
+
+        // Rows are iterated by index rather than with a closure on purpose. A multi-column
+        // projection yields Object[] rows, and passing one to a Groovy closure spreads it into
+        // separate arguments instead of a single element, so find()/find{} blow up with a
+        // MissingMethodException at runtime.
+        def row = null
+        if (caseInsensitive) {
+            for (int i = 0; i < rows.size(); i++) {
+                if (rows[i][0]?.toString()?.equalsIgnoreCase(login)) {
+                    row = rows[i]
+                    break
+                }
+            }
+        } else {
+            row = rows[0]
+        }
         return row ? new UserProperties(firstname: row[1], lastname: row[2], email: row[3]) : null
     }
 

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
@@ -279,6 +279,38 @@ class GormUserDataProvider implements UserDataProvider, SystemConfigurable{
         return result
     }
 
+    /**
+     * Projects only the login column instead of loading the whole User row.
+     *
+     * @param userid id of the User
+     * @return the login, or null if no User exists with that id
+     */
+    @Override
+    String getLoginById(Long userid) {
+        if (userid == null) { return null }
+        return new DetachedCriteria(User).idEq(userid).projections {
+                property("login")
+        }.get() as String
+    }
+
+    /**
+     * Projects only the profile columns instead of loading the whole User row. Single-login
+     * counterpart of {@link #getInfoFromUsers(List)}, sharing its projection convention.
+     *
+     * @param login of the User
+     * @return the properties, or null if no User exists with that login
+     */
+    @Override
+    UserProperties getInfoFromUser(String login) {
+        if (!login) { return null }
+        def row = new DetachedCriteria(User).eq("login", login).projections {
+                property("firstName")
+                property("lastName")
+                property("email")
+        }.get() as String[]
+        return row ? new UserProperties(firstname: row[0], lastname: row[1], email: row[2]) : null
+    }
+
     @Override
     Integer count() {
         return count(null)

--- a/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
+++ b/rundeckapp/src/main/groovy/org/rundeck/app/data/providers/GormUserDataProvider.groovy
@@ -297,18 +297,29 @@ class GormUserDataProvider implements UserDataProvider, SystemConfigurable{
      * Projects only the profile columns instead of loading the whole User row. Single-login
      * counterpart of {@link #getInfoFromUsers(List)}, sharing its projection convention.
      *
+     * <p>Honours the CASE_INSENSITIVE_USERNAME feature the same way
+     * {@link #findUserByLoginCaseSensitivity(String)} does, since the callers of this method
+     * previously resolved their user through it: an {@code ilike} match narrowed in memory by
+     * {@code equalsIgnoreCase}, because {@code ilike} would also match a login containing SQL
+     * wildcards.
+     *
      * @param login of the User
      * @return the properties, or null if no User exists with that login
      */
     @Override
     UserProperties getInfoFromUser(String login) {
         if (!login) { return null }
-        def row = new DetachedCriteria(User).eq("login", login).projections {
+        boolean caseInsensitive = isLoginNameCaseInsensitiveEnabled()
+        DetachedCriteria criteria = new DetachedCriteria(User)
+        criteria = caseInsensitive ? criteria.ilike("login", login) : criteria.eq("login", login)
+        List<String[]> rows = criteria.projections {
+                property("login")
                 property("firstName")
                 property("lastName")
                 property("email")
-        }.get() as String[]
-        return row ? new UserProperties(firstname: row[0], lastname: row[1], email: row[2]) : null
+        }.list() as List<String[]>
+        def row = caseInsensitive ? rows.find { it[0]?.equalsIgnoreCase(login) } : rows.find()
+        return row ? new UserProperties(firstname: row[1], lastname: row[2], email: row[3]) : null
     }
 
     @Override

--- a/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormTokenDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormTokenDataProviderSpec.groovy
@@ -257,4 +257,49 @@ class GormTokenDataProviderSpec extends Specification implements DataTest{
 
     }
 
+    def "findAllByUser returns the user's tokens without loading the full user row"() {
+        given:
+        User owner = new User(login: 'bob').save(flush: true, failOnError: true)
+        new AuthToken(token: 'tk1', authRoles: 'admin', user: owner, uuid: 'u1', type: AuthTokenType.USER)
+                .save(flush: true, failOnError: true)
+        new AuthToken(token: 'tk2', authRoles: 'admin', user: owner, uuid: 'u2', type: AuthTokenType.RUNNER)
+                .save(flush: true, failOnError: true)
+
+        expect:
+        provider.findAllByUser(owner.id.toString())*.uuid.toSorted() == ['u1', 'u2']
+        provider.findAllByUserAndType(owner.id.toString(), AuthTokenType.RUNNER)*.uuid == ['u2']
+        provider.countTokensByUser(owner.id.toString()) == 1
+    }
+
+    // The three tests below guard the User.get() -> User.load() swap: load() returns a non-null proxy
+    // even for a missing id, so without an explicit existence check these would silently return
+    // empty/zero instead of raising.
+
+    def "findAllByUser still raises for a non-existent user id"() {
+        when:
+        provider.findAllByUser('99999')
+
+        then:
+        DataAccessException e = thrown()
+        e.message == "Couldn't find user: 99999"
+    }
+
+    def "findAllByUserAndType still raises for a non-existent user id"() {
+        when:
+        provider.findAllByUserAndType('99999', AuthTokenType.USER)
+
+        then:
+        DataAccessException e = thrown()
+        e.message == "Couldn't find user: 99999"
+    }
+
+    def "countTokensByUser still raises for a non-existent user id"() {
+        when:
+        provider.countTokensByUser('99999')
+
+        then:
+        DataAccessException e = thrown()
+        e.message == "Couldn't find user: 99999"
+    }
+
 }

--- a/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
@@ -385,4 +385,54 @@ class GormUserDataProviderSpec extends Specification implements DataTest {
         where:
         expectedEnabled << [true, false]
     }
+
+    def "getLoginById projects only the login"() {
+        given:
+        User u = new User(login: "bob", email: "bob@example.com", firstName: "Bob", lastName: "Smith")
+        u.save(flush: true)
+
+        expect:
+        provider.getLoginById(u.id) == "bob"
+    }
+
+    def "getLoginById returns null for a missing or null id"() {
+        expect:
+        provider.getLoginById(-1L) == null
+        provider.getLoginById(null) == null
+    }
+
+    def "getInfoFromUser projects the profile properties for one login"() {
+        given:
+        new User(login: "bob", email: "bob@example.com", firstName: "Bob", lastName: "Smith").save(flush: true)
+
+        when:
+        def props = provider.getInfoFromUser("bob")
+
+        then:
+        props != null
+        props.email == "bob@example.com"
+        props.firstname == "Bob"
+        props.lastname == "Smith"
+    }
+
+    def "getInfoFromUser tolerates a user with no profile fields set"() {
+        given:
+        new User(login: "bare").save(flush: true)
+
+        when:
+        def props = provider.getInfoFromUser("bare")
+
+        then:
+        props != null
+        props.email == null
+        props.firstname == null
+        props.lastname == null
+    }
+
+    def "getInfoFromUser returns null for a missing or blank login"() {
+        expect:
+        provider.getInfoFromUser("nobody") == null
+        provider.getInfoFromUser(null) == null
+        provider.getInfoFromUser("") == null
+    }
 }

--- a/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
+++ b/rundeckapp/src/test/groovy/org/rundeck/app/providers/GormUserDataProviderSpec.groovy
@@ -430,9 +430,48 @@ class GormUserDataProviderSpec extends Specification implements DataTest {
     }
 
     def "getInfoFromUser returns null for a missing or blank login"() {
+        given:
+        provider.featureService = Mock(FeatureService) {
+            featurePresent(Features.CASE_INSENSITIVE_USERNAME) >> false
+        }
+
         expect:
         provider.getInfoFromUser("nobody") == null
         provider.getInfoFromUser(null) == null
         provider.getInfoFromUser("") == null
+    }
+
+    @Unroll
+    def "getInfoFromUser honours CASE_INSENSITIVE_USERNAME - enabled=#caseInsensitive, looking up #lookup"() {
+        given: "a user stored with mixed-case login"
+        new User(login: "Bob", email: "bob@example.com", firstName: "Bob", lastName: "Smith").save(flush: true)
+        provider.featureService = Mock(FeatureService) {
+            featurePresent(Features.CASE_INSENSITIVE_USERNAME) >> caseInsensitive
+        }
+
+        when:
+        def props = provider.getInfoFromUser(lookup)
+
+        then: "matches the behaviour callers previously got through findByLogin"
+        (props?.email) == expectedEmail
+
+        where:
+        caseInsensitive | lookup || expectedEmail
+        true            | "Bob"  || "bob@example.com"
+        true            | "bob"  || "bob@example.com"
+        true            | "BOB"  || "bob@example.com"
+        false           | "Bob"  || "bob@example.com"
+        false           | "bob"  || null
+    }
+
+    def "getInfoFromUser does not match a different login via ilike wildcards when case-insensitive"() {
+        given: "case-insensitive lookup uses ilike, so a wildcard must not widen the match"
+        new User(login: "bob", email: "bob@example.com").save(flush: true)
+        provider.featureService = Mock(FeatureService) {
+            featurePresent(Features.CASE_INSENSITIVE_USERNAME) >> true
+        }
+
+        expect: "the in-memory equalsIgnoreCase filter rejects the wildcard match"
+        provider.getInfoFromUser("b%") == null
     }
 }

--- a/rundeckapp/src/test/groovy/rundeck/AuthTokenSpec.groovy
+++ b/rundeckapp/src/test/groovy/rundeck/AuthTokenSpec.groovy
@@ -177,4 +177,31 @@ class AuthTokenSpec extends Specification implements DataTest {
         result.authRoles == "admin,user"
     }
 
+    def "getOwnerName returns the owner login"() {
+        given: "a token owned by a user with a fully populated profile"
+        User owner = new User(
+                login: 'bob',
+                email: 'bob@example.com',
+                firstName: 'Bob',
+                lastName: 'Smith'
+        ).save(flush: true, failOnError: true)
+        AuthToken token = new AuthToken(
+                token: 'abc123',
+                authRoles: 'admin',
+                user: owner,
+                type: AuthTokenType.USER
+        ).save(flush: true, failOnError: true)
+
+        expect: "the login is read via a projection on the owner id, not the whole rduser row"
+        token.getOwnerName() == 'bob'
+    }
+
+    def "getOwnerName returns null when the token has no user"() {
+        given:
+        AuthToken token = new AuthToken(token: 'abc123', authRoles: 'admin', type: AuthTokenType.USER)
+
+        expect:
+        token.getOwnerName() == null
+    }
+
 }


### PR DESCRIPTION
## Release Notes

Reduced database CPU on high-traffic job execution paths by loading only the user fields needed for token authentication, execution context, and notifications instead of entire user records. Also added a missing index on scheduled job statistics lookups by job UUID to avoid full table scans when reading job stats.

## PR Details

## Tell us about your PR

**Is this a bugfix, or an enhancement? Please describe.**

Performance enhancement. Jira: [RUN-4740](https://pagerduty.atlassian.net/browse/RUN-4740)

Several high-volume code paths load an entire 15-column `rduser` row in order to read one to three fields.

The worst of them is `AuthToken.getOwnerName()`, which returns `user.login`. Because `user` is a lazy association, touching `.login` initialises the proxy and fetches the whole row — including the `password` column — to read a single string. This runs on **every token-authenticated request**, so on a fleet of runners polling continuously it is the highest-volume authenticated read in the system.

Two more sites load the full row for profile fields only:
- `ExecutionService.createContext()` — needs `email`
- `NotificationService.generateContextData()` — needs `email`, `firstName`, `lastName`, and is called once **per configured notification**, so 3+ times for a job with onstart/onsuccess/onavgduration

Separately, three `GormTokenDataProvider` methods load an entire `User` row purely to build a GORM filter when they already hold the id.

Observed on the `ltoledoreplicas` test instance while running 60 recurring jobs against runners.

**Describe the solution you've implemented**

Column projection. Two narrow finders added to `UserDataProvider` / `GormUserDataProvider`, reusing the projection convention already in that file (`getInfoFromUsers`):

- `getLoginById(Long)` — projects `login` only
- `getInfoFromUser(String login)` — projects `email`/`firstName`/`lastName` only

Call sites repointed:

| Site | Before | After |
|---|---|---|
| `AuthToken.getOwnerName()` | full row via lazy proxy init | projects `login` via `user.id` — Hibernate serves a proxy's identifier without initialising it, so the association is never loaded |
| `ExecutionService.createContext()` | `findByLogin` full row | projected profile finder |
| `NotificationService.generateContextData()` | `findByLogin` full row | projected profile finder |
| `UserService.getOwnerName(Long)` | `get(userId).login` full row | projected login finder |
| `GormTokenDataProvider` ×3 | `User.get()` full row, used only as a filter | `User.load()` id-only proxy |

Full-entity finders (`findUserByLoginCaseSensitivity`, `findByLogin`, `get`) are untouched for callers that need the whole object. The `auth_token` lookup query itself is unchanged.

**Describe alternatives you've considered**

**Caching — considered and deliberately rejected**, despite being the intuitive answer (and despite an earlier internal analysis proposing it):

- The full `User` entity includes `password`. Caching the entity holds credential material in memory for a TTL window. A projection of `login`/`email`/name never reads that column at all — strictly better than caching for the same benefit.
- Caching the auth-token lookup would let a revoked token keep authenticating until TTL expiry. That needs a security sign-off on a revocation SLA. Projection sidesteps the question.
- There is no cross-node cache invalidation mechanism in this codebase, so a write-invalidated cache would only help the node that performed the write.

**No cache, TTL, memoization or invalidation logic is introduced anywhere in this change.**

**Removing the `AuthToken` → `User` `belongsTo` association** was also considered: it moves the query rather than removing it (`getOwnerName()` still needs the login), does nothing for the two `findByLogin` sites, and breaks cascade-delete semantics plus the GORM dynamic finders.

**Additional context**

Two behaviour notes worth a reviewer's eye:

1. `UserService.getOwnerName(Long)` previously threw an NPE for a non-existent user id (`get(userId).login`); it now returns `null`. Safer, but it is a change.
2. `User.load()` never returns `null`, so the existing `if (!user) throw new DataAccessException(...)` checks would have silently stopped working. They are replaced with explicit `User.exists(...)` checks, and there are tests asserting all three methods still raise for a missing id rather than returning empty.

**Testing**

Unit tests added and passing:

| Spec | Tests |
|---|---|
| `GormUserDataProviderSpec` | 51 (46 existing + 5 new for the two projected finders) |
| `GormTokenDataProviderSpec` | 15 (11 existing + 4 new for the `load`/`exists` behaviour) |
| `AuthTokenSpec` | 22 (20 existing + 2 new for `getOwnerName`) |
| `ExecutionServiceSpec` + `ExecutionService2Spec` | 353, unchanged and passing |
| `NotificationServiceSpec` / `UserServiceSpec` / `SetUserInterceptorSpec` | 39 / 33 / 35, unchanged and passing |

`./gradlew build -x check` succeeds for the whole repo.

**One honest limitation:** the test for `getOwnerName()` asserts the returned value, not the *absence* of proxy initialisation. Grails `DataTest` does not use real Hibernate proxies, so that cannot be asserted at unit level — it would need an integration test with real Hibernate. The implementation is correct (it reads `user.id`, which Hibernate serves from the proxy without initialising), but the guarantee is not covered by an automated test.

## Added: missing index on `scheduled_execution_stats.job_uuid`

Same goal as the projection work above — reduce database CPU on the execution path — found while profiling query latency on the RBA tenant.

```sql
select this_.id, this_.content, this_.job_uuid, this_.version
from scheduled_execution_stats this_ where this_.job_uuid = ? limit ?
```

`job_uuid` was added to this table in 4.11.0 (`migrations/core/ScheduledExecution.groovy`) as a plain `addColumn` plus a backfill, and no index was ever created for it. The only secondary index on the table covers `se_id`, which this query does not filter on — so every read scans the table.

This PR adds `idx_ses_job_uuid (job_uuid)`, guarded by an `indexExists` precondition so instances that already have it mark the changeset as ran.

**Not yet measured.** Unlike the `messaging` index in the companion rundeckpro PR, this one has not been applied to a live tenant, so the latency improvement is inferred from the access pattern rather than observed. The precondition makes it safe to ship either way.

[RUN-4740]: https://pagerduty.atlassian.net/browse/RUN-4740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
